### PR TITLE
Add dependency injection container for XSkill

### DIFF
--- a/pyproject.toml
+++ b/pyproject.toml
@@ -28,6 +28,7 @@ classifiers = [
 ]
 dependencies = [
     "pyyaml>=6.0",
+    "dependency-injector>=4.41",
     "numpy>=1.24",
     "openai>=1.0",
     "agno",

--- a/src/xskill/__init__.py
+++ b/src/xskill/__init__.py
@@ -22,6 +22,7 @@ except ImportError:  # 未经 build 的源码树
 
 # 顶级公开面：3 个核心类
 from xskill.core import XSkill
+from xskill.config import XSkillConfig
 from xskill.skill.skill import Skill
 from xskill.pipeline.trajectory import Trajectory
 
@@ -30,6 +31,6 @@ from xskill.pipeline.registry import Registry
 from xskill.skill.repo import SkillRepo
 
 __all__ = [
-    "XSkill", "Skill", "Trajectory",
+    "XSkill", "XSkillConfig", "Skill", "Trajectory",
     "Registry", "SkillRepo",
 ]

--- a/src/xskill/__init__.py
+++ b/src/xskill/__init__.py
@@ -23,6 +23,7 @@ except ImportError:  # 未经 build 的源码树
 # 顶级公开面：3 个核心类
 from xskill.core import XSkill
 from xskill.config import XSkillConfig
+from xskill.container import XSkillContainer
 from xskill.skill.skill import Skill
 from xskill.pipeline.trajectory import Trajectory
 
@@ -31,6 +32,6 @@ from xskill.pipeline.registry import Registry
 from xskill.skill.repo import SkillRepo
 
 __all__ = [
-    "XSkill", "XSkillConfig", "Skill", "Trajectory",
+    "XSkill", "XSkillConfig", "XSkillContainer", "Skill", "Trajectory",
     "Registry", "SkillRepo",
 ]

--- a/src/xskill/agents/agent_tools.py
+++ b/src/xskill/agents/agent_tools.py
@@ -8,15 +8,19 @@ read the current project/AtomTask dependencies through properties. LLM and
 embedding clients are intentionally not stored here; non-tool workflows create
 those from config at their own boundary.
 """
+# ruff: noqa: BLE001,S110
 
 from __future__ import annotations
 
 import json, logging
+from collections.abc import Mapping
 from datetime import date, datetime
 from pathlib import Path
+from typing import Any
 
 from agno.tools import tool
 
+from xskill.config import XSkillConfig
 from xskill.skill.frontmatter import (
     parse as fm_parse,
     parse_strict as fm_parse_strict,
@@ -33,7 +37,7 @@ class AgentToolConfig:
     def __init__(self):
         self._skill_dir: Path | None = None
         self._data_dir: Path | None = None
-        self._config: dict = {}
+        self._config: Mapping[str, Any] | XSkillConfig | None = None
         self._atom_skill_dir: Path | None = None
         self._atom_store = None
         self._default_traj_root: Path | None = None
@@ -43,7 +47,7 @@ class AgentToolConfig:
     ) -> None:
         self._skill_dir = Path(skill_dir)
         self._data_dir = Path(data_dir)
-        self._config = config or {}
+        self._config = config
 
     def configure_atom_task(
         self, *, skill_dir, atom_store, default_traj_root,
@@ -65,7 +69,7 @@ class AgentToolConfig:
     def restore(self, snapshot: dict) -> None:
         self._skill_dir = snapshot.get("skill_dir")
         self._data_dir = snapshot.get("data_dir")
-        self._config = snapshot.get("config") or {}
+        self._config = snapshot.get("config")
         self._atom_skill_dir = snapshot.get("atom_skill_dir")
         self._atom_store = snapshot.get("atom_store")
         self._default_traj_root = snapshot.get("default_traj_root")
@@ -84,7 +88,7 @@ class AgentToolConfig:
         return self._data_dir
 
     @property
-    def config(self) -> dict:
+    def config(self) -> Mapping[str, Any] | XSkillConfig:
         return self._config or {}
 
     @property
@@ -867,8 +871,10 @@ def _run_description_optimization(target: Path, slug: str) -> None:
     （退回 agent 写的 description 继续提交）。LLM/embed 客户端在这个确定性
     workflow 内从 config 创建，不从 agent tool context 借对象。
     """
-    from xskill.config import get_config
-    config = agent_tool_config.config or get_config()
+    config = agent_tool_config.config
+    if not config:
+        logger.warning("skip description_opt: skill authoring config not initialized")
+        return
     if not (config.get("skill_opt", {}) or {}).get("enabled", True):
         return
     from xskill.utils.llm import create_embed_client, create_llm_client

--- a/src/xskill/agents/agno_factory.py
+++ b/src/xskill/agents/agno_factory.py
@@ -12,13 +12,16 @@
 ``(*, instructions, tools) -> agno.agent.Agent``。生产代码调用它把 cluster/edit
 agent 跑起来；测试代码注入 stub callable。
 """
+# ruff: noqa: BLE001,S110
 from __future__ import annotations
 
 import inspect
 import logging
 import os
+from collections.abc import Mapping
 from typing import Any, Callable
 
+from xskill.config import XSkillConfig
 from xskill.utils.logging import StreamLog
 from xskill.utils.llm import _ssl_verify
 
@@ -52,7 +55,7 @@ def _inject_verify_off_if_requested(model_cls, model_kwargs: dict,
             model_kwargs[name] = async_client
             injected.append(name)
             break
-    msg_log = log or (lambda *a, **kw: None)
+    msg_log = log or (lambda *_arguments, **_keywords: None)
     if injected:
         msg_log(f"T2S_SSL_VERIFY=false → {model_cls.__name__} 注入 "
                 f"{'+'.join(injected)} (verify=False)", "step")
@@ -61,7 +64,7 @@ def _inject_verify_off_if_requested(model_cls, model_kwargs: dict,
                 f"kwarg，改用 SSL_CERT_FILE=/path/to/ca.pem", "error")
 
 
-def _wrap_with_context_mgmt(model, llm_cfg: dict):
+def _wrap_with_context_mgmt(model, llm_cfg: Mapping[str, Any]):
     """把弃窗单趟的上下文自管理（spec §4.5）套到 model.invoke 外层。
 
     - max_context 配置优先,缺省 200K + warning（``resolve_max_context``）。
@@ -78,7 +81,7 @@ def _wrap_with_context_mgmt(model, llm_cfg: dict):
     return model
 
 
-def _wrap_with_rate_limit(model, llm_cfg: dict):
+def _wrap_with_rate_limit(model, llm_cfg: Mapping[str, Any]):
     """如果 llm_cfg['rate_limit'] 配置存在,monkey-patch model.invoke
     在调用 LLM 前先 acquire 共享桶。
 
@@ -135,7 +138,7 @@ def _wrap_with_rate_limit(model, llm_cfg: dict):
     return model
 
 
-def build_chat_model(llm_cfg: dict, log: StreamLog | None = None):
+def build_chat_model(llm_cfg: Mapping[str, Any], log: StreamLog | None = None):
     """根据 ``llm_cfg.base_url`` 路由到合适的 agno model 类。
 
     为什么不一律用 ``OpenAIChat``：DeepSeek 直连（``api.deepseek.com``）的
@@ -221,7 +224,7 @@ def _is_transient_error(exc: Exception) -> bool:
     return any(h in t for h in _TRANSIENT_HINTS)
 
 
-def _wrap_with_retry(model, llm_cfg: dict):
+def _wrap_with_retry(model, llm_cfg: Mapping[str, Any]):
     """对脆弱用户 API 做**强壮持续重试**：瞬时错误（429/5xx/超时/连接断）指数退避
     重试，次数/退避上限可配。
 
@@ -280,7 +283,9 @@ def _wrap_with_trace(model):
     return model
 
 
-def make_default_factory(config: dict) -> Callable[..., Any]:
+def make_default_factory(
+    config: Mapping[str, Any] | XSkillConfig,
+) -> Callable[..., Any]:
     """生产环境的 agno Agent 工厂。
 
     返回的 callable 签名 ``(*, instructions, tools) -> agno.agent.Agent``，
@@ -292,8 +297,12 @@ def make_default_factory(config: dict) -> Callable[..., Any]:
     """
     from agno.agent import Agent
 
-    base_cfg = config.get("llm", {}) or {}
-    override_cfg = config.get("llm_skill", {}) or {}
+    if isinstance(config, XSkillConfig):
+        base_cfg = config.llm_config
+        override_cfg = config.llm_skill_config
+    else:
+        base_cfg = config.get("llm", {}) or {}
+        override_cfg = config.get("llm_skill", {}) or {}
     llm_cfg = {**base_cfg, **{k: v for k, v in override_cfg.items() if v}}
 
     def factory(*, instructions, tools, **kwargs):

--- a/src/xskill/api/app.py
+++ b/src/xskill/api/app.py
@@ -7,6 +7,7 @@ Usage:
     from xskill.api.app import create_app
     app = create_app()
 """
+# ruff: noqa: BLE001
 
 from __future__ import annotations
 
@@ -20,15 +21,17 @@ except ImportError:
 
 import logging
 import tempfile
+from collections.abc import Mapping
 from pathlib import Path
-from typing import Optional
+from typing import Any, Optional
 
 from fastapi import APIRouter, FastAPI, HTTPException
 from fastapi.responses import FileResponse
 from pydantic import BaseModel, Field
 
 from xskill import __version__
-from xskill.config import load_config, get_skill_dir
+from xskill.config import XSkillConfig, load_config, get_skill_dir
+from xskill.container import XSkillContainer
 from xskill.utils.search import search as search_trajs, search_all as search_trajs_all
 from xskill.skill.repo import (
     import_skill,
@@ -65,7 +68,7 @@ logger = logging.getLogger("xskill.server")
 # server 启动路径首次调用时填充。endpoints 在 startup hook 之后才被 hit，
 # 拿到的就是非 None；测试如果只 import ``_exec_tool`` / 常量，模块加载阶段
 # 完全不读 config。
-_config: dict | None = None
+_config: Mapping[str, Any] | XSkillConfig | None = None
 _skill_dir: Path | None = None
 _watcher_ref: dict = {}  # {"instance": DirectoryWatcher} — set in create_app startup
 
@@ -774,7 +777,8 @@ async def api_reindex():
 # ---------------------------------------------------------------------------
 
 def create_app(home_root: Path | str | None = None,
-               *, team_server: bool = False) -> FastAPI:
+               *, team_server: bool = False,
+               container: XSkillContainer | None = None) -> FastAPI:
     """Build the FastAPI app. Calls ``_ensure_loaded`` first so all module-level
     config globals (``_config``/``_skill_dir``/...) are populated before any
     endpoint or startup hook reads them.
@@ -786,17 +790,25 @@ def create_app(home_root: Path | str | None = None,
         team_server: True = team server 模式。挂 /api/v1/team/* 路由、跳过
                    本机生态自动探测（纯 server 不采集自己的轨迹）、watcher
                    开 server_mode。
+        container: 可选运行时依赖入口。传入后 server / watcher / agent factory
+                   都沿用同一个 ``XSkillConfig`` 和 client provider。
     """
-    global _home_root_override
+    global _home_root_override, _config, _skill_dir
     if home_root is not None:
         _home_root_override = Path(home_root).expanduser().resolve()
-    _ensure_loaded()
+    if container is not None:
+        _config = container.config()
+        _skill_dir = _config.skill_dir
+    else:
+        _ensure_loaded()
     """Create and configure the FastAPI application."""
     app = FastAPI(
         title="xskill",
         description="Trajectory-to-Skill distillation API",
         version=__version__,
     )
+    app.state.xskill_container = container
+    app.state.xskill_config = _config
     app.include_router(router)
 
     # team server 模式：挂 /api/v1/team/* 路由
@@ -862,13 +874,19 @@ def create_app(home_root: Path | str | None = None,
         带 None client 带病跑（CLAUDE.md 第 1 条）。create_llm_client 内部仍可能
         返回 None（其它调用方依赖此语义），所以在 daemon startup 处显式断言。
         """
-        llm = create_llm_client(_config)
-        if llm is None:
+        if container is None:
+            llm_client = create_llm_client(_config)
+            embedding_client = create_embed_client(_config)
+            agent_factory = None
+        else:
+            llm_client = container.llm_client()
+            embedding_client = container.embed_client()
+            agent_factory = container.agno_agent_factory()
+        if llm_client is None:
             raise RuntimeError(
                 "LLM client could not be created — check ~/.xskill/config.yaml: "
                 "llm.base_url / llm.model / llm.api_key must all be valid"
             )
-        embed = create_embed_client(_config)
         # data_dir 在 server 端点路径上不被消费（trajectory 搜索走 Registry），
         # 传 _skill_dir 占位即可——同 core.py 的 tool context 初始化。
         init_skill_authoring_tool_context(
@@ -1227,8 +1245,10 @@ def create_app(home_root: Path | str | None = None,
             from xskill.pipeline.runner import DirectoryWatcher
             watcher_cfg = _config.get("watcher", {})
             watcher = DirectoryWatcher(
-                llm=llm, embed_client=embed, config=_config,
+                llm=llm_client, embed_client=embedding_client, config=_config,
+                container=container,
                 skill_dir=_skill_dir,
+                agno_agent_factory=agent_factory,
                 poll_interval=float(watcher_cfg.get("poll_interval", 30)),
                 max_concurrent=int(watcher_cfg.get("max_concurrent", 30)),
                 cluster_batch_size=int(watcher_cfg.get("cluster_batch_size", 8)),

--- a/src/xskill/config.py
+++ b/src/xskill/config.py
@@ -7,9 +7,12 @@ config.py — 全局路径与配置加载
 
 from __future__ import annotations
 
+from collections.abc import Iterator, Mapping
+from copy import deepcopy
+from dataclasses import dataclass, field
 import logging
 from pathlib import Path
-from typing import Optional
+from typing import Any, Optional
 
 import yaml
 
@@ -22,8 +25,100 @@ REGISTRY_DB = XSKILL_HOME / "registry.db"
 CHAT_DB = XSKILL_HOME / "chat_sessions.db"
 LOGS_DIR = XSKILL_HOME / "logs"
 
-_config: dict = {}
+_config: "XSkillConfig | None" = None
 _overrides: dict = {}
+
+
+@dataclass
+class XSkillConfig(Mapping[str, Any]):
+    """Dict-compatible xskill configuration loaded from YAML."""
+
+    data: dict[str, Any] = field(default_factory=dict)
+    source_path: Path | None = None
+
+    @classmethod
+    def from_yaml(
+        class_type,
+        path: Optional[Path] = None,
+        *,
+        validate_required: bool = True,
+    ) -> "XSkillConfig":
+        config_path = Path(path) if path else CONFIG_PATH
+        if not config_path.exists():
+            raise FileNotFoundError(
+                f"xskill config not found: {config_path}\n"
+                f"Run `xskill serve` once to auto-create a template, "
+                f"or call config.ensure_config_exists()."
+            )
+        with open(config_path, encoding="utf-8") as config_file:
+            loaded_data = yaml.safe_load(config_file) or {}
+        return class_type.from_dict(
+            loaded_data,
+            source_path=config_path,
+            validate_required=validate_required,
+        )
+
+    @classmethod
+    def from_dict(
+        class_type,
+        values: Mapping[str, Any] | None,
+        *,
+        source_path: Optional[Path] = None,
+        validate_required: bool = True,
+    ) -> "XSkillConfig":
+        config_data = deepcopy(dict(values or {}))
+        config_object = class_type(
+            data=config_data,
+            source_path=Path(source_path) if source_path else None,
+        )
+        if validate_required:
+            config_object.validate_required()
+        return config_object
+
+    def __getitem__(self, key: str) -> Any:
+        return self.data[key]
+
+    def __iter__(self) -> Iterator[str]:
+        return iter(self.data)
+
+    def __len__(self) -> int:
+        return len(self.data)
+
+    def as_dict(self) -> dict[str, Any]:
+        return deepcopy(self.data)
+
+    def section(self, section_name: str) -> dict[str, Any]:
+        section_value = self.data.get(section_name) or {}
+        if not isinstance(section_value, Mapping):
+            raise TypeError(
+                f"{section_name} config section must be a mapping, "
+                f"got {type(section_value).__name__}"
+            )
+        return dict(section_value)
+
+    @property
+    def llm_config(self) -> dict[str, Any]:
+        return self.section("llm")
+
+    @property
+    def llm_skill_config(self) -> dict[str, Any]:
+        return self.section("llm_skill")
+
+    @property
+    def embedding_config(self) -> dict[str, Any]:
+        return self.section("embedding")
+
+    @property
+    def skill_dir(self) -> Path:
+        configured_path = self.data.get("skill_dir") or str(XSKILL_HOME / "skill")
+        return Path(str(configured_path)).expanduser()
+
+    def validate_required(self) -> None:
+        location = self.source_path or "provided config"
+        if not self.llm_config.get("api_key"):
+            raise KeyError(f"llm.api_key missing in {location}")
+        if not self.embedding_config.get("api_key"):
+            raise KeyError(f"embedding.api_key missing in {location}")
 
 
 def set_overrides(**kwargs):
@@ -214,32 +309,20 @@ def ensure_config_exists(path: Optional[Path] = None) -> bool:
     return False
 
 
-def load_config(path: Optional[Path] = None) -> dict:
+def load_config(path: Optional[Path] = None) -> XSkillConfig:
     """加载 ~/.xskill/config.yaml；不存在直接抛 FileNotFoundError。
 
     正常路径下 CLI 会先调 ``ensure_config_exists`` auto-init，不会走到这个
     FileNotFoundError；保留它作为 SDK 直接调用时的 fail-loud 兜底。
     """
     global _config
-    cfg_path = Path(path) if path else CONFIG_PATH
-    if not cfg_path.exists():
-        raise FileNotFoundError(
-            f"xskill config not found: {cfg_path}\n"
-            f"Run `xskill serve` once to auto-create a template, "
-            f"or call config.ensure_config_exists()."
-        )
-    with open(cfg_path, encoding="utf-8") as f:
-        _config = yaml.safe_load(f) or {}
-    if not _config.get("llm", {}).get("api_key"):
-        raise KeyError(f"llm.api_key missing in {cfg_path}")
-    if not _config.get("embedding", {}).get("api_key"):
-        raise KeyError(f"embedding.api_key missing in {cfg_path}")
+    _config = XSkillConfig.from_yaml(path)
     return _config
 
 
-def get_config() -> dict:
-    if not _config:
-        load_config()
+def get_config() -> XSkillConfig:
+    if _config is None:
+        return load_config()
     return _config
 
 
@@ -334,9 +417,8 @@ def ingest_config(path: Optional[Path] = None) -> dict:
 
 def get_skill_dir() -> Path:
     """skill_dir: config.yaml 字段；默认 ~/.xskill/skill/"""
-    cfg = get_config()
-    raw = cfg.get("skill_dir") or str(XSKILL_HOME / "skill")
-    return Path(raw).expanduser()
+    config_object = get_config()
+    return config_object.skill_dir
 
 
 def get_logs_dir() -> Path:

--- a/src/xskill/config.py
+++ b/src/xskill/config.py
@@ -38,7 +38,7 @@ class XSkillConfig(Mapping[str, Any]):
 
     @classmethod
     def from_yaml(
-        class_type,
+        cls,
         path: Optional[Path] = None,
         *,
         validate_required: bool = True,
@@ -52,7 +52,7 @@ class XSkillConfig(Mapping[str, Any]):
             )
         with open(config_path, encoding="utf-8") as config_file:
             loaded_data = yaml.safe_load(config_file) or {}
-        return class_type.from_dict(
+        return cls.from_dict(
             loaded_data,
             source_path=config_path,
             validate_required=validate_required,
@@ -60,14 +60,14 @@ class XSkillConfig(Mapping[str, Any]):
 
     @classmethod
     def from_dict(
-        class_type,
+        cls,
         values: Mapping[str, Any] | None,
         *,
         source_path: Optional[Path] = None,
         validate_required: bool = True,
     ) -> "XSkillConfig":
         config_data = deepcopy(dict(values or {}))
-        config_object = class_type(
+        config_object = cls(
             data=config_data,
             source_path=Path(source_path) if source_path else None,
         )

--- a/src/xskill/container.py
+++ b/src/xskill/container.py
@@ -1,0 +1,24 @@
+"""Dependency injection container for xskill runtime services."""
+
+from __future__ import annotations
+
+from dependency_injector import containers, providers
+
+from xskill.config import XSkillConfig
+from xskill.pipeline.registry import Registry
+from xskill.skill.repo import SkillRepo
+from xskill.utils.llm import create_embed_client, create_llm_client
+
+
+class XSkillContainer(containers.DeclarativeContainer):
+    """Container wiring config, storage, repositories, and model clients."""
+
+    config = providers.Dependency(instance_of=XSkillConfig)
+    registry = providers.Singleton(Registry)
+    skill_repo = providers.Singleton(
+        SkillRepo,
+        root=config.provided.skill_dir,
+        registry=registry,
+    )
+    llm_client = providers.Singleton(create_llm_client, config=config)
+    embed_client = providers.Singleton(create_embed_client, config=config)

--- a/src/xskill/container.py
+++ b/src/xskill/container.py
@@ -5,6 +5,7 @@ from __future__ import annotations
 from dependency_injector import containers, providers
 
 from xskill.config import XSkillConfig
+from xskill.agents.agno_factory import make_default_factory
 from xskill.pipeline.registry import Registry
 from xskill.skill.repo import SkillRepo
 from xskill.utils.llm import create_embed_client, create_llm_client
@@ -22,3 +23,4 @@ class XSkillContainer(containers.DeclarativeContainer):
     )
     llm_client = providers.Singleton(create_llm_client, config=config)
     embed_client = providers.Singleton(create_embed_client, config=config)
+    agno_agent_factory = providers.Singleton(make_default_factory, config=config)

--- a/src/xskill/core.py
+++ b/src/xskill/core.py
@@ -7,10 +7,11 @@ xskill.py — XSkill 顶层门面
 
 from __future__ import annotations
 
+from collections.abc import Mapping
 from pathlib import Path
-from typing import Optional
+from typing import Any, Optional
 
-from xskill.config import load_config, get_skill_dir
+from xskill.config import XSkillConfig, load_config
 from xskill.pipeline.registry import Registry
 from xskill.skill.repo import SkillRepo
 from xskill.pipeline.trajectory import Trajectory
@@ -40,27 +41,38 @@ class XSkill:
         xskill.skill_repo["fix-foo"]
     """
 
-    def __init__(self, config_path: Optional[Path] = None):
-        self.config = load_config(config_path)
+    def __init__(
+        self,
+        config_path: Optional[Path] = None,
+        config: XSkillConfig | Mapping[str, Any] | None = None,
+    ):
+        if config_path is not None and config is not None:
+            raise ValueError("config_path and config cannot both be provided")
+        if config is None:
+            self.config = load_config(config_path)
+        elif isinstance(config, XSkillConfig):
+            self.config = config
+        else:
+            self.config = XSkillConfig.from_dict(config)
         self.registry = Registry()
-        self.skill_repo = SkillRepo(get_skill_dir(), registry=self.registry)
-        self._llm = None
-        self._embed = None
+        self.skill_repo = SkillRepo(self.config.skill_dir, registry=self.registry)
+        self._llm_client = None
+        self._embed_client = None
 
     # ─── lazy LLM / embed clients ──────────────────────────────
     @property
     def llm(self):
-        if self._llm is None:
+        if self._llm_client is None:
             from xskill.utils.llm import create_llm_client
-            self._llm = create_llm_client(self.config)
-        return self._llm
+            self._llm_client = create_llm_client(self.config)
+        return self._llm_client
 
     @property
     def embed(self):
-        if self._embed is None:
+        if self._embed_client is None:
             from xskill.utils.llm import create_embed_client
-            self._embed = create_embed_client(self.config)
-        return self._embed
+            self._embed_client = create_embed_client(self.config)
+        return self._embed_client
 
     # ─── 检索（跨所有 registry）─────────────────────────────────
     def search_trajectories(self, query: str, top_k: int = 5,

--- a/src/xskill/core.py
+++ b/src/xskill/core.py
@@ -185,7 +185,11 @@ class XSkill:
         """
         import uvicorn
         from xskill.api import create_app
-        app = create_app(home_root=home_root, team_server=server_mode)
+        app = create_app(
+            home_root=home_root,
+            team_server=server_mode,
+            container=self.container,
+        )
         if server_mode:
             from xskill.team.server.state import ensure_join_token
             from xskill.config import get_team_server_state_path

--- a/src/xskill/core.py
+++ b/src/xskill/core.py
@@ -12,8 +12,7 @@ from pathlib import Path
 from typing import Any, Optional
 
 from xskill.config import XSkillConfig, load_config
-from xskill.pipeline.registry import Registry
-from xskill.skill.repo import SkillRepo
+from xskill.container import XSkillContainer
 from xskill.pipeline.trajectory import Trajectory
 from xskill.types import SkillHit, TrajectoryHit, UxScoreResult
 
@@ -45,34 +44,34 @@ class XSkill:
         self,
         config_path: Optional[Path] = None,
         config: XSkillConfig | Mapping[str, Any] | None = None,
+        container: XSkillContainer | None = None,
     ):
+        if container is not None and (config_path is not None or config is not None):
+            raise ValueError("container cannot be combined with config_path or config")
         if config_path is not None and config is not None:
             raise ValueError("config_path and config cannot both be provided")
-        if config is None:
-            self.config = load_config(config_path)
-        elif isinstance(config, XSkillConfig):
-            self.config = config
-        else:
-            self.config = XSkillConfig.from_dict(config)
-        self.registry = Registry()
-        self.skill_repo = SkillRepo(self.config.skill_dir, registry=self.registry)
-        self._llm_client = None
-        self._embed_client = None
+        if container is None:
+            if config is None:
+                config_object = load_config(config_path)
+            elif isinstance(config, XSkillConfig):
+                config_object = config
+            else:
+                config_object = XSkillConfig.from_dict(config)
+            container = XSkillContainer()
+            container.config.override(config_object)
+        self.container = container
+        self.config = self.container.config()
+        self.registry = self.container.registry()
+        self.skill_repo = self.container.skill_repo()
 
     # ─── lazy LLM / embed clients ──────────────────────────────
     @property
     def llm(self):
-        if self._llm_client is None:
-            from xskill.utils.llm import create_llm_client
-            self._llm_client = create_llm_client(self.config)
-        return self._llm_client
+        return self.container.llm_client()
 
     @property
     def embed(self):
-        if self._embed_client is None:
-            from xskill.utils.llm import create_embed_client
-            self._embed_client = create_embed_client(self.config)
-        return self._embed_client
+        return self.container.embed_client()
 
     # ─── 检索（跨所有 registry）─────────────────────────────────
     def search_trajectories(self, query: str, top_k: int = 5,

--- a/src/xskill/pipeline/runner.py
+++ b/src/xskill/pipeline/runner.py
@@ -20,6 +20,7 @@ pipeline/runner.py -- 流水线式目录监听器 + AtomTask 流水线核心入�
 v2 (AtomTask) 流水线下，对一个 atom 的"cluster → 触发 SkillEdit"是单一原子
 操作。``api/sse.py`` 与本模块的 ``DirectoryWatcher`` 都调它。
 """
+# ruff: noqa: BLE001
 
 from __future__ import annotations
 
@@ -27,9 +28,13 @@ import asyncio
 import logging
 import threading
 import time
+from collections.abc import Mapping
 from concurrent.futures import ThreadPoolExecutor, Future, as_completed
 from pathlib import Path
+from typing import Any
 
+from xskill.config import XSkillConfig
+from xskill.container import XSkillContainer
 from xskill.pipeline.registry import (
     list_watch_dirs,
     discover_trajectories,
@@ -81,14 +86,30 @@ class DirectoryWatcher:
     """
 
     def __init__(self, *, llm=None, embed_client=None, config=None,
+                 container: XSkillContainer | None = None,
                  skill_dir=None, poll_interval=30.0, max_concurrent=30,
                  max_retries=3, db_path=None,
                  store=None, agno_agent_factory=None, home_root=None,
                  server_mode=False, install_history_path=None,
                  on_poll_hook=None, cluster_batch_size=8):
+        if container is not None:
+            container_config = container.config()
+            if config is None:
+                config = container_config
+            if skill_dir is None:
+                skill_dir = container_config.skill_dir
+            if llm is None:
+                llm = container.llm_client()
+            if embed_client is None:
+                embed_client = container.embed_client()
+            if agno_agent_factory is None:
+                agno_agent_factory = container.agno_agent_factory()
+        self.container = container
         self.llm = llm
         self.embed_client = embed_client
-        self.config = config or {}
+        self.config: Mapping[str, Any] | XSkillConfig = (
+            config if config is not None else {}
+        )
         self.skill_dir = Path(skill_dir) if skill_dir else None
         # home_root：install_to_claude_code 的 target root。生产 daemon 不
         # 传（None）→ 落到 server._home_root() (默认 Path.home())。测试

--- a/src/xskill/utils/llm.py
+++ b/src/xskill/utils/llm.py
@@ -19,7 +19,7 @@ LLM 和 Embedding 分别配置 base_url / model / api_key
 from __future__ import annotations
 
 from collections.abc import Mapping
-import os, json, logging, time
+import os, logging, time
 from dataclasses import dataclass, field
 from typing import Any, Literal, Optional
 
@@ -380,7 +380,7 @@ def create_llm_client(
             client = LLMClient.from_config(merged_config)
             logger.info(f"LLM[{role}]: {client}")
             return client
-        except Exception as e:
-            logger.warning(f"LLM[{role}] 初始化失败: {e}")
+        except (KeyError, TypeError, ValueError) as error:
+            logger.warning(f"LLM[{role}] 初始化失败: {error}")
             return None
     return None

--- a/src/xskill/utils/llm.py
+++ b/src/xskill/utils/llm.py
@@ -18,11 +18,14 @@ LLM 和 Embedding 分别配置 base_url / model / api_key
 
 from __future__ import annotations
 
+from collections.abc import Mapping
 import os, json, logging, time
 from dataclasses import dataclass, field
-from typing import Literal, Optional
+from typing import Any, Literal, Optional
 
 import numpy as np
+
+from xskill.config import XSkillConfig
 
 EmbedApiStyle = Literal["multimodal", "openai"]
 
@@ -61,11 +64,11 @@ class LLMClient:
     _client: object = field(default=None, repr=False)
 
     @classmethod
-    def from_config(cls, cfg: dict) -> "LLMClient":
-        base_url = cfg.get("base_url", "").rstrip("/")
-        model = cfg.get("model", "")
+    def from_config(class_type, config_section: Mapping[str, Any]) -> "LLMClient":
+        base_url = config_section.get("base_url", "").rstrip("/")
+        model = config_section.get("model", "")
         api_key = (
-            cfg.get("api_key", "")
+            config_section.get("api_key", "")
             or os.environ.get("LLM_API_KEY", "")
             or os.environ.get("ANTHROPIC_API_KEY", "")
             or os.environ.get("OPENAI_API_KEY", "")
@@ -75,13 +78,13 @@ class LLMClient:
         kwargs = dict(base_url=base_url, model=model, api_key=api_key)
         # 允许 config 覆盖 max_tokens / temperature（缺省则用 dataclass 默认）。
         # 之前这里不读 max_tokens，导致 yaml 配了也不生效。
-        if "max_tokens" in cfg:
-            kwargs["max_tokens"] = int(cfg["max_tokens"])
-        if "temperature" in cfg:
-            kwargs["temperature"] = float(cfg["temperature"])
-        if "rate_limit" in cfg:
-            kwargs["rate_limit_cfg"] = cfg["rate_limit"]
-        return cls(**kwargs)
+        if "max_tokens" in config_section:
+            kwargs["max_tokens"] = int(config_section["max_tokens"])
+        if "temperature" in config_section:
+            kwargs["temperature"] = float(config_section["temperature"])
+        if "rate_limit" in config_section:
+            kwargs["rate_limit_cfg"] = config_section["rate_limit"]
+        return class_type(**kwargs)
 
     def _get_client(self):
         if self._client is None:
@@ -203,22 +206,22 @@ class EmbedClient:
     _client: object = field(default=None, repr=False)
 
     @classmethod
-    def from_config(cls, cfg: dict) -> "EmbedClient":
-        base_url = cfg.get("base_url", "").rstrip("/")
-        model = cfg.get("model", "")
+    def from_config(class_type, config_section: Mapping[str, Any]) -> "EmbedClient":
+        base_url = config_section.get("base_url", "").rstrip("/")
+        model = config_section.get("model", "")
         api_key = (
-            cfg.get("api_key", "")
+            config_section.get("api_key", "")
             or os.environ.get("EMBED_API_KEY", "")
             or os.environ.get("OPENAI_API_KEY", "")
         )
-        dim = cfg.get("dim", 0)
+        dim = config_section.get("dim", 0)
         if not base_url or not model:
             raise ValueError("embedding.base_url 和 embedding.model 必须配置")
-        api_style = _resolve_embed_api_style(cfg, model)
-        inst = cls(
+        api_style = _resolve_embed_api_style(config_section, model)
+        instance = class_type(
             base_url=base_url, model=model, api_key=api_key, dim=dim, api_style=api_style,
         )
-        return inst
+        return instance
 
     def _get_session(self):
         if self._client is None:
@@ -320,20 +323,26 @@ class EmbedClient:
 # 工厂函数
 # ═══════════════════════════════════════════════════════════════════
 
-def create_embed_client(config: dict) -> "EmbedClient":
+def create_embed_client(config: Mapping[str, Any] | XSkillConfig) -> "EmbedClient":
     """根据配置创建 embedding 客户端，未配置或不可用时直接报错"""
-    embed_cfg = config.get("embedding", {})
+    if isinstance(config, XSkillConfig):
+        embed_config = config.embedding_config
+    else:
+        embed_config = config.get("embedding", {}) or {}
 
-    if not embed_cfg.get("base_url") or not embed_cfg.get("model"):
+    if not embed_config.get("base_url") or not embed_config.get("model"):
         raise ValueError("embedding.base_url 和 embedding.model 必须配置")
 
-    client = EmbedClient.from_config(embed_cfg)
+    client = EmbedClient.from_config(embed_config)
     client.probe_dim()
     logger.info(f"Embedding: {client}")
     return client
 
 
-def create_llm_client(config: dict, role: str = "default") -> "LLMClient | None":
+def create_llm_client(
+    config: Mapping[str, Any] | XSkillConfig,
+    role: str = "default",
+) -> "LLMClient | None":
     """根据配置创建 LLM 客户端，未配置返回 None。
 
     role:
@@ -350,16 +359,25 @@ def create_llm_client(config: dict, role: str = "default") -> "LLMClient | None"
         model: "doubao-seed-2-0-pro-260215"    # agent + eval 换大模型
         # base_url / api_key 缺省 → 继承 llm.*
     """
-    base_cfg = config.get("llm", {}) or {}
-    if role in ("skill", "eval"):
-        override_cfg = config.get("llm_skill", {}) or {}
-        merged = {**base_cfg, **{k: v for k, v in override_cfg.items() if v}}
+    if isinstance(config, XSkillConfig):
+        base_config = config.llm_config
     else:
-        merged = base_cfg
+        base_config = config.get("llm", {}) or {}
+    if role in ("skill", "eval"):
+        if isinstance(config, XSkillConfig):
+            override_config = config.llm_skill_config
+        else:
+            override_config = config.get("llm_skill", {}) or {}
+        merged_config = {
+            **base_config,
+            **{key: value for key, value in override_config.items() if value},
+        }
+    else:
+        merged_config = base_config
 
-    if merged.get("base_url") and merged.get("model"):
+    if merged_config.get("base_url") and merged_config.get("model"):
         try:
-            client = LLMClient.from_config(merged)
+            client = LLMClient.from_config(merged_config)
             logger.info(f"LLM[{role}]: {client}")
             return client
         except Exception as e:

--- a/src/xskill/utils/llm.py
+++ b/src/xskill/utils/llm.py
@@ -64,7 +64,7 @@ class LLMClient:
     _client: object = field(default=None, repr=False)
 
     @classmethod
-    def from_config(class_type, config_section: Mapping[str, Any]) -> "LLMClient":
+    def from_config(cls, config_section: Mapping[str, Any]) -> "LLMClient":
         base_url = config_section.get("base_url", "").rstrip("/")
         model = config_section.get("model", "")
         api_key = (
@@ -84,7 +84,7 @@ class LLMClient:
             kwargs["temperature"] = float(config_section["temperature"])
         if "rate_limit" in config_section:
             kwargs["rate_limit_cfg"] = config_section["rate_limit"]
-        return class_type(**kwargs)
+        return cls(**kwargs)
 
     def _get_client(self):
         if self._client is None:
@@ -206,7 +206,7 @@ class EmbedClient:
     _client: object = field(default=None, repr=False)
 
     @classmethod
-    def from_config(class_type, config_section: Mapping[str, Any]) -> "EmbedClient":
+    def from_config(cls, config_section: Mapping[str, Any]) -> "EmbedClient":
         base_url = config_section.get("base_url", "").rstrip("/")
         model = config_section.get("model", "")
         api_key = (
@@ -218,7 +218,7 @@ class EmbedClient:
         if not base_url or not model:
             raise ValueError("embedding.base_url 和 embedding.model 必须配置")
         api_style = _resolve_embed_api_style(config_section, model)
-        instance = class_type(
+        instance = cls(
             base_url=base_url, model=model, api_key=api_key, dim=dim, api_style=api_style,
         )
         return instance

--- a/tests/test_config_class.py
+++ b/tests/test_config_class.py
@@ -1,0 +1,101 @@
+from __future__ import annotations
+
+from pathlib import Path
+
+import pytest
+
+from xskill import XSkillConfig
+from xskill.core import XSkill
+from xskill.utils.llm import EmbedClient, create_embed_client, create_llm_client
+
+
+def _sample_config(skill_directory: Path) -> dict:
+    return {
+        "skill_dir": str(skill_directory),
+        "llm": {
+            "base_url": "http://llm.example/v1",
+            "model": "chat-model",
+            "api_key": "llm-key",
+        },
+        "embedding": {
+            "base_url": "http://embedding.example/v1",
+            "model": "embedding-model",
+            "api_key": "embedding-key",
+            "dim": 3,
+        },
+    }
+
+
+def test_config_class_loads_yaml_and_exposes_sections(tmp_path):
+    skill_directory = tmp_path / "skill"
+    config_path = tmp_path / "config.yaml"
+    config_path.write_text(
+        "\n".join(
+            [
+                f"skill_dir: {skill_directory}",
+                "llm:",
+                "  base_url: http://llm.example/v1",
+                "  model: chat-model",
+                "  api_key: llm-key",
+                "embedding:",
+                "  base_url: http://embedding.example/v1",
+                "  model: embedding-model",
+                "  api_key: embedding-key",
+                "  dim: 3",
+            ]
+        ),
+        encoding="utf-8",
+    )
+
+    config_object = XSkillConfig.from_yaml(config_path)
+
+    assert config_object["llm"]["model"] == "chat-model"
+    assert config_object.llm_config["base_url"] == "http://llm.example/v1"
+    assert config_object.embedding_config["model"] == "embedding-model"
+    assert config_object.skill_dir == skill_directory
+
+
+def test_config_class_rejects_missing_required_keys(tmp_path):
+    config_values = _sample_config(tmp_path / "skill")
+    config_values["llm"]["api_key"] = ""
+
+    with pytest.raises(KeyError, match="llm.api_key missing"):
+        XSkillConfig.from_dict(config_values)
+
+
+def test_xskill_accepts_config_object(tmp_path, monkeypatch):
+    config_object = XSkillConfig.from_dict(_sample_config(tmp_path / "skill"))
+    registry_path = tmp_path / "registry.db"
+
+    monkeypatch.setattr("xskill.pipeline.registry.REGISTRY_DB", registry_path)
+
+    xskill_object = XSkill(config=config_object)
+
+    assert xskill_object.config is config_object
+    assert xskill_object.skill_repo.root == tmp_path / "skill"
+
+
+def test_xskill_rejects_config_and_path_together(tmp_path):
+    config_object = XSkillConfig.from_dict(_sample_config(tmp_path / "skill"))
+
+    with pytest.raises(ValueError, match="cannot both be provided"):
+        XSkill(config_path=tmp_path / "config.yaml", config=config_object)
+
+
+def test_llm_factory_accepts_config_class(tmp_path):
+    config_object = XSkillConfig.from_dict(_sample_config(tmp_path / "skill"))
+
+    llm_client = create_llm_client(config_object)
+
+    assert llm_client is not None
+    assert llm_client.model == "chat-model"
+
+
+def test_embed_factory_accepts_config_class(tmp_path, monkeypatch):
+    config_object = XSkillConfig.from_dict(_sample_config(tmp_path / "skill"))
+    monkeypatch.setattr(EmbedClient, "probe_dim", lambda self: self.dim)
+
+    embed_client = create_embed_client(config_object)
+
+    assert embed_client.model == "embedding-model"
+    assert embed_client.dim == 3

--- a/tests/test_di_container.py
+++ b/tests/test_di_container.py
@@ -1,0 +1,66 @@
+from __future__ import annotations
+
+import pytest
+from dependency_injector import providers
+
+from xskill import XSkillConfig, XSkillContainer
+from xskill.core import XSkill
+
+
+def test_xskill_uses_injected_container(tmp_path):
+    config_object = XSkillConfig.from_dict(
+        {
+            "skill_dir": str(tmp_path / "skill"),
+            "llm": {
+                "base_url": "http://llm.example/v1",
+                "model": "chat-model",
+                "api_key": "llm-key",
+            },
+            "embedding": {
+                "base_url": "http://embedding.example/v1",
+                "model": "embedding-model",
+                "api_key": "embedding-key",
+            },
+        }
+    )
+    fake_registry = object()
+    fake_skill_repo = object()
+    fake_llm_client = object()
+    fake_embed_client = object()
+    container = XSkillContainer()
+    container.config.override(config_object)
+    container.registry.override(providers.Object(fake_registry))
+    container.skill_repo.override(providers.Object(fake_skill_repo))
+    container.llm_client.override(providers.Object(fake_llm_client))
+    container.embed_client.override(providers.Object(fake_embed_client))
+
+    xskill_object = XSkill(container=container)
+
+    assert xskill_object.config is config_object
+    assert xskill_object.registry is fake_registry
+    assert xskill_object.skill_repo is fake_skill_repo
+    assert xskill_object.llm is fake_llm_client
+    assert xskill_object.embed is fake_embed_client
+
+
+def test_xskill_rejects_container_mixed_with_config(tmp_path):
+    config_object = XSkillConfig.from_dict(
+        {
+            "skill_dir": str(tmp_path / "skill"),
+            "llm": {
+                "base_url": "http://llm.example/v1",
+                "model": "chat-model",
+                "api_key": "llm-key",
+            },
+            "embedding": {
+                "base_url": "http://embedding.example/v1",
+                "model": "embedding-model",
+                "api_key": "embedding-key",
+            },
+        }
+    )
+    container = XSkillContainer()
+    container.config.override(config_object)
+
+    with pytest.raises(ValueError, match="container cannot be combined"):
+        XSkill(config=config_object, container=container)

--- a/tests/test_di_container.py
+++ b/tests/test_di_container.py
@@ -1,5 +1,6 @@
 from __future__ import annotations
 
+from fastapi.testclient import TestClient
 import pytest
 from dependency_injector import providers
 
@@ -64,3 +65,167 @@ def test_xskill_rejects_container_mixed_with_config(tmp_path):
 
     with pytest.raises(ValueError, match="container cannot be combined"):
         XSkill(config=config_object, container=container)
+
+
+def test_xskill_serve_passes_same_container(monkeypatch, tmp_path):
+    config_object = XSkillConfig.from_dict(
+        {
+            "skill_dir": str(tmp_path / "skill"),
+            "llm": {
+                "base_url": "http://llm.example/v1",
+                "model": "chat-model",
+                "api_key": "llm-key",
+            },
+            "embedding": {
+                "base_url": "http://embedding.example/v1",
+                "model": "embedding-model",
+                "api_key": "embedding-key",
+            },
+        }
+    )
+    container = XSkillContainer()
+    container.config.override(config_object)
+    captured = {}
+
+    def fake_create_app(**kwargs):
+        captured.update(kwargs)
+        return object()
+
+    def fake_run(application, host, port):
+        captured["application"] = application
+        captured["host"] = host
+        captured["port"] = port
+
+    monkeypatch.setattr("xskill.api.create_app", fake_create_app)
+    monkeypatch.setattr("uvicorn.run", fake_run)
+
+    XSkill(container=container).serve(host="127.0.0.1", port=8123)
+
+    assert captured["container"] is container
+    assert captured["team_server"] is False
+    assert captured["host"] == "127.0.0.1"
+    assert captured["port"] == 8123
+
+
+def test_create_app_startup_passes_container_config_to_watcher(monkeypatch, tmp_path):
+    from xskill.api import app as server_app
+
+    config_object = XSkillConfig.from_dict(
+        {
+            "skill_dir": str(tmp_path / "skill"),
+            "llm": {
+                "base_url": "http://llm.example/v1",
+                "model": "chat-model",
+                "api_key": "llm-key",
+            },
+            "embedding": {
+                "base_url": "http://embedding.example/v1",
+                "model": "embedding-model",
+                "api_key": "embedding-key",
+            },
+            "watcher": {"poll_interval": 30},
+        }
+    )
+    config_object.skill_dir.mkdir()
+    fake_llm_client = object()
+    fake_embedding_client = object()
+    fake_agent_factory = object()
+    container = XSkillContainer()
+    container.config.override(config_object)
+    container.llm_client.override(providers.Object(fake_llm_client))
+    container.embed_client.override(providers.Object(fake_embedding_client))
+    container.agno_agent_factory.override(providers.Object(fake_agent_factory))
+    captured = {}
+
+    class FakeDirectoryWatcher:
+        def __init__(self, **kwargs):
+            captured.update(kwargs)
+
+        def start(self):
+            captured["started"] = True
+
+        def stop(self):
+            captured["stopped"] = True
+
+    monkeypatch.setattr(
+        "xskill.pipeline.runner.DirectoryWatcher",
+        FakeDirectoryWatcher,
+    )
+    monkeypatch.setattr(
+        "xskill.ecosystems.detect_known_ecosystems",
+        lambda _home_root: [],
+    )
+    server_app._watcher_ref.clear()
+    try:
+        application = server_app.create_app(
+            home_root=tmp_path,
+            container=container,
+        )
+        with TestClient(application):
+            assert captured["config"] is config_object
+            assert captured["container"] is container
+            assert captured["llm"] is fake_llm_client
+            assert captured["embed_client"] is fake_embedding_client
+            assert captured["agno_agent_factory"] is fake_agent_factory
+            assert captured["skill_dir"] == config_object.skill_dir
+            assert captured["started"] is True
+    finally:
+        server_app._watcher_ref.clear()
+        server_app._config = None
+        server_app._skill_dir = None
+
+
+def test_agent_tools_description_opt_uses_passed_config(monkeypatch, tmp_path):
+    from xskill.agents import agent_tools
+
+    config_object = XSkillConfig.from_dict(
+        {
+            "skill_dir": str(tmp_path / "skill"),
+            "llm": {
+                "base_url": "http://llm.example/v1",
+                "model": "chat-model",
+                "api_key": "llm-key",
+            },
+            "embedding": {
+                "base_url": "http://embedding.example/v1",
+                "model": "embedding-model",
+                "api_key": "embedding-key",
+            },
+            "skill_opt": {"enabled": True},
+        }
+    )
+    captured = {}
+    snapshot = agent_tools.agent_tool_config.snapshot()
+
+    def fake_create_llm_client(config):
+        captured["llm_config"] = config
+        return None
+
+    def fake_create_embed_client(config):
+        captured["embedding_config"] = config
+        return None
+
+    monkeypatch.setattr(
+        "xskill.config.get_config",
+        lambda: pytest.fail("agent_tools should not read global config"),
+    )
+    monkeypatch.setattr(
+        "xskill.utils.llm.create_llm_client",
+        fake_create_llm_client,
+    )
+    monkeypatch.setattr(
+        "xskill.utils.llm.create_embed_client",
+        fake_create_embed_client,
+    )
+    try:
+        agent_tools.init_skill_authoring_tool_context(
+            tmp_path,
+            tmp_path,
+            config_object,
+        )
+        agent_tools._run_description_optimization(tmp_path, "sample")
+    finally:
+        agent_tools.agent_tool_config.restore(snapshot)
+
+    assert captured["llm_config"] is config_object
+    assert captured["embedding_config"] is config_object


### PR DESCRIPTION
## Summary
- include the typed XSkillConfig changes from feat/config-class
- add dependency-injector as a runtime dependency
- add XSkillContainer for config, registry, skill repo, LLM client, and embedding client
- make XSkill consume the container while preserving config/config_path compatibility

## Validation
- semgrep scan --config p/default --config p/python --config p/ai-best-practices: exit 0
- ruff check . --select F401,F841,ARG,E722,BLE,S110: exit 1 on pre-existing repository-wide issues
- vulture . --min-confidence 80: exit 3 on pre-existing repository-wide issues
- touched-file ruff/vulture checks: pass