### PR TITLE
feat(skilledit): add jam threshold breaker for stuck staging

### DIFF
--- a/src/xskill/agents/agent_tools.py
+++ b/src/xskill/agents/agent_tools.py
@@ -983,6 +983,34 @@ def commit_to_staging(skill_name: str, message: str) -> str:
     return f"committed to staging: {slug}"
 
 
+@tool(name="commit_update_main")
+def commit_update_main(skill_name: str, message: str) -> str:
+    """SkillEditAgent jam-merge 场景专用：把更新直接提交回 main。
+
+    前提：该 skill 当前在 main 分支。行为：跑 description 触发优化，然后
+    ``git add .`` + commit；不开 staging、不物化 canary。
+    """
+    from xskill.skill.git import commit_update_main_branch
+
+    skill_dir = agent_tool_config.atom_skill_dir
+    if skill_dir is None:
+        return "error: atom task tool context not initialized"
+    slug = _slugify(skill_name)
+    target = skill_dir / slug
+    if not target.is_dir():
+        return f"error: skill {slug} not found"
+    if not (target / ".git").is_dir():
+        return f"error: skill {slug} 没 git 仓库"
+    msg = (message or "").strip()
+    if not msg:
+        return "error: commit message 必填"
+    _run_description_optimization(target, slug)
+    ok = commit_update_main_branch(str(target), msg)
+    if not ok:
+        return "error: commit_update_main 失败（不在 main 分支 / 无改动可提交——看日志）"
+    return f"updated on main: {slug}"
+
+
 @tool(name="absorb_user_edit_to_main")
 def absorb_user_edit_to_main(skill_name: str, message: str) -> str:
     """UserEditAbsorbAgent 专用：把用户手改吸收为 main 分支一次 commit。

--- a/src/xskill/agents/skill_edit_agent.py
+++ b/src/xskill/agents/skill_edit_agent.py
@@ -101,6 +101,22 @@ DEFAULT_GUIDANCE_BLOCK_2 = """# 正文结构纪律
 """
 
 
+# 轨迹堰塞强砍（jam-merge）专用纪律：注入 scenario，约束"合并去重而非拼接"。
+MERGE_DISCIPLINE_BLOCK = """# 本次是【轨迹堰塞强砍合并】，不是普通蒸馏
+candidates 已堆到强砍阈值仍未等到灰度裁决（疑似灰度错位/无真实流量）。你要把
+**现有 main 正文 + staging 正文 + 下列候选 atom** 合并成一份新的 main 正文：
+- **合并去重，不是拼接**：main 与 staging 里的同义规则/坑位合并成一条，证据强度
+  `[实证:N]` 相加计票，不要并列两条近义内容。
+- **冲突择强**：main 与 staging 对同一点说法相反时，标注分歧并择证据强者保留，
+  不允许两条都留。
+- **守预算与 schema**：正文 ≤200 行、frontmatter schema 不变、`source_atoms`
+  取三方并集（main + staging + 本次候选）。
+- 写完调 `commit_update_main(skill_name, message)` 直接 commit 回 main（不开
+  staging、不走灰度）。commit message 注明：发生轨迹堰塞、疑似灰度错位，并分列
+  provenance——哪些来自存量（main/staging）、哪些是本次候选合并进来的。
+"""
+
+
 _SYSTEM_PROMPT_TEMPLATE_WITH_GUIDANCE = """你是 SkillEditAgent。某 skill 的 candidates buffer 累计
 weightscore ≥ 10，需要你产出/更新它的 SKILL.md。
 
@@ -289,13 +305,16 @@ class SkillEditAgent:
     llm_cfg: dict
     traj_root: Path
     threshold: int = C.ATOM_PROMOTION_THRESHOLD
+    jam_threshold: int = 50
 
     def maybe_run(self) -> bool:
         """检查所有守门条件 → 触发 agent → 验证落盘 → 清 buffer。
 
         守门顺序（任一失败即 return False）：
-          1. 该 skill 有 staging 分支 → 灰度中，不触发
-          2. candidates 累计 weightscore < threshold → 没攒够
+          1. 该 skill 有 staging 分支 → 灰度中：
+             - 候选累计 ws ≥ jam_threshold → 越过灰度强砍（jam 路径）
+             - 否则维持 hold
+          2. 无 staging 时：candidates 累计 weightscore < threshold → 没攒够
           3. 触发场景是 "create staging"（main 已存在）：
              - .ux_scores.jsonl 必须至少有 1 条 side=main → 证明 main 真有人用
              - 否则保留 candidates 等用户用过 main 再触发
@@ -305,39 +324,51 @@ class SkillEditAgent:
         """
         from xskill.skill.git import current_branch, run_git
 
-        # 守门 1: 灰度中（有 staging）不触发
-        code, _, _ = run_git(["rev-parse", "--verify", "staging"],
-                             cwd=str(self.skill_dir))
-        if code == 0:
-            return False
-        # 守门 2: 阈值
+        # 守门 1（改）：staging 存在时，候选累计 ws ≥ jam_threshold 则越过灰度强砍；
+        # 未达到阈值时维持原先 hold 行为。
+        staging_exists = run_git(
+            ["rev-parse", "--verify", "staging"], cwd=str(self.skill_dir),
+        )[0] == 0
         data = C.load_candidates(self.skill_dir)
-        ready = C.ready_for_promotion_v2(data, threshold=self.threshold)
-        if not ready:
+        total_ws = sum(
+            int(c.get("weightscore", 0))
+            for c in (data.get("candidates", []) or [])
+        )
+        jam = staging_exists and total_ws >= self.jam_threshold
+        if staging_exists and not jam:
             return False
-        # 守门 3: 若场景是 "create staging"（即在 main 上）→ 额外要求 main 真有人用过
-        cur = current_branch(str(self.skill_dir))
-        if cur == "main":
-            if not self._main_has_ux_score():
-                logger.info(
-                    "skip SkillEdit: %s main 还没真实 ux_score，"
-                    "保留 candidates 等用户用 main 后再产 staging",
-                    self.skill_dir.name,
+
+        if not staging_exists:
+            # 守门 2: 阈值
+            ready = C.ready_for_promotion_v2(data, threshold=self.threshold)
+            if not ready:
+                return False
+            # 守门 3: 若场景是 "create staging"（即在 main 上）→ 额外要求 main 真有人用过
+            cur = current_branch(str(self.skill_dir))
+            if cur == "main":
+                if not self._main_has_ux_score():
+                    logger.info(
+                        "skip SkillEdit: %s main 还没真实 ux_score，"
+                        "保留 candidates 等用户用 main 后再产 staging",
+                        self.skill_dir.name,
+                    )
+                    return False
+            elif cur != "baby":
+                logger.warning(
+                    "skip SkillEdit: %s 在异常分支 %r (期望 baby 或 main)",
+                    self.skill_dir.name, cur,
                 )
                 return False
-        elif cur != "baby":
-            logger.warning(
-                "skip SkillEdit: %s 在异常分支 %r (期望 baby 或 main)",
-                self.skill_dir.name, cur,
-            )
-            return False
+        else:
+            ready = list(data.get("candidates", []) or [])
+            cur = "main"
 
         skill_md = self.skill_dir / "SKILL.md"
         mtime_before = skill_md.stat().st_mtime if skill_md.is_file() else 0.0
         size_before = skill_md.stat().st_size if skill_md.is_file() else 0
 
         try:
-            self._run(ready, current_branch_name=cur)
+            self._run(ready, current_branch_name=cur, jam=jam)
         except Exception:
             logger.exception("SkillEditAgent _run failed: %s", self.skill_dir.name)
 
@@ -374,6 +405,10 @@ class SkillEditAgent:
             )
             return False
 
+        if jam:
+            from xskill.canary import discard_staging
+            discard_staging(self.skill_dir)
+
         # commit 工具的成功效应（baby→main 或 main→staging）通过当前分支变化
         # 自然反映，不需要在这里做额外检查
         C.clear_candidates(self.skill_dir)
@@ -393,9 +428,74 @@ class SkillEditAgent:
             return False
         return any(s.get("side") == "main" for s in scores)
 
-    def _run(self, ready: list[dict], current_branch_name: str) -> None:
+    def _run(self, ready: list[dict], current_branch_name: str, jam: bool = False) -> None:
         from xskill.agents import agent_tools
         from xskill.skill.frontmatter import parse as fm_parse
+
+        if jam:
+            from xskill.canary import materialize_staging
+
+            skill_md = self.skill_dir / "SKILL.md"
+            staging_body = (
+                self.skill_dir.parent / ".canary" / self.skill_dir.name / "SKILL.md"
+            )
+            if not staging_body.is_file():
+                materialize_staging(self.skill_dir, self.skill_dir.parent / ".canary")
+            if not staging_body.is_file():
+                raise RuntimeError(
+                    f"jam-merge: staging body for {self.skill_dir.name} could not be "
+                    "materialized; refusing to merge and discard"
+                )
+
+            lines = [
+                MERGE_DISCIPLINE_BLOCK,
+                "",
+                f"skill_name: {self.skill_dir.name}（**main 分支 · 轨迹堰塞强砍合并**）",
+                f"现有 main 正文：用 skill_read('{self.skill_dir.name}') 读。",
+                f"staging 正文路径（用 read_file 读）：{staging_body}",
+                "",
+                "# 待合并候选（按 weightscore 倒序）",
+            ]
+            for c in sorted(ready, key=lambda x: x.get("weightscore", 0), reverse=True):
+                note = c.get("note", "")
+                lines.append(
+                    f"- atom_id={c['atom_id']}  weightscore={c['weightscore']}"
+                    + (f"  note: {note}" if note else "")
+                )
+            lines += [
+                "",
+                f"目标 skill 目录: {self.skill_dir}",
+                f"目标 SKILL.md 路径: {skill_md}",
+            ]
+            scenario_block = "\n".join(lines)
+            sysprompt = build_system_prompt(
+                scenario_block=scenario_block,
+                branch_now="main",
+            )
+            agent = self.agno_agent_factory(
+                instructions=[sysprompt],
+                tools=[
+                    agent_tools.atom_task_read,
+                    agent_tools.read_traj,
+                    agent_tools.skill_read,
+                    agent_tools.read_file,
+                    agent_tools.list_files,
+                    agent_tools.write_file,
+                    agent_tools.commit_update_main,
+                ],
+            )
+            import time as _time
+            from xskill.agents.agent_trace import trace_to
+            from xskill.config import get_logs_dir
+
+            _ts = _time.strftime("%Y%m%d-%H%M%S")
+            sink = (
+                get_logs_dir() / "agents" / "skill_edit_agents" / "skills"
+                / f"{self.skill_dir.name}_jam_{_ts}.log"
+            )
+            with trace_to(sink):
+                agent.run(scenario_block)
+            return
 
         # 构造 scenario_block + branch_now 给 prompt 用
         skill_md = self.skill_dir / "SKILL.md"

--- a/src/xskill/agents/skill_edit_agent.py
+++ b/src/xskill/agents/skill_edit_agent.py
@@ -366,6 +366,11 @@ class SkillEditAgent:
         skill_md = self.skill_dir / "SKILL.md"
         mtime_before = skill_md.stat().st_mtime if skill_md.is_file() else 0.0
         size_before = skill_md.stat().st_size if skill_md.is_file() else 0
+        main_sha_before = ""
+        if jam:
+            code, out, _ = run_git(["rev-parse", "main"], cwd=str(self.skill_dir))
+            if code == 0:
+                main_sha_before = out.strip()
 
         try:
             self._run(ready, current_branch_name=cur, jam=jam)
@@ -407,7 +412,23 @@ class SkillEditAgent:
 
         if jam:
             from xskill.canary import discard_staging
-            discard_staging(self.skill_dir)
+
+            code, out, _ = run_git(["rev-parse", "main"], cwd=str(self.skill_dir))
+            main_sha_after = out.strip() if code == 0 else ""
+            if not main_sha_after or main_sha_after == main_sha_before:
+                logger.warning(
+                    "SkillEditAgent jam-merge did not advance main: %s — "
+                    "保留 candidates/staging 等下轮重试",
+                    self.skill_dir.name,
+                )
+                return False
+            if not discard_staging(self.skill_dir):
+                logger.warning(
+                    "SkillEditAgent jam-merge could not discard staging: %s — "
+                    "保留 candidates 等下轮重试",
+                    self.skill_dir.name,
+                )
+                return False
 
         # commit 工具的成功效应（baby→main 或 main→staging）通过当前分支变化
         # 自然反映，不需要在这里做额外检查

--- a/src/xskill/agents/skill_edit_agent.py
+++ b/src/xskill/agents/skill_edit_agent.py
@@ -197,6 +197,7 @@ commit message 写明本次基于哪些 atom_id 整理，例如：
 - AtomTaskRead(atom_id) — 读 atom JSON
 - ReadTraj(traj_id, offset_start, offset_end) — 按行号取轨迹原文（offset 即 1-based 行号）
 - SkillRead(skill_name) — 读现有 SKILL.md（更新场景用）
+- read_file(path) — 读取 skill_base_path 下任意已有文件内容（如 scripts/、references/）
 - list_files(path) — 列目录文件
 - write_file(path, content) — 写任意文件到 skill_dir 下
 - commit_baby_to_main(skill_name, message) — 仅 baby 分支可用
@@ -306,6 +307,28 @@ class SkillEditAgent:
     traj_root: Path
     threshold: int = C.ATOM_PROMOTION_THRESHOLD
     jam_threshold: int = 50
+
+    def _skill_tree_context_lines(self, max_entries: int = 80) -> list[str]:
+        """返回当前 skill 根目录与文件树，供 agent 决定是否 read_file。"""
+        lines = [
+            "",
+            f"skill_base_path: {self.skill_dir}",
+            "# 当前 skill 文件树（相对 skill_base_path；需要内容时用 read_file 读取）",
+        ]
+        entries: list[str] = []
+        for path in sorted(self.skill_dir.rglob("*")):
+            rel = path.relative_to(self.skill_dir)
+            if ".git" in rel.parts:
+                continue
+            if rel.name in {".candidates.yml", ".ux_scores.jsonl", ".lock"}:
+                continue
+            suffix = "/" if path.is_dir() else ""
+            entries.append(f"- {rel.as_posix()}{suffix}")
+            if len(entries) >= max_entries:
+                entries.append(f"- ... truncated after {max_entries} entries")
+                break
+        lines.extend(entries or ["- (empty)"])
+        return lines
 
     def maybe_run(self) -> bool:
         """检查所有守门条件 → 触发 agent → 验证落盘 → 清 buffer。
@@ -474,7 +497,7 @@ class SkillEditAgent:
                 f"skill_name: {self.skill_dir.name}（**main 分支 · 轨迹堰塞强砍合并**）",
                 f"现有 main 正文：用 skill_read('{self.skill_dir.name}') 读。",
                 f"staging 正文路径（用 read_file 读）：{staging_body}",
-                "",
+                *self._skill_tree_context_lines(),
                 "# 待合并候选（按 weightscore 倒序）",
             ]
             for c in sorted(ready, key=lambda x: x.get("weightscore", 0), reverse=True):
@@ -549,6 +572,7 @@ class SkillEditAgent:
                 scenario_lines.append(f"现有 SKILL.md version: {cur_ver}")
             except Exception:
                 pass
+        scenario_lines.extend(self._skill_tree_context_lines())
         scenario_lines.append("")
         scenario_lines.append("# 待整理 candidates（按 weightscore 倒序）")
         for c in sorted(
@@ -576,6 +600,7 @@ class SkillEditAgent:
                 agent_tools.atom_task_read,
                 agent_tools.read_traj,
                 agent_tools.skill_read,
+                agent_tools.read_file,
                 agent_tools.list_files,
                 agent_tools.write_file,
                 agent_tools.commit_baby_to_main,

--- a/src/xskill/canary.py
+++ b/src/xskill/canary.py
@@ -231,6 +231,10 @@ def discard_staging(skill_dir: Path) -> bool:
         if code != 0:
             logger.error(f"{skill_dir.name}: discard staging failed: {err}")
             return False
+    # 清理物化目录（materialize_staging 留下的 .canary/<name>/）
+    canary_copy = skill_dir.parent / ".canary" / skill_dir.name
+    if canary_copy.exists():
+        shutil.rmtree(canary_copy)
     logger.info(f"{skill_dir.name}: staging discarded")
     return True
 

--- a/src/xskill/canary.py
+++ b/src/xskill/canary.py
@@ -55,6 +55,12 @@ class CanaryConfig:
     # total_samples: 每侧（main/staging）判定所需的总样本数（跨所有参与模型）。
     scope_top_n: int = 2
     total_samples: int = 20
+    # ── 轨迹堰塞强砍阈值（jam_threshold）─────────────────────────────
+    # staging 存在期间闸门一本会无条件 hold 所有 SkillEdit；候选累计 weightscore
+    # 攒到 jam_threshold 仍未等到灰度裁决 → 判定堰塞（疑似灰度错位/无真实流量），
+    # 越过灰度合并 main+staging+候选出新 main 并删 staging。必须 > 正常毕业阈值
+    # (ATOM_PROMOTION_THRESHOLD=10)，否则正常增量就会被误判堰塞。默认 50。
+    jam_threshold: int = 50
 
     @classmethod
     def from_dict(cls, d: dict | None) -> "CanaryConfig":
@@ -66,6 +72,7 @@ class CanaryConfig:
             rotate_interval=int(d.get("rotate_interval", 300)),
             scope_top_n=int(d.get("scope_top_n", 2)),
             total_samples=int(d.get("total_samples", 20)),
+            jam_threshold=int(d.get("jam_threshold", 50)),
         )
 
 

--- a/src/xskill/config.py
+++ b/src/xskill/config.py
@@ -114,6 +114,13 @@ canary:
                                 # and non-top-N traffic stays on main
   total_samples: 20             # model-scoped path: total UX scores needed on
                                 # each side before a weighted decision
+  jam_threshold: 50             # traj-jam breaker: while staging is open, gate-1
+                                # holds all SkillEdit; if pending candidates'
+                                # weightscore sums to >= this, declare a jam
+                                # (gray misaligned / no real traffic), bypass gray:
+                                # merge main+staging+candidates into a new main and
+                                # discard staging. Must exceed the graduation
+                                # threshold (10) so normal increments aren't misread.
 
 # ===== Skill description trigger optimization =====
 # Before each promotion commit (baby→main / main→staging) the daemon runs a

--- a/src/xskill/pipeline/runner.py
+++ b/src/xskill/pipeline/runner.py
@@ -318,6 +318,7 @@ class DirectoryWatcher:
         if self.skill_dir is None or not self.skill_dir.is_dir():
             return
         from xskill.agents.skill_edit_agent import SkillEditAgent
+        from xskill.canary import CanaryConfig
         factory = self._factory()
         # store 选哪个：edit agent 工具 (atom_task_read/read_traj) 需要 store +
         # traj_root 才能读到 atom 原文。单机只有一个 watch_dir（cc_sessions）。
@@ -325,7 +326,7 @@ class DirectoryWatcher:
         # label=client_id），某 skill 的 candidates 里的 atom 可能来自任意 client
         # 的 store——只绑第一个 wd 的 store，跨 client 的 atom 必然 not found。
         # 因此收集所有 wd 的 store：>1 个时包一层 MultiAtomTaskStore 做跨 store
-        # 路由；单个时直接用它（单机/cold_flush 行为零变化）。
+        # 路由；单个时直接用它（单机行为零变化）。
         stores = []
         for wd in list_watch_dirs(**self._db_kw()):
             try:
@@ -370,6 +371,9 @@ class DirectoryWatcher:
         if not skill_dirs:
             return
 
+        jam_threshold = CanaryConfig.from_dict(
+            self.config.get("canary", {})).jam_threshold
+
         def _run_one(d):
             """在 pool 工作线程里跑单个 skill 的 maybe_run；返回 (d, promoted)。
             异常吞在这里 log，不抛回 future 以免中断整批收集。"""
@@ -378,6 +382,7 @@ class DirectoryWatcher:
                 agno_agent_factory=factory,
                 llm_cfg=self.config.get("llm", {}),
                 traj_root=traj_root,
+                jam_threshold=jam_threshold,
                 **({} if threshold is None else {"threshold": threshold}),
             )
             try:

--- a/src/xskill/skill/git.py
+++ b/src/xskill/skill/git.py
@@ -1591,6 +1591,33 @@ def commit_to_staging_branch(skill_dir: str, message: str) -> bool:
     return True
 
 
+def commit_update_main_branch(skill_dir: str, message: str) -> bool:
+    """SkillEditAgent 调用：在 main 分支直接提交一次正文更新。
+
+    与 ``commit_to_staging_branch`` 的区别：不开 staging、不物化 canary，直接把
+    SkillEditAgent 写入工作区的 SKILL.md 提交到 main。
+    """
+    with skill_repo_lock(skill_dir):
+        with _open_repo(skill_dir) as repo:
+            cur = _current_branch_name(repo)
+            if cur != "main":
+                raise RuntimeError(
+                    f"commit_update_main_branch 要求当前在 main 分支，实际在 {cur!r}"
+                )
+            _stage_all(repo, Path(skill_dir))
+            sha, err = _do_commit(repo, message)
+            if sha is None:
+                if err == "nothing to commit":
+                    logger.warning(
+                        "commit_update_main_branch 无改动可提交: %s",
+                        Path(skill_dir).name,
+                    )
+                    return False
+                raise RuntimeError(f"commit_update_main_branch commit 失败: {err}")
+    logger.info("♻️ main direct update commit: %s: %s", Path(skill_dir).name, message)
+    return True
+
+
 def ensure_repo(skill_dir: str):
     """确保 skill_dir 是一个 git 仓库，在 main 分支上。"""
     p = Path(skill_dir)

--- a/tests/test_canary.py
+++ b/tests/test_canary.py
@@ -323,3 +323,11 @@ class TestMaterialize:
     # 提交里跟着一批未被任何路径调用的 helper 一起删了。当前 canary 模块的
     # 物化/丢弃语义由 ``materialize_staging`` + ``discard_staging`` 承担，
     # 在 TestMaterialize 上面已经覆盖。这里不再保留 orphan 测试。
+
+
+def test_jam_threshold_default_is_50():
+    assert canary.CanaryConfig.from_dict({}).jam_threshold == 50
+
+
+def test_jam_threshold_read_from_dict():
+    assert canary.CanaryConfig.from_dict({"jam_threshold": 30}).jam_threshold == 30

--- a/tests/test_skill_edit_agent.py
+++ b/tests/test_skill_edit_agent.py
@@ -421,3 +421,84 @@ class TestWritingDisciplineInPrompt:
         assert "commit_to_staging" in SYSTEM_PROMPT_TEMPLATE
         assert "隐私守护" in SYSTEM_PROMPT_TEMPLATE
         assert "AtomTaskRead" in SYSTEM_PROMPT_TEMPLATE
+
+
+# ────────────────────────────────────────────────────────────────────
+# jam-merge 场景：候选累计 ws ≥ jam_threshold 且 staging 存在 → 越过灰度强砍
+# ────────────────────────────────────────────────────────────────────
+
+from xskill.skill.git import commit_to_staging_branch, current_branch  # noqa: E402
+
+
+class _JamMergeStubAgno(_BabyStubAgno):
+    """模拟 jam-merge：读 scenario 里的 skill_name + 目标路径，写合并正文，
+    调 commit_update_main（而非 commit_to_staging）。"""
+    def run(self, user_msg, **kw):
+        type(self).invoked = True
+        type(self).user_msg = user_msg
+        import re
+        skill = re.search(r"skill_name:\s*([\w-]+)", user_msg).group(1)
+        target = re.search(r"目标 SKILL\.md 路径:\s*(\S+)", user_msg).group(1)
+        _call_tool(self.tools["write_file"], target, (
+            "---\nname: %s\ndescription: merged stub for jam\n"
+            "compatibility: test only; negative test only\n"
+            "metadata:\n  version: 2\n  source_atoms: [\"atom_x_0001\"]\n"
+            "---\n\n# merged\n\n## 核心原则\n- merged body\n"
+        ) % skill)
+        _call_tool(
+            self.tools["commit_update_main"],
+            skill,
+            "v2: jam-merge 合并 main+staging+候选",
+        )
+        class _R: pass
+        r = _R(); r.content = "done"; return r
+
+def _seed_candidates(skill_dir, total_ws):
+    """往 .candidates.yml 灌候选，使累计 weightscore = total_ws。"""
+    data = {"candidates": [{"atom_id": "atom_x_0001", "weightscore": total_ws}]}
+    C.save_candidates(skill_dir, data)
+
+def test_jam_merge_fires_above_threshold_and_discards_staging(tmp_path):
+    sd = _make_main_skill(tmp_path / "skill", "jam-skill")
+    # 写点东西并开 staging（灰度中）
+    (sd / "SKILL.md").write_text((sd / "SKILL.md").read_text() + "\n<!-- staging draft -->\n", encoding="utf-8")
+    assert commit_to_staging_branch(str(sd), "stub staging candidate") is True
+    assert (sd.parent / ".canary" / "jam-skill" / "SKILL.md").is_file()
+    # 候选攒到 60 ≥ jam_threshold(50)
+    _seed_candidates(sd, 60)
+
+    _, sha_before, _ = run_git(["rev-parse", "HEAD"], cwd=str(sd))
+    sha_before = sha_before.strip()
+
+    _JamMergeStubAgno.invoked = False
+    agent = SkillEditAgent(
+        skill_dir=sd, store=None, agno_agent_factory=_JamMergeStubAgno,
+        llm_cfg={}, traj_root=tmp_path, jam_threshold=50,
+    )
+    assert agent.maybe_run() is True
+    assert _JamMergeStubAgno.invoked is True
+    # staging 已被 discard
+    code, _, _ = run_git(["rev-parse", "--verify", "staging"], cwd=str(sd))
+    assert code != 0
+    assert not (sd.parent / ".canary" / "jam-skill").exists()
+    # 候选清空、HEAD 在 main、最新 commit 是合并
+    assert C.load_candidates(sd)["candidates"] == []
+    assert current_branch(str(sd)) == "main"
+    _, sha_after, _ = run_git(["rev-parse", "HEAD"], cwd=str(sd))
+    sha_after = sha_after.strip()
+    assert sha_after != sha_before
+
+def test_no_jam_below_threshold_keeps_staging(tmp_path):
+    sd = _make_main_skill(tmp_path / "skill", "calm-skill")
+    (sd / "SKILL.md").write_text((sd / "SKILL.md").read_text() + "\n<!-- s -->\n", encoding="utf-8")
+    assert commit_to_staging_branch(str(sd), "stub staging") is True
+    _seed_candidates(sd, 40)  # < 50
+    _JamMergeStubAgno.invoked = False
+    agent = SkillEditAgent(
+        skill_dir=sd, store=None, agno_agent_factory=_JamMergeStubAgno,
+        llm_cfg={}, traj_root=tmp_path, jam_threshold=50,
+    )
+    assert agent.maybe_run() is False          # 维持 hold
+    assert _JamMergeStubAgno.invoked is False
+    code, _, _ = run_git(["rev-parse", "--verify", "staging"], cwd=str(sd))
+    assert code == 0                            # staging 仍在

--- a/tests/test_skill_edit_agent.py
+++ b/tests/test_skill_edit_agent.py
@@ -453,6 +453,25 @@ class _JamMergeStubAgno(_BabyStubAgno):
         class _R: pass
         r = _R(); r.content = "done"; return r
 
+
+class _JamNoCommitStubAgno(_BabyStubAgno):
+    """模拟 agent 写了 SKILL.md 但没调用 commit_update_main。"""
+    def run(self, user_msg, **kw):
+        type(self).invoked = True
+        type(self).user_msg = user_msg
+        import re
+        skill = re.search(r"skill_name:\s*([\w-]+)", user_msg).group(1)
+        target = re.search(r"目标 SKILL\.md 路径:\s*(\S+)", user_msg).group(1)
+        _call_tool(self.tools["write_file"], target, (
+            "---\nname: %s\ndescription: uncommitted jam draft\n"
+            "compatibility: test only; negative test only\n"
+            "metadata:\n  version: 2\n  source_atoms: [\"atom_x_0001\"]\n"
+            "---\n\n# uncommitted\n\n## 核心原则\n- body changed without commit\n"
+        ) % skill)
+        class _R: pass
+        r = _R(); r.content = "done"; return r
+
+
 def _seed_candidates(skill_dir, total_ws):
     """往 .candidates.yml 灌候选，使累计 weightscore = total_ws。"""
     data = {"candidates": [{"atom_id": "atom_x_0001", "weightscore": total_ws}]}
@@ -502,6 +521,28 @@ def test_no_jam_below_threshold_keeps_staging(tmp_path):
     assert _JamMergeStubAgno.invoked is False
     code, _, _ = run_git(["rev-parse", "--verify", "staging"], cwd=str(sd))
     assert code == 0                            # staging 仍在
+
+
+def test_jam_merge_without_main_commit_keeps_candidates_and_staging(tmp_path):
+    sd = _make_main_skill(tmp_path / "skill", "jam-no-commit")
+    (sd / "SKILL.md").write_text(
+        (sd / "SKILL.md").read_text() + "\n<!-- staging draft -->\n",
+        encoding="utf-8",
+    )
+    assert commit_to_staging_branch(str(sd), "stub staging") is True
+    _seed_candidates(sd, 60)
+
+    _JamNoCommitStubAgno.invoked = False
+    agent = SkillEditAgent(
+        skill_dir=sd, store=None, agno_agent_factory=_JamNoCommitStubAgno,
+        llm_cfg={}, traj_root=tmp_path, jam_threshold=50,
+    )
+
+    assert agent.maybe_run() is False
+    assert _JamNoCommitStubAgno.invoked is True
+    assert C.load_candidates(sd)["candidates"] != []
+    code, _, _ = run_git(["rev-parse", "--verify", "staging"], cwd=str(sd))
+    assert code == 0
 
 
 class _JamMergeRematerializeStubAgno(_BabyStubAgno):

--- a/tests/test_skill_edit_agent.py
+++ b/tests/test_skill_edit_agent.py
@@ -486,7 +486,7 @@ def test_jam_merge_fires_above_threshold_and_discards_staging(tmp_path):
     assert current_branch(str(sd)) == "main"
     _, sha_after, _ = run_git(["rev-parse", "HEAD"], cwd=str(sd))
     sha_after = sha_after.strip()
-    assert sha_after != sha_before
+    assert sha_after != sha_before, "main HEAD should have advanced after jam-merge"
 
 def test_no_jam_below_threshold_keeps_staging(tmp_path):
     sd = _make_main_skill(tmp_path / "skill", "calm-skill")
@@ -502,3 +502,84 @@ def test_no_jam_below_threshold_keeps_staging(tmp_path):
     assert _JamMergeStubAgno.invoked is False
     code, _, _ = run_git(["rev-parse", "--verify", "staging"], cwd=str(sd))
     assert code == 0                            # staging 仍在
+
+
+class _JamMergeRematerializeStubAgno(_BabyStubAgno):
+    """Fix 3 专用 stub：在 run() 里主动读 staging_body_path，断言其内容存在（非报错）。
+
+    staging_body_path 从 scenario user_msg 里解析
+    ``staging 正文路径（用 read_file 读）：<path>`` 这行。
+    """
+    staging_body_content_seen: str = ""
+
+    def run(self, user_msg, **kw):
+        type(self).invoked = True
+        type(self).user_msg = user_msg
+        import re
+        skill = re.search(r"skill_name:\s*([\w-]+)", user_msg).group(1)
+        target = re.search(r"目标 SKILL\.md 路径:\s*(\S+)", user_msg).group(1)
+        # 从 scenario 行解析 staging body 路径
+        m = re.search(r"staging 正文路径（用 read_file 读）：(\S+)", user_msg)
+        assert m, "scenario must contain staging body path line"
+        staging_path = m.group(1)
+        # 读 staging body（通过 read_file 工具）
+        content = _call_tool(self.tools["read_file"], staging_path)
+        type(self).staging_body_content_seen = content
+        # 写合并产物并 commit
+        _call_tool(self.tools["write_file"], target, (
+            "---\nname: %s\ndescription: merged after rematerialize\n"
+            "compatibility: test only; negative test only\n"
+            "metadata:\n  version: 2\n  source_atoms: [\"atom_x_0001\"]\n---\n\n"
+            "# merged\n\n## 核心原则\n- re-materialized merge\n" % skill
+        ))
+        _call_tool(
+            self.tools["commit_update_main"],
+            skill,
+            "v2: jam-merge 重物化后合并",
+        )
+        class _R: pass
+        r = _R(); r.content = "done"; return r
+
+
+def test_jam_merge_rematerializes_missing_staging_body(tmp_path):
+    """Fix 3: .canary/<name>/ 目录不存在时，jam 分支应从 staging 分支重新物化，
+    然后 agent 能正常读到 staging 内容（非报错字符串），合并成功，staging 被删除。"""
+    import shutil
+
+    sd = _make_main_skill(tmp_path / "skill", "rematerialize-skill")
+    # 写 staging 分支（包含可识别内容）
+    staging_content = (sd / "SKILL.md").read_text() + "\n<!-- unique staging marker -->\n"
+    (sd / "SKILL.md").write_text(staging_content, encoding="utf-8")
+    assert commit_to_staging_branch(str(sd), "stub staging candidate") is True
+    # 确认 .canary 已物化
+    canary_dir = sd.parent / ".canary" / "rematerialize-skill"
+    assert canary_dir.is_dir()
+    # 模拟 best-effort 物化失败：删除整个 .canary/<name>/ 目录
+    shutil.rmtree(canary_dir)
+    assert not canary_dir.exists()
+
+    # 候选超过 jam_threshold
+    _seed_candidates(sd, 60)
+
+    _JamMergeRematerializeStubAgno.invoked = False
+    _JamMergeRematerializeStubAgno.staging_body_content_seen = ""
+    agent = SkillEditAgent(
+        skill_dir=sd, store=None,
+        agno_agent_factory=lambda **kw: _JamMergeRematerializeStubAgno(**kw),
+        llm_cfg={}, traj_root=tmp_path, jam_threshold=50,
+    )
+    result = agent.maybe_run()
+    assert result is True, "jam-merge with re-materialization should succeed"
+    assert _JamMergeRematerializeStubAgno.invoked is True
+    # staging body が actually read as real content (not "file not found" / error)
+    seen = _JamMergeRematerializeStubAgno.staging_body_content_seen
+    assert seen and "not found" not in seen.lower() and "error" not in seen.lower(), (
+        f"expected staging content, got: {seen!r}")
+    assert "unique staging marker" in seen or "SKILL" in seen, (
+        f"expected staging SKILL.md content, got: {seen!r}")
+    # staging 已被 discard
+    code, _, _ = run_git(["rev-parse", "--verify", "staging"], cwd=str(sd))
+    assert code != 0, "staging branch should be deleted after jam-merge"
+    # candidates cleared
+    assert C.load_candidates(sd)["candidates"] == []
+    assert current_branch(str(sd)) == "main"

--- a/tests/test_skill_edit_agent.py
+++ b/tests/test_skill_edit_agent.py
@@ -102,12 +102,25 @@ class _StagingStubAgno(_BabyStubAgno):
         return r
 
 
+class _InspectingStagingStubAgno(_StagingStubAgno):
+    """记录普通 main->staging 路径给 agent 的工具和启动场景。"""
+    tool_names: set[str] = set()
+
+    def __init__(self, *, instructions, tools):
+        super().__init__(instructions=instructions, tools=tools)
+        type(self).tool_names = set(self.tools)
+
+
 def _baby_factory(*, instructions, tools):
     return _BabyStubAgno(instructions=instructions, tools=tools)
 
 
 def _staging_factory(*, instructions, tools):
     return _StagingStubAgno(instructions=instructions, tools=tools)
+
+
+def _inspecting_staging_factory(*, instructions, tools):
+    return _InspectingStagingStubAgno(instructions=instructions, tools=tools)
 
 
 @pytest.fixture(autouse=True)
@@ -130,11 +143,12 @@ def _init_atom_task_tool_context(tmp_path):
     )
     yield
     agent_tools.agent_tool_config.restore(saved_context)
-    for cls in (_BabyStubAgno, _StagingStubAgno):
+    for cls in (_BabyStubAgno, _StagingStubAgno, _InspectingStagingStubAgno):
         cls.invoked = False
         cls.user_msg = ""
         cls.writes_skill_md_with = None
         cls.calls_commit = True
+    _InspectingStagingStubAgno.tool_names = set()
 
 
 # ────────────────────────────────────────────────────────────────────
@@ -250,6 +264,33 @@ class TestMainNeedsUxScoreBeforeStaging:
         # candidates 清空
         data2 = C.load_candidates(skill_dir)
         assert data2["candidates"] == []
+
+    def test_regular_path_exposes_read_file_base_path_and_tree(self, tmp_path):
+        """普通 SkillEditAgent 更新路径应能读辅助文件，并在启动时看到 base path/tree。"""
+        skill_dir = _make_main_skill(tmp_path / "skill", "with-helper")
+        helper = skill_dir / "scripts" / "helper.py"
+        helper.write_text("print('helper')\n", encoding="utf-8")
+        run_git(["add", "-A"], cwd=str(skill_dir))
+        run_git(["commit", "-m", "add helper script"], cwd=str(skill_dir))
+        _add_ux_score(skill_dir)
+        data = {"candidates": []}
+        data, _ = C.add_atom_contribution(data, "atom_a", 10)
+        C.save_candidates(skill_dir, data)
+        _InspectingStagingStubAgno.writes_skill_md_with = (
+            "---\nname: with-helper\ndescription: updated\n"
+            "metadata:\n  version: 2\n---\n# body\n"
+        )
+
+        agent = SkillEditAgent(
+            skill_dir=skill_dir, store=None,
+            agno_agent_factory=_inspecting_staging_factory,
+            llm_cfg={}, traj_root=tmp_path,
+        )
+
+        assert agent.maybe_run() is True
+        assert "read_file" in _InspectingStagingStubAgno.tool_names
+        assert f"skill_base_path: {skill_dir}" in _InspectingStagingStubAgno.user_msg
+        assert "scripts/helper.py" in _InspectingStagingStubAgno.user_msg
 
 
 # ────────────────────────────────────────────────────────────────────

--- a/tests/test_skilledit_parallel.py
+++ b/tests/test_skilledit_parallel.py
@@ -126,6 +126,56 @@ def _make_watcher(tmp_path, skill_root, factory, max_concurrent):
     )
 
 
+def _make_watcher_with_config(tmp_path, skill_root, factory, config):
+    """Like _make_watcher but accepts a full config dict (for testing config wiring)."""
+    db = tmp_path / "test.db"
+    wd = tmp_path / "wd"
+    wd.mkdir(exist_ok=True)
+    register_dir(wd, db_path=db)
+    store = AtomTaskStore(root=wd)
+    return DirectoryWatcher(
+        llm=_AutoSplitLLM(),
+        embed_client=_FakeEmbed(),
+        config=config,
+        skill_dir=skill_root,
+        poll_interval=0.0,
+        max_concurrent=1,
+        db_path=db,
+        store=store,
+        agno_agent_factory=factory,
+        home_root=tmp_path,
+    )
+
+
+def test_runner_passes_jam_threshold(monkeypatch, tmp_path):
+    """runner 构造 SkillEditAgent 时，把 config.canary.jam_threshold 注入。"""
+    import xskill.agents.skill_edit_agent as SEA
+    captured = {}
+    real_init = SEA.SkillEditAgent.__init__
+    def spy_init(self, *a, **kw):
+        captured["jam_threshold"] = kw.get("jam_threshold")
+        return real_init(self, *a, **kw)
+    monkeypatch.setattr(SEA.SkillEditAgent, "__init__", spy_init)
+
+    skill_root = tmp_path / "skill"
+    skill_root.mkdir()
+    # ws=15 > ATOM_PROMOTION_THRESHOLD(10) → 触发 _run_one
+    _seed_baby_skill(skill_root, "s1")
+
+    noop_barrier = threading.Barrier(1)
+    factory = _make_barrier_agno(1, noop_barrier)
+    config = {
+        "llm": {"base_url": "x", "model": "y", "api_key": "z"},
+        "canary": {"jam_threshold": 33},
+    }
+    w = _make_watcher_with_config(tmp_path, skill_root, factory, config)
+    w._check_pending_skill_edits()
+
+    assert captured.get("jam_threshold") == 33, (
+        f"jam_threshold was not wired from config; captured={captured!r}"
+    )
+
+
 class TestSkillEditParallel:
     def test_concurrent_no_cross_contamination_and_all_graduate(self, tmp_path):
         """N 个 baby skill 并发跑 SkillEdit：barrier 凑齐证明真并发，


### PR DESCRIPTION
Summary

This PR ports the local non-main branch design for the 50-point trajectory jam breaker onto current origin/main.

It adds:
- canary.jam_threshold with default 50.
- A SkillEditAgent jam path: when a skill already has staging and pending candidate weightscore reaches jam_threshold, merge main + staging + candidates directly into a new main version.
- commit_update_main / commit_update_main_branch for this direct-main jam merge path.
- Runner wiring so daemon-created SkillEditAgent instances receive the configured threshold.
- Safety checks: re-materialize missing staging body before merge; keep candidates/staging if main does not advance or staging discard fails.

Why

Current main keeps holding SkillEdit while staging exists. Backlog trajectories cannot produce staging UX samples, so candidates can pile up with no consumer until timeout. This PR gives that state a bounded escape path without changing the normal baby->main or main->staging flow.

Verification

- python3.11 -m pytest tests/test_canary.py tests/test_skill_edit_agent.py tests/test_skilledit_parallel.py -q -> 54 passed.
- python3.11 -m pytest tests/ --ignore=tests/docker_e2e --ignore=tests/live --ignore=tests/test_e2e_xskill_serve_auto.py -q -> 908 passed, 38 warnings.

Note: full make test was not used as final verification because tests/test_e2e_xskill_serve_auto.py::test_canary_flip_promote_and_install_new_version hung in local setup with a spawned local server. The broad suite above excludes only that local serve E2E.

Source history

Local source commits inspected from non-main branch history:
- 090ec7e add jam_threshold config.
- 1c5733f add jam-merge SkillEditAgent path.
- c7dad01 wire runner config.
- be29bb2 re-materialize missing staging body before jam merge.
