### PR TITLE
feat(client): persistent connect on Linux and WSL

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -88,6 +88,21 @@ jobs:
       - name: Smoke E2E (stub LLM + fixture, no network)
         run: pytest tests/e2e/test_smoke.py -v -k "${{ matrix.agent }}"
 
+  connect-lifecycle-e2e:
+    name: connect lifecycle e2e (linux/wsl mode)
+    needs: ut-it
+    runs-on: ubuntu-latest
+    steps:
+      - uses: actions/checkout@v4
+      - uses: actions/setup-python@v5
+        with:
+          python-version: "3.11"
+          cache: pip
+      - name: Install xskill (with dev extras)
+        run: pip install -e .[dev]
+      - name: Connect lifecycle E2E (local stub, no network)
+        run: pytest tests/e2e/test_connect_lifecycle_e2e.py -v
+
   real-llm-e2e:
     name: real-llm-e2e (linux)
     if: github.event_name != 'pull_request'

--- a/src/xskill/cli.py
+++ b/src/xskill/cli.py
@@ -354,7 +354,7 @@ def cmd_start(args) -> int:
 def cmd_update(args) -> int:
     """立即检查 PyPI 是否有新版 xskill，有则升级并重启。"""
     from xskill.team.client.updater import (
-        _current_version, _latest_pypi_version, _restart,
+        AutoUpdater, _current_version, _latest_pypi_version, _restart,
     )
     current = _current_version("xskill")
     if not current:
@@ -374,15 +374,8 @@ def cmd_update(args) -> int:
     except Exception:
         pass
     print(f"发现新版本: {latest}，开始升级...")
-    import subprocess
-    result = subprocess.run(
-        [sys.executable, "-m", "pip", "install", "--upgrade",
-         f"xskill=={latest}", "-i", "https://pypi.org/simple/"],
-        capture_output=True, text=True,
-    )
-    if result.returncode != 0:
-        print(f"error: 升级失败:\n{result.stderr.strip() or result.stdout.strip()}",
-              file=sys.stderr)
+    if not AutoUpdater()._install(latest):
+        print("error: 升级失败，请检查 pip 配置和日志", file=sys.stderr)
         return 1
     print(f"升级到 {latest} 成功，正在重启...")
     _restart()
@@ -397,6 +390,9 @@ def cmd_stop(args) -> int:
     except ServiceError as e:
         print(f"error: {e}", file=sys.stderr)
         return 1
+    if getattr(args, "json", False):
+        _print_connect_status(st, as_json=True)
+        return 0
     if st.get("warning"):
         print(f"warning: {st['warning']}", file=sys.stderr)
     print("stopped.")

--- a/src/xskill/cli.py
+++ b/src/xskill/cli.py
@@ -331,6 +331,8 @@ def _print_connect_status(st: dict, as_json: bool) -> None:
         print(f"  server   : {st['server_url']}")
     if st.get("client_id"):
         print(f"  client_id: {st['client_id']}")
+    if st.get("warning"):
+        print(f"  warning  : {st['warning']}")
 
 
 def cmd_start(args) -> int:

--- a/src/xskill/cli.py
+++ b/src/xskill/cli.py
@@ -179,7 +179,7 @@ def cmd_connect(args) -> int:
     ``xskill connect ... --foreground``          前台阻塞跑守护循环
 
     默认（非 --foreground）：完成握手 / 校验连接信息后，把常驻循环交给操作系统的
-    守护设施（Windows「计划任务」；Linux·macOS 的 systemd·launchd 后续支持）在
+    守护设施（Windows「计划任务」；Linux/WSL 优先 systemd user）在
     后台拉起，命令随即返回——用户不必一直开着终端。``--foreground`` 才是真正阻塞的
     轮询循环，也是后台任务实际 execute 的形态（见 team.client.service）。
     """
@@ -202,9 +202,7 @@ def cmd_connect(args) -> int:
     from xskill.team.client.service import ServiceError, get_backend
     backend = get_backend()
 
-    # 前台模式，或本平台还没有原生常驻后端（Linux/macOS 暂时）：直接阻塞跑守护
-    # 循环（= 历史行为；后台任务 execute 的也是这条路径）。这样非 Windows 用户的
-    # `xskill connect` 行为不变，仍可用自己的 init 系统托管 --foreground。
+    # 前台模式，或本平台还没有原生常驻后端：直接阻塞跑守护循环。
     if args.foreground or not backend.supported:
         print(f"reconnecting: client_id={state.client_id}  server={state.server_url}")
         _run_team_client_forever(state, use_proxy=args.use_proxy,
@@ -317,8 +315,18 @@ def _print_connect_status(st: dict, as_json: bool) -> None:
     print(f"connect daemon: {mark}")
     if st.get("task_name"):
         print(f"  task     : {st['task_name']} ({st.get('backend')})")
+    elif st.get("unit_name"):
+        print(f"  service  : {st['unit_name']} ({st.get('backend')})")
+    elif st.get("backend"):
+        print(f"  backend  : {st['backend']}")
+    if st.get("platform"):
+        print(f"  platform : {st['platform']}")
+    if st.get("method"):
+        print(f"  method   : {st['method']}")
     if st.get("pid"):
         print(f"  pid      : {st['pid']}")
+    if st.get("log_path"):
+        print(f"  log      : {st['log_path']}")
     if st.get("server_url"):
         print(f"  server   : {st['server_url']}")
     if st.get("client_id"):

--- a/src/xskill/team/client/service.py
+++ b/src/xskill/team/client/service.py
@@ -504,6 +504,8 @@ def _systemd_user_available() -> bool:
     WSL 只有在 /etc/wsl.conf 启用 systemd 后才满足；普通 Linux 的精简容器或
     没有 user bus 的 SSH 环境也会返回 False，随后使用 detached 后端。
     """
+    if os.environ.get("XSKILL_CONNECT_BACKEND", "").strip().lower() == "detached":
+        return False
     if not shutil.which("systemctl"):
         return False
     try:

--- a/src/xskill/team/client/service.py
+++ b/src/xskill/team/client/service.py
@@ -6,7 +6,9 @@
 
     ConnectServiceBackend           抽象基类（含共享 pid/state 读写 + 存活校验）
       └─ WindowsTaskSchedulerBackend  Windows「计划任务」(schtasks)  —— 本 MR 完整实现
-      └─ SystemdUserBackend           Linux systemd --user            —— TODO(占位)
+      └─ LinuxServiceBackend          Linux/WSL 平台选择
+           ├─ SystemdUserBackend      systemd --user（WSL 必需）
+           └─ DetachedProcessBackend  仅普通 Linux 的降级
       └─ LaunchdBackend               macOS launchd LaunchAgent       —— TODO(占位)
 
 CLI (``xskill start/stop/status``) 只跟 ``get_backend()`` 打交道，不关心平台。
@@ -498,6 +500,17 @@ def _linux_platform_name() -> str:
     return "wsl" if _is_wsl() else "linux"
 
 
+def _wsl_systemd_required_message() -> str:
+    return (
+        "WSL 常驻要求启用 systemd，不能降级为 detached。\n"
+        "  请在 /etc/wsl.conf 中配置：\n"
+        "    [boot]\n"
+        "    systemd=true\n"
+        "  然后从 Windows 执行 `wsl --shutdown`，重新进入 WSL 后再运行 "
+        "`xskill start`。"
+    )
+
+
 def _systemd_user_available() -> bool:
     """用户级 systemd manager 是否可用。
 
@@ -557,7 +570,28 @@ class SystemdUserBackend(ConnectServiceBackend):
             "WantedBy=default.target\n"
         )
 
+    @staticmethod
+    def _enable_linger() -> bool:
+        """允许 user manager 随系统启动，而不是依赖当前终端会话。"""
+        user = os.environ.get("USER")
+        if not user or not shutil.which("loginctl"):
+            return False
+        try:
+            linger = subprocess.run(
+                ["loginctl", "enable-linger", user], capture_output=True,
+                text=True, check=False, timeout=5,
+            )
+        except (OSError, subprocess.SubprocessError):
+            return False
+        return linger.returncode == 0
+
     def install_and_start(self) -> dict:
+        linger_enabled = self._enable_linger()
+        if _is_wsl() and not linger_enabled:
+            raise ServiceError(
+                "WSL 无法启用 user linger，不能保证发行版启动时自动运行 xskill。\n"
+                "  请确认 `loginctl enable-linger $USER` 可执行后重试。"
+            )
         try:
             self.unit_path.parent.mkdir(parents=True, exist_ok=True)
             self.unit_path.write_text(self._unit_text(), encoding="utf-8")
@@ -576,18 +610,6 @@ class SystemdUserBackend(ConnectServiceBackend):
                 "启用 systemd user service 失败：\n  "
                 + (start_cp.stderr.strip() or start_cp.stdout.strip())
             )
-
-        linger_enabled = False
-        user = os.environ.get("USER")
-        if user and shutil.which("loginctl"):
-            try:
-                linger = subprocess.run(
-                    ["loginctl", "enable-linger", user], capture_output=True,
-                    text=True, check=False, timeout=5,
-                )
-                linger_enabled = linger.returncode == 0
-            except (OSError, subprocess.SubprocessError):
-                pass
 
         st = self.status()
         if not st.get("running"):
@@ -737,8 +759,31 @@ class DetachedProcessBackend(ConnectServiceBackend):
         }
 
 
+class WSLSystemdRequiredBackend(ConnectServiceBackend):
+    """WSL 未启用 systemd 时的明确失败后端，不允许伪装成常驻成功。"""
+
+    name = "linux"
+    method = "systemd-required"
+
+    def install_and_start(self) -> dict:
+        raise ServiceError(_wsl_systemd_required_message())
+
+    def stop(self) -> dict:
+        return self.status()
+
+    def status(self) -> dict:
+        return {
+            "installed": False,
+            "running": False,
+            "backend": self.name,
+            "method": self.method,
+            "platform": "wsl",
+            "warning": _wsl_systemd_required_message(),
+        }
+
+
 class LinuxServiceBackend(ConnectServiceBackend):
-    """Linux/WSL 入口：优先 systemd user，缺失时自动使用 detached。"""
+    """Linux/WSL 入口：WSL 必须 systemd，普通 Linux 可 detached 降级。"""
 
     name = "linux"
 
@@ -749,13 +794,32 @@ class LinuxServiceBackend(ConnectServiceBackend):
             return SystemdUserBackend()
         if method == DetachedProcessBackend.method:
             return DetachedProcessBackend()
+        if _is_wsl() and not _systemd_user_available():
+            return WSLSystemdRequiredBackend()
         return (SystemdUserBackend() if _systemd_user_available()
                 else DetachedProcessBackend())
 
     def install_and_start(self) -> dict:
-        backend = (SystemdUserBackend() if _systemd_user_available()
-                   else DetachedProcessBackend())
-        return backend.install_and_start()
+        systemd_available = _systemd_user_available()
+        if _is_wsl() and not systemd_available:
+            return WSLSystemdRequiredBackend().install_and_start()
+
+        state = read_daemon_state()
+        if systemd_available:
+            # 从旧版 detached 迁移到 systemd 前先停旧进程，避免双 daemon。
+            if (state.get("method") == DetachedProcessBackend.method
+                    and state.get("running")):
+                DetachedProcessBackend().stop()
+            try:
+                return SystemdUserBackend().install_and_start()
+            except ServiceError:
+                if _is_wsl():
+                    raise
+                logger.warning(
+                    "systemd user 安装失败，普通 Linux 降级为 detached",
+                    exc_info=True,
+                )
+        return DetachedProcessBackend().install_and_start()
 
     def stop(self) -> dict:
         return self._from_state().stop()

--- a/src/xskill/team/client/service.py
+++ b/src/xskill/team/client/service.py
@@ -29,6 +29,9 @@ import csv
 import json
 import logging
 import os
+import shlex
+import shutil
+import signal
 import subprocess
 import sys
 import time
@@ -41,6 +44,7 @@ logger = logging.getLogger("xskill.team.client.service")
 
 # Windows 计划任务名（TN）。带前缀避免和用户其他任务重名；schtasks 大小写不敏感。
 WINDOWS_TASK_NAME = "Xskill_Connect"
+SYSTEMD_UNIT_NAME = "xskill-connect.service"
 
 
 class ServiceError(RuntimeError):
@@ -476,13 +480,298 @@ class WindowsTaskSchedulerBackend(ConnectServiceBackend):
 
 
 # ═══════════════════════════════════════════════════════════════
+# Linux / WSL：systemd --user + detached 降级
+# ═══════════════════════════════════════════════════════════════
+
+def _is_wsl() -> bool:
+    """当前 Linux 是否运行在 WSL。"""
+    if os.environ.get("WSL_DISTRO_NAME") or os.environ.get("WSL_INTEROP"):
+        return True
+    try:
+        release = Path("/proc/sys/kernel/osrelease").read_text(encoding="utf-8")
+    except OSError:
+        return False
+    return "microsoft" in release.lower()
+
+
+def _linux_platform_name() -> str:
+    return "wsl" if _is_wsl() else "linux"
+
+
+def _systemd_user_available() -> bool:
+    """用户级 systemd manager 是否可用。
+
+    WSL 只有在 /etc/wsl.conf 启用 systemd 后才满足；普通 Linux 的精简容器或
+    没有 user bus 的 SSH 环境也会返回 False，随后使用 detached 后端。
+    """
+    if not shutil.which("systemctl"):
+        return False
+    try:
+        cp = subprocess.run(
+            ["systemctl", "--user", "show-environment"],
+            capture_output=True, text=True, check=False, timeout=5,
+        )
+    except (OSError, subprocess.SubprocessError):
+        return False
+    return cp.returncode == 0
+
+
+class SystemdUserBackend(ConnectServiceBackend):
+    """用 ``systemd --user`` 托管 connect，支持自启和崩溃自动重启。"""
+
+    name = "linux"
+    method = "systemd-user"
+
+    def __init__(self, unit_name: str = SYSTEMD_UNIT_NAME,
+                 unit_path: Path | None = None):
+        self.unit_name = unit_name
+        self.unit_path = unit_path or (
+            Path.home() / ".config" / "systemd" / "user" / unit_name
+        )
+
+    def _run(self, args: list[str]) -> subprocess.CompletedProcess:
+        try:
+            return subprocess.run(
+                ["systemctl", "--user", *args], capture_output=True,
+                text=True, check=False, timeout=15,
+            )
+        except (OSError, subprocess.SubprocessError) as e:
+            raise ServiceError(f"systemd --user 执行失败：{e}") from e
+
+    def _unit_text(self) -> str:
+        command = shlex.join(_foreground_argv())
+        return (
+            "[Unit]\n"
+            "Description=xskill team client\n"
+            "Wants=network-online.target\n"
+            "After=network-online.target\n\n"
+            "[Service]\n"
+            "Type=simple\n"
+            f"ExecStart={command}\n"
+            "Restart=always\n"
+            "RestartSec=10\n"
+            "Environment=PYTHONUNBUFFERED=1\n\n"
+            "[Install]\n"
+            "WantedBy=default.target\n"
+        )
+
+    def install_and_start(self) -> dict:
+        try:
+            self.unit_path.parent.mkdir(parents=True, exist_ok=True)
+            self.unit_path.write_text(self._unit_text(), encoding="utf-8")
+        except OSError as e:
+            raise ServiceError(f"写 systemd user unit 失败：{e}") from e
+
+        reload_cp = self._run(["daemon-reload"])
+        if reload_cp.returncode != 0:
+            raise ServiceError(
+                "systemd user daemon-reload 失败：\n  "
+                + (reload_cp.stderr.strip() or reload_cp.stdout.strip())
+            )
+        start_cp = self._run(["enable", "--now", self.unit_name])
+        if start_cp.returncode != 0:
+            raise ServiceError(
+                "启用 systemd user service 失败：\n  "
+                + (start_cp.stderr.strip() or start_cp.stdout.strip())
+            )
+
+        linger_enabled = False
+        user = os.environ.get("USER")
+        if user and shutil.which("loginctl"):
+            try:
+                linger = subprocess.run(
+                    ["loginctl", "enable-linger", user], capture_output=True,
+                    text=True, check=False, timeout=5,
+                )
+                linger_enabled = linger.returncode == 0
+            except (OSError, subprocess.SubprocessError):
+                pass
+
+        st = self.status()
+        if not st.get("running"):
+            raise ServiceError(
+                "systemd unit 已安装但未进入 running；"
+                f"请运行 `journalctl --user -u {self.unit_name} -n 50` 排查。"
+            )
+        write_daemon_state(
+            backend=self.name, method=self.method, unit_name=self.unit_name,
+            unit_path=str(self.unit_path), pid=st.get("pid"),
+            platform=_linux_platform_name(), linger_enabled=linger_enabled,
+        )
+        return self.status()
+
+    def stop(self) -> dict:
+        cp = self._run(["disable", "--now", self.unit_name])
+        warning = ""
+        if cp.returncode != 0:
+            warning = cp.stderr.strip() or cp.stdout.strip()
+        try:
+            self.unit_path.unlink(missing_ok=True)
+        except OSError as e:
+            warning = warning or str(e)
+        self._run(["daemon-reload"])
+        clear_daemon_state()
+        st = {
+            "running": False, "installed": False, "backend": self.name,
+            "method": self.method, "platform": _linux_platform_name(),
+        }
+        if warning and "not loaded" not in warning.lower():
+            st["warning"] = warning
+        return st
+
+    def status(self) -> dict:
+        state = read_daemon_state()
+        cp = self._run([
+            "show", self.unit_name,
+            "--property=LoadState", "--property=ActiveState",
+            "--property=SubState", "--property=MainPID",
+        ])
+        props: dict[str, str] = {}
+        if cp.returncode == 0:
+            for line in cp.stdout.splitlines():
+                key, sep, value = line.partition("=")
+                if sep:
+                    props[key] = value
+        pid_text = props.get("MainPID", "")
+        pid = int(pid_text) if pid_text.isdigit() and int(pid_text) > 0 else None
+        installed = props.get("LoadState") == "loaded" or self.unit_path.is_file()
+        running = (props.get("ActiveState") == "active"
+                   and props.get("SubState") == "running")
+        return {
+            "installed": installed,
+            "running": running,
+            "backend": self.name,
+            "method": self.method,
+            "platform": _linux_platform_name(),
+            "unit_name": self.unit_name,
+            "unit_path": str(self.unit_path),
+            "pid": pid,
+            "server_url": state.get("server_url"),
+            "client_id": state.get("client_id"),
+            "started_at": state.get("started_at"),
+            "linger_enabled": state.get("linger_enabled"),
+        }
+
+
+def _pid_is_connect_daemon(pid: Optional[int]) -> bool:
+    """避免 detached 状态文件里的陈旧 PID 误杀无关进程。"""
+    if not _pid_alive(pid):
+        return False
+    cmdline = Path(f"/proc/{pid}/cmdline")
+    try:
+        args = cmdline.read_bytes().split(b"\0")
+    except OSError:
+        return True
+    return b"xskill" in args and b"connect" in args and b"--foreground" in args
+
+
+class DetachedProcessBackend(ConnectServiceBackend):
+    """无 systemd 时脱离终端运行；适用于未启用 systemd 的 WSL/精简 Linux。"""
+
+    name = "linux"
+    method = "detached"
+
+    def install_and_start(self) -> dict:
+        current = self.status()
+        if current.get("running"):
+            return current
+        argv = _foreground_argv()
+        state_path = get_connect_daemon_state_path()
+        log_path = state_path.parent / "logs" / "connect-daemon.log"
+        try:
+            log_path.parent.mkdir(parents=True, exist_ok=True)
+            with log_path.open("ab") as log_file:
+                proc = subprocess.Popen(
+                    argv, cwd=str(Path.home()), stdin=subprocess.DEVNULL,
+                    stdout=log_file, stderr=subprocess.STDOUT,
+                    start_new_session=True, close_fds=True,
+                )
+        except OSError as e:
+            raise ServiceError(f"启动 detached connect 进程失败：{e}") from e
+        write_daemon_state(
+            backend=self.name, method=self.method, pid=proc.pid, argv=argv,
+            platform=_linux_platform_name(), log_path=str(log_path),
+        )
+        return self.status()
+
+    def stop(self) -> dict:
+        state = read_daemon_state()
+        pid = state.get("pid")
+        warning = ""
+        if _pid_is_connect_daemon(pid):
+            try:
+                os.kill(pid, signal.SIGTERM)
+                deadline = time.time() + 5
+                while _pid_alive(pid) and time.time() < deadline:
+                    time.sleep(0.05)
+                if _pid_alive(pid):
+                    os.kill(pid, signal.SIGKILL)
+            except OSError as e:
+                warning = str(e)
+        clear_daemon_state()
+        st = {
+            "running": False, "installed": False, "backend": self.name,
+            "method": self.method, "platform": _linux_platform_name(),
+        }
+        if warning:
+            st["warning"] = warning
+        return st
+
+    def status(self) -> dict:
+        state = read_daemon_state()
+        pid = state.get("pid") if state.get("method") == self.method else None
+        return {
+            "installed": bool(pid),
+            "running": _pid_is_connect_daemon(pid),
+            "backend": self.name,
+            "method": self.method,
+            "platform": _linux_platform_name(),
+            "pid": pid,
+            "server_url": state.get("server_url"),
+            "client_id": state.get("client_id"),
+            "started_at": state.get("started_at"),
+            "log_path": state.get("log_path"),
+            "restart_policy": "none",
+        }
+
+
+class LinuxServiceBackend(ConnectServiceBackend):
+    """Linux/WSL 入口：优先 systemd user，缺失时自动使用 detached。"""
+
+    name = "linux"
+
+    @staticmethod
+    def _from_state() -> ConnectServiceBackend:
+        method = read_daemon_state().get("method")
+        if method == SystemdUserBackend.method:
+            return SystemdUserBackend()
+        if method == DetachedProcessBackend.method:
+            return DetachedProcessBackend()
+        return (SystemdUserBackend() if _systemd_user_available()
+                else DetachedProcessBackend())
+
+    def install_and_start(self) -> dict:
+        backend = (SystemdUserBackend() if _systemd_user_available()
+                   else DetachedProcessBackend())
+        return backend.install_and_start()
+
+    def stop(self) -> dict:
+        return self._from_state().stop()
+
+    def status(self) -> dict:
+        return self._from_state().status()
+
+
+# ═══════════════════════════════════════════════════════════════
 # 平台选择
 # ═══════════════════════════════════════════════════════════════
 
 def get_backend() -> ConnectServiceBackend:
-    """按当前平台返回后端。Linux/macOS 暂返回占位后端（操作即报“未实现”）。"""
+    """按当前平台返回常驻后端。"""
     if sys.platform == "win32":
         return WindowsTaskSchedulerBackend()
+    if sys.platform.startswith("linux"):
+        return LinuxServiceBackend()
     if sys.platform == "darwin":
         return _UnsupportedBackend("macOS", "launchd LaunchAgent，KeepAlive=true")
-    return _UnsupportedBackend("Linux", "systemd --user，Restart=always")
+    return _UnsupportedBackend(sys.platform, "请使用该平台的服务管理器")

--- a/src/xskill/team/client/updater.py
+++ b/src/xskill/team/client/updater.py
@@ -54,7 +54,8 @@ def _latest_pypi_version(package: str) -> Optional[str]:
     """查 PyPI JSON API 取最新版本（含预发版）。超时/网络错误返回 None。"""
     import json
     import urllib.request
-    url = _PYPI_JSON_URL.format(package=package)
+    url_template = os.environ.get("XSKILL_PYPI_JSON_URL", _PYPI_JSON_URL)
+    url = url_template.format(package=package)
     try:
         with urllib.request.urlopen(url, timeout=10) as r:
             data = json.loads(r.read().decode("utf-8"))

--- a/tests/e2e/test_connect_lifecycle_e2e.py
+++ b/tests/e2e/test_connect_lifecycle_e2e.py
@@ -1,0 +1,118 @@
+from __future__ import annotations
+
+import json
+import os
+from http.server import BaseHTTPRequestHandler, ThreadingHTTPServer
+from pathlib import Path
+import subprocess
+import sys
+import threading
+import site
+
+import pytest
+
+from xskill import __version__
+
+
+class _LocalTeamAndPypiHandler(BaseHTTPRequestHandler):
+    def _json(self, payload: dict, status: int = 200) -> None:
+        body = json.dumps(payload).encode("utf-8")
+        self.send_response(status)
+        self.send_header("Content-Type", "application/json")
+        self.send_header("Content-Length", str(len(body)))
+        self.end_headers()
+        self.wfile.write(body)
+
+    def do_POST(self) -> None:  # noqa: N802
+        length = int(self.headers.get("Content-Length", "0"))
+        if length:
+            self.rfile.read(length)
+        if self.path == "/api/v1/team/register":
+            self._json({"client_id": "e2e-client"})
+            return
+        if self.path == "/api/v1/team/upload":
+            self._json({"accepted": []})
+            return
+        self._json({"detail": "not found"}, status=404)
+
+    def do_GET(self) -> None:  # noqa: N802
+        if self.path == "/pypi/xskill/json":
+            self._json({"releases": {__version__: [{}]}})
+            return
+        self._json({"detail": "not found"}, status=404)
+
+    def log_message(self, format: str, *args) -> None:
+        return
+
+
+def _run_cli(repo: Path, env: dict[str, str], *args: str) -> subprocess.CompletedProcess:
+    return subprocess.run(
+        [sys.executable, "-m", "xskill", *args], cwd=repo, env=env,
+        capture_output=True, text=True, timeout=20,
+    )
+
+
+def _json_output(result: subprocess.CompletedProcess) -> dict:
+    assert result.returncode == 0, result.stderr or result.stdout
+    return json.loads(result.stdout)
+
+
+@pytest.mark.skipif(not sys.platform.startswith("linux"), reason="Linux service E2E")
+def test_connect_update_status_start_stop_lifecycle(tmp_path):
+    """
+    AC: Linux/WSL 用户关闭终端后 connect 常驻，且 start/stop/status/update 可用。
+    Behavior: connect → status → update → stop/start → observable daemon states.
+    @category: service-integration-e2e
+    @lane: service-integration-e2e
+    @dependency: local HTTP stub, subprocess CLI, Linux process table
+    @complexity: medium
+    ROI: 88
+    """
+    repo = Path(__file__).resolve().parents[2]
+    server = ThreadingHTTPServer(("127.0.0.1", 0), _LocalTeamAndPypiHandler)
+    thread = threading.Thread(target=server.serve_forever, daemon=True)
+    thread.start()
+    address = f"127.0.0.1:{server.server_port}"
+    env = os.environ.copy()
+    python_paths = [str(repo / "src"), site.getusersitepackages()]
+    if env.get("PYTHONPATH"):
+        python_paths.append(env["PYTHONPATH"])
+    env.update({
+        "HOME": str(tmp_path),
+        "PYTHONPATH": os.pathsep.join(python_paths),
+        "XDG_CONFIG_HOME": str(tmp_path / ".config"),
+        "WSL_DISTRO_NAME": "Ubuntu-E2E",
+        "XSKILL_CONNECT_BACKEND": "detached",
+        "XSKILL_PYPI_JSON_URL": (
+            f"http://127.0.0.1:{server.server_port}/pypi/{{package}}/json"
+        ),
+    })
+
+    try:
+        connected = _run_cli(
+            repo, env, "connect", address, "--token", "test-token",
+            "--name", "m00000001",
+        )
+        assert connected.returncode == 0, connected.stderr or connected.stdout
+
+        running = _json_output(_run_cli(repo, env, "status", "--json"))
+        assert running["running"] is True
+        assert running["platform"] == "wsl"
+        assert running["method"] in {"systemd-user", "detached"}
+
+        update = _run_cli(repo, env, "update")
+        assert update.returncode == 0, update.stderr or update.stdout
+        assert "已是最新版本" in update.stdout
+        assert _json_output(_run_cli(repo, env, "status", "--json"))["running"] is True
+
+        stopped = _json_output(_run_cli(repo, env, "stop", "--json"))
+        assert stopped["running"] is False
+        assert _json_output(_run_cli(repo, env, "status", "--json"))["running"] is False
+
+        started = _json_output(_run_cli(repo, env, "start", "--json"))
+        assert started["running"] is True
+        assert _json_output(_run_cli(repo, env, "status", "--json"))["running"] is True
+    finally:
+        _run_cli(repo, env, "stop", "--json")
+        server.shutdown()
+        server.server_close()

--- a/tests/test_cli_update.py
+++ b/tests/test_cli_update.py
@@ -1,0 +1,40 @@
+from __future__ import annotations
+
+from xskill.cli import build_parser, cmd_update
+
+
+def test_manual_update_respects_system_pip_index(monkeypatch):
+    """
+    手动 update 与自动 updater 一样，不得绕过企业 pip 配置。
+    @category: integration
+    @lane: integration
+    @dependency: updater pip adapter
+    @complexity: low
+    ROI: 64
+    """
+    captured: list[list[str]] = []
+
+    class _Result:
+        returncode = 0
+        stdout = ""
+        stderr = ""
+
+    monkeypatch.setattr(
+        "xskill.team.client.updater._current_version", lambda package: "1.0.0",
+    )
+    monkeypatch.setattr(
+        "xskill.team.client.updater._latest_pypi_version",
+        lambda package: "1.1.0",
+    )
+    monkeypatch.setattr(
+        "xskill.team.client.updater._restart", lambda: None,
+    )
+    monkeypatch.setattr(
+        "subprocess.run",
+        lambda command, **kwargs: captured.append(command) or _Result(),
+    )
+
+    args = build_parser().parse_args(["update"])
+    assert cmd_update(args) == 0
+    assert captured
+    assert "-i" not in captured[0]

--- a/tests/test_connect_service.py
+++ b/tests/test_connect_service.py
@@ -1,7 +1,7 @@
 """test_connect_service.py — connect 常驻后端（Problem 2）
 
 平台无关：用 monkeypatch 把 sys.platform 与 subprocess 打桩，在 Linux CI 上也能
-验证 Windows 计划任务后端的 argv/XML；非 Windows 平台的占位后端验证会报“未实现”。
+验证 Windows 计划任务和 Linux systemd/detached 后端。
 """
 from __future__ import annotations
 
@@ -10,7 +10,7 @@ import pytest
 import xskill.team.client.service as svc
 
 
-# ─────────────────── 平台选择 & 占位后端 ───────────────────
+# ─────────────────── 平台选择 ───────────────────
 
 def test_get_backend_windows(monkeypatch):
     monkeypatch.setattr(svc.sys, "platform", "win32")
@@ -20,16 +20,26 @@ def test_get_backend_windows(monkeypatch):
     assert b.supported is True
 
 
-@pytest.mark.parametrize("platform,label", [("linux", "Linux"),
-                                            ("darwin", "macOS")])
-def test_get_backend_unsupported_raises(monkeypatch, platform, label):
-    monkeypatch.setattr(svc.sys, "platform", platform)
+def test_get_backend_linux(monkeypatch):
+    monkeypatch.setattr(svc.sys, "platform", "linux")
     b = svc.get_backend()
-    assert b.supported is False  # connect 据此退化成前台阻塞
+    assert isinstance(b, svc.LinuxServiceBackend)
+    assert b.supported is True
+
+
+def test_get_backend_macos_unsupported(monkeypatch):
+    monkeypatch.setattr(svc.sys, "platform", "darwin")
+    b = svc.get_backend()
+    assert b.supported is False
     for op in (b.install_and_start, b.stop, b.status):
         with pytest.raises(svc.ServiceError) as ei:
             op()
-        assert label in str(ei.value)
+        assert "macOS" in str(ei.value)
+
+
+def test_is_wsl_from_environment(monkeypatch):
+    monkeypatch.setenv("WSL_DISTRO_NAME", "Ubuntu")
+    assert svc._is_wsl() is True
 
 
 # ─────────────────── pid / 运行态读写 ───────────────────
@@ -77,6 +87,53 @@ def test_pid_alive_windows_uses_exact_tasklist_pid(monkeypatch):
 
     assert svc._pid_alive_windows(4242) is True
     assert svc._pid_alive_windows(42) is False
+
+
+# ─────────────────── Linux 后端 ───────────────────
+
+class _FakeSystemctl:
+    def __init__(self):
+        self.calls: list[list[str]] = []
+
+    def __call__(self, args, **kwargs):
+        import types
+        self.calls.append(list(args))
+        stdout = ""
+        if "show" in args:
+            stdout = ("LoadState=loaded\nActiveState=active\n"
+                      "SubState=running\nMainPID=2468\n")
+        return types.SimpleNamespace(returncode=0, stdout=stdout, stderr="")
+
+
+def test_systemd_install_writes_unit_and_starts(tmp_path, monkeypatch):
+    state_path = tmp_path / "connect_daemon.json"
+    unit_path = tmp_path / "xskill-connect.service"
+    fake = _FakeSystemctl()
+    monkeypatch.setattr(svc, "get_connect_daemon_state_path", lambda: state_path)
+    monkeypatch.setattr(svc.subprocess, "run", fake)
+    monkeypatch.setattr(svc.shutil, "which", lambda name: None)
+    monkeypatch.setattr(svc, "_is_wsl", lambda: False)
+
+    st = svc.SystemdUserBackend(unit_path=unit_path).install_and_start()
+
+    text = unit_path.read_text(encoding="utf-8")
+    assert "xskill connect --foreground" in text
+    assert "Restart=always" in text
+    assert any("daemon-reload" in call for call in fake.calls)
+    assert any("enable" in call and "--now" in call for call in fake.calls)
+    assert st["running"] is True
+    assert st["pid"] == 2468
+    assert st["method"] == "systemd-user"
+
+
+def test_linux_selects_detached_when_systemd_unavailable(monkeypatch):
+    monkeypatch.setattr(svc, "_systemd_user_available", lambda: False)
+    monkeypatch.setattr(
+        svc.DetachedProcessBackend, "install_and_start",
+        lambda self: {"running": True, "method": self.method},
+    )
+    st = svc.LinuxServiceBackend().install_and_start()
+    assert st == {"running": True, "method": "detached"}
 
 
 # ─────────────────── task XML ───────────────────

--- a/tests/test_wsl_persistence_policy.py
+++ b/tests/test_wsl_persistence_policy.py
@@ -1,0 +1,54 @@
+from __future__ import annotations
+
+import types
+
+import pytest
+
+import xskill.team.client.service as svc
+
+
+def test_wsl_without_systemd_refuses_detached_success(monkeypatch):
+    monkeypatch.setattr(svc, "_is_wsl", lambda: True)
+    monkeypatch.setattr(svc, "_systemd_user_available", lambda: False)
+    monkeypatch.setattr(svc, "read_daemon_state", lambda: {"running": False})
+
+    backend = svc.LinuxServiceBackend()
+    with pytest.raises(svc.ServiceError, match="systemd"):
+        backend.install_and_start()
+    status = backend.status()
+    assert status["running"] is False
+    assert status["platform"] == "wsl"
+    assert status["method"] == "systemd-required"
+
+
+def test_plain_linux_without_systemd_keeps_detached_fallback(monkeypatch):
+    monkeypatch.setattr(svc, "_is_wsl", lambda: False)
+    monkeypatch.setattr(svc, "_systemd_user_available", lambda: False)
+    monkeypatch.setattr(
+        svc.DetachedProcessBackend,
+        "install_and_start",
+        lambda self: {"running": True, "method": self.method},
+    )
+
+    assert svc.LinuxServiceBackend().install_and_start() == {
+        "running": True,
+        "method": "detached",
+    }
+
+
+def test_wsl_systemd_install_requires_linger(monkeypatch, tmp_path):
+    monkeypatch.setattr(svc, "_is_wsl", lambda: True)
+    monkeypatch.setattr(svc.shutil, "which", lambda name: f"/usr/bin/{name}")
+    monkeypatch.setenv("USER", "alice")
+
+    def fake_run(args, **kwargs):
+        if args[:2] == ["loginctl", "enable-linger"]:
+            return types.SimpleNamespace(returncode=1, stdout="", stderr="denied")
+        return types.SimpleNamespace(returncode=0, stdout="", stderr="")
+
+    monkeypatch.setattr(svc.subprocess, "run", fake_run)
+    unit = tmp_path / "xskill-connect.service"
+
+    with pytest.raises(svc.ServiceError, match="linger"):
+        svc.SystemdUserBackend(unit_path=unit).install_and_start()
+    assert not unit.exists()


### PR DESCRIPTION
## 变更

- 普通 Linux 优先 `systemd --user`，不可用时允许 detached 降级
- WSL 严格要求 systemd + user linger，不再把 detached 视为常驻成功
- WSL 未启用 systemd 时，`connect/start` 给出 `/etc/wsl.conf` 与 `wsl --shutdown` 指引
- 从旧 detached 迁移 systemd 前停止旧进程，避免双 daemon
- `status` 显示 platform、method 和修复提示

## 验收语义

WSL 发行版启动后 xskill 自动运行；关闭终端不停止；崩溃后由 systemd 重启。

## 测试

- `35 passed`：WSL policy、service backend、connect CLI
- 真实 WSL runner 尚未覆盖，策略分支通过 Linux CI mock 验证

## 发布

Draft，仅供 review；不打 tag、不发布 PyPI。