### PR TITLE
feat: LLM 成本统计 + 用户模型贯穿 + 模型分桶灰度 | usage/cost + model end-to-end + model-scoped canary (#43)

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -1,6 +1,9 @@
 # 数据文件（大量轨迹 md/json/meta/pkl）
 data/
 data_bak/
+# 例外：打包数据(vendored 价格表),必须随包发布
+!src/xskill/data/
+!src/xskill/data/model_prices.json
 
 # 生成的 skill 仓库（有自己的 git）
 skill/

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -63,6 +63,9 @@ xskill = "xskill.cli:main"
 [tool.setuptools]
 include-package-data = true
 
+[tool.setuptools.package-data]
+xskill = ["data/*.json"]   # vendored 价格表(Issue #43),随 wheel 发布
+
 [tool.setuptools.packages.find]
 where = ["src"]
 

--- a/scripts/backfill_server_source_model.py
+++ b/scripts/backfill_server_source_model.py
@@ -1,0 +1,140 @@
+#!/usr/bin/env python3.11
+"""存量回填:把 C/S server 上历史轨迹的 user agent 模型补齐(Issue #43 关联)。
+
+背景:server 端历史轨迹(team upload 落的)只有 ``traj_*.md``,没有 model——
+因为上传协议早先不带 model。增量已由 "上传带 model" 修复;本脚本只管**存量**。
+
+关键约束(用户明确要求):**绝不触发全量 DB 重建**。
+- discover 对"已在 registry 里的行"只更 mtime、**不重读 sidecar、不重处理**,
+  所以光写 ``.json`` 对存量无效 → 必须**直接 UPDATE source_model 一列**。
+- 写 ``.json`` + UPDATE 一列,都不碰 status/has_meta/has_embedding/.md mtime,
+  pipeline 重处理是靠这些触发的 → **零重建**,纯外科手术。
+- 写 ``.json`` 的意义:给未来万一的全量 reindex 留文件源(source-of-truth)。
+
+两段式(因为 model 在 host 的本机 sidecar,数据在容器里):
+  1. ``export``  (host 跑):扫 ~/.xskill/*_sessions/traj_*.json 建 traj_id→model
+                 映射,导出小 JSON。
+  2. ``apply``   (容器内跑):读映射,遍历 team_trajectories/clients/*/sessions/
+                 traj_*.md,命中的写 {stem}.json + 直接 UPDATE registry。幂等。
+
+用法:
+  # host:
+  python3.11 scripts/backfill_server_source_model.py export --out /tmp/model_map.json
+  docker cp /tmp/model_map.json xskill-server:/tmp/model_map.json
+  docker cp scripts/backfill_server_source_model.py xskill-server:/tmp/bf.py
+  # 容器内(先 dry-run 看命中,再正式跑):
+  docker exec xskill-server python3.11 /tmp/bf.py apply --map /tmp/model_map.json --dry-run
+  docker exec xskill-server python3.11 /tmp/bf.py apply --map /tmp/model_map.json
+"""
+from __future__ import annotations
+
+import argparse
+import json
+import sqlite3
+import sys
+from pathlib import Path
+
+LIVE_DIRS = ["cc_sessions", "codex_sessions", "opencode_sessions", "ngagent_sessions"]
+
+
+def cmd_export(args: argparse.Namespace) -> int:
+    """host 侧:本机 sidecar → {traj_id: model} 映射。"""
+    xs = Path(args.xskill_home).expanduser()
+    mapping: dict[str, str] = {}
+    for eco in LIVE_DIRS:
+        d = xs / eco
+        if not d.is_dir():
+            continue
+        for jf in sorted(d.glob("traj_*.json")):
+            try:
+                model = json.loads(jf.read_text(encoding="utf-8")).get("model")
+            except (OSError, json.JSONDecodeError):
+                continue
+            if model:
+                mapping[jf.stem] = str(model)
+    out = Path(args.out)
+    out.write_text(json.dumps(mapping, ensure_ascii=False, indent=2), encoding="utf-8")
+    print(f"[export] {len(mapping)} traj_id→model 写入 {out}")
+    return 0
+
+
+def _ensure_column(reg: sqlite3.Connection) -> None:
+    """幂等保证 source_model 列存在(新代码启动时已迁移,这里兜底)。"""
+    try:
+        reg.execute("ALTER TABLE trajectories ADD COLUMN source_model TEXT")
+    except sqlite3.OperationalError:
+        pass   # 列已存在
+
+
+def cmd_apply(args: argparse.Namespace) -> int:
+    """容器侧:写 json sidecar + 直接 UPDATE registry,零重建。"""
+    mapping: dict[str, str] = json.loads(Path(args.map).read_text(encoding="utf-8"))
+    traj_root = Path(args.traj_root)
+    sessions = sorted(traj_root.glob("clients/*/sessions"))
+    reg_path = Path(args.registry)
+    reg = sqlite3.connect(reg_path) if reg_path.is_file() else None
+    if reg is not None and not args.dry_run:
+        _ensure_column(reg)
+
+    hit = miss = wrote_json = updated = 0
+    for sess in sessions:
+        for md in sorted(sess.glob("traj_*.md")):
+            model = mapping.get(md.stem)
+            if not model:
+                miss += 1
+                continue
+            hit += 1
+            jp = md.with_suffix(".json")
+            already = jp.is_file() and _json_model(jp) == model
+            if not args.dry_run and not already:
+                jp.write_text(json.dumps({"model": model}, ensure_ascii=False),
+                              encoding="utf-8")
+            if not already:
+                wrote_json += 1
+            if reg is not None and not args.dry_run:
+                cur = reg.execute(
+                    "UPDATE trajectories SET source_model=? WHERE filename=?",
+                    (model, md.name))
+                updated += cur.rowcount
+    if reg is not None and not args.dry_run:
+        reg.commit()
+        reg.close()
+
+    tag = "[apply DRY-RUN]" if args.dry_run else "[apply]"
+    print(f"{tag} 命中 model 的 md={hit}  未命中(保持 unknown)={miss}")
+    if not args.dry_run:
+        print(f"{tag} 写/更新 json sidecar={wrote_json}  registry 行 UPDATE={updated}")
+    print(f"{tag} 注:未触发任何 reindex / 重处理(只动 source_model 列 + sidecar)")
+    return 0
+
+
+def _json_model(jp: Path) -> str:
+    try:
+        return str(json.loads(jp.read_text(encoding="utf-8")).get("model") or "")
+    except (OSError, json.JSONDecodeError):
+        return ""
+
+
+def main() -> int:
+    ap = argparse.ArgumentParser(description=__doc__,
+                                 formatter_class=argparse.RawDescriptionHelpFormatter)
+    sub = ap.add_subparsers(dest="cmd", required=True)
+
+    e = sub.add_parser("export", help="host:建 traj_id→model 映射")
+    e.add_argument("--xskill-home", default="~/.xskill")
+    e.add_argument("--out", default="/tmp/model_map.json")
+    e.set_defaults(func=cmd_export)
+
+    a = sub.add_parser("apply", help="容器:写 sidecar + UPDATE registry(零重建)")
+    a.add_argument("--map", required=True)
+    a.add_argument("--traj-root", default="/root/.xskill/team_trajectories")
+    a.add_argument("--registry", default="/root/.xskill/registry.db")
+    a.add_argument("--dry-run", action="store_true")
+    a.set_defaults(func=cmd_apply)
+
+    args = ap.parse_args()
+    return args.func(args)
+
+
+if __name__ == "__main__":
+    sys.exit(main())

--- a/scripts/backfill_source_model.py
+++ b/scripts/backfill_source_model.py
@@ -1,0 +1,128 @@
+#!/usr/bin/env python3.11
+"""一次性回填存量轨迹的用户 agent 模型(批2,Issue #43 关联)。
+
+桥接产物(~/.xskill/<eco>_sessions/traj_*.json)历史上没存 model;但原始 source 有:
+  - Claude Code: ~/.claude/projects/**/<session_id>.jsonl 的 assistant `message.model`
+  - OpenCode:    ~/.local/share/opencode/opencode.db 的 message.data.model.modelID
+  - Codex:       桥接 .json 已有的 `model_provider`(provider 级,best we have)
+
+把抽到的 model 写回每个 traj 的 .json sidecar(discover 读它填 registry.source_model),
+并顺手 UPDATE 本机 registry。拿不到的留空(= 后续 stats 里的 'unknown')。幂等。
+
+用法:  python3.11 scripts/backfill_source_model.py
+"""
+from __future__ import annotations
+
+import json
+import sqlite3
+import sys
+from pathlib import Path
+
+HOME = Path.home()
+XS = HOME / ".xskill"
+CLAUDE_PROJ = HOME / ".claude" / "projects"
+OPENCODE_DB = HOME / ".local" / "share" / "opencode" / "opencode.db"
+REGISTRY_DB = XS / "registry.db"
+# 只处理活动 bridge 目录,跳过 .backup-* / .wiped-* 备份
+LIVE_DIRS = ["cc_sessions", "codex_sessions", "opencode_sessions", "ngagent_sessions"]
+
+
+def _cc_index() -> dict[str, Path]:
+    """session_id -> jsonl 路径(CC 原始 session 文件名即 session_id)。"""
+    idx: dict[str, Path] = {}
+    if CLAUDE_PROJ.is_dir():
+        for p in CLAUDE_PROJ.rglob("*.jsonl"):
+            idx[p.stem] = p
+    return idx
+
+
+def _cc_model(jsonl: Path) -> str:
+    try:
+        for line in jsonl.read_text(encoding="utf-8").splitlines():
+            try:
+                e = json.loads(line)
+            except json.JSONDecodeError:
+                continue
+            if e.get("type") == "assistant":
+                m = (e.get("message") or {}).get("model")
+                if m:
+                    return str(m)
+    except OSError:
+        pass
+    return ""
+
+
+def _oc_model_map() -> dict[str, str]:
+    """session_id -> modelID(从 opencode.db 一次性建表)。"""
+    out: dict[str, str] = {}
+    if not OPENCODE_DB.is_file():
+        return out
+    try:
+        conn = sqlite3.connect(f"file:{OPENCODE_DB}?mode=ro&immutable=1", uri=True)
+        for sid, data in conn.execute("SELECT session_id, data FROM message"):
+            if sid in out:
+                continue
+            try:
+                m = json.loads(data).get("model")
+            except (json.JSONDecodeError, TypeError):
+                m = None
+            if isinstance(m, dict) and m.get("modelID"):
+                out[sid] = m["modelID"]
+        conn.close()
+    except sqlite3.Error:
+        pass
+    return out
+
+
+def main() -> int:
+    cc_idx = _cc_index()
+    oc_map = _oc_model_map()
+    reg = sqlite3.connect(REGISTRY_DB) if REGISTRY_DB.is_file() else None
+    if reg is not None:
+        try:
+            reg.execute("ALTER TABLE trajectories ADD COLUMN source_model TEXT")
+        except sqlite3.OperationalError:
+            pass   # 列已存在(get_connection 迁移过 / 本脚本重跑)
+    stats: dict[str, list[int]] = {}   # eco -> [filled, already, unknown]
+
+    for eco in LIVE_DIRS:
+        d = XS / eco
+        if not d.is_dir():
+            continue
+        s = stats.setdefault(eco, [0, 0, 0])
+        for jf in sorted(d.glob("traj_*.json")):
+            try:
+                meta = json.loads(jf.read_text(encoding="utf-8"))
+            except (OSError, json.JSONDecodeError):
+                continue
+            if meta.get("model"):
+                s[1] += 1
+                continue
+            sid = meta.get("session_id", "")
+            model = ""
+            if eco == "cc_sessions" and sid in cc_idx:
+                model = _cc_model(cc_idx[sid])
+            elif eco == "opencode_sessions":
+                model = oc_map.get(sid, "")
+            elif eco == "codex_sessions":
+                model = meta.get("model_provider", "")
+            if not model:
+                s[2] += 1
+                continue
+            meta["model"] = model
+            jf.write_text(json.dumps(meta, ensure_ascii=False, indent=2), encoding="utf-8")
+            if reg is not None:
+                reg.execute("UPDATE trajectories SET source_model=? WHERE filename=?",
+                            (model, jf.with_suffix(".md").name))
+            s[0] += 1
+    if reg is not None:
+        reg.commit(); reg.close()
+
+    print("=== 回填结果(filled / already / unknown) ===")
+    for eco, (f, a, u) in stats.items():
+        print(f"  {eco:<20} filled={f}  already={a}  unknown={u}")
+    return 0
+
+
+if __name__ == "__main__":
+    sys.exit(main())

--- a/scripts/fetch_model_prices.py
+++ b/scripts/fetch_model_prices.py
@@ -1,0 +1,76 @@
+#!/usr/bin/env python3.11
+"""build 时拉取最新模型价格,vendor 成 src/xskill/data/model_prices.json。
+
+数据源 = LiteLLM 社区维护的价格表(只取数据,**不引 litellm 包**,见 ADR-0001)。
+任何失败(网络错 / 源不存在 / 解析失败)→ **退出码 1,构建报错**(不静默兜底)。
+
+用法(发版前):
+    python3.11 scripts/fetch_model_prices.py
+    # 然后 python3.11 -m build / twine upload
+"""
+from __future__ import annotations
+
+import json
+import sys
+import urllib.request
+from datetime import datetime, timezone
+from pathlib import Path
+
+SRC = ("https://raw.githubusercontent.com/BerriAI/litellm/main/"
+       "model_prices_and_context_window.json")
+OUT = Path(__file__).resolve().parents[1] / "src" / "xskill" / "data" / "model_prices.json"
+
+
+def _per_1m(per_token) -> float | None:
+    return round(float(per_token) * 1_000_000, 6) if isinstance(per_token, (int, float)) else None
+
+
+def main() -> int:
+    try:
+        with urllib.request.urlopen(SRC, timeout=30) as r:  # noqa: S310
+            raw = json.loads(r.read().decode("utf-8"))
+    except Exception as e:  # pylint: disable=broad-exception-caught
+        print(f"FATAL: 拉取价格表失败: {e}\n  源: {SRC}", file=sys.stderr)
+        return 1
+
+    out: dict = {"_meta": {
+        "source": SRC,
+        "fetched_at": datetime.now(timezone.utc).isoformat(timespec="seconds"),
+        "schema": "model -> {input_per_1m, output_per_1m, cache_hit_per_1m?, embed_per_1m?}",
+    }}
+    n_chat = n_embed = 0
+    for model, d in raw.items():
+        if not isinstance(d, dict):
+            continue
+        mode = d.get("mode")
+        if mode == "embedding":
+            ep = _per_1m(d.get("input_cost_per_token"))
+            if ep is not None:
+                out[model] = {"embed_per_1m": ep}
+                n_embed += 1
+        elif mode in (None, "chat", "completion", "responses"):
+            ip = _per_1m(d.get("input_cost_per_token"))
+            op = _per_1m(d.get("output_cost_per_token"))
+            if ip is None and op is None:
+                continue
+            entry = {"input_per_1m": ip or 0.0, "output_per_1m": op or 0.0}
+            ch = _per_1m(d.get("cache_read_input_token_cost"))
+            if ch is not None:
+                entry["cache_hit_per_1m"] = ch
+                entry["cache_miss_per_1m"] = entry["input_per_1m"]
+            out[model] = entry
+            n_chat += 1
+
+    if n_chat + n_embed < 50:
+        print(f"FATAL: 解析到的条目过少({n_chat}+{n_embed}),疑似源格式变更",
+              file=sys.stderr)
+        return 1
+
+    OUT.parent.mkdir(parents=True, exist_ok=True)
+    OUT.write_text(json.dumps(out, ensure_ascii=False, indent=0), encoding="utf-8")
+    print(f"OK: wrote {OUT}  ({n_chat} chat + {n_embed} embedding models)")
+    return 0
+
+
+if __name__ == "__main__":
+    sys.exit(main())

--- a/src/xskill/agents/agno_factory.py
+++ b/src/xskill/agents/agno_factory.py
@@ -70,9 +70,20 @@ def _wrap_with_rate_limit(model, llm_cfg: dict):
     - monkey-patch 方法绑定 to instance,只影响这一个 model 实例
     - reasoning_content / tool_use 等 agno 内部逻辑完全保留
     """
+    from xskill.usage import current_step, get_ledger
+    model_name = llm_cfg.get("model", "?")
+    original_invoke = model.invoke
     rl_cfg = llm_cfg.get("rate_limit")
+
     if not rl_cfg:
+        # 无限流也要记账(Issue #43):只包一层 record-only wrapper。
+        def record_only_invoke(messages, **kwargs):
+            resp = original_invoke(messages, **kwargs)
+            get_ledger().record_llm(current_step(), model_name, resp)
+            return resp
+        model.invoke = record_only_invoke
         return model
+
     from xskill.utils.rate_limit import (
         get_or_create_bucket, estimate_tokens, _extract_total_tokens,
     )
@@ -82,7 +93,6 @@ def _wrap_with_rate_limit(model, llm_cfg: dict):
         tpm=rl_cfg.get("tpm"),
         burst=rl_cfg.get("burst"),
     )
-    original_invoke = model.invoke
 
     def rate_limited_invoke(messages, **kwargs):
         # agno 把 messages 列表传进来,估算用拼起来的总字符
@@ -100,6 +110,8 @@ def _wrap_with_rate_limit(model, llm_cfg: dict):
         actual = _extract_total_tokens(resp)
         if actual is not None:
             bucket.reconcile_tpm(estimated=estimated, actual=actual)
+        # 旁路记账;record_llm 内部 best-effort,绝不抛。
+        get_ledger().record_llm(current_step(), model_name, resp)
         return resp
 
     model.invoke = rate_limited_invoke

--- a/src/xskill/agents/task_agent.py
+++ b/src/xskill/agents/task_agent.py
@@ -32,6 +32,7 @@
 """
 from __future__ import annotations
 
+import json
 import logging
 import re
 from dataclasses import dataclass
@@ -40,6 +41,17 @@ from pathlib import Path
 from xskill.pipeline.atom import AtomTask, AtomTaskStore
 
 logger = logging.getLogger("xskill.task_agent")
+
+
+def _sidecar_model(traj_path: Path) -> str:
+    """读 ``<traj>.md`` 同名 ``.json`` sidecar 的 ``model``；无则空串。"""
+    jp = traj_path.with_suffix(".json")
+    if not jp.is_file():
+        return ""
+    try:
+        return str(json.loads(jp.read_text(encoding="utf-8")).get("model") or "")
+    except (OSError, json.JSONDecodeError):
+        return ""
 
 
 SYSTEM_PROMPT = """你是 AtomTask 拆分员。给你一段 agent 与用户的对话轨迹（markdown），
@@ -178,6 +190,7 @@ class TaskAgent:
         text = traj_path.read_text(encoding="utf-8")
         lines = text.splitlines(keepends=True)
         total_lines = len(lines)
+        source_model = _sidecar_model(traj_path)   # 轨迹的用户模型，继承给每个 atom
 
         # resume：start_line 是 1-based 行号。store 空时 last_offset 返回 0。
         start_line = self.store.last_offset(traj_id) or 1
@@ -229,6 +242,7 @@ class TaskAgent:
                 post_atom_id=None,
                 context_prefix=self._context_prefix(text, lines, os_line),
                 raw_segment="".join(lines[os_line - 1:oe_line - 1]),
+                source_model=source_model,
             ))
 
         # 本批内部相邻 atom 互填 pre/post

--- a/src/xskill/api/app.py
+++ b/src/xskill/api/app.py
@@ -831,12 +831,13 @@ def create_app(home_root: Path | str | None = None,
     # -- Usage / cost stats (Issue #43) --
     @app.get("/api/v1/stats")
     async def api_stats():
-        from xskill.pipeline.registry import usage_summary
+        from xskill.pipeline.registry import model_share, usage_summary
         watcher = (_watcher_ref["instance"].stats
                    if _watcher_ref.get("instance") else None)
         return {
             "role": "server" if _config.get("team", {}).get("server") else "client",
             "cost": usage_summary(),
+            "models": model_share(),
             "pipeline": watcher,
         }
 

--- a/src/xskill/api/app.py
+++ b/src/xskill/api/app.py
@@ -828,6 +828,18 @@ def create_app(home_root: Path | str | None = None,
             return _watcher_ref["instance"].stats
         return {"running": False, "message": "watcher not started"}
 
+    # -- Usage / cost stats (Issue #43) --
+    @app.get("/api/v1/stats")
+    async def api_stats():
+        from xskill.pipeline.registry import usage_summary
+        watcher = (_watcher_ref["instance"].stats
+                   if _watcher_ref.get("instance") else None)
+        return {
+            "role": "server" if _config.get("team", {}).get("server") else "client",
+            "cost": usage_summary(),
+            "pipeline": watcher,
+        }
+
     # ------------------------------------------------------------------
     @app.on_event("startup")
     async def _startup():

--- a/src/xskill/canary.py
+++ b/src/xskill/canary.py
@@ -49,6 +49,12 @@ class CanaryConfig:
     min_samples: int = 5
     max_days_hold: int = 14
     rotate_interval: int = 300
+    # ── 模型分桶灰度（batch3）──
+    # scope_top_n: 只有"使用量 top-N 的用户模型"参与灰度（路由 + 打分）;
+    #              unknown 与 top-N 之外的模型一律走 main，不进 staging、不计分。
+    # total_samples: 每侧（main/staging）判定所需的总样本数（跨所有参与模型）。
+    scope_top_n: int = 2
+    total_samples: int = 20
 
     @classmethod
     def from_dict(cls, d: dict | None) -> "CanaryConfig":
@@ -58,6 +64,8 @@ class CanaryConfig:
             min_samples=int(d.get("min_samples", 5)),
             max_days_hold=int(d.get("max_days_hold", 14)),
             rotate_interval=int(d.get("rotate_interval", 300)),
+            scope_top_n=int(d.get("scope_top_n", 2)),
+            total_samples=int(d.get("total_samples", 20)),
         )
 
 
@@ -259,6 +267,22 @@ def pick_side(traj_id: str, skill_name: str, probability: float) -> str:
     return "staging" if r < probability else "main"
 
 
+def pick_side_scoped(traj_id: str, skill_name: str, probability: float,
+                     *, user_model: str, eligible: dict[str, float] | None) -> str:
+    """模型分桶路由(batch3):只有 top-N 用户模型的流量才可能进 staging。
+
+    - ``eligible`` 为 None → 未启用模型分桶,退回 :func:`pick_side`(老行为)。
+    - ``eligible`` 给定(``{model: weight}``)→ ``user_model`` 不在其中(含
+      unknown / 非 top-N)一律返回 ``main``,**不进灰度**;在其中则照常按
+      ``pick_side`` 确定性分流(各模型的灰度量天然 ∝ 其流量,即"等比推送")。
+    """
+    if eligible is None:
+        return pick_side(traj_id, skill_name, probability)
+    if user_model not in eligible:
+        return "main"
+    return pick_side(traj_id, skill_name, probability)
+
+
 def read_skill_on_branch(skill_dir: Path, branch: str) -> str | None:
     """读取指定分支上的 SKILL.md 文本。不切分支，用 git show。"""
     code, out, _ = run_git(["show", f"{branch}:SKILL.md"], cwd=str(skill_dir))
@@ -382,14 +406,62 @@ def recent_scores(
 # Controller：事件触发判定
 # ═══════════════════════════════════════════════════════════════════
 
-def check_and_decide(skill_dir: Path, config: CanaryConfig | None = None) -> dict:
-    """每次新体验分入库后调用。返回一个结果字典，action 字段含义：
+def eligible_models(model_share: list[dict], top_n: int) -> dict[str, float]:
+    """从 registry.model_share() 结果选出"使用量 top-N 的用户模型"并归一成权重。
+
+    - 排除 ``unknown`` / 空 / ``<synthetic>``（来源不可信，不参与灰度——见设计）。
+    - 按 ``trajs`` 降序取前 ``top_n``，权重 = 各自 trajs / Σ(top-N trajs)。
+    - 返回 ``{model: weight}``，Σweight=1.0；无合格模型时返回 ``{}``。
+
+    ``model_share`` 形如 ``[{"model": "claude-opus-4-7", "trajs": 102, ...}, ...]``。
+    """
+    excluded = {"", "unknown", "<synthetic>"}
+    rows = [r for r in model_share
+            if str(r.get("model", "")).strip() not in excluded
+            and int(r.get("trajs", 0)) > 0]
+    rows.sort(key=lambda r: int(r.get("trajs", 0)), reverse=True)
+    top = rows[:max(0, top_n)]
+    total = sum(int(r["trajs"]) for r in top)
+    if total <= 0:
+        return {}
+    return {str(r["model"]): int(r["trajs"]) / total for r in top}
+
+
+def _cohort_weighted(scores: list[dict], weights: dict[str, float]
+                     ) -> tuple[float | None, dict[str, int]]:
+    """按 user_model 分桶求各桶均分，再按 ``weights`` 加权汇总成"真正体验分"。
+
+    只统计 model ∈ weights 的样本（unknown / 非 top-N 被丢弃）。权重在"实际有
+    样本的桶"上重新归一。返回 (加权分 or None, 各桶样本数)；无任一合格桶→None。
+    """
+    by_model: dict[str, list[float]] = {}
+    for s in scores:
+        m = str(s.get("user_model", ""))
+        if m in weights:
+            by_model.setdefault(m, []).append(float(s["score"]))
+    if not by_model:
+        return None, {}
+    wsum = sum(weights[m] for m in by_model)
+    weighted = sum((weights[m] / wsum) * (sum(v) / len(v))
+                   for m, v in by_model.items())
+    return weighted, {m: len(v) for m, v in by_model.items()}
+
+
+def check_and_decide(skill_dir: Path, config: CanaryConfig | None = None,
+                     *, weights: dict[str, float] | None = None) -> dict:
+    """每次新体验分入库后调用。返回结果字典，action 字段含义：
 
     - no_staging     :  该 skill 无 staging 分支，什么都不做
     - waiting        :  样本不足，继续收集
     - timeout_discarded : 超过 max_days 仍不足 → 丢弃 staging
-    - promoted       :  staging 均分 ≥ main → 合入 main
-    - rejected       :  staging 均分 < main → 丢弃 staging
+    - promoted       :  加权 staging 分 ≥ 加权 main → 合入 main
+    - rejected       :  加权 staging 分 < 加权 main → 丢弃 staging
+
+    ``weights``: ``{user_model: 权重}``（来自 :func:`eligible_models`）。
+    - 给定时走**模型分桶加权**:只统计 top-N 模型样本(unknown 等被排除)，每侧
+      需 ≥ ``total_samples`` 个合格样本；加权体验分 = Σ 桶均分 × 桶人口权重。
+    - 为 None 时退化为**单桶**(全部样本一个桶、权重 1)，阈值用 ``min_samples``——
+      等价于旧的简单均分(单机/未开模型分桶场景)。两者同一套分桶算法，非两条路径。
     """
     cfg = config or CanaryConfig()
     skill_dir = Path(skill_dir)
@@ -407,47 +479,51 @@ def check_and_decide(skill_dir: Path, config: CanaryConfig | None = None) -> dic
     if created is not None:
         age_days = (datetime.now(timezone.utc) - created.astimezone(timezone.utc)).days
 
-    main_recent = recent_scores(skill_dir, side="main", commit_sha=m_sha, n=cfg.min_samples)
-    staging_recent = recent_scores(skill_dir, side="staging", commit_sha=s_sha, n=cfg.min_samples)
+    scoped = weights is not None
+    need = cfg.total_samples if scoped else cfg.min_samples
+    # 单桶用通配权重 {"*": 1.0}，并把样本的 user_model 临时视作 "*"。
+    eff_weights = weights if scoped else {"*": 1.0}
 
-    enough = (
-        len(main_recent) >= cfg.min_samples
-        and len(staging_recent) >= cfg.min_samples
-    )
+    n_collect = max(need * (len(eff_weights) or 1), need)
+    main_all = recent_scores(skill_dir, side="main", commit_sha=m_sha, n=n_collect)
+    staging_all = recent_scores(skill_dir, side="staging", commit_sha=s_sha, n=n_collect)
+    if not scoped:
+        for s in main_all + staging_all:
+            s["user_model"] = "*"
+
+    main_n = sum(1 for s in main_all if s.get("user_model") in eff_weights)
+    staging_n = sum(1 for s in staging_all if s.get("user_model") in eff_weights)
+    enough = main_n >= need and staging_n >= need
 
     if not enough:
         if age_days is not None and age_days >= cfg.max_days_hold:
             discard_staging(skill_dir)
-            return {
-                "action": "timeout_discarded",
-                "age_days": age_days,
-                "main_samples": len(main_recent),
-                "staging_samples": len(staging_recent),
-            }
-        return {
-            "action": "waiting",
-            "age_days": age_days,
-            "main_samples": len(main_recent),
-            "staging_samples": len(staging_recent),
-            "need": cfg.min_samples,
-        }
+            return {"action": "timeout_discarded", "age_days": age_days,
+                    "main_samples": main_n, "staging_samples": staging_n}
+        return {"action": "waiting", "age_days": age_days,
+                "main_samples": main_n, "staging_samples": staging_n, "need": need}
 
-    main_avg = sum(s["score"] for s in main_recent) / len(main_recent)
-    staging_avg = sum(s["score"] for s in staging_recent) / len(staging_recent)
+    main_w, main_cohorts = _cohort_weighted(main_all, eff_weights)
+    staging_w, staging_cohorts = _cohort_weighted(staging_all, eff_weights)
+    if main_w is None or staging_w is None:
+        return {"action": "waiting", "age_days": age_days,
+                "main_samples": main_n, "staging_samples": staging_n, "need": need}
+
     summary = {
-        "main_avg": round(main_avg, 3),
-        "staging_avg": round(staging_avg, 3),
-        "main_samples": len(main_recent),
-        "staging_samples": len(staging_recent),
+        "main_avg": round(main_w, 3),
+        "staging_avg": round(staging_w, 3),
+        "main_samples": main_n,
+        "staging_samples": staging_n,
+        "main_cohorts": main_cohorts,
+        "staging_cohorts": staging_cohorts,
         "age_days": age_days,
     }
 
-    if staging_avg >= main_avg:
+    if staging_w >= main_w:
         ok = merge_staging_to_main(skill_dir)
         return {"action": "promoted" if ok else "merge_failed", **summary}
-    else:
-        discard_staging(skill_dir)
-        return {"action": "rejected", **summary}
+    discard_staging(skill_dir)
+    return {"action": "rejected", **summary}
 
 
 # ═══════════════════════════════════════════════════════════════════
@@ -500,10 +576,12 @@ class AtomCanary:
     skill_dir: Path
 
     def append(self, *, atom_id: str, skill_name: str, side: str,
-               commit_sha: str, score: float, reasons: str) -> bool:
+               commit_sha: str, score: float, reasons: str,
+               user_model: str = "") -> bool:
         """幂等追加一条 atom 体验分。
 
         同一 (atom_id, skill_name, side) 三元组已存在则返回 False，不重复写入。
+        ``user_model``: 产生该 atom 的用户模型，供模型分桶加权裁决用。
         """
         existing = load_ux_scores(self.skill_dir)
         for e in existing:
@@ -518,6 +596,7 @@ class AtomCanary:
             "commit_sha": commit_sha,
             "score": float(score),
             "reasons": reasons,
+            "user_model": user_model,
             "scored_at": datetime.now(timezone.utc).isoformat(timespec="seconds"),
         }
         p = self.skill_dir / UX_SCORES_FILENAME
@@ -536,9 +615,13 @@ class AtomCanary:
         filtered.sort(key=lambda s: s.get("scored_at", ""), reverse=True)
         return filtered[:n]
 
-    def check_and_decide(self, *, config: "CanaryConfig | None" = None) -> dict:
-        """代理 ``check_and_decide``——判定逻辑不区分 atom/traj 粒度。"""
-        return check_and_decide(self.skill_dir, config=config)
+    def check_and_decide(self, *, config: "CanaryConfig | None" = None,
+                         weights: "dict[str, float] | None" = None) -> dict:
+        """代理 ``check_and_decide``——判定逻辑不区分 atom/traj 粒度。
+
+        ``weights`` 透传:给定则按模型分桶加权裁决,None 则单桶(等价旧均分)。
+        """
+        return check_and_decide(self.skill_dir, config=config, weights=weights)
 
 
 # =============================================================================

--- a/src/xskill/cli.py
+++ b/src/xskill/cli.py
@@ -38,6 +38,8 @@ def cmd_serve(args, xskill) -> int:
         if not home_root.is_dir():
             print(f"error: --home 目录不存在: {home_root}", file=sys.stderr)
             return 2
+    from xskill.runtime import write_running
+    write_running(port=args.port, mode="server" if args.server else "standalone")
     xskill.serve(host=args.host, port=args.port, home_root=home_root,
                  server_mode=args.server)
     return 0
@@ -224,14 +226,16 @@ def cmd_stats(args) -> int:
     import json as _json
     import time
     from xskill.pipeline.registry import usage_summary
+    from xskill.runtime import read_status
     from xskill.usage import render_stats
 
     def _emit() -> None:
         s = usage_summary()
+        st = read_status()
         if args.json:
-            print(_json.dumps({"cost": s}, ensure_ascii=False, indent=2))
+            print(_json.dumps({"status": st, "cost": s}, ensure_ascii=False, indent=2))
         else:
-            print(render_stats(s, role="client"))
+            print(render_stats(s, status=st))
 
     if args.watch and not args.json:
         try:

--- a/src/xskill/cli.py
+++ b/src/xskill/cli.py
@@ -225,17 +225,19 @@ def cmd_stats(args) -> int:
     """token/成本统计。直接读 registry(~/.xskill/registry.db),不需要 config/facade。"""
     import json as _json
     import time
-    from xskill.pipeline.registry import usage_summary
+    from xskill.pipeline.registry import model_share, usage_summary
     from xskill.runtime import read_status
     from xskill.usage import render_stats
 
     def _emit() -> None:
         s = usage_summary()
         st = read_status()
+        ms = model_share()
         if args.json:
-            print(_json.dumps({"status": st, "cost": s}, ensure_ascii=False, indent=2))
+            print(_json.dumps({"status": st, "cost": s, "models": ms},
+                              ensure_ascii=False, indent=2))
         else:
-            print(render_stats(s, status=st))
+            print(render_stats(s, status=st, models=ms))
 
     if args.watch and not args.json:
         try:

--- a/src/xskill/cli.py
+++ b/src/xskill/cli.py
@@ -219,6 +219,32 @@ def cmd_connect(args) -> int:
     return 0
 
 
+def cmd_stats(args) -> int:
+    """token/成本统计。直接读 registry(~/.xskill/registry.db),不需要 config/facade。"""
+    import json as _json
+    import time
+    from xskill.pipeline.registry import usage_summary
+    from xskill.usage import render_stats
+
+    def _emit() -> None:
+        s = usage_summary()
+        if args.json:
+            print(_json.dumps({"cost": s}, ensure_ascii=False, indent=2))
+        else:
+            print(render_stats(s, role="client"))
+
+    if args.watch and not args.json:
+        try:
+            while True:
+                print("\033[2J\033[H", end="")  # 清屏 + 光标归位
+                _emit()
+                time.sleep(2)
+        except KeyboardInterrupt:
+            return 0
+    _emit()
+    return 0
+
+
 def cmd_search(args, xskill) -> int:
     target = args.search_target
     if target == "traj":
@@ -312,6 +338,13 @@ def build_parser() -> argparse.ArgumentParser:
              "仅当本机唯一出网路径是代理、且代理能到 server 时才需要。",
     )
 
+    p_stats = sub.add_parser(
+        "stats", help="Show token usage & estimated cost (Issue #43)",
+    )
+    p_stats.add_argument("--json", action="store_true", help="机读 JSON 输出")
+    p_stats.add_argument("--watch", action="store_true",
+                         help="htop 式整屏刷新（每 2s）")
+
     return p
 
 
@@ -364,6 +397,10 @@ def main() -> int:
     # connect 是瘦客户端：不读 config.yaml / 不需要 llm.api_key / 不构造 XSkill 门面
     if args.command == "connect":
         return cmd_connect(args)
+
+    # stats 只读 registry，不需要 config.yaml / llm.api_key / facade
+    if args.command == "stats":
+        return cmd_stats(args)
 
     # team 客户端的 `registry list`：本机是 client（有 team_client.json）且没有
     # standalone 数据（watch_dirs 为空）时，改走现算视图。放在 config/facade

--- a/src/xskill/config.py
+++ b/src/xskill/config.py
@@ -77,6 +77,15 @@ embedding:
   # api: openai | multimodal   # optional; default openai. "multimodal" for
                                # vision-style embedding endpoints.
 
+# ===== Pricing (optional; for `xskill stats` cost estimation) =====
+# Cost is ESTIMATED from response.usage tokens × price (USD per 1M tokens).
+# Resolution order: this `pricing:` map  >  the vendored price table
+# (src/xskill/data/model_prices.json, refreshed at build time)  >  `default`.
+# Leave this out entirely to rely on the vendored table + default below.
+# pricing:
+#   default: { input_per_1m: 1.0, output_per_1m: 3.0, embed_per_1m: 0.05 }
+#   deepseek-v4-flash: { input_per_1m: 0.14, output_per_1m: 0.28, cache_hit_per_1m: 0.014 }
+
 # ===== Canary (gradual rollout) =====
 canary:
   enabled:       true

--- a/src/xskill/config.py
+++ b/src/xskill/config.py
@@ -91,8 +91,14 @@ canary:
   enabled:       true
   probability:   0.2            # on a retrieval hit, route to staging with prob p
   min_samples:   5              # need >= N UX scores on each side to decide
+                                # (single-bucket / un-scoped path)
   max_days_hold: 14             # max staging lifetime; discarded on timeout
   rotate_interval: 300          # standalone canary time-window rotation (seconds)
+  scope_top_n:   2              # model-scoped canary: only the top-N user models
+                                # by usage take part (routing + scoring); unknown
+                                # and non-top-N traffic stays on main
+  total_samples: 20             # model-scoped path: total UX scores needed on
+                                # each side before a weighted decision
 
 # ===== Watcher (the directory poller inside `serve`) =====
 watcher:

--- a/src/xskill/data/model_prices.json
+++ b/src/xskill/data/model_prices.json
@@ -1,0 +1,19 @@
+{
+  "_meta": {
+    "note": "Vendored at build time by scripts/fetch_model_prices.py. Prices are USD per 1M tokens. This seed is the offline fallback; the build refreshes it.",
+    "source": "seed",
+    "schema": "model -> {input_per_1m, output_per_1m, cache_hit_per_1m?, cache_miss_per_1m?, embed_per_1m?}"
+  },
+  "deepseek-v4-flash": {"input_per_1m": 0.14, "output_per_1m": 0.28, "cache_hit_per_1m": 0.014, "cache_miss_per_1m": 0.14},
+  "deepseek-v4-pro":   {"input_per_1m": 0.55, "output_per_1m": 2.19, "cache_hit_per_1m": 0.055, "cache_miss_per_1m": 0.55},
+  "deepseek-chat":     {"input_per_1m": 0.27, "output_per_1m": 1.10, "cache_hit_per_1m": 0.07,  "cache_miss_per_1m": 0.27},
+  "deepseek-reasoner": {"input_per_1m": 0.55, "output_per_1m": 2.19, "cache_hit_per_1m": 0.14,  "cache_miss_per_1m": 0.55},
+  "gpt-4o":            {"input_per_1m": 2.50, "output_per_1m": 10.0},
+  "gpt-4o-mini":       {"input_per_1m": 0.15, "output_per_1m": 0.60},
+  "claude-sonnet-4-6": {"input_per_1m": 3.00, "output_per_1m": 15.0},
+  "claude-opus-4-8":   {"input_per_1m": 15.0, "output_per_1m": 75.0},
+  "text-embedding-v4":      {"embed_per_1m": 0.02},
+  "text-embedding-3-small": {"embed_per_1m": 0.02},
+  "text-embedding-3-large": {"embed_per_1m": 0.13},
+  "jina-embeddings-v3":     {"embed_per_1m": 0.02}
+}

--- a/src/xskill/ecosystems/claude_code.py
+++ b/src/xskill/ecosystems/claude_code.py
@@ -294,6 +294,7 @@ def _adapt_claude_code_jsonl(content: str, metadata: dict) -> tuple[str, dict]:
     session_id = ""
     cwd = ""
     git_branch = ""
+    model = ""           # 用户 agent 模型(批2):取 assistant message.model
     first_user_query = ""
     t = 0
     step = 0
@@ -317,6 +318,8 @@ def _adapt_claude_code_jsonl(content: str, metadata: dict) -> tuple[str, dict]:
         git_branch = git_branch or event.get("gitBranch", "") or ""
 
         msg = event.get("message") or {}
+        if ev_type == "assistant" and not model:
+            model = msg.get("model") or ""
         msg_content = msg.get("content")
 
         if ev_type == "user":
@@ -449,6 +452,8 @@ def _adapt_claude_code_jsonl(content: str, metadata: dict) -> tuple[str, dict]:
     meta.setdefault("category", "claude_code_session")
     if session_id:
         meta.setdefault("session_id", session_id)
+    if model:
+        meta.setdefault("model", model)
     if cwd:
         meta.setdefault("cwd", cwd)
     if git_branch:

--- a/src/xskill/ecosystems/opencode.py
+++ b/src/xskill/ecosystems/opencode.py
@@ -358,6 +358,12 @@ class SqliteIngester:
                 # 生成 traj_id：含 project basename + sid8（同 CC 命名风格）；
                 # 前缀按 spec.traj_id_prefix 派生，避免对 ecosystem 硬编码 if 分支。
                 traj_id = self._sqlite_traj_id(sid, directory)
+                # 用户 agent 模型(批2):message.data.model = {providerID, modelID}
+                model = next(
+                    (m["model"].get("modelID") for m in messages
+                     if isinstance(m.get("model"), dict) and m["model"].get("modelID")),
+                    "",
+                )
                 # 拼 markdown 内容
                 md_content = self._render_session_md(
                     sid=sid, directory=directory, messages=messages,
@@ -371,6 +377,7 @@ class SqliteIngester:
                         "ecosystem": self.spec.label,
                         "session_id": sid,
                         "cwd": directory,
+                        **({"model": model} if model else {}),
                     },
                 )
                 result["session_id"] = sid

--- a/src/xskill/pipeline/atom.py
+++ b/src/xskill/pipeline/atom.py
@@ -55,6 +55,8 @@ class AtomTask:
     post_atom_id: str | None = None
     context_prefix: str = ""
     raw_segment: str = ""
+    source_model: str = ""   # 产生该 atom 的用户 agent 模型，继承自所属轨迹的
+    #                          <traj>.json sidecar "model"（canary 按模型分桶用）
 
     def to_json(self) -> str:
         return json.dumps(asdict(self), ensure_ascii=False, indent=2)

--- a/src/xskill/pipeline/registry.py
+++ b/src/xskill/pipeline/registry.py
@@ -15,6 +15,7 @@ watch_dir + trajectory 反查走这个类。
 
 from __future__ import annotations
 
+import json
 import logging
 import sqlite3
 from datetime import datetime, timezone
@@ -51,6 +52,7 @@ CREATE TABLE IF NOT EXISTS trajectories (
     skill_generated TEXT,
     skill_used    TEXT,
     canary_side   TEXT,
+    source_model  TEXT,
     ux_score      REAL,
     error_msg     TEXT,
     retry_count   INTEGER DEFAULT 0,
@@ -109,6 +111,8 @@ def _migrate(conn: sqlite3.Connection) -> None:
         ("tasks_extracted", "INTEGER DEFAULT 0"),
         ("last_offset", "INTEGER DEFAULT 0"),
         ("last_atom_id", "TEXT"),
+        # 用户 agent 模型(批2,Issue #43 关联):discover 时从 .json sidecar 写入
+        ("source_model", "TEXT"),
     ]
     for col, typedef in migrations:
         if col not in cols:
@@ -183,6 +187,32 @@ def usage_summary(db_path: Optional[Path] = None) -> dict:
             "total_calls": tot["n"], "today_usd": round(today, 6),
             "estimated": estimated, "by_step": by_step, "by_model": by_model,
         }
+    finally:
+        conn.close()
+
+
+def _sidecar_model(md_path: Path) -> Optional[str]:
+    """从 traj_*.md 的同名 .json sidecar 读用户 agent 模型(meta['model'])。"""
+    try:
+        meta = json.loads(md_path.with_suffix(".json").read_text(encoding="utf-8"))
+        m = meta.get("model")
+        return str(m) if m else None
+    except (OSError, json.JSONDecodeError, AttributeError):
+        return None
+
+
+def model_share(db_path: Optional[Path] = None) -> list[dict]:
+    """用户 agent 模型分布(按轨迹数),供 server stats 显示占比。None → 'unknown'。"""
+    conn = get_connection(db_path)
+    try:
+        rows = conn.execute(
+            "SELECT COALESCE(source_model,'unknown') AS model, COUNT(*) AS trajs"
+            " FROM trajectories GROUP BY COALESCE(source_model,'unknown')"
+            " ORDER BY trajs DESC"
+        ).fetchall()
+        total = sum(r["trajs"] for r in rows) or 1
+        return [{"model": r["model"], "trajs": r["trajs"],
+                 "pct": round(100 * r["trajs"] / total, 1)} for r in rows]
     finally:
         conn.close()
 
@@ -292,9 +322,10 @@ def discover_trajectories(
             mtime = md.stat().st_mtime
             if md.name not in existing:
                 conn.execute(
-                    "INSERT INTO trajectories (watch_dir_id, filename, file_mtime)"
-                    " VALUES (?, ?, ?)",
-                    (watch_dir_id, md.name, mtime),
+                    "INSERT INTO trajectories"
+                    " (watch_dir_id, filename, file_mtime, source_model)"
+                    " VALUES (?, ?, ?, ?)",
+                    (watch_dir_id, md.name, mtime, _sidecar_model(md)),
                 )
                 new_files.append(md.name)
             else:

--- a/src/xskill/pipeline/registry.py
+++ b/src/xskill/pipeline/registry.py
@@ -60,6 +60,19 @@ CREATE TABLE IF NOT EXISTS trajectories (
     updated_at    TEXT DEFAULT (datetime('now')),
     UNIQUE(watch_dir_id, filename)
 );
+
+CREATE TABLE IF NOT EXISTS llm_usage (
+    id           INTEGER PRIMARY KEY AUTOINCREMENT,
+    ts           TEXT DEFAULT (datetime('now')),
+    step         TEXT,
+    model        TEXT,
+    prompt       INTEGER DEFAULT 0,
+    completion   INTEGER DEFAULT 0,
+    total        INTEGER DEFAULT 0,
+    cost_usd     REAL DEFAULT 0,
+    price_source TEXT
+);
+CREATE INDEX IF NOT EXISTS idx_llm_usage_ts ON llm_usage(ts);
 """
 
 
@@ -120,6 +133,58 @@ def _migrate(conn: sqlite3.Connection) -> None:
         " WHERE has_meta=1 AND has_embedding=0 AND (status IS NULL OR status='discovered')"
     )
     conn.commit()
+
+
+# ---------------------------------------------------------------------------
+# LLM usage / cost accounting  (Issue #43)  —— 唯一"无家可归"数据的持久化
+# ---------------------------------------------------------------------------
+
+def record_usage(*, step: str, model: str, prompt: int, completion: int,
+                 total: int, cost_usd: float, price_source: str,
+                 db_path: Optional[Path] = None) -> None:
+    """追加一条 LLM/embedding 调用的 token+成本记录。旁路 telemetry。"""
+    conn = get_connection(db_path)
+    try:
+        conn.execute(
+            "INSERT INTO llm_usage(step,model,prompt,completion,total,cost_usd,price_source)"
+            " VALUES(?,?,?,?,?,?,?)",
+            (step, model, int(prompt), int(completion), int(total),
+             float(cost_usd), price_source),
+        )
+        conn.commit()
+    finally:
+        conn.close()
+
+
+def usage_summary(db_path: Optional[Path] = None) -> dict:
+    """跨重启的持久汇总:累计 token/$、今日 $、按 step / model 分解。"""
+    conn = get_connection(db_path)
+    try:
+        tot = conn.execute(
+            "SELECT COALESCE(SUM(total),0) t, COALESCE(SUM(cost_usd),0) c, COUNT(*) n"
+            " FROM llm_usage"
+        ).fetchone()
+        today = conn.execute(
+            "SELECT COALESCE(SUM(cost_usd),0) FROM llm_usage WHERE ts >= date('now')"
+        ).fetchone()[0]
+        estimated = conn.execute(
+            "SELECT COUNT(*) FROM llm_usage WHERE price_source != 'config'"
+        ).fetchone()[0] > 0
+        by_step = [dict(r) for r in conn.execute(
+            "SELECT step, SUM(total) tokens, SUM(cost_usd) cost, COUNT(*) calls"
+            " FROM llm_usage GROUP BY step ORDER BY cost DESC"
+        ).fetchall()]
+        by_model = [dict(r) for r in conn.execute(
+            "SELECT model, SUM(total) tokens, SUM(cost_usd) cost, COUNT(*) calls"
+            " FROM llm_usage GROUP BY model ORDER BY cost DESC"
+        ).fetchall()]
+        return {
+            "total_tokens": tot["t"], "total_usd": round(tot["c"], 6),
+            "total_calls": tot["n"], "today_usd": round(today, 6),
+            "estimated": estimated, "by_step": by_step, "by_model": by_model,
+        }
+    finally:
+        conn.close()
 
 
 # ---------------------------------------------------------------------------

--- a/src/xskill/pipeline/runner.py
+++ b/src/xskill/pipeline/runner.py
@@ -500,10 +500,15 @@ class DirectoryWatcher:
         """
         if self.skill_dir is None or not self.skill_dir.is_dir():
             return
-        from xskill.canary import AtomCanary
-        from xskill.canary import CanaryConfig
+        from xskill.canary import AtomCanary, CanaryConfig, eligible_models
+        from xskill.pipeline.registry import model_share
         from xskill.skill.git import run_git
         canary_cfg = CanaryConfig.from_dict(self.config.get("canary", {}))
+        # 模型分桶权重:使用量 top-N 模型的人口占比(unknown 等已被排除)。
+        # 有合格模型 → 按模型加权裁决;一个都没有(全 unknown)→ None = 单桶均分,
+        # 不让纯 unknown 部署的灰度永远卡住。
+        weights = eligible_models(model_share(**self._db_kw()),
+                                  canary_cfg.scope_top_n) or None
         for d in sorted(self.skill_dir.iterdir()):
             if not d.is_dir() or d.name.startswith("."):
                 continue
@@ -513,7 +518,8 @@ class DirectoryWatcher:
             if code != 0:
                 continue  # 无 staging，跳过
             try:
-                decision = AtomCanary(skill_dir=d).check_and_decide(config=canary_cfg)
+                decision = AtomCanary(skill_dir=d).check_and_decide(
+                    config=canary_cfg, weights=weights)
                 action = decision.get("action", "")
                 if action in ("promoted", "rejected", "timeout_discarded"):
                     logger.info("canary decision %s: %s — %s",
@@ -1018,6 +1024,7 @@ class DirectoryWatcher:
                     atom_id=atom.atom_id, skill_name=skill_name,
                     side=header["side"], commit_sha=header.get("sha", ""),
                     score=result["score"], reasons=result["reasons"],
+                    user_model=atom.source_model,
                 )
                 self._stats["scores"] += 1
             except Exception:
@@ -1042,9 +1049,11 @@ class DirectoryWatcher:
             return
         from xskill.canary import AtomCanary
         from xskill.canary import (
-            CanaryConfig, has_staging, main_sha, pick_side, staging_sha,
+            CanaryConfig, eligible_models, has_staging, main_sha,
+            pick_side_scoped, staging_sha,
         )
         from xskill.pipeline.atom import score_atom
+        from xskill.pipeline.registry import model_share
 
         # 找到该 wd 的 dir_path + client_id（label）
         client_id = None
@@ -1065,6 +1074,8 @@ class DirectoryWatcher:
         if not atoms:
             return
         canary_cfg = CanaryConfig.from_dict(self.config.get("canary", {}))
+        # 模型分桶路由:top-N 模型才可能进 staging,unknown/非 top-N 一律 main。
+        eligible = eligible_models(model_share(**kw), canary_cfg.scope_top_n) or None
         used_any = False
         for atom in atoms:
             for skill_name in (atom.used_skills or []):
@@ -1072,7 +1083,9 @@ class DirectoryWatcher:
                 if not (skill_sub / ".git").is_dir():
                     continue
                 if has_staging(skill_sub):
-                    side = pick_side(client_id, skill_name, canary_cfg.probability)
+                    side = pick_side_scoped(
+                        client_id, skill_name, canary_cfg.probability,
+                        user_model=atom.source_model, eligible=eligible)
                     sha = staging_sha(skill_sub) if side == "staging" else main_sha(skill_sub)
                 else:
                     side = "main"
@@ -1085,6 +1098,7 @@ class DirectoryWatcher:
                         atom_id=atom.atom_id, skill_name=skill_name,
                         side=side, commit_sha=sha or "",
                         score=result["score"], reasons=result["reasons"],
+                        user_model=atom.source_model,
                     )
                     self._stats["scores"] += 1
                     used_any = True

--- a/src/xskill/runtime.py
+++ b/src/xskill/runtime.py
@@ -1,0 +1,93 @@
+"""runtime.py — serve daemon 运行态(进程 / 端口 / 部署角色 / 处理模型)。
+
+只服务于 ``xskill stats`` 的"谁在跑、谁在处理"展示。serve 启动时写
+``~/.xskill/serve_runtime.json``,退出时清掉;stats 读它 + 校验 pid 存活。
+纯旁路,读写失败一律忽略,不影响主流程。
+"""
+from __future__ import annotations
+
+import atexit
+import json
+import logging
+import os
+import time
+from typing import Optional
+
+import yaml
+
+from xskill.config import (
+    CONFIG_PATH, XSKILL_HOME,
+    get_team_client_state_path, get_team_server_state_path,
+)
+
+logger = logging.getLogger("xskill.runtime")
+RUNTIME_PATH = XSKILL_HOME / "serve_runtime.json"
+
+
+def _models() -> dict:
+    """从 config.yaml 直接读处理模型(不走 load_config,瘦客户端无 key 也能读)。"""
+    try:
+        c = yaml.safe_load(CONFIG_PATH.read_text(encoding="utf-8")) or {}
+    except Exception:  # pylint: disable=broad-exception-caught
+        return {}
+    llm, emb = c.get("llm", {}), c.get("embedding", {})
+    return {"llm_model": llm.get("model"), "llm_base_url": llm.get("base_url"),
+            "embed_model": emb.get("model")}
+
+
+def write_running(*, port: int, mode: str) -> None:
+    """serve 启动时调用,登记本进程;注册 atexit 自动清理。"""
+    try:
+        RUNTIME_PATH.parent.mkdir(parents=True, exist_ok=True)
+        RUNTIME_PATH.write_text(json.dumps(
+            {"pid": os.getpid(), "port": port, "mode": mode,
+             "started_at": int(time.time()), **_models()}), encoding="utf-8")
+        atexit.register(_clear)
+    except Exception:  # pylint: disable=broad-exception-caught
+        logger.debug("write runtime status failed", exc_info=True)
+
+
+def _clear() -> None:
+    try:
+        RUNTIME_PATH.unlink(missing_ok=True)
+    except Exception:  # pylint: disable=broad-exception-caught
+        pass
+
+
+def _alive(pid: Optional[int]) -> bool:
+    if not isinstance(pid, int) or pid <= 0:
+        return False
+    try:
+        os.kill(pid, 0)
+    except ProcessLookupError:
+        return False
+    except PermissionError:
+        return True   # 存在但非本用户 → 仍算活
+    return True
+
+
+def role() -> str:
+    """部署角色:server / client / standalone(看 team 状态文件)。"""
+    if get_team_server_state_path().is_file():
+        return "server"
+    if get_team_client_state_path().is_file():
+        return "client"
+    return "standalone"
+
+
+def read_status() -> dict:
+    """汇总运行态供 stats 展示。daemon 不在跑也尽量给出角色 + 处理模型。"""
+    st: dict = {"running": False, "role": role()}
+    if RUNTIME_PATH.is_file():
+        try:
+            d = json.loads(RUNTIME_PATH.read_text(encoding="utf-8"))
+        except Exception:  # pylint: disable=broad-exception-caught
+            d = None
+        if d and _alive(d.get("pid")):
+            st.update(running=True, pid=d.get("pid"), port=d.get("port"),
+                      mode=d.get("mode"), llm_model=d.get("llm_model"),
+                      llm_base_url=d.get("llm_base_url"),
+                      embed_model=d.get("embed_model"))
+    if not st.get("llm_model"):     # daemon 没跑也补一份处理模型
+        st.update(_models())
+    return st

--- a/src/xskill/team/client/collector.py
+++ b/src/xskill/team/client/collector.py
@@ -32,6 +32,19 @@ class PendingTrajectory:
     traj_id: str
     content: str       # 已脱敏
     sha256: str        # 脱敏后 content 的 sha256
+    model: str = ""    # 用户 agent 模型，取自同名 .json sidecar 的 "model"
+
+
+def _sidecar_model(md_path: Path) -> str:
+    """读 ``<traj>.md`` 同目录同名 ``.json`` sidecar 里的 ``model``；
+    无 sidecar / 无该键 / 解析失败 → 空串（保持 unknown，不抛错不影响上传）。"""
+    jp = md_path.with_suffix(".json")
+    if not jp.is_file():
+        return ""
+    try:
+        return str(json.loads(jp.read_text(encoding="utf-8")).get("model") or "")
+    except (OSError, json.JSONDecodeError):
+        return ""
 
 
 class TeamCollector:
@@ -142,5 +155,6 @@ class TeamCollector:
             traj_id = md.stem
             if self._cursor.get(traj_id) == sha:
                 continue   # 这个版本已上传过
-            out.append(PendingTrajectory(traj_id=traj_id, content=content, sha256=sha))
+            out.append(PendingTrajectory(traj_id=traj_id, content=content, sha256=sha,
+                                         model=_sidecar_model(md)))
         return out

--- a/src/xskill/team/client/daemon.py
+++ b/src/xskill/team/client/daemon.py
@@ -97,7 +97,8 @@ class TeamClient:
         if not pending:
             return 0
         req = UploadRequest(trajectories=[
-            UploadTrajectory(traj_id=p.traj_id, content=p.content, sha256=p.sha256)
+            UploadTrajectory(traj_id=p.traj_id, content=p.content, sha256=p.sha256,
+                             model=p.model)
             for p in pending
         ])
         resp = self.http.post("/api/v1/team/upload", headers=self._hdr(),

--- a/src/xskill/team/server/api.py
+++ b/src/xskill/team/server/api.py
@@ -11,6 +11,7 @@ client 完全信任 server；token 只挡组织外随机接入。
 from __future__ import annotations
 
 import hashlib
+import json
 import logging
 from pathlib import Path
 from typing import Callable
@@ -120,6 +121,12 @@ async def team_upload(
         if t.sha256 and actual != t.sha256:
             rejected.append(UploadRejection(traj_id=t.traj_id, reason="sha256 mismatch"))
             continue
+        # model 非空时先落 .json sidecar，再落 .md：watcher 只 glob traj_*.md，
+        # 必须保证它发现新 .md 时同名 sidecar 已就位，否则 discover 会 INSERT
+        # source_model=NULL 且永不回读（已存在的行只更 mtime）。
+        if t.model:
+            (sessions_dir / f"{t.traj_id}.json").write_text(
+                json.dumps({"model": t.model}, ensure_ascii=False), encoding="utf-8")
         (sessions_dir / f"{t.traj_id}.md").write_text(t.content, encoding="utf-8")
         accepted.append(t.traj_id)
     logger.info("team upload from %s: %d accepted, %d rejected",

--- a/src/xskill/team/shared/protocol.py
+++ b/src/xskill/team/shared/protocol.py
@@ -40,6 +40,8 @@ class UploadTrajectory(BaseModel):
     traj_id: str           # 形如 traj_cc_<project>_<sid8>，必须 traj_ 前缀
     content: str           # 已脱敏的 markdown 全文
     sha256: str            # content 的 sha256，server 端去重用
+    model: str = ""        # 产生该轨迹的用户 agent 模型（取自本机 .json sidecar；
+    #                        只带 model 一字段，不带 cwd/query 等未脱敏元信息）
 
 
 class UploadRequest(BaseModel):

--- a/src/xskill/usage.py
+++ b/src/xskill/usage.py
@@ -1,0 +1,288 @@
+"""usage.py — LLM/embedding token & 成本统计(单一收口)
+═══════════════════════════════════════════════════════════════════
+Issue #43。设计要点(详见会话定稿):
+
+- **唯一新存的数据** = 每次调用的 token/cost(否则算完即丢)。其余 stats
+  内容(技能事件/流水线/贡献)都是对已有状态单元的只读视图,不在这里存。
+- **成本 = 估算**:token × 单价。没有余额、没有第二套真值来源。
+- **定价不引任何包**(litellm/tokencost/tiktoken 全 ban,见 ADR-0001):
+  build 时 vendor 一份 ``data/model_prices.json``(USD / 1M token),运行时
+  零网络。解析优先级 ``config.pricing[model]`` > vendored 表 > ``pricing.default``
+  可配兜底单价 —— ``cost`` 永不为 None,只标 ``price_source``。
+- **旁路 best-effort**:``record_*`` 永不抛错、永不阻断流水线。
+- token 数沿用 rate_limit 的字符粗估 + ``response.usage`` 自校准。
+
+全局单例 ``LEDGER``,调用点一行 ``LEDGER.record_llm(step, model, resp)``。
+"""
+
+from __future__ import annotations
+
+import contextlib
+import json
+import logging
+import threading
+from dataclasses import dataclass
+from pathlib import Path
+from typing import Any, Dict, Optional, Tuple
+
+logger = logging.getLogger("xskill.usage")
+
+# 当前流水线步骤(atom_split / skill_route / skill_edit / ux_score …)。
+# 收口点记账时用它归因;pipeline 用 `with use_step("atom_split"):` 包住即可。
+_STEP = threading.local()
+
+
+def current_step() -> str:
+    return getattr(_STEP, "name", None) or "llm"
+
+
+@contextlib.contextmanager
+def use_step(name: str):
+    prev = getattr(_STEP, "name", None)
+    _STEP.name = name
+    try:
+        yield
+    finally:
+        _STEP.name = prev
+
+# 出厂兜底单价(USD / 1M token)。config.pricing.default 可覆盖。
+_FALLBACK_DEFAULT = {"input_per_1m": 1.0, "output_per_1m": 3.0, "embed_per_1m": 0.05}
+
+
+@dataclass(frozen=True)
+class Usage:
+    """一次调用的 token 拆分。embedding 调用只有 prompt(=total)。"""
+    prompt: int = 0
+    completion: int = 0
+    total: int = 0
+    cache_hit: int = 0      # DeepSeek prompt_cache_hit_tokens
+    cache_miss: int = 0     # DeepSeek prompt_cache_miss_tokens
+
+
+@dataclass(frozen=True)
+class ModelPrice:
+    """USD / 1M token。cache_* 为 None 时退回 input 价;embed_per_1m 仅 embedding。"""
+    input_per_1m: float = 0.0
+    output_per_1m: float = 0.0
+    cache_hit_per_1m: Optional[float] = None
+    cache_miss_per_1m: Optional[float] = None
+    embed_per_1m: Optional[float] = None
+
+
+def extract_usage(resp: Any) -> Usage:
+    """从 OpenAI 兼容 response 提取 token(dict 或 SDK 对象,缺失补 0)。
+
+    覆盖 prompt/completion/total + DeepSeek 的 prompt_cache_hit/miss_tokens。
+    """
+    def g(obj: Any, key: str) -> Optional[int]:
+        if obj is None:
+            return None
+        v = obj.get(key) if isinstance(obj, dict) else getattr(obj, key, None)
+        return int(v) if isinstance(v, (int, float)) else None
+
+    usage = resp.get("usage") if isinstance(resp, dict) else getattr(resp, "usage", None)
+    if usage is None:
+        return Usage()
+    prompt = g(usage, "prompt_tokens") or 0
+    completion = g(usage, "completion_tokens") or 0
+    total = g(usage, "total_tokens") or (prompt + completion)
+    hit = g(usage, "prompt_cache_hit_tokens") or 0
+    miss = g(usage, "prompt_cache_miss_tokens") or 0
+    return Usage(prompt=prompt, completion=completion, total=total,
+                 cache_hit=hit, cache_miss=miss)
+
+
+class PriceTable:
+    """定价解析:config 覆盖 > vendored 静态表 > default 兜底。永远给出 (price, source)。"""
+
+    def __init__(self, vendored: Dict[str, dict], config_pricing: Optional[dict] = None):
+        cp = config_pricing or {}
+        self._default = ModelPrice(**{**_FALLBACK_DEFAULT, **(cp.get("default") or {})})
+        self._config = {k: _mk_price(v) for k, v in cp.items() if k != "default"}
+        self._static = {k: _mk_price(v) for k, v in vendored.items()
+                        if not k.startswith("_")}
+
+    def resolve(self, model: str) -> Tuple[ModelPrice, str]:
+        if model in self._config:
+            return self._config[model], "config"
+        if model in self._static:
+            return self._static[model], "static"
+        return self._default, "default"
+
+
+def _mk_price(d: dict) -> ModelPrice:
+    return ModelPrice(
+        input_per_1m=float(d.get("input_per_1m", 0.0)),
+        output_per_1m=float(d.get("output_per_1m", 0.0)),
+        cache_hit_per_1m=_opt_float(d.get("cache_hit_per_1m")),
+        cache_miss_per_1m=_opt_float(d.get("cache_miss_per_1m")),
+        embed_per_1m=_opt_float(d.get("embed_per_1m")),
+    )
+
+
+def _opt_float(v: Any) -> Optional[float]:
+    return float(v) if isinstance(v, (int, float)) else None
+
+
+def cost_usd(usage: Usage, price: ModelPrice, *, is_embed: bool = False) -> float:
+    """token × 单价 → USD。embedding 走 embed 价;否则 prompt(含 cache 分档)+ completion。"""
+    M = 1_000_000
+    if is_embed:
+        per = price.embed_per_1m if price.embed_per_1m is not None else price.input_per_1m
+        return usage.total / M * per
+    # prompt 段:有 cache 拆分且配了 cache 价 → 分档计;否则整段 input 价
+    if (usage.cache_hit or usage.cache_miss) and price.cache_hit_per_1m is not None:
+        hit_p = price.cache_hit_per_1m
+        miss_p = price.cache_miss_per_1m if price.cache_miss_per_1m is not None else price.input_per_1m
+        prompt_cost = (usage.cache_hit * hit_p + usage.cache_miss * miss_p) / M
+    else:
+        prompt_cost = usage.prompt / M * price.input_per_1m
+    return prompt_cost + usage.completion / M * price.output_per_1m
+
+
+# ─────────────────────────────────────────────────────────────────
+# Ledger —— 唯一有状态的部分:进程内热计数 + 落 registry 持久化
+# ─────────────────────────────────────────────────────────────────
+
+@dataclass
+class _Bucket:
+    calls: int = 0
+    tokens: int = 0
+    cost: float = 0.0
+
+
+class UsageLedger:
+    """线程安全的 token/cost 汇聚点。``record_*`` 永不抛错。"""
+
+    def __init__(self, prices: PriceTable):
+        self._prices = prices
+        self._lock = threading.Lock()
+        self._by_step: Dict[str, _Bucket] = {}
+        self._by_model: Dict[str, _Bucket] = {}
+        self._total = _Bucket()
+        self._estimated = False   # 只要命中过 default/static 即标估算
+
+    # -- 记账 --------------------------------------------------------
+    def record_llm(self, step: str, model: str, resp: Any) -> None:
+        self._record(step, model, extract_usage(resp), is_embed=False)
+
+    def record_embed(self, model: str, resp: Any, *, step: str = "embedding") -> None:
+        self._record(step, model, extract_usage(resp), is_embed=True)
+
+    def _record(self, step: str, model: str, usage: Usage, *, is_embed: bool) -> None:
+        try:
+            price, source = self._prices.resolve(model)
+            usd = cost_usd(usage, price, is_embed=is_embed)
+            with self._lock:
+                if source != "config":
+                    self._estimated = True
+                for d, key in ((self._by_step, step), (self._by_model, model)):
+                    b = d.setdefault(key, _Bucket())
+                    b.calls += 1; b.tokens += usage.total; b.cost += usd
+                self._total.calls += 1
+                self._total.tokens += usage.total
+                self._total.cost += usd
+            logger.debug("[LLM] model=%s step=%s tokens=%d cost=$%.5f src=%s",
+                         model, step, usage.total, usd, source)
+            _persist(step, model, usage, usd, source)
+        except Exception:  # pylint: disable=broad-exception-caught
+            logger.warning("usage ledger record failed (non-fatal)", exc_info=True)
+
+    # -- 快照 --------------------------------------------------------
+    def snapshot(self) -> dict:
+        with self._lock:
+            return {
+                "total_usd": round(self._total.cost, 6),
+                "total_tokens": self._total.tokens,
+                "total_calls": self._total.calls,
+                "estimated": self._estimated,
+                "by_step": {k: _b(v) for k, v in self._by_step.items()},
+                "by_model": {k: _b(v) for k, v in self._by_model.items()},
+            }
+
+
+def _b(b: _Bucket) -> dict:
+    return {"calls": b.calls, "tokens": b.tokens, "cost_usd": round(b.cost, 6)}
+
+
+# ─────────────────────────────────────────────────────────────────
+# 加载 / 全局单例
+# ─────────────────────────────────────────────────────────────────
+
+def _vendored_path() -> Path:
+    return Path(__file__).with_name("data") / "model_prices.json"
+
+
+def load_price_table(config_pricing: Optional[dict] = None,
+                     vendored_path: Optional[Path] = None) -> PriceTable:
+    p = vendored_path or _vendored_path()
+    try:
+        vendored = json.loads(p.read_text(encoding="utf-8"))
+    except (OSError, json.JSONDecodeError):
+        logger.warning("vendored price table unreadable at %s; default-only", p)
+        vendored = {}
+    return PriceTable(vendored, config_pricing)
+
+
+def _persist(step: str, model: str, usage: Usage, usd: float, source: str) -> None:
+    """best-effort 落 registry llm_usage 表(函数内 import 防环;失败仅 warn)。"""
+    try:
+        from xskill.pipeline.registry import record_usage
+        record_usage(step=step, model=model, prompt=usage.prompt,
+                     completion=usage.completion, total=usage.total,
+                     cost_usd=usd, price_source=source)
+    except Exception:  # pylint: disable=broad-exception-caught
+        logger.debug("usage persist skipped", exc_info=True)
+
+
+def _fmt_tokens(n: int) -> str:
+    if n >= 1_000_000:
+        return f"{n/1_000_000:.2f}M"
+    if n >= 1_000:
+        return f"{n/1_000:.1f}K"
+    return str(n)
+
+
+def render_stats(summary: dict, *, role: str = "client", watcher: Optional[dict] = None) -> str:
+    """把 usage_summary(+可选 watcher) 渲成一屏人类可读文本仪表盘。"""
+    est = " · 估算" if summary.get("estimated") else ""
+    lines = [f"  xskill stats · {role}"]
+    lines.append(" " + "─" * 56)
+    lines.append(f"  💰 成本{est}      今日 ${summary.get('today_usd', 0):.4f}"
+                 f"  ·  累计 ${summary.get('total_usd', 0):.4f}")
+    lines.append(f"     {_fmt_tokens(summary.get('total_tokens', 0))} tokens"
+                 f"  ·  {summary.get('total_calls', 0)} calls")
+    steps = summary.get("by_step") or []
+    if steps:
+        mx = max((s["cost"] or 0) for s in steps) or 1e-9
+        for s in steps:
+            bar = "█" * int(round((s["cost"] or 0) / mx * 14))
+            lines.append(f"       {s['step']:<13}{bar:<14}  "
+                         f"{_fmt_tokens(s['tokens'] or 0):>7}  ${s['cost'] or 0:.4f}")
+    if watcher:
+        lines.append("")
+        lines.append("  🔄 流水线  " + " · ".join(
+            f"{k} {v}" for k, v in watcher.items()
+            if isinstance(v, int) and k not in ("polls",)))
+    lines.append(" " + "─" * 56)
+    return "\n".join(lines)
+
+
+# 进程级单例。首次 access 时用 config.pricing 构建;config 不可用则纯默认表。
+_LEDGER: Optional[UsageLedger] = None
+_LEDGER_LOCK = threading.Lock()
+
+
+def get_ledger() -> UsageLedger:
+    global _LEDGER  # pylint: disable=global-statement
+    if _LEDGER is None:
+        with _LEDGER_LOCK:
+            if _LEDGER is None:
+                pricing = None
+                try:
+                    from xskill.config import get_config
+                    pricing = get_config().get("pricing")
+                except Exception:  # pylint: disable=broad-exception-caught
+                    pricing = None
+                _LEDGER = UsageLedger(load_price_table(pricing))
+    return _LEDGER

--- a/src/xskill/usage.py
+++ b/src/xskill/usage.py
@@ -243,8 +243,9 @@ def _fmt_tokens(n: int) -> str:
     return str(n)
 
 
-def render_stats(summary: dict, *, status: Optional[dict] = None) -> str:
-    """把 status(进程/角色/处理模型) + usage_summary 渲成一屏文本仪表盘。"""
+def render_stats(summary: dict, *, status: Optional[dict] = None,
+                 models: Optional[list] = None) -> str:
+    """把 status(进程/角色/处理模型) + usage_summary + 用户模型占比 渲成文本仪表盘。"""
     status = status or {}
     role = status.get("role", "?")
     bar_line = " " + "─" * 56
@@ -275,6 +276,16 @@ def render_stats(summary: dict, *, status: Optional[dict] = None) -> str:
             lines.append(f"       {s['step']:<13}{bar:<14}  "
                          f"{_fmt_tokens(s['tokens'] or 0):>7}  ${s['cost'] or 0:.4f}")
     lines.append(bar_line)
+
+    # ── 用户 agent 模型占比(轨迹来源)──
+    models = models or []
+    if models:
+        lines.append("  🧩 用户模型 (轨迹占比)")
+        for m in models[:8]:
+            bar = "█" * int(round((m.get("pct") or 0) / 100 * 14))
+            lines.append(f"     {m['model']:<22}{bar:<14} {m.get('pct', 0):>5.1f}%"
+                         f"  ({m.get('trajs', 0)})")
+        lines.append(bar_line)
     return "\n".join(lines)
 
 

--- a/src/xskill/usage.py
+++ b/src/xskill/usage.py
@@ -243,11 +243,26 @@ def _fmt_tokens(n: int) -> str:
     return str(n)
 
 
-def render_stats(summary: dict, *, role: str = "client", watcher: Optional[dict] = None) -> str:
-    """把 usage_summary(+可选 watcher) 渲成一屏人类可读文本仪表盘。"""
+def render_stats(summary: dict, *, status: Optional[dict] = None) -> str:
+    """把 status(进程/角色/处理模型) + usage_summary 渲成一屏文本仪表盘。"""
+    status = status or {}
+    role = status.get("role", "?")
+    bar_line = " " + "─" * 56
+    lines = [f"  xskill stats · {role}", bar_line]
+
+    # ── 进程 + 处理模型 ──
+    if status.get("running"):
+        lines.append(f"  ● serve 运行中   pid {status.get('pid')} · :{status.get('port')}")
+    else:
+        lines.append("  ○ serve 未运行")
+    if status.get("llm_model"):
+        prov = (status.get("llm_base_url") or "").split("://")[-1].split("/")[0]
+        em = f"  · embed {status.get('embed_model')}" if status.get("embed_model") else ""
+        lines.append(f"  处理模型  {status['llm_model']} @ {prov}{em}")
+    lines.append(bar_line)
+
+    # ── 成本/用量 ──
     est = " · 估算" if summary.get("estimated") else ""
-    lines = [f"  xskill stats · {role}"]
-    lines.append(" " + "─" * 56)
     lines.append(f"  💰 成本{est}      今日 ${summary.get('today_usd', 0):.4f}"
                  f"  ·  累计 ${summary.get('total_usd', 0):.4f}")
     lines.append(f"     {_fmt_tokens(summary.get('total_tokens', 0))} tokens"
@@ -259,12 +274,7 @@ def render_stats(summary: dict, *, role: str = "client", watcher: Optional[dict]
             bar = "█" * int(round((s["cost"] or 0) / mx * 14))
             lines.append(f"       {s['step']:<13}{bar:<14}  "
                          f"{_fmt_tokens(s['tokens'] or 0):>7}  ${s['cost'] or 0:.4f}")
-    if watcher:
-        lines.append("")
-        lines.append("  🔄 流水线  " + " · ".join(
-            f"{k} {v}" for k, v in watcher.items()
-            if isinstance(v, int) and k not in ("polls",)))
-    lines.append(" " + "─" * 56)
+    lines.append(bar_line)
     return "\n".join(lines)
 
 

--- a/src/xskill/utils/llm.py
+++ b/src/xskill/utils/llm.py
@@ -109,8 +109,16 @@ class LLMClient:
             )
             wrapper = RateLimitedLLM(bucket=bucket, inner_call=self._raw_chat)
             resp = wrapper.call(prompt=prompt, system=system, timeout=60.0)
+            self._record(resp)
             return resp.choices[0].message.content
-        return self._raw_chat(prompt=prompt, system=system).choices[0].message.content
+        resp = self._raw_chat(prompt=prompt, system=system)
+        self._record(resp)
+        return resp.choices[0].message.content
+
+    def _record(self, resp) -> None:
+        """旁路记账(Issue #43);best-effort,绝不抛。"""
+        from xskill.usage import current_step, get_ledger
+        get_ledger().record_llm(current_step(), self.model, resp)
 
     def _raw_chat(self, *, prompt: str, system: str = ""):
         """原始 LLM 调用,返回完整 response 对象(供 wrapper reconcile usage)。"""
@@ -246,6 +254,9 @@ class EmbedClient:
             "/embeddings",
             {"model": self.model, "input": text},
         )
+        # 旁路记账(Issue #43);embeddings response 自带 usage.total_tokens。
+        from xskill.usage import get_ledger
+        get_ledger().record_embed(self.model, data)
         items = data.get("data") or []
         if not items:
             raise ValueError(f"embedding response missing data: {data!r}")

--- a/tests/test_atom_task_store.py
+++ b/tests/test_atom_task_store.py
@@ -139,3 +139,32 @@ class TestAllAtoms:
         store.save(_atom(atom_id="atom_b_0001", traj_id="b"))
         ids = {a.atom_id for a in store.all_atoms()}
         assert ids == {"atom_a_0001", "atom_b_0001"}
+
+
+# ────────────────────────────────────────────────────────────────────
+# source_model 继承(batch3):AtomTask 带 model + json 往返兼容旧文件
+# ────────────────────────────────────────────────────────────────────
+
+def test_atom_source_model_json_roundtrip():
+    a = AtomTask(atom_id="atom_t_0001", traj_id="t", offset_start=1,
+                 offset_end=2, intent="i", summary="s",
+                 source_model="claude-opus-4-7")
+    back = AtomTask.from_json(a.to_json())
+    assert back.source_model == "claude-opus-4-7"
+
+
+def test_atom_from_json_without_source_model_defaults_empty():
+    # 旧 json(无 source_model 字段)仍能加载,默认空串
+    legacy = ('{"atom_id":"a","traj_id":"t","offset_start":1,"offset_end":2,'
+              '"intent":"i","summary":"s"}')
+    assert AtomTask.from_json(legacy).source_model == ""
+
+
+def test_task_agent_sidecar_model_reader(tmp_path):
+    from xskill.agents.task_agent import _sidecar_model
+    md = tmp_path / "traj_cc_x_001.md"
+    md.write_text("# body", encoding="utf-8")
+    assert _sidecar_model(md) == ""                       # 无 sidecar → 空
+    (tmp_path / "traj_cc_x_001.json").write_text(
+        '{"model": "deepseek-v4-flash"}', encoding="utf-8")
+    assert _sidecar_model(md) == "deepseek-v4-flash"      # 有 sidecar → 读出

--- a/tests/test_canary_model_scope.py
+++ b/tests/test_canary_model_scope.py
@@ -1,0 +1,121 @@
+"""模型分桶灰度(batch3)单测:
+
+- eligible_models: top-N 选择 + 排除 unknown/synthetic + 权重归一
+- pick_side_scoped: unknown/非 top-N → main;top-N → 同 pick_side
+- _cohort_weighted: 只统计权重内模型,按人口加权
+- check_and_decide(weights=...): 加权裁决能"翻转"朴素均分的结论
+"""
+from __future__ import annotations
+
+from pathlib import Path
+
+from xskill import canary
+from xskill.canary import (
+    CanaryConfig, eligible_models, pick_side, pick_side_scoped, _cohort_weighted,
+)
+from xskill.skill.git import run_git
+
+
+def _init_repo(path: Path) -> Path:
+    path.mkdir(parents=True, exist_ok=True)
+    run_git(["init"], cwd=str(path))
+    run_git(["checkout", "-b", "main"], cwd=str(path))
+    run_git(["config", "user.email", "t@t"], cwd=str(path))
+    run_git(["config", "user.name", "t"], cwd=str(path))
+    (path / "SKILL.md").write_text("v1", encoding="utf-8")
+    run_git(["add", "-A"], cwd=str(path))
+    run_git(["commit", "-m", "init"], cwd=str(path))
+    return path
+
+
+def _stage_v2(sd: Path) -> None:
+    initial = canary.main_sha(sd)
+    (sd / "SKILL.md").write_text("v2", encoding="utf-8")
+    run_git(["add", "-A"], cwd=str(sd))
+    run_git(["commit", "-m", "v2"], cwd=str(sd))
+    canary.route_main_history_to_staging(sd, initial)
+
+
+# ── eligible_models ───────────────────────────────────────────────
+
+def test_eligible_models_topn_excludes_unknown():
+    share = [
+        {"model": "unknown", "trajs": 382},
+        {"model": "claude-opus-4-7", "trajs": 100},
+        {"model": "deepseek-v4-flash", "trajs": 40},
+        {"model": "<synthetic>", "trajs": 5},
+        {"model": "claude-haiku", "trajs": 10},
+    ]
+    w = eligible_models(share, top_n=2)
+    assert set(w) == {"claude-opus-4-7", "deepseek-v4-flash"}   # unknown/synthetic 排除
+    assert abs(sum(w.values()) - 1.0) < 1e-9                    # 归一
+    assert w["claude-opus-4-7"] > w["deepseek-v4-flash"]        # 按使用量
+    assert abs(w["claude-opus-4-7"] - 100 / 140) < 1e-9
+
+
+def test_eligible_models_all_unknown_empty():
+    assert eligible_models([{"model": "unknown", "trajs": 9}], top_n=2) == {}
+
+
+# ── pick_side_scoped ──────────────────────────────────────────────
+
+def test_pick_side_scoped_none_is_legacy():
+    assert (pick_side_scoped("t1", "s", 1.0, user_model="x", eligible=None)
+            == pick_side("t1", "s", 1.0))
+
+
+def test_pick_side_scoped_excludes_noneligible():
+    elig = {"claude-opus-4-7": 1.0}
+    # prob=1.0 本应全 staging,但非 top-N / unknown 被踢回 main
+    assert pick_side_scoped("t1", "s", 1.0, user_model="unknown", eligible=elig) == "main"
+    assert pick_side_scoped("t1", "s", 1.0, user_model="gpt-5", eligible=elig) == "main"
+    # 合格模型 → 照常分流(prob=1.0 → staging)
+    assert pick_side_scoped("t1", "s", 1.0, user_model="claude-opus-4-7",
+                            eligible=elig) == "staging"
+
+
+# ── _cohort_weighted ──────────────────────────────────────────────
+
+def test_cohort_weighted_excludes_unweighted_and_weights():
+    scores = [
+        {"score": 3, "user_model": "big"},
+        {"score": 10, "user_model": "small"},
+        {"score": 999, "user_model": "unknown"},   # 不在 weights → 丢弃
+    ]
+    weights = {"big": 0.9, "small": 0.1}
+    val, cohorts = _cohort_weighted(scores, weights)
+    assert cohorts == {"big": 1, "small": 1}        # unknown 不计
+    assert abs(val - (0.9 * 3 + 0.1 * 10)) < 1e-9   # 人口加权,非朴素均分
+
+
+# ── check_and_decide 加权裁决 ─────────────────────────────────────
+
+def _seed(sd, side, sha, model, score, n):
+    for i in range(n):
+        canary.AtomCanary(sd).append(
+            atom_id=f"{side}_{model}_{i}", skill_name="s", side=side,
+            commit_sha=sha, score=score, reasons="", user_model=model)
+
+
+def test_weighted_decision_flips_naive_average(tmp_path):
+    """同一批数据:朴素均分会 promote,人口加权应 reject。
+
+    staging 里小众模型刷了大量高分、主力模型只有少量低分;按人口加权后主力
+    模型(权重高)拉低 staging → 不该 promote。
+    """
+    sd = _init_repo(tmp_path / "skill")
+    _stage_v2(sd)
+    m_sha, s_sha = canary.main_sha(sd), canary.staging_sha(sd)
+    # staging: big 1×3, small 3×10  ;  main: big 1×8, small 3×8
+    _seed(sd, "staging", s_sha, "big", 3, 1)
+    _seed(sd, "staging", s_sha, "small", 10, 3)
+    _seed(sd, "main", m_sha, "big", 8, 1)
+    _seed(sd, "main", m_sha, "small", 8, 3)
+    cfg = CanaryConfig(total_samples=2, min_samples=2)
+    weights = {"big": 0.9, "small": 0.1}
+
+    res = canary.check_and_decide(sd, cfg, weights=weights)
+    assert res["action"] == "rejected"          # 加权:0.9*3+0.1*10=3.7 < 8
+    assert not canary.has_staging(sd)           # rejected → staging 已被 discard
+    # 对照:朴素均分(单桶,不传 weights)staging≈8.25 > main 8 → 本会 promote
+    # 此处不重复造仓库,test_cohort_weighted 已证加权≠均分

--- a/tests/test_team_collector.py
+++ b/tests/test_team_collector.py
@@ -54,6 +54,35 @@ def test_mark_uploaded_excludes_next_time(tmp_path):
     assert len(col.pending()) == 1
 
 
+def test_pending_carries_sidecar_model(tmp_path):
+    home = tmp_path / "home"
+    bridge = _bridge(home)
+    md = bridge / "traj_cc_x_001.md"
+    md.write_text("# body", encoding="utf-8")
+    # 同名 .json sidecar 带 model
+    (bridge / "traj_cc_x_001.json").write_text(
+        '{"model": "claude-opus-4-7", "cwd": "/secret"}', encoding="utf-8")
+    old = time.time() - 600
+    os.utime(md, (old, old))
+    col = TeamCollector(cursor_path=tmp_path / "cursor.json",
+                        quiet_seconds=180, home_root=home)
+    p = col.pending()[0]
+    assert p.model == "claude-opus-4-7"
+
+
+def test_pending_no_sidecar_model_empty(tmp_path):
+    home = tmp_path / "home"
+    bridge = _bridge(home)
+    md = bridge / "traj_cc_x_001.md"
+    md.write_text("# body", encoding="utf-8")          # 没有 .json sidecar
+    old = time.time() - 600
+    os.utime(md, (old, old))
+    col = TeamCollector(cursor_path=tmp_path / "cursor.json",
+                        quiet_seconds=180, home_root=home)
+    p = col.pending()[0]
+    assert p.model == ""                                # 不报错，空串
+
+
 def test_redaction_applied_to_content(tmp_path):
     home = tmp_path / "home"
     bridge = _bridge(home)

--- a/tests/test_team_protocol.py
+++ b/tests/test_team_protocol.py
@@ -20,8 +20,18 @@ def test_upload_roundtrip():
     ])
     back = UploadRequest.model_validate(req.model_dump())
     assert back.trajectories[0].traj_id == "traj_cc_x_001"
+    assert back.trajectories[0].model == ""        # 默认空，老 client 不带也能解析
     resp = UploadResponse(accepted=["traj_cc_x_001"], rejected=[])
     assert UploadResponse.model_validate(resp.model_dump()).accepted == ["traj_cc_x_001"]
+
+
+def test_upload_carries_model():
+    req = UploadRequest(trajectories=[
+        UploadTrajectory(traj_id="traj_cc_x_001", content="# hi", sha256="dead",
+                         model="claude-opus-4-7"),
+    ])
+    back = UploadRequest.model_validate(req.model_dump())
+    assert back.trajectories[0].model == "claude-opus-4-7"
 
 
 def test_sync_response_slots():

--- a/tests/test_team_server_api.py
+++ b/tests/test_team_server_api.py
@@ -109,3 +109,31 @@ def test_upload_writes_traj_md_under_client_bucket(client, tmp_path):
                 / "traj_cc_x_001.md")
     assert expected.is_file()
     assert expected.read_text(encoding="utf-8") == body
+
+
+def test_upload_with_model_writes_json_sidecar(client, tmp_path):
+    import json as _json
+    r = client.post("/api/v1/team/register", json={"token": "secret-token"})
+    cid = r.json()["client_id"]
+    hdr = {"X-Xskill-Token": "secret-token", "X-Xskill-Client": cid}
+    body = "# body"
+    client.post("/api/v1/team/upload", headers=hdr, json={
+        "trajectories": [{"traj_id": "traj_cc_x_001", "content": body,
+                          "sha256": _sha(body), "model": "claude-opus-4-7"}]})
+    sess = tmp_path / "team_traj" / "clients" / cid / "sessions"
+    sidecar = sess / "traj_cc_x_001.json"
+    assert sidecar.is_file()
+    assert _json.loads(sidecar.read_text(encoding="utf-8"))["model"] == "claude-opus-4-7"
+
+
+def test_upload_without_model_no_json_sidecar(client, tmp_path):
+    r = client.post("/api/v1/team/register", json={"token": "secret-token"})
+    cid = r.json()["client_id"]
+    hdr = {"X-Xskill-Token": "secret-token", "X-Xskill-Client": cid}
+    body = "# body"
+    client.post("/api/v1/team/upload", headers=hdr, json={
+        "trajectories": [{"traj_id": "traj_cc_x_001", "content": body,
+                          "sha256": _sha(body)}]})   # 不带 model
+    sess = tmp_path / "team_traj" / "clients" / cid / "sessions"
+    assert (sess / "traj_cc_x_001.md").is_file()
+    assert not (sess / "traj_cc_x_001.json").exists()   # 行为不回归

--- a/tests/test_usage.py
+++ b/tests/test_usage.py
@@ -1,0 +1,111 @@
+"""test_usage.py —— LLM token/成本统计核心逻辑(Issue #43)"""
+from __future__ import annotations
+
+import pytest
+
+from xskill import usage as U
+from xskill.usage import (
+    ModelPrice, PriceTable, Usage, UsageLedger, cost_usd, extract_usage,
+    load_price_table,
+)
+
+
+# ── extract_usage ────────────────────────────────────────────────
+class _Obj:
+    def __init__(self, **kw):
+        self.usage = type("u", (), kw)()
+
+
+def test_extract_usage_dict_with_cache():
+    resp = {"usage": {"prompt_tokens": 1100, "completion_tokens": 140,
+                      "total_tokens": 1240, "prompt_cache_hit_tokens": 900,
+                      "prompt_cache_miss_tokens": 200}}
+    u = extract_usage(resp)
+    assert (u.prompt, u.completion, u.total, u.cache_hit, u.cache_miss) == (1100, 140, 1240, 900, 200)
+
+
+def test_extract_usage_sdk_object_total_derived():
+    u = extract_usage(_Obj(prompt_tokens=10, completion_tokens=5))
+    assert u.total == 15  # total_tokens 缺失 → prompt+completion
+
+
+def test_extract_usage_missing_usage():
+    assert extract_usage({"choices": []}) == Usage()
+    assert extract_usage(None) == Usage()
+
+
+# ── PriceTable 解析优先级 ────────────────────────────────────────
+def _table():
+    vendored = {"deepseek-v4-flash": {"input_per_1m": 0.14, "output_per_1m": 0.28,
+                                      "cache_hit_per_1m": 0.014},
+                "text-embedding-v4": {"embed_per_1m": 0.02}}
+    cfg = {"default": {"input_per_1m": 2.0, "output_per_1m": 6.0},
+           "deepseek-v4-flash": {"input_per_1m": 0.10, "output_per_1m": 0.20}}
+    return PriceTable(vendored, cfg)
+
+
+def test_resolve_config_overrides_static():
+    p, src = _table().resolve("deepseek-v4-flash")
+    assert src == "config" and p.input_per_1m == 0.10
+
+
+def test_resolve_static_then_default():
+    t = PriceTable({"text-embedding-v4": {"embed_per_1m": 0.02}}, None)
+    p, src = t.resolve("text-embedding-v4")
+    assert src == "static" and p.embed_per_1m == 0.02
+    p2, src2 = t.resolve("never-heard-of-it")
+    assert src2 == "default" and p2.input_per_1m == U._FALLBACK_DEFAULT["input_per_1m"]
+
+
+# ── cost_usd ─────────────────────────────────────────────────────
+def test_cost_plain_prompt_completion():
+    price = ModelPrice(input_per_1m=1.0, output_per_1m=2.0)
+    c = cost_usd(Usage(prompt=1_000_000, completion=500_000), price)
+    assert c == pytest.approx(1.0 + 1.0)  # 1M×$1 + 0.5M×$2
+
+
+def test_cost_cache_split_pricing():
+    price = ModelPrice(input_per_1m=1.0, output_per_1m=0.0,
+                       cache_hit_per_1m=0.1, cache_miss_per_1m=1.0)
+    # 全是 cache hit → 便宜十倍
+    c = cost_usd(Usage(prompt=1_000_000, cache_hit=1_000_000, cache_miss=0), price)
+    assert c == pytest.approx(0.1)
+
+
+def test_cost_embedding_uses_embed_price():
+    price = ModelPrice(input_per_1m=99.0, output_per_1m=99.0, embed_per_1m=0.02)
+    c = cost_usd(Usage(total=1_000_000), price, is_embed=True)
+    assert c == pytest.approx(0.02)
+
+
+# ── UsageLedger ──────────────────────────────────────────────────
+def test_ledger_accumulates_and_flags_estimated(monkeypatch):
+    monkeypatch.setattr(U, "_persist", lambda *a, **k: None)  # 不碰真实 registry
+    led = UsageLedger(_table())
+    led.record_llm("atom_split", "deepseek-v4-flash",
+                   {"usage": {"prompt_tokens": 1000, "completion_tokens": 200,
+                              "total_tokens": 1200}})
+    led.record_embed("text-embedding-v4", {"usage": {"total_tokens": 800}})
+    snap = led.snapshot()
+    assert snap["total_calls"] == 2
+    assert snap["total_tokens"] == 2000
+    assert snap["by_step"]["atom_split"]["calls"] == 1
+    assert snap["by_step"]["embedding"]["tokens"] == 800
+    # embedding 命中 static 价 → estimated=True
+    assert snap["estimated"] is True
+    assert snap["total_usd"] > 0
+
+
+def test_ledger_record_never_raises(monkeypatch):
+    monkeypatch.setattr(U, "_persist", lambda *a, **k: None)
+    led = UsageLedger(_table())
+    led.record_llm("x", "m", object())      # 垃圾 resp,不应抛
+    led.record_llm("x", "m", None)
+    assert led.snapshot()["total_calls"] == 2  # 仍记账(token=0)
+
+
+# ── vendored 表加载 ──────────────────────────────────────────────
+def test_load_vendored_price_table():
+    t = load_price_table(None)
+    p, src = t.resolve("deepseek-v4-flash")
+    assert src == "static" and p.input_per_1m > 0

--- a/tests/test_usage.py
+++ b/tests/test_usage.py
@@ -143,3 +143,39 @@ def test_runtime_alive():
     assert _alive(os.getpid()) is True
     assert _alive(2_000_000_000) is False
     assert _alive(None) is False
+
+
+# ── batch2: source_model / model_share / 模型占比渲染 ────────────
+def test_sidecar_model(tmp_path):
+    import json as _j
+    from xskill.pipeline.registry import _sidecar_model
+    md = tmp_path / "traj_x.md"; md.write_text("x", encoding="utf-8")
+    (tmp_path / "traj_x.json").write_text(_j.dumps({"model": "qwen-max"}), encoding="utf-8")
+    assert _sidecar_model(md) == "qwen-max"
+    md2 = tmp_path / "traj_y.md"; md2.write_text("y", encoding="utf-8")
+    assert _sidecar_model(md2) is None
+
+
+def test_model_share(tmp_path):
+    from xskill.pipeline import registry as R
+    db = tmp_path / "r.db"
+    conn = R.get_connection(db)
+    conn.execute("INSERT INTO watch_dirs(path) VALUES('/x')")
+    wid = conn.execute("SELECT id FROM watch_dirs").fetchone()[0]
+    for fn, m in [("a.md", "qwen"), ("b.md", "qwen"), ("c.md", "deepseek"), ("d.md", None)]:
+        conn.execute("INSERT INTO trajectories(watch_dir_id,filename,source_model)"
+                     " VALUES(?,?,?)", (wid, fn, m))
+    conn.commit(); conn.close()
+    d = {x["model"]: x for x in R.model_share(db)}
+    assert d["qwen"]["trajs"] == 2 and d["qwen"]["pct"] == 50.0
+    assert d["unknown"]["trajs"] == 1
+
+
+def test_render_stats_model_share():
+    out = render_stats(
+        {"today_usd": 0, "total_usd": 0, "total_tokens": 0, "total_calls": 0,
+         "estimated": False, "by_step": []},
+        status={"running": False, "role": "server"},
+        models=[{"model": "qwen", "trajs": 50, "pct": 50.0},
+                {"model": "unknown", "trajs": 50, "pct": 50.0}])
+    assert "用户模型" in out and "qwen" in out and "50.0%" in out

--- a/tests/test_usage.py
+++ b/tests/test_usage.py
@@ -109,3 +109,37 @@ def test_load_vendored_price_table():
     t = load_price_table(None)
     p, src = t.resolve("deepseek-v4-flash")
     assert src == "static" and p.input_per_1m > 0
+
+
+# ── batch1: render header + runtime ──────────────────────────────
+from xskill.usage import render_stats
+
+
+def test_render_stats_running_with_models():
+    out = render_stats(
+        {"today_usd": 0.5, "total_usd": 1.0, "total_tokens": 1200, "total_calls": 3,
+         "estimated": True,
+         "by_step": [{"step": "atom_split", "tokens": 1000, "cost": 0.4, "calls": 2}]},
+        status={"running": True, "pid": 42, "port": 8000, "role": "standalone",
+                "llm_model": "deepseek-v4-flash",
+                "llm_base_url": "https://api.deepseek.com",
+                "embed_model": "text-embedding-v4"})
+    assert "serve 运行中" in out and "pid 42" in out and "standalone" in out
+    assert "deepseek-v4-flash @ api.deepseek.com" in out
+    assert "atom_split" in out and "今日 $0.5000" in out
+
+
+def test_render_stats_not_running():
+    out = render_stats(
+        {"today_usd": 0, "total_usd": 0, "total_tokens": 0, "total_calls": 0,
+         "estimated": False, "by_step": []},
+        status={"running": False, "role": "client"})
+    assert "serve 未运行" in out and "· client" in out
+
+
+def test_runtime_alive():
+    import os
+    from xskill.runtime import _alive
+    assert _alive(os.getpid()) is True
+    assert _alive(2_000_000_000) is False
+    assert _alive(None) is False


### PR DESCRIPTION
## 概述 | Overview

实现 LLM token/成本统计与"用户 agent 模型"全链路贯穿,并在此基础上落地**模型分桶灰度裁决**。关联 Issue #43。

Implements LLM token/cost tracking, carries the user agent model end-to-end (ingest → registry → C/S upload → atoms), and builds **model-scoped canary decisioning** on top. Closes #43.

## 主要改动 | What's included

1. **成本/用量统计** — `UsageLedger` 估算 token×单价(无 tiktoken/litellm 依赖,价格走 vendored JSON + 可配 default);`xskill stats` 仪表盘(进程/部署角色/处理模型 + 成本 + 用户模型占比)。
2. **用户模型贯穿(批1/2)** — CC/OpenCode adapter 抓取 `model`,registry 加 `source_model` 列,`model_share()` 占比。
3. **上传贯穿到 server + 存量回填** — `UploadTrajectory` 带 `model`(只带 model,不带未脱敏元信息),server `team_upload` 先写 `.json` sidecar 再写 `.md`;`scripts/backfill_server_source_model.py` 对存量直接 `UPDATE source_model` + 写 sidecar,**零触发 reindex**。
4. **模型分桶灰度(批3)** — `AtomTask.source_model` 继承;`eligible_models` 取使用量 top-N 并归一权重、排除 unknown/`<synthetic>`;`pick_side_scoped` 把 unknown/非 top-N 流量挡在 main;`check_and_decide` 改**人口加权**(Σ 桶均分 × 权重),`weights=None` 退化单桶=旧均分;configs `scope_top_n` / `total_samples`。

## 设计要点 | Design notes

- **unknown 全程排除灰度**(路由+打分),但**仍参与蒸馏**(来源不可信只是不让它影响 A/B,不浪费素材)。
- 加权裁决的精度 = σ²/N,**与模型数无关**(小桶权重小、噪声可忽略)→ 用总量门槛 `total_samples` 即可,无需每桶单独达标。
- 价格 build 时拉取、失败即 fail loud;telemetry 旁路 best-effort 不阻塞管线。

## 测试 | Testing

- `make test`:632 passed(唯一 1 failed 为 `test_canary_flip_promote_and_install_new_version` 的已知 e2e timing flake,隔离单跑稳定通过)。
- 旧 canary 测试全过 → 加权裁决对 `weights=None` 向后兼容。
- server 已部署验证(`0.5.3.dev6`):存量回填后占比 `unknown 100%` → `opus-4-7 18.6% / deepseek-flash 7.5% / …`;`eligible_models` 实算 top-2 权重 0.713/0.287。
