### PR TITLE
feat(cold-start): support multi-round main evolution during batch flush

### DIFF
--- a/src/xskill/agents/skill_edit_agent.py
+++ b/src/xskill/agents/skill_edit_agent.py
@@ -184,7 +184,8 @@ commit message 写明本次基于哪些 atom_id 整理，例如：
 - list_files(path) — 列目录文件
 - write_file(path, content) — 写任意文件到 skill_dir 下
 - commit_baby_to_main(skill_name, message) — 仅 baby 分支可用
-- commit_to_staging(skill_name, message) — 仅 main 分支可用
+- commit_to_staging(skill_name, message) — 仅 main 分支可用（灰度路径）
+- commit_update_main(skill_name, message) — main 分支冷启动在线进化：原地 commit 回 main
 
 # 隐私守护
 
@@ -282,6 +283,7 @@ class SkillEditAgent:
     llm_cfg: dict
     traj_root: Path
     threshold: int = C.ATOM_PROMOTION_THRESHOLD
+    cold_flush: bool = False
 
     def maybe_run(self) -> bool:
         """检查所有守门条件 → 触发 agent → 验证落盘 → 清 buffer。
@@ -311,7 +313,10 @@ class SkillEditAgent:
         # 守门 3: 若场景是 "create staging"（即在 main 上）→ 额外要求 main 真有人用过
         cur = current_branch(str(self.skill_dir))
         if cur == "main":
-            if not self._main_has_ux_score():
+            # cold_flush 在线进化：批量冷启动期还没有真实用户流量 → 没有
+            # ux_score；此模式下跳过守门 3，允许 main 技能基于本轮新
+            # candidates 原地重新精炼。
+            if not self.cold_flush and not self._main_has_ux_score():
                 logger.info(
                     "skip SkillEdit: %s main 还没真实 ux_score，"
                     "保留 candidates 等用户用 main 后再产 staging",
@@ -401,6 +406,20 @@ class SkillEditAgent:
                 "写完 SKILL.md 后调 ``commit_baby_to_main(skill_name, message)`` "
                 "graduate 到 main 分支。"
             )
+        elif self.cold_flush:
+            # 冷启动在线进化：main 上的技能基于"现有正文 + 本轮新 candidates"
+            # 原地重写，直接 commit 回 main（不开 staging / 不走灰度）。
+            scenario_lines.append(
+                "skill_name: " + self.skill_dir.name
+                + "（**main 分支 · 冷启动在线进化** —— 原地更新现有 skill）"
+            )
+            scenario_lines.append(
+                "先用 ``skill_read(skill_name)`` 读现有 SKILL.md 正文，**在现有"
+                "正文基础上**融合本轮新 candidates 的 atom 知识重写正文（version "
+                "号 +1），写完后调 ``commit_update_main(skill_name, message)`` "
+                "**直接 commit 回 main**——这是本轮批量进化，不开 staging、"
+                "不走灰度。"
+            )
         else:
             scenario_lines.append(
                 "skill_name: " + self.skill_dir.name + "（**main 分支** —— 更新现有 skill）"
@@ -452,6 +471,7 @@ class SkillEditAgent:
                 ST.write_file,
                 ST.commit_baby_to_main,
                 ST.commit_to_staging,
+                ST.commit_update_main,
             ],
         )
         # 逐轮 CoT/工具调用 → logs/agents/skill_edit_agents/skills/<skill>_<ts>.log

--- a/src/xskill/agents/skill_tools.py
+++ b/src/xskill/agents/skill_tools.py
@@ -879,6 +879,44 @@ def commit_to_staging(skill_name: str, message: str) -> str:
     return f"committed to staging: {slug}"
 
 
+def commit_update_main(skill_name: str, message: str) -> str:
+    """冷启动在线进化专用：把 main 上的技能正文更新**直接 commit 回 main**。
+
+    前提：该 skill 当前在 main 分支（冷启动 flush 已让它毕业到 main）。
+    行为：跑 description 触发优化 → git add . + commit on main（不开 staging /
+    不走灰度 / 不物化 canary）。技能逐 epoch 在 main 上原地进化。
+
+    Args:
+        skill_name: 目标 skill 的 slug
+        message: commit message，应写明本次基于哪些 atom_id 进化
+
+    Returns:
+        成功："updated on main: <skill_name>"
+        失败："error: ..."
+    """
+    from xskill.skill.git import commit_update_main_branch
+    skill_dir = _ctx_v2["skill_dir"]
+    if skill_dir is None:
+        return "error: v2 context not initialized"
+    slug = _slugify(skill_name)
+    target = skill_dir / slug
+    if not target.is_dir():
+        return f"error: skill {slug} not found"
+    if not (target / ".git").is_dir():
+        return f"error: skill {slug} 没 git 仓库"
+    msg = (message or "").strip()
+    if not msg:
+        return "error: commit message 必填"
+    # commit 前先跑 description 触发优化（best desc 写回 frontmatter）。失败只
+    # log，不阻断 commit。
+    _run_description_optimization(target, slug)
+    ok = commit_update_main_branch(str(target), msg)
+    if not ok:
+        return ("error: commit_update_main 失败"
+                "（不在 main 分支 / 无改动可提交——看日志）")
+    return f"updated on main: {slug}"
+
+
 def absorb_user_edit_to_main(skill_name: str, message: str) -> str:
     """UserEditAbsorbAgent 专用：把用户手改吸收为 main 分支一次 commit。
 

--- a/src/xskill/pipeline/cold_start.py
+++ b/src/xskill/pipeline/cold_start.py
@@ -11,6 +11,13 @@ SkillEdit**，让本轮导入的全部子轨迹 atom 攒进各 skill 的 ``.cand
 子轨迹 atom——把 baby 技能批量毕业到 main。消费屏障后轮次计数 +1；跑满
 ``epochs`` 即转入正常在线增量 + 灰度路径。
 
+多轮批量进化语义（``epochs`` ≥ 2 时）：``epochs`` 是总批量 flush 轮数。
+第 1 轮把 baby 技能毕业到 main；第 2..N 轮的 flush 走 ``cold_flush`` 路径——
+main 上的技能跳过 ux_score 守门，基于"现有正文 + 本轮新 candidates 的 atom"
+原地重新精炼并直接 commit 回 main（version 逐轮递增），不开 staging / 不走灰度。
+这适用于批量冷启动期间还没有真实用户流量、但需要多轮历史轨迹继续完善首版技能库
+的场景；跑满 ``epochs`` 后自动回到正常在线增量 + 灰度路径。
+
 设计原则：默认 ``enabled=False`` → 对既有部署零行为变化；非法配置直接抛错
 （不做兜底回退）。屏障用文件 sentinel 而非新增 CLI 子命令，外部批量导入编排
 在一轮导入结束后 ``touch`` 约定路径即可触发。

--- a/src/xskill/pipeline/runner.py
+++ b/src/xskill/pipeline/runner.py
@@ -286,17 +286,22 @@ class DirectoryWatcher:
                     "冷启动批量 flush 屏障到达 → SkillEdit (flush_threshold=%d)",
                     cs.flush_threshold,
                 )
-                self._check_pending_skill_edits(threshold=cs.flush_threshold)
+                self._check_pending_skill_edits(
+                    threshold=cs.flush_threshold, cold_flush=True)
                 cs.consume_barrier()
             # 屏障未到：hold，本轮不写正文（让 atom 继续攒进 candidates）
             return
         self._check_pending_skill_edits()
 
-    def _check_pending_skill_edits(self, threshold=None):
+    def _check_pending_skill_edits(self, threshold=None, cold_flush=False):
         """遍历每个 skill 目录调 SkillEditAgent.maybe_run()。
 
         ``threshold``：None 时各 skill 用默认 ATOM_PROMOTION_THRESHOLD（在线增量）；
         冷启动屏障 flush 传入低门槛（如 1）→ 任何有候选的 skill 都批量毕业。
+
+        ``cold_flush``：冷启动批量 flush 屏障触发时传 True，透传给 SkillEditAgent。
+        作用：main 上的技能跳过 ux_score 守门、基于新 candidates 原地重精炼并
+        直接 commit 回 main（在线进化），不开 staging / 不走灰度。
 
         独立于 process_atom_task：不依赖任何 atom 处理成功；只看 candidates.yml
         当前累计 weightscore 是否够阈值。即便某次 cluster 抛异常导致 buffer
@@ -363,6 +368,7 @@ class DirectoryWatcher:
                 agno_agent_factory=factory,
                 llm_cfg=self.config.get("llm", {}),
                 traj_root=traj_root,
+                cold_flush=cold_flush,
                 **({} if threshold is None else {"threshold": threshold}),
             )
             try:

--- a/src/xskill/skill/git.py
+++ b/src/xskill/skill/git.py
@@ -1591,6 +1591,41 @@ def commit_to_staging_branch(skill_dir: str, message: str) -> bool:
     return True
 
 
+def commit_update_main_branch(skill_dir: str, message: str) -> bool:
+    """冷启动在线进化专用：在 **main 分支原地** commit 一次正文更新。
+
+    与 ``commit_to_staging_branch`` 的区别：不开 staging / 不物化 canary / 不走
+    灰度，直接把 SkillEditAgent 重写后的 SKILL.md（基于现有正文 + 新 epoch 的
+    candidates atom）commit 进 main —— 技能逐 epoch 在 main 上原地进化。
+
+    前提：当前在 main 分支（冷启动 flush 时，已毕业的技能都在 main）。
+    流程：add -A + commit -m <message>（无改动则 nothing-to-commit 返回 False）。
+
+    不在 main → 直接 throw（不做 fallback），由 caller 兜异常并保留 candidates 重试。
+    """
+    with skill_repo_lock(skill_dir):
+        with _open_repo(skill_dir) as repo:
+            cur = _current_branch_name(repo)
+            if cur != "main":
+                raise RuntimeError(
+                    f"commit_update_main_branch 要求当前在 main 分支，实际在 {cur!r}"
+                )
+            _stage_all(repo, Path(skill_dir))
+            sha, err = _do_commit(repo, message)
+            if sha is None:
+                if err == "nothing to commit":
+                    logger.warning(
+                        "commit_update_main_branch 无改动可提交: %s",
+                        Path(skill_dir).name,
+                    )
+                    return False
+                raise RuntimeError(f"commit_update_main_branch commit 失败: {err}")
+    logger.info(
+        "♻️  main 原地进化 commit: %s: %s", Path(skill_dir).name, message
+    )
+    return True
+
+
 def ensure_repo(skill_dir: str):
     """确保 skill_dir 是一个 git 仓库，在 main 分支上。"""
     p = Path(skill_dir)

--- a/tests/test_cold_start_epoch.py
+++ b/tests/test_cold_start_epoch.py
@@ -41,12 +41,72 @@ def _seed_baby(skill_root, slug, weightscore):
     return sd
 
 
+def _add_candidate(sd, atom_id, weightscore):
+    """给已存在的 skill 追加一个候选 atom。"""
+    data = C.load_candidates(sd)
+    data, _ = C.add_atom_contribution(data, atom_id, weightscore)
+    C.save_candidates(sd, data)
+
+
+def _make_evolve_agno():
+    """冷启动在线进化 agno stub：
+      - baby 分支：写正文 + commit_baby_to_main（首次毕业）。
+      - main 分支（冷启动 cold_flush）：读现有正文，写**带递增 version**的新正文，
+        调 commit_update_main 原地 commit 回 main。
+    串扰锚点 = 正文里写自己的 slug。
+    """
+    import re
+
+    class _EvolveStub:
+        def __init__(self, *, instructions, tools):
+            self.instructions = instructions
+            self.tools = {getattr(t, "__name__", ""): t for t in tools}
+
+        def run(self, user_msg, **kw):
+            m_dir = re.search(r"目标 skill 目录:\s*(\S+)", user_msg)
+            slug = m_dir.group(1).rstrip("/").split("/")[-1] if m_dir else "?"
+            m = re.search(r"目标 SKILL\.md 路径:\s*(\S+)", user_msg)
+            md_path = m.group(1) if m else None
+            cold_evolve = "冷启动在线进化" in user_msg
+
+            if cold_evolve:
+                # main 原地进化：读现有版本号 → +1 → 写新正文
+                prev = self.tools["skill_read"](slug) if "skill_read" in self.tools else ""
+                vm = re.search(r"version:\s*(\d+)", prev)
+                ver = (int(vm.group(1)) if vm else 1) + 1
+                if md_path and "write_file" in self.tools:
+                    self.tools["write_file"](
+                        md_path,
+                        f"---\nname: {slug}\ndescription: evolved body for {slug}\n"
+                        f"metadata:\n  version: {ver}\n---\n"
+                        f"# {slug}\nbody-of-{slug}-v{ver}\n",
+                    )
+                if "commit_update_main" in self.tools:
+                    self.tools["commit_update_main"](slug, f"evolve {slug} v{ver}")
+            else:
+                # baby 首次毕业
+                if md_path and "write_file" in self.tools:
+                    self.tools["write_file"](
+                        md_path,
+                        f"---\nname: {slug}\ndescription: real body for {slug}\n"
+                        f"metadata:\n  version: 1\n---\n# {slug}\nbody-of-{slug}-v1\n",
+                    )
+                if "commit_baby_to_main" in self.tools:
+                    self.tools["commit_baby_to_main"](slug, f"graduate {slug}")
+
+            class _R:
+                content = ""
+            return _R()
+
+    return lambda **kw: _EvolveStub(**kw)
+
+
 def _serial_factory():
     """非并发 agno stub：写 SKILL.md + commit_baby_to_main（barrier=1 即时放行）。"""
     return _make_barrier_agno(1, threading.Barrier(1))
 
 
-def _make_watcher(tmp_path, skill_root, cold_start_cfg):
+def _make_watcher(tmp_path, skill_root, cold_start_cfg, factory=None):
     db = tmp_path / "test.db"
     wd = tmp_path / "wd"
     wd.mkdir(exist_ok=True)
@@ -64,7 +124,7 @@ def _make_watcher(tmp_path, skill_root, cold_start_cfg):
         max_concurrent=4,
         db_path=db,
         store=store,
-        agno_agent_factory=_serial_factory(),
+        agno_agent_factory=factory or _serial_factory(),
         home_root=tmp_path,
     )
 
@@ -170,3 +230,79 @@ class TestColdStartEpochFlush:
         (tmp_path / DEFAULT_BARRIER_FILENAME).touch()
         w._run_skill_edit_step()
         assert current_branch(str(second)) == "baby", "在线阶段低分技能不该毕业"
+
+
+# ───────────────────────── 多轮批量在线进化（cold_flush） ─────────────────────────
+
+class TestColdStartMultiEpochEvolution:
+    def test_main_evolves_in_place_across_epochs(self, tmp_path):
+        """多轮冷启动在线进化：
+          第 1 轮 flush → baby 技能毕业到 main（version 1）；
+          给同一技能加新候选 → 第 2 轮 flush（cold_flush）→ 技能**仍在 main**
+          （没开 staging、没被 ux_score 守门挡住）、SKILL.md 正文进化、version
+          递增、candidates 清空。
+        """
+        skill_root = tmp_path / "skill"; skill_root.mkdir()
+        slug = "sk-evolve"
+        sd = _seed_baby(skill_root, slug, weightscore=3)
+        w = _make_watcher(
+            tmp_path, skill_root,
+            cold_start_cfg={"enabled": True, "flush_threshold": 1, "epochs": 2},
+            factory=_make_evolve_agno(),
+        )
+
+        # ── 第 1 轮：baby → main 毕业 ──
+        (tmp_path / DEFAULT_BARRIER_FILENAME).touch()
+        w._run_skill_edit_step()
+        assert current_branch(str(sd)) == "main", "第 1 轮后应毕业到 main"
+        body_v1 = (sd / "SKILL.md").read_text(encoding="utf-8")
+        assert "body-of-sk-evolve-v1" in body_v1
+        assert "version: 1" in body_v1
+        assert C.load_candidates(sd)["candidates"] == [], "第 1 轮后候选应清空"
+        # flush 轮次还没跑满（epochs=2，刚消费 1 个）—— main 上无人用没有
+        # ux_score，但下一轮 cold_flush 仍能进化（证明守门 3 被跳过）
+        assert w._cold_start.active is True
+
+        # ── 给同一技能加新候选（模拟第 2 轮攒进的新 atom）──
+        _add_candidate(sd, f"atom_{slug}_0002", 4)
+        assert C.load_candidates(sd)["candidates"], "新候选应已写入"
+
+        # ── 第 2 轮：cold_flush 原地进化（不走 staging）──
+        (tmp_path / DEFAULT_BARRIER_FILENAME).touch()
+        w._run_skill_edit_step()
+
+        # 仍在 main，没开 staging
+        from xskill.skill.git import run_git
+        code, _, _ = run_git(["rev-parse", "--verify", "staging"], cwd=str(sd))
+        assert code != 0, "cold_flush 进化不该开 staging 分支"
+        assert current_branch(str(sd)) == "main", "第 2 轮进化后仍应在 main"
+
+        # 正文进化 + version 递增 + 候选清空
+        body_v2 = (sd / "SKILL.md").read_text(encoding="utf-8")
+        assert "body-of-sk-evolve-v2" in body_v2, "第 2 轮正文应已进化"
+        assert "version: 2" in body_v2, "第 2 轮 version 应递增到 2"
+        assert body_v2 != body_v1, "第 2 轮正文应与第 1 轮不同"
+        assert C.load_candidates(sd)["candidates"] == [], "第 2 轮后候选应清空"
+
+        # 跑满 2 轮 → 转在线
+        assert w._cold_start.active is False
+        assert w._stats["skills_edited"] == 2
+
+    def test_no_canary_materialized_on_evolution(self, tmp_path):
+        """cold_flush 进化不物化 .canary（不走灰度路径）。"""
+        skill_root = tmp_path / "skill"; skill_root.mkdir()
+        slug = "sk-nocanary"
+        sd = _seed_baby(skill_root, slug, weightscore=3)
+        w = _make_watcher(
+            tmp_path, skill_root,
+            cold_start_cfg={"enabled": True, "flush_threshold": 1, "epochs": 2},
+            factory=_make_evolve_agno(),
+        )
+        (tmp_path / DEFAULT_BARRIER_FILENAME).touch()
+        w._run_skill_edit_step()  # 第 1 轮 graduate
+        _add_candidate(sd, f"atom_{slug}_0002", 5)
+        (tmp_path / DEFAULT_BARRIER_FILENAME).touch()
+        w._run_skill_edit_step()  # 第 2 轮 evolve
+
+        canary_dir = skill_root / ".canary" / slug
+        assert not canary_dir.exists(), "cold_flush 进化不该物化 .canary"


### PR DESCRIPTION
## Summary

Stacked on #53. This PR adds the optional multi-round evolution behavior for cold-start batch flush: after the first flush graduates baby skills to main, later configured flush rounds can refine those main skills in place from newly accumulated candidates.

## Changes

- `SkillEditAgent` gets a `cold_flush` path: when enabled, main skills can skip the `ux_score` gate during cold-start batch rounds.
- Adds `commit_update_main()` tool and `commit_update_main_branch()` git helper so the agent can commit directly on `main` without opening `staging`.
- `DirectoryWatcher` passes `cold_flush=True` only when the cold-start sentinel triggers a flush.
- Extends `ColdStartController` docs to describe multi-round batch evolution in non-benchmark language.
- Extends `tests/test_cold_start_epoch.py` to cover main in-place evolution, version increment, no staging branch, no `.canary` materialization, and return to normal online flow after configured rounds.

## Review notes

This is not required for the atomstore fix and is separated for review. It is intended for batch cold-start / historical trajectory import where there is no user traffic yet; it does not use val set, benchmark score, or canary composite scoring.

## Test plan

- `/usr/bin/python3.11 -m pytest tests/test_cold_start_epoch.py`
- `/usr/bin/python3.11 -m pytest tests/test_skill_tools_dotgit_guard.py tests/test_skilledit_parallel.py tests/test_cold_start_epoch.py`

## Depends on

- #53