### PR TITLE
feat(daemon): 常青运行时多 agent 自适应 sync (CC/Codex/OpenCode)

### DIFF
--- a/src/xskill/ecosystems.py
+++ b/src/xskill/ecosystems.py
@@ -144,10 +144,26 @@ class EcosystemSpec:
 _KNOWN_ECOSYSTEMS: list[dict] = [
     {
         "id": "claude_code",
-        "source_subpath": ".claude/projects",  # CC writes <home>/<this>/<cwd-hash>/*.jsonl
-        "bridge_subpath": ".xskill/cc_sessions",  # we mirror them here as traj_*.md
+        # CC writes <home>/<this>/<cwd-hash>/*.jsonl
+        "source_subpath": ".claude/projects",
+        "bridge_subpath": ".xskill/cc_sessions",
+        "source_kind": "dir",  # 目录存在即视为该生态可用
     },
-    # Future: codex / opencode / etc. follow the same {id, source, bridge} shape.
+    {
+        "id": "codex",
+        # Codex CLI 写 <home>/.codex/sessions/YYYY/MM/DD/rollout-*.jsonl
+        "source_subpath": ".codex/sessions",
+        "bridge_subpath": ".xskill/codex_sessions",
+        "source_kind": "dir",
+    },
+    {
+        "id": "opencode",
+        # OpenCode 走 XDG (~/.local/share/opencode/opencode.db)——SQLite
+        # 文件，不是目录。detect 用 ``source_kind="file"`` 判存在。
+        "source_subpath": ".local/share/opencode/opencode.db",
+        "bridge_subpath": ".xskill/opencode_sessions",
+        "source_kind": "file",
+    },
 ]
 
 
@@ -155,19 +171,27 @@ def detect_known_ecosystems(home_root: Path | str | None = None) -> list[dict]:
     """Probe the user's HOME for known agent tools and report which ones
     have something on disk. Returns a list of detection records:
 
-        {"ecosystem": "claude_code",
-         "source": <abs path of native session dir>,
+        {"ecosystem": "claude_code" | "codex" | "opencode",
+         "source": <abs path of native session dir or db file>,
          "bridge": <abs path of paired xskill watch dir>}
 
-    A record only appears if the source dir exists. The bridge dir is the
-    path daemon should ``register_dir(..., ecosystem=...)`` to put under
-    Registry control — it may or may not exist yet.
+    A record only appears if the source dir/file exists (按
+    ``source_kind`` 区分用 ``is_dir`` 还是 ``is_file``). The bridge dir is
+    the path daemon should ``register_dir(..., ecosystem=...)`` to put
+    under Registry control — it may or may not exist yet.
+
+    设计：每 install 前 watcher 实时调本函数判 detected list（3 次
+    ``Path.is_dir/is_file`` 开销可忽略）——避免启动时缓存导致用户中途
+    装了 codex 后 daemon 看不到。
     """
     root = Path(home_root) if home_root else Path.home()
     found: list[dict] = []
     for spec in _KNOWN_ECOSYSTEMS:
         source = root / spec["source_subpath"]
-        if not source.is_dir():
+        kind = spec.get("source_kind", "dir")
+        if kind == "dir" and not source.is_dir():
+            continue
+        if kind == "file" and not source.is_file():
             continue
         found.append({
             "ecosystem": spec["id"],
@@ -623,17 +647,113 @@ class JsonlIngester:
     4. traj_id 取 ``<spec.traj_id_prefix><project>_<sid8>``——保留 ``traj_`` 前缀
        让 watcher 的 ``traj_*.md`` glob 继续匹配
 
-    无状态——状态由调用方持有（CC 的 ``CCSessionIngester`` 管 seen_sessions
-    + history + assignments）。
+    用法两种：
+
+    - **One-shot**: ``ingester.scan_and_bridge(target_traj_dir, home_root=)``
+      返回 record list 后由调用方处理（live test / 单测 / CLI 单跑用）
+    - **Daemon thread**: ``ingester.start()`` 起后台 daemon 线程周期性
+      ``_loop`` 调 ``scan_and_bridge``；``ingester.stop()`` 干净退出。
+      用于 server.py startup hook 让生态 ingester 与 CC 一样常青运行。
+      使用 daemon 模式时 ``target_traj_dir`` / ``home_root`` 必须在
+      ``__init__`` 时传入（毕竟 thread 自己跑循环，没有调用方）。
     """
 
-    def __init__(self, spec: EcosystemSpec):
+    def __init__(
+        self,
+        spec: EcosystemSpec,
+        *,
+        target_traj_dir: Path | str | None = None,
+        home_root: Path | str | None = None,
+        poll_interval: float = 10.0,
+    ):
         if spec.source_kind != "jsonl":
-            # P2 不实现 sqlite ingester（P3 加）；早期 fail 避免静默走错路
+            # SQLite ingester 用单独的 SqliteIngester；早 fail 避免走错路。
             raise ValueError(
                 f"JsonlIngester only supports source_kind='jsonl', got {spec.source_kind!r}"
             )
         self.spec = spec
+        # daemon thread 用：one-shot 调用方不传，scan_and_bridge 参数兜底。
+        self.target_traj_dir = Path(target_traj_dir) if target_traj_dir else None
+        self.home_root = Path(home_root) if home_root else None
+        self.poll_interval = poll_interval
+        # daemon thread 内部用：seen_sessions 持久化在 instance 上避免每轮
+        # _scan_seen_sessions 重扫（thread 跑期间 traj_*.json 自己也在生成）。
+        self._seen: set[str] = set()
+        self._stop = threading.Event()
+        self._thread: threading.Thread | None = None
+        self._stats = {
+            "polls": 0, "ingested": 0, "errors": 0, "last_poll": None,
+        }
+
+    # ── daemon thread lifecycle ──────────────────────────────────
+
+    def start(self) -> None:
+        """起 daemon 线程，周期性调 ``scan_and_bridge``。幂等：已在跑则
+        no-op。
+
+        要求 ``__init__`` 传入了 ``target_traj_dir``——daemon 线程没有调
+        用方传参数。``home_root`` 可空（fallback ``Path.home()``）。
+        """
+        if self._thread and self._thread.is_alive():
+            return
+        if self.target_traj_dir is None:
+            raise RuntimeError(
+                "JsonlIngester.start() requires target_traj_dir in __init__"
+            )
+        # 重启场景：从磁盘上已有 traj_*.json 恢复 seen 集合，避免重复桥接。
+        self._seen = _scan_seen_sessions(self.target_traj_dir)
+        self._stop.clear()
+        self._thread = threading.Thread(
+            target=self._loop, daemon=True,
+            name=f"xskill-{self.spec.name}-ingester",
+        )
+        self._thread.start()
+        logger.info(
+            "JsonlIngester(%s) started "
+            "(source=%s, target=%s, interval=%.1fs, %d sessions pre-seen)",
+            self.spec.name,
+            self.spec.sessions_path(self.home_root or Path.home()),
+            self.target_traj_dir,
+            self.poll_interval,
+            len(self._seen),
+        )
+
+    def stop(self) -> None:
+        """干净停止 daemon 线程（避免 zombie）。"""
+        self._stop.set()
+        if self._thread:
+            self._thread.join(timeout=self.poll_interval + 5)
+        logger.info("JsonlIngester(%s) stopped", self.spec.name)
+
+    @property
+    def is_running(self) -> bool:
+        return self._thread is not None and self._thread.is_alive()
+
+    @property
+    def stats(self) -> dict:
+        return {**self._stats, "seen_sessions": len(self._seen),
+                "running": self.is_running}
+
+    def _loop(self) -> None:
+        while not self._stop.is_set():
+            try:
+                submitted = self.scan_and_bridge(
+                    target_traj_dir=self.target_traj_dir,
+                    home_root=self.home_root,
+                    seen_sessions=self._seen,
+                )
+                self._stats["polls"] += 1
+                self._stats["last_poll"] = time.time()
+                if submitted:
+                    self._stats["ingested"] += len(submitted)
+                    logger.info(
+                        "JsonlIngester(%s): bridged %d new session(s) → %s",
+                        self.spec.name, len(submitted), self.target_traj_dir,
+                    )
+            except Exception:
+                self._stats["errors"] += 1
+                logger.exception("JsonlIngester(%s) scan error", self.spec.name)
+            self._stop.wait(self.poll_interval)
 
     def scan_and_bridge(
         self,
@@ -1022,6 +1142,21 @@ def install_all_to_codex(
     return _install_all_with(install_to_codex, skill_dir, target_root, names)
 
 
+def install_all_to_opencode(
+    skill_dir: Path | str,
+    target_root: Path | str | None = None,
+    names: Iterable[str] | None = None,
+) -> list[Path]:
+    """Install every skill under ``skill_dir`` (each subdir = one skill) to
+    OpenCode's discovery root (``<target_root>/.agents/skills``——与 Codex 共享
+    user-scope skills 目录). If ``names`` is given, restrict to those.
+
+    注意：Codex 与 OpenCode 的 install 目标是**同一个目录**——重复 install
+    同一 skill 是 idempotent（install_fallback.install_dir 会先 unlink 后重链）。
+    """
+    return _install_all_with(install_to_opencode, skill_dir, target_root, names)
+
+
 def _install_all_with(
     installer: Callable[..., Path],
     skill_dir: Path | str,
@@ -1164,6 +1299,7 @@ class SqliteIngester:
         *,
         home_root: Path | str | None = None,
         spec: SqliteEcosystemSpec = OPENCODE_SPEC,
+        poll_interval: float = 10.0,
     ):
         if spec.source_kind != "sqlite":
             raise ValueError(
@@ -1173,10 +1309,73 @@ class SqliteIngester:
         self.target_traj_dir = Path(target_traj_dir)
         self.home_root = Path(home_root) if home_root else Path.home()
         self.spec = spec
+        self.poll_interval = poll_interval
         # cursor: 上次见过的 session.time_updated 最大值（毫秒，OpenCode 用 epoch ms）
         self._cursor_ms: int = 0
         # 已桥接过的 session id（重启后由 _scan_seen_sessions 重建——同 CC 思路）
         self._seen: set[str] = _scan_seen_sessions(self.target_traj_dir)
+        # daemon thread
+        self._stop = threading.Event()
+        self._thread: threading.Thread | None = None
+        self._stats = {
+            "polls": 0, "ingested": 0, "errors": 0, "last_poll": None,
+        }
+
+    # ── daemon thread lifecycle ──────────────────────────────────
+
+    def start(self) -> None:
+        """起 daemon 线程周期性调 ``run_once``。幂等：已在跑则 no-op。
+
+        SqliteIngester 用 ``?mode=ro&immutable=1`` 打开 DB，与 OpenCode
+        写端并发**永远不会**触发 ``database is locked``——daemon 长跑安全。
+        """
+        if self._thread and self._thread.is_alive():
+            return
+        self._stop.clear()
+        self._thread = threading.Thread(
+            target=self._loop, daemon=True,
+            name=f"xskill-{self.spec.name}-ingester",
+        )
+        self._thread.start()
+        logger.info(
+            "SqliteIngester(%s) started "
+            "(db=%s, target=%s, interval=%.1fs, %d sessions pre-seen)",
+            self.spec.name, self.db_path, self.target_traj_dir,
+            self.poll_interval, len(self._seen),
+        )
+
+    def stop(self) -> None:
+        """干净停止 daemon 线程（避免 zombie）。"""
+        self._stop.set()
+        if self._thread:
+            self._thread.join(timeout=self.poll_interval + 5)
+        logger.info("SqliteIngester(%s) stopped", self.spec.name)
+
+    @property
+    def is_running(self) -> bool:
+        return self._thread is not None and self._thread.is_alive()
+
+    @property
+    def stats(self) -> dict:
+        return {**self._stats, "seen_sessions": len(self._seen),
+                "cursor_ms": self._cursor_ms, "running": self.is_running}
+
+    def _loop(self) -> None:
+        while not self._stop.is_set():
+            try:
+                submitted = self.run_once()
+                self._stats["polls"] += 1
+                self._stats["last_poll"] = time.time()
+                if submitted:
+                    self._stats["ingested"] += len(submitted)
+                    logger.info(
+                        "SqliteIngester(%s): bridged %d new session(s) → %s",
+                        self.spec.name, len(submitted), self.target_traj_dir,
+                    )
+            except Exception:
+                self._stats["errors"] += 1
+                logger.exception("SqliteIngester(%s) scan error", self.spec.name)
+            self._stop.wait(self.poll_interval)
 
     # ── public API ────────────────────────────────────────────────
 

--- a/src/xskill/install_history.py
+++ b/src/xskill/install_history.py
@@ -50,14 +50,51 @@ class InstallHistory:
         sha: str = "",
         t: Optional[float] = None,
     ) -> dict:
-        """写一条 install 记录。返回写入的完整 record（含 t）。"""
+        """写一条 install 成功记录。返回写入的完整 record（含 t）。
+
+        语义：``action`` 字段默认是 ``"install"``——本方法**只**写成功
+        记录。失败请走 ``record_fail()``，那条记录形态不同（无
+        ``side``、含 ``agent`` + ``reason``）。
+        """
         if side not in ("main", "staging"):
             raise ValueError(f"side must be 'main' or 'staging', got {side!r}")
         record = {
             "t": t if t is not None else time.time(),
+            "action": "install",
             "skill": skill,
             "side": side,
             "sha": sha,
+        }
+        with self._lock:
+            with self.path.open("a", encoding="utf-8") as f:
+                f.write(json.dumps(record, ensure_ascii=False) + "\n")
+        return record
+
+    def record_fail(
+        self,
+        *,
+        skill: str,
+        agent: str,
+        reason: str,
+        t: Optional[float] = None,
+    ) -> dict:
+        """写一条 install 失败记录。
+
+        与 ``record()`` 的成功记录共享同一份 jsonl 文件；用 ``action`` 字段
+        区分（``"install"`` vs ``"fail"``）。失败记录不带 side / sha——这两
+        个字段只对成功 install 有意义；记 ``agent`` (``claude_code`` /
+        ``codex`` / ``opencode``) + ``reason`` (异常摘要) 方便运维定位。
+
+        ``lookup()`` / ``count_by_side()`` 内部按 ``action=="install"`` 过滤
+        （成功记录默认无 action 字段或 action=="install"），失败记录不影响
+        side 反查链路。
+        """
+        record = {
+            "t": t if t is not None else time.time(),
+            "action": "fail",
+            "skill": skill,
+            "agent": agent,
+            "reason": reason,
         }
         with self._lock:
             with self.path.open("a", encoding="utf-8") as f:
@@ -81,14 +118,19 @@ class InstallHistory:
         return out
 
     def lookup(self, t: float, *, skill: Optional[str] = None) -> Optional[dict]:
-        """返回 ``t`` 时刻盘上装的是哪条记录（即 ``record.t ≤ t`` 中最晚的）。
+        """返回 ``t`` 时刻盘上装的是哪条**成功**记录（即 ``record.t ≤ t`` 中最晚的）。
 
         ``skill`` 指定时仅在该 skill 的记录里查；不指定时返回**全局**最后一
         条 ``record.t ≤ t``。在多 skill 同时灰度的场景应当传 skill。
 
+        失败记录（``action == "fail"``）被过滤掉——本方法用于反查 side，
+        失败记录无 side 字段，对反查无意义。
+
         没有合适记录（t 早于最早一条 install）返回 None。
         """
         recs = self.all_records()
+        # 仅看成功 install 记录（无 action 字段的老记录默认视为 install）。
+        recs = [r for r in recs if r.get("action", "install") == "install"]
         if skill is not None:
             recs = [r for r in recs if r.get("skill") == skill]
         candidate: Optional[dict] = None
@@ -100,12 +142,21 @@ class InstallHistory:
         return candidate
 
     def count_by_side(self, *, skill: Optional[str] = None) -> dict[str, int]:
-        """各 side 装了多少次（调试 / 测试看分布用）。"""
+        """各 side 装了多少次（调试 / 测试看分布用）。
+
+        失败记录不计入。
+        """
         counts: dict[str, int] = {"main": 0, "staging": 0}
         for r in self.all_records():
+            if r.get("action", "install") != "install":
+                continue
             if skill is not None and r.get("skill") != skill:
                 continue
             side = r.get("side")
             if side in counts:
                 counts[side] += 1
         return counts
+
+    def fail_records(self) -> list[dict]:
+        """返回所有失败记录（``action == "fail"``）。运维 / 测试用。"""
+        return [r for r in self.all_records() if r.get("action") == "fail"]

--- a/src/xskill/server.py
+++ b/src/xskill/server.py
@@ -1420,8 +1420,12 @@ def create_app(home_root: Path | str | None = None) -> FastAPI:
         # traj_*.md. After that the regular watcher takes over.
         try:
             from xskill.ecosystems import (
-                detect_known_ecosystems, CCSessionIngester,
+                detect_known_ecosystems,
+                CCSessionIngester, JsonlIngester, SqliteIngester,
+                CODEX_SPEC, OPENCODE_SPEC,
                 install_all_to_claude_code,
+                install_all_to_codex,
+                install_all_to_opencode,
             )
             from xskill.config import XSKILL_HOME
             from xskill.install_history import InstallHistory
@@ -1434,6 +1438,8 @@ def create_app(home_root: Path | str | None = None) -> FastAPI:
             install_history = InstallHistory(install_history_path)
 
             detections = detect_known_ecosystems(home_root=_home_root())
+            poll_interval = float(_config.get("watcher", {}).get("poll_interval", 10))
+
             for det in detections:
                 bridge: Path = det["bridge"]
                 bridge.mkdir(parents=True, exist_ok=True)
@@ -1442,6 +1448,7 @@ def create_app(home_root: Path | str | None = None) -> FastAPI:
                     label=f"{det['ecosystem']} sessions",
                     ecosystem=det["ecosystem"],
                 )
+
                 if det["ecosystem"] == "claude_code":
                     # 启动时先把现有 skill 全部装 main 到 ~/.claude/skills/，
                     # 同时往 install_history append 起始记录。后续 ingester
@@ -1459,13 +1466,21 @@ def create_app(home_root: Path | str | None = None) -> FastAPI:
                             "startup install_all_to_claude_code: %d skills installed (side=main)",
                             len(installed),
                         )
-                    except Exception:
-                        logger.warning("startup install_all_to_claude_code failed", exc_info=True)
+                    except Exception as e:
+                        logger.warning(
+                            "startup install_all_to_claude_code failed", exc_info=True,
+                        )
+                        install_history.record_fail(
+                            skill="<startup_all>", agent="claude_code",
+                            reason=str(e)[:200],
+                        )
 
+                    # CCSessionIngester 是 CC 专属（处理灰度翻牌 + header 注入），
+                    # 不是普通 JsonlIngester——它在 _loop 里干的事更多。
                     ingester = CCSessionIngester(
                         target_traj_dir=bridge,
                         home_root=_home_root(),
-                        poll_interval=float(_config.get("watcher", {}).get("poll_interval", 10)),
+                        poll_interval=poll_interval,
                         skill_dir=_skill_dir,
                         target_root=_home_root(),
                         history_path=install_history_path,
@@ -1473,6 +1488,65 @@ def create_app(home_root: Path | str | None = None) -> FastAPI:
                     )
                     ingester.start()
                     _watcher_ref[f"ingester_{det['ecosystem']}"] = ingester
+
+                elif det["ecosystem"] == "codex":
+                    # Codex 一次性同步 + 起 daemon 线程；后续 codex session 新写入
+                    # 会被 daemon poll 实时桥接，不必重启 daemon。
+                    try:
+                        installed = install_all_to_codex(
+                            _skill_dir, target_root=_home_root(),
+                        )
+                        logger.info(
+                            "startup install_all_to_codex: %d skills installed to ~/.agents/skills/",
+                            len(installed),
+                        )
+                    except Exception as e:
+                        logger.warning(
+                            "startup install_all_to_codex failed", exc_info=True,
+                        )
+                        install_history.record_fail(
+                            skill="<startup_all>", agent="codex",
+                            reason=str(e)[:200],
+                        )
+                    ingester = JsonlIngester(
+                        CODEX_SPEC,
+                        target_traj_dir=bridge,
+                        home_root=_home_root(),
+                        poll_interval=poll_interval,
+                    )
+                    ingester.start()
+                    _watcher_ref[f"ingester_{det['ecosystem']}"] = ingester
+
+                elif det["ecosystem"] == "opencode":
+                    # OpenCode SQLite + WAL：SqliteIngester 用 immutable=1 打开
+                    # 避免 daemon poll 撞 OpenCode 写端的 WAL 锁。
+                    # Skill install 走 ~/.agents/skills/ (Codex 共享；重复 install
+                    # 是 idempotent)。
+                    try:
+                        installed = install_all_to_opencode(
+                            _skill_dir, target_root=_home_root(),
+                        )
+                        logger.info(
+                            "startup install_all_to_opencode: %d skills installed to ~/.agents/skills/",
+                            len(installed),
+                        )
+                    except Exception as e:
+                        logger.warning(
+                            "startup install_all_to_opencode failed", exc_info=True,
+                        )
+                        install_history.record_fail(
+                            skill="<startup_all>", agent="opencode",
+                            reason=str(e)[:200],
+                        )
+                    ingester = SqliteIngester(
+                        target_traj_dir=bridge,
+                        home_root=_home_root(),
+                        spec=OPENCODE_SPEC,
+                        poll_interval=poll_interval,
+                    )
+                    ingester.start()
+                    _watcher_ref[f"ingester_{det['ecosystem']}"] = ingester
+
                 logger.info(
                     "ecosystem %s detected: source=%s bridge=%s",
                     det["ecosystem"], det["source"], bridge,

--- a/src/xskill/watcher.py
+++ b/src/xskill/watcher.py
@@ -251,34 +251,127 @@ class DirectoryWatcher:
                     # 即时 install 让 Claude Code 立刻看到新生成的 SKILL.md
                     # 不必等 daemon 重启。install_to_claude_code 现在走 symlink，
                     # 后续 xskill 改 SKILL.md 也会被 CC 立即感知。
-                    self._install_skill_to_cc(d)
+                    self._install_skill_to_all_detected(d)
             except Exception:
                 logger.exception("SkillEditAgent failed: %s", d.name)
 
-    def _install_skill_to_cc(self, skill_path):
-        """SkillEdit 成功后立刻把该 skill 装到 ~/.claude/skills/（symlink）。
+    def _resolve_target_root(self):
+        """target_root 优先级：
 
-        target_root 优先级：
         1) ``self.home_root``（测试注入的 tmp_path，或 daemon ``--home``）
         2) ``xskill.server._home_root()``（生产 daemon：默认 Path.home()，
            server 启动时可被 set 成 ``_home_root_override``）
 
         测试如果不传 ``home_root`` 又没启 server，会 fallback 到真
-        ``Path.home()`` → 污染用户 ``~/.claude/skills/``。本仓库 tests/conftest.py
-        加了 autouse 守卫拦截这种调用，请勿在新测试里走这条路径。
+        ``Path.home()`` → 污染用户 ``~/.claude/skills/``。本仓库
+        ``tests/conftest.py`` 加了 autouse 守卫拦截这种调用，请勿在新测试
+        里走这条路径。
+        """
+        if self.home_root is not None:
+            return self.home_root
+        from xskill import server as _srv
+        return _srv._home_root() if hasattr(_srv, "_home_root") else None
+
+    def _install_skill_to_all_detected(self, skill_path):
+        """把该 skill 装到**当前 detected 的所有 agent 生态**。
+
+        每次调用实时跑 ``detect_known_ecosystems`` 决定要装哪些 agent
+        ——3 次 ``Path.is_dir/is_file`` 开销可忽略，比启动时缓存稳定（用户
+        中途装新 agent 也能被发现）。
+
+        每个 installer 独立 ``try/except``：一个失败不影响其它 agent 继续
+        装；失败记录写到 ``~/.xskill/install_history.jsonl`` 的同一个文件
+        （加 ``action="fail"`` 字段）。至少一个成功就算整体 OK——daemon
+        不抛异常给上层 watcher loop。
+
+        Args:
+            skill_path: ``self.skill_dir / <name>`` 的 Path 对象
+
+        Returns:
+            dict[str, Path | Exception]: agent → 安装结果（成功为 dest 路径，
+            失败为异常对象）。便于调用方 / 测试断言。
+        """
+        from xskill.ecosystems import (
+            detect_known_ecosystems,
+            install_to_claude_code,
+            install_to_codex,
+            install_to_opencode,
+        )
+
+        target_root = self._resolve_target_root()
+        # 实时 detect。测试场景下 self.home_root 是 tmp_path，detect 也
+        # 走 tmp_path——只有 tmp_path 里真造了 .claude/projects 之类目录，
+        # 该生态才会被探到，不会污染用户真目录。
+        detect_root = self.home_root or target_root
+        detections = detect_known_ecosystems(home_root=detect_root) if detect_root else []
+
+        installer_by_ecosystem = {
+            "claude_code": install_to_claude_code,
+            "codex": install_to_codex,
+            "opencode": install_to_opencode,
+        }
+
+        results: dict = {}
+        any_ok = False
+        for det in detections:
+            agent = det["ecosystem"]
+            installer = installer_by_ecosystem.get(agent)
+            if installer is None:
+                continue
+            try:
+                dest = installer(skill_path, target_root=target_root, side="main")
+                results[agent] = dest
+                any_ok = True
+                logger.info("installed (symlink) to %s: %s", agent, dest)
+            except Exception as e:
+                results[agent] = e
+                logger.warning(
+                    "install_to_%s failed for %s: %s",
+                    agent, skill_path.name, e,
+                )
+                self._record_install_fail(
+                    skill=skill_path.name, agent=agent, reason=str(e)[:200],
+                )
+        if not detections:
+            logger.debug(
+                "_install_skill_to_all_detected(%s): no agent detected under %s",
+                skill_path.name, detect_root,
+            )
+        elif not any_ok:
+            logger.warning(
+                "_install_skill_to_all_detected(%s): all %d detected agent(s) failed to install",
+                skill_path.name, len(detections),
+            )
+        return results
+
+    def _record_install_fail(self, *, skill: str, agent: str, reason: str) -> None:
+        """把一条 install 失败写到 ``~/.xskill/install_history.jsonl``。
+
+        失败记录走 ``InstallHistory.record_fail``（带 ``action="fail"``
+        字段），与成功 install 记录在同一文件，不分两份避免 source 熵增。
+
+        写盘本身失败不传播——失败日志的失败只能 logger.warning。
         """
         try:
-            from xskill.ecosystems import install_to_claude_code
-            target_root = self.home_root
-            if target_root is None:
-                from xskill import server as _srv
-                target_root = _srv._home_root() if hasattr(_srv, "_home_root") else None
-            dest = install_to_claude_code(
-                skill_path, target_root=target_root, side="main",
+            from xskill.install_history import InstallHistory
+            from xskill.config import XSKILL_HOME
+            history_path = XSKILL_HOME / "install_history.jsonl"
+            InstallHistory(history_path).record_fail(
+                skill=skill, agent=agent, reason=reason,
             )
-            logger.info("installed (symlink) to CC: %s", dest)
         except Exception:
-            logger.exception("install_to_claude_code failed: %s", skill_path.name)
+            logger.exception(
+                "record_install_fail failed (skill=%s agent=%s)",
+                skill, agent,
+            )
+
+    def _install_skill_to_cc(self, skill_path):
+        """Backward-compat thin wrapper for ``_install_skill_to_all_detected``.
+
+        旧调用路径 / 旧测试可能直接调本方法，保留它走多 agent install
+        逻辑（不是只装 CC）。新代码应直接调 ``_install_skill_to_all_detected``。
+        """
+        return self._install_skill_to_all_detected(skill_path)
 
     def _check_user_edits(self):
         """检测每个 skill 是否有用户手改且静默 ≥3 分钟 → 触发 absorb agent。"""
@@ -301,7 +394,7 @@ class DirectoryWatcher:
                     llm_cfg=self.config.get("llm", {}),
                 ).run()
                 if ok:
-                    self._install_skill_to_cc(d)
+                    self._install_skill_to_all_detected(d)
             except Exception:
                 logger.exception("user edit absorb failed: %s", d.name)
 
@@ -334,7 +427,7 @@ class DirectoryWatcher:
                                 d.name, action, decision)
                     # promote 成功 → 重新 install symlink (内容已变)
                     if action == "promoted":
-                        self._install_skill_to_cc(d)
+                        self._install_skill_to_all_detected(d)
             except Exception:
                 logger.exception("check_and_decide failed: %s", d.name)
 

--- a/tests/test_runtime_sync.py
+++ b/tests/test_runtime_sync.py
@@ -1,0 +1,403 @@
+"""tests/test_runtime_sync.py — runtime multi-agent sync 单测
+
+覆盖范围
+========
+
+G1 — Ingester daemon thread:
+    * JsonlIngester.start() / stop() 周期性调 scan_and_bridge，stop 后不留 zombie
+    * SqliteIngester.start() / stop() 同上（针对 OpenCode SQLite 形态）
+
+G2 — Watcher multi-agent install + 失败记录:
+    * _install_skill_to_all_detected 对 detected 的 3 个生态都调 installer
+    * 单个 agent installer raise 不阻断其它 agent；走 record_fail 写入
+      ~/.xskill/install_history.jsonl（action="fail" 字段）
+
+这层只跑 in-process 单元测试，无外部进程（codex / opencode CLI）。E2E live
+测试在 ``tests/live/test_runtime_sync_live.py`` 单独跑。
+"""
+from __future__ import annotations
+
+import json
+import sqlite3
+import time
+from pathlib import Path
+from unittest.mock import patch
+
+import pytest
+
+from xskill.ecosystems import (
+    CC_SPEC,
+    CODEX_SPEC,
+    OPENCODE_SPEC,
+    JsonlIngester,
+    SqliteIngester,
+)
+from xskill.install_history import InstallHistory
+
+
+# ─────────────────────────────────────────────────────────────────
+# G1 — Ingester daemon thread
+# ─────────────────────────────────────────────────────────────────
+
+
+class TestJsonlIngesterDaemonThread:
+    """JsonlIngester.start() / stop() — 周期性 poll，干净退出，无 zombie。"""
+
+    def _make_codex_rollout(self, codex_home: Path, sid: str) -> Path:
+        """在 ``<codex_home>/.codex/sessions/2026/05/14/`` 写一条合规 rollout。
+
+        codex JSONL 首行必须是 ``type=session_meta``，否则 cwd 抽取走默认空。
+        这里造一条最小可被 ``JsonlIngester(CODEX_SPEC)`` 接受的 session。
+        """
+        sess_dir = codex_home / ".codex" / "sessions" / "2026" / "05" / "14"
+        sess_dir.mkdir(parents=True, exist_ok=True)
+        rollout = sess_dir / f"rollout-2026-05-14T10-00-00-{sid}.jsonl"
+        rollout.write_text(
+            json.dumps({
+                "type": "session_meta",
+                "payload": {"cwd": "/tmp/codex_proj", "id": sid},
+                "timestamp": "2026-05-14T10:00:00.000Z",
+            }) + "\n" +
+            json.dumps({
+                "type": "response_item",
+                "payload": {"type": "message", "role": "user",
+                            "content": [{"type": "input_text", "text": "hello"}]},
+                "timestamp": "2026-05-14T10:00:01.000Z",
+            }) + "\n",
+            encoding="utf-8",
+        )
+        return rollout
+
+    def test_start_stop_no_zombie_thread(self, tmp_path):
+        """起 daemon thread → stop → 确认 thread 已 dead。"""
+        ing = JsonlIngester(
+            CODEX_SPEC,
+            target_traj_dir=tmp_path / "traj",
+            home_root=tmp_path,
+            poll_interval=0.1,
+        )
+        assert not ing.is_running
+        ing.start()
+        assert ing.is_running
+        # 让 loop 至少跑一轮
+        time.sleep(0.3)
+        ing.stop()
+        # stop 后 thread 必须 join 完成
+        assert not ing.is_running, "thread still alive after stop() — zombie thread leak"
+        # _thread 对象仍在，但 is_alive() == False
+        assert ing._thread is not None
+        assert not ing._thread.is_alive()
+
+    def test_start_is_idempotent(self, tmp_path):
+        """重复 start 不应起多个 thread（必须 no-op）。"""
+        ing = JsonlIngester(
+            CODEX_SPEC,
+            target_traj_dir=tmp_path / "traj",
+            home_root=tmp_path,
+            poll_interval=0.1,
+        )
+        ing.start()
+        first_thread = ing._thread
+        ing.start()  # second call
+        assert ing._thread is first_thread, "start() created a 2nd thread; not idempotent"
+        ing.stop()
+
+    def test_start_without_target_traj_dir_raises(self):
+        """daemon thread 模式必须在 __init__ 传 target_traj_dir。"""
+        ing = JsonlIngester(CODEX_SPEC)
+        with pytest.raises(RuntimeError, match="target_traj_dir"):
+            ing.start()
+
+    def test_loop_picks_up_new_session_added_after_start(self, tmp_path):
+        """daemon 跑期间新写入 session → 下一轮 poll 桥接。"""
+        traj_dir = tmp_path / "traj"
+        ing = JsonlIngester(
+            CODEX_SPEC,
+            target_traj_dir=traj_dir,
+            home_root=tmp_path,
+            poll_interval=0.2,
+        )
+        ing.start()
+        # 启动后再写 session：模拟用户跑了一条 codex 命令
+        self._make_codex_rollout(tmp_path, sid="11111111-2222-3333-4444-555555555555")
+        # 等 ≥2 个 poll 周期 + adapter 处理时间
+        deadline = time.time() + 5.0
+        bridged_md = None
+        while time.time() < deadline:
+            md_files = list(traj_dir.glob("traj_codex_*.md"))
+            if md_files:
+                bridged_md = md_files[0]
+                break
+            time.sleep(0.1)
+        ing.stop()
+        assert bridged_md is not None, (
+            f"daemon thread did not bridge new codex session within 5s; "
+            f"traj_dir contents: {list(traj_dir.glob('*')) if traj_dir.exists() else 'no dir'}"
+        )
+        # stats 验证
+        assert ing.stats["polls"] >= 1
+        assert ing.stats["ingested"] >= 1
+
+    def test_cc_spec_also_works_via_jsonl_ingester(self, tmp_path):
+        """CC spec 也能走 JsonlIngester.start——CCSessionIngester 是 wrapper
+        加灰度逻辑；底层 jsonl 扫盘逻辑共享。"""
+        ing = JsonlIngester(
+            CC_SPEC,
+            target_traj_dir=tmp_path / "traj",
+            home_root=tmp_path,
+            poll_interval=0.1,
+        )
+        ing.start()
+        time.sleep(0.2)
+        ing.stop()
+        assert not ing.is_running
+
+
+class TestSqliteIngesterDaemonThread:
+    """SqliteIngester.start() / stop() — OpenCode SQLite 形态。"""
+
+    def _make_opencode_db(self, home_root: Path) -> Path:
+        """在 ``<home>/.local/share/opencode/opencode.db`` 造一个最小 schema 的
+        SQLite，含一条 session + 一条 message。
+        """
+        db_dir = home_root / ".local" / "share" / "opencode"
+        db_dir.mkdir(parents=True, exist_ok=True)
+        db_path = db_dir / "opencode.db"
+        conn = sqlite3.connect(str(db_path))
+        try:
+            conn.execute("""
+                CREATE TABLE IF NOT EXISTS session (
+                    id TEXT PRIMARY KEY,
+                    directory TEXT,
+                    time_updated INTEGER
+                )
+            """)
+            conn.execute("""
+                CREATE TABLE IF NOT EXISTS message (
+                    id TEXT PRIMARY KEY,
+                    session_id TEXT,
+                    time_created INTEGER,
+                    data TEXT
+                )
+            """)
+            conn.execute(
+                "INSERT INTO session (id, directory, time_updated) VALUES (?, ?, ?)",
+                ("ses_abcd1234", "/tmp/oc_proj", int(time.time() * 1000)),
+            )
+            conn.execute(
+                "INSERT INTO message (id, session_id, time_created, data) VALUES (?, ?, ?, ?)",
+                ("msg_1", "ses_abcd1234", int(time.time() * 1000),
+                 json.dumps({"role": "user", "content": "hello opencode"})),
+            )
+            conn.commit()
+        finally:
+            conn.close()
+        return db_path
+
+    def test_start_stop_no_zombie_thread(self, tmp_path):
+        ing = SqliteIngester(
+            target_traj_dir=tmp_path / "traj",
+            home_root=tmp_path,
+            spec=OPENCODE_SPEC,
+            poll_interval=0.1,
+        )
+        assert not ing.is_running
+        ing.start()
+        assert ing.is_running
+        time.sleep(0.3)
+        ing.stop()
+        assert not ing.is_running, "SqliteIngester thread leaked after stop()"
+        assert not ing._thread.is_alive()
+
+    def test_start_is_idempotent(self, tmp_path):
+        ing = SqliteIngester(
+            target_traj_dir=tmp_path / "traj",
+            home_root=tmp_path,
+            spec=OPENCODE_SPEC,
+            poll_interval=0.1,
+        )
+        ing.start()
+        first_thread = ing._thread
+        ing.start()
+        assert ing._thread is first_thread
+        ing.stop()
+
+    def test_loop_picks_up_new_session_added_after_start(self, tmp_path):
+        """daemon 跑期间 OpenCode DB 写新 session → 下一轮 poll 桥接。
+
+        SqliteIngester 用 immutable=1 打开，需要 OpenCode 写完后 force
+        checkpoint 才能在 immutable 视图下看到新 session（实际 OpenCode
+        默认 wal_autocheckpoint=1000，几秒一次）；测试里手动 checkpoint。
+        """
+        traj_dir = tmp_path / "traj"
+        ing = SqliteIngester(
+            target_traj_dir=traj_dir,
+            home_root=tmp_path,
+            spec=OPENCODE_SPEC,
+            poll_interval=0.2,
+        )
+        # 先造空 db（保证 path 存在让 daemon 不会因 db_path.is_file()==False 跳过）
+        db_path = self._make_opencode_db(tmp_path)
+        # checkpoint 强制 WAL 数据 → 主 db file
+        ck = sqlite3.connect(str(db_path))
+        try:
+            ck.execute("PRAGMA wal_checkpoint(FULL)")
+            ck.commit()
+        finally:
+            ck.close()
+
+        ing.start()
+        deadline = time.time() + 5.0
+        bridged_md = None
+        while time.time() < deadline:
+            md_files = list(traj_dir.glob("traj_oc_*.md"))
+            if md_files:
+                bridged_md = md_files[0]
+                break
+            time.sleep(0.1)
+        ing.stop()
+        assert bridged_md is not None, (
+            f"daemon thread did not bridge new opencode session within 5s; "
+            f"traj_dir contents: {list(traj_dir.glob('*')) if traj_dir.exists() else 'no dir'}"
+        )
+        assert ing.stats["polls"] >= 1
+        assert ing.stats["ingested"] >= 1
+
+
+# ─────────────────────────────────────────────────────────────────
+# G2 — Watcher multi-agent install + 失败记录
+# ─────────────────────────────────────────────────────────────────
+
+
+def _build_skill(skill_root: Path, name: str = "list-py-files") -> Path:
+    """造一个最小可被 install_to_* 接受的 skill 目录。"""
+    skill = skill_root / name
+    skill.mkdir(parents=True)
+    (skill / "SKILL.md").write_text(
+        "---\nname: " + name + "\ndescription: test\n---\n# Test skill\n",
+        encoding="utf-8",
+    )
+    return skill
+
+
+class TestWatcherInstallSkillToAllDetected:
+    """Watcher._install_skill_to_all_detected — multi-agent + 失败处理。"""
+
+    def _make_watcher(self, tmp_path):
+        from xskill.watcher import DirectoryWatcher
+        return DirectoryWatcher(
+            llm=None, embed_client=None, config={},
+            skill_dir=tmp_path / "skill",
+            home_root=tmp_path,
+        )
+
+    def _make_all_3_agents_detected(self, tmp_path):
+        """造 3 个生态都 detected 的 home 布局：
+
+        * ``<home>/.claude/projects/`` (dir for claude_code)
+        * ``<home>/.codex/sessions/`` (dir for codex)
+        * ``<home>/.local/share/opencode/opencode.db`` (file for opencode)
+        """
+        (tmp_path / ".claude" / "projects").mkdir(parents=True)
+        (tmp_path / ".codex" / "sessions").mkdir(parents=True)
+        (tmp_path / ".local" / "share" / "opencode").mkdir(parents=True)
+        (tmp_path / ".local" / "share" / "opencode" / "opencode.db").write_bytes(b"")
+
+    def test_installs_to_all_3_detected_agents(self, tmp_path):
+        """3 agent 都 detect → 3 个 installer 都被调；都成功 → results 含 3 entry。"""
+        self._make_all_3_agents_detected(tmp_path)
+        skill = _build_skill(tmp_path / "skill")
+        watcher = self._make_watcher(tmp_path)
+
+        results = watcher._install_skill_to_all_detected(skill)
+
+        assert set(results.keys()) == {"claude_code", "codex", "opencode"}
+        for agent, val in results.items():
+            assert not isinstance(val, Exception), (
+                f"{agent} install raised: {val}"
+            )
+            assert isinstance(val, Path), f"{agent} unexpected result: {val}"
+            assert val.exists(), f"{agent} install dest does not exist: {val}"
+
+    def test_single_agent_failure_does_not_block_others(
+        self, tmp_path, monkeypatch
+    ):
+        """codex installer raise → claude_code + opencode 仍装成功 + 失败记录写入。"""
+        self._make_all_3_agents_detected(tmp_path)
+        skill = _build_skill(tmp_path / "skill")
+        watcher = self._make_watcher(tmp_path)
+
+        # 让 install_to_codex 抛错（模拟跨盘 copy fallback 等运行时异常）
+        from xskill import ecosystems as eco
+
+        def _broken_codex(skill_path, *, target_root=None, side="main"):
+            raise RuntimeError("simulated codex install crash")
+
+        monkeypatch.setattr(eco, "install_to_codex", _broken_codex)
+
+        # 把 install_history 路径指向 tmp_path 避免污染 ~/.xskill
+        from xskill import config as cfg
+        history_path = tmp_path / "install_history.jsonl"
+        monkeypatch.setattr(cfg, "XSKILL_HOME", tmp_path)
+
+        results = watcher._install_skill_to_all_detected(skill)
+
+        # claude_code / opencode 成功
+        assert isinstance(results["claude_code"], Path)
+        assert isinstance(results["opencode"], Path)
+        # codex 失败
+        assert isinstance(results["codex"], Exception)
+        assert "simulated codex install crash" in str(results["codex"])
+
+        # 失败记录写入了 install_history.jsonl 并且只有 codex 这条
+        assert history_path.is_file()
+        ih = InstallHistory(history_path)
+        fails = ih.fail_records()
+        assert len(fails) == 1
+        assert fails[0]["action"] == "fail"
+        assert fails[0]["agent"] == "codex"
+        assert fails[0]["skill"] == skill.name
+        assert "codex install crash" in fails[0]["reason"]
+
+    def test_install_history_lookup_unaffected_by_fail_record(
+        self, tmp_path, monkeypatch
+    ):
+        """fail 行不污染 lookup() / count_by_side() 的语义。"""
+        history_path = tmp_path / "ih.jsonl"
+        ih = InstallHistory(history_path)
+        ih.record(skill="s1", side="main", sha="abc", t=100.0)
+        ih.record_fail(skill="s1", agent="codex", reason="boom", t=150.0)
+        ih.record(skill="s1", side="staging", sha="def", t=200.0)
+
+        # lookup at t=180 → 应当返回 main 那条（t=100），不是 fail 那条
+        rec = ih.lookup(180.0, skill="s1")
+        assert rec is not None and rec["side"] == "main"
+        # lookup at t=250 → staging
+        rec2 = ih.lookup(250.0, skill="s1")
+        assert rec2 is not None and rec2["side"] == "staging"
+
+        # count 只算成功
+        counts = ih.count_by_side(skill="s1")
+        assert counts == {"main": 1, "staging": 1}
+
+        # fail_records 拿到那一条
+        fails = ih.fail_records()
+        assert len(fails) == 1
+        assert fails[0]["agent"] == "codex"
+
+    def test_no_agent_detected_returns_empty_results(self, tmp_path):
+        """home 下啥也没造 → detect 空 → installer 一个都不调 → results = {}。"""
+        skill_root = tmp_path / "skill_root"
+        skill_root.mkdir(parents=True)
+        skill = _build_skill(skill_root)
+        watcher = self._make_watcher(tmp_path)
+        results = watcher._install_skill_to_all_detected(skill)
+        assert results == {}
+
+    def test_old_install_skill_to_cc_still_works_as_wrapper(self, tmp_path):
+        """``_install_skill_to_cc`` 别名仍 work，走的是 multi-agent 逻辑。"""
+        self._make_all_3_agents_detected(tmp_path)
+        skill = _build_skill(tmp_path / "skill")
+        watcher = self._make_watcher(tmp_path)
+        results = watcher._install_skill_to_cc(skill)
+        assert set(results.keys()) == {"claude_code", "codex", "opencode"}


### PR DESCRIPTION
## Why

xskill daemon 常青运行，但之前：
- 只有 `claude_code` 被 startup auto-detect；codex/opencode ingester 没接入
- `JsonlIngester` / `SqliteIngester` 只有一次性 method，**没 daemon-thread** —— daemon 跑起来后 codex/opencode 新 session 看不到
- `watcher._install_skill_to_cc` 只装 CC —— 新 skill 不会同步到 `~/.agents/skills/`

本 PR 让 daemon **常青运行期间持续** ingest 三家 agent 新轨迹 + 自动同步新 skill 到各 agent discovery 路径，单 agent 失败记录原因不阻断其他。

## What

**G1 — Ingester daemon-thread**
- `_KNOWN_ECOSYSTEMS` 加 codex + opencode（`source_kind: dir|file`）
- `detect_known_ecosystems` 支持 file kind probe
- `JsonlIngester` / `SqliteIngester` 加 `start()/stop()/_loop()`，仿 `CCSessionIngester`；幂等 start、干净 stop 无 zombie thread

**G2 — Watcher 多 agent install + 失败记录**
- `_install_skill_to_cc` → `_install_skill_to_all_detected`（旧名保留 wrapper）
- 每次 install 实时 `detect_known_ecosystems` → 逐个 agent 装
- per-agent `try/except`：单 agent 失败 → `record_fail`，不传播
- `InstallHistory.record_fail` 写同一 jsonl，`action="fail"` 区分；`lookup()` 过滤 fail 记录
- 三处调用点全切

**G3 — server.py startup 持久线程**
- codex/opencode ingester 从一次性 scan 改成 `.start()` daemon thread
- shutdown hook `.stop()` 所有 ingester

## Test plan

- [x] `tests/test_runtime_sync.py` — 13 unit test 全过
- [x] `pytest tests/ -q` — 346 passed（1 pre-existing e2e fail `test_canary_flip`，main 上同样挂，与本 PR 无关）
- [x] `pytest tests/live -q` — 2 passed
- [ ] CI 3 OS matrix

## Follow-up

**G4 live runtime e2e**（真 spawn codex/opencode 在 daemon 跑期间验证自动桥接）—— subagent 额度中断未做。unit test `test_loop_picks_up_new_session_added_after_start` 已覆盖运行时 daemon-thread 自动 pick-up 机制（stub session），真 spawn 版留 follow-up。

🤖 Generated with [Claude Code](https://claude.com/claude-code)