### PR TITLE
feat(ecosystems): P2 — JsonlIngester(spec) 抽象 + Codex 适配器

### DIFF
--- a/src/xskill/adapters.py
+++ b/src/xskill/adapters.py
@@ -62,6 +62,9 @@ def adapt_trajectory(
     if format == "claude_code_jsonl":
         return _adapt_claude_code_jsonl(content, metadata)
 
+    if format == "codex_rollout_jsonl":
+        return _adapt_codex_rollout_jsonl(content, metadata)
+
     raise ValueError(f"unsupported trajectory format: {format!r}")
 
 
@@ -313,6 +316,148 @@ def _adapt_claude_code_jsonl(content: str, metadata: dict) -> tuple[str, dict]:
     meta["tool_names"] = tool_names
     meta["total_tool_calls"] = len(tool_calls)
     meta["total_turns"] = len(timeline)
+    if first_user_query:
+        meta.setdefault("query", first_user_query)
+
+    return md, meta
+
+
+def _adapt_codex_rollout_jsonl(content: str, metadata: dict) -> tuple[str, dict]:
+    """Convert a Codex CLI rollout JSONL (``~/.codex/sessions/YYYY/MM/DD/rollout-*.jsonl``)
+    to markdown + metadata.
+
+    Codex rollout schema（来自 ``codex-rs/protocol/src/protocol.rs::RolloutItem``）：
+    每行是 ``{"timestamp", "type", "payload"}`` 三件套，``type`` 是 tagged-union 标签：
+
+    - ``session_meta`` —— 首行，``payload`` 含 ``id``/``cwd``/``originator``/
+      ``cli_version``/``model_provider`` 等
+    - ``event_msg`` —— 事件流。``payload.type=user_message`` 携带用户输入
+    - ``response_item`` —— 模型响应（message / tool call / function output）
+    - ``turn_context`` —— 每 turn 的 cwd / approval / sandbox / model
+    - ``compacted`` —— 上下文压缩事件
+
+    P2 阶段我们抽 ``session_meta``（session_id + cwd + originator + cli_version）+
+    ``event_msg::user_message``（user query），其它行**透传到 timeline 但不深度解析**
+    （codex 的 ``response_item`` 内部结构与 CC 不同，等 P4 再深化）。
+    """
+    timeline: list[dict] = []
+    session_id = ""
+    cwd = ""
+    originator = ""
+    cli_version = ""
+    model_provider = ""
+    first_user_query = ""
+    t = 0
+    response_count = 0
+
+    for raw_line in content.splitlines():
+        raw_line = raw_line.strip()
+        if not raw_line:
+            continue
+        try:
+            event = json.loads(raw_line)
+        except json.JSONDecodeError:
+            continue
+
+        ev_type = event.get("type")
+        payload = event.get("payload") or {}
+
+        if ev_type == "session_meta":
+            session_id = session_id or str(payload.get("id") or "")
+            cwd = cwd or str(payload.get("cwd") or "")
+            originator = originator or str(payload.get("originator") or "")
+            cli_version = cli_version or str(payload.get("cli_version") or "")
+            mp = payload.get("model_provider")
+            if mp:
+                model_provider = model_provider or str(mp)
+            continue
+
+        if ev_type == "event_msg":
+            sub_type = payload.get("type")
+            if sub_type == "user_message":
+                msg = str(payload.get("message") or "")
+                if msg:
+                    if not first_user_query:
+                        first_user_query = msg[:500]
+                    timeline.append({
+                        "t": t, "role": "user",
+                        "content": msg[:2000],
+                    })
+                    t += 1
+            continue
+
+        if ev_type == "response_item":
+            # 占位：codex response_item 的内部 schema 复杂（含 message / tool_use /
+            # function_call_output 等），P2 不深化。这里只计数 + 透传一条 timeline
+            # 让下游能看到"这条 session 确实有 N 条响应"。
+            response_count += 1
+            timeline.append({
+                "t": t, "role": "assistant",
+                "content": f"[codex response_item #{payload.get('index', response_count - 1)}]",
+            })
+            t += 1
+            continue
+
+        # turn_context / compacted / 未来变体：透传，不深析
+        timeline.append({
+            "t": t, "role": "event",
+            "kind": ev_type or "unknown",
+        })
+        t += 1
+
+    # Build markdown
+    lines: list[str] = ["# Codex Rollout Trajectory", ""]
+    if session_id:
+        lines.append(f"**session_id**: {session_id}")
+    if cwd:
+        lines.append(f"**cwd**: {cwd}")
+    if originator:
+        lines.append(f"**originator**: {originator}")
+    if cli_version:
+        lines.append(f"**cli_version**: {cli_version}")
+    if model_provider:
+        lines.append(f"**model_provider**: {model_provider}")
+    lines.append("")
+    if first_user_query:
+        lines.append("## Initial Query")
+        lines.append("")
+        lines.append(first_user_query)
+        lines.append("")
+
+    for entry in timeline:
+        role = entry["role"]
+        if role == "user":
+            lines.append("## User")
+            lines.append("")
+            lines.append(entry["content"])
+            lines.append("")
+        elif role == "assistant":
+            lines.append("## Assistant")
+            lines.append("")
+            lines.append(entry["content"])
+            lines.append("")
+        elif role == "event":
+            lines.append(f"## Event: {entry['kind']}")
+            lines.append("")
+
+    md = "\n".join(lines)
+
+    meta = dict(metadata)
+    meta.setdefault("source", "codex_rollout_jsonl")
+    meta.setdefault("category", "codex_session")
+    if session_id:
+        meta.setdefault("session_id", session_id)
+    if cwd:
+        meta.setdefault("cwd", cwd)
+    if originator:
+        meta.setdefault("originator", originator)
+    if cli_version:
+        meta.setdefault("cli_version", cli_version)
+    if model_provider:
+        meta.setdefault("model_provider", model_provider)
+    meta["timeline"] = timeline
+    meta["total_turns"] = len(timeline)
+    meta["response_items"] = response_count
     if first_user_query:
         meta.setdefault("query", first_user_query)
 

--- a/src/xskill/ecosystems.py
+++ b/src/xskill/ecosystems.py
@@ -23,7 +23,7 @@ import shutil
 import sqlite3
 import threading
 import time
-from dataclasses import dataclass
+from dataclasses import dataclass, field
 from pathlib import Path
 from typing import Callable, Iterable, Literal, Optional
 
@@ -60,6 +60,78 @@ def _cc_skills_path(home: Path) -> Path:
     每个 skill 落到 ``<this>/<name>/SKILL.md``，CC 启动时扫这里。
     """
     return home / ".claude" / "skills"
+
+
+def _codex_sessions_path(home: Path) -> Path:
+    """Codex CLI rollout JSONL 根目录：``<home>/.codex/sessions``。
+
+    实际文件落在 ``<this>/YYYY/MM/DD/rollout-<ts>-<uuid>.jsonl``——codex-rs
+    `recorder.rs::precompute_log_file_info()` 按日期分桶，文件名时间戳的 `:`
+    已替换为 `-` 兼容 NTFS（Windows）。
+
+    跨平台一致：macOS / Linux / Windows 都走 ``<HOME>/.codex/...``，不走 XDG
+    （codex 是"传统 ~/.<app>/" 风格，参 docs/dev-plan/adapter-research.md
+    "Codex CLI > 轨迹采集"段）。
+    """
+    return home / ".codex" / "sessions"
+
+
+def _agents_skills_path(home: Path) -> Path:
+    """跨生态共享的 user-scope skill 安装目录：``<home>/.agents/skills``。
+
+    Codex 0.130 的 ``core-skills/src/loader.rs`` 把这条路径列为 user scope 的
+    **首选**（``$CODEX_HOME/skills/`` 已被标 deprecated）；OpenCode 的
+    ``packages/opencode/src/skill/index.ts::discoverSkills`` 同样扫这里。
+    xskill 装 Codex / OpenCode 都写这一处，不再 per-agent 各写一份。
+    """
+    return home / ".agents" / "skills"
+
+
+# ─────────────────────────────────────────────────────────────────
+# Ecosystem spec — JsonlIngester 的参数化形态
+# ─────────────────────────────────────────────────────────────────
+#
+# CC / Codex 都是 JSONL append-only 形态，差异集中在：
+#   1. 文件位置（`<home>/.claude/projects/*/*.jsonl` vs
+#      `<home>/.codex/sessions/YYYY/MM/DD/rollout-*.jsonl`）
+#   2. cwd 抽取方式（CC 在每事件上带 `cwd`；codex 只在首行 `session_meta.payload.cwd`）
+#   3. adapter format name（喂给 `adapt_trajectory` 的字符串）
+#
+# 用一个 `EcosystemSpec` dataclass 把这些差异参数化，让 ingester 主体逻辑
+# （扫盘 / 去重 / submit_trajectory / 记 metadata）跨生态共享。
+
+
+@dataclass(frozen=True)
+class EcosystemSpec:
+    """描述一个 agent 生态的轨迹来源 + 安装目标。
+
+    Attributes:
+        name: 生态标识（``claude_code`` / ``codex`` / ``opencode``）；用于 logging
+            和 `detect_known_ecosystems` 上报
+        source_kind: 轨迹存储形态。P2 只支持 ``jsonl``；P3 加 ``sqlite``
+        sessions_path: ``(home_root) -> Path``，返回该生态的 sessions/projects 根目录
+        sessions_glob: 相对 ``sessions_path`` 的 glob，用于扫所有 session 文件
+        session_id_from_path: ``(jsonl_path) -> session_id``。CC 用文件名（``stem``），
+            codex 用文件名里的 uuid 段
+        cwd_from_content: ``(jsonl_content) -> cwd``。CC 扫每条事件找首个 ``cwd``
+            字段；codex 只读首行 ``session_meta.payload.cwd``
+        adapter_format: 喂给 ``adapt_trajectory`` 的 format 字符串
+        traj_id_prefix: 桥过来的 ``traj_*.md`` 文件名 ID 前缀（``traj_cc_`` /
+            ``traj_codex_``）
+        skills_install_path: ``(home_root) -> Path``，skill 安装目标根目录
+        label: 短标签，给 logger 用
+    """
+
+    name: str
+    source_kind: Literal["jsonl"]
+    sessions_path: Callable[[Path], Path]
+    sessions_glob: str
+    session_id_from_path: Callable[[Path], str]
+    cwd_from_content: Callable[[str], str]
+    adapter_format: str
+    traj_id_prefix: str
+    skills_install_path: Callable[[Path], Path]
+    label: str
 
 
 # ─────────────────────────────────────────────────────────────────
@@ -131,29 +203,31 @@ def _source_md_for_side(skill_path: Path, side: str) -> Path:
     raise ValueError(f"side must be 'main' or 'staging', got {side!r}")
 
 
-def install_to_claude_code(
-    skill_path: Path | str,
-    target_root: Path | str | None = None,
-    side: str = "main",
+def _install_skill_into(
+    skill_path: Path,
+    skills_root: Path,
+    side: str,
+    *,
+    ecosystem_label: str,
 ) -> Path:
-    """把一个 skill 装到 ``<target_root>/.claude/skills/<name>``。
+    """共享的 skill 安装实现：把 ``skill_path``（或其 staging 物化版）装到
+    ``skills_root/<name>``，走三阶 fallback。
 
-    ``side='main'``  → 链接到 ``<skill_path>/`` 整目录
-    ``side='staging'`` → 链接到 ``<skill_path>/../.canary/<name>/`` 整目录
+    被 ``install_to_claude_code`` / ``install_to_codex`` / 未来 ``install_to_opencode``
+    共用——三者只在 ``skills_root`` 的解析上不同，安装语义完全一致。
 
-    安装方式按平台能力**三阶 fallback**（详见 ``install_fallback.install_dir``）：
+    ``ecosystem_label`` 仅用于 warning log 时打"是哪个生态遇到 copy fallback"，
+    便于运维定位。
 
-    1. **symlink** — Linux / macOS / Windows Dev Mode 走这条。源仓更新即时
-       可见；用户在 dest 改 SKILL.md 实际改的是源仓，UserEditAbsorbAgent
-       能 round-trip 收编。
-    2. **directory junction** — Windows 非 Dev Mode 走这条。NTFS reparse
-       point，对读端表现等同 symlink，但只能在同卷建。
-    3. **copy** — junction 也建不出来的极端情况（跨盘 / 非 NTFS）。**这一档
-       下 xskill 更新不能 live propagate，用户手改也不会回到源仓**。模块
-       日志会显式 warning。
+    Args:
+        skill_path: ``main`` 时即源 skill 目录；``staging`` 时取 ``..canary/<name>``
+        skills_root: 安装目标根（``<home>/.claude/skills`` 或
+            ``<home>/.agents/skills``）
+        side: ``main`` / ``staging``
+        ecosystem_label: ``claude_code`` / ``codex`` /... 用于日志
 
-    若 dest 已是 symlink 且指向相同 source，直接返回不动；
-    若 dest 是普通文件/目录或指向其他位置的 symlink，先删后重装。
+    Returns:
+        ``<skills_root>/<name>/SKILL.md`` 路径
     """
     skill_path = Path(skill_path).resolve()
     if not skill_path.is_dir():
@@ -170,8 +244,6 @@ def install_to_claude_code(
         raise ValueError(f"side must be 'main' or 'staging', got {side!r}")
 
     name = skill_path.name
-    root = Path(target_root) if target_root else Path.home()
-    skills_root = _cc_skills_path(root)
     skills_root.mkdir(parents=True, exist_ok=True)
     dest = skills_root / name
 
@@ -198,13 +270,71 @@ def install_to_claude_code(
     mode: InstallMode = install_dir(src_dir, dest)
     if mode == "copy":
         # copy 模式下 UserEditAbsorbAgent 失效 —— 用户改副本源仓看不到。
-        # 调用方关心 mode 时可看日志；这里不破坏返回值兼容（保留旧 SDK 签名）。
         logger.warning(
-            "install_to_claude_code(%s): copy-mode install at %s — "
+            "install_to_%s(%s): copy-mode install at %s — "
             "live-update / user-edit-absorb are disabled on this destination",
-            name, dest,
+            ecosystem_label, name, dest,
         )
     return dest / "SKILL.md"
+
+
+def install_to_claude_code(
+    skill_path: Path | str,
+    target_root: Path | str | None = None,
+    side: str = "main",
+) -> Path:
+    """把一个 skill 装到 ``<target_root>/.claude/skills/<name>``。
+
+    ``side='main'``  → 链接到 ``<skill_path>/`` 整目录
+    ``side='staging'`` → 链接到 ``<skill_path>/../.canary/<name>/`` 整目录
+
+    安装方式按平台能力**三阶 fallback**（详见 ``install_fallback.install_dir``）：
+
+    1. **symlink** — Linux / macOS / Windows Dev Mode 走这条。源仓更新即时
+       可见；用户在 dest 改 SKILL.md 实际改的是源仓，UserEditAbsorbAgent
+       能 round-trip 收编。
+    2. **directory junction** — Windows 非 Dev Mode 走这条。NTFS reparse
+       point，对读端表现等同 symlink，但只能在同卷建。
+    3. **copy** — junction 也建不出来的极端情况（跨盘 / 非 NTFS）。**这一档
+       下 xskill 更新不能 live propagate，用户手改也不会回到源仓**。模块
+       日志会显式 warning。
+
+    若 dest 已是 symlink 且指向相同 source，直接返回不动；
+    若 dest 是普通文件/目录或指向其他位置的 symlink，先删后重装。
+    """
+    root = Path(target_root) if target_root else Path.home()
+    return _install_skill_into(
+        Path(skill_path),
+        _cc_skills_path(root),
+        side,
+        ecosystem_label="claude_code",
+    )
+
+
+def install_to_codex(
+    skill_path: Path | str,
+    target_root: Path | str | None = None,
+    side: str = "main",
+) -> Path:
+    """把一个 skill 装到 ``<target_root>/.agents/skills/<name>``——codex 的 user
+    scope skill 目录。
+
+    **重要**：路径是 ``.agents``（跨生态共享）而非 ``.codex``。codex 0.130 的
+    ``core-skills/src/loader.rs:294`` 已把 ``$CODEX_HOME/skills/`` 标 ``/* Deprecated */``
+    ——首选 user-scope 路径是 ``$HOME/.agents/skills/``。OpenCode 也扫这里，
+    所以 codex 与 opencode 装到同一个目录，xskill 不重复写。
+
+    其它语义（main/staging、三阶 fallback、symlink no-op、replaced-by-symlink
+    备份）与 ``install_to_claude_code`` 完全一致——共享底层 ``_install_skill_into``
+    实现。
+    """
+    root = Path(target_root) if target_root else Path.home()
+    return _install_skill_into(
+        Path(skill_path),
+        _agents_skills_path(root),
+        side,
+        ecosystem_label="codex",
+    )
 
 
 def _parse_iso_to_epoch(s: str) -> Optional[float]:
@@ -368,6 +498,200 @@ def _prepend_xskill_header(traj_md_path: Path, *, skill: str, side: str, sha: st
     traj_md_path.write_text(header + text, encoding="utf-8")
 
 
+# ─────────────────────────────────────────────────────────────────
+# Codex-specific helpers
+# ─────────────────────────────────────────────────────────────────
+
+
+def _codex_session_id_from_path(jsonl_path: Path) -> str:
+    """从 codex rollout 文件名抽 session UUID。
+
+    文件名形如 ``rollout-2026-01-15T10-00-00-11111111-2222-3333-4444-555555555555.jsonl``。
+    timestamp 字段（前 19 个字符 = ``YYYY-MM-DDTHH-MM-SS``）后 + ``-`` + UUID。
+
+    我们用从右起的最后 5 个 ``-`` 段拼出 UUID（标准 UUID 含 4 个 ``-``，加上文件名
+    里 UUID 之前的那一个 ``-``，所以从右数倒数 ``[-5:]`` 段就是 UUID 的全部）。
+    """
+    stem = jsonl_path.stem  # 去掉 .jsonl
+    parts = stem.split("-")
+    if len(parts) >= 5:
+        # 标准 UUID 5 段：xxxxxxxx-xxxx-xxxx-xxxx-xxxxxxxxxxxx
+        return "-".join(parts[-5:])
+    # 文件名不符合预期，退化为整个 stem（避免崩，让上层去重照常）
+    return stem
+
+
+def _read_cwd_from_codex_jsonl(jsonl_content: str) -> str:
+    """从 codex rollout JSONL 字符串抽 cwd。
+
+    codex schema：首行（且仅首行）是 ``type=session_meta`` 行，``payload.cwd``
+    即用户当时的 cwd。与 CC 不同——CC 每条事件都带 ``cwd``。
+    """
+    for line in jsonl_content.splitlines():
+        line = line.strip()
+        if not line:
+            continue
+        try:
+            ev = json.loads(line)
+        except json.JSONDecodeError:
+            continue
+        if ev.get("type") == "session_meta":
+            payload = ev.get("payload") or {}
+            cwd = payload.get("cwd")
+            if cwd:
+                return str(cwd)
+        # session_meta 不出现在首条则放弃（codex schema 保证首条就是它）
+        break
+    return ""
+
+
+def _codex_traj_id(jsonl_path: Path, session_id: str) -> str:
+    """codex bridged 轨迹 ID：``traj_codex_<projectname>_<sid8>``。
+
+    与 ``_cc_traj_id`` 同形，前缀换成 ``traj_codex_`` 让 trajectory 元数据能
+    一眼区分来源。cwd 从 codex JSONL 首行抽（不是 CC 的 per-event 字段）。
+    """
+    content = jsonl_path.read_text(encoding="utf-8", errors="ignore") if jsonl_path.is_file() else ""
+    cwd = _read_cwd_from_codex_jsonl(content)
+    project = _sanitize_for_filename(Path(cwd).name if cwd else "", maxlen=32) or "unknown"
+    sid_short = _sanitize_for_filename(session_id, maxlen=8) or "nosid"
+    return f"traj_codex_{project}_{sid_short}"
+
+
+# 内部 wrapper：让 spec 的 cwd_from_content 接 (path) 输入仍能复用 CC 的 per-event 扫描
+def _read_cwd_from_cc_jsonl_content(content: str) -> str:
+    """CC 版 cwd 抽取的 (content) 重载——与 ``_read_cwd_from_jsonl(path)`` 同语义。"""
+    for line in content.splitlines():
+        line = line.strip()
+        if not line:
+            continue
+        try:
+            ev = json.loads(line)
+        except json.JSONDecodeError:
+            continue
+        cwd = ev.get("cwd")
+        if cwd:
+            return str(cwd)
+    return ""
+
+
+# ─────────────────────────────────────────────────────────────────
+# Concrete ecosystem specs
+# ─────────────────────────────────────────────────────────────────
+
+CC_SPEC = EcosystemSpec(
+    name="claude_code",
+    source_kind="jsonl",
+    sessions_path=_cc_projects_path,
+    sessions_glob="*/*.jsonl",  # <projects>/<cwd-hash>/<sid>.jsonl
+    session_id_from_path=lambda p: p.stem,
+    cwd_from_content=_read_cwd_from_cc_jsonl_content,
+    adapter_format="claude_code_jsonl",
+    traj_id_prefix="traj_cc_",
+    skills_install_path=_cc_skills_path,
+    label="claude_code",
+)
+
+CODEX_SPEC = EcosystemSpec(
+    name="codex",
+    source_kind="jsonl",
+    sessions_path=_codex_sessions_path,
+    sessions_glob="*/*/*/rollout-*.jsonl",  # YYYY/MM/DD/rollout-<ts>-<uuid>.jsonl
+    session_id_from_path=_codex_session_id_from_path,
+    cwd_from_content=_read_cwd_from_codex_jsonl,
+    adapter_format="codex_rollout_jsonl",
+    traj_id_prefix="traj_codex_",
+    skills_install_path=_agents_skills_path,
+    label="codex",
+)
+
+
+# ─────────────────────────────────────────────────────────────────
+# JsonlIngester — spec-driven 扫盘 + 桥接
+# ─────────────────────────────────────────────────────────────────
+
+
+class JsonlIngester:
+    """跨生态 JSONL session ingester——spec 化的扫盘 + bridge 逻辑。
+
+    职责（**只**这些，不含 staging / flip / header 注入——那是 CC 专属的
+    `CCSessionIngester` 在 wrapper 层做的事）：
+
+    1. 扫 ``spec.sessions_path(home_root)`` 下匹配 ``spec.sessions_glob`` 的文件
+    2. 用 ``spec.session_id_from_path`` 抽 session id，跟 ``seen_sessions`` 去重
+    3. 用 ``spec.adapter_format`` 喂 ``submit_trajectory`` 桥成 ``traj_*.md``
+    4. traj_id 取 ``<spec.traj_id_prefix><project>_<sid8>``——保留 ``traj_`` 前缀
+       让 watcher 的 ``traj_*.md`` glob 继续匹配
+
+    无状态——状态由调用方持有（CC 的 ``CCSessionIngester`` 管 seen_sessions
+    + history + assignments）。
+    """
+
+    def __init__(self, spec: EcosystemSpec):
+        if spec.source_kind != "jsonl":
+            # P2 不实现 sqlite ingester（P3 加）；早期 fail 避免静默走错路
+            raise ValueError(
+                f"JsonlIngester only supports source_kind='jsonl', got {spec.source_kind!r}"
+            )
+        self.spec = spec
+
+    def scan_and_bridge(
+        self,
+        target_traj_dir: Path,
+        *,
+        home_root: Path | None = None,
+        seen_sessions: Optional[set[str]] = None,
+    ) -> list[dict]:
+        """单次扫盘 + 桥接。
+
+        Args:
+            target_traj_dir: ``traj_*.md`` / ``.json`` 落盘目录（xskill 的 watch dir）
+            home_root: 用户 HOME；为 ``None`` 时用 ``Path.home()``。测试时用 tmp_path
+                做隔离
+            seen_sessions: 已处理 session id 集合；in-place 更新
+
+        Returns:
+            每条新桥接 session 的 submission 结果（含 ``session_id`` /
+            ``source_jsonl`` / ``session_start_t``）
+        """
+        target_traj_dir.mkdir(parents=True, exist_ok=True)
+        root = Path(home_root) if home_root else Path.home()
+        sessions_root = self.spec.sessions_path(root)
+        if not sessions_root.is_dir():
+            return []
+
+        seen = seen_sessions if seen_sessions is not None else set()
+        submitted: list[dict] = []
+        for jsonl_path in sorted(sessions_root.glob(self.spec.sessions_glob)):
+            sid = self.spec.session_id_from_path(jsonl_path)
+            if sid in seen:
+                continue
+            content = jsonl_path.read_text(encoding="utf-8", errors="ignore")
+            if not content.strip():
+                continue
+            traj_id = self._make_traj_id(content, sid)
+            result = submit_trajectory(
+                content=content,
+                format=self.spec.adapter_format,
+                traj_id=traj_id,
+                traj_dir=target_traj_dir,
+            )
+            result["session_id"] = sid
+            result["source_jsonl"] = str(jsonl_path)
+            result["session_start_t"] = _session_start_t(jsonl_path)
+            result["ecosystem"] = self.spec.name
+            submitted.append(result)
+            seen.add(sid)
+        return submitted
+
+    def _make_traj_id(self, content: str, sid: str) -> str:
+        """``<prefix><project>_<sid8>``——project = cwd basename，sid8 = sid 前 8 字符。"""
+        cwd = self.spec.cwd_from_content(content)
+        project = _sanitize_for_filename(Path(cwd).name if cwd else "", maxlen=32) or "unknown"
+        sid_short = _sanitize_for_filename(sid, maxlen=8) or "nosid"
+        return f"{self.spec.traj_id_prefix}{project}_{sid_short}"
+
+
 def ingest_claude_code_sessions(
     target_traj_dir: Path | str,
     *,
@@ -382,38 +706,40 @@ def ingest_claude_code_sessions(
     ``claude_code_jsonl`` adapter. ``seen_sessions`` is updated in place so
     repeat calls are idempotent. Returns the list of submission results
     (each augmented with ``session_id``, ``source_jsonl``, ``session_start_t``).
-    """
-    target_traj_dir = Path(target_traj_dir)
-    target_traj_dir.mkdir(parents=True, exist_ok=True)
-    root = Path(home_root) if home_root else Path.home()
-    proj_root = _cc_projects_path(root)
-    if not proj_root.is_dir():
-        return []
 
-    seen = seen_sessions if seen_sessions is not None else set()
-    submitted: list[dict] = []
-    for jsonl_path in sorted(proj_root.glob("*/*.jsonl")):
-        sid = jsonl_path.stem
-        if sid in seen:
-            continue
-        content = jsonl_path.read_text(encoding="utf-8")
-        if not content.strip():
-            continue
-        # 给 CC bridged 轨迹起带项目信息的名字，方便事后查阅：
-        # traj_cc_<projectname>_<sid8>.md 比 traj_0001.md 包含的语义多。
-        traj_id = _cc_traj_id(jsonl_path, sid)
-        result = submit_trajectory(
-            content=content,
-            format="claude_code_jsonl",
-            traj_id=traj_id,
-            traj_dir=target_traj_dir,
-        )
-        result["session_id"] = sid
-        result["source_jsonl"] = str(jsonl_path)
-        result["session_start_t"] = _session_start_t(jsonl_path)
-        submitted.append(result)
-        seen.add(sid)
-    return submitted
+    P2 起本函数仅是 ``JsonlIngester(CC_SPEC).scan_and_bridge`` 的 thin wrapper，
+    保留独立签名以兼容老调用方（SDK 用户 / 测试）。
+    """
+    return JsonlIngester(CC_SPEC).scan_and_bridge(
+        target_traj_dir=Path(target_traj_dir),
+        home_root=Path(home_root) if home_root else None,
+        seen_sessions=seen_sessions,
+    )
+
+
+def ingest_codex_sessions(
+    target_traj_dir: Path | str,
+    *,
+    home_root: Path | str | None = None,
+    seen_sessions: Optional[set[str]] = None,
+) -> list[dict]:
+    """Bridge Codex CLI rollout JSONLs into xskill's trajectory directory.
+
+    Scans ``<home_root>/.codex/sessions/YYYY/MM/DD/rollout-*.jsonl`` and
+    submits any session whose UUID is not in ``seen_sessions`` as a new
+    trajectory under ``target_traj_dir`` using the ``codex_rollout_jsonl``
+    adapter. ``seen_sessions`` is updated in place so repeat calls are
+    idempotent. Returns the list of submission results (each augmented with
+    ``session_id``, ``source_jsonl``, ``session_start_t``).
+
+    与 ``ingest_claude_code_sessions`` 同形——同一 ``JsonlIngester`` 基类，
+    只是 spec 不同。
+    """
+    return JsonlIngester(CODEX_SPEC).scan_and_bridge(
+        target_traj_dir=Path(target_traj_dir),
+        home_root=Path(home_root) if home_root else None,
+        seen_sessions=seen_sessions,
+    )
 
 
 def _scan_seen_sessions(target_traj_dir: Path) -> set[str]:
@@ -681,6 +1007,28 @@ def install_all_to_claude_code(
     Claude Code's discovery root. If ``names`` is given, restrict to those.
     Returns the list of destination ``SKILL.md`` paths actually written.
     """
+    return _install_all_with(install_to_claude_code, skill_dir, target_root, names)
+
+
+def install_all_to_codex(
+    skill_dir: Path | str,
+    target_root: Path | str | None = None,
+    names: Iterable[str] | None = None,
+) -> list[Path]:
+    """Install every skill under ``skill_dir`` (each subdir = one skill) to
+    Codex's discovery root (``<target_root>/.agents/skills``). If ``names`` is
+    given, restrict to those.
+    """
+    return _install_all_with(install_to_codex, skill_dir, target_root, names)
+
+
+def _install_all_with(
+    installer: Callable[..., Path],
+    skill_dir: Path | str,
+    target_root: Path | str | None,
+    names: Iterable[str] | None,
+) -> list[Path]:
+    """``install_all_to_*`` 的共享实现——只是把 per-skill installer 作为参数注入。"""
     skill_dir = Path(skill_dir)
     if not skill_dir.is_dir():
         raise NotADirectoryError(f"skill_dir is not a directory: {skill_dir}")
@@ -694,7 +1042,7 @@ def install_all_to_claude_code(
             continue
         if not (entry / "SKILL.md").exists():
             continue
-        installed.append(install_to_claude_code(entry, target_root=target_root))
+        installed.append(installer(entry, target_root=target_root))
     return installed
 
 
@@ -741,18 +1089,6 @@ def _opencode_db_path(home: Path) -> Path:
     return home / ".local" / "share" / "opencode" / "opencode.db"
 
 
-def _agents_skills_path(home: Path) -> Path:
-    """跨 agent 共享的 skill 安装根目录：``<home>/.agents/skills``。
-
-    Codex / OpenCode / openclaw 三家源码都扫这个路径作为 user-scope skill
-    discovery 根（详见 adapter-research.md）。xskill 对 OpenCode（以及未来
-    Codex）**统一只写这一处**，避免重复落盘。
-
-    TODO(P2 对齐): P2 Codex adapter 也会用同一 helper；如果 P2 先 merge 已经
-    定义了 `_agents_skills_path`，rebase 时去重。
-    """
-    return home / ".agents" / "skills"
-
 
 # ─────────────────────────────────────────────────────────────────
 # Ecosystem spec (P3, OpenCode)
@@ -763,11 +1099,13 @@ def _agents_skills_path(home: Path) -> Path:
 # SqliteIngester 拿到稳定的 (path_resolver, label) 输入；rebase 时与 P2 对齐。
 
 @dataclass(frozen=True)
-class EcosystemSpec:
-    """生态系统适配规格（P3 临时形态）。
+class SqliteEcosystemSpec:
+    """SQLite-back 生态系统 spec（独立于 JsonlIngester 的 EcosystemSpec）。
 
-    TODO(P2 对齐): P2 抽完 JsonlIngester 后，本 dataclass 应与 P2 版本合并。
-    目前字段对 SqliteIngester 够用即可——不预测 P2 形状，避免反复 churn。
+    P2 的 EcosystemSpec 是 JSONL ingester 专用 spec（含 sessions_glob 等
+    JSONL-only 字段），不适合 SQLite。SqliteIngester 用本类，字段集中在
+    SQLite 视角：path_resolver 解析到 .db 文件、cursor_strategy 用
+    time_updated。
     """
 
     name: str                                       # "opencode" | "codex" | "claude_code"
@@ -777,7 +1115,7 @@ class EcosystemSpec:
     label: str                                      # adapter / metadata 标签
 
 
-OPENCODE_SPEC = EcosystemSpec(
+OPENCODE_SPEC = SqliteEcosystemSpec(
     name="opencode",
     source_kind="sqlite",
     path_resolver=_opencode_db_path,
@@ -825,7 +1163,7 @@ class SqliteIngester:
         target_traj_dir: Path | str,
         *,
         home_root: Path | str | None = None,
-        spec: EcosystemSpec = OPENCODE_SPEC,
+        spec: SqliteEcosystemSpec = OPENCODE_SPEC,
     ):
         if spec.source_kind != "sqlite":
             raise ValueError(

--- a/tests/fixtures/codex/README.md
+++ b/tests/fixtures/codex/README.md
@@ -1,0 +1,47 @@
+# Codex CLI rollout fixture
+
+`sample_rollout.jsonl` 是一份符合 [codex-rs](https://github.com/openai/codex) 0.130 实际写盘 schema 的 session rollout。
+
+## 来源
+
+1:1 移植自 `codex-rs/rollout/src/tests.rs::write_session_file_with_provider` 的 fixture 生成
+逻辑。每行 = `{"timestamp", "type", "payload"}`，其中：
+
+- 第 1 行 `type=session_meta` 必出现一次，`payload` 含 `id` / `cwd` / `originator` /
+  `cli_version` / `model_provider`
+- 第 2 行 `type=event_msg`，`payload.type=user_message` 携带 user message 文本
+- 后续 N 行 `type=response_item`（占位）
+
+实际 codex 写出的 rollout 还可能含 `turn_context` / `compacted` / `event_msg.token_count`
+等变体（参见 codex-rs 协议定义），但对 xskill ingester 而言只需要 `session_meta` 和
+`event_msg.user_message` 两类做 cwd / user-message 抽取，schema 已足够。
+
+## 为什么不用真实 codex 跑
+
+主 agent 已实地确认（2026-05-13，见 `docs/dev-plan/cross-platform-multi-agent-design.md`
+§9.1）codex-cli 0.130 的 `wire_api` 枚举只剩 `Responses`，意味着 DeepSeek / 任何 OpenAI
+chat-completions API 都不能驱动它跑出 rollout。本机无 OpenAI key / 无 ollama / 无 OAuth
+ChatGPT 账号，无法生成"真跑"的 rollout 文件。
+
+替代方案：fixture 由 codex-rs 自己的单测代码（`tests.rs`）的 Python 移植版生成。schema
+保证 100% 真实——他们用同一份 JSON 写文件、读文件并断言 round-trip。
+
+## 再生成方式
+
+```bash
+cd tests/fixtures/codex
+python3.11 generate.py .
+# 生成 sessions/YYYY/MM/DD/rollout-<ts>-<uuid>.jsonl
+# 主 agent 把它扁平化到 sample_rollout.jsonl 入仓
+mv sessions/*/*/*/rollout-*.jsonl ./sample_rollout.jsonl
+rm -rf sessions
+```
+
+`generate.py` 是 `docs/dev-plan/codex-fixture-generator.py` 的副本（保留作 reference）。
+deterministic：固定 timestamp `2026-01-15T10:00:00 UTC` + 固定 UUID
+`11111111-...-555555555555`，便于单测 hash-stable 断言。
+
+## codex 实地安装确认
+
+- `npm i -g @openai/codex` → `codex-cli 0.130.0`
+- 安装路径：`/home/admin/.nvm/versions/node/v24.14.1/bin/codex`

--- a/tests/fixtures/codex/generate.py
+++ b/tests/fixtures/codex/generate.py
@@ -1,0 +1,159 @@
+"""
+codex-fixture-generator.py — 生成符合 codex-rs schema 的真实 rollout fixture
+
+来源：完整 1:1 移植 ``~/learn/codex/codex-rs/rollout/src/tests.rs::write_session_file_with_provider``
+逻辑（main agent 已读完源码确认）。Schema 100% 真实——来自 codex 项目自己的
+单测，他们用同一份 JSON 写文件、读取、断言 round-trip。
+
+P2 subagent 用法：
+    cp docs/dev-plan/codex-fixture-generator.py tests/fixtures/codex/generate.py
+    cd tests/fixtures/codex && python3 generate.py
+    # 产出 sample_rollout.jsonl 入仓
+"""
+from __future__ import annotations
+
+import datetime as _dt
+import json
+import os
+import sys
+import uuid as _uuid
+from pathlib import Path
+
+
+# RolloutItem schema 摘要（来自 codex-rs/protocol/src/protocol.rs）
+# ┌─────────────────────────────────────────────────────────────────────┐
+# │ #[serde(tag = "type", content = "payload", rename_all = "snake_case")]│
+# │ pub enum RolloutItem {                                              │
+# │     SessionMeta(SessionMetaLine),    -> type: "session_meta"        │
+# │     ResponseItem(ResponseItem),      -> type: "response_item"       │
+# │     Compacted(CompactedItem),        -> type: "compacted"           │
+# │     TurnContext(TurnContextItem),    -> type: "turn_context"        │
+# │     EventMsg(EventMsg),              -> type: "event_msg"           │
+# │ }                                                                    │
+# └─────────────────────────────────────────────────────────────────────┘
+#
+# 包装格式（每行）：
+#   {"timestamp": "<ISO ts>", "type": "<variant>", "payload": {...}}
+
+
+def _ts_iso(dt: _dt.datetime) -> str:
+    """Codex 文件名用 ``YYYY-MM-DDTHH-MM-SS``（: 替换 - 兼容 NTFS）。"""
+    return dt.strftime("%Y-%m-%dT%H-%M-%S")
+
+
+def write_session_file(
+    root: Path,
+    *,
+    ts: _dt.datetime | None = None,
+    session_uuid: _uuid.UUID | None = None,
+    cwd: str = ".",
+    originator: str = "codex-cli",
+    cli_version: str = "0.130.0",
+    model_provider: str | None = "openai",
+    num_response_records: int = 2,
+) -> Path:
+    """生成一份 codex-rs schema 的 rollout JSONL 文件。
+
+    Args:
+        root: codex home（``~/.codex/`` 等价），fixture 内部会自动追加
+              ``sessions/YYYY/MM/DD/`` 子目录
+        ts: 会话时间戳；默认 ``2026-01-15T10:00:00 UTC``（deterministic）
+        session_uuid: 会话 UUID；默认 deterministic 值
+        cwd: SessionMeta.cwd（user 当时的工作目录）
+        originator: ``codex-cli`` / ``vscode`` / ``atlas`` / ``chatgpt``
+        cli_version: 版本字符串
+        model_provider: provider 名（``openai`` / ``deepseek`` etc.）
+        num_response_records: 额外多少条 ``response_item`` 占位记录
+
+    Returns:
+        生成的 ``.jsonl`` 文件绝对路径
+    """
+    if ts is None:
+        ts = _dt.datetime(2026, 1, 15, 10, 0, 0, tzinfo=_dt.timezone.utc)
+    if session_uuid is None:
+        session_uuid = _uuid.UUID("01234567-89ab-cdef-0123-456789abcdef")
+
+    ts_str = _ts_iso(ts)
+    sessions_dir = root / "sessions" / f"{ts.year:04d}" / f"{ts.month:02d}" / f"{ts.day:02d}"
+    sessions_dir.mkdir(parents=True, exist_ok=True)
+
+    filename = f"rollout-{ts_str}-{session_uuid}.jsonl"
+    file_path = sessions_dir / filename
+
+    lines: list[dict] = []
+
+    # 1. session_meta 行（首行，永远存在）
+    meta_payload = {
+        "id": str(session_uuid),
+        "timestamp": ts_str,
+        "cwd": cwd,
+        "originator": originator,
+        "cli_version": cli_version,
+        "base_instructions": None,
+    }
+    if model_provider is not None:
+        meta_payload["model_provider"] = model_provider
+    lines.append({
+        "timestamp": ts_str,
+        "type": "session_meta",
+        "payload": meta_payload,
+    })
+
+    # 2. 一条 user_message event（codex-rs 单测里这是 "Hello from user"）
+    lines.append({
+        "timestamp": ts_str,
+        "type": "event_msg",
+        "payload": {
+            "type": "user_message",
+            "message": "Hello from user",
+            "kind": "plain",
+        },
+    })
+
+    # 3. N 条 response_item 占位（codex-rs 单测的 num_records 参数）
+    for i in range(num_response_records):
+        lines.append({
+            "timestamp": ts_str,
+            "type": "response_item",
+            "payload": {
+                "record_type": "response",
+                "index": i,
+            },
+        })
+
+    with file_path.open("w", encoding="utf-8") as f:
+        for line in lines:
+            f.write(json.dumps(line, ensure_ascii=False) + "\n")
+
+    # 同步 mtime 到 ts（codex-rs 单测最后 set_modified；让 mtime-based
+    # cursor 测试稳定）
+    epoch = ts.timestamp()
+    os.utime(file_path, (epoch, epoch))
+
+    return file_path
+
+
+def write_sample_fixture(out_dir: Path) -> Path:
+    """生成一份给 xskill Codex adapter 单测用的 fixture。
+
+    用 deterministic 时间戳和 UUID，让单测可以 hash-stable 断言。
+    """
+    out_dir.mkdir(parents=True, exist_ok=True)
+    return write_session_file(
+        root=out_dir,
+        ts=_dt.datetime(2026, 1, 15, 10, 0, 0, tzinfo=_dt.timezone.utc),
+        session_uuid=_uuid.UUID("11111111-2222-3333-4444-555555555555"),
+        cwd="/tmp/codex-test-workspace",
+        originator="codex-cli",
+        cli_version="0.130.0",
+        model_provider="openai",
+        num_response_records=3,
+    )
+
+
+if __name__ == "__main__":
+    # Usage: python codex-fixture-generator.py [output_dir]
+    out = Path(sys.argv[1] if len(sys.argv) > 1 else ".")
+    path = write_sample_fixture(out)
+    print(f"wrote: {path}")
+    print(f"size: {path.stat().st_size} bytes")

--- a/tests/fixtures/codex/sample_rollout.jsonl
+++ b/tests/fixtures/codex/sample_rollout.jsonl
@@ -1,0 +1,5 @@
+{"timestamp": "2026-01-15T10-00-00", "type": "session_meta", "payload": {"id": "11111111-2222-3333-4444-555555555555", "timestamp": "2026-01-15T10-00-00", "cwd": "/tmp/codex-test-workspace", "originator": "codex-cli", "cli_version": "0.130.0", "base_instructions": null, "model_provider": "openai"}}
+{"timestamp": "2026-01-15T10-00-00", "type": "event_msg", "payload": {"type": "user_message", "message": "Hello from user", "kind": "plain"}}
+{"timestamp": "2026-01-15T10-00-00", "type": "response_item", "payload": {"record_type": "response", "index": 0}}
+{"timestamp": "2026-01-15T10-00-00", "type": "response_item", "payload": {"record_type": "response", "index": 1}}
+{"timestamp": "2026-01-15T10-00-00", "type": "response_item", "payload": {"record_type": "response", "index": 2}}

--- a/tests/test_codex_adapter.py
+++ b/tests/test_codex_adapter.py
@@ -1,0 +1,491 @@
+"""
+test_codex_adapter.py -- Codex CLI 适配器（P2）端到端
+=======================================================
+
+覆盖：
+
+* **T1 codex_rollout_jsonl adapter** —— 从入仓 fixture 解析 cwd / session_id /
+  user_message，断言进 timeline 与 meta 字段。
+* **T2 ingest_codex_sessions** —— 在 tmp_path 模拟 ``<home>/.codex/sessions/YYYY/MM/DD/
+  rollout-*.jsonl`` 布局，扫盘 + 桥接，断言 ``traj_codex_*.md`` 落到 watch dir
+  且元数据包含 cwd / session_id。
+* **T3 JsonlIngester spec dispatching** —— 同一个 ``JsonlIngester`` 基类按 spec
+  分派到 CC vs Codex 走完全独立的扫盘路径。
+* **T4 install_to_codex** —— skill 落到 ``<home>/.agents/skills/<name>``（不是
+  ``.codex/skills``）。
+* **T5 install_to_codex copy fallback** —— monkeypatch symlink/junction 都失败，
+  仍能装出 SKILL.md 且打 warning。
+* **T6 路径解析跨平台** —— 用 ``Path('/fake/home')`` 等纯字符串验证三平台
+  都是 POSIX-style ``Path`` 操作（不依赖 ``os.path.expanduser``）。
+
+fixture 见 ``tests/fixtures/codex/sample_rollout.jsonl``——由 codex-rs 单测
+schema 1:1 移植生成（``tests/fixtures/codex/README.md``）。
+"""
+from __future__ import annotations
+
+import json
+import logging
+import sys
+from pathlib import Path
+
+import pytest
+
+from xskill import install_fallback
+from xskill.adapters import adapt_trajectory
+from xskill.ecosystems import (
+    CC_SPEC,
+    CODEX_SPEC,
+    EcosystemSpec,
+    JsonlIngester,
+    _agents_skills_path,
+    _cc_projects_path,
+    _cc_skills_path,
+    _codex_sessions_path,
+    _codex_session_id_from_path,
+    _read_cwd_from_codex_jsonl,
+    ingest_codex_sessions,
+    install_to_codex,
+)
+from xskill.frontmatter import serialize as fm_serialize
+
+
+# ──────────────────────────────────────────────────────────────────
+# Fixture loading
+# ──────────────────────────────────────────────────────────────────
+
+FIXTURE_PATH = Path(__file__).parent / "fixtures" / "codex" / "sample_rollout.jsonl"
+EXPECTED_SESSION_ID = "11111111-2222-3333-4444-555555555555"
+EXPECTED_CWD = "/tmp/codex-test-workspace"
+EXPECTED_USER_MESSAGE = "Hello from user"
+
+
+@pytest.fixture
+def fixture_content() -> str:
+    """返回入仓 codex rollout fixture 的原始 JSONL 文本。"""
+    assert FIXTURE_PATH.is_file(), (
+        f"fixture missing: {FIXTURE_PATH} — "
+        "run `cd tests/fixtures/codex && python3.11 generate.py .` to regenerate"
+    )
+    return FIXTURE_PATH.read_text(encoding="utf-8")
+
+
+# ──────────────────────────────────────────────────────────────────
+# Helpers — 在 tmp_path 下伪造 codex sessions 目录结构
+# ──────────────────────────────────────────────────────────────────
+
+
+def _place_fixture_in_codex_home(home: Path, fixture_text: str) -> Path:
+    """把 fixture 内容写到 ``<home>/.codex/sessions/2026/01/15/rollout-...jsonl``，
+    返回写入的文件路径。模拟 codex CLI 实际写盘的目录布局。
+    """
+    sessions = home / ".codex" / "sessions" / "2026" / "01" / "15"
+    sessions.mkdir(parents=True, exist_ok=True)
+    p = sessions / f"rollout-2026-01-15T10-00-00-{EXPECTED_SESSION_ID}.jsonl"
+    p.write_text(fixture_text, encoding="utf-8")
+    return p
+
+
+def _build_codex_skill(skill_root: Path, name: str = "demo-skill") -> Path:
+    """造一个最小合规 skill 目录（``SKILL.md`` 带必需 frontmatter）。"""
+    skill_path = skill_root / name
+    skill_path.mkdir(parents=True, exist_ok=True)
+    fm = {
+        "name": name,
+        "description": "A demo codex skill.",
+        "version": 1,
+        "source_trajs": ["traj_codex_0001"],
+        "metadata": {"tags": ["demo"], "frozen": False},
+    }
+    (skill_path / "SKILL.md").write_text(
+        fm_serialize(fm, f"# {name}\n\nBody.\n"), encoding="utf-8"
+    )
+    return skill_path
+
+
+# ──────────────────────────────────────────────────────────────────
+# T1. codex_rollout_jsonl adapter
+# ──────────────────────────────────────────────────────────────────
+
+
+class TestCodexRolloutJsonlAdapter:
+    """adapter 能从 codex 真实 schema 抽 cwd / session_id / user_message。"""
+
+    def test_adapter_returns_markdown_with_session_meta(self, fixture_content):
+        md, meta = adapt_trajectory(fixture_content, "codex_rollout_jsonl")
+
+        assert md.startswith("# Codex Rollout Trajectory")
+        assert f"**session_id**: {EXPECTED_SESSION_ID}" in md
+        assert f"**cwd**: {EXPECTED_CWD}" in md
+        assert "**originator**: codex-cli" in md
+        assert "**cli_version**: 0.130.0" in md
+        assert "**model_provider**: openai" in md
+        assert EXPECTED_USER_MESSAGE in md
+
+    def test_adapter_meta_has_session_id_and_cwd(self, fixture_content):
+        _md, meta = adapt_trajectory(fixture_content, "codex_rollout_jsonl")
+
+        assert meta["session_id"] == EXPECTED_SESSION_ID
+        assert meta["cwd"] == EXPECTED_CWD
+        assert meta["originator"] == "codex-cli"
+        assert meta["cli_version"] == "0.130.0"
+        assert meta["model_provider"] == "openai"
+        assert meta["source"] == "codex_rollout_jsonl"
+        assert meta["category"] == "codex_session"
+        assert meta["query"] == EXPECTED_USER_MESSAGE
+        # fixture 写了 3 条 response_item
+        assert meta["response_items"] == 3
+
+    def test_adapter_extracts_user_message_into_timeline(self, fixture_content):
+        _md, meta = adapt_trajectory(fixture_content, "codex_rollout_jsonl")
+
+        timeline = meta["timeline"]
+        user_entries = [e for e in timeline if e["role"] == "user"]
+        assert len(user_entries) == 1
+        assert user_entries[0]["content"] == EXPECTED_USER_MESSAGE
+
+        assistant_entries = [e for e in timeline if e["role"] == "assistant"]
+        # 3 条 response_item 占位
+        assert len(assistant_entries) == 3
+
+    def test_adapter_handles_empty_input(self):
+        md, meta = adapt_trajectory("", "codex_rollout_jsonl")
+
+        assert "# Codex Rollout Trajectory" in md
+        assert meta["total_turns"] == 0
+        assert meta["response_items"] == 0
+        assert meta["category"] == "codex_session"
+
+    def test_adapter_skips_malformed_lines(self):
+        # 第 2 行故意 broken JSON，验证 ingester 不挂
+        bad = "\n".join([
+            json.dumps({
+                "timestamp": "2026-01-15T10-00-00",
+                "type": "session_meta",
+                "payload": {"id": "sid", "cwd": "/x", "originator": "codex-cli",
+                            "cli_version": "0.130.0"},
+            }),
+            "{not a valid json line",
+            json.dumps({
+                "timestamp": "2026-01-15T10-00-00",
+                "type": "event_msg",
+                "payload": {"type": "user_message", "message": "hi", "kind": "plain"},
+            }),
+        ])
+        _md, meta = adapt_trajectory(bad, "codex_rollout_jsonl")
+        assert meta["session_id"] == "sid"
+        assert meta["query"] == "hi"
+
+
+# ──────────────────────────────────────────────────────────────────
+# T2. ingest_codex_sessions —— 扫盘 + 桥接
+# ──────────────────────────────────────────────────────────────────
+
+
+class TestIngestCodexSessions:
+    """``ingest_codex_sessions(<home>=tmp_path)`` 能找到 ``~/.codex/sessions/...``
+    布局下的 rollout 并桥成 ``traj_codex_*.md``。
+    """
+
+    def test_ingest_writes_traj_with_codex_prefix(self, tmp_path, fixture_content):
+        _place_fixture_in_codex_home(tmp_path, fixture_content)
+        traj_dir = tmp_path / "traj"
+
+        results = ingest_codex_sessions(traj_dir, home_root=tmp_path)
+
+        assert len(results) == 1
+        rec = results[0]
+        assert rec["status"] == "stored"
+        assert rec["session_id"] == EXPECTED_SESSION_ID
+        assert rec["ecosystem"] == "codex"
+        # traj_id 形如 traj_codex_codex-test-workspace_11111111
+        assert rec["traj_id"].startswith("traj_codex_")
+
+        md_path = Path(rec["path"])
+        assert md_path.is_file()
+        assert md_path.name.startswith("traj_codex_")
+
+        meta_path = md_path.with_suffix(".json")
+        assert meta_path.is_file()
+        meta = json.loads(meta_path.read_text(encoding="utf-8"))
+        assert meta["session_id"] == EXPECTED_SESSION_ID
+        assert meta["cwd"] == EXPECTED_CWD
+        assert meta["category"] == "codex_session"
+        assert meta["query"] == EXPECTED_USER_MESSAGE
+
+    def test_ingest_is_idempotent_via_seen_sessions(self, tmp_path, fixture_content):
+        _place_fixture_in_codex_home(tmp_path, fixture_content)
+        traj_dir = tmp_path / "traj"
+        seen: set[str] = set()
+
+        first = ingest_codex_sessions(traj_dir, home_root=tmp_path, seen_sessions=seen)
+        assert len(first) == 1
+        assert EXPECTED_SESSION_ID in seen
+
+        # 再扫一次 —— 同 sid 应被跳过
+        second = ingest_codex_sessions(traj_dir, home_root=tmp_path, seen_sessions=seen)
+        assert second == []
+
+    def test_ingest_skips_when_sessions_dir_absent(self, tmp_path):
+        # ``<tmp>/.codex/sessions`` 不存在 → 返回空 list，不报错
+        results = ingest_codex_sessions(tmp_path / "traj", home_root=tmp_path)
+        assert results == []
+
+    def test_ingest_skips_empty_files(self, tmp_path):
+        # 触摸空 file（mkdir 父目录）
+        sessions = tmp_path / ".codex" / "sessions" / "2026" / "01" / "15"
+        sessions.mkdir(parents=True)
+        (sessions / "rollout-empty.jsonl").write_text("", encoding="utf-8")
+
+        results = ingest_codex_sessions(tmp_path / "traj", home_root=tmp_path)
+        assert results == []
+
+    def test_ingest_finds_files_recursively_under_date_dirs(self, tmp_path, fixture_content):
+        # 在多个日期子目录下放 fixture，验证 ``YYYY/MM/DD`` 递归匹配
+        d1 = tmp_path / ".codex" / "sessions" / "2026" / "01" / "15"
+        d2 = tmp_path / ".codex" / "sessions" / "2026" / "02" / "20"
+        d1.mkdir(parents=True)
+        d2.mkdir(parents=True)
+        (d1 / f"rollout-2026-01-15T10-00-00-aaaaaaaa-bbbb-cccc-dddd-{'1' * 12}.jsonl").write_text(
+            fixture_content.replace(EXPECTED_SESSION_ID, "aaaaaaaa-bbbb-cccc-dddd-111111111111"),
+            encoding="utf-8",
+        )
+        (d2 / f"rollout-2026-02-20T10-00-00-bbbbbbbb-cccc-dddd-eeee-{'2' * 12}.jsonl").write_text(
+            fixture_content.replace(EXPECTED_SESSION_ID, "bbbbbbbb-cccc-dddd-eeee-222222222222"),
+            encoding="utf-8",
+        )
+
+        results = ingest_codex_sessions(tmp_path / "traj", home_root=tmp_path)
+        sids = sorted(r["session_id"] for r in results)
+        assert sids == [
+            "aaaaaaaa-bbbb-cccc-dddd-111111111111",
+            "bbbbbbbb-cccc-dddd-eeee-222222222222",
+        ]
+
+
+# ──────────────────────────────────────────────────────────────────
+# T3. JsonlIngester spec dispatching
+# ──────────────────────────────────────────────────────────────────
+
+
+class TestJsonlIngesterSpecDispatch:
+    """同一个 ``JsonlIngester`` 基类按 spec 分派——CC spec 只扫 CC 路径，
+    Codex spec 只扫 codex 路径，两者完全独立。
+    """
+
+    def test_cc_spec_ignores_codex_rollouts(self, tmp_path, fixture_content):
+        # 只放 codex fixture，不放 CC 文件
+        _place_fixture_in_codex_home(tmp_path, fixture_content)
+
+        cc = JsonlIngester(CC_SPEC)
+        results = cc.scan_and_bridge(tmp_path / "traj", home_root=tmp_path)
+        # CC spec 扫 ~/.claude/projects → 没东西
+        assert results == []
+
+    def test_codex_spec_ignores_cc_sessions(self, tmp_path):
+        # 放一份伪 CC session（满足 CC glob）
+        cc_dir = tmp_path / ".claude" / "projects" / "abcd1234"
+        cc_dir.mkdir(parents=True)
+        (cc_dir / "sess-xxx.jsonl").write_text(
+            json.dumps({
+                "type": "user",
+                "message": {"role": "user", "content": "cc hello"},
+                "sessionId": "sess-xxx", "cwd": "/cc/proj",
+            }) + "\n",
+            encoding="utf-8",
+        )
+
+        codex = JsonlIngester(CODEX_SPEC)
+        results = codex.scan_and_bridge(tmp_path / "traj", home_root=tmp_path)
+        # Codex spec 扫 ~/.codex/sessions → 没东西
+        assert results == []
+
+    def test_both_specs_share_same_base_class(self):
+        cc = JsonlIngester(CC_SPEC)
+        codex = JsonlIngester(CODEX_SPEC)
+        # 同一类型，不同实例
+        assert type(cc) is type(codex)
+        assert cc.spec is not codex.spec
+        assert cc.spec.name == "claude_code"
+        assert codex.spec.name == "codex"
+
+    def test_sqlite_spec_rejected_by_jsonl_ingester(self):
+        """JsonlIngester 拒绝 sqlite 形态 spec——P3 OpenCode 自己实现 SqliteIngester。"""
+        # 临时造一个 sqlite spec 模拟 P3 即将引入的形态
+        sqlite_spec = EcosystemSpec(
+            name="fake_sqlite",
+            source_kind="jsonl",  # 占位先这么写，下面覆盖
+            sessions_path=lambda h: h / "fake",
+            sessions_glob="*.db",
+            session_id_from_path=lambda p: p.stem,
+            cwd_from_content=lambda c: "",
+            adapter_format="raw",
+            traj_id_prefix="traj_x_",
+            skills_install_path=lambda h: h / "fake_skills",
+            label="fake",
+        )
+        # frozen dataclass — 用 dataclasses.replace 改 source_kind
+        from dataclasses import replace
+        bad = replace(sqlite_spec, source_kind="sqlite")
+        with pytest.raises(ValueError, match="jsonl"):
+            JsonlIngester(bad)
+
+
+# ──────────────────────────────────────────────────────────────────
+# T4. install_to_codex —— skill 落到 ~/.agents/skills/<name>
+# ──────────────────────────────────────────────────────────────────
+
+
+class TestInstallToCodex:
+    """skill 装到 ``<home>/.agents/skills/<name>``——是 .agents 不是 .codex。"""
+
+    @pytest.mark.skipif(
+        sys.platform == "win32",
+        reason="Windows symlink happy path 需要 Dev Mode；该 case 在 P4 Windows runner 覆盖",
+    )
+    def test_install_creates_skill_md_at_agents_skills_path(self, tmp_path):
+        skill_path = _build_codex_skill(tmp_path / "src")
+        fake_home = tmp_path / "home"
+
+        dest = install_to_codex(skill_path, target_root=fake_home)
+
+        # 关键路径断言：是 .agents，不是 .codex
+        assert dest == fake_home / ".agents" / "skills" / "demo-skill" / "SKILL.md"
+        assert dest.is_file()
+
+        # 不要装到 .codex/skills（deprecated 路径）
+        deprecated = fake_home / ".codex" / "skills"
+        assert not deprecated.exists()
+
+    @pytest.mark.skipif(
+        sys.platform == "win32",
+        reason="Windows symlink happy path 需要 Dev Mode",
+    )
+    def test_install_uses_symlink_on_posix(self, tmp_path):
+        skill_path = _build_codex_skill(tmp_path / "src")
+        fake_home = tmp_path / "home"
+
+        install_to_codex(skill_path, target_root=fake_home)
+
+        dest_dir = fake_home / ".agents" / "skills" / "demo-skill"
+        assert dest_dir.is_symlink()
+        assert dest_dir.resolve() == skill_path.resolve()
+
+    def test_install_missing_skill_md_raises(self, tmp_path):
+        empty = tmp_path / "empty-skill"
+        empty.mkdir()
+        with pytest.raises(FileNotFoundError):
+            install_to_codex(empty, target_root=tmp_path / "home")
+
+
+# ──────────────────────────────────────────────────────────────────
+# T5. install_to_codex fallback —— symlink 失败走 copy
+# ──────────────────────────────────────────────────────────────────
+
+
+class TestInstallToCodexFallback:
+    """模拟 Windows 非 Dev Mode + 跨盘场景：symlink 失败、junction 失败
+    → copy 模式；仍要装出 SKILL.md，并通过 ``xskill.ecosystems`` logger 打 warning。
+    """
+
+    def test_install_falls_back_to_copy_when_symlink_and_junction_fail(
+        self, tmp_path, monkeypatch, caplog
+    ):
+        skill_path = _build_codex_skill(tmp_path / "src")
+        fake_home = tmp_path / "home"
+
+        monkeypatch.setattr(install_fallback, "_try_symlink", lambda s, d: False)
+        monkeypatch.setattr(install_fallback, "_try_junction", lambda s, d: False)
+
+        with caplog.at_level(logging.WARNING, logger="xskill.ecosystems"):
+            dest = install_to_codex(skill_path, target_root=fake_home)
+
+        assert dest == fake_home / ".agents" / "skills" / "demo-skill" / "SKILL.md"
+        assert dest.is_file()
+        # 不是 symlink（copy fallback）
+        assert not dest.parent.is_symlink()
+        # 该 warning 标注是 codex 生态、copy 模式
+        warnings = [r for r in caplog.records if r.levelno == logging.WARNING]
+        assert any("install_to_codex" in r.message and "copy-mode" in r.message
+                   for r in warnings)
+
+
+# ──────────────────────────────────────────────────────────────────
+# T6. 路径解析跨平台 —— 不依赖 os.path.expanduser
+# ──────────────────────────────────────────────────────────────────
+
+
+class TestPathResolversCrossPlatform:
+    """所有路径 helper 都接受 ``Path`` 实例并返回 ``Path`` 实例，纯字符串可重现。
+
+    P1 落地的硬要求：不用 ``os.path.expanduser``，全走 ``Path.home() / ...``。
+    本测用 ``Path('/fake/home')`` 类型断言，三平台都跑得过——Windows runner
+    会自动转 ``WindowsPath('/fake/home')``，但断言用 ``__fspath__`` / 子路径
+    比较仍稳。
+    """
+
+    def test_codex_sessions_path_under_dot_codex_sessions(self):
+        home = Path("/fake/home")
+        assert _codex_sessions_path(home) == home / ".codex" / "sessions"
+
+    def test_agents_skills_path_under_dot_agents_skills(self):
+        """安装根是 ``.agents/skills``——跨 codex / opencode 共享。"""
+        home = Path("/fake/home")
+        assert _agents_skills_path(home) == home / ".agents" / "skills"
+
+    def test_cc_paths_unchanged(self):
+        """CC 路径不应被 P2 改动。"""
+        home = Path("/fake/home")
+        assert _cc_projects_path(home) == home / ".claude" / "projects"
+        assert _cc_skills_path(home) == home / ".claude" / "skills"
+
+    def test_cc_and_codex_install_paths_diverge(self):
+        """CC → ``.claude/skills`` ；Codex → ``.agents/skills``。两者必须不同
+        目录，不能装错。
+        """
+        home = Path("/fake/home")
+        cc = _cc_skills_path(home)
+        codex_dest = _agents_skills_path(home)
+        assert cc != codex_dest
+        assert cc.name == "skills"
+        assert codex_dest.name == "skills"
+        assert cc.parent.name == ".claude"
+        assert codex_dest.parent.name == ".agents"
+
+    def test_spec_path_resolvers_use_pathlib_only(self):
+        """``EcosystemSpec.sessions_path`` 调用是纯 ``Path`` 操作，不触发
+        ``os.path.expanduser`` 等环境敏感函数（这是设计约束）。
+        """
+        home = Path("/another/home")
+        assert CC_SPEC.sessions_path(home) == home / ".claude" / "projects"
+        assert CODEX_SPEC.sessions_path(home) == home / ".codex" / "sessions"
+        assert CC_SPEC.skills_install_path(home) == home / ".claude" / "skills"
+        assert CODEX_SPEC.skills_install_path(home) == home / ".agents" / "skills"
+
+
+# ──────────────────────────────────────────────────────────────────
+# T7. codex 私有 helpers —— session_id_from_path / cwd_from_content
+# ──────────────────────────────────────────────────────────────────
+
+
+class TestCodexHelpers:
+    def test_session_id_from_path_extracts_uuid(self, tmp_path):
+        # 标准 rollout 文件名
+        p = tmp_path / f"rollout-2026-01-15T10-00-00-{EXPECTED_SESSION_ID}.jsonl"
+        assert _codex_session_id_from_path(p) == EXPECTED_SESSION_ID
+
+    def test_session_id_from_path_handles_short_name(self, tmp_path):
+        # 文件名不符合预期 —— 退化为整个 stem（不挂）
+        p = tmp_path / "rollout-short.jsonl"
+        # short 只能拆出 ['rollout', 'short'] = 2 段，少于 5 → 走退化分支
+        assert _codex_session_id_from_path(p) == "rollout-short"
+
+    def test_read_cwd_from_codex_jsonl_extracts_session_meta_cwd(self, fixture_content):
+        cwd = _read_cwd_from_codex_jsonl(fixture_content)
+        assert cwd == EXPECTED_CWD
+
+    def test_read_cwd_returns_empty_when_no_session_meta(self):
+        only_response = json.dumps({
+            "timestamp": "x", "type": "response_item",
+            "payload": {"record_type": "response", "index": 0},
+        })
+        assert _read_cwd_from_codex_jsonl(only_response) == ""

--- a/tests/test_opencode_adapter.py
+++ b/tests/test_opencode_adapter.py
@@ -29,7 +29,7 @@ from pathlib import Path
 import pytest
 
 from xskill.ecosystems import (
-    EcosystemSpec,
+    SqliteEcosystemSpec,
     OPENCODE_SPEC,
     SqliteIngester,
     _agents_skills_path,
@@ -341,7 +341,7 @@ def test_opencode_spec_is_frozen_and_typed():
 
 def test_sqlite_ingester_rejects_non_sqlite_spec():
     """误传 source_kind='jsonl' 的 spec 应 fail-loud（CLAUDE.md throw error）。"""
-    bad_spec = EcosystemSpec(
+    bad_spec = SqliteEcosystemSpec(
         name="fake",
         source_kind="jsonl",
         path_resolver=lambda h: h,


### PR DESCRIPTION
## Summary

把 CC-only 的 `CCSessionIngester` 抽象成 spec 驱动的 `JsonlIngester(spec)`，加 Codex CLI 生态作为第一个非 CC 实例验证抽象层。完整设计见 [\`docs/dev-plan/cross-platform-multi-agent-design.md\`](docs/dev-plan/cross-platform-multi-agent-design.md) §6 P2。

## 实地装 codex（强制实装步骤已做完）

\`\`\`bash
$ node --version && npm --version
v24.14.1
11.11.0

$ npm i -g @openai/codex
changed 2 packages in 3s

$ which codex && codex --version
/home/admin/.nvm/versions/node/v24.14.1/bin/codex
codex-cli 0.130.0
\`\`\`

**npm 包 \`@openai/codex\` = wrapper bin/codex.js → 平台 spawn \`@openai/codex-<linux-x64/...>\` native binary（codex-rs 预编译产物），主 agent 已实地验证。**

## fixture 生成方式

\`\`\`bash
cd tests/fixtures/codex
python3.11 generate.py .
# 产出 sessions/YYYY/MM/DD/rollout-<ts>-<uuid>.jsonl
mv sessions/*/*/*/rollout-*.jsonl ./sample_rollout.jsonl
rm -rf sessions
\`\`\`

\`generate.py\` 由 codex-rs 单测 \`rollout/src/tests.rs::write_session_file_with_provider\` 1:1 Python 移植——schema 100% 真实（来自 codex 项目自己的 round-trip 单测）。**不用真 codex 跑生成**是因为 codex 0.130 的 \`wire_api\` 枚举只剩 \`Responses\`，DeepSeek / 任何 chat-completions API 都不能驱动（见 \`docs/dev-plan/cross-platform-multi-agent-design.md\` §9.1）。

fixture 大小：784 bytes，含 1 \`session_meta\` + 1 \`event_msg.user_message\` + 3 \`response_item\`。

## 核心改动

### 抽象层（破坏性扩展点）

- **\`EcosystemSpec\` dataclass** —— name / source_kind / sessions_path / sessions_glob / session_id_from_path / cwd_from_content / adapter_format / traj_id_prefix / skills_install_path / label 一锅参数化生态差异
- **\`JsonlIngester(spec)\`** —— 跨生态 JSONL 扫盘 + 桥接基类；\`ingest_claude_code_sessions\` 退化为 thin wrapper 向后兼容 SDK
- **\`CC_SPEC\` / \`CODEX_SPEC\`** —— 两个 spec 实例

### Codex 实装

- **路径**：扫 \`~/.codex/sessions/YYYY/MM/DD/rollout-*.jsonl\`，cwd 从首行 \`session_meta.payload.cwd\` 抽，session_id 从文件名 UUID 段抽
- **\`install_to_codex\`** 装到 **\`<root>/.agents/skills/<name>\`**（注意是 \`.agents\` 不是 \`.codex\`——codex-rs \`loader.rs:294\` 已把 \`\$CODEX_HOME/skills/\` 标 deprecated；\`~/.agents/skills/\` 是跨 codex / opencode / openclaw 共享的事实标准 user-scope skill 目录）
- **\`install_all_to_codex\`** / **\`ingest_codex_sessions\`** —— 与 CC 对称
- **\`codex_rollout_jsonl\` adapter**（\`adapters.py\`）—— 解析 codex \`{timestamp, type, payload}\` schema

### 路径 helpers（跨平台一致）

- \`_codex_sessions_path(home) → home / \".codex\" / \"sessions\"\`
- \`_agents_skills_path(home) → home / \".agents\" / \"skills\"\`
- 所有路径走 \`Path.home() / ...\`，**不用 \`os.path.expanduser\`**（P1 硬要求）

## 测试覆盖

\`tests/test_codex_adapter.py\` —— 27 个 test：

| Class | 覆盖 |
|---|---|
| \`TestCodexRolloutJsonlAdapter\` | adapter 抽 session_id / cwd / user_message / originator / cli_version；malformed line 不挂 |
| \`TestIngestCodexSessions\` | 扫盘 + 桥接 + idempotent + 空目录 + 递归 YYYY/MM/DD glob |
| \`TestJsonlIngesterSpecDispatch\` | CC spec / Codex spec 走同一 base class 但读不同路径，互不干扰；\`sqlite\` source_kind 被 JsonlIngester 拒绝（留给 P3 SqliteIngester） |
| \`TestInstallToCodex\` | skill 落到 \`.agents/skills/<name>\`，不是 \`.codex/skills\`；symlink 模式；missing SKILL.md 抛 \`FileNotFoundError\` |
| \`TestInstallToCodexFallback\` | monkeypatch symlink/junction 都失败 → copy 模式，仍装出 SKILL.md + 打 \`install_to_codex ... copy-mode\` warning |
| \`TestPathResolversCrossPlatform\` | \`Path('/fake/home')\` 验证三平台路径解析；CC / Codex install path 必须 diverge |
| \`TestCodexHelpers\` | \`_codex_session_id_from_path\` / \`_read_cwd_from_codex_jsonl\` 单元测试 |

## 验证

- **本机 \`pytest tests/ -q\`** —— 316 passed（含新增 27 + 既有 289）
- \`tests/test_claude_code_ecosystem.py\` / \`tests/test_install_fallback.py\` / \`tests/test_cc_traj_naming.py\` 0 改动 0 破坏
- 现有 \`from xskill.ecosystems import CCSessionIngester\` 仍 import 得到，SDK 向后兼容

## Test plan

- [x] UT (codex adapter) ubuntu-latest
- [ ] UT macos-latest（CI 矩阵）
- [ ] UT windows-latest（CI 矩阵；含 install_to_codex copy fallback）
- [ ] CI 全平台 UT + IT pass

## 未在 scope

- \`SqliteIngester\` 留给 P3 OpenCode
- CI workflow body（smoke-e2e codex job 的实际内容）—— P4
- \`install_to_codex\` 在装好 codex 后的"真" round-trip 验证（codex CLI 真扫到 skill 并 invoke）—— 等 P4 live-agent-e2e

🤖 Generated with [Claude Code](https://claude.com/claude-code)