### PR TITLE
feat(nga3): 接入 CodeAgent3 轨迹与 skill 同步

### DIFF
--- a/pyproject.toml
+++ b/pyproject.toml
@@ -34,6 +34,7 @@ dependencies = [
     "tqdm",
     "httpx",
     "fastapi",
+    "python-multipart",
     "uvicorn",
     "sse-starlette",
     "rank-bm25>=0.2",

--- a/src/xskill/api/app.py
+++ b/src/xskill/api/app.py
@@ -921,11 +921,12 @@ def create_app(home_root: Path | str | None = None,
                 from xskill.ecosystems import (
                     detect_known_ecosystems,
                     CCSessionIngester, JsonlIngester, SqliteIngester,
-                    CODEX_SPEC, OPENCODE_SPEC, NGAGENT_SPEC,
+                    CODEX_SPEC, NGA3_SPEC, OPENCODE_SPEC, NGAGENT_SPEC,
                     OPENCLAW_SPEC, CURSOR_SPEC,
                     TraeIngester,
                     install_all_to_claude_code,
                     install_all_to_codex,
+                    install_all_to_nga3,
                     install_all_to_opencode,
                     install_all_to_ngagent,
                     install_all_to_openclaw,
@@ -1019,6 +1020,38 @@ def create_app(home_root: Path | str | None = None,
                             )
                         ingester = JsonlIngester(
                             CODEX_SPEC,
+                            target_traj_dir=bridge,
+                            home_root=_home_root(),
+                            poll_interval=poll_interval,
+                        )
+                        ingester.start()
+                        _watcher_ref[ingester_key] = ingester
+
+                    elif eco == "nga3":
+                        # nga3 / CodeAgent3: sessions in ~/.cac/projects and
+                        # skills in ~/.cac/skills, both JSONL/symlink-first.
+                        try:
+                            installed = install_all_to_nga3(
+                                _skill_dir, target_root=_home_root(),
+                            )
+                            for dest in installed:
+                                install_history.record(
+                                    skill=dest.parent.name, side="main", sha="",
+                                )
+                            logger.info(
+                                "startup install_all_to_nga3: %d skills installed to ~/.cac/skills/",
+                                len(installed),
+                            )
+                        except Exception as e:
+                            logger.warning(
+                                "startup install_all_to_nga3 failed", exc_info=True,
+                            )
+                            install_history.record_fail(
+                                skill="<startup_all>", agent="nga3",
+                                reason=str(e)[:200],
+                            )
+                        ingester = JsonlIngester(
+                            NGA3_SPEC,
                             target_traj_dir=bridge,
                             home_root=_home_root(),
                             poll_interval=poll_interval,

--- a/src/xskill/ecosystems/__init__.py
+++ b/src/xskill/ecosystems/__init__.py
@@ -7,6 +7,7 @@
   claude_code.py— Claude Code：_adapt_claude_code_jsonl + install_to_claude_code
                   + ingest_claude_code_sessions + CCSessionIngester
   codex.py      — Codex CLI：适配 + install/ingest
+  nga3.py       — nga3 / CodeAgent3：适配 + install/ingest
   cursor.py     — Cursor：适配 + install/ingest
   trae.py       — Trae IDE / Trae Agent：适配 + install/ingest
   openclaw.py   — OpenClaw：适配 + install/ingest + canary flip hook
@@ -57,6 +58,16 @@ from xskill.ecosystems.codex import (
     _codex_sessions_path,
     _codex_session_id_from_path,
     _read_cwd_from_codex_jsonl,
+)
+from xskill.ecosystems.nga3 import (
+    NGA3_SPEC,
+    install_to_nga3,
+    install_all_to_nga3,
+    ingest_nga3_sessions,
+    _nga3_projects_path,
+    _nga3_skills_path,
+    _nga3_session_id_from_path,
+    _read_cwd_from_nga3_jsonl_content,
 )
 from xskill.ecosystems.cursor import (
     CURSOR_SPEC,
@@ -112,20 +123,21 @@ SQLITE_SPEC_BY_ECO: dict = {
 
 __all__ = [
     "EcosystemSpec", "SqliteEcosystemSpec",
-    "CC_SPEC", "CODEX_SPEC", "OPENCLAW_SPEC", "CURSOR_SPEC", "OPENCODE_SPEC",
-    "NGAGENT_SPEC",
+    "CC_SPEC", "CODEX_SPEC", "NGA3_SPEC", "OPENCLAW_SPEC", "CURSOR_SPEC",
+    "OPENCODE_SPEC", "NGAGENT_SPEC",
     "SQLITE_SPEC_BY_ECO", "bridge_dir_for",
     "JsonlIngester", "SqliteIngester", "CCSessionIngester",
     "detect_known_ecosystems",
-    "install_to_claude_code", "install_to_codex", "install_to_cursor",
+    "install_to_claude_code", "install_to_codex", "install_to_nga3",
+    "install_to_cursor",
     "install_to_trae",
     "install_to_openclaw", "install_to_opencode", "install_to_ngagent",
     "install_all_to_claude_code", "install_all_to_codex",
-    "install_all_to_cursor", "install_all_to_trae",
+    "install_all_to_nga3", "install_all_to_cursor", "install_all_to_trae",
     "install_all_to_openclaw",
     "install_all_to_opencode", "install_all_to_ngagent",
     "ingest_claude_code_sessions", "ingest_codex_sessions",
-    "ingest_cursor_sessions", "ingest_trae_sessions",
+    "ingest_nga3_sessions", "ingest_cursor_sessions", "ingest_trae_sessions",
     "ingest_openclaw_sessions",
     "TraeIngester", "detect_trae_record",
     "make_openclaw_canary_flip_hook",

--- a/src/xskill/ecosystems/_shared.py
+++ b/src/xskill/ecosystems/_shared.py
@@ -168,6 +168,13 @@ _KNOWN_ECOSYSTEMS: list[dict] = [
         "source_kind": "file",
     },
     {
+        "id": "nga3",
+        # nga3 / CodeAgent3 写 <home>/.cac/projects/<encoded-cwd>/<sid>.jsonl
+        "source_subpath": ".cac/projects",
+        "bridge_subpath": ".xskill/nga3_sessions",
+        "source_kind": "dir",
+    },
+    {
         "id": "openclaw",
         # OpenClaw 写 <home>/.openclaw/agents/<agent>/sessions/<sid>.trajectory.jsonl
         "source_subpath": ".openclaw/agents",
@@ -514,8 +521,9 @@ def adapt_trajectory(
       Converted to a markdown trajectory.
     - ``raw`` -- plain text; wrapped in a basic trajectory markdown template.
     - ``claude_code_jsonl`` / ``codex_rollout_jsonl`` /
-      ``openclaw_trajectory_jsonl`` / ``cursor_transcripts_jsonl`` /
-      ``trae_ide_session_json`` / ``trae_agent_trajectory_json`` -- 各 agent
+      ``nga3_jsonl`` / ``zcode_jsonl`` / ``openclaw_trajectory_jsonl`` /
+      ``cursor_transcripts_jsonl`` / ``trae_ide_session_json`` /
+      ``trae_agent_trajectory_json`` -- 各 agent
       生态原生 session；分发到对应平台模块的 ``_adapt_*``。
 
     Returns ``(md_content, json_metadata)``.
@@ -523,6 +531,7 @@ def adapt_trajectory(
     # 平台 ``_adapt_*`` 延迟 import，避免 _shared <-> 平台模块循环 import。
     from xskill.ecosystems.claude_code import _adapt_claude_code_jsonl
     from xskill.ecosystems.codex import _adapt_codex_rollout_jsonl
+    from xskill.ecosystems.nga3 import _adapt_nga3_jsonl
     from xskill.ecosystems.openclaw import _adapt_openclaw_trajectory_jsonl
     from xskill.ecosystems.cursor import _adapt_cursor_transcripts_jsonl
     from xskill.ecosystems.trae import (
@@ -546,6 +555,9 @@ def adapt_trajectory(
 
     if format == "codex_rollout_jsonl":
         return _adapt_codex_rollout_jsonl(content, metadata)
+
+    if format in ("nga3_jsonl", "zcode_jsonl"):
+        return _adapt_nga3_jsonl(content, metadata)
 
     if format == "openclaw_trajectory_jsonl":
         return _adapt_openclaw_trajectory_jsonl(content, metadata)

--- a/src/xskill/ecosystems/nga3.py
+++ b/src/xskill/ecosystems/nga3.py
@@ -1,0 +1,416 @@
+"""
+ecosystems/nga3.py -- nga3 / CodeAgent3 生态适配
+================================================
+
+把蒸馏出的 Skill 装进 CodeAgent3 的 skill discovery 目录
+（``~/.cac/skills/<name>/``），并把 nga3 原生 JSONL
+（``~/.cac/projects/<encoded-cwd>/<sid>.jsonl``）桥接回 xskill 的标准
+``traj_*.md`` 格式。
+"""
+
+from __future__ import annotations
+
+import json
+import logging
+from pathlib import Path
+from typing import Iterable, Optional
+
+from xskill.ecosystems._shared import (
+    EcosystemSpec,
+    JsonlIngester,
+    _install_all_with,
+    _install_skill_into,
+)
+
+logger = logging.getLogger("xskill.ecosystems")
+
+LOCAL_COMMAND_CAVEAT_OPEN = "<local-command-caveat>"
+
+
+# ─────────────────────────────────────────────────────────────────
+# Path helpers
+# ─────────────────────────────────────────────────────────────────
+
+
+def _nga3_projects_path(home: Path) -> Path:
+    """nga3 / CodeAgent3 session JSONL 根目录：``<home>/.cac/projects``."""
+    return home / ".cac" / "projects"
+
+
+def _nga3_skills_path(home: Path) -> Path:
+    """nga3 / CodeAgent3 skill discovery 根目录：``<home>/.cac/skills``."""
+    return home / ".cac" / "skills"
+
+
+# ─────────────────────────────────────────────────────────────────
+# Installer
+# ─────────────────────────────────────────────────────────────────
+
+
+def install_to_nga3(
+    skill_path: Path | str,
+    target_root: Path | str | None = None,
+    side: str = "main",
+) -> Path:
+    """把一个 skill 装到 ``<target_root>/.cac/skills/<name>``。
+
+    与 Claude Code / Cursor 一样走 symlink-first 三阶 fallback；staging
+    语义也复用 ``_install_skill_into``。
+    """
+    root = Path(target_root) if target_root else Path.home()
+    return _install_skill_into(
+        Path(skill_path),
+        _nga3_skills_path(root),
+        side,
+        ecosystem_label="nga3",
+    )
+
+
+def install_all_to_nga3(
+    skill_dir: Path | str,
+    target_root: Path | str | None = None,
+    names: Iterable[str] | None = None,
+) -> list[Path]:
+    """Install every skill under ``skill_dir`` to ``<target_root>/.cac/skills``."""
+    return _install_all_with(install_to_nga3, skill_dir, target_root, names)
+
+
+# ─────────────────────────────────────────────────────────────────
+# nga3 trajectory helpers
+# ─────────────────────────────────────────────────────────────────
+
+
+def _nga3_session_id_from_path(jsonl_path: Path) -> str:
+    """``<sid>.jsonl`` → ``<sid>``。"""
+    return jsonl_path.stem
+
+
+def _read_cwd_from_nga3_jsonl_content(content: str) -> str:
+    """读 nga3 JSONL 第一条带 ``cwd`` 字段的事件。"""
+    for line in content.splitlines():
+        line = line.strip()
+        if not line:
+            continue
+        try:
+            ev = json.loads(line)
+        except json.JSONDecodeError:
+            continue
+        cwd = ev.get("cwd")
+        if cwd:
+            return str(cwd).replace("\\", "/")
+    return ""
+
+
+NGA3_SPEC = EcosystemSpec(
+    name="nga3",
+    source_kind="jsonl",
+    sessions_path=_nga3_projects_path,
+    sessions_glob="*/*.jsonl",  # <projects>/<encoded-cwd>/<sid>.jsonl
+    session_id_from_path=_nga3_session_id_from_path,
+    cwd_from_content=_read_cwd_from_nga3_jsonl_content,
+    adapter_format="nga3_jsonl",
+    traj_id_prefix="traj_nga3_",
+    skills_install_path=_nga3_skills_path,
+    label="nga3",
+)
+
+
+def _is_local_command_caveat(content: object) -> bool:
+    if isinstance(content, str):
+        return LOCAL_COMMAND_CAVEAT_OPEN in content
+    if isinstance(content, list):
+        for part in content:
+            if isinstance(part, dict):
+                text = part.get("text") or part.get("content")
+                if isinstance(text, str) and LOCAL_COMMAND_CAVEAT_OPEN in text:
+                    return True
+    return False
+
+
+def _tool_result_to_text(result_content: object) -> str:
+    if isinstance(result_content, str):
+        return result_content
+    if isinstance(result_content, list):
+        parts: list[str] = []
+        for item in result_content:
+            if isinstance(item, dict):
+                if item.get("type") == "text":
+                    parts.append(str(item.get("text") or ""))
+                else:
+                    parts.append(json.dumps(item, ensure_ascii=False))
+            else:
+                parts.append(str(item))
+        return "\n".join(p for p in parts if p)
+    if isinstance(result_content, dict):
+        return json.dumps(result_content, ensure_ascii=False)
+    if result_content is None:
+        return ""
+    return str(result_content)
+
+
+def _set_first(meta: dict, key: str, value: object) -> None:
+    if value not in (None, "") and not meta.get(key):
+        meta[key] = value
+
+
+def _capture_event_metadata(event: dict, meta: dict) -> None:
+    _set_first(meta, "provider", event.get("_cac_providerId"))
+    _set_first(meta, "model", event.get("_cac_modelId"))
+    _set_first(meta, "agent_type", event.get("_cac_agentType"))
+    _set_first(meta, "internal_prompt_id", event.get("_cac_promptId"))
+    _set_first(meta, "prompt_id", event.get("promptId"))
+    _set_first(meta, "permission_mode", event.get("permissionMode"))
+    _set_first(meta, "client_version", event.get("version"))
+    _set_first(meta, "entrypoint", event.get("entrypoint"))
+    _set_first(meta, "user_type", event.get("userType"))
+    _set_first(meta, "slug", event.get("slug"))
+
+
+def _append_meta_event(event: dict, meta_events: list[dict]) -> None:
+    meta_events.append({
+        "type": event.get("type") or "unknown",
+        "uuid": event.get("uuid") or "",
+        "message_id": event.get("messageId") or "",
+        "timestamp": event.get("timestamp") or "",
+        "is_snapshot_update": bool(event.get("isSnapshotUpdate")),
+    })
+
+
+def _adapt_nga3_jsonl(content: str, metadata: dict) -> tuple[str, dict]:
+    """Convert a nga3 / CodeAgent3 JSONL session to markdown + metadata."""
+    timeline: list[dict] = []
+    tool_calls: list[dict] = []
+    tool_names: list[str] = []
+    meta_events: list[dict] = []
+    session_id = ""
+    cwd = ""
+    git_branch = ""
+    first_user_query = ""
+    thinking_blocks = 0
+    t = 0
+    step = 0
+    pending_tool_by_id: dict[str, str] = {}
+
+    meta = dict(metadata)
+
+    for raw_line in content.splitlines():
+        raw_line = raw_line.strip()
+        if not raw_line:
+            continue
+        try:
+            event = json.loads(raw_line)
+        except json.JSONDecodeError:
+            continue
+
+        _capture_event_metadata(event, meta)
+
+        ev_type = event.get("type")
+        if ev_type not in ("user", "assistant"):
+            _append_meta_event(event, meta_events)
+            continue
+
+        session_id = session_id or str(event.get("sessionId") or "")
+        cwd = cwd or str(event.get("cwd") or "")
+        git_branch = git_branch or str(event.get("gitBranch") or "")
+
+        msg = event.get("message") or {}
+        if ev_type == "assistant":
+            _set_first(meta, "model", msg.get("model"))
+        msg_content = msg.get("content")
+
+        if ev_type == "user":
+            if event.get("isMeta") and _is_local_command_caveat(msg_content):
+                meta_events.append({
+                    "type": "local-command-caveat",
+                    "uuid": event.get("uuid") or "",
+                    "timestamp": event.get("timestamp") or "",
+                })
+                continue
+
+            if isinstance(msg_content, str):
+                if _is_local_command_caveat(msg_content):
+                    meta_events.append({
+                        "type": "local-command-caveat",
+                        "uuid": event.get("uuid") or "",
+                        "timestamp": event.get("timestamp") or "",
+                    })
+                    continue
+                if not first_user_query:
+                    first_user_query = msg_content[:500]
+                timeline.append({
+                    "t": t, "role": "user",
+                    "content": msg_content[:2000],
+                    "uuid": event.get("uuid") or "",
+                    "prompt_id": event.get("promptId") or "",
+                })
+                t += 1
+            elif isinstance(msg_content, list):
+                for part in msg_content:
+                    if not isinstance(part, dict):
+                        continue
+                    ptype = part.get("type")
+                    if ptype == "text":
+                        text = (part.get("text") or "").strip()
+                        if not text or _is_local_command_caveat(text):
+                            continue
+                        if not first_user_query:
+                            first_user_query = text[:500]
+                        timeline.append({
+                            "t": t, "role": "user",
+                            "content": text[:2000],
+                            "uuid": event.get("uuid") or "",
+                            "prompt_id": event.get("promptId") or "",
+                        })
+                        t += 1
+                    elif ptype == "tool_result":
+                        tc_id = part.get("tool_use_id", "")
+                        tool_name = pending_tool_by_id.get(tc_id, "unknown")
+                        output_text = _tool_result_to_text(part.get("content"))[:2000]
+                        entry = {
+                            "t": t, "role": "tool_output",
+                            "tool": tool_name,
+                            "tool_use_id": tc_id,
+                            "output": output_text,
+                            "is_error": bool(part.get("is_error")),
+                            "source_tool_assistant_uuid": event.get("sourceToolAssistantUUID") or "",
+                            "tool_use_result": event.get("toolUseResult") or {},
+                        }
+                        timeline.append(entry)
+                        for call in reversed(tool_calls):
+                            if call.get("_tc_id") == tc_id:
+                                call["output"] = output_text
+                                call["output_available"] = True
+                                call["is_error"] = bool(part.get("is_error"))
+                                call["source_tool_assistant_uuid"] = (
+                                    event.get("sourceToolAssistantUUID") or ""
+                                )
+                                call["tool_use_result"] = event.get("toolUseResult") or {}
+                                break
+                        t += 1
+
+        else:  # assistant
+            if isinstance(msg_content, list):
+                for part in msg_content:
+                    if not isinstance(part, dict):
+                        continue
+                    ptype = part.get("type")
+                    if ptype == "text":
+                        text = (part.get("text") or "").strip()
+                        if text:
+                            timeline.append({
+                                "t": t, "role": "assistant",
+                                "content": text[:2000],
+                                "uuid": event.get("uuid") or "",
+                            })
+                            t += 1
+                    elif ptype == "tool_use":
+                        tc_id = part.get("id", "")
+                        tool_name = part.get("name", "unknown")
+                        tool_input = part.get("input") or {}
+                        caller = part.get("caller") or {}
+                        if tool_name not in tool_names:
+                            tool_names.append(tool_name)
+                        pending_tool_by_id[tc_id] = tool_name
+                        timeline.append({
+                            "t": t, "role": "tool_call",
+                            "tool": tool_name,
+                            "input": tool_input,
+                            "caller": caller,
+                            "tool_use_id": tc_id,
+                            "uuid": event.get("uuid") or "",
+                        })
+                        tool_calls.append({
+                            "step": step,
+                            "tool": tool_name,
+                            "input": tool_input,
+                            "caller": caller,
+                            "output": "",
+                            "output_available": False,
+                            "_tc_id": tc_id,
+                        })
+                        step += 1
+                        t += 1
+                    elif ptype == "thinking":
+                        thinking_blocks += 1
+
+    for entry in tool_calls:
+        entry.pop("_tc_id", None)
+
+    lines: list[str] = ["# NGA3 Session Trajectory", ""]
+    if session_id:
+        lines.append(f"**session_id**: {session_id}")
+    if cwd:
+        lines.append(f"**cwd**: {cwd}")
+    if git_branch:
+        lines.append(f"**git_branch**: {git_branch}")
+    if meta.get("model"):
+        lines.append(f"**model**: {meta['model']}")
+    lines.append("")
+
+    if first_user_query:
+        lines.append("## Initial Query")
+        lines.append("")
+        lines.append(first_user_query)
+        lines.append("")
+
+    for entry in timeline:
+        role = entry["role"]
+        if role == "user":
+            lines.append("## User")
+            lines.append("")
+            lines.append(entry["content"])
+            lines.append("")
+        elif role == "assistant":
+            lines.append("## Assistant")
+            lines.append("")
+            lines.append(entry["content"])
+            lines.append("")
+        elif role == "tool_call":
+            lines.append(f"## Tool Call: {entry['tool']}")
+            lines.append("```json")
+            lines.append(json.dumps(entry["input"], ensure_ascii=False)[:1000])
+            lines.append("```")
+            lines.append("")
+        elif role == "tool_output":
+            err_tag = " (error)" if entry.get("is_error") else ""
+            lines.append(f"## Tool Output: {entry['tool']}{err_tag}")
+            lines.append("```")
+            lines.append(entry["output"])
+            lines.append("```")
+            lines.append("")
+
+    md = "\n".join(lines)
+
+    meta.setdefault("source", "nga3_session_jsonl")
+    meta.setdefault("category", "nga3_session")
+    if session_id:
+        meta.setdefault("session_id", session_id)
+    if cwd:
+        meta.setdefault("cwd", cwd)
+    if git_branch:
+        meta.setdefault("git_branch", git_branch)
+    meta["timeline"] = timeline
+    meta["tool_calls"] = tool_calls
+    meta["tool_names"] = tool_names
+    meta["total_tool_calls"] = len(tool_calls)
+    meta["total_turns"] = len(timeline)
+    meta["thinking_blocks"] = thinking_blocks
+    meta["meta_events"] = meta_events
+    if first_user_query:
+        meta.setdefault("query", first_user_query)
+
+    return md, meta
+
+
+def ingest_nga3_sessions(
+    target_traj_dir: Path | str,
+    *,
+    home_root: Path | str | None = None,
+    seen_sessions: Optional[set[str]] = None,
+) -> list[dict]:
+    """Bridge nga3 JSONLs into xskill's trajectory directory."""
+    return JsonlIngester(NGA3_SPEC).scan_and_bridge(
+        target_traj_dir=Path(target_traj_dir),
+        home_root=Path(home_root) if home_root else None,
+        seen_sessions=seen_sessions,
+    )

--- a/src/xskill/pipeline/runner.py
+++ b/src/xskill/pipeline/runner.py
@@ -485,6 +485,7 @@ class DirectoryWatcher:
             detect_known_ecosystems,
             install_to_claude_code,
             install_to_codex,
+            install_to_nga3,
             install_to_opencode,
             install_to_ngagent,
             install_to_openclaw,
@@ -502,6 +503,7 @@ class DirectoryWatcher:
         installer_by_ecosystem = {
             "claude_code": install_to_claude_code,
             "codex": install_to_codex,
+            "nga3": install_to_nga3,
             "opencode": install_to_opencode,
             "ngagent": install_to_ngagent,  # opencode 企业分支，独立 skill 目录
             "openclaw": install_to_openclaw,  # copy 模式，详见 install_to_openclaw docstring

--- a/src/xskill/team/client/daemon.py
+++ b/src/xskill/team/client/daemon.py
@@ -169,12 +169,13 @@ class TeamClient:
         """
         from xskill.ecosystems import (
             detect_known_ecosystems, install_to_claude_code,
-            install_to_codex, install_to_opencode, install_to_ngagent,
+            install_to_codex, install_to_nga3, install_to_opencode, install_to_ngagent,
             install_to_openclaw, install_to_cursor, install_to_trae,
         )
         installer = {
             "claude_code": install_to_claude_code,
             "codex": install_to_codex,
+            "nga3": install_to_nga3,
             "opencode": install_to_opencode,
             "ngagent": install_to_ngagent,
             "openclaw": install_to_openclaw,

--- a/tests/test_nga3_adapter.py
+++ b/tests/test_nga3_adapter.py
@@ -1,0 +1,326 @@
+"""
+test_nga3_adapter.py -- nga3 / CodeAgent3 生态测试
+=================================================
+"""
+from __future__ import annotations
+
+import json
+from pathlib import Path
+
+import pytest
+
+from xskill.ecosystems import JsonlIngester, adapt_trajectory, detect_known_ecosystems
+from xskill.ecosystems.nga3 import (
+    NGA3_SPEC,
+    _nga3_projects_path,
+    _nga3_session_id_from_path,
+    _nga3_skills_path,
+    _read_cwd_from_nga3_jsonl_content,
+    ingest_nga3_sessions,
+    install_to_nga3,
+)
+
+
+def _nga3_jsonl_sample() -> str:
+    return "\n".join([
+        json.dumps({
+            "type": "file-history-snapshot",
+            "messageId": "snap-1",
+            "snapshot": {"messageId": "snap-1", "trackedFileBackups": {}},
+            "isSnapshotUpdate": False,
+        }),
+        json.dumps({
+            "parentUuid": None,
+            "isSidechain": False,
+            "type": "user",
+            "message": {
+                "role": "user",
+                "content": "<local-command-caveat>hello world message</local-command-caveat>",
+            },
+            "isMeta": True,
+            "uuid": "meta-user",
+            "timestamp": "2026-07-07T07:36:48.532Z",
+            "userType": "external",
+            "entrypoint": "cli",
+            "cwd": r"D:\02-code\nga-xx",
+            "sessionId": "sess-nga3",
+            "version": "1.2605.02-IN.1",
+            "gitBranch": "HEAD",
+        }),
+        json.dumps({
+            "parentUuid": "meta-user",
+            "isSidechain": False,
+            "promptId": "prompt-uuid",
+            "type": "user",
+            "message": {"role": "user", "content": "列出当前目录下所有 txt 文件"},
+            "uuid": "user-1",
+            "timestamp": "2026-07-07T07:40:36.191Z",
+            "permissionMode": "default",
+            "userType": "external",
+            "entrypoint": "cli",
+            "cwd": r"D:\02-code\nga-xx",
+            "sessionId": "sess-nga3",
+            "version": "1.2605.02-IN.1",
+            "gitBranch": "HEAD",
+        }),
+        json.dumps({
+            "parentUuid": "user-1",
+            "isSidechain": False,
+            "message": {
+                "id": "msg_1",
+                "type": "message",
+                "role": "assistant",
+                "content": [
+                    {"type": "thinking", "thinking": "I will glob files", "signature": "sig"},
+                    {
+                        "type": "tool_use",
+                        "id": "call_glob",
+                        "name": "Glob",
+                        "input": {"pattern": "**/*.txt"},
+                        "caller": {"type": "direct"},
+                    },
+                ],
+                "model": "Glm-5.1",
+            },
+            "type": "assistant",
+            "uuid": "assistant-1",
+            "timestamp": "2026-07-07T07:40:42.171Z",
+            "_cac_providerId": "openai",
+            "_cac_modelId": "Glm-5.1",
+            "_cac_agentType": "main",
+            "_cac_promptId": "prompt_internal",
+            "userType": "external",
+            "entrypoint": "cli",
+            "cwd": r"D:\02-code\nga-xx",
+            "sessionId": "sess-nga3",
+            "version": "1.2605.02-IN.1",
+            "gitBranch": "HEAD",
+        }),
+        json.dumps({
+            "parentUuid": "assistant-1",
+            "isSidechain": False,
+            "promptId": "prompt-uuid",
+            "type": "user",
+            "message": {
+                "role": "user",
+                "content": [
+                    {
+                        "tool_use_id": "call_glob",
+                        "type": "tool_result",
+                        "content": "hello.txt",
+                    }
+                ],
+            },
+            "uuid": "tool-result-1",
+            "timestamp": "2026-07-07T07:40:42.212Z",
+            "toolUseResult": {
+                "filenames": ["hello.txt"],
+                "durationMs": 12,
+                "numFiles": 1,
+                "truncated": False,
+            },
+            "sourceToolAssistantUUID": "assistant-1",
+            "userType": "external",
+            "entrypoint": "cli",
+            "cwd": r"D:\02-code\nga-xx",
+            "sessionId": "sess-nga3",
+            "version": "1.2605.02-IN.1",
+            "gitBranch": "HEAD",
+            "slug": "indexed-twirling-reddy",
+        }),
+        json.dumps({
+            "parentUuid": "tool-result-1",
+            "isSidechain": False,
+            "message": {
+                "id": "msg_2",
+                "type": "message",
+                "role": "assistant",
+                "content": [
+                    {
+                        "type": "tool_use",
+                        "id": "call_read",
+                        "name": "Read",
+                        "input": {"file_path": r"D:\02-code\nga-xx\hello.txt"},
+                        "caller": {"type": "direct"},
+                    }
+                ],
+                "model": "Glm-5.1",
+            },
+            "type": "assistant",
+            "uuid": "assistant-2",
+            "timestamp": "2026-07-07T07:40:45.220Z",
+            "_cac_providerId": "openai",
+            "_cac_modelId": "Glm-5.1",
+            "_cac_agentType": "main",
+            "_cac_promptId": "prompt_internal_2",
+            "cwd": r"D:\02-code\nga-xx",
+            "sessionId": "sess-nga3",
+        }),
+        json.dumps({
+            "parentUuid": "assistant-2",
+            "isSidechain": False,
+            "promptId": "prompt-uuid",
+            "type": "user",
+            "message": {
+                "role": "user",
+                "content": [
+                    {
+                        "type": "tool_result",
+                        "content": "File content exceeds maximum allowed tokens",
+                        "is_error": True,
+                        "tool_use_id": "call_read",
+                    }
+                ],
+            },
+            "uuid": "tool-result-2",
+            "timestamp": "2026-07-07T07:40:45.562Z",
+            "toolUseResult": {
+                "type": "Error",
+                "message": "File content exceeds maximum allowed tokens",
+            },
+            "sourceToolAssistantUUID": "assistant-2",
+            "cwd": r"D:\02-code\nga-xx",
+            "sessionId": "sess-nga3",
+            "slug": "indexed-twirling-reddy",
+        }),
+    ])
+
+
+def _build_skill(root: Path, name: str = "demo-skill") -> Path:
+    skill_path = root / name
+    skill_path.mkdir(parents=True)
+    (skill_path / "SKILL.md").write_text("# demo skill\n", encoding="utf-8")
+    return skill_path
+
+
+class TestNga3Adapter:
+    def test_adapter_accepts_nga3_jsonl_format(self):
+        md, meta = adapt_trajectory(_nga3_jsonl_sample(), "nga3_jsonl")
+
+        assert "# NGA3 Session Trajectory" in md
+        assert "## Initial Query" in md
+        assert "列出当前目录下所有 txt 文件" in md
+        assert "Tool Call: Glob" in md
+        assert "Tool Output: Glob" in md
+        assert "Tool Output: Read (error)" in md
+        assert "local-command-caveat" not in md
+
+        assert meta["category"] == "nga3_session"
+        assert meta["source"] == "nga3_session_jsonl"
+        assert meta["session_id"] == "sess-nga3"
+        assert meta["cwd"] == r"D:\02-code\nga-xx"
+        assert meta["git_branch"] == "HEAD"
+        assert meta["model"] == "Glm-5.1"
+        assert meta["provider"] == "openai"
+        assert meta["agent_type"] == "main"
+        assert meta["internal_prompt_id"] == "prompt_internal"
+        assert meta["prompt_id"] == "prompt-uuid"
+        assert meta["permission_mode"] == "default"
+        assert meta["client_version"] == "1.2605.02-IN.1"
+        assert meta["entrypoint"] == "cli"
+        assert meta["user_type"] == "external"
+        assert meta["slug"] == "indexed-twirling-reddy"
+        assert meta["thinking_blocks"] == 1
+        assert meta["tool_names"] == ["Glob", "Read"]
+        assert meta["total_tool_calls"] == 2
+        assert meta["tool_calls"][0]["caller"] == {"type": "direct"}
+        assert meta["tool_calls"][1]["is_error"] is True
+        assert any(e["type"] == "local-command-caveat" for e in meta["meta_events"])
+
+    def test_zcode_alias_uses_same_adapter(self):
+        md, meta = adapt_trajectory(_nga3_jsonl_sample(), "zcode_jsonl")
+        assert "# NGA3 Session Trajectory" in md
+        assert meta["category"] == "nga3_session"
+
+    def test_read_cwd_normalizes_windows_path_for_traj_id(self):
+        assert _read_cwd_from_nga3_jsonl_content(_nga3_jsonl_sample()) == "D:/02-code/nga-xx"
+
+
+class TestNga3DetectAndIngest:
+    def test_detect_reports_nga3_when_cac_projects_exists(self, tmp_path):
+        (tmp_path / ".cac" / "projects").mkdir(parents=True)
+
+        found = detect_known_ecosystems(home_root=tmp_path)
+        ecos = {r["ecosystem"] for r in found}
+        assert "nga3" in ecos
+
+        rec = next(r for r in found if r["ecosystem"] == "nga3")
+        assert rec["source"] == (tmp_path / ".cac" / "projects").resolve()
+        assert rec["bridge"] == (tmp_path / ".xskill" / "nga3_sessions").resolve()
+
+    def test_ingest_nga3_sessions_bridges_cac_project_jsonl(self, tmp_path):
+        src_dir = tmp_path / ".cac" / "projects" / "D--02-code-nga-xx"
+        src_dir.mkdir(parents=True)
+        (src_dir / "sess-nga3.jsonl").write_text(
+            _nga3_jsonl_sample(), encoding="utf-8",
+        )
+
+        bridge = tmp_path / "bridge"
+        ingester = JsonlIngester(NGA3_SPEC, settle_seconds=0)
+        submitted = ingester.scan_and_bridge(bridge, home_root=tmp_path)
+
+        assert len(submitted) == 1
+        assert submitted[0]["session_id"] == "sess-nga3"
+        md_path = Path(submitted[0]["path"])
+        assert md_path.name.startswith("traj_nga3_nga-xx_sess-nga")
+        assert md_path.is_file()
+
+        meta = json.loads(md_path.with_suffix(".json").read_text(encoding="utf-8"))
+        assert meta["category"] == "nga3_session"
+        assert meta["model"] == "Glm-5.1"
+
+    def test_ingest_wrapper_uses_nga3_spec(self, tmp_path):
+        src_dir = tmp_path / ".cac" / "projects" / "D--02-code-nga-xx"
+        src_dir.mkdir(parents=True)
+        (src_dir / "sess-nga3.jsonl").write_text(
+            _nga3_jsonl_sample(), encoding="utf-8",
+        )
+
+        submitted = ingest_nga3_sessions(
+            tmp_path / "bridge", home_root=tmp_path, seen_sessions=set(),
+        )
+
+        assert len(submitted) == 1
+        assert submitted[0]["ecosystem"] == "nga3"
+
+
+class TestNga3Installer:
+    def test_path_resolvers(self):
+        home = Path("/fake/home")
+        assert _nga3_projects_path(home) == home / ".cac" / "projects"
+        assert _nga3_skills_path(home) == home / ".cac" / "skills"
+        assert _nga3_session_id_from_path(Path("abc123.jsonl")) == "abc123"
+
+    def test_spec_fields(self):
+        assert NGA3_SPEC.name == "nga3"
+        assert NGA3_SPEC.source_kind == "jsonl"
+        assert NGA3_SPEC.sessions_glob == "*/*.jsonl"
+        assert NGA3_SPEC.adapter_format == "nga3_jsonl"
+        assert NGA3_SPEC.traj_id_prefix == "traj_nga3_"
+        assert NGA3_SPEC.skills_install_path(Path("/fake/home")) == (
+            Path("/fake/home") / ".cac" / "skills"
+        )
+
+    def test_install_creates_skill_md_at_cac_skills_path(self, tmp_path):
+        skill_path = _build_skill(tmp_path / "src")
+        fake_home = tmp_path / "home"
+
+        dest = install_to_nga3(skill_path, target_root=fake_home)
+
+        assert dest == fake_home / ".cac" / "skills" / "demo-skill" / "SKILL.md"
+        assert dest.is_file()
+        assert dest.read_text(encoding="utf-8") == "# demo skill\n"
+        assert not (fake_home / ".agents" / "skills").exists()
+
+    def test_install_missing_skill_md_raises(self, tmp_path):
+        empty = tmp_path / "empty-skill"
+        empty.mkdir()
+        with pytest.raises(FileNotFoundError):
+            install_to_nga3(empty, target_root=tmp_path / "home")
+
+    def test_watcher_installer_dict_includes_nga3(self):
+        import inspect
+        from xskill.pipeline.runner import DirectoryWatcher
+
+        src = inspect.getsource(DirectoryWatcher._install_skill_to_all_detected)
+        assert '"nga3": install_to_nga3' in src


### PR DESCRIPTION
## Summary

This PR adds first-class nga3 / CodeAgent3 support to xskill.

## Changes

| Area | Change |
| --- | --- |
| Trajectory ingest | Read CodeAgent3 JSONL from `~/.cac/projects/<encoded-cwd>/<sid>.jsonl`. |
| Adapter | Add `nga3_jsonl` and `zcode_jsonl` formats. |
| Skill sync | Install generated skills to `~/.cac/skills/<name>/SKILL.md`. |
| Runtime wiring | Register nga3 in auto-detect, `xskill serve`, pipeline install, and team client sync. |
| Metadata | Preserve `_cac_*`, `promptId`, `permissionMode`, `entrypoint`, `slug`, `caller`, and tool result metadata. |
| Dependency | Add `python-multipart`, required by FastAPI `UploadFile` / `Form` routes at import time. |
| Tests | Add nga3 adapter, detect, ingest, and install coverage. |

## Validation

GitHub Actions is green on the latest commit:

| Check group | Result |
| --- | --- |
| Analyze | pass |
| verify-build | pass |
| ut+it | pass on Ubuntu, macOS, and Windows for Python 3.9-3.12 |
| smoke-e2e | pass |
| live-agent-e2e | pass |
| real-llm-e2e | skipped by workflow |

<details>
<summary>Local commands run</summary>

```bash
python3.11 -m py_compile   src/xskill/ecosystems/nga3.py   src/xskill/ecosystems/_shared.py   src/xskill/ecosystems/__init__.py   src/xskill/api/app.py   src/xskill/pipeline/runner.py   src/xskill/team/client/daemon.py   tests/test_nga3_adapter.py

python3.11 -m pytest -q tests/test_nga3_adapter.py

python3.11 -m pytest -q   tests/test_claude_code_ecosystem.py   tests/test_cursor_adapter.py   tests/test_openclaw_adapter.py   tests/test_ecosystem_ngagent.py   tests/test_runtime_sync.py

python3.11 -m pytest -q   tests/test_client_identity.py   tests/test_recommend_gaps.py   tests/test_team_client.py   tests/test_team_ingest_db.py   tests/test_team_reconnect_identity.py   tests/test_team_server_api.py   tests/test_team_sync_profile.py
```

</details>