### PR TITLE
feat(skillhub): support nested scan and team push

### DIFF
--- a/pyproject.toml
+++ b/pyproject.toml
@@ -34,6 +34,7 @@ dependencies = [
     "tqdm",
     "httpx",
     "fastapi",
+    "python-multipart",
     "uvicorn",
     "sse-starlette",
     "rank-bm25>=0.2",

--- a/src/xskill/api/app.py
+++ b/src/xskill/api/app.py
@@ -1256,6 +1256,7 @@ def create_app(home_root: Path | str | None = None,
                     total_slots=int(team_cfg.get("skill_slots", 100)),
                     register_dir=_team_register_dir,
                     allow_anonymous_user=_allow_anonymous(_config),
+                    skillhub=_engine.skillhub,
                 )
                 logger.info("team server context ready (traj_root=%s)", traj_root)
             except Exception:

--- a/src/xskill/dashboard/router.py
+++ b/src/xskill/dashboard/router.py
@@ -202,7 +202,7 @@ def build_dashboard_router(db_path: Optional[Path] = None, *,
         hub = _build_skillhub()
         if hub is None:
             raise HTTPException(status_code=404, detail="skillhub disabled")
-        _skillhub_path(hub.dir, name)  # 越权校验 + 存在校验
+        _skillhub_path(hub, name)  # 越权校验 + 存在校验
         versions = hub.ux_scores_by_version(name, days=days)
         return {
             "skill": name,
@@ -218,7 +218,7 @@ def build_dashboard_router(db_path: Optional[Path] = None, *,
         hub = _build_skillhub()
         if hub is None:
             raise HTTPException(status_code=404, detail="skillhub disabled")
-        _skillhub_path(hub.dir, name)
+        _skillhub_path(hub, name)
         traj_root = _resolve_traj_root()
         scores = hub.ux_scores_with_atoms(
             name, commit_sha=commit_sha, days=days, traj_root=traj_root)
@@ -416,9 +416,9 @@ def _build_skillhub() -> Optional["object"]:
     return hub if hub.enabled else None
 
 
-def _skillhub_path(hub_dir: Path, name: str) -> Path:
-    """解析并校验三方 skill 子目录，防 name 里塞 ``../`` 越权 + 不存在抛 404。"""
-    root = (Path(hub_dir) / name).resolve()
-    if root.parent != Path(hub_dir).resolve() or not root.is_dir():
+def _skillhub_path(hub, name: str) -> Path:
+    """解析并校验三方 skill 子目录；不存在抛 404。"""
+    root = hub.skill_path(name)
+    if root is None:
         raise HTTPException(status_code=404, detail=f"skill not found: {name!r}")
     return root

--- a/src/xskill/recommend/engine.py
+++ b/src/xskill/recommend/engine.py
@@ -81,16 +81,23 @@ class SkillRecommendEngine:
 
         返回 ``(names, embeddings, is_skillhub)``。三方 skill 标记 True（仅相关性位）。
         """
-        idx = self._skill_index()
-        repo_names = list(idx.get("skill_names") or [])
-        repo_embs = np.asarray(idx["embeddings"], dtype=float)
+        hub_entries = self._skillhub_entries()
+        idx_path = self.skill_dir / ".skill_index.pkl"
+        if idx_path.is_file():
+            idx = self._skill_index()
+            repo_names = list(idx.get("skill_names") or [])
+            repo_embs = np.asarray(idx["embeddings"], dtype=float)
+        else:
+            repo_names = []
+            dim = len(hub_entries[0]["vec"]) if hub_entries else 0
+            repo_embs = np.zeros((0, dim), dtype=float)
         distributable = {s.name for s in self._distributable_skills()}
         # 仅保留可分发 skill（排除 baby / 已删）
         keep = [i for i, n in enumerate(repo_names) if n in distributable]
         names = [repo_names[i] for i in keep]
         embs = repo_embs[keep] if keep else np.zeros((0, repo_embs.shape[1] if repo_embs.ndim == 2 else 0))
         is_hub = {n: False for n in names}
-        for e in self._skillhub_entries():
+        for e in hub_entries:
             if e["name"] in is_hub:
                 continue  # 自有 skill 同名优先
             names.append(e["name"])
@@ -224,8 +231,6 @@ class SkillRecommendEngine:
         pool = self._distributable_skills()
         if exclude_names:
             pool = [s for s in pool if s.name not in exclude_names]
-        if not pool:
-            return []
 
         quality_ratio = self.rcfg["quality_ratio"]
         qn = min(math.ceil(skill_num * quality_ratio), len(pool))
@@ -239,7 +244,7 @@ class SkillRecommendEngine:
         relevance: list["Skill"] = []
         ci = client_user.client_interest
         if ci is not None and ci.feature_tensor is not None:
-            names, embs, _is_hub = self._combined_relevance()
+            names, embs, is_hub = self._combined_relevance()
             by_name = {s.name: s for s in pool}  # pool 已排除 exclude_names
             picked = set(quality_names)
             for center in ci.feature_tensor:
@@ -251,8 +256,16 @@ class SkillRecommendEngine:
                 order = np.argsort(-sims)
                 for i in order:
                     nm = names[i]
-                    # 仅返回可分发 skill（skillhub-only 无 git，不能作为 slot 分发）
-                    if nm in by_name and nm not in picked:
+                    if nm in picked:
+                        continue
+                    if is_hub.get(nm):
+                        entry = self.skillhub.entry(nm)
+                        if entry is not None:
+                            relevance.append(entry)
+                            picked.add(nm)
+                            if len(quality) + len(relevance) >= skill_num:
+                                break
+                    elif nm in by_name:
                         relevance.append(by_name[nm])
                         picked.add(nm)
                         if len(quality) + len(relevance) >= skill_num:
@@ -275,14 +288,27 @@ class SkillRecommendEngine:
         # 记录推荐 + resolve side（双向）
         client_user.recommended_skills = []
         for s in chosen:
-            side = self.resolve_side(s, client_user)
-            sha = staging_sha(s.path) if side == "staging" else (main_sha(s.path) or "")
+            if isinstance(s, dict) and s.get("source") == "skillhub":
+                side = "main"
+                sha = s["content_sha"]
+                skill_name = s["skill_id"]
+                rec = {
+                    "skill": skill_name,
+                    "branch": side,
+                    "hash": sha,
+                    "source": "skillhub",
+                    "display_name": s["display_name"],
+                    "source_path": s["source_path"],
+                }
+            else:
+                side = self.resolve_side(s, client_user)
+                sha = staging_sha(s.path) if side == "staging" else (main_sha(s.path) or "")
+                skill_name = s.name
+                rec = {"skill": skill_name, "branch": side, "hash": sha}
             self.reco_store.record(
-                user_id=client_user.user_id, skill_name=s.name, side=side, sha=sha,
+                user_id=client_user.user_id, skill_name=skill_name, side=side, sha=sha,
             )
-            client_user.recommended_skills.append(
-                {"skill": s.name, "branch": side, "hash": sha}
-            )
+            client_user.recommended_skills.append(rec)
         return chosen
 
     # ── 5.4 resolve_side：staging 优先达量 ───────────────────────

--- a/src/xskill/recommend/engine.py
+++ b/src/xskill/recommend/engine.py
@@ -64,17 +64,18 @@ class SkillRecommendEngine:
         self.canary_cfg = canary_config or CanaryConfig.from_dict(config.get("canary", {}))
         self.staging_need = self.rcfg["staging_need"] or self.canary_cfg.min_samples
         self._skill_index_cache: Optional[dict] = None
-        self._skillhub_cache: Optional[list[dict]] = None
+        self._skillhub_cache: Optional[tuple[tuple, list[dict]]] = None
         self._profile_fp_cache: dict[str, tuple] = {}  # user_id → 上次画像计算时的 atom 指纹
         self.skillhub = SkillHub.from_config(config, embed_client)
         self.client_registry = client_registry  # 用于 user_name → 目录名解析
 
     # ─§6 三方 skill 检索池 ────────────────────────────────────────
     def _skillhub_entries(self) -> list[dict]:
-        """三方 skill ``{name, vec}``（缓存）。禁用时为空。"""
-        if self._skillhub_cache is None:
-            self._skillhub_cache = self.skillhub.index()
-        return self._skillhub_cache
+        """三方 skill ``{name, vec}``（按内容指纹缓存）。禁用时为空。"""
+        fp = self.skillhub.fingerprint()
+        if self._skillhub_cache is None or self._skillhub_cache[0] != fp:
+            self._skillhub_cache = (fp, self.skillhub.index())
+        return self._skillhub_cache[1]
 
     def _combined_relevance(self) -> tuple[list[str], np.ndarray, dict[str, bool]]:
         """合并检索池：可分发 skill 的 desc 向量 + 三方 skill 向量。

--- a/src/xskill/recommend/skillhub.py
+++ b/src/xskill/recommend/skillhub.py
@@ -11,6 +11,7 @@
 from __future__ import annotations
 
 import hashlib
+import re
 from datetime import datetime
 from pathlib import Path
 
@@ -26,6 +27,19 @@ def _normalize(v: np.ndarray) -> np.ndarray:
     return v / n if n > 0 else v
 
 
+def _safe_id_part(value: str) -> str:
+    safe = re.sub(r"[^A-Za-z0-9_.-]+", "-", value).strip(".-")
+    return safe or "skill"
+
+
+def _content_sha(md: Path) -> str:
+    return hashlib.sha256(md.read_bytes()).hexdigest()[:16]
+
+
+def _path_hash(source_path: str) -> str:
+    return hashlib.sha256(source_path.encode("utf-8")).hexdigest()[:12]
+
+
 class SkillHub:
     """三方 skill 扫描器 + ux 查询。``enabled=False``（缺省）时为 no-op。"""
 
@@ -39,8 +53,7 @@ class SkillHub:
         cfg = skillhub_config(config)
         return cls(enabled=cfg["enabled"], hub_dir=cfg["dir"], embed_client=embed_client)
 
-    def index(self) -> list[dict]:
-        """返回 ``[{name, vec, description}]``。禁用 → 空 list；启用但目录缺失 → raise。"""
+    def _entries(self, *, include_vec: bool, require_description: bool) -> list[dict]:
         if not self.enabled:
             return []
         if not self.dir.is_dir():
@@ -48,19 +61,65 @@ class SkillHub:
                 f"skillhub.dir 不存在: {self.dir}（启用 skillhub 前请放置三方 skill）"
             )
         entries: list[dict] = []
-        for sub in sorted(self.dir.iterdir()):
-            if not sub.is_dir() or sub.name.startswith("."):
+        for md in sorted(self.dir.rglob("SKILL.md")):
+            sub = md.parent
+            try:
+                rel = sub.relative_to(self.dir).as_posix()
+            except ValueError:
                 continue
-            md = sub / "SKILL.md"
-            if not md.is_file():
+            if any(part.startswith(".") for part in Path(rel).parts):
                 continue
             fm, _body = fm_parse(md.read_text(encoding="utf-8"))
+            raw_name = fm.get("name") or sub.name
+            display_name = str(raw_name).strip() or sub.name
             desc = (fm.get("description") or "").strip()
-            if not desc:
+            if require_description and not desc:
                 continue
-            vec = _normalize(np.asarray(self.embed_client.encode(desc), dtype=float))
-            entries.append({"name": sub.name, "vec": vec, "description": desc})
+            content_sha = _content_sha(md)
+            path_hash = _path_hash(rel)
+            skill_id = f"{_safe_id_part(display_name)}@{path_hash}"
+            entry = {
+                "source": "skillhub",
+                "name": skill_id,
+                "skill_id": skill_id,
+                "display_name": display_name,
+                "source_path": rel,
+                "path_hash": path_hash,
+                "content_sha": content_sha,
+                "description": desc,
+                "path": sub,
+            }
+            if include_vec:
+                vec = _normalize(np.asarray(self.embed_client.encode(desc), dtype=float))
+                entry["vec"] = vec
+            entries.append(entry)
         return entries
+
+    def index(self) -> list[dict]:
+        """返回三方 skill 索引。禁用 → 空 list；启用但目录缺失 → raise。
+
+        skill 以 ``skillhub.dir`` 下任意层级中包含 ``SKILL.md`` 的目录为单位。
+        ``name`` / ``skill_id`` 是稳定分发身份，展示名放 ``display_name``。
+        """
+        return self._entries(include_vec=True, require_description=True)
+
+    def entry(self, name: str) -> dict | None:
+        """按 skill_id / source_path / 唯一 display_name 找当前磁盘上的 skill。"""
+        if not self.enabled:
+            return None
+        matches: list[dict] = []
+        for entry in self._entries(include_vec=False, require_description=False):
+            if name in {
+                entry["skill_id"], entry["name"], entry["source_path"],
+                entry["display_name"],
+            }:
+                matches.append(entry)
+        if len(matches) == 1:
+            return matches[0]
+        for entry in matches:
+            if name in {entry["skill_id"], entry["name"], entry["source_path"]}:
+                return entry
+        return None
 
     # ── §7 三方 skill ux 定位 / 版本 / 查询 ──────────────────────
     # 三方 skill 无 git → 版本号用 SKILL.md 内容 sha256 前 16 位；side 恒 "main"
@@ -69,19 +128,20 @@ class SkillHub:
     # 本类只负责读回。
     def skill_path(self, name: str) -> Path | None:
         """返回三方 skill 目录路径（含 ``SKILL.md``）；未启用 / 不存在 → None。"""
-        if not self.enabled:
+        entry = self.entry(name)
+        if entry is None:
             return None
-        sub = self.dir / name
+        sub = Path(entry["path"])
         if not sub.is_dir() or not (sub / "SKILL.md").is_file():
             return None
         return sub
 
     def content_sha(self, name: str) -> str | None:
         """三方 skill 版本号 = ``SKILL.md`` 内容 sha256 前 16 位。无 git → 内容哈希。"""
-        sub = self.skill_path(name)
-        if sub is None:
+        entry = self.entry(name)
+        if entry is None:
             return None
-        return hashlib.sha256((sub / "SKILL.md").read_bytes()).hexdigest()[:16]
+        return entry["content_sha"]
 
     def recent_ux_scores(self, name: str, days: int = 30) -> list[dict]:
         """读三方 skill 的 ``.ux_scores.jsonl``，按 ``days`` 截断近期。无数据 → []。"""

--- a/src/xskill/recommend/skillhub.py
+++ b/src/xskill/recommend/skillhub.py
@@ -95,6 +95,16 @@ class SkillHub:
             entries.append(entry)
         return entries
 
+    def fingerprint(self) -> tuple[tuple[str, str, str], ...]:
+        """当前 skillhub 内容指纹，用于推荐引擎缓存自动失效。
+
+        只包含稳定身份、相对路径和内容版本；新增、删除、改内容都会改变该值。
+        """
+        return tuple(
+            (entry["skill_id"], entry["source_path"], entry["content_sha"])
+            for entry in self._entries(include_vec=False, require_description=True)
+        )
+
     def index(self) -> list[dict]:
         """返回三方 skill 索引。禁用 → 空 list；启用但目录缺失 → raise。
 

--- a/src/xskill/team/client/daemon.py
+++ b/src/xskill/team/client/daemon.py
@@ -9,9 +9,12 @@ _tick 一轮：
 """
 from __future__ import annotations
 
+import io
+import json
 import logging
 import shutil
 import threading
+import zipfile
 from pathlib import Path
 
 from xskill.skill.git import run_git
@@ -149,6 +152,14 @@ class TeamClient:
                 logger.warning("bundle fetch failed: %s HTTP %s",
                                slot.skill_name, r.status_code)
                 continue
+            if getattr(slot, "source", "repo") == "skillhub":
+                self._apply_skillhub_archive(
+                    r.content, repo_dir, expected_sha=slot.sha,
+                    display_name=slot.display_name,
+                    source_path=slot.source_path,
+                )
+                self._install_to_ecosystems(repo_dir)
+                continue
             apply_repo_bundle(r.content, repo_dir)
             # 步骤 1 = manifest 给的 (side, sha)；2/3/4 = 共享助手
             reconcile_skill_side(
@@ -156,6 +167,52 @@ class TeamClient:
                 history=self.history, on_changed=self._install_to_ecosystems,
             )
         logger.info("reconciled %d skills", len(manifest.slots))
+
+    def _apply_skillhub_archive(
+        self, archive_bytes: bytes, dest_dir: Path, *, expected_sha: str,
+        display_name: str | None, source_path: str | None,
+    ) -> None:
+        """Install a non-git skillhub skill archive into the local skill directory."""
+        dest_dir = Path(dest_dir)
+        meta_path = dest_dir / ".xskill_skillhub.json"
+        if meta_path.is_file() and (dest_dir / "SKILL.md").is_file():
+            try:
+                meta = json.loads(meta_path.read_text(encoding="utf-8"))
+                if meta.get("sha") == expected_sha:
+                    return
+            except (OSError, ValueError):
+                pass
+
+        tmp_dir = dest_dir.with_name(f".{dest_dir.name}.tmp")
+        shutil.rmtree(tmp_dir, ignore_errors=True)
+        tmp_dir.mkdir(parents=True, exist_ok=True)
+        with zipfile.ZipFile(io.BytesIO(archive_bytes)) as zf:
+            root = tmp_dir.resolve()
+            for info in zf.infolist():
+                target = (tmp_dir / info.filename).resolve()
+                try:
+                    target.relative_to(root)
+                except ValueError:
+                    raise RuntimeError(f"unsafe skillhub archive path: {info.filename}")
+                if info.is_dir():
+                    target.mkdir(parents=True, exist_ok=True)
+                    continue
+                target.parent.mkdir(parents=True, exist_ok=True)
+                with zf.open(info) as src, open(target, "wb") as dst:
+                    shutil.copyfileobj(src, dst)
+        if not (tmp_dir / "SKILL.md").is_file():
+            shutil.rmtree(tmp_dir, ignore_errors=True)
+            raise RuntimeError("skillhub archive missing SKILL.md")
+        (tmp_dir / ".xskill_skillhub.json").write_text(
+            json.dumps({
+                "sha": expected_sha,
+                "display_name": display_name,
+                "source_path": source_path,
+            }, ensure_ascii=False),
+            encoding="utf-8",
+        )
+        shutil.rmtree(dest_dir, ignore_errors=True)
+        tmp_dir.replace(dest_dir)
 
     def _install_to_ecosystems(self, repo_dir: Path) -> None:
         """把一个已 checkout 好的 skill working copy 装到本机所有生态。

--- a/src/xskill/team/server/api.py
+++ b/src/xskill/team/server/api.py
@@ -11,10 +11,12 @@ client 完全信任 server；token 只挡组织外随机接入。
 from __future__ import annotations
 
 import hashlib
+import io
 import json
 import logging
 from pathlib import Path
 from typing import Callable
+import zipfile
 
 from fastapi import APIRouter, File, Form, Header, HTTPException, Request, UploadFile
 from fastapi.responses import Response
@@ -43,6 +45,7 @@ class _Ctx:
     total_slots: int = 100
     allow_anonymous_user: bool = True
     register_dir: Callable[[Path, str], None] | None = None
+    skillhub = None
 
 
 _ctx = _Ctx()
@@ -59,6 +62,7 @@ def init_team_context(
     total_slots: int,
     register_dir: Callable[[Path, str], None],
     allow_anonymous_user: bool = True,
+    skillhub=None,
 ) -> None:
     """create_app(team_server=True) 在 startup 时调用一次。"""
     _ctx.join_token = join_token
@@ -70,6 +74,7 @@ def init_team_context(
     _ctx.total_slots = total_slots
     _ctx.allow_anonymous_user = allow_anonymous_user
     _ctx.register_dir = register_dir
+    _ctx.skillhub = skillhub
 
 
 def _auth(token: str | None, client_id: str | None) -> str:
@@ -242,9 +247,27 @@ async def team_skill_bundle(
     _auth(x_xskill_token, x_xskill_client)
     repo_dir = _ctx.skill_dir / name
     if not (repo_dir / ".git").is_dir():
-        raise HTTPException(status_code=404, detail=f"skill not found: {name}")
+        hub = _ctx.skillhub
+        if hub is None:
+            raise HTTPException(status_code=404, detail=f"skill not found: {name}")
+        hub_dir = hub.skill_path(name)
+        if hub_dir is None:
+            raise HTTPException(status_code=404, detail=f"skill not found: {name}")
+        archive = _make_skillhub_archive(hub_dir)
+        return Response(content=archive, media_type="application/zip")
     bundle = make_repo_bundle(repo_dir)
     return Response(content=bundle, media_type="application/octet-stream")
+
+
+def _make_skillhub_archive(skill_dir: Path) -> bytes:
+    """Pack a non-git skillhub directory as a zip archive for thin clients."""
+    skill_dir = Path(skill_dir)
+    buf = io.BytesIO()
+    with zipfile.ZipFile(buf, "w", compression=zipfile.ZIP_DEFLATED) as zf:
+        for p in sorted(skill_dir.rglob("*")):
+            if p.is_file():
+                zf.write(p, p.relative_to(skill_dir).as_posix())
+    return buf.getvalue()
 
 
 @router.post("/push-edit", response_model=PushEditResponse)

--- a/src/xskill/team/server/skill_manifest.py
+++ b/src/xskill/team/server/skill_manifest.py
@@ -47,8 +47,26 @@ def _rank_key(skill: Skill) -> tuple[float, int]:
     return (avg if avg is not None else 0.0, skill.use_count)
 
 
-def _resolve_slot(skill: Skill, client_id: str, probability: float, bucket: str) -> SkillSlot:
+def _resolve_slot(
+    skill: Skill | dict, client_id: str, probability: float, bucket: str,
+) -> SkillSlot | None:
     """对一个 skill 现算它对该 client 的 side + sha。"""
+    if isinstance(skill, dict) and skill.get("source") == "skillhub":
+        eng = get_recommend_engine()
+        if eng is None or eng.skillhub.skill_path(skill["skill_id"]) is None:
+            return None
+        current_sha = eng.skillhub.content_sha(skill["skill_id"])
+        if not current_sha:
+            return None
+        return SkillSlot(
+            skill_name=skill["skill_id"],
+            side="main",
+            sha=current_sha,
+            bucket=bucket,
+            source="skillhub",
+            display_name=skill.get("display_name"),
+            source_path=skill.get("source_path"),
+        )
     if has_staging(skill.path):
         if _engine is not None:
             from xskill.recommend.client_user import ClientUser
@@ -110,7 +128,9 @@ def build_manifest(
     slots: list[SkillSlot] = []
     for idx, skill in enumerate(chosen):
         bucket = "ranked" if idx < ranked_slots else "recommended"
-        slots.append(_resolve_slot(skill, client_id, probability, bucket))
+        slot = _resolve_slot(skill, client_id, probability, bucket)
+        if slot is not None:
+            slots.append(slot)
     # 埋点：只记画像推荐位(recommended bucket)——推荐触发率衡量的就是这部分命中。
     # best-effort，记录失败绝不阻断同步。
     try:
@@ -151,7 +171,7 @@ def _pick_recommended(
     if _engine is not None:
         # 索引缺失时（rebuild --force 后到 /reindex 前的窗口）不能进引擎——
         # _combined_relevance 会 raise。退回 ux_tail（与既有 RECOMMENDER 守卫一致）。
-        if not (skill_dir / ".skill_index.pkl").is_file():
+        if not (skill_dir / ".skill_index.pkl").is_file() and not _engine._skillhub_entries():
             return ux_tail[:reco_slots]
         user = _engine.load_client_user(client_id)
         if user.client_interest is not None and user.client_interest.feature_tensor is not None:

--- a/src/xskill/team/shared/protocol.py
+++ b/src/xskill/team/shared/protocol.py
@@ -20,6 +20,7 @@ from pydantic import BaseModel, Field
 
 Side = Literal["main", "staging"]
 Bucket = Literal["ranked", "recommended"]
+SkillSource = Literal["repo", "skillhub"]
 
 
 class RegisterRequest(BaseModel):
@@ -72,6 +73,9 @@ class SkillSlot(BaseModel):
     side: Side
     sha: str
     bucket: Bucket         # ranked = ux_score 滑窗；recommended = SP3 画像位（SP1 占位）
+    source: SkillSource = "repo"
+    display_name: str | None = None
+    source_path: str | None = None
 
 
 class SyncResponse(BaseModel):

--- a/tests/test_skillhub.py
+++ b/tests/test_skillhub.py
@@ -294,6 +294,61 @@ class TestEngineSkillhubPool:
         assert slot.source_path == "hub-a/foo"
         assert slot.sha == entry["content_sha"]
 
+    def test_adding_skillhub_after_empty_scan_refreshes_recommendations(
+        self, tmp_path,
+    ):
+        skill_dir = tmp_path / "skills"
+        skill_dir.mkdir()
+        _write_index(skill_dir, [], dim=4)
+        hub_dir = tmp_path / "hub"
+        hub_dir.mkdir()
+        eng = SkillRecommendEngine(
+            config={
+                "recommend": {"quality_ratio": 0.0},
+                "skillhub": {"enabled": True, "dir": str(hub_dir)},
+            },
+            skill_dir=skill_dir,
+            traj_root=tmp_path / "traj",
+            embed_client=FakeEmbed(dim=4),
+            profile_db=tmp_path / "p.db",
+        )
+        q = FakeEmbed(dim=4).encode("django migration helper")
+        q = q / np.linalg.norm(q)
+        eng.profile_store.upsert(
+            "client-one",
+            feature_tensor=np.asarray([q]),
+            mean_tensor=q,
+            used_skills=[],
+        )
+        set_recommend_engine(eng)
+        try:
+            first = build_manifest(
+                client_id="client-one",
+                skill_dir=skill_dir,
+                probability=0.0,
+                ranked_slots=0,
+                total_slots=1,
+                traj_root=tmp_path / "traj",
+            )
+            assert first.slots == []
+
+            _write_hub_skill(
+                hub_dir, "hub-a/foo", "django migration helper", name="foo",
+            )
+            second = build_manifest(
+                client_id="client-one",
+                skill_dir=skill_dir,
+                probability=0.0,
+                ranked_slots=0,
+                total_slots=1,
+                traj_root=tmp_path / "traj",
+            )
+        finally:
+            set_recommend_engine(None)
+
+        assert len(second.slots) == 1
+        assert second.slots[0].source == "skillhub"
+
 
 # ── Team push path ───────────────────────────────────────────────
 

--- a/tests/test_skillhub.py
+++ b/tests/test_skillhub.py
@@ -6,14 +6,25 @@ TDD: 缺省关 no-op；启用扫描+向量化；启用但目录缺失抛错；�
 from __future__ import annotations
 
 import pickle
+import shutil
 import subprocess
 from pathlib import Path
 
 import numpy as np
 import pytest
+from fastapi import FastAPI
+from fastapi.testclient import TestClient
 
+from xskill.recommend.client_interest import ClientInterest
+from xskill.recommend.client_user import ClientUser
 from xskill.recommend.engine import SkillRecommendEngine
 from xskill.recommend.skillhub import SkillHub
+from xskill.team.client.daemon import TeamClient
+from xskill.team.client.state import ClientState
+from xskill.team.server import api as server_api
+from xskill.team.server.client_registry import ClientRegistry
+from xskill.team.server.skill_manifest import build_manifest, set_recommend_engine
+from xskill.team.shared.protocol import SkillSlot, SyncResponse
 
 
 class FakeEmbed:
@@ -46,11 +57,15 @@ def _make_main_skill(parent: Path, name: str, desc: str = "d"):
     return d
 
 
-def _write_hub_skill(hub_dir: Path, name: str, desc: str):
-    d = hub_dir / name
+def _write_hub_skill(
+    hub_dir: Path, rel_path: str, desc: str, *, name: str | None = None,
+):
+    d = hub_dir / rel_path
     d.mkdir(parents=True)
+    frontmatter_name = name or d.name
     (d / "SKILL.md").write_text(
-        f"---\nname: {name}\ndescription: {desc}\n---\n# {name}\n", encoding="utf-8")
+        f"---\nname: {frontmatter_name}\ndescription: {desc}\n---\n# {frontmatter_name}\n",
+        encoding="utf-8")
 
 
 def _write_index(skill_dir: Path, names: list[str], dim: int):
@@ -74,10 +89,14 @@ class TestSkillHub:
         _write_hub_skill(hub_dir, "bar", "react component gen")
         hub = SkillHub(enabled=True, hub_dir=hub_dir, embed_client=FakeEmbed(dim=4))
         entries = hub.index()
-        names = {e["name"] for e in entries}
+        names = {e["display_name"] for e in entries}
         assert names == {"foo", "bar"}
         for e in entries:
             assert abs(np.linalg.norm(e["vec"]) - 1.0) < 1e-6  # L2 归一
+            assert e["name"] == e["skill_id"]
+            assert e["source"] == "skillhub"
+            assert e["source_path"] in {"foo", "bar"}
+            assert e["content_sha"]
 
     def test_enabled_dir_missing_raises(self, tmp_path):
         hub = SkillHub(enabled=True, hub_dir=tmp_path / "nope", embed_client=FakeEmbed())
@@ -88,6 +107,64 @@ class TestSkillHub:
         hub = SkillHub.from_config({}, FakeEmbed())
         assert hub.enabled is False
         assert hub.index() == []
+
+    def test_recursively_scans_nested_skill_md_under_multiple_folders(self, tmp_path):
+        hub_dir = tmp_path / "hub"
+        _write_hub_skill(
+            hub_dir, "hub-a/excel/format", "spreadsheet format helper",
+            name="format-helper",
+        )
+        _write_hub_skill(
+            hub_dir, "hub-b/ops/deploy", "deployment runbook helper",
+            name="deploy-helper",
+        )
+        _write_hub_skill(
+            hub_dir, "hub-b/flat", "flat folder helper",
+            name="flat-helper",
+        )
+        (hub_dir / "hub-a" / "empty-folder").mkdir(parents=True)
+
+        hub = SkillHub(enabled=True, hub_dir=hub_dir, embed_client=FakeEmbed(dim=4))
+
+        entries = hub.index()
+
+        assert {e["source_path"] for e in entries} == {
+            "hub-a/excel/format",
+            "hub-b/ops/deploy",
+            "hub-b/flat",
+        }
+        assert {e["display_name"] for e in entries} == {
+            "format-helper",
+            "deploy-helper",
+            "flat-helper",
+        }
+
+    def test_duplicate_display_names_are_distinguished_by_relative_path(self, tmp_path):
+        hub_dir = tmp_path / "hub"
+        _write_hub_skill(hub_dir, "hub-a/foo", "django helper", name="foo")
+        _write_hub_skill(hub_dir, "hub-b/foo", "react helper", name="foo")
+
+        hub = SkillHub(enabled=True, hub_dir=hub_dir, embed_client=FakeEmbed(dim=4))
+
+        entries = sorted(hub.index(), key=lambda e: e["source_path"])
+
+        assert [e["display_name"] for e in entries] == ["foo", "foo"]
+        assert [e["source_path"] for e in entries] == ["hub-a/foo", "hub-b/foo"]
+        assert entries[0]["skill_id"] != entries[1]["skill_id"]
+
+    def test_same_name_and_content_are_still_distinguished_by_relative_path(
+        self, tmp_path,
+    ):
+        hub_dir = tmp_path / "hub"
+        _write_hub_skill(hub_dir, "hub-a/foo", "same helper", name="foo")
+        _write_hub_skill(hub_dir, "hub-b/foo", "same helper", name="foo")
+
+        hub = SkillHub(enabled=True, hub_dir=hub_dir, embed_client=FakeEmbed(dim=4))
+
+        entries = sorted(hub.index(), key=lambda e: e["source_path"])
+
+        assert entries[0]["content_sha"] == entries[1]["content_sha"]
+        assert entries[0]["skill_id"] != entries[1]["skill_id"]
 
 
 # ── 引擎检索池合并 ───────────────────────────────────────────────
@@ -113,9 +190,10 @@ class TestEngineSkillhubPool:
         q = FakeEmbed(dim=4).encode("django migration helper")
         q = q / np.linalg.norm(q)
         results = eng.relevance_search(q, top_k=5)
-        names = [n for n, _h in results]
-        assert "extfoo" in names  # 三方 skill 进了检索池
-        assert "s0" in names
+        all_names = [n for n, _is_hub in results]
+        hub_names = [n for n, is_hub in results if is_hub]
+        assert any(n.startswith("extfoo@") for n in hub_names)  # 三方 skill 进了检索池
+        assert "s0" in all_names
 
     def test_skillhub_not_in_quality_bucket(self, tmp_path):
         hub_dir = tmp_path / "hub"
@@ -131,3 +209,174 @@ class TestEngineSkillhubPool:
         results = eng.relevance_search(q, top_k=5)
         names = [n for n, _h in results]
         assert "extfoo" not in names
+
+    def test_recommends_existing_skillhub_entries_and_skips_deleted_cache(
+        self, tmp_path,
+    ):
+        skill_dir = tmp_path / "skills"
+        skill_dir.mkdir()
+        _write_index(skill_dir, [], dim=4)
+        hub_dir = tmp_path / "hub"
+        first = hub_dir / "hub-a" / "foo"
+        _write_hub_skill(hub_dir, "hub-a/foo", "django migration helper", name="foo")
+        _write_hub_skill(hub_dir, "hub-b/foo", "react component helper", name="foo")
+        eng = SkillRecommendEngine(
+            config={
+                "recommend": {"quality_ratio": 0.0},
+                "skillhub": {"enabled": True, "dir": str(hub_dir)},
+            },
+            skill_dir=skill_dir,
+            traj_root=tmp_path / "traj",
+            embed_client=FakeEmbed(dim=4),
+            profile_db=tmp_path / "p.db",
+        )
+        entries = sorted(eng._skillhub_entries(), key=lambda e: e["source_path"])
+        stale_id = entries[0]["skill_id"]
+        shutil.rmtree(first)
+
+        q = FakeEmbed(dim=4).encode("django migration helper")
+        q = q / np.linalg.norm(q)
+        user = ClientUser(
+            "u",
+            client_interest=ClientInterest("u", feature_tensor=np.asarray([q])),
+        )
+
+        picked = eng.get_skill_for_client(user, 2)
+
+        assert stale_id not in {p["skill_id"] for p in picked}
+        assert all(p["source"] == "skillhub" for p in picked)
+
+    def test_manifest_can_include_skillhub_slot_with_identity_and_version(
+        self, tmp_path,
+    ):
+        skill_dir = tmp_path / "skills"
+        skill_dir.mkdir()
+        _write_index(skill_dir, [], dim=4)
+        hub_dir = tmp_path / "hub"
+        _write_hub_skill(hub_dir, "hub-a/foo", "django migration helper", name="foo")
+        eng = SkillRecommendEngine(
+            config={
+                "recommend": {"quality_ratio": 0.0},
+                "skillhub": {"enabled": True, "dir": str(hub_dir)},
+            },
+            skill_dir=skill_dir,
+            traj_root=tmp_path / "traj",
+            embed_client=FakeEmbed(dim=4),
+            profile_db=tmp_path / "p.db",
+        )
+        q = FakeEmbed(dim=4).encode("django migration helper")
+        q = q / np.linalg.norm(q)
+        eng.profile_store.upsert(
+            "client-one",
+            feature_tensor=np.asarray([q]),
+            mean_tensor=q,
+            used_skills=[],
+        )
+        set_recommend_engine(eng)
+        try:
+            resp = build_manifest(
+                client_id="client-one",
+                skill_dir=skill_dir,
+                probability=0.0,
+                ranked_slots=0,
+                total_slots=1,
+                traj_root=tmp_path / "traj",
+            )
+        finally:
+            set_recommend_engine(None)
+
+        assert len(resp.slots) == 1
+        slot = resp.slots[0]
+        entry = eng.skillhub.index()[0]
+        assert slot.source == "skillhub"
+        assert slot.skill_name == entry["skill_id"]
+        assert slot.display_name == "foo"
+        assert slot.source_path == "hub-a/foo"
+        assert slot.sha == entry["content_sha"]
+
+
+# ── Team push path ───────────────────────────────────────────────
+
+class TestSkillhubTeamPush:
+    def _app(self, tmp_path, hub: SkillHub, reg: ClientRegistry):
+        skill_dir = tmp_path / "skills"
+        skill_dir.mkdir(exist_ok=True)
+        server_api.init_team_context(
+            join_token="tok",
+            client_registry=reg,
+            skill_dir=skill_dir,
+            traj_root=tmp_path / "traj",
+            probability=0.0,
+            ranked_slots=0,
+            total_slots=1,
+            register_dir=lambda _p, _l: None,
+            skillhub=hub,
+        )
+        app = FastAPI()
+        app.include_router(server_api.router)
+        return TestClient(app)
+
+    def test_server_serves_skillhub_archive_and_404_after_delete(self, tmp_path):
+        hub_dir = tmp_path / "hub"
+        skill_path = hub_dir / "hub-a" / "foo"
+        _write_hub_skill(hub_dir, "hub-a/foo", "django migration helper", name="foo")
+        hub = SkillHub(enabled=True, hub_dir=hub_dir, embed_client=FakeEmbed(dim=4))
+        entry = hub.index()[0]
+        reg = ClientRegistry(tmp_path / "clients.db")
+        client_id = reg.register(label="alice", hostname="host")
+        http = self._app(tmp_path, hub, reg)
+        headers = {"X-Xskill-Token": "tok", "X-Xskill-Client": client_id}
+
+        ok = http.get(f"/api/v1/team/skill/{entry['skill_id']}/bundle", headers=headers)
+        assert ok.status_code == 200
+        assert (ok.content[:2] == b"PK")  # zip archive
+
+        shutil.rmtree(skill_path)
+        missing = http.get(
+            f"/api/v1/team/skill/{entry['skill_id']}/bundle", headers=headers,
+        )
+        assert missing.status_code == 404
+
+    def test_client_materializes_skillhub_slot_without_git(self, tmp_path):
+        hub_dir = tmp_path / "hub"
+        _write_hub_skill(hub_dir, "hub-a/foo", "django migration helper", name="foo")
+        hub = SkillHub(enabled=True, hub_dir=hub_dir, embed_client=FakeEmbed(dim=4))
+        entry = hub.index()[0]
+        reg = ClientRegistry(tmp_path / "clients.db")
+        client_id = reg.register(label="alice", hostname="host")
+        http = self._app(tmp_path, hub, reg)
+        state = ClientState(
+            server_url="http://testserver",
+            client_id=client_id,
+            join_token="tok",
+        )
+        client = TeamClient(
+            state=state,
+            http=http,
+            skill_dir=tmp_path / "client_home" / ".xskill" / "skill",
+            cursor_path=tmp_path / "cursor.json",
+            history_path=tmp_path / "history.jsonl",
+            home_root=tmp_path / "client_home",
+            min_change_interval=0,
+        )
+        manifest = SyncResponse(
+            server_time=1.0,
+            slots=[
+                SkillSlot(
+                    skill_name=entry["skill_id"],
+                    side="main",
+                    sha=entry["content_sha"],
+                    bucket="recommended",
+                    source="skillhub",
+                    display_name=entry["display_name"],
+                    source_path=entry["source_path"],
+                )
+            ],
+        )
+
+        client.reconcile_skill_sides(manifest)
+
+        installed = client.skill_dir / entry["skill_id"]
+        assert (installed / "SKILL.md").is_file()
+        assert not (installed / ".git").exists()
+        assert (installed / ".xskill_skillhub.json").is_file()


### PR DESCRIPTION
## Summary

- Recursively scan skillhub folders and treat any directory containing `SKILL.md` as a skill.
- Allow duplicate display names by using a stable skillhub identity based on display name plus relative path hash.
- Include existing skillhub entries in recommended slots, verify existence before manifest push, and stop pushing deleted entries.
- Add server zip delivery and client materialization for non-git skillhub skills.
- Update dashboard skillhub lookup to use the same identity/path resolver.

## Tests

- `PYTHONPATH=/home/admin/traj2skill/src python3.11 -m pytest -q tests/test_skillhub.py tests/test_skillhub_ux.py tests/test_ux_query.py tests/test_team_client.py tests/test_team_server_api.py tests/test_recommend_gaps.py tests/test_recommend_engine.py tests/test_team_sync_profile.py tests/test_cli_version.py tests/test_cli_serve_guard.py tests/test_cli_stats.py tests/test_rebuild.py tests/test_team_cli_connect.py tests/test_team_cli_registry_list_client.py tests/test_team_cli_serve.py tests/test_team_create_app.py` (119 passed)
- `PYTHONPATH=/home/admin/traj2skill/src python3.11 -m py_compile src/xskill/recommend/skillhub.py src/xskill/recommend/engine.py src/xskill/team/server/skill_manifest.py src/xskill/team/server/api.py src/xskill/team/client/daemon.py src/xskill/team/shared/protocol.py src/xskill/dashboard/router.py src/xskill/api/app.py`
- `git diff --check`

## Not tested

- No real image/container pull-run validation was performed.
- No live server with real user trajectory data was exercised.
