### PR TITLE
docs(openspec): 慢后端韧性设计提案 | backend-slow resilience proposal

### DIFF
--- a/openspec/changes/backend-slow-resilience/.openspec.yaml
+++ b/openspec/changes/backend-slow-resilience/.openspec.yaml
@@ -1,0 +1,2 @@
+schema: spec-driven
+created: 2026-07-10

--- a/openspec/changes/backend-slow-resilience/design.md
+++ b/openspec/changes/backend-slow-resilience/design.md
@@ -1,0 +1,232 @@
+## Context
+
+xskill team-CS 模式的服务端是一个 FastAPI 应用，`/api/v1/team/*`、dashboard、`/api/v1/*`
+共用同一个进程与同一个 anyio 默认工作线程池（40 线程）。同一进程还跑着 skill watcher
+（生产 `watcher.max_concurrent=4`）。
+
+**已知的上一层修复**：`29ce2fe`（2026-07-10 上午）修了「事件循环冻住 → 全端点连不上」，
+让主线程 `ep_poll` 正常。当时的判断是「`async` 里跑同步慢活会冻事件循环，所以把 `/sync`
+写成 `def` 丢线程池」——这是对的，但只解决了**事件循环**这一层。
+
+**本次事故（同日下午）暴露了下一层**：`def` 路由丢进的那个线程池是**有限的（40）**，而
+`/sync` 的慢活会**长时间独占**一个线程：
+
+- `team_sync`（`api.py:469`，`def`）→ `update_user_interest`（`engine.py:212`）→
+  `encode_batch`（`llm.py:291`）。
+- `encode_batch` 是**假批量**：`for text in texts:` 逐条 `_call_api_single`，每条一个 HTTP
+  请求、`httpx.Client(timeout=60)`（`llm.py:227`）。冷启动期用户 atom 集频繁变化、画像
+  指纹屡屡失效，一次 `/sync` 要串行 embedding 几十条 → **占线程数分钟**。
+- 每个 client `poll_interval=30`（`daemon.py:76`）周期性打 `/sync`。client 侧 httpx
+  `timeout=30.0`（`cli.py:288`）到点断开，但**服务端线程还在把 N 条 embedding 跑完**
+  （僵尸工作），client `_tick` 30s 后又整齐重来（`daemon.py:373`，无 jitter / 无退避 /
+  不认 `Retry-After`——全仓无 `Retry-After` 处理）→ 僵尸线程**只堆不减**。
+- dashboard 的 `/`、`/app.js` 等**也全是 `def`**（`router.py:57,62`），与 `/sync` 抢同一个
+  40 线程池 → 池被 `/sync` 占满，**网页也打不开**。
+- 现场 `/proc` 线程 dump：40 anyio + 4 watcher = 44 个线程全卡在 `poll_schedule_timeout`。
+
+**旁证的同类隐患**：
+
+- embedding 通路完全裸奔——`rate_limit` 只在 chat LLM 客户端构造时接入
+  （`llm.py:99-108`），embedding client 无 `rate_limit`、无重试、无 `SHUTTING_DOWN` 打断
+  （`llm.py:196-316`）。
+- `/api/v1/reindex`（`api/app.py:769`，`def`）全量 `encode_batch`，同样分钟级独占线程。
+- agno Agent 外层 `retries=3`（`agno_factory.py:308`）× 内层 `_wrap_with_retry` 8 次 → 单次
+  `agent.run()` 理论最坏 ≈ 33 分钟，把慢后端放大成「几乎不返回」。
+
+**tick 失败语义（已确认，是本设计敢于「服务端拒绝 / 降级」的前提）**：`_tick`
+（`daemon.py:347-355`）里 `collect_and_upload` / `sync` / `reconcile` 任一异常都被
+`logger.exception` 兜住，30s 后**幂等全量重来**，无状态累积、零丢失。所以服务端**快速返回
+陈旧数据、甚至直接 503**，对最终一致性无害。
+
+约束（CLAUDE.md）：不写 fallback、遇问题 throw；OOP；不新老配置兼容、手动迁移；commit
+中英双语；单测 `make test`、发版前 `make e2e`；pylint；不引入重包。
+
+## Goals / Non-Goals
+
+**Goals:**
+
+- **后端任意劣化时，服务可用性不受影响**：网页、`/api/v1/health`、`/register`、`/upload`
+  在 embedding / LLM 后端排队 / 超时 / 挂掉时仍**毫秒级响应**。
+- **推荐新鲜度是唯一允许降级的维度**：画像 / manifest 可以陈旧 30s ~ 几分钟。
+- 慢活（embedding、reindex、agent.run）**永不占用共享请求线程池**到「拖垮其他端点」的程度。
+- client 在后端慢 / 503 时**主动削峰**（jitter + 退避 + 认 `Retry-After`），不再制造僵尸线程。
+- 后端劣化**可观测**：运维能从 `health` / `status` 一眼看出「是后端慢，不是服务挂」。
+
+**Non-Goals:**
+
+- 不改推荐算法本身（80/20 质量 + 相关性、staging 达量等 `skill-recommend-engine` 的逻辑不动）。
+- 不承诺「后端慢时推荐依然新鲜」——新鲜度**本来就允许降级**，这是设计选择不是遗憾。
+- 不引入外部队列 / broker（Redis/Celery 等重依赖）；用进程内 `anyio` 队列 + worker 即可。
+- 不改 client 瘦客户端「不读 config.yaml」原则（jitter / 退避是 client 内建行为，参数走
+  CLI flag 或内建缺省）。
+- 不重写 watcher 并发模型（`watcher.max_concurrent` 不动；本设计只保证 watcher 不再与
+  `/sync` 争抢到饿死）。
+- 不改 `29ce2fe` 的事件循环解冻成果——本设计**建立在其之上**，不回退。
+
+## Decisions
+
+### D1: `/sync` 改回 `async def` + stale-while-revalidate（核心）
+
+**选择**：`team_sync` 从 `def`（丢线程池、同步跑 embedding）改回 `async def`，但**请求路径内
+不做任何 embedding**：直接读**上次已算好的画像快照**产出 manifest 并立即返回（毫秒级）；
+把「该 client 画像该刷新了」这件事**入后台队列**，由独立 worker 异步消化。
+
+**理由**：`29ce2fe` 之所以把 `/sync` 写成 `def`，是因为「`async` 里跑同步慢活会冻事件
+循环」。但根本问题是**慢活根本不该在请求路径里**——无论放事件循环（冻循环）还是放线程池
+（占满 40 线程），只要它在请求路径就会伤害可用性。移出请求路径后，`/sync` 变成纯读，
+`async def` 无同步阻塞、不冻循环、不占线程池，两全。
+
+**替代方案**：① 保持 `def`、只调大线程池 → 治标：后端够慢时任意大的池都会被填满，且吃内存。
+② `def` + 给 `/sync` 单独一个 `CapacityLimiter` → 能防「占满全局池」，但被限流的 `/sync`
+仍会让该 client 拿不到 manifest（等于慢后端直接影响可用性）。stale-while-revalidate 让
+可用性与后端速度**彻底解耦**。
+
+### D2: 后台刷新队列 + 独立 worker + 同 client coalesce 去重
+
+**选择**：进程内 `anyio.create_memory_object_stream` 队列 + 固定数量后台 worker
+（`team.server.refresh_workers`，缺省小，如 2）。入队前查「该 client 是否已有 pending
+刷新」（内存 set），有则**跳过（coalesce）**。worker 调 `update_user_interest`（唯一
+embedding 触发点），完成后 upsert 画像快照、从 pending set 移除。
+
+**理由**：`/sync` 每 30s 一次、多 client 并发，不去重会让「同一 client 的重复刷新」堆满
+队列。coalesce 保证「一个 client 最多一个在途刷新任务」，队列深度 ≈ 活跃 client 数，
+有界。worker 数固定 → embedding 后端的并发压力**可控且可配**（与 D3 的 `CapacityLimiter`
+叠加成双保险）。
+
+**替代方案**：① 每个 `/sync` 起一个 `asyncio.create_task` → 无背压、无去重，等于把「无限
+线程」问题换成「无限 task」。② 外部 broker（Celery）→ 违背「不引重依赖」。选进程内有界队列。
+
+### D3: embedding 真批量 + 统一 `CapacityLimiter` + `SHUTTING_DOWN` 可打断 + `rate_limit` 桶
+
+**选择**：
+1. `encode_batch` 优先走**后端真批量端点**（一次 POST N 条 → `(N, dim)`），后端不支持时才
+   回退逐条（此回退是**能力探测**结果，非运行时 fallback：按后端 capability 一次性决定）。
+2. 所有 embedding 出站调用穿过一个进程级 `anyio.CapacityLimiter(embedding.max_concurrency)`，
+   与 chat LLM 共用「统一出站并发上限」语义。
+3. 每条 / 每批之间检查 `SHUTTING_DOWN`，置位则立即抛 `ShuttingDown` 中断（不再干等 60s×N）。
+4. embedding client 接入与 chat 同源的 `rate_limit` 桶（`llm.py:99-108` 的机制推广到 embedding）。
+
+**理由**：假批量是本次事故的放大器（N 条 ×60s 串行）。真批量把「数分钟」压成「一次请求」。
+`CapacityLimiter` 给「即便在后台 worker 里，embedding 并发也有全局上限」，防止 worker
+数 × 批大小把共享后端打爆。`SHUTTING_DOWN` 打断呼应 `29ce2fe` 的可中断重试成果，让优雅
+停机不被 embedding 拖到 SIGKILL。
+
+**替代方案**：① 只做真批量不做 `CapacityLimiter` → 多 worker 仍可能并发打爆后端。
+② 只加并发上限不做真批量 → 单任务内部仍串行 N×60s。三者正交、都要。
+
+### D4: dashboard / reindex 请求路径去慢化
+
+**选择**：
+- dashboard 静态 / 查询路由（`router.py:57,62` 等）改 `async def`：纯文件读直接 `async`
+  返回；SQLite 查询用 `run_in_threadpool` 显式短占（查询是毫秒级，不是分钟级）。
+- `/api/v1/reindex`（`app.py:769`）改为**入后台任务 + 立即 202**，另开 `GET /reindex/status`
+  查进度；reindex 的 embedding 同样走 D3 的 `CapacityLimiter`。
+
+**理由**：dashboard 与 `/sync` 共享线程池是「网页打不开」的直接原因。把静态 / 轻查询与
+embedding 慢活**物理隔离**：轻活不进那个会被 embedding 占满的池。reindex 是天然的长任务，
+同步等分钟级返回本就是坏 API 形态，202 + 进度查是正解。
+
+**替代方案**：dashboard 全保持 `def` + 给 embedding 单独 `CapacityLimiter` → 也能隔离，但
+dashboard 路由本就无阻塞，`async` 更省线程、更直接。
+
+### D5: agno 重试单层化（外层 `retries=0`，保留内层）
+
+**选择**：`agno_factory` 里 Agent 的外层 `retries` 缺省改 0（不再 `setdefault("retries", 3)`），
+把重试**唯一收敛到内层 `_wrap_with_retry`**（8 次 ×60s + 指数退避，已是可中断的）。
+
+**理由**：两层重试**相乘**（3 × ~662s ≈ 33 分钟）是慢后端下「agent 几乎不返回」的根因。
+内层已经是设计过的、可中断的、带退避的重试点；外层是历史缺省叠加上去的。留一层即可，
+留内层（更细粒度、可中断、已被 `29ce2fe` 加固）。
+
+**替代方案**：留外层删内层 → 内层的可中断 / 细粒度退避会丢。留内层删外层更优。
+
+### D6: client 削峰——jitter + 指数退避 + 认 `Retry-After`
+
+**选择**：
+- `_tick` 的 `poll_interval` 加 **±jitter**（如 ±20%，`daemon.py:373` 的 `wait` 时长随机化），
+  打散多 client 的整点齐步。
+- 维护**连续失败计数**：`_tick` 连续失败时 sleep 走**指数退避**（`base × 2^n`，封顶如 5 分钟），
+  成功即归零。
+- `sync` / `collect_and_upload` 识别 `503` 与 `Retry-After` 响应头（`daemon.py:131-135` 等），
+  按服务端指示的秒数退让，优先于本地退避。
+- client httpx `timeout=30.0`（`cli.py:288`）拆成 `connect` / `read` 分离超时，read 可略长
+  但配合服务端「快返回」后不再需要长 read。
+
+**理由**：僵尸线程堆积的直接推手是 client「30s 整齐重试」。jitter 削峰、退避在后端持续慢时
+拉长间隔、`Retry-After` 让服务端能主动要求 client 退让。三者把 client 从「压力放大器」变成
+「配合削峰的一方」。tick 失败幂等（`daemon.py:347-355`）保证退避 / 拉长间隔不丢数据。
+
+**替代方案**：只加 jitter 不加退避 → 后端持续慢时仍每 30s 一压。三者配合才闭环。
+
+### D7: 兼容性——新旧 client / server 混跑
+
+**选择**：本设计**不引入破坏性 wire 变更**，允许灰度期新旧混跑：
+
+- **旧 client 打新 server**：`/sync` 响应结构（`SyncResponse` / manifest slots）**不变**，只是
+  从「阻塞数分钟」变「毫秒返回（可能陈旧一轮）」。旧 client 感知不到差异，纯获益。新 server
+  发的 `503`/`Retry-After` 旧 client 不认 → 退回其现有的「`_tick` 兜异常 + 30s 重来」行为，
+  依然安全（只是不削峰）。
+- **新 client 打旧 server**：jitter / 退避 / `Retry-After` 识别是**纯 client 侧行为**，旧 server
+  不发这些头时，新 client 的 `Retry-After` 分支不触发、退避只在真失败时启动 → 对旧 server
+  完全兼容，且顺带削峰。
+- **服务端内部**：`team_sync` `def`→`async`、`encode_batch` 真批量、worker 队列均为
+  server 进程内部实现，不改任何 client 可见契约。
+
+**理由**：内网部署无法原子升级所有 client。响应结构不变 + 新行为都是「加法且可降级」保证
+任意混跑组合都不破。
+
+## Risks / Trade-offs
+
+- **[画像陈旧一轮]** stale-while-revalidate 下，client 首次触发某刷新到 worker 消化完之间
+  （30s ~ 几分钟）拿到的是**上一次**画像 → 缓解：推荐本就是 30s 轮询、幂等重算，陈旧一轮
+  对推荐质量无实质影响（这是 Goals 里明确接受的降级维度）。
+- **[冷启动首个 `/sync` 无快照]** 某 client 从未算过画像时，第一次 `/sync` 没有缓存可返回 →
+  缓解：返回「纯 ux 排序 manifest」（与现有 `ClientProfileRecommender` 冷启动退 ux 排序行为
+  一致，非新 fallback），同时入队首次刷新；下一轮即有个性化画像。
+- **[后台队列积压]** 活跃 client 极多 + 后端极慢时，刷新队列可能持续满、画像越来越旧 →
+  缓解：coalesce 让队列深度有界（≈ 活跃 client 数）；`health` 暴露队列深度让运维可见；
+  worker 数 + `CapacityLimiter` 可调。画像旧 ≠ 服务不可用（可用性已与后端解耦）。
+- **[真批量后端不支持]** 共享后端可能不支持一次 N 条 → 缓解：能力探测一次性决定走批量还是
+  逐条；逐条时仍有 `CapacityLimiter` + `SHUTTING_DOWN` 打断兜底，不退回「裸奔串行」。
+- **[reindex 202 语义变化]** 调用方从「同步等完成」变「拿 202 轮询」→ 缓解：`/reindex` 是
+  运维 / 内部端点，调用点少；提供 `GET /reindex/status`，文档更新。属破坏性但影响面小。
+- **[退避封顶下的可用性]** client 指数退避封顶 5 分钟意味着后端恢复后最长 5 分钟才恢复新鲜
+  → 缓解：封顶可配；`Retry-After` 优先于本地退避，服务端可主动缩短。可用性（网页 / health）
+  与此无关，只影响推荐新鲜度恢复速度。
+
+## Migration Plan
+
+各 capability **独立可分批合入**，互不阻塞：
+
+1. **`client-load-shedding`（先行、纯 client 侧、零 server 依赖）**：jitter + 退避 + `Retry-After`
+   识别。新 client 打旧 server 兼容（D7），可**最先发**以立即缓解僵尸线程堆积。
+2. **`embedding-hardening`**：真批量 + `CapacityLimiter` + `SHUTTING_DOWN` + `rate_limit`。纯
+   server 内部，无 wire 变更。需 `embedding.max_concurrency` / `embedding.rate_limit` 配置项
+   （缺省保守值，手动迁移按 CLAUDE.md 不做新老兼容层）。
+3. **`stale-while-revalidate-sync` + 后台 worker**：`/sync` `def`→`async` + 队列 + worker +
+   coalesce。响应结构不变（D7），旧 client 无感。冷启动返 ux 排序快照。
+4. **`request-path-isolation`**：dashboard 路由 `async` 化 + `/reindex` 202。reindex 调用方
+   需改为轮询 `status`（破坏性但面小）。
+5. **`retry-convergence`**：`agno_factory` 外层 `retries` 缺省 0。行为收敛，无接口变更。
+6. **`resilience-observability`**：`health` 加字段（加法，向后兼容）+ `status` 加计数。最后发，
+   验证前几步效果。
+
+回滚：每个 capability 独立开关。`stale-while-revalidate` 若需回滚，可临时把 worker 数设 0 +
+`/sync` 内联刷新（回到旧 `def` 语义）——但按 CLAUDE.md 不长期保留两套。
+
+## Open Questions
+
+- **共享 embedding 后端是否支持真批量端点？** 需先 `curl` 探测（参见 MEMORY「先验证外部
+  API」）。若不支持，D3 的真批量降级为「逐条 + `CapacityLimiter`」，收益从「数分钟→一次请求」
+  变成「数分钟→受控并发的数分钟（但不占请求线程池）」，仍达可用性目标。
+- **`refresh_workers` 与 `embedding.max_concurrency` 的缺省值**：内网共享后端排队严重，worker
+  数宜小（2？）、并发上限宜小（2~4？）。倾向保守缺省 + 可配，实测调优。待定。
+- **画像快照存哪**：复用 `ProfileStore`（`client_interest` 表，`skill-recommend-engine` 已建）
+  的 upsert 即可承载「已算好的画像」，`/sync` 读它、worker 写它。是否需要额外的
+  「manifest 快照」缓存层（避免每次 `/sync` 都 `build_manifest`），还是 `build_manifest` 读
+  缓存画像已足够快？倾向后者（`build_manifest` 不含 embedding 就已是毫秒级），待压测确认。
+- **`Retry-After` 的服务端触发条件**：是「队列深度超阈值」还是「`CapacityLimiter` 满」时对
+  `/sync` 返 503 + `Retry-After`？倾向队列深度阈值（更贴近「刷新跟不上」的真实信号）。待定。
+- **dashboard SQLite 查询走 `run_in_threadpool` 还是 async 驱动**：现用同步 sqlite3。查询是
+  毫秒级，`run_in_threadpool` 短占可接受；是否值得引 aiosqlite（新依赖）存疑。倾向
+  `run_in_threadpool`，不引新包。待定。

--- a/openspec/changes/backend-slow-resilience/proposal.md
+++ b/openspec/changes/backend-slow-resilience/proposal.md
@@ -1,0 +1,127 @@
+# 慢后端韧性：把慢活移出请求路径
+# Backend-Slow Resilience: get the slow work off the request path
+
+> 状态：**设计草案（讨论中）**。本 proposal 覆盖一次「后端劣化不拖垮服务可用性」的总体
+> 设计；实现按 capability 分批出 PR。未决问题见 `design.md` §Open Questions，拍板后细化
+> `tasks.md` 到可执行粒度。
+
+## Why
+
+**2026-07-10 生产事故**：内网部署（LLM / embedding 后端为公用共享服务，长期慢、排队是
+常态）出现「服务失联」——网页打不开、team client 全部 `ReadTimeout`，但进程活着、watcher
+正常。当天上午合入的 `29ce2fe`（事件循环解冻）**已生效**（主线程 `ep_poll` 正常），故障
+机制是**新的一层**：anyio 默认线程池（40）被 `/sync` 的**同步 embedding 调用**打满。
+
+代码级事实链（均为 origin/main 上可查）：
+
+1. **`GET /api/v1/team/sync` 是 `def` 路由**（`src/xskill/team/server/api.py:469`），FastAPI 自动
+   丢进 anyio 线程池执行。其内部 `update_user_interest` → `encode_batch`
+   （`src/xskill/recommend/engine.py:212`）。
+2. **`encode_batch` 是假批量**：逐条串行、每条一个 HTTP 请求、每条 60s 超时
+   （`src/xskill/utils/llm.py:291-300`，client `timeout=60` 见 `llm.py:227`）；冷启动期画像指纹
+   频繁失效（`api.py` `team_sync` 注释），**单个 `/sync` 可占一个线程数分钟**。
+3. **client 侧 httpx `timeout=30.0` 整体标量**（`src/xskill/cli.py:288`），超时断开后**服务端
+   线程继续跑完**（僵尸工作）；client 无退避、无 jitter、不认 `Retry-After`（`_tick` 固定
+   `poll_interval=30` 定时重来，`src/xskill/team/client/daemon.py:347,373`；全仓无任何
+   `Retry-After` 处理），**30s 后整齐重试 → 僵尸线程持续堆积**。
+4. **dashboard 所有路由**含静态页 `/`、`/app.js` **全是 `def`**
+   （`src/xskill/dashboard/router.py:57,62`），与 `/sync` **共享同一个 40 线程池** → 池满则
+   网页打不开。
+5. **故障现场实测**：40 anyio 线程 + 4 watcher 线程全部卡在网络 poll（`/proc` 线程 dump：
+   44 个 `poll_schedule_timeout`），与生产配置 `watcher.max_concurrent=4` 严丝合缝。
+6. **embedding 通路完全裸奔**：无重试、无 `rate_limit` 桶（`rate_limit` 只包 chat LLM，
+   `src/xskill/utils/llm.py:99-108`）、无 `SHUTTING_DOWN` 打断（`llm.py:196-316`）。
+7. **`/api/v1/reindex` 也是 `def`**（`src/xskill/api/app.py:769`），全量 `encode_batch` 分钟级
+   长占线程。
+8. **agno 双层重试相乘**：Agent `retries=3`（`src/xskill/agents/agno_factory.py:308`）× 内层
+   `_wrap_with_retry` 8 次 ×60s + 退避 ≈ 662s → 单次 `agent.run()` 理论最坏 ≈ 33 分钟。
+9. **tick 失败语义已确认安全**：幂等全量重算、30s 自然重来、零丢失
+   （`daemon.py:347-355`）——所以**服务端拒绝 / 降级是安全的**。
+
+**根因不是 bug，是设计缺口**：把「后端一慢就长时间占用」的同步慢活放进了共享请求线程池，
+且客户端无削峰。后端排队是**常态**，当前架构却把常态当异常来承受。
+
+## What Changes
+
+设计约束：**后端永远慢、永远排队，这是常态不是故障**。目标：后端任意劣化时，服务
+可用性（网页、`health`、注册、`upload`）**不受影响**，仅推荐新鲜度降级。
+
+### 1. 核心：慢活移出请求路径（stale-while-revalidate）
+
+- `/sync` 改回 `async def`，**立即返回上次已计算的画像 / manifest**（毫秒级）；画像刷新
+  变成**后台队列任务**，由独立 worker 消化。
+- 同一 client 的刷新任务**合并去重（coalesce）**：队列里已有该 client 的 pending 刷新则跳过。
+- 画像过期 30s ~ 几分钟对推荐系统无实质影响（本来就是 30s 轮询）。
+
+### 2. embedding 通路加固
+
+- **真批量 API**：一次请求携带 N 条文本（若后端支持），替换逐条串行。
+- 纳入**统一出站并发上限** `CapacityLimiter`（可配 `embedding.max_concurrency`）。
+- 加 `SHUTTING_DOWN` **可打断**（关闭时不再干等 60s×N）。
+- 与 chat LLM 一样**接入 `rate_limit` 桶**。
+
+### 3. 轻重隔离
+
+- dashboard 静态 / 查询路由改 `async`（纯文件读 / SQLite 用 `run_in_threadpool` 或保持轻量），
+  不再与 embedding 慢活共享线程。
+- `/api/v1/reindex` 改为**后台任务 + 立即返回 202** + 进度可查。
+
+### 4. 重试收敛
+
+- agno Agent 外层 `retries=3` 与 `agno_factory` 内层 8 次**二选一**（建议保留内层、外层设 0），
+  消除 33 分钟最坏情形。
+
+### 5. client 侧削峰
+
+- tick 加**随机 jitter**（如 ±20%），避免多 client 整点齐步。
+- 连续失败**指数退避**（封顶如 5 分钟）。
+- 识别 `503` / `Retry-After`，按服务端指示退让。
+
+### 6. 可观测
+
+- `/api/v1/health` 增加**线程池水位、后台刷新队列深度、embedding/LLM 后端最近延迟**。
+- `xskill status` 显示 **tick 连续失败计数**。
+
+## Capabilities
+
+### New Capabilities
+
+- `stale-while-revalidate-sync`: `/sync` 改 `async`、立即返回缓存 manifest；画像刷新入
+  后台队列 + 独立 worker + 同 client coalesce 去重。
+- `embedding-hardening`: 真批量 embedding API、统一 `CapacityLimiter` 出站并发上限、
+  `SHUTTING_DOWN` 可打断、接入 `rate_limit` 桶。
+- `request-path-isolation`: dashboard 静态 / 查询路由改 `async` / 轻量；`/reindex` 改后台
+  任务 + 202 + 进度查询。
+- `retry-convergence`: agno 双层重试收敛为单层，消除相乘最坏情形。
+- `client-load-shedding`: tick jitter + 连续失败指数退避 + `503`/`Retry-After` 识别。
+- `resilience-observability`: `health` 暴露线程池水位 / 队列深度 / 后端延迟；`status`
+  显示 tick 连续失败计数。
+
+### Modified Capabilities
+
+（无——`openspec/specs/` 当前为空，无既有 spec 需修改。`team_sync` 由 `def` 改 `async`、
+`encode_batch` 语义收紧、dashboard/reindex 路由形态变化，均为实现契约调整而非已成文的
+spec 级契约变更。）
+
+## Impact
+
+- **`src/xskill/team/server/api.py`**：`team_sync` `def` → `async def`，只读缓存 manifest +
+  入队刷新；`/register`、`/upload` 保持轻量不触 embedding。
+- **`src/xskill/team/server/`（新增刷新 worker）**：后台画像刷新队列 + 独立 worker +
+  coalesce 去重；`skill_manifest.build_manifest` 读缓存画像不现算。
+- **`src/xskill/recommend/engine.py`**：`update_user_interest` 从 `/sync` 同步路径移出，
+  由 worker 调用；`get_skill_for_client` 读上次快照。
+- **`src/xskill/utils/llm.py`**：`encode_batch` 真批量 + `CapacityLimiter` + `SHUTTING_DOWN`
+  打断 + `rate_limit` 桶（对齐 chat 通路 `llm.py:99-108`）。
+- **`src/xskill/dashboard/router.py`**：静态 / 查询路由 `def` → `async`（或 `run_in_threadpool`）。
+- **`src/xskill/api/app.py`**：`/reindex` `def` → 后台任务 + 202 + `GET /reindex/status`。
+- **`src/xskill/agents/agno_factory.py`**：外层 `retries` 缺省 0（内层 `_wrap_with_retry` 唯一
+  重试点），消除相乘。
+- **`src/xskill/team/client/daemon.py`** + **`src/xskill/cli.py`**：`_tick` 加 jitter + 指数退避 +
+  连续失败计数；`sync`/`collect_and_upload` 识别 `503`/`Retry-After`；client `timeout` 分离
+  connect / read。
+- **`src/xskill/config.py`**：新增 `embedding.max_concurrency` / `embedding.rate_limit`、
+  `team.server.refresh_workers`、client `poll_jitter` / `backoff_max` 等配置项。
+- **`tests/`**：覆盖 `/sync` 快返回 + 后台刷新、coalesce 去重、embedding 并发上限 /
+  可打断、dashboard 池隔离、reindex 202、退避 + `Retry-After`、health 水位字段。
+- **依赖**：不新增重包（`anyio.CapacityLimiter` 随 anyio 已在依赖内）。

--- a/openspec/changes/backend-slow-resilience/specs/client-load-shedding/spec.md
+++ b/openspec/changes/backend-slow-resilience/specs/client-load-shedding/spec.md
@@ -1,0 +1,45 @@
+## ADDED Requirements
+
+### Requirement: tick 轮询加随机 jitter
+
+team client 的 `_tick` 轮询间隔 SHALL 在 `poll_interval` 基础上叠加随机 jitter（缺省 ±20%），
+使多个 client 的轮询时刻错开，SHALL NOT 让所有 client 在固定周期整点齐步打 server。
+
+#### Scenario: 轮询间隔带 jitter
+
+- **当** `poll_interval=30s`、jitter=±20%
+- **那么** 每轮实际等待 SHALL 落在 24s~36s 区间内的随机值
+
+### Requirement: 连续失败时指数退避
+
+team client SHALL 维护连续失败计数：`_tick` 成功时 SHALL 归零，失败时 SHALL 自增。连续失败
+时下一轮等待 SHALL 走指数退避 `min(base * 2**n, backoff_max)`（`backoff_max` 缺省 5 分钟）。
+退避 SHALL NOT 导致数据丢失（tick 幂等、全量重算）。
+
+#### Scenario: 后端持续慢时拉长间隔
+
+- **当** `_tick` 连续失败 n 次
+- **那么** 下一轮等待 SHALL 按指数退避增长，直到封顶 `backoff_max`
+
+#### Scenario: 成功后间隔归位
+
+- **当** 一次 `_tick` 在若干次失败后成功
+- **那么** 连续失败计数 SHALL 归零，等待间隔 SHALL 回到 `poll_interval`(+jitter)
+
+### Requirement: 识别 503 与 Retry-After
+
+team client 的 `sync` / `collect_and_upload` SHALL 识别服务端返回的 `503` 与 `Retry-After`
+响应头，并按其指示的秒数退让；`Retry-After` 指示 SHALL 优先于本地指数退避。当服务端不返回
+`Retry-After`（如旧 server）时，client SHALL 退回本地退避行为。
+
+#### Scenario: 遵守服务端 Retry-After
+
+- **当** server 对 `/sync` 返回 `503` + `Retry-After: 120`
+- **那么** client SHALL 至少等待 120s 再重试
+- **且** 该指示 SHALL 优先于本地退避计算值
+
+#### Scenario: 旧 server 无 Retry-After 兼容
+
+- **当** client 打的是不发 `Retry-After` 的旧 server
+- **那么** client 的 `Retry-After` 分支 SHALL 不触发
+- **且** client SHALL 退回既有的失败即幂等重来行为

--- a/openspec/changes/backend-slow-resilience/specs/embedding-hardening/spec.md
+++ b/openspec/changes/backend-slow-resilience/specs/embedding-hardening/spec.md
@@ -1,0 +1,50 @@
+## ADDED Requirements
+
+### Requirement: encode_batch 优先走后端真批量端点
+
+`encode_batch(texts)` SHALL 在后端支持批量 embedding 端点时，以**单个请求**携带全部 `texts`
+并返回 `(N, dim)` 矩阵，SHALL NOT 对每条文本发一个独立 HTTP 请求。是否走批量 SHALL 由对后端
+能力的一次性探测决定；后端不支持批量时才逐条调用（此为能力探测结果，非运行时 fallback）。
+
+#### Scenario: 批量后端单请求编码
+
+- **当** 后端支持批量 embedding，`encode_batch` 收到 20 条文本
+- **那么** 它 SHALL 以单个 HTTP 请求编码全部 20 条
+- **且** 返回 `(20, dim)` 矩阵
+
+#### Scenario: 非批量后端逐条降级
+
+- **当** 后端不支持批量端点
+- **那么** `encode_batch` SHALL 逐条调用，且仍受并发上限与可打断约束
+
+### Requirement: embedding 出站调用受统一并发上限约束
+
+所有 embedding 出站调用 SHALL 穿过一个进程级 `anyio.CapacityLimiter`，其上限由
+`embedding.max_concurrency` 配置。在途 embedding 调用数 SHALL NOT 超过该上限，即便调用来自
+多个后台刷新 worker。
+
+#### Scenario: 并发上限生效
+
+- **当** `embedding.max_concurrency=2`，且多个 worker 同时请求 embedding
+- **那么** 任意时刻在途 embedding 调用数 SHALL NOT 超过 2
+
+### Requirement: embedding 调用在关闭时可被打断
+
+embedding 调用路径 SHALL 在每批（或每条）之间检查 `SHUTTING_DOWN` 标志，置位时 SHALL 立即
+中断（抛中断异常）而 SHALL NOT 继续干等后端返回。
+
+#### Scenario: 关闭时不干等 embedding
+
+- **当** 一个多条 embedding 任务进行中，`SHUTTING_DOWN` 被置位
+- **那么** 该任务 SHALL 在下一个检查点立即中断
+- **且** SHALL NOT 等待剩余条目的 60s 超时
+
+### Requirement: embedding 接入统一 rate_limit 桶
+
+embedding client SHALL 接入与 chat LLM 同源的 `rate_limit` 令牌桶（当配置提供 `rate_limit`
+时）。embedding 出站速率 SHALL 受该桶的 rpm/tpm/burst 约束。
+
+#### Scenario: embedding 被 rate_limit 节流
+
+- **当** 配置了 embedding `rate_limit`，且短时间内提交大量 embedding
+- **那么** 出站请求速率 SHALL 被令牌桶约束在配置的 rpm/tpm 内

--- a/openspec/changes/backend-slow-resilience/specs/request-path-isolation/spec.md
+++ b/openspec/changes/backend-slow-resilience/specs/request-path-isolation/spec.md
@@ -1,0 +1,29 @@
+## ADDED Requirements
+
+### Requirement: dashboard 路由不与 embedding 慢活共享长占线程
+
+dashboard 静态资产路由（`/`、`/app.js` 等）SHALL 为 `async` 并直接返回文件内容，SHALL NOT
+被丢进会被 embedding 慢活长占的共享线程池。dashboard 的 SQLite 查询路由 SHALL 只做毫秒级的
+短占（如 `run_in_threadpool`），SHALL NOT 在请求路径内执行分钟级慢活。
+
+#### Scenario: 慢 /sync 不拖垮 dashboard
+
+- **当** 多个 client 并发打慢 `/sync`（每个后台刷新排队）
+- **那么** dashboard 的 `/` 与 `/app.js` SHALL 仍正常、快速返回
+
+### Requirement: /reindex 改为后台任务并立即返回 202
+
+`POST /api/v1/reindex` SHALL 把重建索引作为后台任务提交并立即返回 `202 Accepted`，SHALL NOT
+在请求路径内同步等待全量 `encode_batch` 完成。reindex 的 embedding SHALL 走统一的
+`CapacityLimiter`。server SHALL 提供 `GET /api/v1/reindex/status` 查询进度。
+
+#### Scenario: reindex 立即返回并可查进度
+
+- **当** 调用方 `POST /api/v1/reindex`
+- **那么** 端点 SHALL 立即返回 `202`
+- **且** 调用方 SHALL 能通过 `GET /api/v1/reindex/status` 轮询到最终完成
+
+#### Scenario: reindex 不占满请求线程池
+
+- **当** reindex 后台任务正在全量编码
+- **那么** `/health` 与 dashboard 路由 SHALL 仍正常响应

--- a/openspec/changes/backend-slow-resilience/specs/resilience-observability/spec.md
+++ b/openspec/changes/backend-slow-resilience/specs/resilience-observability/spec.md
@@ -1,0 +1,29 @@
+## ADDED Requirements
+
+### Requirement: health 暴露线程池水位、队列深度与后端延迟
+
+`GET /api/v1/health` SHALL 在响应中增加韧性可观测字段：anyio 工作线程池水位（活跃 / 上限）、
+后台画像刷新队列深度、以及 embedding/LLM 后端的最近延迟（滑窗统计）。这些字段 SHALL 为**加法**
+新增，旧监控 / 旧 client 遇未知字段 SHALL 能忽略而不报错。
+
+#### Scenario: health 反映后端劣化
+
+- **当** embedding 后端变慢、后台刷新队列开始堆积
+- **那么** `/health` 的队列深度字段 SHALL 增大、后端延迟字段 SHALL 升高
+- **且** 运维 SHALL 能据此判断「是后端慢，不是服务挂」
+
+#### Scenario: health 新字段向后兼容
+
+- **当** 一个只读旧字段的监控解析新 `/health` 响应
+- **那么** 它 SHALL 忽略新增的韧性字段而不报错
+
+### Requirement: status 显示 tick 连续失败计数
+
+`xskill status` SHALL 显示 team client 的 tick 连续失败计数与当前退避间隔，使运维能看出
+client 是否正处于「后端慢 → 退避削峰」状态。
+
+#### Scenario: status 反映连续失败
+
+- **当** client `_tick` 已连续失败若干次
+- **那么** `xskill status` SHALL 显示该连续失败计数与当前退避间隔
+- **且** 一次成功后计数 SHALL 显示为归零

--- a/openspec/changes/backend-slow-resilience/specs/retry-convergence/spec.md
+++ b/openspec/changes/backend-slow-resilience/specs/retry-convergence/spec.md
@@ -1,0 +1,18 @@
+## ADDED Requirements
+
+### Requirement: agent 重试收敛为单层
+
+`agno_factory` 构造 Agent 时，外层 `retries` 缺省 SHALL 为 0，重试 SHALL 唯一收敛到内层
+`_wrap_with_retry`（可中断、带指数退避）。外层与内层重试次数 SHALL NOT 相乘。当调用方显式
+传入 `retries` 时，该显式值 SHALL 被尊重。
+
+#### Scenario: 单次 agent.run 最坏时长不再相乘
+
+- **当** 后端持续限流，触发一次 `agent.run()`
+- **那么** 最坏总耗时 SHALL 收敛到内层单层重试上限（8 次量级）
+- **且** SHALL NOT 出现外层 3 次 × 内层的相乘放大（约 33 分钟）
+
+#### Scenario: 显式 retries 被尊重
+
+- **当** 调用方显式传入 `retries=2`
+- **那么** 该显式值 SHALL 被使用，而非缺省 0

--- a/openspec/changes/backend-slow-resilience/specs/stale-while-revalidate-sync/spec.md
+++ b/openspec/changes/backend-slow-resilience/specs/stale-while-revalidate-sync/spec.md
@@ -1,0 +1,66 @@
+## ADDED Requirements
+
+### Requirement: /sync 在请求路径内不执行任何 embedding
+
+`GET /api/v1/team/sync` SHALL 为 `async` 路由，且在请求处理路径内 SHALL NOT 执行任何 embedding
+调用（同步或异步）。它 SHALL 只读上一次已计算的画像快照并据此构建 manifest 后立即返回。
+当 embedding / LLM 后端慢或不可用时，`/sync` 的响应延迟 SHALL NOT 因此增加。
+
+#### Scenario: 后端慢时 /sync 仍毫秒返回
+
+- **当** embedding 后端每条请求耗时 60s，且某 client 打 `/sync`
+- **那么** `/sync` SHALL 立即（毫秒级）返回上一次画像快照构建的 manifest
+- **且** 该请求 SHALL NOT 触发任何同步 embedding 调用
+
+#### Scenario: /sync 响应结构对旧 client 不变
+
+- **当** 一个未升级的旧 client 打新 server 的 `/sync`
+- **那么** 响应体 SHALL 仍是既有的 `SyncResponse` 结构（slots 契约不变）
+- **且** 旧 client SHALL 能正常解析并 reconcile
+
+### Requirement: 画像刷新入后台队列由独立 worker 消化
+
+server SHALL 维护一个进程内后台刷新队列与固定数量的 worker（数量由
+`team.server.refresh_workers` 配置）。`/sync` 判定某 client 画像需刷新时 SHALL 只把刷新任务
+入队，SHALL NOT 在请求路径内等待其完成。worker SHALL 是 `engine.update_user_interest`（触发
+embedding 的唯一入口）的唯一调用者，并在完成后把新画像快照 upsert 持久化。
+
+#### Scenario: 刷新在后台完成并持久化
+
+- **当** 某 client 的 atom 集变化触发一次画像刷新入队
+- **那么** 后台 worker SHALL 消化该任务、重算画像、upsert 快照
+- **且** 该 client 下一次 `/sync` SHALL 读到刷新后的画像
+
+### Requirement: 同一 client 的刷新任务合并去重
+
+当某 client 已有一个在途（pending）刷新任务时，server SHALL NOT 为同一 client 再入队第二个
+刷新任务（coalesce）。队列深度因此 SHALL 以活跃 client 数为上界。
+
+#### Scenario: 重复 /sync 不堆积刷新任务
+
+- **当** 同一 client 在其上一个刷新任务尚未完成时连续多次打 `/sync`
+- **那么** server SHALL 只保留一个在途刷新任务
+- **且** 后续重复的刷新请求 SHALL 被跳过
+
+### Requirement: 冷启动无快照时返回 ux 排序 manifest
+
+当某 client 从无任何画像快照（冷启动）时，`/sync` SHALL 返回纯 ux 排序的 manifest（与既有
+冷启动行为一致），并 SHALL 入队该 client 的首次画像刷新。
+
+#### Scenario: 首次 /sync 冷启动
+
+- **当** 一个从未算过画像的 client 首次打 `/sync`
+- **那么** `/sync` SHALL 立即返回 ux 排序 manifest
+- **且** server SHALL 入队该 client 的首次画像刷新
+
+### Requirement: 刷新队列过载时对 /sync 施加背压
+
+当后台刷新队列深度超过配置阈值时，server SHALL 能对触发新刷新的 `/sync` 返回 `503` 并带
+`Retry-After` 头以指示 client 退让。此背压 SHALL NOT 影响其他端点（`/health`、`/register`、
+`/upload`、dashboard）的可用性。
+
+#### Scenario: 队列过载返回 Retry-After
+
+- **当** 后台刷新队列深度超过阈值，且某 client 打 `/sync` 触发新刷新
+- **那么** server MAY 返回 `503` 并带 `Retry-After`
+- **且** 同一时刻 `/health` 与 dashboard 静态页 SHALL 仍正常响应

--- a/openspec/changes/backend-slow-resilience/tasks.md
+++ b/openspec/changes/backend-slow-resilience/tasks.md
@@ -1,0 +1,85 @@
+# Tasks — 慢后端韧性 / Backend-Slow Resilience
+
+> 骨架版（设计草案）。Open Questions（`design.md` §Open Questions）拍板后细化到可执行
+> 粒度。各阶段按 `design.md` §Migration Plan 的顺序独立可合入。
+
+## 1. client 侧削峰 client-load-shedding（先行、零 server 依赖）
+
+- [ ] 1.1 `team/client/daemon.py` `_tick` 循环：`poll_interval` 加 ±jitter（缺省 ±20%），随机化
+      `self._stop.wait(...)` 时长，打散多 client 齐步
+- [ ] 1.2 连续失败计数 `_consecutive_failures`：`_tick` 成功归零、异常自增；失败时 sleep 走
+      指数退避 `min(base * 2**n, backoff_max)`（缺省 `backoff_max=300s`）
+- [ ] 1.3 `sync` / `collect_and_upload` 识别 `503` + `Retry-After` 响应头，按指示秒数退让，
+      优先于本地退避；无该头时退回本地退避（对旧 server 兼容）
+- [ ] 1.4 `cli.py:288` client httpx `timeout=30.0` 拆 `connect` / `read` 分离超时
+- [ ] 1.5 内建缺省 + 可选 CLI flag（`--poll-jitter` / `--backoff-max`），不破瘦客户端「不读
+      config.yaml」原则
+- [ ] 1.6 `tests/`：jitter 区间、连续失败退避曲线 + 成功归零、`Retry-After` 优先、旧 server
+      无头兼容、tick 幂等不丢数据
+
+## 2. embedding 通路加固 embedding-hardening
+
+- [ ] 2.1 `utils/llm.py` `encode_batch`：能力探测后端是否支持真批量端点（一次 POST N 条 →
+      `(N, dim)`）；支持走批量，不支持逐条（探测结果一次性决定，非运行时 fallback）
+- [ ] 2.2 进程级 `anyio.CapacityLimiter(embedding.max_concurrency)` 包裹所有 embedding 出站
+      调用；缺省保守值
+- [ ] 2.3 每批 / 每条前检查 `SHUTTING_DOWN`，置位则抛中断（呼应 `29ce2fe` 可中断重试）
+- [ ] 2.4 embedding client 接入与 chat 同源 `rate_limit` 桶（推广 `llm.py:99-108` 机制）
+- [ ] 2.5 `config.py` 加 `embedding.max_concurrency` / `embedding.rate_limit`（显式默认，坏类型
+      抛 ValueError）
+- [ ] 2.6 `tests/`：真批量单请求、逐条降级、并发上限生效、`SHUTTING_DOWN` 打断、rate_limit 桶
+      节流、config 读取
+
+## 3. stale-while-revalidate stale-while-revalidate-sync（核心）
+
+- [ ] 3.1 `team/server/api.py` `team_sync` `def` → `async def`：请求路径内只读上次画像快照 →
+      `build_manifest` → 立即返回；**不触任何 embedding**
+- [ ] 3.2 后台刷新队列：`anyio` memory object stream + `team.server.refresh_workers` 个 worker
+      协程，随 app lifespan 起停
+- [ ] 3.3 coalesce 去重：入队前查 pending set（该 client 已有在途刷新则跳过）；worker 完成后
+      移除
+- [ ] 3.4 worker 调 `engine.update_user_interest`（唯一 embedding 触发点）→ upsert 画像快照到
+      `ProfileStore`
+- [ ] 3.5 冷启动无快照：返回纯 ux 排序 manifest（与现有 `ClientProfileRecommender` 冷启动一致）
+      + 入队首次刷新
+- [ ] 3.6 队列深度超阈值时 `/sync` 返 503 + `Retry-After`（与 §1.3 client 削峰闭环）
+- [ ] 3.7 `config.py` 加 `team.server.refresh_workers` / 队列深度阈值
+- [ ] 3.8 `tests/`：`/sync` 毫秒返回（mock 慢 embedding 不阻塞）、后台刷新最终 upsert、coalesce
+      去重、冷启动 ux 快照、队列满返 503、旧 client 响应结构不变
+
+## 4. 轻重隔离 request-path-isolation
+
+- [ ] 4.1 `dashboard/router.py` 静态路由（`/`、`/app.js` 等 `router.py:57,62`）`def` → `async`：
+      纯文件读直接 async 返回
+- [ ] 4.2 dashboard SQLite 查询路由：`run_in_threadpool` 短占（毫秒级），不与 embedding 慢活
+      共享长占
+- [ ] 4.3 `api/app.py` `/reindex`（`app.py:769`）`def` → 后台任务 + 立即 202；reindex embedding
+      走 §2.2 `CapacityLimiter`
+- [ ] 4.4 新增 `GET /api/v1/reindex/status` 查进度；更新调用方与文档（破坏性、面小）
+- [ ] 4.5 `tests/`：dashboard 路由不被慢 `/sync` 拖垮（并发压测）、reindex 返 202 + status 轮询
+      到完成
+
+## 5. 重试收敛 retry-convergence
+
+- [ ] 5.1 `agents/agno_factory.py:308` 外层 `retries` 缺省改 0（删 `setdefault("retries", 3)`），
+      重试唯一收敛到内层 `_wrap_with_retry`
+- [ ] 5.2 保留内层 8 次 ×60s + 指数退避 + 可中断（`29ce2fe` 成果）不变
+- [ ] 5.3 `tests/`：单次 `agent.run()` 最坏时长 ≈ 内层单层上限（不再 ×3 相乘）；显式传 `retries`
+      仍被尊重
+
+## 6. 可观测 resilience-observability
+
+- [ ] 6.1 `/api/v1/health` 加字段：anyio 线程池水位（活跃 / 上限）、后台刷新队列深度、
+      embedding/LLM 后端最近延迟（滑窗）
+- [ ] 6.2 `xskill status`（client）显示 tick 连续失败计数 + 当前退避间隔
+- [ ] 6.3 `tests/`：health 新字段存在且数值合理、status 计数随失败增长 / 成功归零
+- [ ] 6.4 health 字段为**加法**，旧监控 / 旧 client 忽略未知字段，向后兼容
+
+## 7. 验收 / Verification
+
+- [ ] 7.1 `make test`：各 capability 新增测试全绿；不引入新 pylint warning
+- [ ] 7.2 `pylint` 改动文件 E+W 10.00/10
+- [ ] 7.3 故障复现回归：mock「embedding 后端每条 sleep 60s」，断言 `/`、`/health`、`/register`、
+      `/upload` 在多 client 并发 `/sync` 下仍毫秒响应（线程池不被占满）
+- [ ] 7.4 `make e2e`（Docker E2E）：慢后端场景端到端（网页可开 + client 削峰 + 画像最终刷新）
+- [ ] 7.5 兼容性矩阵：旧 client×新 server、新 client×旧 server 两组混跑冒烟（D7）


### PR DESCRIPTION
> OpenSpec 设计草案（讨论中）。仅新增 `openspec/changes/backend-slow-resilience/`，不动任何源码。`openspec validate backend-slow-resilience --strict` 通过。

## 动机 | Motivation

2026-07-10 内网生产事故：LLM/embedding 后端是公用共享服务（长期慢、排队是常态），出现「服务失联」——网页打不开、team client 全部 `ReadTimeout`，但进程活着、watcher 正常。

当天上午合入的 `29ce2fe`（事件循环解冻）**已生效**（主线程 `ep_poll` 正常），故障是**新的一层**：`GET /api/v1/team/sync` 是 `def` 路由（`api.py:469`），FastAPI 丢进 anyio 40 线程池；其内部 `encode_batch` 是**假批量**（逐条串行、每条 60s，`llm.py:291`），单个 `/sync` 占一个线程数分钟。dashboard 静态页 `/`、`/app.js` 也全是 `def`（`router.py:57,62`），与 `/sync` 共享同一个池 → 池满则网页打不开。现场 `/proc` dump：40 anyio + 4 watcher 线程全卡在网络 poll。client 侧无 jitter、无退避、不认 `Retry-After`（`cli.py:288` timeout=30、`daemon.py:373`），30s 整齐重试 → 僵尸线程只堆不减。

**根因不是 bug，是设计缺口**：把「后端一慢就长时间占用」的同步慢活放进共享请求线程池，且客户端无削峰。后端排队是常态，架构却把常态当异常承受。

## 方案 | Approach

设计约束：**后端永远慢、永远排队是常态**。目标：后端任意劣化时，服务可用性（网页、health、注册、upload）不受影响，仅推荐新鲜度降级。6 个 capability：

1. **`stale-while-revalidate-sync`**（核心）：`/sync` 改 `async`、立即返回上次画像快照，刷新入后台队列 + 独立 worker + 同 client coalesce 去重。
2. **`embedding-hardening`**：真批量 API、统一 `CapacityLimiter` 出站并发上限、`SHUTTING_DOWN` 可打断、接入 `rate_limit` 桶。
3. **`request-path-isolation`**：dashboard 静态/查询路由改 `async`；`/reindex` 改后台任务 + 202 + 进度查询。
4. **`retry-convergence`**：agno 外层 `retries=3` × 内层 8 次相乘（最坏 ≈33 分钟）收敛为单层。
5. **`client-load-shedding`**：tick jitter + 连续失败指数退避 + 识别 `503`/`Retry-After`。
6. **`resilience-observability`**：health 暴露线程池水位/队列深度/后端延迟，status 显示 tick 连续失败计数。

`_tick` 失败语义已确认安全（幂等全量重算、30s 自然重来、零丢失），故服务端拒绝/降级安全。

## 兼容性 | Compatibility

- **旧 client × 新 server**：`SyncResponse`/manifest 结构不变，只是从「阻塞数分钟」变「毫秒返回」，旧 client 纯获益；不认新 `Retry-After` 则退回既有幂等重来，安全。
- **新 client × 旧 server**：jitter/退避/`Retry-After` 识别是纯 client 行为，旧 server 不发这些头时分支不触发，完全兼容。
- 无破坏性 wire 变更，允许灰度期新旧混跑。

## 文件 | Files

`proposal.md` / `design.md`（含 7 条 Decision + 兼容性 D7 + Open Questions）/ `tasks.md`（6 阶段骨架，按 Migration Plan 独立可合入）+ 6 个 `specs/*/spec.md`。不含源码改动。

🤖 Generated with [Claude Code](https://claude.com/claude-code)
