### PR TITLE
feat(cli): 加 -v / --version 标志 | add -v / --version flag with single-source __version__

### DIFF
--- a/src/xskill/cli.py
+++ b/src/xskill/cli.py
@@ -16,6 +16,7 @@ import argparse
 import logging
 import sys
 
+from xskill import __version__
 from xskill.config import set_overrides
 
 
@@ -177,6 +178,14 @@ def build_parser() -> argparse.ArgumentParser:
     p = argparse.ArgumentParser(
         prog="xskill",
         description="xskill — distill reusable Skills from AI Agent trajectories",
+    )
+    # -v / --version 唯一从 xskill.__version__ 读取，而 __version__ 在
+    # src/xskill/__init__.py 里只 import 自 setuptools_scm 写出的 _version.py
+    # —— 即 git tag 是单一真源，不在任何代码里硬编。
+    p.add_argument(
+        "-v", "--version",
+        action="version",
+        version=f"xskill {__version__}",
     )
     p.add_argument("--debug", action="store_true", help="verbose logging")
     p.add_argument("--quiet", action="store_true", help="quiet mode")

--- a/tests/test_cli_version.py
+++ b/tests/test_cli_version.py
@@ -1,0 +1,26 @@
+"""
+test_cli_version.py — `xskill -v` / `xskill --version` 烟测
+
+确认：
+1. 两个 flag 都触发 argparse 的 version action 并以 SystemExit(0) 退出
+2. 打印的版本字符串严格等于 ``xskill <__version__>``——即不在 cli.py 里
+   硬编版本，单一真源在 setuptools_scm 写出的 ``_version.py``
+"""
+from __future__ import annotations
+
+import pytest
+
+from xskill import __version__
+from xskill.cli import build_parser
+
+
+@pytest.mark.parametrize("flag", ["-v", "--version"])
+def test_version_flag_prints_and_exits(flag, capsys):
+    parser = build_parser()
+    with pytest.raises(SystemExit) as exc_info:
+        parser.parse_args([flag])
+    # argparse `action="version"` 用 SystemExit(0) 表示成功打印后退出
+    assert exc_info.value.code == 0
+    captured = capsys.readouterr()
+    # version 走 stdout（argparse 行为）
+    assert captured.out.strip() == f"xskill {__version__}"


### PR DESCRIPTION
## 改动 / Change

加 `xskill -v` 和 `xskill --version`，输出 `xskill <版本号>`。

Adds `xskill -v` and `xskill --version` flags that print `xskill <version>`.

## 单一真源 / Single Source of Truth

| 环节 | 读取来源 |
|---|---|
| `xskill -v` / `--version` | `xskill.__version__` ← **本 PR 新接入** |
| `/api/v1/health` 的 `version` 字段 | `xskill.__version__` ← 早就接入 |
| build/whl 的 metadata version | setuptools_scm 派生 |
| `xskill.__version__` 自身 | `from xskill._version import __version__`（setuptools_scm 写出的文件）|
| setuptools_scm 派生 | git tag `vX.Y.Z` |

整条链一直追到 **git tag**，没有任何中间节点硬编版本号。这次新加的 `cli.py` 也直接 `from xskill import __version__`，不在 CLI 里二次定义版本字符串。

## 测试 / Tests

`tests/test_cli_version.py` 烟测两个 flag：
- 都触发 argparse 的 `action='version'` 走 `SystemExit(0)`
- 输出严格等于 `xskill {__version__}`（任何 cli.py 内的硬编漂移都会被测试卡住）

Smoke test asserts both flags exit cleanly with output strictly equal to `xskill {__version__}` — any future hardcoded drift in cli.py will be caught.

## 输出示例 / Sample output

```bash
$ xskill --version
xskill 0.5.1a2

$ xskill -v
xskill 0.5.1a2
```

源码树 checkout 未 build 时（无 `_version.py`）输出 `xskill 0.0.0+unknown`——fallback 已经在 `__init__.py` 里写明。