### PR TITLE
feat(pipeline): 过滤无效 trajectory 入流水线 | filter invalid trajectories be…

### DIFF
--- a/src/xskill/api/sse.py
+++ b/src/xskill/api/sse.py
@@ -145,6 +145,7 @@ async def api_index(req: IndexRequest):
         try:
             from xskill.pipeline.atom import AtomTaskStore
             from xskill.agents.task_agent import TaskAgent
+            from xskill.pipeline.trajectory import validate_trajectory_source
 
             config = load_config()
             log_fn = make_sse_log(queue)
@@ -181,6 +182,18 @@ async def api_index(req: IndexRequest):
 
             agent = TaskAgent(llm=llm, store=store)
             for idx, md in enumerate(md_files, 1):
+                validation = validate_trajectory_source(md)
+                if not validation.valid:
+                    log_fn(
+                        f"[{idx}/{total}] {md.name} filtered: {validation.reason}",
+                        "step",
+                    )
+                    _push(queue, "progress", {
+                        "step": "拆分 AtomTask",
+                        "current": idx,
+                        "total": total,
+                    })
+                    continue
                 try:
                     atoms = agent.run(traj_id=md.stem, traj_path=md)
                     log_fn(f"[{idx}/{total}] {md.name} -> {len(atoms)} atoms", "step")
@@ -234,6 +247,7 @@ async def api_process(req: ProcessRequest):
             from xskill.pipeline.atom import AtomTaskStore
             from xskill.agents.task_agent import TaskAgent
             from xskill.pipeline.runner import process_atom_task
+            from xskill.pipeline.trajectory import validate_trajectory_source
             from xskill.agents.agno_factory import make_default_factory
             from xskill.skill.git import ensure_repo
 
@@ -243,6 +257,14 @@ async def api_process(req: ProcessRequest):
             traj_path = Path(req.traj_path)
             if not traj_path.is_file():
                 _fail(queue, f"traj file not found: {traj_path}")
+                return
+            validation = validate_trajectory_source(traj_path)
+            if not validation.valid:
+                _finish(queue, {
+                    "status": "filtered",
+                    "traj": traj_path.name,
+                    "reason": validation.reason,
+                })
                 return
 
             _push(queue, "progress", {
@@ -322,6 +344,7 @@ async def api_batch(req: BatchRequest):
             from xskill.pipeline.atom import AtomTaskStore
             from xskill.agents.task_agent import TaskAgent
             from xskill.pipeline.runner import process_atom_task
+            from xskill.pipeline.trajectory import validate_trajectory_source
             from xskill.agents.agno_factory import make_default_factory
             from xskill.skill.git import ensure_repo
 
@@ -359,6 +382,13 @@ async def api_batch(req: BatchRequest):
 
             # Phase 1: 整批拆 atom + 重建索引
             for idx, md in enumerate(md_files, 1):
+                validation = validate_trajectory_source(md)
+                if not validation.valid:
+                    log_fn(
+                        f"[{idx}/{total}] filtered: {md.name}: {validation.reason}",
+                        "step",
+                    )
+                    continue
                 try:
                     atoms = TaskAgent(llm=llm, store=store).run(
                         traj_id=md.stem, traj_path=md,

--- a/src/xskill/pipeline/runner.py
+++ b/src/xskill/pipeline/runner.py
@@ -43,6 +43,7 @@ from xskill.pipeline.registry import (
     increment_retry,
 )
 from xskill.pipeline.trajectory import parse_traj_header
+from xskill.pipeline.trajectory import validate_trajectory_source
 
 logger = logging.getLogger("xskill.watcher")
 
@@ -648,6 +649,18 @@ class DirectoryWatcher:
             ):
                 if self._too_many_in_flight():
                     break
+                validation = validate_trajectory_source(dir_path / fname)
+                if not validation.valid:
+                    update_traj_status(
+                        wd_id, fname, "filtered",
+                        error_msg=validation.reason or "invalid_trajectory",
+                        **kw,
+                    )
+                    logger.info(
+                        "%s filtered before split: %s",
+                        fname, validation.reason,
+                    )
+                    continue
                 update_traj_status(wd_id, fname, "splitting", **kw)
                 fut = self._pool.submit(self._do_split, dir_path, fname)
                 self._futures[fut] = {"wd_id": wd_id, "fname": fname, "stage": "split"}
@@ -753,8 +766,12 @@ class DirectoryWatcher:
         """跑 TaskAgent 拆 AtomTask。返回 (fname, num_atoms_added, last_offset, last_atom_id, err)。"""
         from xskill.agents.task_agent import TaskAgent
         md_path = dir_path / fname
-        if not md_path.is_file():
-            return (fname, 0, 0, None, "file not found")
+        validation = validate_trajectory_source(md_path)
+        if not validation.valid:
+            return (
+                fname, 0, 0, None,
+                validation.reason or "invalid_trajectory",
+            )
         traj_id = md_path.stem
         store = self._store_for(dir_path)
         atoms = TaskAgent(llm=self.llm, store=store).run(

--- a/src/xskill/pipeline/trajectory.py
+++ b/src/xskill/pipeline/trajectory.py
@@ -17,6 +17,7 @@ from __future__ import annotations
 
 import json
 import re
+from dataclasses import dataclass
 from pathlib import Path
 from typing import TYPE_CHECKING, Optional
 
@@ -102,6 +103,124 @@ class Trajectory:
 
     def __repr__(self) -> str:
         return f"Trajectory({self.path.name})"
+
+
+# =============================================================================
+# 轨迹入口有效性校验
+# =============================================================================
+
+_USER_HEADER_RE = re.compile(r"^##\s+User\b", re.IGNORECASE)
+_SECTION_HEADER_RE = re.compile(r"^##\s+\S+")
+
+
+@dataclass(frozen=True)
+class TrajectoryValidation:
+    """标准 ``traj_*.md`` 文件进入 AtomTask 流水线前的校验结果。"""
+
+    valid: bool
+    reason: str | None = None
+    detail: str = ""
+    user_intent_count: int = 0
+
+
+def _read_trajectory_text(path: Path) -> tuple[str | None, str | None]:
+    try:
+        raw = path.read_bytes()
+    except OSError as e:
+        return None, f"{type(e).__name__}: {e}"
+    if raw == b"":
+        return "", None
+    try:
+        return raw.decode("utf-8"), None
+    except UnicodeDecodeError as e:
+        return None, f"{type(e).__name__}: {e}"
+
+
+def _extract_user_sections(md_text: str) -> tuple[list[str], bool]:
+    """从标准化 trajectory markdown 中提取 ``## User`` 段落正文。
+
+    返回 ``(sections, has_malformed_user_header)``。TaskAgent 只认可
+    ``## User`` 标题作为切分信号，因此这里使用同一类信号做入口判定。
+    """
+    sections: list[str] = []
+    current: list[str] | None = None
+    malformed_user_header = False
+
+    for line in md_text.splitlines(keepends=True):
+        stripped = line.strip()
+        if _SECTION_HEADER_RE.match(stripped):
+            if current is not None:
+                sections.append("".join(current))
+                current = None
+            if _USER_HEADER_RE.match(stripped):
+                current = []
+            elif stripped.lower().startswith("## user"):
+                malformed_user_header = True
+            continue
+        if current is not None:
+            current.append(line)
+
+    if current is not None:
+        sections.append("".join(current))
+    return sections, malformed_user_header
+
+
+def validate_trajectory_source(path: str | Path) -> TrajectoryValidation:
+    """校验 trajectory 是否可进入 Atom 拆分/索引/候选池流程。
+
+    该函数只检查已经标准化落盘的 ``traj_*.md``。不同 agent 的原生格式
+    先由各 adapter 转成统一 markdown，再走这里，从而避免每个来源各写一套
+    空轨迹判断。
+    """
+    p = Path(path)
+    if not p.is_file():
+        return TrajectoryValidation(
+            valid=False,
+            reason="unreadable_source",
+            detail=f"trajectory file not found: {p}",
+        )
+
+    text, read_error = _read_trajectory_text(p)
+    if read_error is not None:
+        return TrajectoryValidation(
+            valid=False,
+            reason="unreadable_source",
+            detail=read_error,
+        )
+    assert text is not None
+    if text == "":
+        return TrajectoryValidation(
+            valid=False,
+            reason="empty_content",
+            detail="trajectory file is empty",
+        )
+    if not text.strip():
+        return TrajectoryValidation(
+            valid=False,
+            reason="whitespace_only",
+            detail="trajectory file contains only whitespace",
+        )
+
+    sections, malformed_user_header = _extract_user_sections(text)
+    if malformed_user_header:
+        return TrajectoryValidation(
+            valid=False,
+            reason="malformed_trajectory",
+            detail="malformed user section header",
+        )
+
+    non_empty_user_sections = [s for s in sections if s.strip()]
+    if not non_empty_user_sections:
+        return TrajectoryValidation(
+            valid=False,
+            reason="no_user_intent",
+            detail="no non-empty ## User section found",
+        )
+
+    return TrajectoryValidation(
+        valid=True,
+        user_intent_count=len(non_empty_user_sections),
+    )
 
 
 # =============================================================================


### PR DESCRIPTION
在标准化后的 `traj_*.md` 进入 AtomTask 流程前增加入口校验。
过滤不可读、空文件、纯空白、格式异常、缺少有效 `## User` 意图的轨迹文件。
在 SSE index/process/batch 流程和 `DirectoryWatcher` 中统一应用该过滤逻辑。
该改动避免无效 trajectory 进入 AtomTask 拆分、索引、候选池生成和 skill edit 流程。
