### PR TITLE
fix(updater): 打通华为内网镜像回退链路 / wire up the intranet PyPI mirror fallback

### DIFF
--- a/src/xskill/cli.py
+++ b/src/xskill/cli.py
@@ -244,9 +244,12 @@ def _connect_handshake(args, state_path):
     # 作为 ``claimed_client_id`` 一起发给 server——server 按 (claimed/fingerprint/
     # new) 三级判定续用。state 不在 → existing_client_id=None，让 server 按指纹回查。
     existing_client_id: str | None = None
+    existing_pypi_url: str | None = None
     if state_path.is_file():
         try:
-            existing_client_id = load_client_state(state_path).client_id
+            existing_state = load_client_state(state_path)
+            existing_client_id = existing_state.client_id
+            existing_pypi_url = existing_state.pypi_url
         except Exception:
             # state 文件损坏不阻断重连——按"无本地身份"处理，让 server 走指纹回查
             # 或新发。损坏的 state 接下来会被新的 save 覆盖。
@@ -269,7 +272,8 @@ def _connect_handshake(args, state_path):
         print(f"error: 注册失败: {e}", file=sys.stderr)
         return None
     state = ClientState(server_url=server_url, client_id=client_id,
-                        join_token=args.token)
+                        join_token=args.token,
+                        pypi_url=args.pypi_url or existing_pypi_url)
     save_client_state(state, state_path)
     name_hint = f"  (--name={args.name})" if args.name else ""
     print(f"connected: client_id={client_id}  server={server_url}{name_hint}")
@@ -337,41 +341,47 @@ def cmd_start(args) -> int:
 
 
 def cmd_update(args) -> int:
-    """立即检查 PyPI 是否有新版 xskill，有则升级并重启。"""
-    from xskill.team.client.updater import (
-        _current_version, _latest_pypi_version, _restart,
-    )
+    """立即检查是否有新版 xskill，有则升级并重启。
+
+    复用 ``AutoUpdater`` 的三级回退链路（公网 PyPI → 已连接过的内网镜像 →
+    team server wheel），而不是自己另开一条查询/安装逻辑——这样手动
+    `xskill update` 和后台每小时自动检查行为完全一致，不会出现"自动更新能
+    绕过公网不可达，手动触发却直接报错"的不一致。
+    """
+    from xskill.config import get_team_client_state_path
+    from xskill.team.client.state import load_client_state
+    from xskill.team.client.updater import AutoUpdater, _current_version
+
     current = _current_version("xskill")
     if not current:
         print("error: 无法读取当前版本", file=sys.stderr)
         return 1
     print(f"当前版本: {current}")
-    print("正在查询 PyPI...")
-    latest = _latest_pypi_version("xskill")
-    if not latest:
-        print("error: 查询 PyPI 失败，请检查网络", file=sys.stderr)
-        return 1
-    try:
-        from packaging.version import Version
-        if Version(latest) <= Version(current):
-            print(f"已是最新版本 ({current})")
-            return 0
-    except Exception:
-        pass
-    print(f"发现新版本: {latest}，开始升级...")
-    import subprocess
-    result = subprocess.run(
-        [sys.executable, "-m", "pip", "install", "--upgrade",
-         f"xskill=={latest}", "-i", "https://pypi.org/simple/"],
-        capture_output=True, text=True,
-    )
-    if result.returncode != 0:
-        print(f"error: 升级失败:\n{result.stderr.strip() or result.stdout.strip()}",
+
+    kwargs: dict = {}
+    state_path = get_team_client_state_path()
+    if state_path.is_file():
+        try:
+            state = load_client_state(state_path)
+            kwargs.update(server_url=state.server_url, client_id=state.client_id,
+                         join_token=state.join_token)
+            if state.pypi_url:
+                kwargs["pypi_url"] = state.pypi_url
+        except Exception:
+            pass  # state 文件损坏：退化为「只查公网 PyPI」
+
+    print("正在检查更新（公网 PyPI"
+         + ("、内网镜像" if kwargs.get("pypi_url") else "")
+         + ("、team server 回退" if kwargs.get("server_url") else "") + "）...")
+
+    updater = AutoUpdater(**kwargs)
+    if not updater.run_once():
+        print("error: 升级失败：所有可用来源均不可用或安装失败，详情见上方日志",
               file=sys.stderr)
         return 1
-    print(f"升级到 {latest} 成功，正在重启...")
-    _restart()
-    return 0  # 不会到达这里
+    # 升级成功时 _restart() 已替换/重启进程，走不到这里；到这里说明本来就是最新版本。
+    print(f"已是最新版本 ({current})")
+    return 0
 
 
 def cmd_stop(args) -> int:
@@ -648,6 +658,13 @@ def build_parser() -> argparse.ArgumentParser:
     p_conn.add_argument(
         "--no-auto-update", action="store_true", dest="no_auto_update",
         help="禁用自动更新检查（默认每小时查一次 PyPI，有新版则升级重启）。",
+    )
+    p_conn.add_argument(
+        "--pypi-url", default=None, metavar="URL",
+        help="内网 PyPI 镜像地址（PEP 503 /simple/ 索引），自动更新会在公网 "
+             "PyPI 不可达时用它查版本、装包，装 server 回退 wheel 时的依赖也走它。"
+             "落盘到本地连接信息，后续 `xskill connect` / `xskill update` 复用，"
+             "不用每次都传。默认不设，只用公网 PyPI + server wheel 回退。",
     )
 
     p_start = sub.add_parser(

--- a/src/xskill/team/client/daemon.py
+++ b/src/xskill/team/client/daemon.py
@@ -356,11 +356,12 @@ class TeamClient:
 
     def run_forever(self) -> None:
         """阻塞循环。先起 collector ingester，再每 poll_interval 跑一轮 _tick。"""
-        from xskill.team.client.updater import AutoUpdater
+        from xskill.team.client.updater import AutoUpdater, PUBLIC_PYPI_SIMPLE_URL
         updater = AutoUpdater(
             server_url=self.state.server_url,
             client_id=self.state.client_id,
             join_token=self.state.join_token,
+            pypi_url=self.state.pypi_url or PUBLIC_PYPI_SIMPLE_URL,
         ) if self.auto_update else None
         if updater:
             updater.start()

--- a/src/xskill/team/client/state.py
+++ b/src/xskill/team/client/state.py
@@ -18,6 +18,7 @@ class ClientState:
     server_url: str          # 形如 http://1.2.3.4:8000
     client_id: str
     join_token: str
+    pypi_url: str | None = None   # 内网 PyPI 镜像，供自动更新回退用；None=只用公网 PyPI
 
 
 def save_client_state(state: ClientState, path: Path | str) -> None:
@@ -40,4 +41,5 @@ def load_client_state(path: Path | str) -> ClientState:
         server_url=data["server_url"],
         client_id=data["client_id"],
         join_token=data["join_token"],
+        pypi_url=data.get("pypi_url"),
     )

--- a/src/xskill/team/client/updater.py
+++ b/src/xskill/team/client/updater.py
@@ -1,8 +1,15 @@
 """updater.py — xskill client 自动更新
 
 TeamClient 跑起来后每隔一段时间（默认 1 小时）查 PyPI，发现新版就升级并重启。
-如果 PyPI 查询或安装失败，且 client 已连接 team server，则读取 server 版本；
-server 版本高于本地版本时，下载 server 暴露的 wheel 并安装。
+查询/安装链路三级回退：
+
+1. 公网 PyPI（JSON API 查版本 + ``pip install -i pypi_url``）
+2. 已配置的内网 PyPI 镜像（``pypi_url`` 非公网地址时，``pip index versions``
+   查版本 + 复用同一 ``-i pypi_url`` 安装）——多数内网镜像（devpi/artifactory）
+   不提供 pypi.org 的 legacy JSON API，所以查询手段和公网不同，但安装命令相同。
+3. 都不可用，且 client 已连接 team server：读取 server 版本，高于本地时下载
+   server 暴露的 wheel 安装——wheel 依赖同样经 ``pypi_url``（配了镜像就用镜像，
+   否则退回公网）解析，不会因为装了新依赖又绕回不可达的公网索引。
 
 重启机制
 ────────
@@ -13,7 +20,7 @@ server 版本高于本地版本时，下载 server 暴露的 wheel 并安装。
 ────────
 - 包含预发版（a/b/rc），因为内部用 alpha 版本
 - 严格大于当前版本才升级，不降级
-- 网络/PyPI/server 故障不会打断主循环
+- 网络/PyPI/镜像/server 故障不会打断主循环
 """
 from __future__ import annotations
 
@@ -29,6 +36,7 @@ from typing import Any, Optional
 logger = logging.getLogger("xskill.team.client.updater")
 
 _PYPI_JSON_URL = "https://pypi.org/pypi/{package}/json"
+PUBLIC_PYPI_SIMPLE_URL = "https://pypi.org/simple/"
 
 
 def _team_api_url(server_url: str, path: str) -> str:
@@ -70,6 +78,33 @@ def _latest_pypi_version(package: str) -> Optional[str]:
         return str(max(all_versions))
     except Exception:
         logger.debug("updater: 查 PyPI 失败", exc_info=True)
+        return None
+
+
+def _latest_mirror_version(package: str, pypi_url: str) -> Optional[str]:
+    """查内网 PyPI 镜像取最新版本（含预发版）。
+
+    内网镜像（devpi/artifactory 等）通常不实现 pypi.org 的 legacy JSON API，
+    只有标准 PEP 503 ``/simple/`` 索引，所以改用 ``pip index versions``
+    （走的正是同一个 ``/simple/`` 索引，公网/镜像通用）。超时/查询失败返回 None。
+    """
+    try:
+        result = subprocess.run(
+            [sys.executable, "-m", "pip", "index", "versions", package,
+             "--pre", "-i", pypi_url],
+            capture_output=True, text=True, timeout=20,
+        )
+        from packaging.version import Version
+        for line in result.stdout.splitlines():
+            if not line.startswith("Available versions:"):
+                continue
+            versions = [v.strip() for v in line.split(":", 1)[1].split(",") if v.strip()]
+            parsed = [Version(v) for v in versions]
+            if parsed:
+                return str(max(parsed))
+        return None
+    except Exception:
+        logger.debug("updater: 查镜像 %s 版本失败", pypi_url, exc_info=True)
         return None
 
 
@@ -194,7 +229,7 @@ class AutoUpdater:
         self,
         package: str = "xskill",
         interval: float = 3600,       # 默认 1 小时
-        pypi_url: str = "https://pypi.org/simple/",
+        pypi_url: str = PUBLIC_PYPI_SIMPLE_URL,
         server_url: str | None = None,
         client_id: str | None = None,
         join_token: str | None = None,
@@ -221,6 +256,20 @@ class AutoUpdater:
     def stop(self) -> None:
         self._stop.set()
 
+    def run_once(self) -> bool:
+        """立即检查一次并在有新版时升级（供 ``xskill update`` 手动触发）。
+
+        返回是否成功：已是最新版本 / 升级成功（后者 ``_restart()`` 会直接
+        替换进程，通常不会真的返回到这里）都算 True；所有可用来源都升级
+        失败才是 False。
+        """
+        return self._check_and_update()
+
+    def _has_mirror(self) -> bool:
+        return bool(self.pypi_url) and (
+            self.pypi_url.rstrip("/") != PUBLIC_PYPI_SIMPLE_URL.rstrip("/")
+        )
+
     # ─────────────────────────────────────────────────────────────
 
     def _loop(self) -> None:
@@ -230,39 +279,42 @@ class AutoUpdater:
             self._check_and_update()
             self._stop.wait(self.interval)
 
-    def _check_and_update(self) -> None:
+    def _check_and_update(self) -> bool:
         current_str = _current_version(self.package)
         if not current_str:
             logger.debug("updater: 无法读取当前版本，跳过本次检查")
-            return
+            return False
         try:
             from packaging.version import Version
             current = Version(current_str)
         except Exception:
             logger.debug("updater: 当前版本不可解析: %s", current_str, exc_info=True)
-            return
+            return False
 
         latest_str = _latest_pypi_version(self.package)
+        reason = "pypi_query_failed"
+        if not latest_str and self._has_mirror():
+            latest_str = _latest_mirror_version(self.package, self.pypi_url)
+            reason = "mirror_query_failed"
         if not latest_str:
-            self._check_server_fallback(current_str, current, reason="pypi_query_failed")
-            return
+            return self._check_server_fallback(current_str, current, reason=reason)
 
         try:
             latest = Version(latest_str)
         except Exception:
-            return
+            return False
 
         if latest <= current:
             logger.debug("updater: 当前版本 %s 已是最新", current_str)
-            return
+            return True
 
         logger.info("updater: 发现新版本 %s（当前 %s），开始升级...",
                     latest_str, current_str)
         if self._install(latest_str):
             _restart()   # 升级成功后重启，不会走到这行之后的代码
             # （_restart 在 Windows 上 os._exit；Linux 上 execv）
-            return
-        self._check_server_fallback(current_str, current, reason="pypi_install_failed")
+            return True
+        return self._check_server_fallback(current_str, current, reason="pypi_install_failed")
 
     def _install(self, target_version: str) -> bool:
         """用 pip 升级到指定版本。返回是否成功。"""
@@ -284,15 +336,20 @@ class AutoUpdater:
             logger.warning("updater: 执行 pip 失败", exc_info=True)
             return False
 
-    def _check_server_fallback(self, current_str: str, current, *, reason: str) -> None:
-        """PyPI 不可用时，从 team server 下载同版本 wheel 回退升级。"""
+    def _check_server_fallback(self, current_str: str, current, *, reason: str) -> bool:
+        """PyPI/镜像都不可用时，从 team server 下载同版本 wheel 回退升级。
+
+        返回值语义与 ``_check_and_update`` 一致：没有更高版本可装（无论是
+        因为没配 server、server 版本不比本地新，还是本来就已最新）算 True；
+        明确「有更新但装不上」才是 False。
+        """
         if not (self.server_url and self.client_id and self.join_token):
             logger.debug("updater: 无 server 回退配置，跳过（%s）", reason)
-            return
+            return False
 
         info = _server_version(self.server_url, self.join_token, self.client_id)
         if not info:
-            return
+            return False
 
         server_version_str = str(info.get("version") or "")
         try:
@@ -301,16 +358,16 @@ class AutoUpdater:
         except Exception:
             logger.debug("updater: server 版本不可解析: %s",
                          server_version_str, exc_info=True)
-            return
+            return False
 
         if server_version <= current:
             logger.debug("updater: server 版本 %s 不高于当前版本 %s",
                          server_version_str, current_str)
-            return
+            return True
         if not info.get("wheel_available"):
             logger.warning("updater: server 版本 %s 可用，但未提供 wheel",
                            server_version_str)
-            return
+            return False
 
         with tempfile.TemporaryDirectory(prefix="xskill-update-") as td:
             wheel = _download_server_wheel(
@@ -321,17 +378,25 @@ class AutoUpdater:
                 str(info.get("wheel_filename") or ""),
             )
             if wheel is None:
-                return
-            logger.info("updater: PyPI 不可用（%s），改用 server wheel 升级到 %s",
+                return False
+            logger.info("updater: PyPI/镜像不可用（%s），改用 server wheel 升级到 %s",
                         reason, server_version_str)
             if self._install_wheel(wheel):
                 _restart()
+                return True
+            return False
 
     def _install_wheel(self, wheel_path: Path) -> bool:
-        """用 pip 安装 server 下载的 wheel。返回是否成功。"""
+        """用 pip 安装 server 下载的 wheel。返回是否成功。
+
+        显式传 ``-i self.pypi_url``：wheel 本体来自 server，但它的依赖仍要
+        走一个可达的索引解析——配了内网镜像就用镜像，没配就退回公网 PyPI，
+        绝不能静默吃 pip 自己的默认索引配置（那台机器上很可能压根没配）。
+        """
         cmd = [
             sys.executable, "-m", "pip", "install", "--upgrade",
             str(wheel_path),
+            "-i", self.pypi_url,
             "-q",
         ]
         try:

--- a/tests/test_cli_update.py
+++ b/tests/test_cli_update.py
@@ -1,0 +1,92 @@
+from __future__ import annotations
+
+from xskill.cli import build_parser, cmd_update
+
+
+def _args():
+    return build_parser().parse_args(["update"])
+
+
+def test_update_no_current_version_errors(monkeypatch, tmp_path):
+    monkeypatch.setattr("xskill.config.get_team_client_state_path",
+                        lambda: tmp_path / "absent.json")
+    monkeypatch.setattr(
+        "xskill.team.client.updater._current_version", lambda package: None)
+    rc = cmd_update(_args())
+    assert rc == 1
+
+
+def test_update_success_delegates_to_autoupdater_run_once(monkeypatch, tmp_path, capsys):
+    monkeypatch.setattr("xskill.config.get_team_client_state_path",
+                        lambda: tmp_path / "absent.json")
+    monkeypatch.setattr(
+        "xskill.team.client.updater._current_version", lambda package: "1.0.0")
+
+    calls: list[bool] = []
+
+    class _FakeUpdater:
+        def __init__(self, **kwargs):
+            self.kwargs = kwargs
+
+        def run_once(self):
+            calls.append(True)
+            return True
+
+    monkeypatch.setattr("xskill.team.client.updater.AutoUpdater", _FakeUpdater)
+    rc = cmd_update(_args())
+    assert rc == 0
+    assert calls == [True]
+    assert "已是最新版本" in capsys.readouterr().out
+
+
+def test_update_all_sources_fail_returns_error(monkeypatch, tmp_path):
+    monkeypatch.setattr("xskill.config.get_team_client_state_path",
+                        lambda: tmp_path / "absent.json")
+    monkeypatch.setattr(
+        "xskill.team.client.updater._current_version", lambda package: "1.0.0")
+
+    class _FakeUpdater:
+        def __init__(self, **kwargs):
+            pass
+
+        def run_once(self):
+            return False
+
+    monkeypatch.setattr("xskill.team.client.updater.AutoUpdater", _FakeUpdater)
+    rc = cmd_update(_args())
+    assert rc == 1
+
+
+def test_update_reuses_persisted_server_and_pypi_url(monkeypatch, tmp_path):
+    """已 connect 过的机器：team_client.json 里的 server/token/pypi_url 应
+    自动喂给 AutoUpdater，不需要用户在 `xskill update` 时重新指定。"""
+    from xskill.team.client.state import ClientState, save_client_state
+
+    state_path = tmp_path / "team_client.json"
+    save_client_state(
+        ClientState(server_url="http://server", client_id="cid-1",
+                    join_token="tok", pypi_url="http://mirror/simple"),
+        state_path,
+    )
+    monkeypatch.setattr("xskill.config.get_team_client_state_path", lambda: state_path)
+    monkeypatch.setattr(
+        "xskill.team.client.updater._current_version", lambda package: "1.0.0")
+
+    captured: dict = {}
+
+    class _FakeUpdater:
+        def __init__(self, **kwargs):
+            captured.update(kwargs)
+
+        def run_once(self):
+            return True
+
+    monkeypatch.setattr("xskill.team.client.updater.AutoUpdater", _FakeUpdater)
+    rc = cmd_update(_args())
+    assert rc == 0
+    assert captured == {
+        "server_url": "http://server",
+        "client_id": "cid-1",
+        "join_token": "tok",
+        "pypi_url": "http://mirror/simple",
+    }

--- a/tests/test_team_cli_connect.py
+++ b/tests/test_team_cli_connect.py
@@ -245,3 +245,49 @@ def test_connect_unsupported_platform_falls_back_to_foreground(
     rc = cmd_connect(args)
     assert rc == 0
     assert ran["forever"] == 1  # 退化成前台阻塞
+
+
+# ── --pypi-url：内网镜像地址落盘，供自动更新回退用 ──
+
+def test_pypi_url_flag_parses():
+    parser = build_parser()
+    args = parser.parse_args(["connect", "1.2.3.4:8000", "--token", "t"])
+    assert args.pypi_url is None
+    args2 = parser.parse_args(
+        ["connect", "1.2.3.4:8000", "--token", "t",
+         "--pypi-url", "http://mirror/simple"])
+    assert args2.pypi_url == "http://mirror/simple"
+
+
+def test_pypi_url_persisted_on_first_connect(tmp_path, monkeypatch):
+    from xskill.team.client.state import load_client_state
+    state_path = tmp_path / "team_client.json"
+    monkeypatch.setattr("xskill.config.get_team_client_state_path",
+                        lambda: state_path)
+    _install_fakes(monkeypatch)
+    parser = build_parser()
+    args = parser.parse_args(
+        ["connect", "1.2.3.4:8000", "--token", "t",
+         "--pypi-url", "http://mirror/simple"])
+    rc = cmd_connect(args)
+    assert rc == 0
+    assert load_client_state(state_path).pypi_url == "http://mirror/simple"
+
+
+def test_pypi_url_preserved_on_reconnect_without_flag(tmp_path, monkeypatch):
+    """重连时不重复传 --pypi-url，应沿用上次已存的镜像地址，而不是被清空。"""
+    from xskill.team.client.state import ClientState, load_client_state, save_client_state
+    state_path = tmp_path / "team_client.json"
+    monkeypatch.setattr("xskill.config.get_team_client_state_path",
+                        lambda: state_path)
+    save_client_state(
+        ClientState(server_url="http://1.2.3.4:8000", client_id="cid-1",
+                    join_token="old-tok", pypi_url="http://mirror/simple"),
+        state_path,
+    )
+    _install_fakes(monkeypatch)
+    parser = build_parser()
+    args = parser.parse_args(["connect", "1.2.3.4:8000", "--token", "t"])
+    rc = cmd_connect(args)
+    assert rc == 0
+    assert load_client_state(state_path).pypi_url == "http://mirror/simple"

--- a/tests/test_team_client_state.py
+++ b/tests/test_team_client_state.py
@@ -17,3 +17,23 @@ def test_save_then_load_roundtrip(tmp_path):
 def test_load_missing_raises(tmp_path):
     with pytest.raises(FileNotFoundError):
         load_client_state(tmp_path / "absent.json")
+
+
+def test_save_then_load_roundtrip_with_pypi_url(tmp_path):
+    p = tmp_path / "team_client.json"
+    st = ClientState(server_url="http://1.2.3.4:8000", client_id="cid-1",
+                     join_token="tok", pypi_url="http://mirror/simple")
+    save_client_state(st, p)
+    back = load_client_state(p)
+    assert back == st
+
+
+def test_load_old_format_without_pypi_url_defaults_none(tmp_path):
+    """老版本写的 team_client.json 没有 pypi_url 字段，读取时应默认 None 而不是报错。"""
+    import json
+    p = tmp_path / "team_client.json"
+    p.write_text(json.dumps({
+        "server_url": "http://1.2.3.4:8000", "client_id": "cid-1", "join_token": "tok",
+    }))
+    back = load_client_state(p)
+    assert back.pypi_url is None

--- a/tests/test_team_client_updater.py
+++ b/tests/test_team_client_updater.py
@@ -3,7 +3,43 @@ from __future__ import annotations
 from pathlib import Path
 
 from xskill.team.client import updater as updater_mod
-from xskill.team.client.updater import AutoUpdater
+from xskill.team.client.updater import AutoUpdater, _latest_mirror_version
+
+
+def test_latest_mirror_version_parses_pip_index_output(monkeypatch):
+    class FakeResult:
+        stdout = (
+            "xskill (1.3.0)\n"
+            "Available versions: 1.3.0, 1.2.0a3, 1.2.0, 1.0.0\n"
+            "  INSTALLED: 1.0.0\n"
+        )
+        stderr = ""
+        returncode = 0
+
+    captured_cmds: list[list[str]] = []
+
+    def fake_run(cmd, **kwargs):
+        captured_cmds.append(cmd)
+        return FakeResult()
+
+    monkeypatch.setattr(updater_mod.subprocess, "run", fake_run)
+
+    version = _latest_mirror_version("xskill", "http://mirror/simple")
+
+    assert version == "1.3.0"
+    cmd = captured_cmds[0]
+    assert cmd[:5] == [updater_mod.sys.executable, "-m", "pip", "index", "versions"]
+    assert "-i" in cmd and cmd[cmd.index("-i") + 1] == "http://mirror/simple"
+    assert "--pre" in cmd
+
+
+def test_latest_mirror_version_returns_none_on_failure(monkeypatch):
+    def fake_run(cmd, **kwargs):
+        raise OSError("no route to host")
+
+    monkeypatch.setattr(updater_mod.subprocess, "run", fake_run)
+
+    assert _latest_mirror_version("xskill", "http://mirror/simple") is None
 
 
 def test_pypi_newer_version_uses_pypi_and_skips_server(monkeypatch):
@@ -156,3 +192,79 @@ def test_server_fallback_skips_non_newer_server_version(monkeypatch):
     updater._check_and_update()
 
     assert downloaded == []
+
+
+def test_mirror_tried_before_server_when_pypi_unreachable(monkeypatch):
+    """公网 PyPI 查询失败但配了内网镜像时，应该先试镜像，不直接跳到 server。"""
+    installed: list[str] = []
+    restarted: list[bool] = []
+
+    monkeypatch.setattr(updater_mod, "_current_version", lambda package: "1.0.0")
+    monkeypatch.setattr(updater_mod, "_latest_pypi_version", lambda package: None)
+    monkeypatch.setattr(
+        updater_mod, "_latest_mirror_version",
+        lambda package, pypi_url: "1.3.0" if pypi_url == "http://mirror/simple" else None,
+    )
+    monkeypatch.setattr(
+        updater_mod, "_server_version",
+        lambda *a, **k: (_ for _ in ()).throw(AssertionError("server fallback used")),
+    )
+    monkeypatch.setattr(updater_mod, "_restart", lambda: restarted.append(True))
+
+    updater = AutoUpdater(pypi_url="http://mirror/simple")
+    monkeypatch.setattr(updater, "_install", lambda version: installed.append(version) or True)
+
+    ok = updater._check_and_update()
+
+    assert installed == ["1.3.0"]
+    assert restarted == [True]
+    assert ok is True
+
+
+def test_mirror_not_queried_when_not_configured(monkeypatch):
+    """没配镜像（pypi_url 仍是公网默认值）时，PyPI 查询失败应直接走 server 回退，
+    不应该尝试查一个根本没配置的"镜像"。"""
+    monkeypatch.setattr(updater_mod, "_current_version", lambda package: "1.0.0")
+    monkeypatch.setattr(updater_mod, "_latest_pypi_version", lambda package: None)
+    monkeypatch.setattr(
+        updater_mod, "_latest_mirror_version",
+        lambda *a, **k: (_ for _ in ()).throw(AssertionError("mirror query used")),
+    )
+
+    updater = AutoUpdater()  # 无 server 配置 -> fallback 也是空操作
+    ok = updater._check_and_update()
+
+    assert ok is False
+
+
+def test_install_wheel_passes_pypi_url_as_index(monkeypatch):
+    """server wheel 的依赖必须走一个明确可达的索引（镜像优先），不能吃 pip 默认索引。"""
+    captured_cmds: list[list[str]] = []
+
+    class FakeResult:
+        returncode = 0
+        stdout = ""
+        stderr = ""
+
+    def fake_run(cmd, **kwargs):
+        captured_cmds.append(cmd)
+        return FakeResult()
+
+    monkeypatch.setattr(updater_mod.subprocess, "run", fake_run)
+
+    updater = AutoUpdater(pypi_url="http://mirror/simple")
+    ok = updater._install_wheel(Path("/tmp/xskill-1.3.0-py3-none-any.whl"))
+
+    assert ok is True
+    assert captured_cmds
+    cmd = captured_cmds[0]
+    assert "-i" in cmd
+    assert cmd[cmd.index("-i") + 1] == "http://mirror/simple"
+
+
+def test_up_to_date_returns_true(monkeypatch):
+    monkeypatch.setattr(updater_mod, "_current_version", lambda package: "1.0.0")
+    monkeypatch.setattr(updater_mod, "_latest_pypi_version", lambda package: "1.0.0")
+
+    updater = AutoUpdater()
+    assert updater._check_and_update() is True


### PR DESCRIPTION
## 背景 / Background

0.6.5 加了 team server wheel 回退（#70），但排查华为内网部署场景时发现三个没打通的地方，导致对纯内网（连不上公网 PyPI）用户来说，回退实际上不work：

1. `AutoUpdater.pypi_url` 从没在任何调用点被设成公网默认值以外的东西——`daemon.py` 构造 `AutoUpdater` 时压根不传这个参数。公网 PyPI 查询失败时，代码直接跳到 server wheel 回退，配了内网镜像也用不上。
2. `_install_wheel` 装 server 下发的 wheel 完全不带 `-i`——wheel 本体虽然来自 server，但它的依赖解析会悄悄吃 pip 默认索引（通常是不可达的公网 pypi.org）。纯内网机器上这一步大概率直接卡死/失败，等于回退没真正回退成。
3. 手动 `xskill update`（CLI 命令）是完全独立的一条逻辑，没有任何回退——公网 PyPI JSON 查询失败就直接报错退出，和后台每小时的自动检查行为不一致。skill 安装向导的"日常维护"一节推荐用户用这条命令，但它在内网环境下必挂。

## 改动 / Changes

- `ClientState` 新增可选字段 `pypi_url`，通过 `xskill connect --pypi-url <url>` 设置，落盘到 `~/.xskill/team_client.json`，重连时若不重新传参会沿用上次的值。
- `AutoUpdater` 现在按 **公网 PyPI → 已配置的内网镜像（用 `pip index versions`，兼容大多数只有 PEP 503 `/simple/` 索引、没有 pypi.org legacy JSON API 的内网镜像）→ team server wheel** 三级顺序回退。
- `_install_wheel` 现在总是带 `-i self.pypi_url`，wheel 的依赖解析走一个明确可达的索引，不会悄悄吃 pip 默认配置。
- `cmd_update`（`xskill update`）重写为复用 `AutoUpdater.run_once()`，加载已持久化的 server/mirror 配置，不再是一条更窄、没有回退的独立逻辑。

## 测试 / Testing

- 新增/调整单测覆盖：镜像查询顺序、`_install_wheel` 的 `-i` 参数、`ClientState` 新字段的持久化与向后兼容（老 json 没有 `pypi_url` 字段时默认 `None`）、`cmd_update` 委托给 `AutoUpdater` 且正确复用持久化配置。
- `make test`（不含 docker_e2e / live）：**1144 passed**。
- 跳过了 `tests/test_e2e_xskill_serve_auto.py::test_canary_flip_promote_and_install_new_version`——这个测试会真的 spawn `claude -p` 子进程，在当前沙箱环境（已经跑在一个 Claude Code 会话里，嵌套调用 `claude` CLI）里会一直挂起，和本次改动无关（该改动完全没碰灰度/canary 相关代码）。建议在真实 CI 里补跑一遍确认。
- 没有跑 `make e2e`（docker），建议合并前在有网络访问的环境里跑一遍。

## 兼容性 / Compatibility

- 不带 `--pypi-url` 的 `xskill connect` 行为完全不变（`pypi_url` 默认 `None`，回退链路退化为"公网 PyPI → server wheel"，和现在一样）。
- 老版本 `team_client.json`（没有 `pypi_url` 字段）能正常读取，字段默认 `None`。
- `xskill-internal-install-guide` 那边的 `install.ps1` 已经改成在 `connect` 时传 `--pypi-url`，并且做了老版本 xskill（argparse 报 unrecognized argument，退出码 2）时自动降级重试，所以这个 PR 和已部署的旧版本 server/client 之间不会因为参数不认识而报错——但只有等这个版本真正发布、部署到 server 上之后，`--pypi-url` 才会真正生效。

不要求立即合并，先看一下改动方向对不对。

🤖 Generated with [Claude Code](https://claude.com/claude-code)