### PR TITLE
fix(watcher): ignore cluster futures during split cleanup

### DIFF
--- a/src/xskill/pipeline/runner.py
+++ b/src/xskill/pipeline/runner.py
@@ -769,8 +769,10 @@ class DirectoryWatcher:
         #  indexed，下一轮天然重新进池。遗留 clustering 在下方无条件回退 indexed。）
         for fname in get_trajs_by_status(wd_id, "splitting", **kw):
             if not any(
-                i["fname"] == fname and i["wd_id"] == wd_id and i["stage"] == "split"
-                for i in self._futures.values()
+                future_info.get("stage") == "split"
+                and future_info.get("wd_id") == wd_id
+                and future_info.get("fname") == fname
+                for future_info in self._futures.values()
             ):
                 update_traj_status(wd_id, fname, "discovered", **kw)
 

--- a/tests/test_watcher_atom.py
+++ b/tests/test_watcher_atom.py
@@ -1,6 +1,7 @@
 """watcher v2 流水线：discovered → splitting → split_done → indexed → clustering → done"""
 from __future__ import annotations
 
+from concurrent.futures import Future
 import time
 
 from xskill.pipeline.atom import AtomTaskStore
@@ -145,6 +146,45 @@ class TestZombieCleanup:
             get_trajs_by_status(wd_id, "discovered", db_path=db) == []
             or len(watcher._futures) > 0
         )
+
+    def test_splitting_zombie_ignores_cluster_future_without_filename(self, tmp_path):
+        database_path = tmp_path / "test.db"
+        watch_directory = tmp_path / "wd"
+        watch_directory.mkdir()
+        skill_directory = tmp_path / "skill"
+        skill_directory.mkdir()
+        (watch_directory / "traj_x.md").write_text(_TRAJ_MD, encoding="utf-8")
+
+        watch_dir_id = register_dir(watch_directory, db_path=database_path)
+        discover_trajectories(watch_dir_id, watch_directory, db_path=database_path)
+        update_traj_status(
+            watch_dir_id, "traj_x.md", "splitting", db_path=database_path,
+        )
+
+        watcher = DirectoryWatcher(
+            llm=None,
+            embed_client=None,
+            config={},
+            skill_dir=skill_directory,
+            poll_interval=0.0,
+            max_concurrent=2,
+            db_path=database_path,
+            home_root=tmp_path,
+        )
+        cluster_future = Future()
+        watcher._futures[cluster_future] = {
+            "wd_id": watch_dir_id,
+            "stage": "cluster",
+            "atom_ids": ["atom_traj_x_0001"],
+        }
+
+        watcher._scan_once()
+
+        assert "traj_x.md" in get_trajs_by_status(
+            watch_dir_id, "discovered", db_path=database_path,
+        )
+        assert watcher._futures[cluster_future]["stage"] == "cluster"
+        watcher._pool.shutdown(wait=False)
 
     def test_clustering_zombie_rolls_back_to_indexed(self, tmp_path):
         db = tmp_path / "test.db"


### PR DESCRIPTION
## Summary
- Fix splitting zombie cleanup so it only matches split futures and safely reads optional future metadata.
- Add a regression test for a pending cluster future without `fname`.

## Tests
- `/usr/bin/python3.11 -m pytest tests/test_watcher_atom.py tests/test_watcher.py tests/test_watcher_on_poll_hook.py`
- `git diff --check`
- `ruff check tests/test_watcher_atom.py --select F401,F841,ARG,E722,BLE,S110`
- `semgrep scan --config p/default --config p/python --config p/ai-best-practices` passes with existing findings reported
- `ruff check . --select F401,F841,ARG,E722,BLE,S110` reports existing repo findings
- `vulture . --min-confidence 80` reports existing repo findings