### PR TITLE
fix(context): 控制 SkillEditAgent 工具结果上下文

### DIFF
--- a/docs/plans/2026-07-08-skilledit-context-spill-compact-plan.md
+++ b/docs/plans/2026-07-08-skilledit-context-spill-compact-plan.md
@@ -1,0 +1,183 @@
+# SkillEditAgent 上下文超限问题与改造计划
+
+日期：2026-07-08
+
+## 问题现象
+
+SkillEditAgent 在处理 `.candidates.yml` 累积候选时，LLM 请求出现两类问题：
+
+1. LLM API 持续超时。
+2. 请求 token 超过模型上下文上限，例如 `you requested 136832 tokens, max is 131071`。
+
+表面看起来像 SkillEditAgent 把所有 candidates 和源轨迹一次性塞进 prompt。实际不是初始 prompt 暴力拼接，而是多轮工具调用历史累积导致的等效结果。
+
+## 当前根因
+
+SkillEditAgent 初始 user message 只包含 skill 场景、候选 `atom_id / weightscore / note`、目标路径等信息，不直接展开全部源轨迹。
+
+问题发生在工具调用之后：
+
+1. `TaskAgent` 落盘 AtomTask 时会保存完整 `raw_segment`。
+2. `atom_task_read(atom_id)` 必须返回完整 AtomTask JSON，其中包含 `raw_segment`。
+3. Agno 会把工具返回作为后续请求的历史消息继续发给模型。
+4. 当 SkillEditAgent 连续读取多个 atom 或 trajectory 片段时，旧工具结果会在消息历史里累计。
+5. 原来的上下文剪裁只处理 `look/readfile`，没有处理 `atom_task_read/read_traj/read_file/skill_read`。
+
+因此，从 API 视角看，后续请求会携带大量 raw segment，效果等价于把源轨迹塞进 prompt。
+
+## 约束
+
+1. `atom_task_read` 必须返回 `raw_segment`，不能直接删掉原始证据。
+2. `read_traj` 没有摘要，不能依赖摘要替代原文。
+3. trim 不能破坏 agent 的证据可追溯性：被移出上下文的内容必须可回读。
+4. 不能随意删除 OpenAI/Agno 的 tool-call 消息配对；旧工具结果应该被替换成短占位，而不是移除消息。
+
+## 已完成改造
+
+### 1. 工具结果 spill
+
+在 `ContextManager` 的 trim 逻辑中扩展可剪裁工具：
+
+- `atom_task_read`
+- `read_traj`
+- `read_file`
+- `skill_read`
+- 保留原有 `look/readfile`
+
+当上下文达到 `max_context * 0.85` 时：
+
+- `look` 旧结果继续替换为短标记。
+- 读文件类工具结果写入 `/tmp/xskill/skilleditagent/<timestamp>/<uuid>_<tool>.txt`。
+- 原 tool result 消息替换为短占位，包含：
+  - `tool_name`
+  - `spill_path`
+  - 原内容字符数
+  - 回读提示
+  - 如果是 `atom_task_read`，额外保留 `atom_id / traj_id / offset_start / offset_end / intent / summary / raw_segment_chars`
+
+### 2. `read_file` 支持 `/tmp`
+
+`read_file` 允许读取：
+
+- skill workspace 下文件
+- `/tmp` 下文件，包括 `/tmp/xskill/skilleditagent/...`
+
+越界路径仍会报错，并列出允许读取的 roots。
+
+### 3. `read_file` 增加行窗口参数
+
+`read_file` 当前签名：
+
+```python
+read_file(path: str, offset: int = 1, limit: int = 200) -> str
+```
+
+参数语义：
+
+- `offset`：1-based 开始行号
+- `limit`：读取行数
+
+返回头只保留：
+
+```text
+source_path: <agent 传入的原始 path>
+resolved_path: <实际解析后的绝对 path>
+line_range: [offset, offset + returned_lines)
+--- file content ---
+<content>
+```
+
+示例：
+
+```text
+source_path: /tmp/xskill/skilleditagent/readfile-demo.txt
+resolved_path: /tmp/xskill/skilleditagent/readfile-demo.txt
+line_range: [2, 4)
+--- file content ---
+L2 selected
+L3 selected
+```
+
+## 后续改造计划
+
+### Phase 1：稳定 spill 机制
+
+1. 给 spill 文件增加 run 级目录标识，最好与 SkillEditAgent trace sink 的 skill/timestamp 对齐。
+2. 在日志中记录每次 spill 的 tool name、原始字符数、spill path、触发时估算 token。
+3. 给 `/tmp/xskill/skilleditagent` 增加清理策略，例如保留最近 N 天或最近 N 个 run。
+4. 增加测试覆盖：
+   - `read_traj` 旧结果 spill。
+   - `read_file` 旧结果 spill。
+   - 已经 spill 的 tool result 不重复 spill。
+   - 超长兜底 `force_all=True` 时仍保留最近可追溯路径。
+
+### Phase 2：增加 compact 阶段
+
+当 spill 后估算 token 仍超过 `compact_token_limit` 时，触发 LLM compact。
+
+compact 输入：
+
+- system prompt
+- turn0 scenario/userinfo
+- 旧历史中保留的 spill 占位和关键 tool call 轨迹
+- 最近 N 轮完整消息
+
+compact 输出需要包含：
+
+- 已读证据摘要
+- 已形成的可复用规则和坑位
+- 待处理 candidates / atom_id 列表
+- 已写文件和待写文件
+- 所有可回读的 `spill_path`
+
+compact 后继续运行时，保留：
+
+1. system message
+2. turn0 user scenario
+3. compact 摘要 message
+4. 最近 N 轮完整 tool-call 配对
+
+当前已实现：
+
+- `ContextManager` 支持 `compact_token_limit`
+- `ContextManager` 支持注入 `compact_fn(prompt) -> summary`
+- 已加入 compact prompt 模板
+- spill 后若仍超过 `compact_token_limit`，会调用 `compact_fn`
+- 生产 `agno_factory` 从 `llm/llm_skill` 合并后的配置读取 `compact_token_limit`
+- 未显式注入 `compact_fn` 时，使用当前 Agno model 的 `invoke` 发起真实 compact 请求
+- compact 后会将 history 收敛为：system、turn0 user、compact summary、最近完整消息块
+- 最近消息保留会避开孤立 `tool` message，避免破坏 OpenAI/DeepSeek tool-call 结构
+
+尚未完成：
+
+- 尚未在 trace 中记录 compact 事件
+- 尚未做 spill 文件清理策略
+- 尚未在真实 GLM-V5.1-internal 配置下跑回放
+
+### Phase 3：配置化
+
+当前配置项放在 `llm` 或 `llm_skill` 段，`llm_skill` 可覆盖 `llm`：
+
+```yaml
+llm:
+  compact_token_limit: 100000
+  compact_keep_recent_messages: 6
+```
+
+仍建议后续补充：
+
+- `spill_retention_days`
+- `spill_root`
+- trace 事件开关或 trace 字段格式
+
+### Phase 4：观测与回归
+
+1. 在 SkillEditAgent trace 里记录 trim/spill/compact 事件。
+2. 增加端到端测试：构造多个大 `raw_segment` atom，验证请求历史不会超过配置上限。
+3. 在真实 GLM-V5.1-internal 配置下跑一次回放，确认不会再触发 131071 token 超限。
+
+## 当前状态
+
+已完成基础 spill、`read_file(offset, limit)`、`list_files` 完整路径输出，以及
+compact prompt、可注入 `compact_fn`、从配置读取 compact 阈值、生产 Agno model
+真实 compact 调用、最近消息块安全保留。

--- a/src/xskill/agents/agent_tools.py
+++ b/src/xskill/agents/agent_tools.py
@@ -11,7 +11,7 @@ those from config at their own boundary.
 
 from __future__ import annotations
 
-import json, logging
+import json, logging, tempfile
 from datetime import date, datetime
 from pathlib import Path
 
@@ -135,6 +135,15 @@ def _slugify(name: str) -> str:
     return name.strip().lower().replace("_", "-").replace(" ", "-")
 
 
+def _is_relative_to(path: Path, root: Path) -> bool:
+    """Python 3.9 compatible Path.is_relative_to."""
+    try:
+        path.relative_to(root)
+        return True
+    except ValueError:
+        return False
+
+
 def _sanitize_frontmatter_dates(fm: dict) -> dict:
     """不让 LLM 写的日期字段污染 frontmatter。
     - created: 必须是合法 ISO date 且 ≤ 今天；否则替换成今天（保留历史 created 优先）
@@ -216,23 +225,82 @@ def search_similar_trajs(query: str, top_k: int = 5, filter: str = "all") -> str
 
 
 @tool(name="read_file")
-def read_file(path: str) -> str:
-    """Read an arbitrary file under the project root."""
-    p = Path(path)
-    root = agent_tool_config.skill_dir.parent
-    try:
-        p.resolve().relative_to(root.resolve())
-    except ValueError:
-        return f"error: outside project root ({path})"
+def read_file(path: str, offset: int = 1, limit: int = 200) -> str:
+    """Read a file under the skill workspace or /tmp spill area.
 
-    if not p.exists():
+    SkillEditAgent may receive trimmed tool results that point at files under
+    /tmp/xskill/skilleditagent. Use read_file(spill_path, offset, limit) to
+    reload those raw tool results in line windows when the short placeholder is
+    insufficient.
+
+    Args:
+        path: File path under the skill workspace or /tmp.
+        offset: 1-based start line.
+        limit: Number of lines to read from offset.
+    """
+    try:
+        line_offset = int(offset)
+        line_limit = int(limit)
+    except (TypeError, ValueError):
+        return f"error: offset and limit must be integers (offset={offset!r}, limit={limit!r})"
+    if line_offset < 1:
+        return f"error: offset must be >= 1 (got {line_offset})"
+    if line_limit < 1:
+        return f"error: limit must be >= 1 (got {line_limit})"
+
+    p = Path(path)
+    configured_root = agent_tool_config.skill_dir or agent_tool_config.atom_skill_dir
+    roots: list[Path] = []
+    if configured_root is not None:
+        roots.append(Path(configured_root).parent.resolve())
+    roots.append(Path(tempfile.gettempdir()).resolve())
+    roots = list(dict.fromkeys(roots))
+    resolved = p.resolve()
+    try:
+        allowed = any(_is_relative_to(resolved, root) for root in roots)
+    except OSError as e:
+        return f"error: path resolution failed ({path}): {e}"
+    if not allowed:
+        allowed_block = "\n".join(f"- {root}" for root in roots)
+        return (
+            "error: outside allowed read roots\n"
+            f"source_path: {path}\n"
+            f"resolved_path: {resolved}\n"
+            f"allowed_roots:\n{allowed_block}"
+        )
+
+    if not resolved.exists():
         return f"error: file not found ({path})"
 
     try:
-        content = p.read_text(encoding="utf-8")
-        if len(content) > 10000:
-            return content[:10000] + f"\n\n... (truncated, full length {len(content)} chars)"
-        return content
+        content = resolved.read_text(encoding="utf-8")
+        lines = content.splitlines(keepends=True)
+        total_lines = len(lines)
+        if line_offset > total_lines + 1:
+            return (
+                "error: offset outside file\n"
+                f"source_path: {path}\n"
+                f"resolved_path: {resolved}\n"
+                f"line_offset: {line_offset}\n"
+                f"total_lines: {total_lines}"
+            )
+        start = line_offset - 1
+        selected_lines = lines[start:start + line_limit]
+        selected = "".join(selected_lines)
+        line_end_exclusive = line_offset + len(selected_lines)
+        header = (
+            f"source_path: {path}\n"
+            f"resolved_path: {resolved}\n"
+            f"line_range: [{line_offset}, {line_end_exclusive})\n"
+            "--- file content ---\n"
+        )
+        if len(selected) > 10000:
+            return (
+                header + selected[:10000]
+                + f"\n\n... (truncated, selected length {len(selected)} chars; "
+                f"full file length {len(content)} chars)"
+            )
+        return header + selected
     except Exception as e:
         return f"error: read failed ({e})"
 
@@ -862,7 +930,7 @@ def make_task_agent_tools(
 
 @tool(name="list_files")
 def list_files(path: str) -> str:
-    """列目录下的文件 / 子目录。
+    """列目录下的文件 / 子目录，返回可直接传给 read_file 的完整路径。
 
     给 SkillEditAgent 用来摸清当前 skill 已有什么文件（避免重复写、便于增量
     更新）。路径必须在 skill_dir 范围内；越界返回 error。
@@ -881,7 +949,8 @@ def list_files(path: str) -> str:
     if not entries:
         return "(empty)"
     return "\n".join(
-        f"{'[dir] ' if e.is_dir() else ''}{e.name}" for e in entries
+        f"{'[dir] ' if e.is_dir() else '[file] '}{e.resolve()}{'/' if e.is_dir() else ''}"
+        for e in entries
     )
 
 

--- a/src/xskill/agents/agent_tools.py
+++ b/src/xskill/agents/agent_tools.py
@@ -234,7 +234,7 @@ def read_file(path: str, offset: int = 1, limit: int = 200) -> str:
     insufficient.
 
     Args:
-        path: File path under the skill workspace or /tmp.
+        path: File path under the skill workspace or /tmp/xskill/skilleditagent (spill dir).
         offset: 1-based start line.
         limit: Number of lines to read from offset.
     """
@@ -253,7 +253,7 @@ def read_file(path: str, offset: int = 1, limit: int = 200) -> str:
     roots: list[Path] = []
     if configured_root is not None:
         roots.append(Path(configured_root).parent.resolve())
-    roots.append(Path(tempfile.gettempdir()).resolve())
+    roots.append((Path(tempfile.gettempdir()) / "xskill" / "skilleditagent").resolve())
     roots = list(dict.fromkeys(roots))
     resolved = p.resolve()
     try:

--- a/src/xskill/agents/agno_factory.py
+++ b/src/xskill/agents/agno_factory.py
@@ -65,7 +65,8 @@ def _wrap_with_context_mgmt(model, llm_cfg: dict):
     """把弃窗单趟的上下文自管理（spec §4.5）套到 model.invoke 外层。
 
     - max_context 配置优先,缺省 200K + warning（``resolve_max_context``）。
-    - 发请求前到 85% 主动剪裁旧 look/readfile 工具返回（纯截断,不调模型）。
+    - 发请求前到 85% 主动剪裁旧 look/readfile 工具返回。
+    - 若 llm/llm_skill 配了 compact_token_limit，剪裁后仍超限时做一次摘要。
     - 唯一底层兜底：抓后端"上下文超长"报错 → 再剪 → 重发一次。
     - 记后端真实 prompt_tokens 供 ``context_budget()`` 工具读。
 
@@ -73,7 +74,7 @@ def _wrap_with_context_mgmt(model, llm_cfg: dict):
     """
     from xskill.agents.context_budget import ContextManager, resolve_max_context
     max_ctx = resolve_max_context(llm_cfg)
-    cm = ContextManager(max_ctx)
+    cm = ContextManager(max_ctx, config=llm_cfg)
     model.invoke = cm.wrap(model.invoke)
     return model
 

--- a/src/xskill/agents/context_budget.py
+++ b/src/xskill/agents/context_budget.py
@@ -3,17 +3,19 @@
 
 弃窗单趟拆分把"全轨迹 User 地图"喂一次,agent 用 ``look`` 工具按需读 assistant
 正文。一条怪物轨迹（数万行）下,反复 ``look`` 的返回会把对话历史撑大。这里实现
-**纯剪裁**的上下文自管理（不调模型压缩,见 ADR：我们选纯剪裁不用 agno 自带 LLM
-压缩）：
+上下文自管理：
 
 1. **分母 max_context**：无统一查询 API。**配置优先**（``llm.max_context``）；
    缺省 **200K** 并打一条 warning（提醒用户按自己模型上限反注释配置）。
 2. **主动剪裁**：每次发请求前,若历史估算 token 到 max_context 的 **85%**,把旧的
-   ``look`` / ``readfile`` 工具返回 message 的 content **纯截断**（look 结果可
-   重读,丢了安全）。从最旧的开始剪,剪到回落 85% 以下为止。
-3. **最底层兜底（唯一）**：抓住后端抛的"上下文超长"报错 → 再剪一轮历史 →
+   ``look`` 工具结果替换成短标记；把 SkillEdit 的读文件类工具结果 spill 到
+   ``/tmp/xskill/skilleditagent``，message 里只保留摘要 + ``spill_path``。
+   从最旧的开始剪,剪到回落 85% 以下为止。
+3. **可选 compact**：如果本轮剪裁后仍超过 ``compact_token_limit``，调用同一个
+   model 做一次工作记忆摘要，然后保留 system、首轮 user、摘要和最近完整消息块。
+4. **最底层兜底（唯一）**：抓住后端抛的"上下文超长"报错 → 再剪一轮历史 →
    **重发一次**。就这一条,不做解析上限学分母、不做多触发统一。
-4. **真实已用 token**：每次请求拿到 ``usage.prompt_tokens`` 写进 thread-local,
+5. **真实已用 token**：每次请求拿到 ``usage.prompt_tokens`` 写进 thread-local,
    供 TaskAgent 的 ``context_budget()`` 工具读"后端真实已用"。
 
 线程模型：watcher 并发拆多条 traj,每条在各自线程跑一个 agent.run()。用
@@ -21,17 +23,57 @@
 """
 from __future__ import annotations
 
+import json
 import logging
+import tempfile
 import threading
-from typing import Any
+import time
+import uuid
+from copy import copy
+from pathlib import Path
+from typing import Any, Callable
 
 logger = logging.getLogger("xskill.context_budget")
 
 DEFAULT_MAX_CONTEXT = 200_000          # 配置缺省时的兜底上限（spec §4.5）
 TRIM_TRIGGER_RATIO = 0.85              # 到上限 85% 触发主动剪裁
 CHARS_PER_TOKEN = 4                    # 4 字符/token 粗估（仅估未发出去那部分）
-_TRIMMABLE_TOOLS = ("look", "readfile")
+DEFAULT_SPILL_ROOT = Path(tempfile.gettempdir()) / "xskill" / "skilleditagent"
+_TRIMMABLE_TOOLS = (
+    "look", "readfile", "read_file", "atom_task_read", "read_traj", "skill_read",
+)
+_SPILLABLE_TOOLS = ("readfile", "read_file", "atom_task_read", "read_traj", "skill_read")
 _TRIM_MARK = "[…look 旧结果已剪裁,需要可重新 look…]"
+_COMPACT_MARK = "[compacted_skill_edit_agent_memory]"
+
+COMPACT_PROMPT_TEMPLATE = """You are compacting SkillEditAgent working memory.
+
+Keep only information needed to continue editing the skill safely.
+
+You must preserve:
+1. The original task scenario and target skill name.
+2. Candidate atom_ids, weightscore, intent, summary, and unresolved work.
+3. Evidence already read from atom_task_read/read_traj/read_file/skill_read.
+4. Any concrete rules, pitfalls, commands, or file edits already inferred.
+5. Files already read, files already written, and pending files to edit.
+6. All spill_path values needed to reload full evidence later.
+
+Do not invent evidence.
+Do not drop unresolved candidates.
+Do not copy long raw trajectory text; summarize it and keep spill_path.
+
+Output sections:
+## Current Goal
+## Candidate Status
+## Evidence Summary
+## Derived Rules
+## File State
+## Pending Actions
+## Reloadable Spill Paths
+
+Conversation history to compact:
+{history}
+"""
 
 # 上下文超长报错的特征关键词（不同后端措辞不一,只做子串命中即兜底重发）。
 _OVERLONG_HINTS = (
@@ -83,11 +125,90 @@ def resolve_max_context(llm_cfg: dict) -> int:
 
 def _msg_content_str(msg: Any) -> str:
     c = getattr(msg, "content", None)
+    if c is None and isinstance(msg, dict):
+        c = msg.get("content")
     if isinstance(c, str):
         return c
     if c is None:
         return ""
     return str(c)
+
+
+def _msg_role(msg: Any) -> str:
+    role = getattr(msg, "role", None)
+    if role is None and isinstance(msg, dict):
+        role = msg.get("role")
+    return str(role or "")
+
+
+def _msg_tool_call_id(msg: Any) -> str:
+    value = getattr(msg, "tool_call_id", None)
+    if value is None and isinstance(msg, dict):
+        value = msg.get("tool_call_id")
+    return str(value or "")
+
+
+def _tool_name(msg: Any) -> str:
+    name = getattr(msg, "tool_name", None) or getattr(msg, "name", None)
+    if name is None and isinstance(msg, dict):
+        name = msg.get("tool_name") or msg.get("name")
+    return str(name or "")
+
+
+def _assistant_tool_call_ids(msg: Any) -> list[str]:
+    calls = getattr(msg, "tool_calls", None)
+    if calls is None and isinstance(msg, dict):
+        calls = msg.get("tool_calls")
+    ids: list[str] = []
+    for call in calls or []:
+        value = None
+        if isinstance(call, dict):
+            value = call.get("id")
+        else:
+            value = getattr(call, "id", None)
+        if value:
+            ids.append(str(value))
+    return ids
+
+
+def _set_msg_role(msg: Any, role: str) -> None:
+    if isinstance(msg, dict):
+        msg["role"] = role
+        return
+    try:
+        msg.role = role
+    except (AttributeError, TypeError):
+        pass
+
+
+def _new_summary_message(template: Any, content: str) -> Any:
+    """Create a compact-summary message shaped like existing history messages."""
+    if isinstance(template, dict):
+        return {"role": "assistant", "content": content}
+    try:
+        msg = copy(template)
+    except Exception:  # pylint: disable=broad-exception-caught
+        from types import SimpleNamespace
+        return SimpleNamespace(role="assistant", content=content)
+    _set_msg_role(msg, "assistant")
+    _replace_tool_content(msg, content)
+    for attr in ("tool_name", "name", "tool_call_id", "tool_calls"):
+        if hasattr(msg, attr):
+            try:
+                setattr(msg, attr, None)
+            except (AttributeError, TypeError):
+                pass
+    return msg
+
+
+def _positive_int_or_none(value: Any) -> int | None:
+    if value in (None, ""):
+        return None
+    try:
+        parsed = int(value)
+    except (TypeError, ValueError):
+        return None
+    return parsed if parsed > 0 else None
 
 
 def _estimate_history_tokens(messages: list) -> int:
@@ -98,15 +219,136 @@ def _estimate_history_tokens(messages: list) -> int:
     return chars // CHARS_PER_TOKEN
 
 
+def build_compact_prompt(messages: list) -> str:
+    """Build the LLM prompt used to compact SkillEditAgent working memory."""
+    parts: list[str] = []
+    for i, msg in enumerate(messages or [], 1):
+        role = _msg_role(msg) or "unknown"
+        tool = _tool_name(msg)
+        title = f"### message {i}: role={role}"
+        if tool:
+            title += f" tool={tool}"
+        parts.append(title)
+        parts.append(_msg_content_str(msg))
+    return COMPACT_PROMPT_TEMPLATE.format(history="\n\n".join(parts))
+
+
+def _safe_recent_tail(messages: list, keep_recent_messages: int) -> list:
+    """Return a recent tail without breaking assistant tool_calls/tool messages."""
+    tail_count = max(0, int(keep_recent_messages))
+    if not messages or not tail_count:
+        return []
+    blocks: list[list] = []
+    i = 0
+    while i < len(messages):
+        msg = messages[i]
+        role = _msg_role(msg)
+        if role == "tool":
+            i += 1
+            continue
+        tool_call_ids = _assistant_tool_call_ids(msg)
+        if role == "assistant" and tool_call_ids:
+            block = [msg]
+            remaining = set(tool_call_ids)
+            j = i + 1
+            while j < len(messages) and _msg_role(messages[j]) == "tool":
+                tool_id = _msg_tool_call_id(messages[j])
+                if tool_id and remaining and tool_id not in remaining:
+                    break
+                block.append(messages[j])
+                if tool_id:
+                    remaining.discard(tool_id)
+                j += 1
+                if not remaining:
+                    break
+            if not remaining and len(block) > 1:
+                blocks.append(block)
+            i = max(j, i + 1)
+            continue
+        blocks.append([msg])
+        i += 1
+
+    selected: list = []
+    count = 0
+    for block in reversed(blocks):
+        selected = block + selected
+        count += len(block)
+        if count >= tail_count:
+            break
+    return selected
+
+
 def _is_trimmable_tool_msg(msg: Any) -> bool:
-    if getattr(msg, "role", None) != "tool":
+    role = getattr(msg, "role", None)
+    if role is None and isinstance(msg, dict):
+        role = msg.get("role")
+    if role != "tool":
         return False
-    name = (getattr(msg, "tool_name", None) or getattr(msg, "name", None) or "")
-    return str(name) in _TRIMMABLE_TOOLS
+    return _tool_name(msg) in _TRIMMABLE_TOOLS
+
+
+def _is_already_trimmed(content: str) -> bool:
+    return content == _TRIM_MARK or content.startswith("[trimmed_tool_result]")
+
+
+def _safe_tool_filename(tool_name: str) -> str:
+    chars = []
+    for ch in tool_name:
+        chars.append(ch if ch.isalnum() or ch in ("-", "_") else "_")
+    return "".join(chars) or "tool"
+
+
+def _atom_task_summary(content: str) -> list[str]:
+    try:
+        data = json.loads(content)
+    except Exception:  # pylint: disable=broad-exception-caught
+        return []
+    if not isinstance(data, dict):
+        return []
+    lines: list[str] = []
+    for key in ("atom_id", "traj_id", "offset_start", "offset_end", "intent", "summary"):
+        val = data.get(key)
+        if val not in (None, ""):
+            lines.append(f"{key}: {str(val).replace(chr(10), ' ')[:500]}")
+    raw = data.get("raw_segment")
+    if isinstance(raw, str):
+        lines.append(f"raw_segment_chars: {len(raw)}")
+    return lines
+
+
+def _spill_tool_result(msg: Any, content: str, spill_root: Path) -> str:
+    """把旧工具结果写到 spill 文件,返回留在上下文里的短占位。"""
+    tool_name = _tool_name(msg)
+    run_dir = spill_root / time.strftime("%Y%m%d-%H%M%S")
+    run_dir.mkdir(parents=True, exist_ok=True)
+    path = run_dir / f"{uuid.uuid4().hex}_{_safe_tool_filename(tool_name)}.txt"
+    path.write_text(content, encoding="utf-8")
+    lines = [
+        "[trimmed_tool_result]",
+        f"tool_name: {tool_name}",
+        f"spill_path: {path}",
+        f"chars: {len(content)}",
+        "reload: call read_file(spill_path, offset=1, limit=200) and page as needed",
+    ]
+    if tool_name == "atom_task_read":
+        lines.extend(_atom_task_summary(content))
+    return "\n".join(lines)
+
+
+def _replace_tool_content(msg: Any, content: str) -> bool:
+    try:
+        msg.content = content
+        return True
+    except (AttributeError, TypeError):
+        if isinstance(msg, dict):
+            msg["content"] = content
+            return True
+    return False
 
 
 def _trim_old_look_results(messages: list, target_tokens: int,
-                           *, force_all: bool = False) -> int:
+                           *, force_all: bool = False,
+                           spill_root: Path = DEFAULT_SPILL_ROOT) -> int:
     """从最旧的 look/readfile 工具返回开始纯截断,直到估算回落 target 以下。
 
     ``force_all=True`` 时无视估算,把所有可剪的 look/readfile 返回一律剪掉
@@ -119,27 +361,115 @@ def _trim_old_look_results(messages: list, target_tokens: int,
             break
         if not _is_trimmable_tool_msg(m):
             continue
-        if _msg_content_str(m) == _TRIM_MARK:
+        original = _msg_content_str(m)
+        if _is_already_trimmed(original):
             continue
-        try:
-            m.content = _TRIM_MARK
+        name = _tool_name(m)
+        replacement = (
+            _spill_tool_result(m, original, spill_root)
+            if name in _SPILLABLE_TOOLS else _TRIM_MARK
+        )
+        if _replace_tool_content(m, replacement):
             trimmed += 1
-        except (AttributeError, TypeError):
-            continue
     return trimmed
+
+
+def _compact_history_in_place(
+    messages: list,
+    *,
+    compact_fn: Callable[[str], str],
+    keep_recent_messages: int,
+) -> bool:
+    """Compact old history while preserving system, turn0 user, and recent tail."""
+    if not messages:
+        return False
+    system_msg = next((m for m in messages if _msg_role(m) == "system"), None)
+    first_user = next((m for m in messages if _msg_role(m) == "user"), None)
+    tail = _safe_recent_tail(messages, keep_recent_messages)
+    prompt = build_compact_prompt(messages)
+    summary = (compact_fn(prompt) or "").strip()
+    if not summary:
+        return False
+    template = system_msg or first_user or messages[0]
+    summary_msg = _new_summary_message(
+        template,
+        _COMPACT_MARK + "\n" + summary,
+    )
+    new_messages: list = []
+    for msg in (system_msg, first_user):
+        if msg is not None and msg not in new_messages:
+            new_messages.append(msg)
+    new_messages.append(summary_msg)
+    for msg in tail:
+        if msg not in new_messages:
+            new_messages.append(msg)
+    messages[:] = new_messages
+    return True
+
+
+def _response_text(resp: Any, assistant_message: Any | None = None) -> str:
+    content = getattr(resp, "content", None)
+    if content is None and isinstance(resp, dict):
+        content = resp.get("content")
+    if content is None and assistant_message is not None:
+        content = getattr(assistant_message, "content", None)
+    if content is None:
+        return ""
+    if isinstance(content, str):
+        return content
+    return str(content)
+
+
+def _model_compact_fn(original_invoke: Callable[..., Any]) -> Callable[[str], str]:
+    def compact(prompt: str) -> str:
+        from agno.models.message import Message
+
+        assistant_message = Message(role="assistant", content=None)
+        resp = original_invoke(
+            [Message(role="user", content=prompt)],
+            assistant_message=assistant_message,
+        )
+        return _response_text(resp, assistant_message)
+
+    return compact
 
 
 class ContextManager:
     """把 model.invoke 包成"发请求前主动剪裁 + 超长兜底重发 + 记真实已用"。
 
     构造时拿 ``max_context``（已 resolve）。``wrap(original_invoke)`` 返回新的
-    invoke,生产/测试都能套。剪裁直接改传进来的 ``messages`` 列表里
-    look/readfile 工具返回的 content（纯截断,不调模型）。
+    invoke,生产/测试都能套。剪裁直接改传进来的 ``messages`` 列表里：
+    ``look`` 旧结果替换成短标记；SkillEdit 读文件类工具结果先 spill 到
+    ``/tmp/xskill/skilleditagent``，上下文只留摘要和可回读路径。
     """
 
-    def __init__(self, max_context: int):
+    def __init__(
+        self,
+        max_context: int,
+        spill_root: Path | str | None = None,
+        compact_token_limit: int | None = None,
+        compact_keep_recent_messages: int = 6,
+        compact_fn: Callable[[str], str] | None = None,
+        config: dict | None = None,
+    ):
+        cfg = config or {}
+        if spill_root is None and cfg.get("spill_root"):
+            spill_root = cfg.get("spill_root")
+        if compact_token_limit is None:
+            compact_token_limit = _positive_int_or_none(cfg.get("compact_token_limit"))
+        if cfg.get("compact_keep_recent_messages") not in (None, ""):
+            configured_keep = _positive_int_or_none(cfg.get("compact_keep_recent_messages"))
+            if configured_keep is not None:
+                compact_keep_recent_messages = configured_keep
+
         self.max_context = int(max_context)
         self.trigger = int(self.max_context * TRIM_TRIGGER_RATIO)
+        self.spill_root = Path(spill_root) if spill_root is not None else DEFAULT_SPILL_ROOT
+        self.compact_token_limit = (
+            int(compact_token_limit) if compact_token_limit is not None else None
+        )
+        self.compact_keep_recent_messages = int(compact_keep_recent_messages)
+        self.compact_fn = compact_fn
 
     @staticmethod
     def _is_overlong_error(exc: Exception) -> bool:
@@ -150,13 +480,36 @@ class ContextManager:
         """返回包好上下文自管理的 invoke。"""
         def managed_invoke(messages, **kwargs):
             set_max_context(self.max_context)
-            # 1) 主动剪裁：到 85% 就剪旧 look 结果（纯截断,不调模型）。
+            # 1) 主动剪裁：到 85% 就剪旧工具结果（纯截断/spill,不调模型）。
             est = _estimate_history_tokens(messages)
+            trimmed = 0
             if est >= self.trigger:
-                n = _trim_old_look_results(messages, self.trigger)
-                if n:
-                    logger.info("上下文到 %d/%d token,主动剪裁 %d 条旧 look 结果",
-                                est, self.max_context, n)
+                trimmed = _trim_old_look_results(
+                    messages, self.trigger, spill_root=self.spill_root,
+                )
+                if trimmed:
+                    logger.info("上下文到 %d/%d token,主动剪裁 %d 条旧工具结果",
+                                est, self.max_context, trimmed)
+            if (
+                trimmed
+                and self.compact_token_limit is not None
+                and _estimate_history_tokens(messages) > self.compact_token_limit
+            ):
+                compact_fn = self.compact_fn or _model_compact_fn(original_invoke)
+                try:
+                    compacted = _compact_history_in_place(
+                        messages,
+                        compact_fn=compact_fn,
+                        keep_recent_messages=self.compact_keep_recent_messages,
+                    )
+                except Exception as exc:  # noqa: BLE001
+                    compacted = False
+                    logger.warning("上下文 compact 失败,继续使用剪裁后的历史：%s", exc)
+                if compacted:
+                    logger.info(
+                        "上下文仍超过 compact_token_limit=%d,已压缩历史到 %d 条消息",
+                        self.compact_token_limit, len(messages or []),
+                    )
             try:
                 resp = original_invoke(messages, **kwargs)
             except Exception as exc:  # noqa: BLE001 — 唯一底层兜底
@@ -165,7 +518,8 @@ class ContextManager:
                 # 2) 超长兜底（唯一）：再狠剪一轮 → 重发一次。
                 logger.warning("后端报上下文超长,剪裁历史后重发一次：%s", exc)
                 _trim_old_look_results(messages, self.max_context // 2,
-                                       force_all=True)
+                                       force_all=True,
+                                       spill_root=self.spill_root)
                 resp = original_invoke(messages, **kwargs)
             # 3) 记后端真实 prompt_tokens（context_budget 工具读这个）。
             self._record_prompt_tokens(resp)

--- a/src/xskill/agents/context_budget.py
+++ b/src/xskill/agents/context_budget.py
@@ -230,7 +230,7 @@ def build_compact_prompt(messages: list) -> str:
             title += f" tool={tool}"
         parts.append(title)
         parts.append(_msg_content_str(msg))
-    return COMPACT_PROMPT_TEMPLATE.format(history="\n\n".join(parts))
+    return COMPACT_PROMPT_TEMPLATE.replace("{history}", "\n\n".join(parts))
 
 
 def _safe_recent_tail(messages: list, keep_recent_messages: int) -> list:
@@ -263,6 +263,10 @@ def _safe_recent_tail(messages: list, keep_recent_messages: int) -> list:
                     break
             if not remaining and len(block) > 1:
                 blocks.append(block)
+            elif block:
+                # incomplete block: at minimum keep the assistant message
+                # so it isn't silently dropped from the compact tail
+                blocks.append([block[0]])
             i = max(j, i + 1)
             continue
         blocks.append([msg])
@@ -491,8 +495,7 @@ class ContextManager:
                     logger.info("上下文到 %d/%d token,主动剪裁 %d 条旧工具结果",
                                 est, self.max_context, trimmed)
             if (
-                trimmed
-                and self.compact_token_limit is not None
+                self.compact_token_limit is not None
                 and _estimate_history_tokens(messages) > self.compact_token_limit
             ):
                 compact_fn = self.compact_fn or _model_compact_fn(original_invoke)

--- a/src/xskill/agents/skill_edit_agent.py
+++ b/src/xskill/agents/skill_edit_agent.py
@@ -197,8 +197,9 @@ commit message 写明本次基于哪些 atom_id 整理，例如：
 - AtomTaskRead(atom_id) — 读 atom JSON
 - ReadTraj(traj_id, offset_start, offset_end) — 按行号取轨迹原文（offset 即 1-based 行号）
 - SkillRead(skill_name) — 读现有 SKILL.md（更新场景用）
-- read_file(path) — 读取 skill_base_path 下任意已有文件内容（如 scripts/、references/）
-- list_files(path) — 列目录文件
+- read_file(path, offset=1, limit=200) — 按 1-based 行号窗口读取 skill workspace
+  或 /tmp 下的 spill 文件；trim 后的 ``spill_path`` 也用它分页回读
+- list_files(path) — 列目录文件，返回可直接传给 read_file 的完整路径
 - write_file(path, content) — 写任意文件到 skill_dir 下
 - commit_baby_to_main(skill_name, message) — 仅 baby 分支可用
 - commit_to_staging(skill_name, message) — 仅 main 分支可用

--- a/src/xskill/config.py
+++ b/src/xskill/config.py
@@ -66,6 +66,12 @@ llm:
                          # default (a warning is logged). Uncomment and set it
                          # to YOUR model's real context limit (e.g. 128000 for
                          # gpt-4o, 64000 for deepseek-chat).
+  # compact_token_limit: 120000  # optional; after trimming/spilling old tool
+                         # results, if the estimated history is still above this
+                         # limit, ask the same chat model to summarize old
+                         # SkillEditAgent memory. Leave commented to disable.
+  # compact_keep_recent_messages: 6 # optional; recent complete message blocks
+                         # kept verbatim after compact. Default 6.
   # temperature: 0.0     # optional; default 0 (deterministic)
   # request_timeout: 60  # optional; per-request wall-clock cap in seconds
                          # (default 60). Explicit so an unreachable endpoint

--- a/tests/test_agno_factory_probe_smoke.py
+++ b/tests/test_agno_factory_probe_smoke.py
@@ -106,6 +106,56 @@ def test_factory_builds_real_agno_agent():
     assert agent.model.timeout is not None
 
 
+def test_context_management_reads_compact_config_and_calls_compactor(tmp_path):
+    """生产包装从 llm_cfg 读取 compact 配置,并用原 model.invoke 做摘要请求。"""
+    from agno.models.response import ModelResponse
+    from xskill.agents.agno_factory import _wrap_with_context_mgmt
+
+    calls: list[dict] = []
+
+    class _FakeModel:
+        def invoke(self, messages, assistant_message=None, **_kwargs):
+            calls.append({
+                "messages": messages,
+                "assistant_message": assistant_message,
+            })
+            if len(calls) == 1:
+                assert len(messages) == 1
+                assert "SkillEditAgent working memory" in messages[0].content
+                if assistant_message is not None:
+                    assistant_message.role = "assistant"
+                    assistant_message.content = "COMPACT SUMMARY"
+                return ModelResponse(role="assistant", content="COMPACT SUMMARY")
+            return ModelResponse(role="assistant", content="final", input_tokens=10)
+
+    model = _wrap_with_context_mgmt(_FakeModel(), {
+        "max_context": 1000,
+        "compact_token_limit": 20,
+        "compact_keep_recent_messages": 2,
+        "spill_root": str(tmp_path / "spill"),
+    })
+    assistant_message = Message(role="assistant", content=None)
+    messages = [
+        Message(role="system", content="SkillEditAgent system prompt"),
+        Message(role="user", content="turn0 scenario"),
+        Message(role="assistant", content="old reasoning"),
+        Message(role="tool", content="OLD_ATOM_RESULT\n" + ("x" * 8000),
+                tool_name="atom_task_read", tool_call_id="call_old"),
+        Message(role="assistant", content="recent reasoning"),
+        Message(role="user", content="continue"),
+    ]
+
+    model.invoke(messages=messages, assistant_message=assistant_message)
+
+    assert len(calls) == 2
+    final_messages = calls[1]["messages"]
+    assert [m.role for m in final_messages] == [
+        "system", "user", "assistant", "assistant", "user",
+    ]
+    assert "COMPACT SUMMARY" in final_messages[2].content
+    assert "spill_path:" in calls[0]["messages"][0].content
+
+
 def _tarpit_server():
     """开一个本地"陷阱"端口：接受 TCP 连接但永不回包——模拟防火墙 DROP /
     黑洞路由式的不可达端点（连接成功但响应永远不来）。纯本机，零外网。"""

--- a/tests/test_skill_tools_atom.py
+++ b/tests/test_skill_tools_atom.py
@@ -80,6 +80,61 @@ class TestReadTraj:
         assert out.startswith("error")
 
 
+class TestReadFile:
+    def test_reads_tmp_spill_file_with_path_context(self, tmp_path):
+        skill_dir, _ = _setup(tmp_path)
+        agent_tools.init_skill_authoring_tool_context(
+            skill_dir, skill_dir, {"skill_opt": {"enabled": False}},
+        )
+        spill = Path("/tmp/xskill/skilleditagent") / f"{tmp_path.name}-spill.txt"
+        spill.parent.mkdir(parents=True, exist_ok=True)
+        spill.write_text("spilled raw tool result\n", encoding="utf-8")
+
+        out = agent_tools.read_file.entrypoint(str(spill))
+
+        assert "source_path:" in out
+        assert "resolved_path:" in out
+        assert str(spill) in out
+        assert "spilled raw tool result" in out
+
+    def test_reads_line_window_with_offset_and_limit(self, tmp_path):
+        skill_dir, _ = _setup(tmp_path)
+        agent_tools.init_skill_authoring_tool_context(
+            skill_dir, skill_dir, {"skill_opt": {"enabled": False}},
+        )
+        spill = Path("/tmp/xskill/skilleditagent") / f"{tmp_path.name}-window.txt"
+        spill.parent.mkdir(parents=True, exist_ok=True)
+        spill.write_text("L1\nL2\nL3\nL4\n", encoding="utf-8")
+
+        out = agent_tools.read_file.entrypoint(str(spill), offset=2, limit=2)
+
+        assert "source_path:" in out
+        assert "resolved_path:" in out
+        assert "line_range: [2, 4)" in out
+        assert "line_offset:" not in out
+        assert "line_limit:" not in out
+        assert "total_lines:" not in out
+        assert "L2\nL3\n" in out
+        assert "L1\n" not in out
+        assert "L4\n" not in out
+
+
+class TestListFiles:
+    def test_returns_paths_read_file_can_use(self, tmp_path):
+        skill_dir, _ = _setup(tmp_path)
+        agent_tools.init_skill_authoring_tool_context(
+            skill_dir, skill_dir, {"skill_opt": {"enabled": False}},
+        )
+        note = skill_dir / "notes.md"
+        note.write_text("hello from listed file\n", encoding="utf-8")
+
+        listing = agent_tools.list_files.entrypoint(str(skill_dir))
+
+        assert str(note) in listing
+        out = agent_tools.read_file.entrypoint(str(note), offset=1, limit=20)
+        assert "hello from listed file" in out
+
+
 class TestNewSkillFolder:
     def test_creates_directory_with_skeleton(self, tmp_path):
         skill_dir, _ = _setup(tmp_path)

--- a/tests/test_task_agent.py
+++ b/tests/test_task_agent.py
@@ -851,6 +851,144 @@ class TestContextManager:
         # 旧 look 返回被剪成标记
         assert sent["look_content"] == _TRIM_MARK
 
+    def test_trim_spills_atom_task_read_result_with_metadata(self, tmp_path):
+        """SkillEditAgent 的旧 atom_task_read 结果应落临时文件,上下文只留摘要+路径。"""
+        import json
+        import re
+        from xskill.agents.context_budget import ContextManager
+
+        class _Msg:
+            def __init__(self, role, content, tool_name=None):
+                self.role = role
+                self.content = content
+                self.tool_name = tool_name
+
+        atom_payload = {
+            "atom_id": "atom_traj_demo_0001",
+            "traj_id": "traj_demo",
+            "offset_start": 10,
+            "offset_end": 30,
+            "intent": "修复 SkillEditAgent 上下文超限",
+            "summary": "读 atom 后 raw_segment 过大导致下一轮请求超窗",
+            "raw_segment": "RAW_SEGMENT_SHOULD_NOT_STAY_IN_CONTEXT\n" * 500,
+        }
+        original_tool_content = json.dumps(atom_payload, ensure_ascii=False)
+        messages = [
+            _Msg("user", "scenario"),
+            _Msg("tool", original_tool_content, "atom_task_read"),
+        ]
+        sent = {}
+
+        def fake_invoke(msgs, **_keyword_arguments):
+            sent["tool_content"] = msgs[1].content
+            return {"usage": {"prompt_tokens": 123}}
+
+        cm = ContextManager(max_context=1000, spill_root=tmp_path / "spill")
+        cm.wrap(fake_invoke)(messages)
+
+        content = sent["tool_content"]
+        assert "trimmed_tool_result" in content
+        assert "tool_name: atom_task_read" in content
+        assert "atom_id: atom_traj_demo_0001" in content
+        assert "intent: 修复 SkillEditAgent 上下文超限" in content
+        assert "summary: 读 atom 后 raw_segment 过大导致下一轮请求超窗" in content
+        assert "RAW_SEGMENT_SHOULD_NOT_STAY_IN_CONTEXT" not in content
+        spill_path = re.search(r"spill_path: (.+)", content).group(1).strip()
+        assert Path(spill_path).read_text(encoding="utf-8") == original_tool_content
+
+    def test_compact_runs_after_spill_when_history_still_exceeds_limit(self, tmp_path):
+        """spill 后仍超 compact_token_limit 时,应调用 compact_fn 并收敛历史。"""
+        from xskill.agents.context_budget import ContextManager
+
+        class _Msg:
+            def __init__(self, role, content, tool_name=None):
+                self.role = role
+                self.content = content
+                self.tool_name = tool_name
+
+        compact_calls: list[str] = []
+
+        def compact_fn(prompt: str) -> str:
+            compact_calls.append(prompt)
+            return "COMPACTED: keep atom evidence and pending edits"
+
+        messages = [
+            _Msg("system", "SkillEditAgent system prompt"),
+            _Msg("user", "turn0 scenario with target skill"),
+            _Msg("assistant", "I will inspect atoms"),
+            _Msg("tool", "OLD_ATOM_RESULT\n" + ("x" * 8000), "atom_task_read"),
+            _Msg("assistant", "recent reasoning"),
+            _Msg("user", "recent continuation"),
+        ]
+        seen = {}
+
+        def fake_invoke(msgs, **_keyword_arguments):
+            seen["messages"] = msgs
+            return {"usage": {"prompt_tokens": 100}}
+
+        cm = ContextManager(
+            max_context=1000,
+            spill_root=tmp_path / "spill",
+            compact_token_limit=20,
+            compact_keep_recent_messages=2,
+            compact_fn=compact_fn,
+        )
+        cm.wrap(fake_invoke)(messages)
+
+        assert len(compact_calls) == 1
+        assert "SkillEditAgent working memory" in compact_calls[0]
+        assert "spill_path:" in compact_calls[0]
+        compacted = seen["messages"]
+        assert [m.role for m in compacted] == [
+            "system", "user", "assistant", "assistant", "user",
+        ]
+        assert compacted[0].content == "SkillEditAgent system prompt"
+        assert compacted[1].content == "turn0 scenario with target skill"
+        assert "COMPACTED" in compacted[2].content
+        assert compacted[-2].content == "recent reasoning"
+        assert compacted[-1].content == "recent continuation"
+
+    def test_compact_recent_tail_does_not_keep_orphan_tool_message(self, tmp_path):
+        """compact 后不能留下没有对应 assistant tool_calls 的 tool 消息。"""
+        from xskill.agents.context_budget import ContextManager
+
+        class _Msg:
+            def __init__(self, role, content, tool_name=None, tool_call_id=None):
+                self.role = role
+                self.content = content
+                self.tool_name = tool_name
+                self.tool_call_id = tool_call_id
+
+        messages = [
+            _Msg("system", "SkillEditAgent system prompt"),
+            _Msg("user", "turn0 scenario"),
+            _Msg("assistant", "old reasoning"),
+            _Msg("tool", "OLD_ATOM_RESULT\n" + ("x" * 8000), "atom_task_read"),
+            _Msg("tool", "RECENT_TOOL_WITHOUT_ASSISTANT", "read_file", "call_recent"),
+            _Msg("user", "continue after tool"),
+        ]
+        seen = {}
+
+        def fake_invoke(msgs, **_keyword_arguments):
+            seen["messages"] = msgs
+            return {"usage": {"prompt_tokens": 100}}
+
+        cm = ContextManager(
+            max_context=1000,
+            spill_root=tmp_path / "spill",
+            compact_token_limit=20,
+            compact_keep_recent_messages=2,
+            compact_fn=lambda _prompt: "summary includes recent tool evidence",
+        )
+        cm.wrap(fake_invoke)(messages)
+
+        compacted = seen["messages"]
+        assert [m.role for m in compacted] == [
+            "system", "user", "assistant", "assistant", "user",
+        ]
+        assert all(m.content != "RECENT_TOOL_WITHOUT_ASSISTANT" for m in compacted)
+        assert compacted[-1].content == "continue after tool"
+
     def test_overlong_error_triggers_retrim_and_resend(self):
         from xskill.agents.context_budget import ContextManager, _TRIM_MARK
 


### PR DESCRIPTION
## Summary

- 将 SkillEditAgent 旧工具结果 spill 到 /tmp/xskill/skilleditagent，并在上下文中保留可回读路径
- 为 read_file 增加 offset/limit 和 /tmp spill 文件读取能力，list_files 返回可直接读取的完整路径
- 从 llm/llm_skill 配置读取 compact_token_limit，并在 spill 后仍超限时使用当前 Agno model 生成 compact 摘要
- compact 后保留 system、首轮 user、摘要和最近完整消息块，避免孤立 tool 消息
- 补充计划文档和相关单测

## Tests

- python3.11 -m pytest tests/test_task_agent.py::TestContextManager -q
- python3.11 -m pytest tests/test_agno_factory_probe_smoke.py tests/test_agent_model_routing.py -q
- python3.11 -m pytest tests/test_skill_tools_atom.py -q
- python3.11 -m py_compile src/xskill/agents/context_budget.py src/xskill/agents/agno_factory.py src/xskill/config.py
