### PR TITLE
feat(updater): 支持 server wheel 静默更新回退

### DIFF
--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -60,6 +60,35 @@ jobs:
       - name: Build sdist and wheel
         run: python -m build
 
+      - name: Verify release wheel contains xskill package code
+        run: |
+          python - <<'PY'
+          from pathlib import Path
+          import zipfile
+
+          wheels = sorted(Path("dist").glob("xskill-*.whl"))
+          if len(wheels) != 1:
+              raise SystemExit(f"expected exactly one xskill wheel, got {len(wheels)}: {wheels}")
+
+          with zipfile.ZipFile(wheels[0]) as zf:
+              names = set(zf.namelist())
+
+          required = {
+              "xskill/__init__.py",
+              "xskill/team/client/updater.py",
+              "xskill/team/server/api.py",
+          }
+          missing = sorted(required - names)
+          if missing:
+              raise SystemExit(f"wheel is missing required package files: {missing}")
+
+          package_py = [name for name in names if name.startswith("xskill/") and name.endswith(".py")]
+          if not package_py:
+              raise SystemExit("wheel does not contain xskill Python package code")
+
+          print(f"verified {wheels[0]} contains {len(package_py)} xskill Python files")
+          PY
+
       - name: Twine check
         run: twine check dist/*
 

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -37,6 +37,7 @@ dependencies = [
     "python-multipart",
     "uvicorn",
     "sse-starlette",
+    "packaging>=23",
     "rank-bm25>=0.2",
     # team 模式上传前的轨迹脱敏（team/client/redact.py）。脱敏是上传链路的
     # 强制环节，故列为主依赖而非 optional extra——缺库就该 import 失败。

--- a/src/xskill/config.py
+++ b/src/xskill/config.py
@@ -568,6 +568,13 @@ def get_team_clients_db_path() -> Path:
     return XSKILL_HOME / "team_clients.db"
 
 
+def get_team_server_whl_dir() -> Path:
+    """server 端静默更新回退 wheel 目录（~/.xskill/whls）。"""
+    d = XSKILL_HOME / "whls"
+    d.mkdir(parents=True, exist_ok=True)
+    return d
+
+
 def get_team_client_state_path() -> Path:
     """client 端连接信息（server_url / client_id / join_token）。"""
     return XSKILL_HOME / "team_client.json"

--- a/src/xskill/team/client/daemon.py
+++ b/src/xskill/team/client/daemon.py
@@ -300,7 +300,11 @@ class TeamClient:
     def run_forever(self) -> None:
         """阻塞循环。先起 collector ingester，再每 poll_interval 跑一轮 _tick。"""
         from xskill.team.client.updater import AutoUpdater
-        updater = AutoUpdater() if self.auto_update else None
+        updater = AutoUpdater(
+            server_url=self.state.server_url,
+            client_id=self.state.client_id,
+            join_token=self.state.join_token,
+        ) if self.auto_update else None
         if updater:
             updater.start()
         self.collector.start_ingesters()

--- a/src/xskill/team/client/updater.py
+++ b/src/xskill/team/client/updater.py
@@ -1,6 +1,8 @@
 """updater.py — xskill client 自动更新
 
 TeamClient 跑起来后每隔一段时间（默认 1 小时）查 PyPI，发现新版就升级并重启。
+如果 PyPI 查询或安装失败，且 client 已连接 team server，则读取 server 版本；
+server 版本高于本地版本时，下载 server 暴露的 wheel 并安装。
 
 重启机制
 ────────
@@ -11,20 +13,33 @@ TeamClient 跑起来后每隔一段时间（默认 1 小时）查 PyPI，发现�
 ────────
 - 包含预发版（a/b/rc），因为内部用 alpha 版本
 - 严格大于当前版本才升级，不降级
-- 网络/PyPI 故障直接跳过，不打断主循环
+- 网络/PyPI/server 故障不会打断主循环
 """
 from __future__ import annotations
 
 import logging
 import os
+from pathlib import Path
 import subprocess
 import sys
+import tempfile
 import threading
-from typing import Optional
+from typing import Any, Optional
 
 logger = logging.getLogger("xskill.team.client.updater")
 
 _PYPI_JSON_URL = "https://pypi.org/pypi/{package}/json"
+
+
+def _team_api_url(server_url: str, path: str) -> str:
+    return f"{server_url.rstrip('/')}/api/v1/team{path}"
+
+
+def _team_headers(join_token: str, client_id: str) -> dict[str, str]:
+    return {
+        "X-Xskill-Token": join_token,
+        "X-Xskill-Client": client_id,
+    }
 
 
 def _current_version(package: str) -> Optional[str]:
@@ -55,6 +70,59 @@ def _latest_pypi_version(package: str) -> Optional[str]:
         return str(max(all_versions))
     except Exception:
         logger.debug("updater: 查 PyPI 失败", exc_info=True)
+        return None
+
+
+def _server_version(
+    server_url: str,
+    join_token: str,
+    client_id: str,
+) -> dict[str, Any] | None:
+    """从 team server 读取版本信息。网络/鉴权失败返回 None。"""
+    import json
+    import urllib.request
+
+    req = urllib.request.Request(
+        _team_api_url(server_url, "/version"),
+        headers=_team_headers(join_token, client_id),
+    )
+    try:
+        with urllib.request.urlopen(req, timeout=10) as r:
+            return json.loads(r.read().decode("utf-8"))
+    except Exception:
+        logger.debug("updater: 查询 server 版本失败", exc_info=True)
+        return None
+
+
+def _download_server_wheel(
+    server_url: str,
+    join_token: str,
+    client_id: str,
+    dest_dir: Path,
+    filename: str | None,
+) -> Path | None:
+    """从 team server 下载 wheel 到临时目录。失败返回 None。"""
+    import urllib.request
+
+    safe_name = Path(filename or "xskill-server.whl").name
+    if not safe_name.endswith(".whl"):
+        safe_name = "xskill-server.whl"
+    dest_dir.mkdir(parents=True, exist_ok=True)
+    dest = dest_dir / safe_name
+    req = urllib.request.Request(
+        _team_api_url(server_url, "/wheel"),
+        headers=_team_headers(join_token, client_id),
+    )
+    try:
+        with urllib.request.urlopen(req, timeout=60) as r:
+            data = r.read()
+        if not data:
+            logger.warning("updater: server wheel 为空")
+            return None
+        dest.write_bytes(data)
+        return dest
+    except Exception:
+        logger.debug("updater: 下载 server wheel 失败", exc_info=True)
         return None
 
 
@@ -127,10 +195,16 @@ class AutoUpdater:
         package: str = "xskill",
         interval: float = 3600,       # 默认 1 小时
         pypi_url: str = "https://pypi.org/simple/",
+        server_url: str | None = None,
+        client_id: str | None = None,
+        join_token: str | None = None,
     ):
         self.package = package
         self.interval = interval
         self.pypi_url = pypi_url
+        self.server_url = server_url
+        self.client_id = client_id
+        self.join_token = join_token
         self._stop = threading.Event()
         self._thread: Optional[threading.Thread] = None
 
@@ -161,14 +235,19 @@ class AutoUpdater:
         if not current_str:
             logger.debug("updater: 无法读取当前版本，跳过本次检查")
             return
-
-        latest_str = _latest_pypi_version(self.package)
-        if not latest_str:
-            return   # 网络问题，静默跳过
-
         try:
             from packaging.version import Version
             current = Version(current_str)
+        except Exception:
+            logger.debug("updater: 当前版本不可解析: %s", current_str, exc_info=True)
+            return
+
+        latest_str = _latest_pypi_version(self.package)
+        if not latest_str:
+            self._check_server_fallback(current_str, current, reason="pypi_query_failed")
+            return
+
+        try:
             latest = Version(latest_str)
         except Exception:
             return
@@ -182,6 +261,8 @@ class AutoUpdater:
         if self._install(latest_str):
             _restart()   # 升级成功后重启，不会走到这行之后的代码
             # （_restart 在 Windows 上 os._exit；Linux 上 execv）
+            return
+        self._check_server_fallback(current_str, current, reason="pypi_install_failed")
 
     def _install(self, target_version: str) -> bool:
         """用 pip 升级到指定版本。返回是否成功。"""
@@ -201,4 +282,66 @@ class AutoUpdater:
             return False
         except Exception:
             logger.warning("updater: 执行 pip 失败", exc_info=True)
+            return False
+
+    def _check_server_fallback(self, current_str: str, current, *, reason: str) -> None:
+        """PyPI 不可用时，从 team server 下载同版本 wheel 回退升级。"""
+        if not (self.server_url and self.client_id and self.join_token):
+            logger.debug("updater: 无 server 回退配置，跳过（%s）", reason)
+            return
+
+        info = _server_version(self.server_url, self.join_token, self.client_id)
+        if not info:
+            return
+
+        server_version_str = str(info.get("version") or "")
+        try:
+            from packaging.version import Version
+            server_version = Version(server_version_str)
+        except Exception:
+            logger.debug("updater: server 版本不可解析: %s",
+                         server_version_str, exc_info=True)
+            return
+
+        if server_version <= current:
+            logger.debug("updater: server 版本 %s 不高于当前版本 %s",
+                         server_version_str, current_str)
+            return
+        if not info.get("wheel_available"):
+            logger.warning("updater: server 版本 %s 可用，但未提供 wheel",
+                           server_version_str)
+            return
+
+        with tempfile.TemporaryDirectory(prefix="xskill-update-") as td:
+            wheel = _download_server_wheel(
+                self.server_url,
+                self.join_token,
+                self.client_id,
+                Path(td),
+                str(info.get("wheel_filename") or ""),
+            )
+            if wheel is None:
+                return
+            logger.info("updater: PyPI 不可用（%s），改用 server wheel 升级到 %s",
+                        reason, server_version_str)
+            if self._install_wheel(wheel):
+                _restart()
+
+    def _install_wheel(self, wheel_path: Path) -> bool:
+        """用 pip 安装 server 下载的 wheel。返回是否成功。"""
+        cmd = [
+            sys.executable, "-m", "pip", "install", "--upgrade",
+            str(wheel_path),
+            "-q",
+        ]
+        try:
+            result = subprocess.run(cmd, capture_output=True, text=True)
+            if result.returncode == 0:
+                logger.info("updater: 安装 server wheel 成功: %s", wheel_path.name)
+                return True
+            logger.warning("updater: server wheel 安装失败:\n%s",
+                           result.stderr.strip() or result.stdout.strip())
+            return False
+        except Exception:
+            logger.warning("updater: 执行 pip 安装 server wheel 失败", exc_info=True)
             return False

--- a/src/xskill/team/server/api.py
+++ b/src/xskill/team/server/api.py
@@ -10,11 +10,17 @@ client 完全信任 server；token 只挡组织外随机接入。
 """
 from __future__ import annotations
 
+import base64
+import csv
 import hashlib
+import io
 import json
 import logging
 from pathlib import Path
+import tempfile
+import threading
 from typing import Callable
+import zipfile
 
 from fastapi import APIRouter, File, Form, Header, HTTPException, Request, UploadFile
 from fastapi.responses import FileResponse, Response
@@ -48,6 +54,7 @@ class _Ctx:
 
 
 _ctx = _Ctx()
+_WHEEL_BUILD_LOCK = threading.Lock()
 
 
 def init_team_context(
@@ -111,6 +118,197 @@ def _find_server_wheel(package: str = "xskill", version: str | None = None) -> P
     return matches[-1] if matches else None
 
 
+def _ensure_server_wheel(package: str = "xskill", version: str | None = None) -> Path | None:
+    """返回 server wheel；缓存缺失时从当前已安装 distribution 懒生成。"""
+    version = version or XSKILL_VERSION
+    wheel = _find_server_wheel(package=package, version=version)
+    if wheel is not None:
+        return wheel
+    with _WHEEL_BUILD_LOCK:
+        wheel = _find_server_wheel(package=package, version=version)
+        if wheel is not None:
+            return wheel
+        try:
+            return _build_installed_distribution_wheel(package, version)
+        except Exception:
+            logger.warning("failed to build server wheel for %s==%s",
+                           package, version, exc_info=True)
+            return None
+
+
+def _build_installed_distribution_wheel(package: str, version: str) -> Path | None:
+    """把当前环境中已安装的 package 重组为 wheel，并缓存到 ~/.xskill/whls。
+
+    这里不依赖源码 checkout，也不运行 ``python -m build``；只读取已安装
+    distribution 的 package 文件和 dist-info 元数据，重写 wheel 的 RECORD。
+    """
+    from importlib.metadata import PackageNotFoundError, distribution
+    from packaging.utils import canonicalize_name
+    from packaging.version import Version
+
+    try:
+        dist = distribution(package)
+    except PackageNotFoundError:
+        logger.warning("cannot build server wheel: distribution not found: %s", package)
+        return None
+
+    try:
+        if Version(dist.version) != Version(version):
+            logger.warning("cannot build server wheel: installed %s==%s, server version=%s",
+                           package, dist.version, version)
+            return None
+    except Exception:
+        logger.warning("cannot build server wheel: invalid version (%s, %s)",
+                       dist.version, version, exc_info=True)
+        return None
+
+    files = list(dist.files or [])
+    if not files:
+        logger.warning("cannot build server wheel: distribution file list unavailable")
+        return None
+
+    dist_info_dir = _distribution_dist_info_dir(files)
+    if not dist_info_dir:
+        logger.warning("cannot build server wheel: dist-info directory not found")
+        return None
+    if _distribution_is_editable(dist, files, dist_info_dir):
+        logger.warning("cannot build server wheel from editable install: %s", package)
+        return None
+
+    package_root = canonicalize_name(package).replace("-", "_")
+    entries = _distribution_wheel_entries(dist, files, dist_info_dir, package_root)
+    names = {name for name, _path in entries}
+    required = {f"{dist_info_dir}/METADATA", f"{dist_info_dir}/WHEEL"}
+    missing = sorted(required - names)
+    if missing:
+        logger.warning("cannot build server wheel: missing metadata files: %s", missing)
+        return None
+    if not any(name.startswith(f"{package_root}/") for name in names):
+        logger.warning("cannot build server wheel: package files not found: %s",
+                       package_root)
+        return None
+
+    tags = _distribution_wheel_tags(dist, dist_info_dir)
+    wheel_name = _wheel_filename(package, version, tags)
+    wheel_dir = get_team_server_whl_dir()
+    wheel_dir.mkdir(parents=True, exist_ok=True)
+    dest = wheel_dir / wheel_name
+    tmp = tempfile.NamedTemporaryFile(
+        prefix=f".{wheel_name}.", suffix=".tmp", dir=wheel_dir, delete=False,
+    )
+    tmp_path = Path(tmp.name)
+    tmp.close()
+    try:
+        _write_wheel_zip(entries, dist_info_dir, tmp_path)
+        tmp_path.replace(dest)
+        logger.info("generated server wheel: %s", dest)
+        return dest
+    except Exception:
+        tmp_path.unlink(missing_ok=True)
+        raise
+
+
+def _distribution_dist_info_dir(files) -> str | None:
+    for file in files:
+        rel = _dist_file_rel(file)
+        first = rel.split("/", 1)[0]
+        if first.endswith(".dist-info"):
+            return first
+    return None
+
+
+def _distribution_is_editable(dist, files, dist_info_dir: str) -> bool:
+    direct_url = f"{dist_info_dir}/direct_url.json"
+    for file in files:
+        if _dist_file_rel(file) != direct_url:
+            continue
+        path = Path(dist.locate_file(file))
+        try:
+            data = json.loads(path.read_text(encoding="utf-8"))
+        except Exception:
+            return False
+        return bool(data.get("dir_info", {}).get("editable"))
+    return False
+
+
+def _distribution_wheel_entries(
+    dist,
+    files,
+    dist_info_dir: str,
+    package_root: str,
+) -> list[tuple[str, Path]]:
+    skip_dist_info = {"RECORD", "INSTALLER", "REQUESTED", "direct_url.json"}
+    entries: dict[str, Path] = {}
+    for file in files:
+        rel = _dist_file_rel(file)
+        if not rel or rel.startswith("../") or rel.startswith("/"):
+            continue
+        parts = rel.split("/")
+        if "__pycache__" in parts or rel.endswith(".pyc"):
+            continue
+        if parts[0] == package_root:
+            pass
+        elif parts[0] == dist_info_dir:
+            if parts[-1] in skip_dist_info:
+                continue
+        else:
+            continue
+        path = Path(dist.locate_file(file))
+        if path.is_file():
+            entries[rel] = path
+    return sorted(entries.items())
+
+
+def _distribution_wheel_tags(dist, dist_info_dir: str) -> str:
+    wheel_file = Path(dist.locate_file(f"{dist_info_dir}/WHEEL"))
+    try:
+        text = wheel_file.read_text(encoding="utf-8")
+    except Exception:
+        return "py3-none-any"
+    tags = [
+        line.split(":", 1)[1].strip()
+        for line in text.splitlines()
+        if line.lower().startswith("tag:")
+    ]
+    return ".".join(tags) if tags else "py3-none-any"
+
+
+def _wheel_filename(package: str, version: str, tags: str) -> str:
+    from packaging.utils import canonicalize_name
+
+    name = canonicalize_name(package).replace("-", "_")
+    safe_version = str(version).replace("-", "_")
+    return f"{name}-{safe_version}-{tags}.whl"
+
+
+def _dist_file_rel(file) -> str:
+    return str(file).replace("\\", "/")
+
+
+def _write_wheel_zip(
+    entries: list[tuple[str, Path]],
+    dist_info_dir: str,
+    dest: Path,
+) -> None:
+    records: list[tuple[str, str, str]] = []
+    with zipfile.ZipFile(dest, "w", compression=zipfile.ZIP_DEFLATED) as zf:
+        for rel, path in entries:
+            data = path.read_bytes()
+            zf.writestr(rel, data)
+            digest = base64.urlsafe_b64encode(
+                hashlib.sha256(data).digest(),
+            ).rstrip(b"=").decode("ascii")
+            records.append((rel, f"sha256={digest}", str(len(data))))
+
+        record_rel = f"{dist_info_dir}/RECORD"
+        buf = io.StringIO()
+        writer = csv.writer(buf, lineterminator="\n")
+        for row in records:
+            writer.writerow(row)
+        writer.writerow((record_rel, "", ""))
+        zf.writestr(record_rel, buf.getvalue().encode("utf-8"))
+
+
 @router.get("/version")
 async def team_version(
     x_xskill_token: str | None = Header(default=None),
@@ -118,7 +316,7 @@ async def team_version(
 ) -> dict:
     """返回 server 当前 xskill 版本，以及同版本 wheel 是否可下载。"""
     _auth(x_xskill_token, x_xskill_client)
-    wheel = _find_server_wheel()
+    wheel = _ensure_server_wheel()
     return {
         "package": "xskill",
         "version": XSKILL_VERSION,
@@ -134,7 +332,7 @@ async def team_wheel(
 ) -> FileResponse:
     """下载 server 当前版本对应的 xskill wheel。"""
     _auth(x_xskill_token, x_xskill_client)
-    wheel = _find_server_wheel()
+    wheel = _ensure_server_wheel()
     if wheel is None:
         raise HTTPException(status_code=404, detail="xskill wheel not found")
     return FileResponse(

--- a/src/xskill/team/server/api.py
+++ b/src/xskill/team/server/api.py
@@ -17,8 +17,10 @@ from pathlib import Path
 from typing import Callable
 
 from fastapi import APIRouter, File, Form, Header, HTTPException, Request, UploadFile
-from fastapi.responses import Response
+from fastapi.responses import FileResponse, Response
 
+from xskill import __version__ as XSKILL_VERSION
+from xskill.config import get_team_server_whl_dir
 from xskill.team.server.client_registry import ClientRegistry
 from xskill.team.shared.git_bundle import fetch_branch_from_bundle, make_repo_bundle
 from xskill.team.server.skill_manifest import build_manifest
@@ -82,6 +84,64 @@ def _auth(token: str | None, client_id: str | None) -> str:
         raise HTTPException(status_code=403, detail="unknown client_id")
     _ctx.client_registry.touch(client_id)
     return client_id
+
+
+def _find_server_wheel(package: str = "xskill", version: str | None = None) -> Path | None:
+    """从 ~/.xskill/whls 中选择与 server 当前版本严格匹配的 wheel。"""
+    from packaging.utils import canonicalize_name, parse_wheel_filename
+    from packaging.version import Version
+
+    want_name = canonicalize_name(package)
+    version = version or XSKILL_VERSION
+    try:
+        want_version = Version(version)
+    except Exception:
+        logger.debug("invalid xskill version for wheel lookup: %s", version, exc_info=True)
+        return None
+
+    matches: list[Path] = []
+    for path in sorted(get_team_server_whl_dir().glob("*.whl")):
+        try:
+            name, wheel_version, _build, _tags = parse_wheel_filename(path.name)
+        except Exception:
+            logger.debug("skip invalid wheel filename: %s", path, exc_info=True)
+            continue
+        if canonicalize_name(str(name)) == want_name and wheel_version == want_version:
+            matches.append(path)
+    return matches[-1] if matches else None
+
+
+@router.get("/version")
+async def team_version(
+    x_xskill_token: str | None = Header(default=None),
+    x_xskill_client: str | None = Header(default=None),
+) -> dict:
+    """返回 server 当前 xskill 版本，以及同版本 wheel 是否可下载。"""
+    _auth(x_xskill_token, x_xskill_client)
+    wheel = _find_server_wheel()
+    return {
+        "package": "xskill",
+        "version": XSKILL_VERSION,
+        "wheel_available": wheel is not None,
+        "wheel_filename": wheel.name if wheel else None,
+    }
+
+
+@router.get("/wheel")
+async def team_wheel(
+    x_xskill_token: str | None = Header(default=None),
+    x_xskill_client: str | None = Header(default=None),
+) -> FileResponse:
+    """下载 server 当前版本对应的 xskill wheel。"""
+    _auth(x_xskill_token, x_xskill_client)
+    wheel = _find_server_wheel()
+    if wheel is None:
+        raise HTTPException(status_code=404, detail="xskill wheel not found")
+    return FileResponse(
+        wheel,
+        media_type="application/octet-stream",
+        filename=wheel.name,
+    )
 
 
 @router.post("/register", response_model=RegisterResponse)

--- a/tests/test_team_client_updater.py
+++ b/tests/test_team_client_updater.py
@@ -1,0 +1,158 @@
+from __future__ import annotations
+
+from pathlib import Path
+
+from xskill.team.client import updater as updater_mod
+from xskill.team.client.updater import AutoUpdater
+
+
+def test_pypi_newer_version_uses_pypi_and_skips_server(monkeypatch):
+    installed: list[str] = []
+    restarted: list[bool] = []
+
+    monkeypatch.setattr(updater_mod, "_current_version", lambda package: "1.0.0")
+    monkeypatch.setattr(updater_mod, "_latest_pypi_version", lambda package: "1.1.0")
+    monkeypatch.setattr(
+        updater_mod,
+        "_server_version",
+        lambda *args, **kwargs: (_ for _ in ()).throw(AssertionError("server fallback used")),
+    )
+    monkeypatch.setattr(updater_mod, "_restart", lambda: restarted.append(True))
+
+    updater = AutoUpdater(server_url="http://server", client_id="cid", join_token="tok")
+    monkeypatch.setattr(updater, "_install", lambda version: installed.append(version) or True)
+
+    updater._check_and_update()
+
+    assert installed == ["1.1.0"]
+    assert restarted == [True]
+
+
+def test_current_pypi_version_does_not_fallback_to_server(monkeypatch):
+    monkeypatch.setattr(updater_mod, "_current_version", lambda package: "1.0.0")
+    monkeypatch.setattr(updater_mod, "_latest_pypi_version", lambda package: "1.0.0")
+    monkeypatch.setattr(
+        updater_mod,
+        "_server_version",
+        lambda *args, **kwargs: (_ for _ in ()).throw(AssertionError("server fallback used")),
+    )
+
+    updater = AutoUpdater(server_url="http://server", client_id="cid", join_token="tok")
+    monkeypatch.setattr(
+        updater,
+        "_install",
+        lambda version: (_ for _ in ()).throw(AssertionError("pypi install used")),
+    )
+
+    updater._check_and_update()
+
+
+def test_pypi_query_failure_falls_back_to_server_wheel(monkeypatch):
+    installed_wheels: list[str] = []
+    restarted: list[bool] = []
+
+    monkeypatch.setattr(updater_mod, "_current_version", lambda package: "1.0.0")
+    monkeypatch.setattr(updater_mod, "_latest_pypi_version", lambda package: None)
+    monkeypatch.setattr(
+        updater_mod,
+        "_server_version",
+        lambda server_url, join_token, client_id: {
+            "version": "1.2.0",
+            "wheel_available": True,
+            "wheel_filename": "xskill-1.2.0-py3-none-any.whl",
+        },
+    )
+
+    def fake_download(
+        server_url: str,
+        join_token: str,
+        client_id: str,
+        dest_dir: Path,
+        filename: str | None,
+    ) -> Path:
+        wheel = dest_dir / (filename or "xskill-1.2.0-py3-none-any.whl")
+        wheel.write_bytes(b"wheel")
+        return wheel
+
+    monkeypatch.setattr(updater_mod, "_download_server_wheel", fake_download)
+    monkeypatch.setattr(updater_mod, "_restart", lambda: restarted.append(True))
+
+    updater = AutoUpdater(server_url="http://server", client_id="cid", join_token="tok")
+    monkeypatch.setattr(
+        updater,
+        "_install_wheel",
+        lambda wheel: installed_wheels.append(wheel.name) or True,
+    )
+
+    updater._check_and_update()
+
+    assert installed_wheels == ["xskill-1.2.0-py3-none-any.whl"]
+    assert restarted == [True]
+
+
+def test_pypi_install_failure_can_fallback_to_server_wheel(monkeypatch):
+    installed_wheels: list[str] = []
+
+    monkeypatch.setattr(updater_mod, "_current_version", lambda package: "1.0.0")
+    monkeypatch.setattr(updater_mod, "_latest_pypi_version", lambda package: "1.2.0")
+    monkeypatch.setattr(
+        updater_mod,
+        "_server_version",
+        lambda server_url, join_token, client_id: {
+            "version": "1.2.0",
+            "wheel_available": True,
+            "wheel_filename": "xskill-1.2.0-py3-none-any.whl",
+        },
+    )
+
+    def fake_download(
+        server_url: str,
+        join_token: str,
+        client_id: str,
+        dest_dir: Path,
+        filename: str | None,
+    ) -> Path:
+        wheel = dest_dir / (filename or "xskill-1.2.0-py3-none-any.whl")
+        wheel.write_bytes(b"wheel")
+        return wheel
+
+    monkeypatch.setattr(updater_mod, "_download_server_wheel", fake_download)
+    monkeypatch.setattr(updater_mod, "_restart", lambda: None)
+
+    updater = AutoUpdater(server_url="http://server", client_id="cid", join_token="tok")
+    monkeypatch.setattr(updater, "_install", lambda version: False)
+    monkeypatch.setattr(
+        updater,
+        "_install_wheel",
+        lambda wheel: installed_wheels.append(wheel.name) or True,
+    )
+
+    updater._check_and_update()
+
+    assert installed_wheels == ["xskill-1.2.0-py3-none-any.whl"]
+
+
+def test_server_fallback_skips_non_newer_server_version(monkeypatch):
+    downloaded: list[bool] = []
+
+    monkeypatch.setattr(updater_mod, "_current_version", lambda package: "1.2.0")
+    monkeypatch.setattr(updater_mod, "_latest_pypi_version", lambda package: None)
+    monkeypatch.setattr(
+        updater_mod,
+        "_server_version",
+        lambda server_url, join_token, client_id: {
+            "version": "1.2.0",
+            "wheel_available": True,
+            "wheel_filename": "xskill-1.2.0-py3-none-any.whl",
+        },
+    )
+    monkeypatch.setattr(
+        updater_mod,
+        "_download_server_wheel",
+        lambda *args, **kwargs: downloaded.append(True),
+    )
+
+    updater = AutoUpdater(server_url="http://server", client_id="cid", join_token="tok")
+    updater._check_and_update()
+
+    assert downloaded == []

--- a/tests/test_team_server_api.py
+++ b/tests/test_team_server_api.py
@@ -131,6 +131,11 @@ def test_wheel_endpoint_404_when_matching_wheel_missing(client, tmp_path, monkey
     (whl_dir / "xskill-1.2.2-py3-none-any.whl").write_bytes(b"old")
     monkeypatch.setattr(server_api, "XSKILL_VERSION", "1.2.3")
     monkeypatch.setattr(server_api, "get_team_server_whl_dir", lambda: whl_dir)
+    monkeypatch.setattr(
+        server_api,
+        "_build_installed_distribution_wheel",
+        lambda package, version: None,
+    )
 
     r = client.post("/api/v1/team/register", json={"token": "secret-token"})
     cid = r.json()["client_id"]
@@ -143,6 +148,40 @@ def test_wheel_endpoint_404_when_matching_wheel_missing(client, tmp_path, monkey
 
     r = client.get("/api/v1/team/wheel", headers=hdr)
     assert r.status_code == 404
+
+
+def test_version_lazily_generates_server_wheel(client, tmp_path, monkeypatch):
+    whl_dir = tmp_path / "whls"
+    whl_dir.mkdir()
+    generated = whl_dir / "xskill-1.2.3-py3-none-any.whl"
+    monkeypatch.setattr(server_api, "XSKILL_VERSION", "1.2.3")
+    monkeypatch.setattr(server_api, "get_team_server_whl_dir", lambda: whl_dir)
+
+    def fake_build(package: str, version: str) -> Path:
+        assert package == "xskill"
+        assert version == "1.2.3"
+        generated.write_bytes(b"generated-wheel")
+        return generated
+
+    monkeypatch.setattr(
+        server_api,
+        "_build_installed_distribution_wheel",
+        fake_build,
+    )
+
+    r = client.post("/api/v1/team/register", json={"token": "secret-token"})
+    cid = r.json()["client_id"]
+    hdr = {"X-Xskill-Token": "secret-token", "X-Xskill-Client": cid}
+
+    r = client.get("/api/v1/team/version", headers=hdr)
+    assert r.status_code == 200
+    assert r.json()["wheel_available"] is True
+    assert r.json()["wheel_filename"] == "xskill-1.2.3-py3-none-any.whl"
+    assert generated.read_bytes() == b"generated-wheel"
+
+    r = client.get("/api/v1/team/wheel", headers=hdr)
+    assert r.status_code == 200
+    assert r.content == b"generated-wheel"
 
 
 def test_upload_writes_traj_md_under_client_bucket(client, tmp_path):

--- a/tests/test_team_server_api.py
+++ b/tests/test_team_server_api.py
@@ -97,6 +97,54 @@ def test_unknown_client_rejected(client):
     assert r.status_code == 403
 
 
+def test_version_reports_matching_server_wheel(client, tmp_path, monkeypatch):
+    whl_dir = tmp_path / "whls"
+    whl_dir.mkdir()
+    wheel = whl_dir / "xskill-1.2.3-py3-none-any.whl"
+    wheel.write_bytes(b"wheel-bytes")
+    (whl_dir / "xskill-1.2.2-py3-none-any.whl").write_bytes(b"old")
+    (whl_dir / "other-1.2.3-py3-none-any.whl").write_bytes(b"other")
+    monkeypatch.setattr(server_api, "XSKILL_VERSION", "1.2.3")
+    monkeypatch.setattr(server_api, "get_team_server_whl_dir", lambda: whl_dir)
+
+    r = client.post("/api/v1/team/register", json={"token": "secret-token"})
+    cid = r.json()["client_id"]
+    hdr = {"X-Xskill-Token": "secret-token", "X-Xskill-Client": cid}
+
+    r = client.get("/api/v1/team/version", headers=hdr)
+    assert r.status_code == 200
+    assert r.json() == {
+        "package": "xskill",
+        "version": "1.2.3",
+        "wheel_available": True,
+        "wheel_filename": "xskill-1.2.3-py3-none-any.whl",
+    }
+
+    r = client.get("/api/v1/team/wheel", headers=hdr)
+    assert r.status_code == 200
+    assert r.content == b"wheel-bytes"
+
+
+def test_wheel_endpoint_404_when_matching_wheel_missing(client, tmp_path, monkeypatch):
+    whl_dir = tmp_path / "whls"
+    whl_dir.mkdir()
+    (whl_dir / "xskill-1.2.2-py3-none-any.whl").write_bytes(b"old")
+    monkeypatch.setattr(server_api, "XSKILL_VERSION", "1.2.3")
+    monkeypatch.setattr(server_api, "get_team_server_whl_dir", lambda: whl_dir)
+
+    r = client.post("/api/v1/team/register", json={"token": "secret-token"})
+    cid = r.json()["client_id"]
+    hdr = {"X-Xskill-Token": "secret-token", "X-Xskill-Client": cid}
+
+    r = client.get("/api/v1/team/version", headers=hdr)
+    assert r.status_code == 200
+    assert r.json()["wheel_available"] is False
+    assert r.json()["wheel_filename"] is None
+
+    r = client.get("/api/v1/team/wheel", headers=hdr)
+    assert r.status_code == 404
+
+
 def test_upload_writes_traj_md_under_client_bucket(client, tmp_path):
     r = client.post("/api/v1/team/register", json={"token": "secret-token"})
     cid = r.json()["client_id"]


### PR DESCRIPTION
## 变更内容

- server 新增 `GET /api/v1/team/version`：返回当前 server 端 xskill 版本，以及 `~/.xskill/whls` 中是否存在同版本 xskill wheel。
- server 新增 `GET /api/v1/team/wheel`：只下载包名为 `xskill` 且版本等于 server 当前版本的 wheel。
- client `AutoUpdater` 接入 team server 的 `server_url/client_id/join_token`，PyPI 查询失败或 PyPI 安装失败时，读取 server 版本并在 server 版本高于本地版本时下载 wheel 安装。
- release workflow 在 build 后校验 release wheel 必须包含 xskill 包代码，以及 updater/server API 关键文件。

## 行为约束

- 不降级：server 版本不高于本地版本时不安装。
- PyPI 正常且本地已是最新时，不走 server fallback。
- server wheel 目录允许存在旧 wheel 或其他包 wheel，但下载接口只选择当前 server 版本的 xskill wheel。

## 验证

- `python3.11 -m pytest tests/test_team_client_updater.py tests/test_team_server_api.py -q`：12 passed
- `python3.11 -m pytest tests/test_team_client_updater.py tests/test_team_server_api.py tests/test_team_client.py tests/test_cli_version.py -q`：19 passed
- `python3.11 -m pytest tests/test_team_*.py -q`：116 passed
- 本地用临时 outdir 构建 wheel，并执行 release workflow 同等 wheel 内容检查：通过
