### PR TITLE
feat(daemon): startup 自动接 codex + opencode (扫描 + skill install)

### DIFF
--- a/src/xskill/ecosystems.py
+++ b/src/xskill/ecosystems.py
@@ -145,9 +145,24 @@ _KNOWN_ECOSYSTEMS: list[dict] = [
     {
         "id": "claude_code",
         "source_subpath": ".claude/projects",  # CC writes <home>/<this>/<cwd-hash>/*.jsonl
-        "bridge_subpath": ".xskill/cc_sessions",  # we mirror them here as traj_*.md
+        "bridge_subpath": ".xskill/cc_sessions",
+        "source_kind": "dir",  # 目录存在即视为该生态可用
     },
-    # Future: codex / opencode / etc. follow the same {id, source, bridge} shape.
+    {
+        "id": "codex",
+        # Codex CLI 写 <home>/.codex/sessions/YYYY/MM/DD/rollout-*.jsonl
+        "source_subpath": ".codex/sessions",
+        "bridge_subpath": ".xskill/codex_sessions",
+        "source_kind": "dir",
+    },
+    {
+        "id": "opencode",
+        # OpenCode 走 XDG (~/.local/share/opencode/opencode.db) ——
+        # SQLite 文件不是目录。detect 用 ``source_kind="file"`` 判存在。
+        "source_subpath": ".local/share/opencode/opencode.db",
+        "bridge_subpath": ".xskill/opencode_sessions",
+        "source_kind": "file",
+    },
 ]
 
 
@@ -155,19 +170,22 @@ def detect_known_ecosystems(home_root: Path | str | None = None) -> list[dict]:
     """Probe the user's HOME for known agent tools and report which ones
     have something on disk. Returns a list of detection records:
 
-        {"ecosystem": "claude_code",
-         "source": <abs path of native session dir>,
+        {"ecosystem": "claude_code" | "codex" | "opencode",
+         "source": <abs path of native session dir or db file>,
          "bridge": <abs path of paired xskill watch dir>}
 
-    A record only appears if the source dir exists. The bridge dir is the
-    path daemon should ``register_dir(..., ecosystem=...)`` to put under
+    A record only appears if the source dir/file exists. The bridge dir is
+    the path daemon should ``register_dir(..., ecosystem=...)`` to put under
     Registry control — it may or may not exist yet.
     """
     root = Path(home_root) if home_root else Path.home()
     found: list[dict] = []
     for spec in _KNOWN_ECOSYSTEMS:
         source = root / spec["source_subpath"]
-        if not source.is_dir():
+        kind = spec.get("source_kind", "dir")
+        if kind == "dir" and not source.is_dir():
+            continue
+        if kind == "file" and not source.is_file():
             continue
         found.append({
             "ecosystem": spec["id"],
@@ -1020,6 +1038,22 @@ def install_all_to_codex(
     given, restrict to those.
     """
     return _install_all_with(install_to_codex, skill_dir, target_root, names)
+
+
+def install_all_to_opencode(
+    skill_dir: Path | str,
+    target_root: Path | str | None = None,
+    names: Iterable[str] | None = None,
+) -> list[Path]:
+    """Install every skill under ``skill_dir`` (each subdir = one skill) to
+    OpenCode's discovery root (``<target_root>/.agents/skills``——与 Codex 共享
+    user-scope skills 目录). If ``names`` is given, restrict to those.
+
+    注意：Codex 与 OpenCode 的 install 目标是**同一个目录**——重复 install
+    同一 skill 是 idempotent（install_fallback.install_dir 会先 unlink 后重链）。
+    """
+    # install_to_opencode 默认 side='main'；这里走 default。
+    return _install_all_with(install_to_opencode, skill_dir, target_root, names)
 
 
 def _install_all_with(

--- a/src/xskill/server.py
+++ b/src/xskill/server.py
@@ -1421,7 +1421,11 @@ def create_app(home_root: Path | str | None = None) -> FastAPI:
         try:
             from xskill.ecosystems import (
                 detect_known_ecosystems, CCSessionIngester,
+                JsonlIngester, SqliteIngester,
+                CODEX_SPEC, OPENCODE_SPEC,
                 install_all_to_claude_code,
+                install_all_to_codex,
+                install_all_to_opencode,
             )
             from xskill.config import XSKILL_HOME
             from xskill.install_history import InstallHistory
@@ -1434,6 +1438,8 @@ def create_app(home_root: Path | str | None = None) -> FastAPI:
             install_history = InstallHistory(install_history_path)
 
             detections = detect_known_ecosystems(home_root=_home_root())
+            poll_interval = float(_config.get("watcher", {}).get("poll_interval", 10))
+
             for det in detections:
                 bridge: Path = det["bridge"]
                 bridge.mkdir(parents=True, exist_ok=True)
@@ -1442,6 +1448,7 @@ def create_app(home_root: Path | str | None = None) -> FastAPI:
                     label=f"{det['ecosystem']} sessions",
                     ecosystem=det["ecosystem"],
                 )
+
                 if det["ecosystem"] == "claude_code":
                     # 启动时先把现有 skill 全部装 main 到 ~/.claude/skills/，
                     # 同时往 install_history append 起始记录。后续 ingester
@@ -1453,19 +1460,21 @@ def create_app(home_root: Path | str | None = None) -> FastAPI:
                         for dest in installed:
                             install_history.record(
                                 skill=dest.parent.name, side="main",
-                                sha="",  # 启动时不取 sha，避免硬依赖 git 状态
+                                sha="",
                             )
                         logger.info(
-                            "startup install_all_to_claude_code: %d skills installed (side=main)",
+                            "startup install_all_to_claude_code: %d skills installed",
                             len(installed),
                         )
                     except Exception:
-                        logger.warning("startup install_all_to_claude_code failed", exc_info=True)
-
+                        logger.warning(
+                            "startup install_all_to_claude_code failed",
+                            exc_info=True,
+                        )
                     ingester = CCSessionIngester(
                         target_traj_dir=bridge,
                         home_root=_home_root(),
-                        poll_interval=float(_config.get("watcher", {}).get("poll_interval", 10)),
+                        poll_interval=poll_interval,
                         skill_dir=_skill_dir,
                         target_root=_home_root(),
                         history_path=install_history_path,
@@ -1473,6 +1482,70 @@ def create_app(home_root: Path | str | None = None) -> FastAPI:
                     )
                     ingester.start()
                     _watcher_ref[f"ingester_{det['ecosystem']}"] = ingester
+
+                elif det["ecosystem"] == "codex":
+                    # Codex CLI 写 ~/.codex/sessions/YYYY/MM/DD/rollout-*.jsonl
+                    # 形态与 CC JSONL 一致——复用 JsonlIngester(CODEX_SPEC)。
+                    # Skill install 走 ~/.agents/skills/ (Codex/OpenCode 共享)。
+                    try:
+                        installed = install_all_to_codex(
+                            _skill_dir, target_root=_home_root(),
+                        )
+                        logger.info(
+                            "startup install_all_to_codex: %d skills installed to ~/.agents/skills/",
+                            len(installed),
+                        )
+                    except Exception:
+                        logger.warning(
+                            "startup install_all_to_codex failed", exc_info=True,
+                        )
+                    # JsonlIngester 当前没有内置 daemon 线程；走一次性 scan_and_bridge
+                    # 由后续每轮 watcher poll 通过 register_dir + bridge_subpath 自动
+                    # 走 split → embed → cluster 链路。
+                    try:
+                        bridged = JsonlIngester(CODEX_SPEC).scan_and_bridge(
+                            target_traj_dir=bridge,
+                            home_root=_home_root(),
+                        )
+                        logger.info(
+                            "startup codex ingester: bridged %d sessions to %s",
+                            len(bridged), bridge,
+                        )
+                    except Exception:
+                        logger.warning("startup codex ingester failed", exc_info=True)
+
+                elif det["ecosystem"] == "opencode":
+                    # OpenCode 走 SQLite + WAL（~/.local/share/opencode/opencode.db）
+                    # —— SqliteIngester 用 ?mode=ro&immutable=1 避免 WAL 锁。
+                    # Skill install 走 ~/.agents/skills/ (Codex/OpenCode 共享；
+                    # 与 codex install_all 重复 install 同一目录是 idempotent)。
+                    try:
+                        installed = install_all_to_opencode(
+                            _skill_dir, target_root=_home_root(),
+                        )
+                        logger.info(
+                            "startup install_all_to_opencode: %d skills installed to ~/.agents/skills/",
+                            len(installed),
+                        )
+                    except Exception:
+                        logger.warning(
+                            "startup install_all_to_opencode failed", exc_info=True,
+                        )
+                    try:
+                        bridged = SqliteIngester(
+                            target_traj_dir=bridge,
+                            home_root=_home_root(),
+                            spec=OPENCODE_SPEC,
+                        ).run_once()
+                        logger.info(
+                            "startup opencode ingester: bridged %d sessions to %s",
+                            len(bridged), bridge,
+                        )
+                    except Exception:
+                        logger.warning(
+                            "startup opencode ingester failed", exc_info=True,
+                        )
+
                 logger.info(
                     "ecosystem %s detected: source=%s bridge=%s",
                     det["ecosystem"], det["source"], bridge,


### PR DESCRIPTION
## Why

用户报告：装好 opencode 后想立刻用 xskill，但 daemon 启动**不会自动扫 opencode 轨迹也不会装 skill 到 ~/.agents/skills/**。原因：

- `_KNOWN_ECOSYSTEMS` 只列 `claude_code`
- server.py startup 只调 `install_all_to_claude_code` + 起 `CCSessionIngester`
- P2/P3 落地的 Codex/OpenCode adapter / spec / ingester 没接入这条 startup hook

P2-P5 落地了 adapter 但没接入 daemon → 用户必须手动调 ingester。本 PR 补上。

## What

- `_KNOWN_ECOSYSTEMS` 加 codex + opencode 两条 entry，每条带 `source_kind`（`dir` for codex sessions / `file` for opencode .db）
- `detect_known_ecosystems` 支持 file kind probe
- server.py startup 按 ecosystem 分支：
  - **codex** → `install_all_to_codex(~/.agents/skills/)` + `JsonlIngester(CODEX_SPEC).scan_and_bridge`
  - **opencode** → `install_all_to_opencode(~/.agents/skills/)` + `SqliteIngester(spec=OPENCODE_SPEC).run_once`
- 加 `install_all_to_opencode`（同 `install_all_to_codex` / `_cc` 三阶 fallback）

注意：codex + opencode 共用 `~/.agents/skills/` 目录（Codex/OpenCode 源码都扫这个 user-scope 路径）；两次 install_all 同一目标是 idempotent。

## Test plan

- [x] `detect_known_ecosystems()` 在 /home/admin（用户真 home）返回 `['claude_code', 'opencode']` — opencode .db 检测到，codex 路径不存在所以缺，符合预期
- [x] `pytest tests/ -q` — 333 passed（1 historical e2e fail，与本 PR 无关）
- [x] `pytest tests/live -m live_agent` — 2/2 passed
- [ ] CI 3 OS matrix 全绿（push 后 `gh pr checks` 验）

🤖 Generated with [Claude Code](https://claude.com/claude-code)