### PR TITLE
fix(rebuild): clear derived state on force rebuild

### DIFF
--- a/src/xskill/cli.py
+++ b/src/xskill/cli.py
@@ -346,13 +346,14 @@ def cmd_rebuild(args, _xskill) -> int:
 
     默认：删除已拆 atom + index.pkl、轨迹状态翻回 discovered，让运行中的 watcher
     从头重拆重聚（删 atom 是真正触发重拆的动作——splitter 续接点取自 atom 文件，
-    不读 DB offset）。``--force``：额外先清空 skill 仓（删除重建）。
+    不读 DB offset）。``--force``：额外先清空 skill 仓、看板派生埋点和安装历史。
 
     换模型护栏：rebuild 的重跑是交给**正在运行的 daemon**，而 daemon 的模型是
     启动时缓存的（改 config 不重启不生效）。若 daemon 在跑且其模型 ≠ 当前 config
     模型 → 默认拒绝并提示先重启 serve，否则会静默用旧模型重生成（`--ignore-
     model-mismatch` 可强行用当前运行的模型重跑）。
     """
+    from xskill.config import XSKILL_HOME
     from xskill.pipeline.registry import reset_trajectories
     from xskill.runtime import config_models, read_status
 
@@ -378,14 +379,28 @@ def cmd_rebuild(args, _xskill) -> int:
 
     if args.force:
         from xskill.config import get_skill_dir
+        from xskill.pipeline.registry import clear_rebuild_derived_state
         from xskill.skill.repo import SkillRepo
         skill_count = SkillRepo(get_skill_dir()).wipe_all_skills()
         print(f"--force: 清空 skill 仓（删 {skill_count} 个 skill）")
+        deleted_counts = clear_rebuild_derived_state()
+        print(
+            "--force: 清空看板派生数据（"
+            f"recommendation_log={deleted_counts['recommendation_log']}, "
+            f"atom_adoption={deleted_counts['atom_adoption']}, "
+            f"canary_decision={deleted_counts['canary_decision']}, "
+            f"skill_trigger_eval={deleted_counts['skill_trigger_eval']}）"
+        )
+        install_history_path = XSKILL_HOME / "install_history.jsonl"
+        if install_history_path.is_file():
+            install_history_path.unlink()
+            print("--force: 删除安装历史 install_history.jsonl")
+        else:
+            print("--force: 安装历史为空")
 
     trajectory_count = reset_trajectories(eco=args.eco, traj_id=args.traj)
     print(f"rebuild: 重置 {trajectory_count} 条轨迹（已删 atom + index.pkl，将从头重拆）")
 
-    from xskill.config import XSKILL_HOME
     from xskill.pipeline.cold_start import ColdStartSignal
     cold_start_signal = ColdStartSignal(XSKILL_HOME)
     signal_path = cold_start_signal.create()

--- a/src/xskill/pipeline/registry.py
+++ b/src/xskill/pipeline/registry.py
@@ -326,6 +326,31 @@ def record_canary_decision(*, skill: str, action: str, main_avg: float,
         conn.close()
 
 
+def clear_rebuild_derived_state(
+    *, registry_path: Optional[Path] = None,
+) -> dict[str, int]:
+    """Clear global derived dashboard state for ``xskill rebuild --force``.
+
+    ``llm_usage`` is deliberately retained: it is cost accounting for already
+    paid calls, not skill state derived from the current repository contents.
+    """
+    connection = get_connection(registry_path)
+    deleted_counts: dict[str, int] = {}
+    try:
+        cursor = connection.execute("DELETE FROM recommendation_log")
+        deleted_counts["recommendation_log"] = cursor.rowcount
+        cursor = connection.execute("DELETE FROM atom_adoption")
+        deleted_counts["atom_adoption"] = cursor.rowcount
+        cursor = connection.execute("DELETE FROM canary_decision")
+        deleted_counts["canary_decision"] = cursor.rowcount
+        cursor = connection.execute("DELETE FROM skill_trigger_eval")
+        deleted_counts["skill_trigger_eval"] = cursor.rowcount
+        connection.commit()
+        return deleted_counts
+    finally:
+        connection.close()
+
+
 def usage_summary(db_path: Optional[Path] = None) -> dict:
     """跨重启的持久汇总:累计 token/$、今日 $、按 step / model 分解。"""
     conn = get_connection(db_path)
@@ -1019,7 +1044,8 @@ def reset_trajectories(
     同时删该目录的 ``index.pkl``（atom 的向量索引）——否则 atom 已删而索引仍留
     陈旧 embedding，cluster 阶段向量检索会命中已不存在的 atom。
 
-    DB ``status`` 翻回 ``discovered`` 让 watcher 下轮重新排 split。
+    DB ``status`` 翻回 ``discovered`` 让 watcher 下轮重新排 split；轨迹级
+    skill / canary / UX 派生字段一并清空，避免 rebuild 后看板继续挂旧 skill。
 
     Args:
         eco: 只重置该生态（``watch_dirs.ecosystem``）的轨迹；None=全部。
@@ -1030,43 +1056,48 @@ def reset_trajectories(
     """
     conn = get_connection(db_path)
     try:
-        sql = (
+        query_text = (
             "SELECT t.id, t.filename, w.path FROM trajectories t "
             "JOIN watch_dirs w ON t.watch_dir_id = w.id WHERE 1=1"
         )
-        params: list = []
+        query_parameters: list = []
         if eco:
-            sql += " AND w.ecosystem = ?"
-            params.append(eco)
+            query_text += " AND w.ecosystem = ?"
+            query_parameters.append(eco)
         if traj_id:
-            sql += " AND (t.filename = ? OR t.filename = ?)"
-            params += [traj_id, f"{traj_id}.md"]
-        rows = conn.execute(sql, params).fetchall()
+            query_text += " AND (t.filename = ? OR t.filename = ?)"
+            query_parameters += [traj_id, f"{traj_id}.md"]
+        trajectory_rows = conn.execute(query_text, query_parameters).fetchall()
 
-        dirs_seen: set[str] = set()
-        for r in rows:
+        directories_seen: set[str] = set()
+        for trajectory_row in trajectory_rows:
             conn.execute(
                 "UPDATE trajectories SET status='discovered', process_action=NULL, "
                 "error_msg=NULL, interest_fingerprint=NULL, last_offset=0, "
                 "last_atom_id=NULL, tasks_extracted=0, "
                 "has_meta=0, has_embedding=0, indexed_at=NULL, "
+                "skill_generated=NULL, skill_used=NULL, canary_side=NULL, "
+                "ux_score=NULL, "
                 "updated_at=datetime('now') WHERE id=?",
-                (r["id"],),
+                (trajectory_row["id"],),
             )
-            stem = (r["filename"][:-3] if r["filename"].endswith(".md")
-                    else r["filename"])
-            tasks_dir = Path(r["path"]) / stem / "tasks"
-            if tasks_dir.is_dir():
-                for af in tasks_dir.glob("atom_*.json"):
-                    af.unlink()
-            dirs_seen.add(r["path"])
+            trajectory_stem = (
+                trajectory_row["filename"][:-3]
+                if trajectory_row["filename"].endswith(".md")
+                else trajectory_row["filename"]
+            )
+            tasks_directory = Path(trajectory_row["path"]) / trajectory_stem / "tasks"
+            if tasks_directory.is_dir():
+                for atom_file in tasks_directory.glob("atom_*.json"):
+                    atom_file.unlink()
+            directories_seen.add(trajectory_row["path"])
         conn.commit()
         # 清各目录的陈旧向量索引（AtomTaskStore.INDEX_FILE = "index.pkl"）。
-        for d in dirs_seen:
-            idx = Path(d) / "index.pkl"
-            if idx.is_file():
-                idx.unlink()
-        return len(rows)
+        for directory_path in directories_seen:
+            index_path = Path(directory_path) / "index.pkl"
+            if index_path.is_file():
+                index_path.unlink()
+        return len(trajectory_rows)
     finally:
         conn.close()
 

--- a/tests/test_rebuild.py
+++ b/tests/test_rebuild.py
@@ -6,6 +6,7 @@ from __future__ import annotations
 
 import argparse
 import json
+from unittest.mock import Mock
 
 import pytest
 
@@ -19,6 +20,7 @@ from xskill.pipeline.registry import (
     get_trajs_by_status,
     reset_trajectories,
     mark_not_fit,
+    clear_rebuild_derived_state,
 )
 from xskill.skill.repo import SkillRepo
 
@@ -135,23 +137,134 @@ def test_reset_requeues_not_fit_and_clears_interest_fields(tmp_path, db_path):
     assert directory_path.is_dir()
 
 
+def test_reset_clears_skill_usage_canary_and_ux_fields(tmp_path, db_path):
+    _directory_path, watch_dir_id = _seed_done_traj(tmp_path, db_path)
+    connection = get_connection(db_path)
+    connection.execute(
+        "UPDATE trajectories SET skill_generated=?, skill_used=?, "
+        "canary_side=?, ux_score=? WHERE filename=?",
+        ("legacy-skill", "legacy-skill", "staging", 9.0, "traj_ng_x.md"),
+    )
+    connection.commit()
+    connection.close()
+
+    reset_trajectories(eco="ngagent", db_path=db_path)
+
+    connection = get_connection(db_path)
+    trajectory_row = connection.execute(
+        "SELECT skill_generated, skill_used, canary_side, ux_score "
+        "FROM trajectories WHERE filename='traj_ng_x.md'"
+    ).fetchone()
+    connection.close()
+    assert trajectory_row["skill_generated"] is None
+    assert trajectory_row["skill_used"] is None
+    assert trajectory_row["canary_side"] is None
+    assert trajectory_row["ux_score"] is None
+
+
+def test_clear_rebuild_derived_state_keeps_llm_usage(tmp_path):
+    registry_path = tmp_path / "registry.db"
+    connection = get_connection(registry_path)
+    connection.execute(
+        "INSERT INTO recommendation_log(client_id, skill, side, bucket) "
+        "VALUES('client-one', 'skill-one', 'main', 'recommended')"
+    )
+    connection.execute(
+        "INSERT INTO atom_adoption(atom_id, skill, weightscore, was_new) "
+        "VALUES('atom-one', 'skill-one', 5, 1)"
+    )
+    connection.execute(
+        "INSERT INTO canary_decision(skill, action, main_avg, staging_avg, "
+        "main_samples, staging_samples, age_days) "
+        "VALUES('skill-one', 'promoted', 8.0, 9.0, 6, 6, 1.0)"
+    )
+    connection.execute(
+        "INSERT INTO skill_trigger_eval(skill, exp_id, train_score, "
+        "test_score, n_cases, catalog_size) "
+        "VALUES('skill-one', 'experiment-one', 0.7, 0.6, 10, 4)"
+    )
+    connection.execute(
+        "INSERT INTO llm_usage(step, model, prompt, completion, total, cost_usd, "
+        "price_source) VALUES('split', 'model-one', 1, 2, 3, 0.01, 'config')"
+    )
+    connection.commit()
+    connection.close()
+
+    deleted_counts = clear_rebuild_derived_state(registry_path=registry_path)
+
+    assert deleted_counts == {
+        "recommendation_log": 1,
+        "atom_adoption": 1,
+        "canary_decision": 1,
+        "skill_trigger_eval": 1,
+    }
+    connection = get_connection(registry_path)
+    assert connection.execute(
+        "SELECT COUNT(*) FROM recommendation_log").fetchone()[0] == 0
+    assert connection.execute(
+        "SELECT COUNT(*) FROM atom_adoption").fetchone()[0] == 0
+    assert connection.execute(
+        "SELECT COUNT(*) FROM canary_decision").fetchone()[0] == 0
+    assert connection.execute(
+        "SELECT COUNT(*) FROM skill_trigger_eval").fetchone()[0] == 0
+    assert connection.execute("SELECT COUNT(*) FROM llm_usage").fetchone()[0] == 1
+    connection.close()
+
+
 def test_wipe_all_skills_removes_skill_dirs_keeps_references(tmp_path):
-    root = tmp_path / "skill"
-    root.mkdir()
-    foo = root / "foo"
-    foo.mkdir()
-    (foo / "SKILL.md").write_text("---\nname: foo\ndescription: d\n---\n", encoding="utf-8")
-    bar = root / "bar"
-    (bar / ".git").mkdir(parents=True)  # baby 态：只有 .git 还没 SKILL.md
-    refs = root / "references"
-    refs.mkdir()
-    (refs / "x.md").write_text("keep me", encoding="utf-8")
+    skill_root = tmp_path / "skill"
+    skill_root.mkdir()
+    first_skill_path = skill_root / "foo"
+    first_skill_path.mkdir()
+    (first_skill_path / "SKILL.md").write_text(
+        "---\nname: foo\ndescription: d\n---\n",
+        encoding="utf-8",
+    )
+    second_skill_path = skill_root / "bar"
+    (second_skill_path / ".git").mkdir(parents=True)  # baby 态：只有 .git 还没 SKILL.md
+    references_directory = skill_root / "references"
+    references_directory.mkdir()
+    (references_directory / "x.md").write_text("keep me", encoding="utf-8")
+    (skill_root / ".skill_index.pkl").write_bytes(b"stale-skill-index")
 
-    n = SkillRepo(root).wipe_all_skills()
+    removed_count = SkillRepo(skill_root).wipe_all_skills()
 
-    assert n == 2
-    assert not foo.exists() and not bar.exists()
-    assert refs.exists(), "references 不应被删"
+    assert removed_count == 2
+    assert not first_skill_path.exists() and not second_skill_path.exists()
+    assert references_directory.exists(), "references 不应被删"
+    assert not (skill_root / ".skill_index.pkl").exists()
+
+
+def test_rebuild_force_clears_derived_state_and_install_history(
+    monkeypatch, tmp_path,
+):
+    skill_root = tmp_path / "skill"
+    skill_root.mkdir()
+    install_history_path = tmp_path / "install_history.jsonl"
+    install_history_path.write_text("{}\n", encoding="utf-8")
+    cleanup_mock = Mock(
+        return_value={
+            "recommendation_log": 1,
+            "atom_adoption": 2,
+            "canary_decision": 3,
+            "skill_trigger_eval": 4,
+        }
+    )
+    reset_mock = Mock(return_value=0)
+    monkeypatch.setattr("xskill.config.XSKILL_HOME", tmp_path)
+    monkeypatch.setattr("xskill.config.get_skill_dir", Mock(return_value=skill_root))
+    monkeypatch.setattr("xskill.runtime.read_status", Mock(return_value={"running": False}))
+    monkeypatch.setattr(
+        "xskill.pipeline.registry.clear_rebuild_derived_state",
+        cleanup_mock,
+    )
+    monkeypatch.setattr("xskill.pipeline.registry.reset_trajectories", reset_mock)
+
+    assert cmd_rebuild(_rebuild_args(force=True), None) == 0
+
+    cleanup_mock.assert_called_once_with()
+    reset_mock.assert_called_once_with(eco=None, traj_id=None)
+    assert not install_history_path.exists()
 
 
 # ── 换模型护栏（0.6.1a2）──────────────────────────────────────────

--- a/tests/test_rebuild.py
+++ b/tests/test_rebuild.py
@@ -138,7 +138,7 @@ def test_reset_requeues_not_fit_and_clears_interest_fields(tmp_path, db_path):
 
 
 def test_reset_clears_skill_usage_canary_and_ux_fields(tmp_path, db_path):
-    _directory_path, watch_dir_id = _seed_done_traj(tmp_path, db_path)
+    _, watch_dir_id = _seed_done_traj(tmp_path, db_path)
     connection = get_connection(db_path)
     connection.execute(
         "UPDATE trajectories SET skill_generated=?, skill_used=?, "


### PR DESCRIPTION
## 背景

`xskill rebuild --force` 会清空 skill 仓并重跑轨迹，但看板派生表和安装历史仍保留旧 skill 数据，导致 force rebuild 后 dashboard 仍可能显示旧 skill（例如 recommendation/rates 里的历史 skill 名称）。

## 变更

- `--force` 额外清空全局派生看板表：
  - `recommendation_log`
  - `atom_adoption`
  - `canary_decision`
  - `skill_trigger_eval`
- `--force` 删除 `~/.xskill/install_history.jsonl`，避免旧安装 side/skill 归因继续参与后续判断。
- `reset_trajectories()` 除已有 atom/index/状态重置外，额外清空轨迹级派生字段：
  - `skill_generated`
  - `skill_used`
  - `canary_side`
  - `ux_score`
- 保留 `llm_usage`，因为它是已发生调用的成本账本，不是当前 skill 仓派生状态。
- 保留 raw trajectory、watch_dirs、config/interests、source model/harness 等可复用输入与身份信息。

## 验证

- `/usr/bin/python3.11 -m pytest tests/test_rebuild.py tests/test_dashboard_instrumentation.py tests/test_dashboard_metrics.py`：36 passed
- `semgrep scan --config p/default --config p/python --config p/ai-best-practices`：exit 0，48 个既有 findings
- `ruff check . --select F401,F841,ARG,E722,BLE,S110`：exit 1，390 个既有 findings；改动相关 `src/xskill/pipeline/registry.py tests/test_rebuild.py` 单独检查通过
- `vulture . --min-confidence 80`：exit 3，3 个既有 findings
- `git diff --check`：通过
