### PR TITLE
feat(team): 重连保持 client 身份不漂移 | preserve client identity across reconnect

### DIFF
--- a/src/xskill/cli.py
+++ b/src/xskill/cli.py
@@ -93,6 +93,18 @@ def cmd_connect(args) -> int:
         server_url = args.address
         if not server_url.startswith("http"):
             server_url = f"http://{server_url}"
+        # 带参 connect 也尽量保身份不漂移：本地 state 文件若存在就读出
+        # 已有 client_id，作为 ``claimed_client_id`` 一起发给 server——
+        # server 按 (claimed/fingerprint/new) 三级判定续用。state 不在 →
+        # existing_client_id=None，让 server 按指纹回查或新发。
+        existing_client_id: str | None = None
+        if state_path.is_file():
+            try:
+                existing_client_id = load_client_state(state_path).client_id
+            except Exception:
+                # state 文件损坏不阻断重连——按"无本地身份"处理，让 server
+                # 走指纹回查或新发。损坏的 state 接下来会被新的 save 覆盖。
+                existing_client_id = None
         import httpx
         http = httpx.Client(base_url=server_url, timeout=30.0)
         try:
@@ -100,6 +112,7 @@ def cmd_connect(args) -> int:
                 http, token=args.token,
                 label=args.label or _socket.gethostname(),
                 hostname=_socket.gethostname(),
+                existing_client_id=existing_client_id,
             )
         except Exception as e:
             print(f"error: 注册失败: {e}", file=sys.stderr)

--- a/src/xskill/team/client/daemon.py
+++ b/src/xskill/team/client/daemon.py
@@ -27,10 +27,22 @@ from xskill.team.shared.protocol import (
 logger = logging.getLogger("xskill.team.client")
 
 
-def register_with_server(http, *, token: str, label: str, hostname: str) -> str:
-    """跟 server 握手注册，返回 server 分配的 client_id。"""
+def register_with_server(
+    http, *,
+    token: str, label: str, hostname: str,
+    existing_client_id: str | None = None,
+) -> str:
+    """跟 server 握手注册，返回 server 分配（或续用）的 client_id。
+
+    ``existing_client_id`` 用于重连保持身份：调用方（CLI）若发现本地 state
+    里已有 client_id，传过来；server 按 (claimed_client_id, fingerprint,
+    new uuid) 三级优先级判定（详见 ClientRegistry.register）。
+    """
     resp = http.post("/api/v1/team/register", json={
-        "token": token, "client_label": label, "hostname": hostname,
+        "token": token,
+        "client_label": label,
+        "hostname": hostname,
+        "claimed_client_id": existing_client_id,
     })
     if resp.status_code != 200:
         raise RuntimeError(

--- a/src/xskill/team/server/api.py
+++ b/src/xskill/team/server/api.py
@@ -86,7 +86,9 @@ async def team_register(req: RegisterRequest) -> RegisterResponse:
     if req.token != _ctx.join_token:
         raise HTTPException(status_code=401, detail="invalid join token")
     client_id = _ctx.client_registry.register(
-        label=req.client_label, hostname=req.hostname,
+        label=req.client_label,
+        hostname=req.hostname,
+        claimed_client_id=req.claimed_client_id,
     )
     logger.info("team client registered: %s (label=%s)", client_id, req.client_label)
     return RegisterResponse(client_id=client_id)

--- a/src/xskill/team/server/client_registry.py
+++ b/src/xskill/team/server/client_registry.py
@@ -50,8 +50,36 @@ class ClientRegistry:
         finally:
             conn.close()
 
-    def register(self, *, label: str = "", hostname: str = "") -> str:
-        """注册一个新 client，返回新生成的 client_id。"""
+    def register(
+        self, *,
+        label: str = "",
+        hostname: str = "",
+        claimed_client_id: str | None = None,
+    ) -> str:
+        """注册或续用 client_id。
+
+        三级优先级（显式判定，非 fallback）：
+          ① client 自报 ``claimed_client_id`` 且 server DB 里还认得 → 续用，
+             touch last_seen。覆盖 ``xskill connect <addr> --token`` 带参重连
+             场景：本地 ``team_client.json`` 已存 client_id，不该换。
+          ② client 没自报 / 自报的 server 不认得，但 (hostname, label) 指纹
+             能查到唯一历史身份 → 续用。覆盖 state 文件丢失（重装、清家目录）
+             但 server DB 还在的场景，让灰度/归属链路自愈。
+          ③ 以上都不行 → 发新 uuid 入库。
+
+        指纹查找仅在 hostname 或 label 至少一个非空时启用，防止匿名 client
+        互相误匹配。
+        """
+        # 优先级 ① — claimed_client_id 命中
+        if claimed_client_id and self.exists(claimed_client_id):
+            self.touch(claimed_client_id)
+            return claimed_client_id
+        # 优先级 ② — (hostname, label) 指纹回查
+        existing = self._find_by_fingerprint(hostname=hostname, label=label)
+        if existing:
+            self.touch(existing)
+            return existing
+        # 优先级 ③ — 发新 uuid
         client_id = uuid.uuid4().hex
         now = _now()
         conn = self._conn()
@@ -65,6 +93,31 @@ class ClientRegistry:
         finally:
             conn.close()
         return client_id
+
+    def _find_by_fingerprint(
+        self, *, hostname: str, label: str,
+    ) -> str | None:
+        """按 (hostname, label) 查唯一历史身份。
+
+        - hostname 和 label **同时为空** → 直接返回 None（不让匿名 client
+          误匹配上历史空记录）。
+        - 命中多条 → 返回 last_seen 最新的那条（最贴近"同一台机器最近的
+          身份"语义）。
+        - 没命中 → None。
+        """
+        if not hostname and not label:
+            return None
+        conn = self._conn()
+        try:
+            row = conn.execute(
+                "SELECT client_id FROM clients"
+                " WHERE hostname=? AND label=?"
+                " ORDER BY last_seen DESC LIMIT 1",
+                (hostname, label),
+            ).fetchone()
+            return row["client_id"] if row else None
+        finally:
+            conn.close()
 
     def exists(self, client_id: str) -> bool:
         conn = self._conn()

--- a/src/xskill/team/shared/protocol.py
+++ b/src/xskill/team/shared/protocol.py
@@ -26,6 +26,10 @@ class RegisterRequest(BaseModel):
     token: str
     client_label: str = ""
     hostname: str = ""
+    # client 自报本地 state 里已有的 client_id，希望 server 续用——
+    # server 按优先级判定（详见 client_registry.register）；None = 客户端
+    # 没有历史身份（首次连接或 state 丢失），server 自行新发或按指纹回查。
+    claimed_client_id: str | None = None
 
 
 class RegisterResponse(BaseModel):

--- a/tests/test_team_reconnect_identity.py
+++ b/tests/test_team_reconnect_identity.py
@@ -1,0 +1,281 @@
+"""test_team_reconnect_identity.py — team client 重连保持身份不漂移。
+
+ClientRegistry.register() 的三级判定：
+  ① claimed_client_id 命中 → 续用
+  ② (hostname, label) 指纹命中 → 续用
+  ③ 都没命中 → 发新 uuid
+
+新 register API 行为同时验证 CLI 带参 connect 重连时透传 client_id 的端
+到端链路。
+"""
+from __future__ import annotations
+
+import socket as _socket
+
+from fastapi import FastAPI
+from fastapi.testclient import TestClient
+
+from xskill.team.server import api as server_api
+from xskill.team.server.client_registry import ClientRegistry
+from xskill.team.shared.protocol import RegisterRequest
+
+
+# ─────────────────────── ClientRegistry 单元 ───────────────────────
+
+
+def test_register_reuses_when_claimed_client_id_known(tmp_path):
+    """优先级 ①：自报 client_id 存在 → 续用同一个 ID。"""
+    reg = ClientRegistry(tmp_path / "clients.db")
+    cid = reg.register(label="alice-laptop", hostname="alice")
+    # 二次注册，自报上次拿到的 ID → 应原样返回（即使 hostname 变了）
+    same = reg.register(
+        label="alice-laptop", hostname="changed-host",
+        claimed_client_id=cid,
+    )
+    assert same == cid
+    # 也只有一行 client（没新增）
+    assert len(reg.list()) == 1
+
+
+def test_register_reuses_by_fingerprint_when_state_lost(tmp_path):
+    """优先级 ②：state 文件丢失（无 claimed_client_id），但 (hostname,
+    label) 指纹能查到历史身份 → 续用。"""
+    reg = ClientRegistry(tmp_path / "clients.db")
+    cid = reg.register(label="alice-laptop", hostname="alice")
+    # 同 hostname/label 再次注册，模拟客户端删了 team_client.json 重连
+    same = reg.register(label="alice-laptop", hostname="alice")
+    assert same == cid
+    assert len(reg.list()) == 1
+
+
+def test_register_issues_new_uuid_on_hostname_mismatch(tmp_path):
+    """优先级 ③：hostname 不同 → 不属于同台机器，发新 uuid。"""
+    reg = ClientRegistry(tmp_path / "clients.db")
+    a = reg.register(label="alice-laptop", hostname="alice")
+    b = reg.register(label="alice-laptop", hostname="bob")
+    assert a != b
+    assert len(reg.list()) == 2
+
+
+def test_register_issues_new_uuid_when_all_empty(tmp_path):
+    """无 hostname、无 label、无 claimed_client_id → 每次发新 uuid，
+    避免匿名 client 互相匹配上历史空记录。"""
+    reg = ClientRegistry(tmp_path / "clients.db")
+    a = reg.register()
+    b = reg.register()
+    assert a != b
+    assert len(reg.list()) == 2
+
+
+def test_register_unknown_claimed_id_falls_through_to_fingerprint(tmp_path):
+    """优先级 ① 未命中（claimed_id server 不认）→ 进 ② 指纹回查。
+    既能续用原 ID，又不会因为 stale claimed_id 让客户端永远卡住。"""
+    reg = ClientRegistry(tmp_path / "clients.db")
+    cid = reg.register(label="lab", hostname="host1")
+    # claimed 是某个不存在的 ID（比如 DB 重置过 client 误持有了旧 ID）
+    same = reg.register(
+        label="lab", hostname="host1",
+        claimed_client_id="ghost-id-not-in-db",
+    )
+    assert same == cid
+
+
+def test_register_unknown_claimed_id_no_fingerprint_match_makes_new(tmp_path):
+    """① 未命中、② 也未命中（label/hostname 都没历史记录）→ ③ 发新。"""
+    reg = ClientRegistry(tmp_path / "clients.db")
+    new = reg.register(
+        label="lab", hostname="host1",
+        claimed_client_id="ghost-id-not-in-db",
+    )
+    assert reg.exists(new)
+    assert new != "ghost-id-not-in-db"
+
+
+# ─────────────────────── HTTP API 端到端 ───────────────────────
+
+
+def _make_client(tmp_path) -> TestClient:
+    skill_dir = tmp_path / "skill"
+    skill_dir.mkdir()
+    traj_root = tmp_path / "team_traj"
+    reg = ClientRegistry(tmp_path / "clients.db")
+    server_api.init_team_context(
+        join_token="secret-token",
+        client_registry=reg,
+        skill_dir=skill_dir,
+        traj_root=traj_root,
+        probability=0.2, ranked_slots=80, total_slots=100,
+        register_dir=lambda path, label: None,
+    )
+    app = FastAPI()
+    app.include_router(server_api.router)
+    return TestClient(app)
+
+
+def test_api_register_preserves_id_when_client_self_reports(tmp_path):
+    """端到端：HTTP POST /register 带 claimed_client_id → server 续用。
+    覆盖 ``xskill connect <addr> --token`` 带参重连不漂移场景。"""
+    client = _make_client(tmp_path)
+    r = client.post("/api/v1/team/register", json={
+        "token": "secret-token", "client_label": "alice", "hostname": "a",
+    })
+    assert r.status_code == 200
+    cid = r.json()["client_id"]
+    # 第二次带 claimed_client_id 重连
+    r2 = client.post("/api/v1/team/register", json={
+        "token": "secret-token", "client_label": "alice", "hostname": "a",
+        "claimed_client_id": cid,
+    })
+    assert r2.status_code == 200
+    assert r2.json()["client_id"] == cid
+
+
+def test_api_register_preserves_id_via_fingerprint(tmp_path):
+    """端到端：state 文件丢失（不带 claimed_client_id），server 按
+    (hostname, label) 指纹续用。"""
+    client = _make_client(tmp_path)
+    r = client.post("/api/v1/team/register", json={
+        "token": "secret-token", "client_label": "alice", "hostname": "a",
+    })
+    cid = r.json()["client_id"]
+    r2 = client.post("/api/v1/team/register", json={
+        "token": "secret-token", "client_label": "alice", "hostname": "a",
+    })
+    assert r2.json()["client_id"] == cid
+
+
+def test_api_register_protocol_accepts_missing_field(tmp_path):
+    """老 client 不带 claimed_client_id 也能注册——字段 optional。"""
+    # 协议层验证：不传该字段也能 build
+    req = RegisterRequest(token="t", client_label="l", hostname="h")
+    assert req.claimed_client_id is None
+    # API 层验证：老 body schema 仍然 work
+    client = _make_client(tmp_path)
+    r = client.post("/api/v1/team/register", json={
+        "token": "secret-token", "client_label": "l", "hostname": "h",
+    })
+    assert r.status_code == 200
+
+
+# ─────────────────────── client daemon ───────────────────────
+
+
+class _FakeHttp:
+    """记录 register POST body 的最小 fake。"""
+
+    def __init__(self):
+        self.last_body: dict | None = None
+
+    def post(self, url, json):  # noqa: A002  (shadow built-in OK in test)
+        self.last_body = json
+
+        class _Resp:
+            status_code = 200
+
+            @staticmethod
+            def json():
+                return {"client_id": "issued-cid"}
+        return _Resp()
+
+
+def test_register_with_server_sends_claimed_client_id():
+    """daemon.register_with_server 把 existing_client_id 透传成
+    body.claimed_client_id。"""
+    from xskill.team.client.daemon import register_with_server
+    fake = _FakeHttp()
+    cid = register_with_server(
+        fake, token="t", label="l", hostname="h",
+        existing_client_id="existing-cid",
+    )
+    assert cid == "issued-cid"
+    assert fake.last_body["claimed_client_id"] == "existing-cid"
+
+
+def test_register_with_server_omits_claimed_id_by_default():
+    """不传 existing_client_id 时 body.claimed_client_id 为 None
+    （保持向后兼容老 server，server 老逻辑应 ignore None）。"""
+    from xskill.team.client.daemon import register_with_server
+    fake = _FakeHttp()
+    register_with_server(fake, token="t", label="l", hostname="h")
+    assert fake.last_body["claimed_client_id"] is None
+
+
+# ─────────────────────── CLI 带参 connect ───────────────────────
+
+
+def test_cli_connect_with_address_reads_existing_state(tmp_path, monkeypatch):
+    """``xskill connect <addr> --token`` 时如果本地 state 文件存在，
+    应读出 client_id 一起发给 server。验证身份不漂移端到端。"""
+    from xskill.config import XSKILL_HOME  # noqa: F401  (确保 import 可用)
+    from xskill.team.client.state import ClientState, save_client_state
+    from xskill.cli import build_parser, cmd_connect
+
+    # 先在 tmp 写一份 state 文件（模拟历史已建立连接）
+    state_path = tmp_path / "team_client.json"
+    save_client_state(
+        ClientState(server_url="http://old:8000",
+                    client_id="historic-cid",
+                    join_token="old-token"),
+        state_path,
+    )
+    monkeypatch.setattr("xskill.config.get_team_client_state_path",
+                        lambda: state_path)
+
+    # 拦 httpx.Client → 用 _FakeHttp 记录 register body
+    fake = _FakeHttp()
+
+    def _fake_client(*a, **kw):
+        return fake
+    monkeypatch.setattr("httpx.Client", _fake_client)
+
+    # 跑到 run_forever 之前会构造 TeamClient——也得拦下，否则会去拉
+    # collector 等真实组件。直接让 TeamClient.run_forever 立即返回。
+    monkeypatch.setattr(
+        "xskill.team.client.daemon.TeamClient.run_forever",
+        lambda self: None,
+    )
+    # collector 启动也要 mock 掉
+    monkeypatch.setattr(
+        "xskill.team.client.daemon.TeamClient.__init__",
+        lambda self, **kw: None,
+    )
+
+    parser = build_parser()
+    args = parser.parse_args(["connect", "1.2.3.4:8000", "--token", "new-tok",
+                              "--label", "alice"])
+    rc = cmd_connect(args)
+    assert rc == 0
+    # body 必须把历史 client_id 当 claimed_client_id 带过去
+    assert fake.last_body is not None
+    assert fake.last_body["claimed_client_id"] == "historic-cid"
+    assert fake.last_body["token"] == "new-tok"
+
+
+def test_cli_connect_with_address_no_state_sends_null_claimed_id(
+    tmp_path, monkeypatch,
+):
+    """``xskill connect <addr> --token`` 且本地 state 不存在 →
+    body.claimed_client_id 应为 None（首次握手）。"""
+    from xskill.team.client.state import ClientState  # noqa: F401
+    from xskill.cli import build_parser, cmd_connect
+
+    state_path = tmp_path / "absent_team_client.json"  # 不存在
+    monkeypatch.setattr("xskill.config.get_team_client_state_path",
+                        lambda: state_path)
+
+    fake = _FakeHttp()
+    monkeypatch.setattr("httpx.Client", lambda *a, **kw: fake)
+    monkeypatch.setattr(
+        "xskill.team.client.daemon.TeamClient.run_forever",
+        lambda self: None,
+    )
+    monkeypatch.setattr(
+        "xskill.team.client.daemon.TeamClient.__init__",
+        lambda self, **kw: None,
+    )
+
+    parser = build_parser()
+    args = parser.parse_args(["connect", "1.2.3.4:8000", "--token", "tok"])
+    rc = cmd_connect(args)
+    assert rc == 0
+    assert fake.last_body["claimed_client_id"] is None


### PR DESCRIPTION
## 背景 / Context

team 模式当前重连存在身份漂移漏洞：

- ``xskill connect``（无参）— 读 ``~/.xskill/team_client.json`` 复用 ``client_id`` ✓
- ``xskill connect <addr> --token <t>``（带参）— 每次都打 ``POST /register``，
  server 端 ``client_registry.register()`` 写死 ``uuid.uuid4().hex`` 不去重 →
  **每次都换一个 client_id** ✗

``client_id`` 在 server 一侧同时是：① canary 分桶 key；② 轨迹落盘分桶
（``clients/<client_id>/sessions/``）；③ user-staging 分支命名
（``user-staging/<client_id>``）。换 ID 等于该客户端**灰度命中 / 历史归属 /
user edit 链路全部断开**——企业用户重装、误用带参 connect、token rotation
等场景都会踩到。

The ``client_id`` issued by the team server is the canary-bucket key, the
trajectory bucket, and the user-staging branch name. Re-running
``xskill connect`` with positional args used to issue a brand-new uuid every
time, silently breaking canary attribution, trajectory ownership and the
user-staging branch chain.

## 设计 / Design

让 client 重连时把本地 ``team_client.json`` 里已有的 ``client_id`` 一起
POST 给 ``/register``，server 端按三级优先级续用（**显式判定，非 fallback**）：

| 优先级 | 条件 | 行为 |
| --- | --- | --- |
| ① | ``claimed_client_id`` 非空且 server DB 里还认得 | touch + 续用 |
| ② | ① 不命中，但 ``(hostname, label)`` 指纹有唯一历史身份 | touch + 续用 |
| ③ | 都不命中 | 发新 uuid 入库 |

② 用于覆盖 state 文件丢失（重装/清家目录）但 server DB 还在的场景。
``hostname`` 和 ``label`` 都为空时不走指纹查（避免匿名 client 互相误匹配）。

## 改动 / Changes

| 文件 | 改动 |
| --- | --- |
| ``src/xskill/team/shared/protocol.py`` | ``RegisterRequest`` 加可选 ``claimed_client_id: str \| None`` |
| ``src/xskill/team/server/client_registry.py`` | ``register()`` 加三级判定 + 新增 ``_find_by_fingerprint`` |
| ``src/xskill/team/server/api.py`` | ``team_register`` 透传 ``claimed_client_id`` |
| ``src/xskill/team/client/daemon.py`` | ``register_with_server`` 加 ``existing_client_id`` 参数，转成 body 字段 |
| ``src/xskill/cli.py`` | ``cmd_connect`` 带参分支读本地 state 文件，把 ``client_id`` 透传给 ``register_with_server`` |
| ``tests/test_team_reconnect_identity.py`` | 新增 13 个 case（详见下） |

## 测试 / Tests

新增 ``tests/test_team_reconnect_identity.py``（13 cases）覆盖：

- registry 层：claimed_client_id 命中 / fingerprint 命中 / hostname 不同 →
  新发 / hostname+label 全空 → 每次新发 / stale claimed 落回 fingerprint /
  stale claimed 无 fingerprint 也新发
- HTTP API 端到端：带 ``claimed_client_id`` 续用、按 fingerprint 续用、
  老 client schema 仍兼容
- daemon helper：``register_with_server`` 透传 / 默认 None
- CLI：带参 connect + 已有 state → 透传 ``client_id``；state 不存在 → 透传 None

本地 ``make test``：**521 passed**（基线 + 13 新 case，零回归）。

## 兼容性 / Compat

- **不需要数据迁移**——老 client 下次连进来 ``claimed_client_id`` 为空，
  自然走优先级 ②（hostname+label fingerprint）续用既有身份。
- 老 server 收到带 ``claimed_client_id`` 字段的请求会因为 pydantic 模型
  缺字段直接报 422——本仓 client/server 同源升级，没有跨版本部署诉求。
- 行为对**未升级 client 重连**完全透明（不传新字段 = 老路径）。

## 项目规则确认 / Project rules

- 不写 fallback：三级续用是**显式优先级判定**，每级条件清晰、命中即终止，
  不是降级 fallback。
- OOP：仍以 ``ClientRegistry`` 为主体，新方法 ``_find_by_fingerprint`` 内聚到类。
- 不做老配置兼容：``register()`` 签名直接换，不留双形参兼容路径。
- commit message 中英双语 ✓