### PR TITLE
fix: replace invalid DeepSeek embedding defaults with working providers

### DIFF
--- a/README.md
+++ b/README.md
@@ -49,8 +49,12 @@ llm:
   api_key:  YOUR_KEY
 
 embedding:
-  base_url: https://api.deepseek.com
-  model:    deepseek-embedding
+  # DeepSeek does NOT provide embeddings. Alternatives:
+  # Alibaba DashScope:  base_url=https://dashscope.aliyuncs.com/compatible-mode/v1  model=text-embedding-v4
+  # OpenAI:             base_url=https://api.openai.com/v1                          model=text-embedding-3-small
+  # Ollama (local):     base_url=http://localhost:11434/v1                          model=nomic-embed-text
+  base_url: https://dashscope.aliyuncs.com/compatible-mode/v1
+  model:    text-embedding-v4
   api_key:  YOUR_KEY
   dim:      0
 ```

--- a/src/xskill/config.py
+++ b/src/xskill/config.py
@@ -63,9 +63,15 @@ llm:
 
 # ===== Embedding (vector retrieval) =====
 # Any OpenAI-compatible embeddings endpoint. dim: 0 auto-probes on first call.
+#
+# DeepSeek does NOT provide an embeddings API. Choose one of these:
+#   • Alibaba DashScope:  base_url=https://dashscope.aliyuncs.com/compatible-mode/v1  model=text-embedding-v4
+#   • OpenAI:             base_url=https://api.openai.com/v1                          model=text-embedding-3-small
+#   • Ollama (local):     base_url=http://localhost:11434/v1                          model=nomic-embed-text
+#   • Jina AI:            base_url=https://api.jina.ai/v1                             model=jina-embeddings-v3
 embedding:
-  base_url: https://api.deepseek.com
-  model:    deepseek-embedding
+  base_url: https://dashscope.aliyuncs.com/compatible-mode/v1
+  model:    text-embedding-v4
   api_key:  PUT_YOUR_EMBEDDING_API_KEY_HERE
   dim:      0
   # api: openai | multimodal   # optional; default openai. "multimodal" for


### PR DESCRIPTION
## Problem

DeepSeek API does **not** provide an `/embeddings` endpoint. This is confirmed by:
- [Official DeepSeek API docs](https://api-docs.deepseek.com) — no embeddings listed
- [Community issue deepseek-ai/DeepSeek-R1#802](https://github.com/deepseek-ai/DeepSeek-R1/issues/802) — feature requested but not implemented

The current default config template and README both point to `api.deepseek.com` for embeddings, which causes a **404 error** on first run:

```
httpx.HTTPStatusError: Client error '404 Not Found' for url 'https://api.deepseek.com/embeddings'
```

Users hit this immediately after `pip install xskill && xskill serve` — not a good first experience.

## Changes

### `src/xskill/config.py` CONFIG_TEMPLATE
- Switch embedding default from `api.deepseek.com` / `deepseek-embedding` to **Alibaba DashScope** (`dashscope.aliyuncs.com/compatible-mode/v1`) / `text-embedding-v4`
- Add comment listing 4 verified alternatives: DashScope, OpenAI, Ollama (local), Jina AI
- Include `base_url` + `model` for each so users can copy-paste

### `README.md`
- Update 'Get started' code block: same fix as config template
- Add inline comments noting DeepSeek lacks embeddings and listing alternatives

## Alternatives considered

- **OpenAI as default**: widely known but requires separate API key; DashScope is more accessible to Chinese users who already use DeepSeek for LLM
- **Ollama as default**: free and local, but requires extra install step (`ollama pull`)
- **Blank template**: would force every user to research providers themselves

DashScope was chosen as the default because it has the lowest barrier for the existing user base (many DeepSeek users also have Alibaba Cloud accounts).

## Testing

- [x] `xskill serve` starts successfully with DashScope embeddings
- [x] Embedding dimension auto-probe returns `dim=1024`
- [x] Atom splitting and skill routing work end-to-end