### PR TITLE
feat(pipeline): add configurable interest filter

### DIFF
--- a/src/xskill/agents/agent_tools.py
+++ b/src/xskill/agents/agent_tools.py
@@ -732,6 +732,7 @@ def make_task_agent_tools(
     total_lines: int,
     all_lines: list[str],
     user_msg: str,
+    not_fit_reasons: list[str] | None = None,
 ):
     """Create TaskAgent run-scoped tools bound to one trajectory."""
     valid = set(valid_lines)
@@ -752,6 +753,11 @@ def make_task_agent_tools(
             used_skills: agent 实际触发的 skill 名列表,没有传 []。
             ux_score: 1~10 整数。
         """
+        if not_fit_reasons:
+            return (
+                "error: 已调用 mark_not_fit，不能再调用 submit_atom；"
+                "如果轨迹相关，请不要调用 mark_not_fit"
+            )
         try:
             sl = int(start_line)
         except (TypeError, ValueError):
@@ -778,6 +784,26 @@ def make_task_agent_tools(
             and 1 <= ux_score <= 10 else None,
         })
         return f"ok: 已记录 atom #{len(submitted)} (start_line={sl})"
+
+    @tool(name="mark_not_fit")
+    def mark_not_fit(reason: str) -> str:
+        """标记整条轨迹不符合配置的 interests，并结束拆分。
+
+        Args:
+            reason: 简短说明为什么整条轨迹与 interests 无关。
+        """
+        if not_fit_reasons is None:
+            return "error: 当前未启用 interests 过滤"
+        if submitted:
+            return (
+                "error: 已经提交过 submit_atom，不能再调用 mark_not_fit；"
+                "部分相关的轨迹应继续正常拆分"
+            )
+        normalized_reason = str(reason or "").strip()
+        if not normalized_reason:
+            normalized_reason = "trajectory does not match configured interests"
+        not_fit_reasons.append(normalized_reason)
+        return f"ok: not_fit 已记录 ({normalized_reason})"
 
     @tool(name="look")
     def look(line: int, before: int = 40, after: int = 20) -> str:
@@ -828,7 +854,10 @@ def make_task_agent_tools(
             spans.append(f"[{st},{end})")
         return " ".join(spans)
 
-    return [look, submit_atom, context_budget, my_atoms]
+    tools = [look, submit_atom, context_budget, my_atoms]
+    if not_fit_reasons is not None:
+        tools.append(mark_not_fit)
+    return tools
 
 
 @tool(name="list_files")

--- a/src/xskill/agents/task_agent.py
+++ b/src/xskill/agents/task_agent.py
@@ -169,11 +169,7 @@ INTEREST_FILTER_SECTION_TEMPLATE = """\
 本次运行配置了兴趣列表：
 {interests_block}
 
-在拆分前先判断**整条轨迹**是否与这些兴趣相关。判断标准：
-- 只要轨迹中有一部分能为这些兴趣之一提供可复用经验，就继续正常 submit_atom。
-- 如果整条轨迹都无关，调用 ``mark_not_fit(reason)``，说明原因，然后结束。
-- 调用 ``mark_not_fit`` 后不要再调用 ``submit_atom``。
-- 已经调用过 ``submit_atom`` 后，不允许再调用 ``mark_not_fit``。
+先根据用户提问地图判断是否明显无关；判断前最多调用 3 次 ``look`` 查看上下文，明显无关就调用 ``mark_not_fit(reason)``，否则继续正常拆分。
 """
 
 

--- a/src/xskill/agents/task_agent.py
+++ b/src/xskill/agents/task_agent.py
@@ -46,6 +46,7 @@ from dataclasses import dataclass
 from pathlib import Path
 from typing import Any, Callable
 
+from xskill.config import interests_config
 from xskill.pipeline.atom import AtomTask, AtomTaskStore
 
 logger = logging.getLogger("xskill.task_agent")
@@ -60,6 +61,14 @@ def _sidecar_model(traj_path: Path) -> str:
         return str(json.loads(jp.read_text(encoding="utf-8")).get("model") or "")
     except (OSError, json.JSONDecodeError):
         return ""
+
+
+class TrajectoryNotFit(RuntimeError):
+    """Raised when TaskAgent marks a trajectory unrelated to configured interests."""
+
+    def __init__(self, reason: str):
+        self.reason = reason
+        super().__init__(reason)
 
 
 SYSTEM_PROMPT = """你是 AtomTask 拆分员。给你一条 agent 与用户的对话轨迹（markdown）的
@@ -150,6 +159,21 @@ ux_score 严格分档表
 2. 拿不准某个回合是"新意图"还是"上一意图的追问/撤销"时,用 ``look`` 读那行附近
    的 assistant 原文再判。
 3. 对每个新 atom 调一次 submit_atom（提交即校验,error 就改了重提）。完成后结束。
+"""
+
+
+INTEREST_FILTER_SECTION_TEMPLATE = """\
+
+兴趣过滤（重要）
+================
+本次运行配置了兴趣列表：
+{interests_block}
+
+在拆分前先判断**整条轨迹**是否与这些兴趣相关。判断标准：
+- 只要轨迹中有一部分能为这些兴趣之一提供可复用经验，就继续正常 submit_atom。
+- 如果整条轨迹都无关，调用 ``mark_not_fit(reason)``，说明原因，然后结束。
+- 调用 ``mark_not_fit`` 后不要再调用 ``submit_atom``。
+- 已经调用过 ``submit_atom`` 后，不允许再调用 ``mark_not_fit``。
 """
 
 
@@ -293,6 +317,8 @@ class TaskAgent:
     # look 白名单根：默认取 store.root（轨迹文件所在目录）。
     traj_root: Path | None = None
     skill_dir: Path | None = None
+    # 顶层 config.interests 规范化后传入；空列表禁用兴趣过滤。
+    interests: list[str] | None = None
 
     def __post_init__(self) -> None:
         if self.traj_root is None:
@@ -301,6 +327,16 @@ class TaskAgent:
             self.traj_root = Path(self.traj_root)
         if self.skill_dir is not None:
             self.skill_dir = Path(self.skill_dir)
+        self.interests = interests_config({"interests": self.interests or []})
+
+    @property
+    def _system_prompt(self) -> str:
+        if not self.interests:
+            return SYSTEM_PROMPT
+        interests_block = "\n".join(f"- {interest}" for interest in self.interests)
+        return SYSTEM_PROMPT + INTEREST_FILTER_SECTION_TEMPLATE.format(
+            interests_block=interests_block
+        )
 
     # ── public API ────────────────────────────────────────────────
 
@@ -435,6 +471,7 @@ class TaskAgent:
         拆多条 traj 不串）。``agent.run()`` 后查 run_response.status,error 即抛。
         """
         submitted: list[dict] = []
+        not_fit_reasons: list[str] = []
         user_msg = self._build_user_msg(
             traj_id=traj_id, traj_path=traj_path, source_model=source_model,
             resume_line=resume_line, prior_atoms=prior_atoms,
@@ -448,9 +485,10 @@ class TaskAgent:
             total_lines=total_lines,
             all_lines=all_lines,
             user_msg=user_msg,
+            not_fit_reasons=not_fit_reasons if self.interests else None,
         )
         agent = self.agno_agent_factory(
-            instructions=[SYSTEM_PROMPT],
+            instructions=[self._system_prompt],
             tools=tools,
         )
         # 把这次拆分的逐轮 CoT/工具调用流式写进 logs/agents/task_agents/<traj_id>.log
@@ -460,6 +498,8 @@ class TaskAgent:
         with trace_to(sink):
             run_response = agent.run(user_msg)
         self._check_run_status(traj_id, run_response)
+        if not_fit_reasons and not submitted:
+            raise TrajectoryNotFit(not_fit_reasons[-1])
         return submitted
 
     @staticmethod

--- a/src/xskill/api/sse.py
+++ b/src/xskill/api/sse.py
@@ -15,7 +15,6 @@ from __future__ import annotations
 import asyncio
 import json
 import logging
-import traceback
 from concurrent.futures import ThreadPoolExecutor
 from pathlib import Path
 from typing import Optional
@@ -24,7 +23,7 @@ from fastapi import APIRouter
 from pydantic import BaseModel
 from sse_starlette.sse import EventSourceResponse
 
-from xskill.config import load_config, get_skill_dir, get_traj_dir
+from xskill.config import load_config, get_skill_dir, get_traj_dir, interests_config
 from xskill.utils.llm import create_llm_client, create_embed_client
 
 logger = logging.getLogger("xskill.tasks")
@@ -144,7 +143,7 @@ async def api_index(req: IndexRequest):
     def run():
         try:
             from xskill.pipeline.atom import AtomTaskStore
-            from xskill.agents.task_agent import TaskAgent
+            from xskill.agents.task_agent import TaskAgent, TrajectoryNotFit
             from xskill.agents.agno_factory import make_default_factory
             from xskill.pipeline.trajectory import validate_trajectory_source
 
@@ -184,6 +183,7 @@ async def api_index(req: IndexRequest):
             agent = TaskAgent(
                 agno_agent_factory=make_default_factory(config),
                 store=store, traj_root=dataset_dir, skill_dir=get_skill_dir(),
+                interests=interests_config(config),
             )
             for idx, md in enumerate(md_files, 1):
                 validation = validate_trajectory_source(md)
@@ -201,6 +201,12 @@ async def api_index(req: IndexRequest):
                 try:
                     atoms = agent.run(traj_id=md.stem, traj_path=md)
                     log_fn(f"[{idx}/{total}] {md.name} -> {len(atoms)} atoms", "step")
+                except TrajectoryNotFit as not_fit_error:
+                    log_fn(
+                        f"[{idx}/{total}] {md.name} filtered/not_fit: "
+                        f"{not_fit_error.reason}",
+                        "step",
+                    )
                 except Exception as e:
                     log_fn(f"[{idx}/{total}] {md.name} 拆分失败: {e}", "error")
                 _push(queue, "progress", {
@@ -249,7 +255,7 @@ async def api_process(req: ProcessRequest):
     def run():
         try:
             from xskill.pipeline.atom import AtomTaskStore
-            from xskill.agents.task_agent import TaskAgent
+            from xskill.agents.task_agent import TaskAgent, TrajectoryNotFit
             from xskill.pipeline.runner import process_atom_task
             from xskill.pipeline.trajectory import validate_trajectory_source
             from xskill.agents.agno_factory import make_default_factory
@@ -281,10 +287,20 @@ async def api_process(req: ProcessRequest):
             store = AtomTaskStore(root=traj_path.parent)
 
             _push(queue, "progress", {"step": "拆分 AtomTask", "current": 0, "total": 1})
-            atoms = TaskAgent(
-                agno_agent_factory=make_default_factory(config),
-                store=store, traj_root=traj_path.parent, skill_dir=skill_dir,
-            ).run(traj_id=traj_path.stem, traj_path=traj_path)
+            try:
+                atoms = TaskAgent(
+                    agno_agent_factory=make_default_factory(config),
+                    store=store, traj_root=traj_path.parent, skill_dir=skill_dir,
+                    interests=interests_config(config),
+                ).run(traj_id=traj_path.stem, traj_path=traj_path)
+            except TrajectoryNotFit as not_fit_error:
+                _finish(queue, {
+                    "status": "filtered",
+                    "process_action": "not_fit",
+                    "traj": traj_path.name,
+                    "reason": not_fit_error.reason,
+                })
+                return
             log_fn(f"拆出 {len(atoms)} 个 atom", "step")
             _push(queue, "progress", {"step": "拆分 AtomTask", "current": 1, "total": 1})
 
@@ -346,7 +362,7 @@ async def api_batch(req: BatchRequest):
     def run():
         try:
             from xskill.pipeline.atom import AtomTaskStore
-            from xskill.agents.task_agent import TaskAgent
+            from xskill.agents.task_agent import TaskAgent, TrajectoryNotFit
             from xskill.pipeline.runner import process_atom_task
             from xskill.pipeline.trajectory import validate_trajectory_source
             from xskill.agents.agno_factory import make_default_factory
@@ -385,6 +401,7 @@ async def api_batch(req: BatchRequest):
             split_agent = TaskAgent(
                 agno_agent_factory=make_default_factory(config),
                 store=store, traj_root=dataset_dir, skill_dir=skill_dir,
+                interests=interests_config(config),
             )
 
             # Phase 1: 整批拆 atom + 重建索引
@@ -400,6 +417,12 @@ async def api_batch(req: BatchRequest):
                     atoms = split_agent.run(traj_id=md.stem, traj_path=md)
                     log_fn(f"[{idx}/{total}] split: {md.name} -> {len(atoms)} atoms",
                            "step")
+                except TrajectoryNotFit as not_fit_error:
+                    log_fn(
+                        f"[{idx}/{total}] filtered/not_fit: {md.name}: "
+                        f"{not_fit_error.reason}",
+                        "step",
+                    )
                 except Exception as e:
                     log_fn(f"[{idx}/{total}] split failed: {md.name}: {e}", "error")
             store.rebuild_vector_index(embed)

--- a/src/xskill/config.py
+++ b/src/xskill/config.py
@@ -7,6 +7,8 @@ config.py — 全局路径与配置加载
 
 from __future__ import annotations
 
+import hashlib
+import json
 import logging
 from pathlib import Path
 from typing import Optional
@@ -43,6 +45,8 @@ CONFIG_TEMPLATE = """\
 
 # ===== Skill repository =====
 skill_dir: ~/.xskill/skill            # the single global skill repo
+interests: []                         # optional top-level interest filter;
+                                      # non-empty list enables TaskAgent filtering
 
 # ===== LLM (generation / scoring / chat) =====
 # Any OpenAI-compatible chat-completions endpoint works (DeepSeek, OpenAI,
@@ -242,6 +246,52 @@ def load_config(path: Optional[Path] = None) -> dict:
     if not _config.get("embedding", {}).get("api_key"):
         raise KeyError(f"embedding.api_key missing in {cfg_path}")
     return _config
+
+
+def interests_config(config_data: Optional[dict] = None) -> list[str]:
+    """Return normalized top-level interests.
+
+    Missing or empty interests disable filtering. Values must be a list of
+    strings; each string is stripped and blank entries are removed.
+    """
+    source_config = config_data or {}
+    raw_interests = source_config.get("interests") or []
+    if not isinstance(raw_interests, list):
+        raise ValueError(
+            f"interests 必须是字符串列表，got {type(raw_interests).__name__}"
+        )
+    normalized_interests: list[str] = []
+    for interest_index, interest_value in enumerate(raw_interests):
+        if not isinstance(interest_value, str):
+            raise ValueError(
+                "interests"
+                f"[{interest_index}] 必须是字符串，got {type(interest_value).__name__}"
+            )
+        normalized_interest = interest_value.strip()
+        if normalized_interest:
+            normalized_interests.append(normalized_interest)
+    return normalized_interests
+
+
+def interests_fingerprint(interests: list[str]) -> str:
+    """Return an order-sensitive fingerprint for normalized interests."""
+    normalized_interests = interests_config({"interests": interests})
+    serialized_interests = json.dumps(
+        normalized_interests, ensure_ascii=False, separators=(",", ":")
+    )
+    return hashlib.sha256(serialized_interests.encode("utf-8")).hexdigest()
+
+
+def read_interests_config(path: Optional[Path] = None) -> list[str]:
+    """Read only top-level interests from config.yaml without client validation."""
+    config_path = Path(path) if path else CONFIG_PATH
+    if not config_path.exists():
+        return []
+    with open(config_path, encoding="utf-8") as config_file:
+        config_data = yaml.safe_load(config_file) or {}
+    if not isinstance(config_data, dict):
+        raise ValueError("config.yaml 顶层必须是 mapping")
+    return interests_config(config_data)
 
 
 def get_config() -> dict:

--- a/src/xskill/pipeline/registry.py
+++ b/src/xskill/pipeline/registry.py
@@ -19,6 +19,7 @@ import json
 import logging
 import sqlite3
 from datetime import datetime, timezone
+from enum import Enum
 from pathlib import Path
 from typing import Optional
 
@@ -26,6 +27,24 @@ from xskill.config import get_registry_db_path
 from xskill.types import WatchDir
 
 logger = logging.getLogger("xskill.registry")
+
+
+class TrajectoryStatus(str, Enum):
+    DISCOVERED = "discovered"
+    UPDATED = "updated"
+    SPLITTING = "splitting"
+    SPLIT_DONE = "split_done"
+    INDEXED = "indexed"
+    DONE = "done"
+    FILTERED = "filtered"
+    ERROR = "error"
+    CLUSTERING = "clustering"
+    META_DONE = "meta_done"
+
+
+class ProcessAction(str, Enum):
+    CLUSTERED = "clustered"
+    NOT_FIT = "not_fit"
 
 # ---------------------------------------------------------------------------
 # Connection
@@ -49,6 +68,7 @@ CREATE TABLE IF NOT EXISTS trajectories (
     has_embedding INTEGER DEFAULT 0,
     status        TEXT DEFAULT 'discovered',
     process_action TEXT,
+    interest_fingerprint TEXT,
     skill_generated TEXT,
     skill_used    TEXT,
     canary_side   TEXT,
@@ -150,6 +170,7 @@ def _migrate(conn: sqlite3.Connection) -> None:
     migrations = [
         ("status", "TEXT DEFAULT 'discovered'"),
         ("process_action", "TEXT"),
+        ("interest_fingerprint", "TEXT"),
         ("skill_generated", "TEXT"),
         ("ux_score", "REAL"),
         ("error_msg", "TEXT"),
@@ -518,7 +539,7 @@ def discover_trajectories(
         existing = {
             row["filename"]: row
             for row in conn.execute(
-                "SELECT filename, status, file_mtime FROM trajectories"
+                "SELECT filename, status, process_action, file_mtime FROM trajectories"
                 " WHERE watch_dir_id=?",
                 (watch_dir_id,),
             ).fetchall()
@@ -551,6 +572,17 @@ def discover_trajectories(
             if status == "discovered":
                 # 还没开拆,后续 split 会读到最新内容（last_offset=0 全量拆）。
                 # 只更 mtime,不必翻 updated。
+                conn.execute(
+                    "UPDATE trajectories SET file_mtime=?"
+                    " WHERE watch_dir_id=? AND filename=?",
+                    (mtime, watch_dir_id, md.name),
+                )
+                continue
+            if (
+                status == TrajectoryStatus.FILTERED.value
+                and row["process_action"] == ProcessAction.NOT_FIT.value
+            ):
+                # Interest-filtered trajectories re-enter only after interests change.
                 conn.execute(
                     "UPDATE trajectories SET file_mtime=?"
                     " WHERE watch_dir_id=? AND filename=?",
@@ -889,6 +921,87 @@ def update_traj_offset(
         conn.close()
 
 
+def mark_not_fit(
+    watch_dir_id: int,
+    filename: str,
+    reason: str,
+    interest_fingerprint: str,
+    *,
+    db_path: Optional[Path] = None,
+) -> None:
+    """Mark a trajectory as terminally filtered by the configured interests."""
+    conn = get_connection(db_path)
+    try:
+        conn.execute(
+            "UPDATE trajectories SET status=?, process_action=?, error_msg=?, "
+            "interest_fingerprint=?, updated_at=datetime('now')"
+            " WHERE watch_dir_id=? AND filename=?",
+            (
+                TrajectoryStatus.FILTERED.value,
+                ProcessAction.NOT_FIT.value,
+                reason,
+                interest_fingerprint,
+                watch_dir_id,
+                filename,
+            ),
+        )
+        conn.commit()
+    finally:
+        conn.close()
+
+
+def reset_not_fit_for_interest_change(
+    *,
+    old_interest_fingerprint: str,
+    new_interest_fingerprint: str,
+    db_path: Optional[Path] = None,
+) -> int:
+    """Reset only stale filtered/not_fit trajectories for re-evaluation."""
+    if old_interest_fingerprint == new_interest_fingerprint:
+        return 0
+    conn = get_connection(db_path)
+    try:
+        rows = conn.execute(
+            "SELECT t.id, t.filename, w.path FROM trajectories t "
+            "JOIN watch_dirs w ON t.watch_dir_id = w.id "
+            "WHERE t.status=? AND t.process_action=? "
+            "AND (t.interest_fingerprint IS NULL OR t.interest_fingerprint != ?)",
+            (
+                TrajectoryStatus.FILTERED.value,
+                ProcessAction.NOT_FIT.value,
+                new_interest_fingerprint,
+            ),
+        ).fetchall()
+        directories_seen: set[str] = set()
+        for row in rows:
+            conn.execute(
+                "UPDATE trajectories SET status=?, process_action=NULL, "
+                "error_msg=NULL, interest_fingerprint=NULL, last_offset=0, "
+                "last_atom_id=NULL, tasks_extracted=0, has_meta=0, "
+                "has_embedding=0, indexed_at=NULL, updated_at=datetime('now') "
+                "WHERE id=?",
+                (TrajectoryStatus.DISCOVERED.value, row["id"]),
+            )
+            trajectory_stem = (
+                row["filename"][:-3]
+                if row["filename"].endswith(".md")
+                else row["filename"]
+            )
+            tasks_directory = Path(row["path"]) / trajectory_stem / "tasks"
+            if tasks_directory.is_dir():
+                for atom_file in tasks_directory.glob("atom_*.json"):
+                    atom_file.unlink()
+            directories_seen.add(row["path"])
+        conn.commit()
+        for directory_path in directories_seen:
+            index_path = Path(directory_path) / "index.pkl"
+            if index_path.is_file():
+                index_path.unlink()
+        return len(rows)
+    finally:
+        conn.close()
+
+
 def reset_trajectories(
     *,
     eco: Optional[str] = None,
@@ -933,7 +1046,8 @@ def reset_trajectories(
         dirs_seen: set[str] = set()
         for r in rows:
             conn.execute(
-                "UPDATE trajectories SET status='discovered', last_offset=0, "
+                "UPDATE trajectories SET status='discovered', process_action=NULL, "
+                "error_msg=NULL, interest_fingerprint=NULL, last_offset=0, "
                 "last_atom_id=NULL, tasks_extracted=0, "
                 "has_meta=0, has_embedding=0, indexed_at=NULL, "
                 "updated_at=datetime('now') WHERE id=?",

--- a/src/xskill/pipeline/runner.py
+++ b/src/xskill/pipeline/runner.py
@@ -30,12 +30,21 @@ import time
 from concurrent.futures import ThreadPoolExecutor, Future, as_completed
 from pathlib import Path
 
+from xskill.config import (
+    interests_config,
+    interests_fingerprint,
+    read_interests_config,
+)
 from xskill.pipeline.registry import (
+    ProcessAction,
+    TrajectoryStatus,
     list_watch_dirs,
     discover_trajectories,
     get_trajs_by_status,
     mark_indexed,
     mark_skill_used,
+    mark_not_fit,
+    reset_not_fit_for_interest_change,
     update_traj_status,
     increment_retry,
 )
@@ -125,6 +134,8 @@ class DirectoryWatcher:
         # 多个 atom 的位置，减少往返次数提速。聚类仍串行（同 wd 同时只一个 batch
         # future）。1 = 退回逐 atom 一次往返的旧行为。
         self.cluster_batch_size = max(1, int(cluster_batch_size))
+        self.interests = interests_config(self.config)
+        self.interest_fingerprint = interests_fingerprint(self.interests)
 
         # v2 注入：AtomTaskStore + agno agent 工厂
         # store None 时本 watcher 不能跑 splitting/clustering（仅 ux_score 还能跑）
@@ -194,6 +205,26 @@ class DirectoryWatcher:
     def _db_kw(self):
         return {"db_path": self.db_path} if self.db_path else {}
 
+    def _refresh_interests(self):
+        """Hot-reload top-level interests without rebuilding LLM/embed clients."""
+        current_interests = read_interests_config()
+        current_interest_fingerprint = interests_fingerprint(current_interests)
+        if current_interest_fingerprint == self.interest_fingerprint:
+            return
+        previous_interest_fingerprint = self.interest_fingerprint
+        self.interests = current_interests
+        self.interest_fingerprint = current_interest_fingerprint
+        reset_count = reset_not_fit_for_interest_change(
+            old_interest_fingerprint=previous_interest_fingerprint,
+            new_interest_fingerprint=current_interest_fingerprint,
+            **self._db_kw(),
+        )
+        logger.info(
+            "interests reloaded: %d active, %d stale not_fit trajectories reset",
+            len(current_interests),
+            reset_count,
+        )
+
     # ───────────────────────────────────────────────────────────
     # Main loop
     # ───────────────────────────────────────────────────────────
@@ -220,6 +251,7 @@ class DirectoryWatcher:
         self._last_poll = time.time()
         self._stats["polls"] += 1
         kw = self._db_kw()
+        self._refresh_interests()
 
         # ── Step 0: 收割已完成的 futures ──
         self._harvest()
@@ -877,7 +909,7 @@ class DirectoryWatcher:
         新增内容。
         """
         import time
-        from xskill.agents.task_agent import TaskAgent
+        from xskill.agents.task_agent import TaskAgent, TrajectoryNotFit
         md_path = dir_path / fname
         validation = validate_trajectory_source(md_path)
         if not validation.valid:
@@ -896,12 +928,34 @@ class DirectoryWatcher:
             n_lines = -1
         logger.info("⟳ split 开始 %s（%d 行）", fname, n_lines)
         t0 = time.monotonic()
-        atoms = TaskAgent(
-            agno_agent_factory=self._factory(),
-            store=store,
-            traj_root=dir_path,
-            skill_dir=self.skill_dir,
-        ).run(traj_id=traj_id, traj_path=md_path)
+        current_interests = list(self.interests)
+        current_interest_fingerprint = self.interest_fingerprint
+        try:
+            atoms = TaskAgent(
+                agno_agent_factory=self._factory(),
+                store=store,
+                traj_root=dir_path,
+                skill_dir=self.skill_dir,
+                interests=current_interests,
+            ).run(traj_id=traj_id, traj_path=md_path)
+        except TrajectoryNotFit as not_fit_error:
+            logger.info(
+                "⊘ split not_fit %s（interest_fingerprint=%s）: %s",
+                fname,
+                current_interest_fingerprint[:12],
+                not_fit_error.reason,
+            )
+            return (
+                fname,
+                0,
+                store.last_offset(traj_id),
+                store.last_atom_id(traj_id),
+                {
+                    "process_action": ProcessAction.NOT_FIT.value,
+                    "reason": not_fit_error.reason,
+                    "interest_fingerprint": current_interest_fingerprint,
+                },
+            )
         last_off = store.last_offset(traj_id)
         last_id = store.last_atom_id(traj_id)
         # 处理后：打一条"拆完"(带 atom 数 + 耗时),0 个也明确说明是"无可拆 User 回合"。
@@ -983,9 +1037,27 @@ class DirectoryWatcher:
         from xskill.pipeline.registry import update_traj_offset
         _fname, n_atoms, last_off, last_id, err = result
         if err is not None:
-            update_traj_status(wd_id, fname, "filtered", error_msg=err, **kw)
+            if (
+                isinstance(err, dict)
+                and err.get("process_action") == ProcessAction.NOT_FIT.value
+            ):
+                mark_not_fit(
+                    wd_id,
+                    fname,
+                    str(err.get("reason") or "not fit"),
+                    str(err.get("interest_fingerprint") or self.interest_fingerprint),
+                    **kw,
+                )
+                return
+            update_traj_status(
+                wd_id,
+                fname,
+                TrajectoryStatus.FILTERED.value,
+                error_msg=str(err),
+                **kw,
+            )
             return
-        update_traj_status(wd_id, fname, "split_done", **kw)
+        update_traj_status(wd_id, fname, TrajectoryStatus.SPLIT_DONE.value, **kw)
         update_traj_offset(
             wd_id, fname,
             last_offset=last_off, last_atom_id=last_id,

--- a/tests/test_config_autoinit.py
+++ b/tests/test_config_autoinit.py
@@ -10,7 +10,14 @@ from pathlib import Path
 import pytest
 import yaml
 
-from xskill.config import CONFIG_TEMPLATE, ensure_config_exists, get_traj_dir
+from xskill.config import (
+    CONFIG_TEMPLATE,
+    ensure_config_exists,
+    get_traj_dir,
+    interests_config,
+    interests_fingerprint,
+    read_interests_config,
+)
 
 
 def test_creates_template_when_missing(tmp_path):
@@ -55,8 +62,47 @@ def test_template_top_level_keys_are_exactly_live_set():
     parsed = yaml.safe_load(CONFIG_TEMPLATE)
     assert set(parsed.keys()) == {
         "skill_dir", "llm", "embedding", "canary", "watcher", "team", "dashboard",
-        "skill_opt", "ingest",  # ingest 段由 config.ingest_config 消费（settle 屏障/去壳掩码）
+        "skill_opt", "ingest", "interests",
+        # ingest 段由 config.ingest_config 消费（settle 屏障/去壳掩码）
     }, f"模板顶层键漂移：{sorted(parsed.keys())}"
+
+
+class TestInterestsConfig:
+    def test_missing_interests_disables_filter(self):
+        assert interests_config({}) == []
+
+    def test_empty_interests_disables_filter(self):
+        assert interests_config({"interests": []}) == []
+
+    def test_strips_blank_items_and_keeps_chinese(self):
+        assert interests_config({
+            "interests": [" infra ", "", "docker", " 中文 技能 "],
+        }) == ["infra", "docker", "中文 技能"]
+
+    def test_non_list_interests_raise(self):
+        with pytest.raises(ValueError, match="interests"):
+            interests_config({"interests": "infra"})
+
+    def test_non_string_interest_item_raise(self):
+        with pytest.raises(ValueError, match="interests"):
+            interests_config({"interests": ["infra", 123]})
+
+    def test_fingerprint_uses_normalized_order_sensitive_values(self):
+        first_fingerprint = interests_fingerprint([" infra ", "", "docker"])
+        second_fingerprint = interests_fingerprint(["infra", "docker"])
+        reversed_fingerprint = interests_fingerprint(["docker", "infra"])
+
+        assert first_fingerprint == second_fingerprint
+        assert first_fingerprint != reversed_fingerprint
+
+    def test_read_interests_config_reads_only_top_level_interests(self, tmp_path):
+        config_path = tmp_path / "config.yaml"
+        config_path.write_text(
+            "interests:\n  - 基础设施\n  - ' docker '\n",
+            encoding="utf-8",
+        )
+
+        assert read_interests_config(config_path) == ["基础设施", "docker"]
 
 
 def test_get_traj_dir_returns_first_registered_watch_dir(monkeypatch):

--- a/tests/test_rebuild.py
+++ b/tests/test_rebuild.py
@@ -11,12 +11,14 @@ import pytest
 
 from xskill.cli import cmd_rebuild
 from xskill.pipeline.registry import (
+    get_connection,
     register_dir,
     discover_trajectories,
     update_traj_status,
     update_traj_offset,
     get_trajs_by_status,
     reset_trajectories,
+    mark_not_fit,
 )
 from xskill.skill.repo import SkillRepo
 
@@ -104,6 +106,33 @@ def test_reset_deletes_stale_index_pkl(tmp_path, db_path):
     reset_trajectories(eco="ngagent", db_path=db_path)
 
     assert not idx.exists(), "reset 应删陈旧 index.pkl"
+
+
+def test_reset_requeues_not_fit_and_clears_interest_fields(tmp_path, db_path):
+    directory_path, watch_dir_id = _seed_done_traj(tmp_path, db_path)
+    mark_not_fit(
+        watch_dir_id,
+        "traj_ng_x.md",
+        "not infra",
+        "fingerprint-old",
+        db_path=db_path,
+    )
+
+    reset_count = reset_trajectories(eco="ngagent", db_path=db_path)
+
+    assert reset_count == 1
+    assert "traj_ng_x.md" in get_trajs_by_status(
+        watch_dir_id, "discovered", db_path=db_path)
+    conn = get_connection(db_path)
+    row = conn.execute(
+        "SELECT process_action, error_msg, interest_fingerprint "
+        "FROM trajectories WHERE filename='traj_ng_x.md'"
+    ).fetchone()
+    conn.close()
+    assert row["process_action"] is None
+    assert row["error_msg"] is None
+    assert row["interest_fingerprint"] is None
+    assert directory_path.is_dir()
 
 
 def test_wipe_all_skills_removes_skill_dirs_keeps_references(tmp_path):

--- a/tests/test_registry.py
+++ b/tests/test_registry.py
@@ -3,7 +3,6 @@
 from __future__ import annotations
 
 import os
-import pickle
 from pathlib import Path
 
 import pytest
@@ -25,6 +24,8 @@ from xskill.pipeline.registry import (
     find_traj_file,
     update_traj_status,
     get_trajs_by_status,
+    mark_not_fit,
+    reset_not_fit_for_interest_change,
 )
 
 
@@ -188,6 +189,33 @@ class TestContinuationDetection:
         assert "traj_0001.md" in get_trajs_by_status(wid, "splitting", db_path=db_path)
         assert get_trajs_by_status(wid, "updated", db_path=db_path) == []
 
+    def test_not_fit_filtered_mtime_change_stays_filtered(self, traj_dir, db_path):
+        wid = register_dir(traj_dir, db_path=db_path)
+        discover_trajectories(wid, traj_dir, db_path=db_path)
+        mark_not_fit(wid, "traj_0001.md", "not infra", "fingerprint-old",
+                     db_path=db_path)
+        trajectory_path = traj_dir / "traj_0001.md"
+        trajectory_path.write_text("# traj 1\n## User\nchanged\n", encoding="utf-8")
+        self._bump_mtime(trajectory_path)
+
+        discover_trajectories(wid, traj_dir, db_path=db_path)
+
+        assert "traj_0001.md" in get_trajs_by_status(wid, "filtered", db_path=db_path)
+        assert "traj_0001.md" not in get_trajs_by_status(wid, "updated", db_path=db_path)
+
+    def test_regular_filtered_mtime_change_flips_updated(self, traj_dir, db_path):
+        wid = register_dir(traj_dir, db_path=db_path)
+        discover_trajectories(wid, traj_dir, db_path=db_path)
+        update_traj_status(wid, "traj_0001.md", "filtered",
+                           error_msg="invalid source", db_path=db_path)
+        trajectory_path = traj_dir / "traj_0001.md"
+        trajectory_path.write_text("# traj 1\n## User\nchanged\n", encoding="utf-8")
+        self._bump_mtime(trajectory_path)
+
+        discover_trajectories(wid, traj_dir, db_path=db_path)
+
+        assert "traj_0001.md" in get_trajs_by_status(wid, "updated", db_path=db_path)
+
     def test_mark_meta_and_indexed(self, traj_dir, db_path):
         wid = register_dir(traj_dir, db_path=db_path)
         discover_trajectories(wid, traj_dir, db_path=db_path)
@@ -214,6 +242,62 @@ class TestContinuationDetection:
         conn.close()
         assert row["skill_used"] == "fix_django"
         assert row["canary_side"] == "staging"
+
+
+class TestInterestChangeReset:
+    def test_resets_only_stale_not_fit_rows(self, traj_dir, db_path):
+        wid = register_dir(traj_dir, db_path=db_path)
+        discover_trajectories(wid, traj_dir, db_path=db_path)
+        (traj_dir / "traj_0003.md").write_text("# traj 3\n", encoding="utf-8")
+        (traj_dir / "traj_0004.md").write_text("# traj 4\n", encoding="utf-8")
+        discover_trajectories(wid, traj_dir, db_path=db_path)
+        mark_not_fit(wid, "traj_0001.md", "not infra", "old", db_path=db_path)
+        mark_not_fit(wid, "traj_0002.md", "not infra", "new", db_path=db_path)
+        update_traj_status(wid, "traj_0003.md", "filtered",
+                           error_msg="ordinary", db_path=db_path)
+        update_traj_status(wid, "traj_0004.md", "done", db_path=db_path)
+
+        reset_count = reset_not_fit_for_interest_change(
+            old_interest_fingerprint="old",
+            new_interest_fingerprint="new",
+            db_path=db_path,
+        )
+
+        assert reset_count == 1
+        assert "traj_0001.md" in get_trajs_by_status(wid, "discovered", db_path=db_path)
+        assert "traj_0002.md" in get_trajs_by_status(wid, "filtered", db_path=db_path)
+        assert "traj_0003.md" in get_trajs_by_status(wid, "filtered", db_path=db_path)
+        assert "traj_0004.md" in get_trajs_by_status(wid, "done", db_path=db_path)
+
+        conn = get_connection(db_path)
+        row = conn.execute(
+            "SELECT process_action, interest_fingerprint, error_msg "
+            "FROM trajectories WHERE filename='traj_0001.md'"
+        ).fetchone()
+        conn.close()
+        assert row["process_action"] is None
+        assert row["interest_fingerprint"] is None
+        assert row["error_msg"] is None
+
+    def test_reset_deletes_stale_atoms_and_index(self, traj_dir, db_path):
+        wid = register_dir(traj_dir, db_path=db_path)
+        discover_trajectories(wid, traj_dir, db_path=db_path)
+        mark_not_fit(wid, "traj_0001.md", "not infra", "old", db_path=db_path)
+        tasks_directory = traj_dir / "traj_0001" / "tasks"
+        tasks_directory.mkdir(parents=True)
+        (tasks_directory / "atom_traj_0001_0001.json").write_text(
+            "{}", encoding="utf-8")
+        index_path = traj_dir / "index.pkl"
+        index_path.write_bytes(b"stale")
+
+        reset_not_fit_for_interest_change(
+            old_interest_fingerprint="old",
+            new_interest_fingerprint="new",
+            db_path=db_path,
+        )
+
+        assert not list(tasks_directory.glob("atom_*.json"))
+        assert not index_path.exists()
 
 
 # ---- Cross-dataset search support ----

--- a/tests/test_task_agent.py
+++ b/tests/test_task_agent.py
@@ -16,9 +16,9 @@ from pathlib import Path
 
 import pytest
 
-from xskill.pipeline.atom import AtomTask, AtomTaskStore
+from xskill.pipeline.atom import AtomTaskStore
 from xskill.agents.task_agent import (
-    TaskAgent, _extract_user_queries, _is_machine_noise_block,
+    TaskAgent, TrajectoryNotFit, _extract_user_queries, _is_machine_noise_block,
 )
 
 
@@ -74,7 +74,7 @@ class _AutoSplitAgno:
         self.instructions = instructions
         self.tools = {_tool_name(t): t for t in tools}
 
-    def run(self, user_msg, **kw):
+    def run(self, user_msg, **_keyword_arguments):
         autosplit_submit(user_msg, self.tools)
         return _RunResult()
 
@@ -93,7 +93,7 @@ def _scripted_factory(submit_calls, *, status=None):
         captured["tool_names"] = sorted(toolmap)
 
         class _A:
-            def run(self, user_msg, **kw):
+            def run(self, user_msg, **_keyword_arguments):
                 captured["user_msg"] = user_msg
                 for c in submit_calls:
                     captured["results"].append(
@@ -537,10 +537,11 @@ class TestLookTool:
         captured_look: dict = {}
 
         def factory(*, instructions, tools):
+            captured_look["instructions"] = instructions
             toolmap = {_tool_name(t): t for t in tools}
 
             class _A:
-                def run(self, user_msg, **kw):
+                def run(self, _user_msg, **_keyword_arguments):
                     # 用 look 读第 5 行（## User）附近,验证向前看包含 assistant
                     captured_look["out"] = _call_tool(
                         toolmap["look"], line=11, before=3, after=2)
@@ -570,10 +571,11 @@ class TestLookTool:
         captured_my: dict = {}
 
         def factory(*, instructions, tools):
+            captured_my["instructions"] = instructions
             toolmap = {_tool_name(t): t for t in tools}
 
             class _A:
-                def run(self, user_msg, **kw):
+                def run(self, _user_msg, **_keyword_arguments):
                     _call_tool(
                         toolmap["submit_atom"],
                         start_line=5,
@@ -653,6 +655,157 @@ class TestSystemPrompt:
         assert "{start_line}" in user_msg
 
 
+class TestInterestFilter:
+    def test_empty_interests_keep_existing_four_tools(self, tmp_path):
+        traj_dir = tmp_path / "cc-sessions"
+        traj_dir.mkdir()
+        traj_path = traj_dir / "traj_interest_empty.md"
+        traj_path.write_text(_TRAJ_MD, encoding="utf-8")
+        store = AtomTaskStore(root=traj_dir)
+        factory = _scripted_factory([
+            dict(start_line=5, intent="deploy", summary="done"),
+            dict(start_line=17, intent="frontend", summary="done"),
+        ])
+
+        TaskAgent(
+            agno_agent_factory=factory, store=store, interests=[],
+        ).run(traj_id="traj_interest_empty", traj_path=traj_path)
+
+        assert factory.captured["tool_names"] == [
+            "context_budget", "look", "my_atoms", "submit_atom",
+        ]
+
+    def test_non_empty_interests_add_tool_and_prompt(self, tmp_path):
+        traj_dir = tmp_path / "cc-sessions"
+        traj_dir.mkdir()
+        traj_path = traj_dir / "traj_interest_prompt.md"
+        traj_path.write_text(_TRAJ_MD, encoding="utf-8")
+        store = AtomTaskStore(root=traj_dir)
+        factory = _scripted_factory([
+            dict(start_line=5, intent="deploy", summary="done"),
+            dict(start_line=17, intent="frontend", summary="done"),
+        ])
+
+        TaskAgent(
+            agno_agent_factory=factory,
+            store=store,
+            interests=[" 基础设施 ", "docker"],
+        ).run(traj_id="traj_interest_prompt", traj_path=traj_path)
+
+        assert "mark_not_fit" in factory.captured["tool_names"]
+        system_prompt = factory.captured["instructions"][0]
+        assert "兴趣过滤" in system_prompt
+        assert "- 基础设施" in system_prompt
+        assert "- docker" in system_prompt
+
+    def test_mark_not_fit_raises_without_writing_atoms(self, tmp_path):
+        traj_dir = tmp_path / "cc-sessions"
+        traj_dir.mkdir()
+        traj_path = traj_dir / "traj_not_fit.md"
+        traj_path.write_text(_TRAJ_MD, encoding="utf-8")
+        store = AtomTaskStore(root=traj_dir)
+
+        def factory(*, instructions, tools):
+            assert instructions
+            toolmap = {_tool_name(tool): tool for tool in tools}
+
+            class _Agent:
+                def run(self, _user_msg, **_keyword_arguments):
+                    _call_tool(toolmap["mark_not_fit"], reason="not infra")
+                    return _RunResult()
+
+            return _Agent()
+
+        with pytest.raises(TrajectoryNotFit, match="not infra"):
+            TaskAgent(
+                agno_agent_factory=factory,
+                store=store,
+                interests=["infra"],
+            ).run(traj_id="traj_not_fit", traj_path=traj_path)
+
+        assert store.list_by_traj("traj_not_fit") == []
+        assert not (traj_dir / "traj_not_fit" / "tasks").exists()
+
+    def test_submit_atom_after_mark_not_fit_returns_error(self, tmp_path):
+        traj_dir = tmp_path / "cc-sessions"
+        traj_dir.mkdir()
+        traj_path = traj_dir / "traj_submit_after_not_fit.md"
+        traj_path.write_text(_TRAJ_MD, encoding="utf-8")
+        store = AtomTaskStore(root=traj_dir)
+        captured: dict = {"results": []}
+
+        def factory(*, instructions, tools):
+            assert instructions
+            toolmap = {_tool_name(tool): tool for tool in tools}
+
+            class _Agent:
+                def run(self, _user_msg, **_keyword_arguments):
+                    captured["results"].append(
+                        _call_tool(toolmap["mark_not_fit"], reason="not infra")
+                    )
+                    captured["results"].append(
+                        _call_tool(
+                            toolmap["submit_atom"],
+                            start_line=5,
+                            intent="deploy",
+                            summary="done",
+                        )
+                    )
+                    return _RunResult()
+
+            return _Agent()
+
+        with pytest.raises(TrajectoryNotFit):
+            TaskAgent(
+                agno_agent_factory=factory,
+                store=store,
+                interests=["infra"],
+            ).run(traj_id="traj_submit_after_not_fit", traj_path=traj_path)
+
+        assert captured["results"][0].startswith("ok:")
+        assert captured["results"][1].startswith("error:")
+        assert store.list_by_traj("traj_submit_after_not_fit") == []
+
+    def test_mark_not_fit_after_submit_atom_returns_error_and_keeps_atom(self, tmp_path):
+        traj_dir = tmp_path / "cc-sessions"
+        traj_dir.mkdir()
+        traj_path = traj_dir / "traj_mark_after_submit.md"
+        traj_path.write_text(_TRAJ_MD, encoding="utf-8")
+        store = AtomTaskStore(root=traj_dir)
+        captured: dict = {"results": []}
+
+        def factory(*, instructions, tools):
+            assert instructions
+            toolmap = {_tool_name(tool): tool for tool in tools}
+
+            class _Agent:
+                def run(self, _user_msg, **_keyword_arguments):
+                    captured["results"].append(
+                        _call_tool(
+                            toolmap["submit_atom"],
+                            start_line=5,
+                            intent="deploy",
+                            summary="done",
+                        )
+                    )
+                    captured["results"].append(
+                        _call_tool(toolmap["mark_not_fit"], reason="not infra")
+                    )
+                    return _RunResult()
+
+            return _Agent()
+
+        atoms = TaskAgent(
+            agno_agent_factory=factory,
+            store=store,
+            interests=["infra"],
+        ).run(traj_id="traj_mark_after_submit", traj_path=traj_path)
+
+        assert len(atoms) == 1
+        assert captured["results"][0].startswith("ok:")
+        assert captured["results"][1].startswith("error:")
+
+
 # ────────────────────────────────────────────────────────────────────
 # 上下文自管理（context_budget 模块）：剪裁 + 超长兜底 + max_context 解析
 # ────────────────────────────────────────────────────────────────────
@@ -689,7 +842,7 @@ class TestContextManager:
         ]
         sent = {}
 
-        def fake_invoke(msgs, **kw):
+        def fake_invoke(msgs, **_keyword_arguments):
             sent["look_content"] = msgs[1].content
             return {"usage": {"prompt_tokens": 123}}
 
@@ -714,7 +867,7 @@ class TestContextManager:
         ]
         calls = {"n": 0}
 
-        def flaky_invoke(msgs, **kw):
+        def flaky_invoke(_messages, **_keyword_arguments):
             calls["n"] += 1
             if calls["n"] == 1:
                 raise RuntimeError("maximum context length exceeded")
@@ -730,7 +883,7 @@ class TestContextManager:
         from xskill.agents.context_budget import ContextManager
         cm = ContextManager(max_context=100000)
 
-        def boom(msgs, **kw):
+        def boom(_messages, **_keyword_arguments):
             raise ValueError("totally unrelated failure")
 
         with pytest.raises(ValueError, match="unrelated"):
@@ -741,7 +894,7 @@ class TestContextManager:
             ContextManager, get_used_tokens)
         cm = ContextManager(max_context=100000)
 
-        def ok_invoke(msgs, **kw):
+        def ok_invoke(_messages, **_keyword_arguments):
             return {"usage": {"prompt_tokens": 777}}
 
         cm.wrap(ok_invoke)([])

--- a/tests/test_watcher_atom.py
+++ b/tests/test_watcher_atom.py
@@ -434,9 +434,7 @@ class TestUxScoreAtomLevel:
             home_root=tmp_path,
         )
         # mock score_atom 返回固定分数
-        with patch("xskill.pipeline.runner.score_atom",
-                   return_value={"score": 8, "reasons": "ok"}) if False else \
-             patch("xskill.pipeline.atom.score_atom",
+        with patch("xskill.pipeline.atom.score_atom",
                    return_value={"score": 8, "reasons": "ok"}) as mock_score:
             # 多轮推进到 done
             for _ in range(20):

--- a/tests/test_watcher_atom.py
+++ b/tests/test_watcher_atom.py
@@ -2,15 +2,13 @@
 from __future__ import annotations
 
 import time
-from pathlib import Path
-
-import pytest
 
 from xskill.pipeline.atom import AtomTaskStore
 from xskill.pipeline.registry import (
     register_dir, discover_trajectories, update_traj_status,
-    get_trajs_by_status, get_status_counts,
+    get_trajs_by_status, get_status_counts, get_connection, mark_not_fit,
 )
+from xskill.config import interests_fingerprint
 from xskill.pipeline.runner import DirectoryWatcher
 from tests.test_atom_task_store import _FakeEmbed
 from tests.test_task_agent import _TRAJ_MD, _AutoSplitLLM, autosplit_submit
@@ -37,7 +35,7 @@ class _StubAgno:
         self.instructions = instructions
         self.tools = {_tool_name(t): t for t in tools}
 
-    def run(self, user_msg, **kw):
+    def run(self, user_msg, **_keyword_arguments):
         head = (self.instructions[0] if self.instructions else "")[:80]
         if "AtomTask 拆分员" in head:
             autosplit_submit(user_msg, self.tools)
@@ -82,6 +80,19 @@ class _StubAgno:
                 )
         class _R: pass
         r = _R(); r.content = "stub"; return r
+
+
+class _NotFitAgno:
+    def __init__(self, *, instructions, tools):
+        self.instructions = instructions
+        self.tools = {_tool_name(tool): tool for tool in tools}
+
+    def run(self, _user_msg, **_keyword_arguments):
+        if "mark_not_fit" in self.tools:
+            _call_tool(self.tools["mark_not_fit"], "not infra")
+        class _RunResult:
+            content = "not fit"
+        return _RunResult()
 
 
 class TestNewStatusValuesAccepted:
@@ -191,7 +202,7 @@ class TestClusterSerial:
             def __init__(self, **kw):
                 pass
 
-            def run(self, msg, **kw):
+            def run(self, _message, **_keyword_arguments):
                 import time
                 time.sleep(5)  # 模拟 cluster 长时间运行，让 future 留在飞
                 class _R: pass
@@ -205,7 +216,7 @@ class TestClusterSerial:
         store = AtomTaskStore(root=wd)
         # 4 条 indexed 轨迹 × 2 atom，batch_size=2 → 即便有 8 个待消费 atom、
         # 4 个批次的量，同 wd 也只起 1 个 batch future（串行）。
-        wd_id = _seed_indexed_with_atoms(wd, store, db, n_trajs=4, atoms_per_traj=2)
+        _seed_indexed_with_atoms(wd, store, db, n_trajs=4, atoms_per_traj=2)
 
         watcher = DirectoryWatcher(
             llm=_AutoSplitLLM(),
@@ -251,7 +262,7 @@ class TestClusterAllFailed:
             def __init__(self, *, instructions, tools):
                 self.instructions = instructions
                 self.tools = {_tool_name(t): t for t in tools}
-            def run(self, msg, **kw):
+            def run(self, msg, **_keyword_arguments):
                 head = (self.instructions[0] or "")[:80]
                 if "AtomTask 拆分员" in head:
                     autosplit_submit(msg, self.tools)
@@ -324,7 +335,7 @@ class TestIndependentSkillEditScan:
             def __init__(self, *, instructions, tools):
                 self.instructions = instructions
                 self.tools = {_tool_name(t): t for t in tools}
-            def run(self, msg, **kw):
+            def run(self, msg, **_keyword_arguments):
                 head = (self.instructions[0] if self.instructions else "")[:80]
                 if "AtomTask 拆分员" in head:
                     autosplit_submit(msg, self.tools)
@@ -494,8 +505,7 @@ class TestContinuationResplit:
     """续写重拆验收：同名轨迹追加内容后重传 → 出现新 atom（行号 ≥ 续接点、
     不与旧 atom 重叠、旧 atom 不被重复生成）。"""
 
-    def _drive_to_done(self, watcher, db, fname, rounds=25):
-        from xskill.pipeline.registry import register_dir as _reg
+    def _drive_to_done(self, watcher, db, _filename, rounds=25):
         for _ in range(rounds):
             watcher._scan_once()
             for _ in range(30):
@@ -572,6 +582,103 @@ class TestContinuationResplit:
             assert kept[a.atom_id] == (a.offset_start, a.offset_end)
         # 链表衔接：新 atom 接在旧末 atom 之后
         assert na.pre_atom_id in first_ids
+
+
+class TestInterestFiltering:
+    def test_do_split_not_fit_marks_registry_row(self, tmp_path):
+        db_path = tmp_path / "test.db"
+        watch_directory = tmp_path / "wd"
+        watch_directory.mkdir()
+        skill_directory = tmp_path / "skill"
+        skill_directory.mkdir()
+        (watch_directory / "traj_interest.md").write_text(_TRAJ_MD, encoding="utf-8")
+        watch_dir_id = register_dir(watch_directory, auto_index=False,
+                                    db_path=db_path)
+        discover_trajectories(watch_dir_id, watch_directory, db_path=db_path)
+        configured_interests = ["infra"]
+        watcher = DirectoryWatcher(
+            llm=_AutoSplitLLM(),
+            embed_client=_FakeEmbed(),
+            config={
+                "interests": configured_interests,
+                "llm": {"base_url": "x", "model": "y", "api_key": "z"},
+            },
+            skill_dir=skill_directory,
+            poll_interval=0.0,
+            max_concurrent=1,
+            db_path=db_path,
+            store=AtomTaskStore(root=watch_directory),
+            agno_agent_factory=_NotFitAgno,
+            home_root=tmp_path,
+        )
+
+        result = watcher._do_split(watch_directory, "traj_interest.md")
+        watcher._on_split_done(watch_dir_id, "traj_interest.md", result,
+                               **watcher._db_kw())
+
+        conn = get_connection(db_path)
+        row = conn.execute(
+            "SELECT status, process_action, error_msg, interest_fingerprint "
+            "FROM trajectories WHERE filename='traj_interest.md'"
+        ).fetchone()
+        conn.close()
+        assert row["status"] == "filtered"
+        assert row["process_action"] == "not_fit"
+        assert row["error_msg"] == "not infra"
+        assert row["interest_fingerprint"] == interests_fingerprint(configured_interests)
+        assert not list((watch_directory / "traj_interest" / "tasks").glob("atom_*.json"))
+
+    def test_scan_once_interest_reload_resets_only_stale_not_fit(
+        self, tmp_path, monkeypatch,
+    ):
+        db_path = tmp_path / "test.db"
+        watch_directory = tmp_path / "wd"
+        watch_directory.mkdir()
+        skill_directory = tmp_path / "skill"
+        skill_directory.mkdir()
+        for trajectory_name in ("traj_old.md", "traj_current.md", "traj_done.md"):
+            (watch_directory / trajectory_name).write_text(
+                _TRAJ_MD, encoding="utf-8")
+        watch_dir_id = register_dir(watch_directory, auto_index=False,
+                                    db_path=db_path)
+        discover_trajectories(watch_dir_id, watch_directory, db_path=db_path)
+        old_fingerprint = interests_fingerprint(["old"])
+        new_fingerprint = interests_fingerprint(["new"])
+        mark_not_fit(watch_dir_id, "traj_old.md", "old", old_fingerprint,
+                     db_path=db_path)
+        mark_not_fit(watch_dir_id, "traj_current.md", "current", new_fingerprint,
+                     db_path=db_path)
+        update_traj_status(watch_dir_id, "traj_done.md", "done", db_path=db_path)
+        monkeypatch.setattr(
+            "xskill.pipeline.runner.read_interests_config",
+            lambda: ["new"],
+        )
+        watcher = DirectoryWatcher(
+            llm=_AutoSplitLLM(),
+            embed_client=_FakeEmbed(),
+            config={
+                "interests": ["old"],
+                "llm": {"base_url": "x", "model": "y", "api_key": "z"},
+            },
+            skill_dir=skill_directory,
+            poll_interval=0.0,
+            max_concurrent=1,
+            db_path=db_path,
+            store=AtomTaskStore(root=watch_directory),
+            agno_agent_factory=_StubAgno,
+            home_root=tmp_path,
+        )
+
+        watcher._scan_once()
+
+        assert watcher.interests == ["new"]
+        assert watcher.interest_fingerprint == new_fingerprint
+        assert "traj_old.md" in get_trajs_by_status(
+            watch_dir_id, "discovered", db_path=db_path)
+        assert "traj_current.md" in get_trajs_by_status(
+            watch_dir_id, "filtered", db_path=db_path)
+        assert "traj_done.md" in get_trajs_by_status(
+            watch_dir_id, "done", db_path=db_path)
 
 
 class TestPipelineRun:


### PR DESCRIPTION
## Summary
- add top-level `interests` config normalization, Chinese string support, and order-sensitive fingerprinting
- add TaskAgent interest filtering with conditional `mark_not_fit(reason)` and `TrajectoryNotFit`
- persist unrelated trajectories as `filtered` + `process_action=not_fit` with `interest_fingerprint`
- hot-reload interests in DirectoryWatcher and re-evaluate only stale not_fit trajectories
- pass interests through watcher and SSE/manual processing paths

## Verification
- PASS: `/usr/bin/python3.11 -m pytest tests/test_config_autoinit.py tests/test_task_agent.py tests/test_registry.py tests/test_rebuild.py tests/test_watcher_atom.py` (101 passed)
- PASS: `/usr/bin/python3.11 -m pytest tests/test_server_no_llm_fallback.py tests/test_server_watcher_startup.py tests/test_watcher.py tests/test_watcher_on_poll_hook.py` (12 passed, warnings only)
- PASS: `semgrep scan --config p/default --config p/python --config p/ai-best-practices` (exit 0; 48 existing findings)
- RAN: `ruff check . --select F401,F841,ARG,E722,BLE,S110` (exit 1; repo-wide existing findings, 390 reported)
- RAN: `vulture . --min-confidence 80` (exit 3; existing findings)
- KNOWN: full `/usr/bin/python3.11 -m pytest` still fails during collection with existing `xskill.__version__` import issue; `tests/test_cli_version.py -q` passes when run directly.
