### PR TITLE
fix(team): 用 SQLite 缓存客户端上传状态

### DIFF
--- a/src/xskill/cli.py
+++ b/src/xskill/cli.py
@@ -120,35 +120,39 @@ def cmd_registry_list_client() -> int:
     """team 客户端模式的 ``registry list``。
 
     瘦客户端不写 ``watch_dirs`` / ``trajectories`` 表（那是 standalone/server
-    的存储），它靠实时 ``detect_known_ecosystems`` 采集 + ``team_client_cursor``
+    的存储），它靠实时 ``detect_known_ecosystems`` 采集 + client SQLite 状态
     记上传进度。所以这里**现算**视图：每个探测到的生态显示
 
         ECOSYSTEM  COLLECTED  UPLOADED  SOURCE
 
     - COLLECTED = 该生态 bridge 目录下 ``traj_*.json`` 数（已镜像采集的轨迹）
-    - UPLOADED  = 上述轨迹里已记入 cursor（已上传 server）的数
+    - UPLOADED  = 上述轨迹里已记入 client_state.db（已上传 server）的数
     - SOURCE    = 用户真实的原生目录（如 ~/.claude/projects），非内部 bridge
 
     不依赖 config.yaml / XSkill 门面——纯客户端机器也能直接看。
     """
-    import json
     from pathlib import Path
     from xskill.config import (
         XSKILL_HOME, get_team_client_state_path, get_team_client_cursor_path,
+        get_team_client_state_db_path,
     )
     from xskill.ecosystems import detect_known_ecosystems
     from xskill.team.client.state import load_client_state
+    from xskill.team.client.upload_state import TrajectoryUploadStateStore
 
     home = XSKILL_HOME.parent  # 与 XSKILL_HOME 同源,避免 home 解析漂移
-    # 游标按 server 分目录（方案 A）——先读连接状态拿 server_url 才能定位。
-    # 没连过 server（无 state）则没有任何上传游标，uploaded 全 0。
+    # 上传状态按 server 分目录（方案 A）——先读连接状态拿 server_url 才能定位。
+    # 没连过 server（无 state）则没有任何上传状态，uploaded 全 0。
     uploaded_ids: set[str] = set()
     state_path = get_team_client_state_path()
     if state_path.is_file():
-        cursor_path = get_team_client_cursor_path(
-            load_client_state(state_path).server_url)
-        if cursor_path.is_file():
-            uploaded_ids = set(json.loads(cursor_path.read_text(encoding="utf-8")))
+        state = load_client_state(state_path)
+        store = TrajectoryUploadStateStore(
+            db_path=get_team_client_state_db_path(state.server_url),
+            legacy_cursor_path=get_team_client_cursor_path(state.server_url),
+            home_root=home,
+        )
+        uploaded_ids = store.uploaded_trajectory_ids()
 
     dets = detect_known_ecosystems(home_root=home)
     if not dets:

--- a/src/xskill/config.py
+++ b/src/xskill/config.py
@@ -490,12 +490,17 @@ def get_team_client_dir(server_url: str) -> Path:
 
 
 def get_team_client_cursor_path(server_url: str) -> Path:
-    """client 端上传游标（traj_id -> 已上传内容 sha256），按 server 分目录。
+    """旧版 client 上传游标 JSON 路径，按 server 分目录。
 
-    去抖 sidecar 由 collector 从本路径派生（``cursor.debounce.json``），自动
-    同目录隔离。
+    新版运行时状态落 ``client_state.db``；本路径保留为旧
+    ``cursor.json`` / ``cursor.debounce.json`` 的一次性迁移来源。
     """
     return get_team_client_dir(server_url) / "cursor.json"
+
+
+def get_team_client_state_db_path(server_url: str) -> Path:
+    """client 端上传状态 SQLite，按 server 分目录。"""
+    return get_team_client_dir(server_url) / "client_state.db"
 
 
 def get_team_client_history_path(server_url: str) -> Path:

--- a/src/xskill/team/client/collector.py
+++ b/src/xskill/team/client/collector.py
@@ -7,8 +7,9 @@
    （即 ``detect_known_ecosystems`` 返回的 ``bridge`` 路径——不另造一份
    平行 outbox）。这些 ingester 是纯镜像——不做 canary/header 注入。
 2. pending() —— 扫 ``~/.xskill/*_sessions/``，吐出"静默 ≥quiet_seconds 且
-   未上传过/内容已变"的 traj，content 已过脱敏 hook。游标落 cursor.json：
-   traj_id -> sha256。
+   未上传过/内容已变"的 traj，content 已过脱敏 hook。上传状态落
+   ``client_state.db``，旧 ``cursor.json`` / ``cursor.debounce.json`` 只作为
+   一次性迁移来源。
 
 静默窗口 = 设计里约定的上传时机点（与 xskill 既有的"用户手改静默 3min
 才吸收"同源），也天然是脱敏 hook 的插入位。
@@ -23,6 +24,7 @@ from dataclasses import dataclass
 from pathlib import Path
 from typing import Callable
 
+from xskill.team.client.upload_state import TrajectoryUploadStateStore
 from xskill.team.client.redact import redact_text
 
 logger = logging.getLogger("xskill.team.client.collector")
@@ -79,6 +81,7 @@ class TeamCollector:
         home_root: Path | None = None,
         poll_interval: float = 10.0,
         time_fn: Callable[[], float] = time.time,
+        state_db_path: Path | None = None,
     ):
         self.cursor_path = Path(cursor_path)
         self.quiet_seconds = quiet_seconds
@@ -97,45 +100,20 @@ class TeamCollector:
         # 返回的 bridge 路径一致。
         self._bridge_root = self.home_root / ".xskill"
         self._ingesters: list = []
-        self._cursor: dict[str, str] = self._load_cursor()
-        # 去抖状态：traj_id -> {"sha": <当前未上传版本的 hash>, "since": <该 hash
-        # 首次出现的时间戳>}。落盘到 cursor 旁的 sidecar,重启后不丢去抖计时。
-        self._debounce_path = self.cursor_path.with_suffix(".debounce.json")
-        self._change_state: dict[str, dict] = self._load_change_state()
-
-    # ── 游标 ─────────────────────────────────────────────────────
-    def _load_cursor(self) -> dict[str, str]:
-        if not self.cursor_path.is_file():
-            return {}
-        try:
-            return json.loads(self.cursor_path.read_text(encoding="utf-8"))
-        except (json.JSONDecodeError, OSError):
-            return {}
-
-    def _save_cursor(self) -> None:
-        self.cursor_path.parent.mkdir(parents=True, exist_ok=True)
-        self.cursor_path.write_text(json.dumps(self._cursor), encoding="utf-8")
+        self.state_db_path = (
+            Path(state_db_path) if state_db_path
+            else self.cursor_path.with_name("client_state.db")
+        )
+        self._state_store = TrajectoryUploadStateStore(
+            db_path=self.state_db_path,
+            legacy_cursor_path=self.cursor_path,
+            home_root=self.home_root,
+            time_fn=self._now,
+        )
 
     def mark_uploaded(self, traj_id: str, sha256: str) -> None:
         """记录某 traj 的某版本已上传。同时清掉它的去抖状态（该版本已落地）。"""
-        self._cursor[traj_id] = sha256
-        self._save_cursor()
-        if self._change_state.pop(traj_id, None) is not None:
-            self._save_change_state()
-
-    # ── hash-变更去抖状态 ────────────────────────────────────────
-    def _load_change_state(self) -> dict[str, dict]:
-        if not self._debounce_path.is_file():
-            return {}
-        try:
-            return json.loads(self._debounce_path.read_text(encoding="utf-8"))
-        except (json.JSONDecodeError, OSError):
-            return {}
-
-    def _save_change_state(self) -> None:
-        self._debounce_path.parent.mkdir(parents=True, exist_ok=True)
-        self._debounce_path.write_text(
-            json.dumps(self._change_state), encoding="utf-8")
+        self._state_store.mark_uploaded(traj_id, sha256)
 
     # ── ingester 生命周期 ────────────────────────────────────────
     def start_ingesters(self) -> None:
@@ -202,39 +180,120 @@ class TeamCollector:
         now = self._now()
         out: list[PendingTrajectory] = []
         seen_ids: set[str] = set()
-        changed = False
         for md in sorted(self._bridge_root.glob("*_sessions/traj_*.md")):
             if not md.is_file():
                 continue
             traj_id = md.stem
             seen_ids.add(traj_id)
-            # 闸 1：mtime 静默窗口
-            if (now - md.stat().st_mtime) < self.quiet_seconds:
+            try:
+                stat = md.stat()
+            except OSError:
                 continue
-            raw = md.read_text(encoding="utf-8")
-            content = redact_text(raw)
-            sha = hashlib.sha256(content.encode("utf-8")).hexdigest()
-            if self._cursor.get(traj_id) == sha:
-                # 这个版本已上传过——清掉残留去抖状态
-                if self._change_state.pop(traj_id, None) is not None:
-                    changed = True
+            # 闸 1：mtime 静默窗口
+            if (now - stat.st_mtime) < self.quiet_seconds:
+                continue
+            model_name = _sidecar_model(md)
+            harness_name = _harness_for(md)
+            state = self._state_store.get(traj_id)
+            metadata_same = (
+                state is not None
+                and state["file_size_bytes"] == stat.st_size
+                and state["file_modified_time_nanoseconds"] == stat.st_mtime_ns
+                and state["file_changed_time_nanoseconds"] == stat.st_ctime_ns
+            )
+            if metadata_same:
+                sha = state["cleaned_content_hash"]
+                if sha and state["uploaded_cleaned_content_hash"] == sha:
+                    if state["waiting_content_hash"] is not None:
+                        self._state_store.clear_waiting(traj_id)
+                    continue
+                if not sha:
+                    raw = md.read_text(encoding="utf-8")
+                    raw_sha = hashlib.sha256(raw.encode("utf-8")).hexdigest()
+                    content = redact_text(raw)
+                    sha = hashlib.sha256(content.encode("utf-8")).hexdigest()
+                    self._state_store.record_seen_file(
+                        trajectory_id=traj_id,
+                        file_path=str(md),
+                        harness_name=harness_name,
+                        model_name=model_name,
+                        file_size_bytes=stat.st_size,
+                        file_modified_time_nanoseconds=stat.st_mtime_ns,
+                        file_changed_time_nanoseconds=stat.st_ctime_ns,
+                        original_content_hash=raw_sha,
+                        cleaned_content_hash=sha,
+                    )
+                else:
+                    content = None
+            else:
+                raw = md.read_text(encoding="utf-8")
+                raw_sha = hashlib.sha256(raw.encode("utf-8")).hexdigest()
+                if state is not None and state["original_content_hash"] == raw_sha:
+                    sha = state["cleaned_content_hash"]
+                    content = None
+                    self._state_store.record_seen_file(
+                        trajectory_id=traj_id,
+                        file_path=str(md),
+                        harness_name=harness_name,
+                        model_name=model_name,
+                        file_size_bytes=stat.st_size,
+                        file_modified_time_nanoseconds=stat.st_mtime_ns,
+                        file_changed_time_nanoseconds=stat.st_ctime_ns,
+                        original_content_hash=raw_sha,
+                    )
+                    refreshed = self._state_store.get(traj_id)
+                    if (
+                        sha
+                        and refreshed is not None
+                        and refreshed["uploaded_cleaned_content_hash"] == sha
+                    ):
+                        if refreshed["waiting_content_hash"] is not None:
+                            self._state_store.clear_waiting(traj_id)
+                        continue
+                else:
+                    content = redact_text(raw)
+                    sha = hashlib.sha256(content.encode("utf-8")).hexdigest()
+                    self._state_store.record_seen_file(
+                        trajectory_id=traj_id,
+                        file_path=str(md),
+                        harness_name=harness_name,
+                        model_name=model_name,
+                        file_size_bytes=stat.st_size,
+                        file_modified_time_nanoseconds=stat.st_mtime_ns,
+                        file_changed_time_nanoseconds=stat.st_ctime_ns,
+                        original_content_hash=raw_sha,
+                        cleaned_content_hash=sha,
+                    )
+                    refreshed = self._state_store.get(traj_id)
+                    if (
+                        refreshed is not None
+                        and refreshed["uploaded_cleaned_content_hash"] == sha
+                    ):
+                        if refreshed["waiting_content_hash"] is not None:
+                            self._state_store.clear_waiting(traj_id)
+                        continue
+            if not sha:
                 continue
             # 闸 2：hash-变更去抖。内容（hash）每变一次就把 since 重置成此刻,
             # 必须自上次变更起稳定满 min_change_interval 秒才放行。
-            st = self._change_state.get(traj_id)
-            if st is None or st.get("sha") != sha:
-                st = {"sha": sha, "since": now}
-                self._change_state[traj_id] = st
-                changed = True
-            if (now - st["since"]) < self.min_change_interval:
+            state = self._state_store.get(traj_id)
+            if state is None or state["waiting_content_hash"] != sha:
+                self._state_store.set_waiting(
+                    trajectory_id=traj_id,
+                    waiting_content_hash=sha,
+                    waiting_started_at_seconds=now,
+                )
+                waiting_started_at = now
+            else:
+                waiting_started_at = float(state["waiting_started_at_seconds"] or now)
+            if (now - waiting_started_at) < self.min_change_interval:
                 continue  # 还没稳定满窗口,继续拦（min_change_interval<=0 时恒放行）
+            if content is None:
+                raw = md.read_text(encoding="utf-8")
+                content = redact_text(raw)
             out.append(PendingTrajectory(traj_id=traj_id, content=content,
-                                         sha256=sha, model=_sidecar_model(md),
-                                         harness=_harness_for(md)))
+                                         sha256=sha, model=model_name,
+                                         harness=harness_name))
         # 清理已消失的 traj 的去抖状态,避免无限增长
-        for gone in [k for k in self._change_state if k not in seen_ids]:
-            del self._change_state[gone]
-            changed = True
-        if changed:
-            self._save_change_state()
+        self._state_store.clear_waiting_for_missing(seen_ids)
         return out

--- a/src/xskill/team/client/upload_state.py
+++ b/src/xskill/team/client/upload_state.py
@@ -1,0 +1,373 @@
+"""SQLite state for team client trajectory uploads."""
+from __future__ import annotations
+
+import json
+import sqlite3
+import time
+from pathlib import Path
+from typing import Iterable
+
+
+class TrajectoryUploadStateStore:
+    """Persist per-trajectory upload state for one team server."""
+
+    def __init__(
+        self,
+        *,
+        db_path: Path,
+        legacy_cursor_path: Path | None = None,
+        home_root: Path | None = None,
+        time_fn=time.time,
+    ):
+        self.db_path = Path(db_path)
+        self.legacy_cursor_path = Path(legacy_cursor_path) if legacy_cursor_path else None
+        self.home_root = Path(home_root) if home_root else Path.home()
+        self._now = time_fn
+        self.db_path.parent.mkdir(parents=True, exist_ok=True)
+        self._conn = sqlite3.connect(str(self.db_path))
+        self._conn.row_factory = sqlite3.Row
+        self._init_schema()
+        self._migrate_legacy_json_once()
+
+    def _init_schema(self) -> None:
+        self._conn.executescript(
+            """
+            CREATE TABLE IF NOT EXISTS trajectory_upload_state (
+              trajectory_id TEXT PRIMARY KEY,
+              file_path TEXT NOT NULL,
+              harness_name TEXT DEFAULT '',
+              model_name TEXT DEFAULT '',
+
+              file_size_bytes INTEGER,
+              file_modified_time_nanoseconds INTEGER,
+              file_changed_time_nanoseconds INTEGER,
+
+              original_content_hash TEXT,
+              cleaned_content_hash TEXT,
+
+              uploaded_cleaned_content_hash TEXT,
+              uploaded_at_seconds REAL,
+
+              waiting_content_hash TEXT,
+              waiting_started_at_seconds REAL,
+
+              first_seen_at_seconds REAL NOT NULL,
+              last_seen_at_seconds REAL NOT NULL,
+              updated_at_seconds REAL NOT NULL
+            );
+
+            CREATE TABLE IF NOT EXISTS client_state_metadata (
+              key TEXT PRIMARY KEY,
+              value TEXT NOT NULL
+            );
+            """
+        )
+        self._conn.commit()
+
+    def _migrate_legacy_json_once(self) -> None:
+        if self._metadata_get("legacy_json_migrated_at") is not None:
+            return
+        now = self._now()
+        path_by_id = self._known_trajectory_paths()
+        if self.legacy_cursor_path and self.legacy_cursor_path.is_file():
+            for trajectory_id, uploaded_hash in self._read_json_dict(
+                self.legacy_cursor_path
+            ).items():
+                if isinstance(uploaded_hash, str) and uploaded_hash:
+                    self._upsert_legacy_uploaded(
+                        trajectory_id=trajectory_id,
+                        uploaded_cleaned_content_hash=uploaded_hash,
+                        file_path=str(path_by_id.get(trajectory_id, "")),
+                        now=now,
+                    )
+
+        legacy_debounce_path = (
+            self.legacy_cursor_path.with_suffix(".debounce.json")
+            if self.legacy_cursor_path else None
+        )
+        if legacy_debounce_path and legacy_debounce_path.is_file():
+            for trajectory_id, state in self._read_json_dict(
+                legacy_debounce_path
+            ).items():
+                if not isinstance(state, dict):
+                    continue
+                waiting_hash = state.get("sha")
+                waiting_since = state.get("since")
+                if isinstance(waiting_hash, str) and waiting_hash:
+                    try:
+                        waiting_since = float(waiting_since)
+                    except (TypeError, ValueError):
+                        waiting_since = now
+                    self._upsert_legacy_waiting(
+                        trajectory_id=trajectory_id,
+                        waiting_content_hash=waiting_hash,
+                        waiting_started_at_seconds=waiting_since,
+                        file_path=str(path_by_id.get(trajectory_id, "")),
+                        now=now,
+                    )
+        self._metadata_set("legacy_json_migrated_at", str(now))
+        self._conn.commit()
+
+    def _known_trajectory_paths(self) -> dict[str, Path]:
+        bridge_root = self.home_root / ".xskill"
+        if not bridge_root.is_dir():
+            return {}
+        return {
+            path.stem: path
+            for path in bridge_root.glob("*_sessions/traj_*.md")
+            if path.is_file()
+        }
+
+    @staticmethod
+    def _read_json_dict(path: Path) -> dict:
+        try:
+            data = json.loads(path.read_text(encoding="utf-8"))
+        except (OSError, json.JSONDecodeError):
+            return {}
+        return data if isinstance(data, dict) else {}
+
+    def _metadata_get(self, key: str) -> str | None:
+        row = self._conn.execute(
+            "SELECT value FROM client_state_metadata WHERE key = ?", (key,)
+        ).fetchone()
+        return None if row is None else str(row["value"])
+
+    def _metadata_set(self, key: str, value: str) -> None:
+        self._conn.execute(
+            """
+            INSERT INTO client_state_metadata (key, value) VALUES (?, ?)
+            ON CONFLICT(key) DO UPDATE SET value = excluded.value
+            """,
+            (key, value),
+        )
+
+    def _upsert_legacy_uploaded(
+        self,
+        *,
+        trajectory_id: str,
+        uploaded_cleaned_content_hash: str,
+        file_path: str,
+        now: float,
+    ) -> None:
+        self._conn.execute(
+            """
+            INSERT INTO trajectory_upload_state (
+              trajectory_id, file_path, uploaded_cleaned_content_hash,
+              first_seen_at_seconds, last_seen_at_seconds, updated_at_seconds
+            ) VALUES (?, ?, ?, ?, ?, ?)
+            ON CONFLICT(trajectory_id) DO UPDATE SET
+              file_path = CASE
+                WHEN trajectory_upload_state.file_path = '' THEN excluded.file_path
+                ELSE trajectory_upload_state.file_path
+              END,
+              uploaded_cleaned_content_hash = COALESCE(
+                trajectory_upload_state.uploaded_cleaned_content_hash,
+                excluded.uploaded_cleaned_content_hash
+              ),
+              last_seen_at_seconds = excluded.last_seen_at_seconds,
+              updated_at_seconds = excluded.updated_at_seconds
+            """,
+            (trajectory_id, file_path, uploaded_cleaned_content_hash, now, now, now),
+        )
+
+    def _upsert_legacy_waiting(
+        self,
+        *,
+        trajectory_id: str,
+        waiting_content_hash: str,
+        waiting_started_at_seconds: float,
+        file_path: str,
+        now: float,
+    ) -> None:
+        self._conn.execute(
+            """
+            INSERT INTO trajectory_upload_state (
+              trajectory_id, file_path, waiting_content_hash,
+              waiting_started_at_seconds, first_seen_at_seconds,
+              last_seen_at_seconds, updated_at_seconds
+            ) VALUES (?, ?, ?, ?, ?, ?, ?)
+            ON CONFLICT(trajectory_id) DO UPDATE SET
+              file_path = CASE
+                WHEN trajectory_upload_state.file_path = '' THEN excluded.file_path
+                ELSE trajectory_upload_state.file_path
+              END,
+              waiting_content_hash = COALESCE(
+                trajectory_upload_state.waiting_content_hash,
+                excluded.waiting_content_hash
+              ),
+              waiting_started_at_seconds = COALESCE(
+                trajectory_upload_state.waiting_started_at_seconds,
+                excluded.waiting_started_at_seconds
+              ),
+              last_seen_at_seconds = excluded.last_seen_at_seconds,
+              updated_at_seconds = excluded.updated_at_seconds
+            """,
+            (
+                trajectory_id,
+                file_path,
+                waiting_content_hash,
+                waiting_started_at_seconds,
+                now,
+                now,
+                now,
+            ),
+        )
+
+    def get(self, trajectory_id: str) -> sqlite3.Row | None:
+        return self._conn.execute(
+            """
+            SELECT * FROM trajectory_upload_state
+            WHERE trajectory_id = ?
+            """,
+            (trajectory_id,),
+        ).fetchone()
+
+    def record_seen_file(
+        self,
+        *,
+        trajectory_id: str,
+        file_path: str,
+        harness_name: str,
+        model_name: str,
+        file_size_bytes: int,
+        file_modified_time_nanoseconds: int,
+        file_changed_time_nanoseconds: int,
+        original_content_hash: str | None = None,
+        cleaned_content_hash: str | None = None,
+    ) -> None:
+        now = self._now()
+        self._conn.execute(
+            """
+            INSERT INTO trajectory_upload_state (
+              trajectory_id, file_path, harness_name, model_name,
+              file_size_bytes, file_modified_time_nanoseconds,
+              file_changed_time_nanoseconds, original_content_hash,
+              cleaned_content_hash, first_seen_at_seconds,
+              last_seen_at_seconds, updated_at_seconds
+            ) VALUES (?, ?, ?, ?, ?, ?, ?, ?, ?, ?, ?, ?)
+            ON CONFLICT(trajectory_id) DO UPDATE SET
+              file_path = excluded.file_path,
+              harness_name = excluded.harness_name,
+              model_name = excluded.model_name,
+              file_size_bytes = excluded.file_size_bytes,
+              file_modified_time_nanoseconds =
+                excluded.file_modified_time_nanoseconds,
+              file_changed_time_nanoseconds =
+                excluded.file_changed_time_nanoseconds,
+              original_content_hash = COALESCE(
+                excluded.original_content_hash,
+                trajectory_upload_state.original_content_hash
+              ),
+              cleaned_content_hash = COALESCE(
+                excluded.cleaned_content_hash,
+                trajectory_upload_state.cleaned_content_hash
+              ),
+              last_seen_at_seconds = excluded.last_seen_at_seconds,
+              updated_at_seconds = excluded.updated_at_seconds
+            """,
+            (
+                trajectory_id,
+                file_path,
+                harness_name,
+                model_name,
+                file_size_bytes,
+                file_modified_time_nanoseconds,
+                file_changed_time_nanoseconds,
+                original_content_hash,
+                cleaned_content_hash,
+                now,
+                now,
+                now,
+            ),
+        )
+        self._conn.commit()
+
+    def set_waiting(
+        self,
+        *,
+        trajectory_id: str,
+        waiting_content_hash: str,
+        waiting_started_at_seconds: float,
+    ) -> None:
+        now = self._now()
+        self._conn.execute(
+            """
+            UPDATE trajectory_upload_state
+            SET waiting_content_hash = ?,
+                waiting_started_at_seconds = ?,
+                updated_at_seconds = ?
+            WHERE trajectory_id = ?
+            """,
+            (waiting_content_hash, waiting_started_at_seconds, now, trajectory_id),
+        )
+        self._conn.commit()
+
+    def clear_waiting(self, trajectory_id: str) -> None:
+        now = self._now()
+        self._conn.execute(
+            """
+            UPDATE trajectory_upload_state
+            SET waiting_content_hash = NULL,
+                waiting_started_at_seconds = NULL,
+                updated_at_seconds = ?
+            WHERE trajectory_id = ?
+            """,
+            (now, trajectory_id),
+        )
+        self._conn.commit()
+
+    def clear_waiting_for_missing(self, seen_trajectory_ids: Iterable[str]) -> None:
+        seen = set(seen_trajectory_ids)
+        if not seen:
+            self._conn.execute(
+                """
+                UPDATE trajectory_upload_state
+                SET waiting_content_hash = NULL,
+                    waiting_started_at_seconds = NULL,
+                    updated_at_seconds = ?
+                WHERE waiting_content_hash IS NOT NULL
+                """,
+                (self._now(),),
+            )
+            self._conn.commit()
+            return
+        rows = self._conn.execute(
+            """
+            SELECT trajectory_id FROM trajectory_upload_state
+            WHERE waiting_content_hash IS NOT NULL
+            """
+        ).fetchall()
+        for row in rows:
+            if row["trajectory_id"] not in seen:
+                self.clear_waiting(str(row["trajectory_id"]))
+
+    def mark_uploaded(self, trajectory_id: str, cleaned_content_hash: str) -> None:
+        now = self._now()
+        self._conn.execute(
+            """
+            INSERT INTO trajectory_upload_state (
+              trajectory_id, file_path, uploaded_cleaned_content_hash,
+              uploaded_at_seconds, first_seen_at_seconds,
+              last_seen_at_seconds, updated_at_seconds
+            ) VALUES (?, '', ?, ?, ?, ?, ?)
+            ON CONFLICT(trajectory_id) DO UPDATE SET
+              uploaded_cleaned_content_hash =
+                excluded.uploaded_cleaned_content_hash,
+              uploaded_at_seconds = excluded.uploaded_at_seconds,
+              waiting_content_hash = NULL,
+              waiting_started_at_seconds = NULL,
+              last_seen_at_seconds = excluded.last_seen_at_seconds,
+              updated_at_seconds = excluded.updated_at_seconds
+            """,
+            (trajectory_id, cleaned_content_hash, now, now, now, now),
+        )
+        self._conn.commit()
+
+    def uploaded_trajectory_ids(self) -> set[str]:
+        rows = self._conn.execute(
+            """
+            SELECT trajectory_id FROM trajectory_upload_state
+            WHERE uploaded_cleaned_content_hash IS NOT NULL
+            """
+        ).fetchall()
+        return {str(row["trajectory_id"]) for row in rows}

--- a/tests/test_skill_edit_agent.py
+++ b/tests/test_skill_edit_agent.py
@@ -521,7 +521,7 @@ def _seed_candidates(skill_dir, total_ws):
 def test_jam_merge_fires_above_threshold_and_discards_staging(tmp_path):
     sd = _make_main_skill(tmp_path / "skill", "jam-skill")
     # 写点东西并开 staging（灰度中）
-    (sd / "SKILL.md").write_text((sd / "SKILL.md").read_text() + "\n<!-- staging draft -->\n", encoding="utf-8")
+    (sd / "SKILL.md").write_text((sd / "SKILL.md").read_text(encoding="utf-8") + "\n<!-- staging draft -->\n", encoding="utf-8")
     assert commit_to_staging_branch(str(sd), "stub staging candidate") is True
     assert (sd.parent / ".canary" / "jam-skill" / "SKILL.md").is_file()
     # 候选攒到 60 ≥ jam_threshold(50)
@@ -550,7 +550,7 @@ def test_jam_merge_fires_above_threshold_and_discards_staging(tmp_path):
 
 def test_no_jam_below_threshold_keeps_staging(tmp_path):
     sd = _make_main_skill(tmp_path / "skill", "calm-skill")
-    (sd / "SKILL.md").write_text((sd / "SKILL.md").read_text() + "\n<!-- s -->\n", encoding="utf-8")
+    (sd / "SKILL.md").write_text((sd / "SKILL.md").read_text(encoding="utf-8") + "\n<!-- s -->\n", encoding="utf-8")
     assert commit_to_staging_branch(str(sd), "stub staging") is True
     _seed_candidates(sd, 40)  # < 50
     _JamMergeStubAgno.invoked = False
@@ -567,7 +567,7 @@ def test_no_jam_below_threshold_keeps_staging(tmp_path):
 def test_jam_merge_without_main_commit_keeps_candidates_and_staging(tmp_path):
     sd = _make_main_skill(tmp_path / "skill", "jam-no-commit")
     (sd / "SKILL.md").write_text(
-        (sd / "SKILL.md").read_text() + "\n<!-- staging draft -->\n",
+        (sd / "SKILL.md").read_text(encoding="utf-8") + "\n<!-- staging draft -->\n",
         encoding="utf-8",
     )
     assert commit_to_staging_branch(str(sd), "stub staging") is True
@@ -630,7 +630,7 @@ def test_jam_merge_rematerializes_missing_staging_body(tmp_path):
 
     sd = _make_main_skill(tmp_path / "skill", "rematerialize-skill")
     # 写 staging 分支（包含可识别内容）
-    staging_content = (sd / "SKILL.md").read_text() + "\n<!-- unique staging marker -->\n"
+    staging_content = (sd / "SKILL.md").read_text(encoding="utf-8") + "\n<!-- unique staging marker -->\n"
     (sd / "SKILL.md").write_text(staging_content, encoding="utf-8")
     assert commit_to_staging_branch(str(sd), "stub staging candidate") is True
     # 确认 .canary 已物化

--- a/tests/test_team_cli_registry_list_client.py
+++ b/tests/test_team_cli_registry_list_client.py
@@ -22,8 +22,9 @@ def test_cmd_registry_list_client(tmp_path, monkeypatch, capsys):
         (bridge / tid).write_text("x", encoding="utf-8")        # 必须被忽略
     (bridge / "index.pkl").write_text("x", encoding="utf-8")     # 必须被忽略
 
-    # 客户端连接状态 + 按 server 分目录的游标（方案 A）：cmd_registry_list_client
-    # 先读 team_client.json 拿 server_url，再定位该 server 的 cursor.json。
+    # 客户端连接状态 + 按 server 分目录的旧游标（方案 A）：
+    # cmd_registry_list_client 先读 team_client.json 拿 server_url，再把
+    # 旧 cursor.json 迁移进 client_state.db。
     server_url = "http://7.220.144.233:9961"
     (xskill_home / "team_client.json").write_text(
         json.dumps({"server_url": server_url, "client_id": "cid", "join_token": "t"}),
@@ -47,7 +48,7 @@ def test_cmd_registry_list_client(tmp_path, monkeypatch, capsys):
     assert rc == 0
     lines = capsys.readouterr().out.splitlines()
     assert lines[0] == "ECOSYSTEM\tCOLLECTED\tUPLOADED\tSOURCE"
-    row = next(l for l in lines if l.startswith("claude_code")).split("\t")
+    row = next(line for line in lines if line.startswith("claude_code")).split("\t")
     assert row == ["claude_code", "3", "2", str(src)]   # 采集3 / 上传2 / 真实源目录
 
 

--- a/tests/test_team_client_server_scope.py
+++ b/tests/test_team_client_server_scope.py
@@ -10,8 +10,6 @@ import os
 import time
 from pathlib import Path
 
-import pytest
-
 from xskill import config
 from xskill.team.client.collector import TeamCollector
 
@@ -22,8 +20,12 @@ def test_client_dir_is_under_clients_and_per_server(tmp_path, monkeypatch):
 
     a = config.get_team_client_cursor_path("http://1.1.1.1:8000")
     b = config.get_team_client_cursor_path("http://2.2.2.2:9961")
+    db_a = config.get_team_client_state_db_path("http://1.1.1.1:8000")
+    db_b = config.get_team_client_state_db_path("http://2.2.2.2:9961")
 
     assert a != b                              # 两个 server 互不污染
+    assert db_a != db_b
+    assert db_a.parent == a.parent
     assert a.parent.parent.name == "clients"   # ~/.xskill/clients/<id>/cursor.json
     assert a.parent.parent.parent == tmp_path / ".xskill"
 
@@ -43,7 +45,9 @@ def test_cursor_and_history_share_one_server_dir(tmp_path, monkeypatch):
     url = "http://7.220.144.233:9961"
     cur = config.get_team_client_cursor_path(url)
     hist = config.get_team_client_history_path(url)
+    db = config.get_team_client_state_db_path(url)
     assert cur.parent == hist.parent           # 同一个 <server_id> 目录
+    assert cur.parent == db.parent
 
 
 # ── 行为：换 server 后历史轨迹不再被上一个 server 的游标压制 ──────────

--- a/tests/test_team_collector.py
+++ b/tests/test_team_collector.py
@@ -1,10 +1,14 @@
 from __future__ import annotations
 
+import hashlib
+import json
 import os
 import time
 from pathlib import Path
 
+import xskill.team.client.collector as collector_mod
 from xskill.team.client.collector import TeamCollector
+from xskill.team.client.redact import redact_text
 
 
 def _bridge(home_root: Path) -> Path:
@@ -54,6 +58,110 @@ def test_mark_uploaded_excludes_next_time(tmp_path):
     md.write_text("# body changed", encoding="utf-8")
     os.utime(md, (old, old))
     assert len(col.pending()) == 1
+
+
+def test_uploaded_unchanged_file_skips_redaction(tmp_path, monkeypatch):
+    home = tmp_path / "home"
+    bridge = _bridge(home)
+    md = bridge / "traj_cc_x_001.md"
+    md.write_text("# body", encoding="utf-8")
+    old = time.time() - 600
+    os.utime(md, (old, old))
+
+    col = TeamCollector(cursor_path=tmp_path / "cursor.json",
+                        quiet_seconds=180, min_change_interval=0,
+                        home_root=home)
+    p = col.pending()[0]
+    col.mark_uploaded(p.traj_id, p.sha256)
+
+    def _redact_should_not_run(_text: str) -> str:
+        raise AssertionError("unchanged uploaded file should not be redacted")
+
+    monkeypatch.setattr(collector_mod, "redact_text", _redact_should_not_run)
+    assert col.pending() == []
+
+
+def test_same_content_after_mtime_change_skips_redaction(tmp_path, monkeypatch):
+    home = tmp_path / "home"
+    bridge = _bridge(home)
+    md = bridge / "traj_cc_x_001.md"
+    md.write_text("# body", encoding="utf-8")
+    old = time.time() - 600
+    os.utime(md, (old, old))
+
+    col = TeamCollector(cursor_path=tmp_path / "cursor.json",
+                        quiet_seconds=180, min_change_interval=0,
+                        home_root=home)
+    p = col.pending()[0]
+    col.mark_uploaded(p.traj_id, p.sha256)
+    os.utime(md, (old + 10, old + 10))
+
+    def _redact_should_not_run(_text: str) -> str:
+        raise AssertionError("same raw content should not be redacted")
+
+    monkeypatch.setattr(collector_mod, "redact_text", _redact_should_not_run)
+    assert col.pending() == []
+
+
+def test_changed_content_runs_redaction_again(tmp_path, monkeypatch):
+    home = tmp_path / "home"
+    bridge = _bridge(home)
+    md = bridge / "traj_cc_x_001.md"
+    md.write_text("# body", encoding="utf-8")
+    old = time.time() - 600
+    os.utime(md, (old, old))
+
+    col = TeamCollector(cursor_path=tmp_path / "cursor.json",
+                        quiet_seconds=180, min_change_interval=0,
+                        home_root=home)
+    p = col.pending()[0]
+    col.mark_uploaded(p.traj_id, p.sha256)
+
+    calls = {"count": 0}
+
+    def _counting_redact(text: str) -> str:
+        calls["count"] += 1
+        return text
+
+    monkeypatch.setattr(collector_mod, "redact_text", _counting_redact)
+    md.write_text("# body changed", encoding="utf-8")
+    os.utime(md, (old, old))
+    out = col.pending()
+    assert len(out) == 1
+    assert calls["count"] == 1
+
+
+def test_legacy_cursor_json_migrates_to_sqlite(tmp_path):
+    cursor = tmp_path / "cursor.json"
+    cursor.write_text(json.dumps({"traj_cc_x_001": "cleaned-hash"}),
+                      encoding="utf-8")
+
+    col = TeamCollector(cursor_path=cursor, quiet_seconds=0,
+                        min_change_interval=0, home_root=tmp_path / "home")
+    assert "traj_cc_x_001" in col._state_store.uploaded_trajectory_ids()
+
+
+def test_legacy_debounce_json_migrates_to_sqlite(tmp_path):
+    home = tmp_path / "home"
+    bridge = _bridge(home)
+    md = bridge / "traj_cc_x_001.md"
+    body = "# stable body"
+    md.write_text(body, encoding="utf-8")
+    old = time.time() - 600
+    os.utime(md, (old, old))
+
+    cursor = tmp_path / "cursor.json"
+    cleaned_hash = hashlib.sha256(redact_text(body).encode("utf-8")).hexdigest()
+    cursor.with_suffix(".debounce.json").write_text(
+        json.dumps({"traj_cc_x_001": {"sha": cleaned_hash, "since": old}}),
+        encoding="utf-8",
+    )
+
+    col = TeamCollector(cursor_path=cursor, quiet_seconds=0,
+                        min_change_interval=600, home_root=home)
+    out = col.pending()
+    assert len(out) == 1
+    assert out[0].traj_id == "traj_cc_x_001"
 
 
 def test_pending_carries_sidecar_model(tmp_path):


### PR DESCRIPTION
## Summary

- 将 team client 上传状态迁移到 server-scoped SQLite：`client_state.db`
- 旧 `cursor.json` / `cursor.debounce.json` 作为一次性迁移来源
- `pending()` 先用 size/mtime/ctime 跳过未变化文件，必要时才读文件和脱敏
- `registry list` 改为从 SQLite 统计已上传轨迹

## Verification

- `python3.11 -m ruff check src/xskill/team/client/upload_state.py src/xskill/team/client/collector.py src/xskill/cli.py src/xskill/config.py tests/test_team_collector.py tests/test_team_client_server_scope.py tests/test_team_cli_registry_list_client.py`
- `python3.11 -m pytest tests/test_team_collector.py tests/test_team_client_server_scope.py tests/test_team_cli_registry_list_client.py tests/test_team_client.py -v` (28 passed)
- `python3.11 -m py_compile src/xskill/team/client/upload_state.py src/xskill/team/client/collector.py src/xskill/cli.py src/xskill/config.py`
- `git diff --check`
