### PR TITLE
fix(tests): 堵住测试污染用户真 ~/.claude/skills 的路径

### DIFF
--- a/src/xskill/watcher.py
+++ b/src/xskill/watcher.py
@@ -65,11 +65,15 @@ class DirectoryWatcher:
     def __init__(self, *, llm=None, embed_client=None, config=None,
                  skill_dir=None, poll_interval=30.0, max_concurrent=30,
                  max_retries=3, db_path=None, cold_start_threshold=3,
-                 store=None, agno_agent_factory=None):
+                 store=None, agno_agent_factory=None, home_root=None):
         self.llm = llm
         self.embed_client = embed_client
         self.config = config or {}
         self.skill_dir = Path(skill_dir) if skill_dir else None
+        # home_root：install_to_claude_code 的 target root。生产 daemon 不
+        # 传（None）→ 落到 server._home_root() (默认 Path.home())。测试
+        # 必须显式传 tmp_path 防止污染真实 ~/.claude/skills/。
+        self.home_root = Path(home_root) if home_root else None
         self.poll_interval = poll_interval
         self.max_concurrent = max_concurrent
         self.max_retries = max_retries
@@ -252,13 +256,23 @@ class DirectoryWatcher:
                 logger.exception("SkillEditAgent failed: %s", d.name)
 
     def _install_skill_to_cc(self, skill_path):
-        """SkillEdit 成功后立刻把该 skill 装到 ~/.claude/skills/（symlink）。"""
+        """SkillEdit 成功后立刻把该 skill 装到 ~/.claude/skills/（symlink）。
+
+        target_root 优先级：
+        1) ``self.home_root``（测试注入的 tmp_path，或 daemon ``--home``）
+        2) ``xskill.server._home_root()``（生产 daemon：默认 Path.home()，
+           server 启动时可被 set 成 ``_home_root_override``）
+
+        测试如果不传 ``home_root`` 又没启 server，会 fallback 到真
+        ``Path.home()`` → 污染用户 ``~/.claude/skills/``。本仓库 tests/conftest.py
+        加了 autouse 守卫拦截这种调用，请勿在新测试里走这条路径。
+        """
         try:
             from xskill.ecosystems import install_to_claude_code
-            # 从 home_root 取 install target——生产用 Path.home()，debug 用
-            # 自定义。watcher 不持有 home_root，从 server 模块全局取
-            from xskill import server as _srv
-            target_root = _srv._home_root() if hasattr(_srv, "_home_root") else None
+            target_root = self.home_root
+            if target_root is None:
+                from xskill import server as _srv
+                target_root = _srv._home_root() if hasattr(_srv, "_home_root") else None
             dest = install_to_claude_code(
                 skill_path, target_root=target_root, side="main",
             )

--- a/tests/conftest.py
+++ b/tests/conftest.py
@@ -1,7 +1,159 @@
-"""pytest 入口：把 src/ 加进 sys.path，避免必须 pip install -e . 才能跑测试"""
+"""pytest 入口 + 全局防御。
+
+历史背景
+========
+
+2026-05-13: watcher 的 ``_install_skill_to_cc`` 落到 ``~/.claude/skills/``
+时只取 ``server._home_root()``，而 server 模块未启动时该函数 fallback 到
+``Path.home()`` —— 测试用 ``tmp_path`` 跑完后这些 symlink 全变 broken，
+导致用户真实 ``claude`` 命令启动扫 skill 卡住。
+
+本 conftest 提供三道防御：
+
+1. 把 ``src/`` 加进 ``sys.path``
+2. **autouse function-scope fixture**：每个测试前后都断言用户真实
+   ``~/.claude/skills/`` 没新增任何指向 ``/tmp/pytest-*`` 的子项。一旦
+   被污染（不论哪个测试写的）当场 fail 并清理污染条目。
+3. **install_to_claude_code 守卫**（autouse monkeypatch）：拦截
+   ``target_root`` 解析后等于真 ``Path.home()`` 或 ``None`` 的调用，直接
+   raise。生产 daemon 显式调用不走 pytest 入口，不受影响。
+"""
+import os
 import sys
 from pathlib import Path
+
+import pytest
 
 SRC = Path(__file__).resolve().parent.parent / "src"
 if str(SRC) not in sys.path:
     sys.path.insert(0, str(SRC))
+
+
+# ─────────────────────────────────────────────────────────────────
+# 真实 ~/.claude/skills/ 防污染快照
+# ─────────────────────────────────────────────────────────────────
+
+REAL_HOME = Path(os.path.expanduser("~"))
+REAL_SKILLS_DIR = REAL_HOME / ".claude" / "skills"
+
+
+def _snapshot_skills_dir() -> set[str]:
+    """返回当前 ~/.claude/skills/ 的子项名集合。"""
+    if not REAL_SKILLS_DIR.is_dir():
+        return set()
+    try:
+        return {p.name for p in REAL_SKILLS_DIR.iterdir()}
+    except OSError:
+        return set()
+
+
+def _find_tmp_polluted_entries() -> list[Path]:
+    """列出 ~/.claude/skills/ 下指向 /tmp/ 或 pytest-* 的 symlink，
+    以及任何 broken symlink。"""
+    if not REAL_SKILLS_DIR.is_dir():
+        return []
+    out: list[Path] = []
+    try:
+        for p in REAL_SKILLS_DIR.iterdir():
+            if p.is_symlink():
+                try:
+                    target = os.readlink(p)
+                except OSError:
+                    continue
+                target_str = str(target)
+                if "/tmp/" in target_str or "pytest-" in target_str:
+                    out.append(p)
+                elif not p.exists():
+                    out.append(p)  # broken symlink
+    except OSError:
+        pass
+    return out
+
+
+@pytest.fixture(autouse=True)
+def _block_real_home_pollution(request):
+    """每个测试前后扫描真实 ~/.claude/skills/，确保没被污染。
+
+    - **setUp**：扫描 + 清理（避免上个测试遗留干扰本测试 baseline）
+    - **tearDown**：再扫，新增指向 tmp 的 symlink → fail 测试并清理
+    """
+    baseline = _snapshot_skills_dir()
+    for p in _find_tmp_polluted_entries():
+        try:
+            p.unlink()
+        except OSError:
+            pass
+
+    yield
+
+    post_polluted = _find_tmp_polluted_entries()
+    new_polluted = [p for p in post_polluted if p.name not in baseline]
+    # 不管是不是新加的，只要指向 tmp 都清掉（防止 cascade）
+    for p in post_polluted:
+        try:
+            p.unlink()
+        except OSError:
+            pass
+    if new_polluted:
+        names = ", ".join(p.name for p in new_polluted)
+        pytest.fail(
+            f"测试污染了真实 ~/.claude/skills/：新增指向 /tmp 的 symlink "
+            f"{names}（test: {request.node.nodeid}）。说明该测试调 "
+            f"install_to_claude_code / DirectoryWatcher 没显式传 "
+            f"target_root / home_root=tmp_path。已自动清理。"
+        )
+
+
+# ─────────────────────────────────────────────────────────────────
+# install_to_claude_code 守卫
+# ─────────────────────────────────────────────────────────────────
+
+
+@pytest.fixture(autouse=True)
+def _guard_install_to_claude_code(monkeypatch):
+    """拦截任何 ``install_to_claude_code`` 调用，如果解析后的 root 等于真
+    ``Path.home()`` 或 target_root=None，直接 raise（fail-loud，符合
+    CLAUDE.md "no fallback" 原则）。
+
+    生产 daemon 通过 ``xskill.server._home_root()`` 取 root，daemon 不走
+    pytest 入口，所以这层守卫只影响测试。
+    """
+    import xskill.ecosystems as _eco
+
+    real_install = _eco.install_to_claude_code
+    real_install_all = _eco.install_all_to_claude_code
+    real_home = Path(os.path.expanduser("~")).resolve()
+
+    def _guarded_install(skill_path, *, target_root=None, side="main", **kw):
+        if target_root is None:
+            raise RuntimeError(
+                "[conftest guard] install_to_claude_code 被调时 target_root=None；"
+                "测试必须显式传 target_root=tmp_path 防污染用户真 ~/.claude/。"
+            )
+        resolved = Path(target_root).expanduser().resolve()
+        if resolved == real_home:
+            raise RuntimeError(
+                f"[conftest guard] install_to_claude_code target_root 解析为真 "
+                f"Path.home() = {real_home}；测试必须传 tmp_path 之类的隔离目录。"
+            )
+        return real_install(skill_path, target_root=target_root, side=side, **kw)
+
+    def _guarded_install_all(skill_dir, *, target_root=None, names=None, **kw):
+        if target_root is None:
+            raise RuntimeError(
+                "[conftest guard] install_all_to_claude_code 被调时 target_root=None；"
+                "测试必须显式传 target_root=tmp_path。"
+            )
+        resolved = Path(target_root).expanduser().resolve()
+        if resolved == real_home:
+            raise RuntimeError(
+                f"[conftest guard] install_all_to_claude_code target_root 解析为真 "
+                f"Path.home() = {real_home}；测试必须传隔离目录。"
+            )
+        return real_install_all(skill_dir, target_root=target_root, names=names, **kw)
+
+    monkeypatch.setattr(_eco, "install_to_claude_code", _guarded_install)
+    monkeypatch.setattr(_eco, "install_all_to_claude_code", _guarded_install_all)
+    # watcher.py 是 ``from xskill.ecosystems import install_to_claude_code``
+    # 但在函数内 lazy import，所以只 patch 模块属性就够了——下次 from import
+    # 拿到的是 patched 版本。

--- a/tests/test_no_real_home_pollution.py
+++ b/tests/test_no_real_home_pollution.py
@@ -1,0 +1,139 @@
+"""regression: 测试不该污染用户真 ~/.claude/skills/。
+
+2026-05-13 发现 bug：watcher 的 ``_install_skill_to_cc`` 在 server 模块没
+启动的情况下 fallback 到 ``Path.home()``，导致测试用 ``tmp_path`` 跑 watcher
+时把 symlink 装到用户真实 ``~/.claude/skills/<name>/`` → pytest 清完 tmp
+→ symlink 全 broken → 用户 ``claude`` 命令启动卡住。
+
+本测试做两件事：
+
+1. 跑一个完整 watcher chain（最有可能触发 install_to_claude_code），断言
+   用户真 ``~/.claude/skills/`` 的子项列表 + mtime 完全不变。
+2. 显式断言 conftest 的 ``_guard_install_to_claude_code`` 守卫在
+   ``target_root=None`` 或 ``target_root=Path.home()`` 时会 raise。
+
+conftest.py 的 autouse 守卫是第二道防御，本测试是第一道显式 regression。
+"""
+from __future__ import annotations
+
+import os
+import time
+from pathlib import Path
+
+import pytest
+
+from xskill.atom_task import AtomTaskStore
+from xskill.registry import register_dir, get_status_counts
+from xskill.watcher import DirectoryWatcher
+from tests.test_atom_task_store import _FakeEmbed
+from tests.test_task_agent import _SPLIT_XML, _StubLLM
+from tests.test_watcher_atom import _StubAgno
+
+
+REAL_HOME = Path(os.path.expanduser("~"))
+REAL_SKILLS = REAL_HOME / ".claude" / "skills"
+
+
+def _real_skills_snapshot() -> dict[str, tuple]:
+    """记录 ~/.claude/skills/ 每个子项的 (is_symlink, target/None, mtime_ns)。
+
+    用 lstat 抓 mtime（不跟随 symlink）。
+    """
+    if not REAL_SKILLS.is_dir():
+        return {}
+    out: dict[str, tuple] = {}
+    for p in REAL_SKILLS.iterdir():
+        try:
+            st = p.lstat()
+        except OSError:
+            continue
+        target = None
+        if p.is_symlink():
+            try:
+                target = os.readlink(p)
+            except OSError:
+                target = None
+        out[p.name] = (p.is_symlink(), target, st.st_mtime_ns)
+    return out
+
+
+class TestNoRealHomePollution:
+    def test_watcher_full_chain_does_not_touch_real_home(self, tmp_path):
+        """完整 watcher chain：discover → split → embed → cluster → SkillEdit →
+        install_to_claude_code。整个过程必须只动 tmp_path，不动真 ~/.claude/。
+        """
+        before = _real_skills_snapshot()
+
+        db = tmp_path / "test.db"
+        wd = tmp_path / "wd"
+        wd.mkdir()
+        skill_dir = tmp_path / "skill"
+        skill_dir.mkdir()
+        (wd / "traj_x.md").write_text("X" * 250, encoding="utf-8")
+
+        register_dir(wd, db_path=db)
+        store = AtomTaskStore(root=wd)
+        watcher = DirectoryWatcher(
+            llm=_StubLLM([_SPLIT_XML]),
+            embed_client=_FakeEmbed(),
+            config={"llm": {"base_url": "x", "model": "y", "api_key": "z"}},
+            skill_dir=skill_dir,
+            poll_interval=0.0,
+            max_concurrent=4,
+            db_path=db,
+            cold_start_threshold=999,
+            store=store,
+            agno_agent_factory=_StubAgno,
+            home_root=tmp_path,  # 关键：所有 install 都落 tmp
+        )
+
+        # 跑足够多轮让 chain 走完
+        for _ in range(25):
+            watcher._scan_once()
+            for _ in range(30):
+                if not watcher._futures:
+                    break
+                time.sleep(0.05)
+                watcher._harvest()
+            if get_status_counts(db_path=db).get("done"):
+                break
+        watcher._pool.shutdown(wait=False)
+
+        # 关键断言 1：真 ~/.claude/skills/ 子项 + mtime 必须完全没变
+        after = _real_skills_snapshot()
+        assert before == after, (
+            f"真 ~/.claude/skills/ 被污染：\n"
+            f"  before={before}\n"
+            f"  after ={after}"
+        )
+
+        # 关键断言 2：install 走了 tmp_path/.claude/skills/
+        tmp_skills = tmp_path / ".claude" / "skills"
+        # auto-skill 在 _StubAgno 里被创建并被 SkillEdit 推进到 main —
+        # 应该装到 tmp_skills（如果 SkillEdit 没触发就跳过这一断言）
+        if tmp_skills.is_dir():
+            assert any(tmp_skills.iterdir()), (
+                f"watcher 应该把 auto-skill 装到 {tmp_skills}，但目录是空的"
+            )
+
+    def test_explicit_target_root_none_raises_via_guard(self, tmp_path):
+        """conftest 守卫：调 install_to_claude_code 传 target_root=None 应 raise。"""
+        from xskill.ecosystems import install_to_claude_code
+
+        skill = tmp_path / "fake_skill"
+        skill.mkdir()
+        (skill / "SKILL.md").write_text("---\nname: fake\n---\nbody\n")
+
+        with pytest.raises(RuntimeError, match="target_root=None"):
+            install_to_claude_code(skill, target_root=None)
+
+    def test_explicit_real_home_raises_via_guard(self, tmp_path):
+        """conftest 守卫：显式传 target_root=真 Path.home() 也得 raise。"""
+        from xskill.ecosystems import install_to_claude_code
+
+        skill = tmp_path / "fake_skill"
+        skill.mkdir()
+        (skill / "SKILL.md").write_text("---\nname: fake\n---\nbody\n")
+
+        with pytest.raises(RuntimeError, match="Path.home"):
+            install_to_claude_code(skill, target_root=Path.home())

--- a/tests/test_watcher.py
+++ b/tests/test_watcher.py
@@ -56,12 +56,13 @@ def skill_dir(tmp_path):
 class TestWatcherDiscovery:
     """Test that _scan_once discovers files and updates DB."""
 
-    def test_discover_new_files(self, traj_dir, skill_dir, db_path):
+    def test_discover_new_files(self, traj_dir, skill_dir, db_path, tmp_path):
         wid = register_dir(traj_dir, db_path=db_path)
 
         watcher = DirectoryWatcher(
             llm=None, embed_client=None, config={},
             skill_dir=skill_dir, poll_interval=1, db_path=db_path,
+            home_root=tmp_path,
         )
         watcher._scan_once()
         _drain(watcher)
@@ -74,12 +75,13 @@ class TestWatcherDiscovery:
         assert len(rows) == 1
         assert rows[0]["filename"] == "traj_0001.md"
 
-    def test_stats_updated(self, traj_dir, skill_dir, db_path):
+    def test_stats_updated(self, traj_dir, skill_dir, db_path, tmp_path):
         register_dir(traj_dir, db_path=db_path)
 
         watcher = DirectoryWatcher(
             llm=None, embed_client=None, config={},
             skill_dir=skill_dir, poll_interval=1, db_path=db_path,
+            home_root=tmp_path,
         )
         watcher._scan_once()
 
@@ -94,6 +96,7 @@ class TestWatcherStartStop:
         watcher = DirectoryWatcher(
             llm=None, embed_client=None, config={},
             skill_dir=tmp_path, poll_interval=0.1, db_path=db_path,
+            home_root=tmp_path,
         )
         assert not watcher.is_running
         watcher.start()
@@ -105,6 +108,7 @@ class TestWatcherStartStop:
         watcher = DirectoryWatcher(
             llm=None, embed_client=None, config={},
             skill_dir=tmp_path, poll_interval=0.1, db_path=db_path,
+            home_root=tmp_path,
         )
         watcher.start()
         watcher.start()  # should not error

--- a/tests/test_watcher_atom.py
+++ b/tests/test_watcher_atom.py
@@ -100,6 +100,7 @@ class TestZombieCleanup:
             cold_start_threshold=999,
             store=store,
             agno_agent_factory=_StubAgno,
+            home_root=tmp_path,
         )
         # 新 watcher 进程 _futures 为空 → 僵尸 splitting 应回退到 discovered
         # 然后同一轮提交新 split future
@@ -132,6 +133,7 @@ class TestZombieCleanup:
             cold_start_threshold=999,
             store=store,
             agno_agent_factory=_StubAgno,
+            home_root=tmp_path,
         )
         watcher._scan_once()
         # 僵尸 clustering 应被回退到 indexed（同一轮内可能又被重新提交，OK）
@@ -180,6 +182,7 @@ class TestColdStartSerial:
             cold_start_threshold=3,
             store=store,
             agno_agent_factory=lambda **k: _BlockingStub(**k),
+            home_root=tmp_path,
         )
         watcher._scan_once()
         # cold-start 应该只让 1 个 cluster 在飞
@@ -231,6 +234,7 @@ class TestColdStartSerial:
             cold_start_threshold=10,  # 高阈值 → 2 条不触发 cold-start
             store=store,
             agno_agent_factory=lambda **k: _BlockingStub(**k),
+            home_root=tmp_path,
         )
         watcher._scan_once()
         cluster_in_flight = sum(
@@ -275,6 +279,7 @@ class TestClusterAllFailed:
             store=store,
             max_retries=0,  # 不让 watcher 自动 retry，便于断言"留在 error"
             agno_agent_factory=lambda **kw: _AlwaysFailAgno(**kw),
+            home_root=tmp_path,
         )
 
         # 跑足够多轮把 traj 推到 cluster 阶段
@@ -353,6 +358,7 @@ class TestIndependentSkillEditScan:
             cold_start_threshold=999,
             store=store,
             agno_agent_factory=lambda **kw: _MixedStub(**kw),
+            home_root=tmp_path,
         )
 
         for _ in range(10):
@@ -415,6 +421,7 @@ class TestUxScoreAtomLevel:
             cold_start_threshold=999,
             store=store,
             agno_agent_factory=_StubAgno,
+            home_root=tmp_path,
         )
         # mock score_atom 返回固定分数
         with patch("xskill.watcher.score_atom",
@@ -470,6 +477,7 @@ class TestUxScoreAtomLevel:
             cold_start_threshold=999,
             store=store,
             agno_agent_factory=_StubAgno,
+            home_root=tmp_path,
         )
         with patch("xskill.ux_score.score_atom") as mock_score:
             for _ in range(20):
@@ -506,6 +514,7 @@ class TestPipelineRun:
             cold_start_threshold=999,  # 关闭门控避免阻塞
             store=store,
             agno_agent_factory=_StubAgno,
+            home_root=tmp_path,
         )
 
         # 多轮 scan + harvest 推动状态流转


### PR DESCRIPTION
## 背景

2026-05-13 暴露的 bug：watcher 的 `_install_skill_to_cc` 通过 `server._home_root()` 取 install target，但 server 模块没启动时该函数 fallback 到 `Path.home()` → 测试用 `tmp_path` 跑 watcher 时把 symlink 装到用户**真** `~/.claude/skills/<name>/`。pytest 清完 tmp 后 symlink 全 broken，用户 `claude` 命令启动扫 skills 卡住。

## Summary

- `watcher.DirectoryWatcher` 加 `home_root` 参数：测试显式注入 `tmp_path` 后 install target 走 tmp。生产 daemon 不传仍走 `server._home_root()`，行为不变。
- `tests/test_watcher_atom.py` 9 处 + `test_watcher.py` 4 处 `DirectoryWatcher(...)` 全部加 `home_root=tmp_path`。
- `tests/conftest.py` 加两道 autouse 防御：
  - `_block_real_home_pollution`: 每个测试前后扫 `~/.claude/skills/`，发现新增指向 `/tmp` 的 symlink 立刻 fail 测试并清理。
  - `_guard_install_to_claude_code`: monkeypatch 拦截 `install_to_claude_code` / `install_all_to_claude_code`，`target_root=None` 或解析为真 `Path.home()` 时直接 raise（符合 CLAUDE.md "no fallback"）。
- `tests/test_no_real_home_pollution.py` 新增 regression：watcher full chain 跑完断言真 `~/.claude/skills/` 子项 + mtime 完全没变。

## Test plan

- [x] `python3.11 -m pytest tests/ -q --ignore=tests/test_e2e_xskill_serve_auto.py` → 332 passed
- [x] 本机 `ls -la ~/.claude/skills/` 验证测试前后只有 `managing-tx-minecraft`，没新增 tmp symlink
- [x] 手动验证 `DirectoryWatcher(home_root='/tmp/foo')` 成功接受参数

🤖 Generated with [Claude Code](https://claude.com/claude-code)