### PR TITLE
feat(dashboard): skillhub 三方技能前端可见(列表/评分/详情/散点) + 原子索引增量 embedding

### DIFF
--- a/src/xskill/dashboard/metrics.py
+++ b/src/xskill/dashboard/metrics.py
@@ -116,57 +116,91 @@ def _branches(skill_path: Path) -> set[str]:
     return out
 
 
-def skills_catalog(skill_dir: Path) -> list[dict]:
+def _skillhub_entries(skillhub) -> list[dict]:
+    """把 ``skills_catalog`` 的 skillhub 入参归一成三方 skill 原始条目列表。
+
+    入参三态（契约）：``None`` → 无三方 skill（[]）；``list`` → 已是条目列表直接
+    用；否则视作 ``SkillHub`` 对象，读其无向量条目（``include_vec=False`` 免去
+    embed_client——技能库列表不需要向量，只要 name/description/来源路径）。禁用的
+    SkillHub 返回 []（其 ``_entries`` 内部已判 ``enabled``）。
+    """
+    if skillhub is None:
+        return []
+    if isinstance(skillhub, list):
+        return skillhub
+    return skillhub._entries(  # pylint: disable=protected-access
+        include_vec=False, require_description=True)
+
+
+def skills_catalog(skill_dir: Path, skillhub=None) -> list[dict]:
     """列出 skill 库里的所有 skill —— 纯分析式(读目录 + SKILL.md + .candidates.yml)。
 
     不依赖任何埋点事件,永远有内容(只要库里有 skill 目录)。每条含:
-    name / state(baby|main|staging) / description / version / use_count / candidates。
-    供"技能库"页直接展示库存,不再只靠空的触发率表。
+    name / state(baby|main|staging) / description / version / use_count / candidates,
+    并统一带 ``source``：自产 git 技能为 ``"native"``。
+
+    ``skillhub``（可选，向后兼容——不传即旧行为）：三方 skill 来源，可传 SkillHub
+    对象或其条目列表。合入的三方条目 ``source="skillhub"`` / ``state="skillhub"``
+    （无 git 分支）,额外带 ``hub``（skillhub 目录下相对路径/子目录名）与 ``skill_id``
+    （``name@path_hash``）,``use_count`` 有则带否则 0。
     """
     from xskill.skill.frontmatter import parse as fm_parse
     skill_dir = Path(skill_dir)
-    if not skill_dir.is_dir():
-        return []
     out: list[dict] = []
-    for d in sorted(skill_dir.iterdir()):
-        if not d.is_dir() or d.name.startswith("."):
-            continue
-        branches = _branches(d)
-        if "staging" in branches:
-            state = "staging"
-        elif "main" in branches:
-            state = "main"
-        elif "baby" in branches:
-            state = "baby"
-        else:
-            state = "unknown"
-        desc, version = "", 0
-        smd = d / "SKILL.md"
-        if smd.is_file():
-            try:
-                fm, _ = fm_parse(smd.read_text(encoding="utf-8"))
-                desc = (fm.get("description") or "").strip().replace("\n", " ")
-                meta = fm.get("metadata", {}) or {}
-                version = meta.get("version", 0)
-            except Exception:  # pylint: disable=broad-exception-caught
-                pass
-        n_cand = 0
-        cand = d / ".candidates.yml"
-        if cand.is_file():
-            try:
-                import yaml
-                data = yaml.safe_load(cand.read_text(encoding="utf-8")) or {}
-                n_cand = len(data.get("candidates", []) or [])
-            except Exception:  # pylint: disable=broad-exception-caught
-                pass
-        out.append({
-            "name": d.name, "state": state,
-            "description": desc[:300], "version": version,
-            "candidates": n_cand,
-        })
+    if skill_dir.is_dir():
+        for d in sorted(skill_dir.iterdir()):
+            if not d.is_dir() or d.name.startswith("."):
+                continue
+            branches = _branches(d)
+            if "staging" in branches:
+                state = "staging"
+            elif "main" in branches:
+                state = "main"
+            elif "baby" in branches:
+                state = "baby"
+            else:
+                state = "unknown"
+            desc, version = "", 0
+            smd = d / "SKILL.md"
+            if smd.is_file():
+                try:
+                    fm, _ = fm_parse(smd.read_text(encoding="utf-8"))
+                    desc = (fm.get("description") or "").strip().replace("\n", " ")
+                    meta = fm.get("metadata", {}) or {}
+                    version = meta.get("version", 0)
+                except Exception:  # pylint: disable=broad-exception-caught
+                    pass
+            n_cand = 0
+            cand = d / ".candidates.yml"
+            if cand.is_file():
+                try:
+                    import yaml
+                    data = yaml.safe_load(cand.read_text(encoding="utf-8")) or {}
+                    n_cand = len(data.get("candidates", []) or [])
+                except Exception:  # pylint: disable=broad-exception-caught
+                    pass
+            out.append({
+                "name": d.name, "state": state, "source": "native",
+                "description": desc[:300], "version": version,
+                "candidates": n_cand,
+            })
     # main/staging（已正式产出）排前,其次 baby,再按名字
     order = {"main": 0, "staging": 0, "baby": 1, "unknown": 2}
     out.sort(key=lambda s: (order.get(s["state"], 3), s["name"]))
+    # 三方（skillhub）技能追加在自产之后：独立目录、无 git 分支 → state="skillhub"。
+    hub_rows: list[dict] = []
+    for e in _skillhub_entries(skillhub):
+        desc = str(e.get("description") or "").strip().replace("\n", " ")
+        hub_rows.append({
+            "name": e.get("display_name") or e.get("name") or "",
+            "state": "skillhub", "source": "skillhub",
+            "hub": e.get("source_path") or "",
+            "skill_id": e.get("skill_id") or e.get("name") or "",
+            "description": desc[:300], "version": 0,
+            "candidates": 0, "use_count": e.get("use_count", 0) or 0,
+        })
+    hub_rows.sort(key=lambda s: (s["hub"], s["name"]))
+    out.extend(hub_rows)
     return out
 
 

--- a/src/xskill/dashboard/profile_viz.py
+++ b/src/xskill/dashboard/profile_viz.py
@@ -36,6 +36,21 @@ def profile_db_for(db_path: Optional[Path]) -> Path:
     return XSKILL_HOME / "team_profile.db"
 
 
+def skillhub_index_for(db_path: Optional[Path]) -> Path:
+    """三方 skill 向量缓存 ``<skillhub_dir>/.skillhub_index.pkl`` 的旁推定位。
+
+    该缓存由 ``SkillHub.index()`` 算好向量时落盘（自产 skill 有 ``.skill_index.pkl``，
+    三方 skill 走这份）——dashboard 端无 embed_client，只能读缓存把用户用过的三方
+    skill 画成散点 ▲（D6:读不到不画,绝不现算）。定位约定同 ``profile_db_for``:
+    独立只读实例（显式 db_path）按 registry 同级的 ``skillhub_skills`` 旁推,serve
+    内置挂载（db_path=None）走 config 的 ``skillhub.dir``。
+    """
+    if db_path is not None:
+        return Path(db_path).parent / "skillhub_skills" / ".skillhub_index.pkl"
+    from xskill.config import get_config, skillhub_config
+    return skillhub_config(get_config())["dir"] / ".skillhub_index.pkl"
+
+
 _PCA_PREDIM = 50  # 高维 embedding 进降维算法前的 PCA 预降维目标维度
 _SCATTER_MAX_POINTS = 300  # 散点单次投影的原子数上限(超出按兴趣中心分层抽样)
 
@@ -362,14 +377,38 @@ def _skill_index_vecs(skill_dir: Optional[Path]) -> dict[str, np.ndarray]:
         return {}
 
 
+def _skillhub_index_vecs(cache_path: Optional[Path]) -> dict[str, np.ndarray]:
+    """读三方 skill 向量缓存（``skillhub.index()`` 落盘,结构对齐自产索引）。
+    缓存不存在/不可读 → 空(散点图不画三方 skill 三角,D6 不现算)。"""
+    if not cache_path:
+        return {}
+    cache_path = Path(cache_path)
+    if not cache_path.is_file():
+        return {}
+    try:
+        with open(cache_path, "rb") as f:
+            idx = pickle.load(f)
+        names = idx.get("skill_names") or []
+        embeddings = idx.get("embeddings")
+        if embeddings is None:
+            return {}
+        return {n: np.asarray(embeddings[i], dtype=float)
+                for i, n in enumerate(names)}
+    except (OSError, pickle.UnpicklingError, ValueError, IndexError):
+        logger.warning("skillhub index unreadable: %s", cache_path, exc_info=True)
+        return {}
+
+
 class ProfileViz:
     """画像可视化数据装配（读 ProfileStore + skill 索引,纯 numpy,无 LLM）。"""
 
     def __init__(self, profile_db: Path, *, skill_dir: Optional[Path] = None,
-                 db_path: Optional[Path] = None):
+                 db_path: Optional[Path] = None,
+                 skillhub_index: Optional[Path] = None):
         self._store = ProfileStore(profile_db)
         self._skill_dir = skill_dir
         self._db_path = db_path
+        self._skillhub_index = skillhub_index  # 三方 skill 向量缓存路径(读不到→不画)
 
     # ── §2.3 画像散点 ────────────────────────────────────────────
 
@@ -404,14 +443,22 @@ class ProfileViz:
         centers = (np.asarray(centers, dtype=float) if centers is not None
                    else np.zeros((0, points.shape[1])))
 
-        skill_vecs = _skill_index_vecs(self._skill_dir)
-        skill_entries = []
+        # 自产 skill 向量取自 .skill_index.pkl,三方(skillhub)取自 skillhub 缓存;
+        # 同名以自产优先。两个缓存都拿不到 → 不画(D6),绝不现场调 embedding。
+        native_vecs = _skill_index_vecs(self._skill_dir)
+        hub_vecs = _skillhub_index_vecs(self._skillhub_index)
+        skill_entries = []  # (name, use_count, vec, source)
         for entry in profile.get("used_skills") or []:
             name = entry.get("name") or ""
-            vec = skill_vecs.get(name)
-            if vec is None or vec.shape[0] != points.shape[1]:
-                continue  # 索引没有该 skill 的缓存向量 → 不画(D6),不现算
-            skill_entries.append((name, entry.get("use_count", 0), vec))
+            if name in native_vecs:
+                vec, source = native_vecs[name], "native"
+            elif name in hub_vecs:
+                vec, source = hub_vecs[name], "skillhub"
+            else:
+                continue  # 两个缓存都没有该 skill 的向量 → 不画(D6),不现算
+            if vec.shape[0] != points.shape[1]:
+                continue  # 维度不一致(换过 embedding 模型)→ 不画,不报错
+            skill_entries.append((name, entry.get("use_count", 0), vec, source))
 
         # 簇归属:最近兴趣中心(高维余弦,向量均已 L2 归一——投影前算,分层抽样也据它)
         if len(centers):
@@ -431,7 +478,7 @@ class ProfileViz:
 
         blocks = [points, centers]
         if skill_entries:
-            blocks.append(np.vstack([v for _, _, v in skill_entries]))
+            blocks.append(np.vstack([v for _, _, v, _ in skill_entries]))
         combined = np.vstack(blocks)
         coords_all = projector_cls().fit(combined)
         coords = coords_all[:len(points)]
@@ -467,8 +514,9 @@ class ProfileViz:
             {"name": name,
              "x": round(float(skill_coords[i, 0]), 4),
              "y": round(float(skill_coords[i, 1]), 4),
-             "use_count": use_count}
-            for i, (name, use_count, _vec) in enumerate(skill_entries)
+             "use_count": use_count,
+             "source": source}  # 共同数据契约:native / skillhub(据向量来自哪个缓存)
+            for i, (name, use_count, _vec, source) in enumerate(skill_entries)
         ]
 
         return {

--- a/src/xskill/dashboard/router.py
+++ b/src/xskill/dashboard/router.py
@@ -504,14 +504,16 @@ def _register_explorer_endpoints(router: APIRouter, db_path: Optional[Path],
     def user_scatter_ep(user_key: str, method: str = "tsne") -> dict:
         """画像散点（图③,P3-3.4）:原子点降维投影 + 兴趣中心 + skill 向量。
         ``method`` ∈ {tsne, umap}——同一批向量、同款前置,换降维算法对比效果。"""
-        from xskill.dashboard.profile_viz import ProfileViz, profile_db_for
+        from xskill.dashboard.profile_viz import (
+            ProfileViz, profile_db_for, skillhub_index_for)
         pdb = profile_db_for(db_path)
         if not pdb.is_file():
             raise HTTPException(status_code=404,
                                 detail="画像库不存在(team 模式未启用或还没有画像)")
         try:
-            return ProfileViz(pdb, skill_dir=skill_dir,
-                              db_path=db_path).user_scatter(user_key, method=method)
+            return ProfileViz(pdb, skill_dir=skill_dir, db_path=db_path,
+                              skillhub_index=skillhub_index_for(db_path)
+                              ).user_scatter(user_key, method=method)
         except KeyError as e:
             raise HTTPException(status_code=404, detail=str(e)) from e
         except ValueError as e:

--- a/src/xskill/dashboard/router.py
+++ b/src/xskill/dashboard/router.py
@@ -112,8 +112,13 @@ def build_dashboard_router(db_path: Optional[Path] = None, *,
 
     @router.get("/api/v1/dashboard/skills")
     def skills() -> dict:
-        """skill 库存清单(分析式：读 skill 目录,不依赖埋点)。"""
-        cat = skills_catalog(skill_dir)
+        """skill 库存清单(分析式：读 skill 目录,不依赖埋点)。
+
+        自产 git 技能标 ``source="native"``；skillhub 三方技能（启用时）合入
+        并标 ``source="skillhub"`` + ``hub`` + ``skill_id``。skillhub 缺省禁用
+        → ``_build_skillhub()`` 返回 None → no-op，列表只有自产技能。
+        """
+        cat = skills_catalog(skill_dir, skillhub=_build_skillhub())
         states: dict = {}
         for s in cat:
             states[s["state"]] = states.get(s["state"], 0) + 1

--- a/src/xskill/dashboard/static/app.js
+++ b/src/xskill/dashboard/static/app.js
@@ -369,10 +369,25 @@ function renderDiff(diff) {
 }
 
 let _curSkill = null;
+// 判定某 skill 属于自产(native)还是三方(skillhub)——从技能库列表载荷取
+// source 字段(列表由另一路渲染，本函数只读)。jc 已缓存该端点，无额外请求。
+// 拿不到 source / 请求失败 → 安全兜底按自产走，绝不因缺字段崩。
+async function skillSource(name) {
+  try {
+    const d = await jc('api/v1/dashboard/skills');
+    const hit = (d.skills || []).find(s => s.name === name);
+    return (hit && hit.source === 'skillhub') ? 'skillhub' : 'native';
+  } catch (_e) {
+    return 'native';
+  }
+}
+
 async function openSkill(name) {
   _curSkill = name;
   const box = document.getElementById('skill-detail');
   box.innerHTML = `<div class="bg-white rounded-2xl ring-1 ring-slate-200 p-5 text-slate-400">加载 ${esc(name)} …</div>`;
+  // 三方 skill 无 git / staging，走 skillhub 专用端点(自产 detail 对其 404)。
+  if (await skillSource(name) === 'skillhub') { await renderSkillhubDetail(name, box); return; }
   const [dR, gR, uR, lR, tR] = await Promise.allSettled([
     jc('api/v1/dashboard/skill/' + encodeURIComponent(name) + '/detail'),
     jc('api/v1/dashboard/skill/' + encodeURIComponent(name) + '/graph'),
@@ -489,6 +504,80 @@ async function openSkill(name) {
   </div>`;
   box.scrollIntoView({ behavior: 'smooth' });
   loadTriggerPanel(name).catch(console.error);
+}
+
+// 三方(skillhub)技能详情：无 git / 无灰度 staging / 无进化路径，只有按
+// content_sha 版本聚合的 ux 均分与关联打分原子。故不渲染自产才有的
+// 进化路径 / staging 灰度 / 晋升 / 离线探针版块，仅展示三方可得的评分事实。
+async function renderSkillhubDetail(name, box) {
+  const [vR, aR] = await Promise.allSettled([
+    jc('api/v1/dashboard/skillhub/' + encodeURIComponent(name) + '/ux?days=30'),
+    jc('api/v1/dashboard/skillhub/' + encodeURIComponent(name) + '/ux/atoms?days=30'),
+  ]);
+  if (vR.status === 'rejected') {
+    box.innerHTML = `<div class="bg-white rounded-2xl ring-1 ring-slate-200 p-5 text-rose-600">加载失败：${esc(vR.reason)}</div>`;
+    return;
+  }
+  const d = vR.value;
+  const at = aR.status === 'fulfilled' ? aR.value : { scores: [], atom_lookup: 'unavailable' };
+  const versions = d.versions || [];
+  const curSha = (d.current_version && d.current_version.content_sha) || '';
+  const totalSamples = versions.reduce((n, v) => n + (v.count || 0), 0);
+
+  const vrows = versions.map(v => {
+    const isCur = curSha && v.commit_sha === curSha;
+    return `<tr><td class="py-2"><code class="text-[11px]">${esc((v.commit_sha || '').slice(0, 8))}</code>`
+      + `${isCur ? ' <span class="px-1.5 py-0.5 rounded bg-sky-50 text-sky-700 ring-1 ring-sky-200 text-[10px] font-medium">当前</span>' : ''}</td>`
+      + `<td class="text-right tabular-nums">${v.count}</td>`
+      + `<td class="text-right tabular-nums">${ux(v.avg)}</td>`
+      + `<td class="text-slate-500 pl-4">${fdate(v.first_scored_at).slice(0, 10)}</td>`
+      + `<td class="text-slate-500 pl-4">${fdate(v.last_scored_at).slice(0, 10)}</td></tr>`;
+  }).join('') || '<tr><td colspan="5" class="py-2 text-slate-400">还没有 ux 打分数据</td></tr>';
+
+  const scores = at.scores || [];
+  const atomUnavailable = (at.atom_lookup !== 'ok');
+  const arows = scores.map(s =>
+    `<div class="py-2.5">
+      <div class="flex items-center justify-between gap-2">
+        <span class="flex items-center gap-2 min-w-0">
+          <code class="text-[11px] text-slate-400 shrink-0">${esc((s.commit_sha || '').slice(0, 7))}</code>
+          <span class="text-[11px] text-slate-400 truncate">${esc(s.user_model) || '—'} · ${fdate(s.scored_at).slice(0, 10)}</span>
+        </span>
+        <span class="px-2 py-0.5 rounded-md bg-teal-50 text-teal-700 text-[11px] font-semibold tabular-nums shrink-0">${s.score != null ? esc(s.score) : '—'}</span>
+      </div>
+      ${s.reasons ? `<div class="text-[11px] text-slate-500 mt-1">${esc(s.reasons)}</div>` : ''}
+    </div>`).join('') || '<div class="py-2 text-slate-400 text-xs">还没有关联打分原子</div>';
+
+  box.innerHTML = `
+  <div class="bg-white rounded-2xl ring-1 ring-slate-200 p-5">
+    <div class="text-xs text-slate-400 mb-1.5">技能库 <span class="mx-1">/</span> <span class="text-slate-600">${esc(name)}</span></div>
+    <div class="flex items-start justify-between gap-3 flex-wrap">
+      <div>
+        <div class="flex items-center gap-2 flex-wrap">
+          <h2 class="text-lg font-bold tracking-tight">${esc(name)}</h2>
+          <span class="inline-flex items-center gap-1.5 px-2.5 py-1 rounded-lg bg-sky-50 ring-1 ring-sky-200 text-xs font-medium text-sky-700">第三方 · skillhub</span>
+        </div>
+        <div class="text-slate-500 text-xs mt-1">按 content_sha 版本聚合 · 累计样本 <b class="text-slate-800 tabular-nums">${totalSamples}</b> 次
+          ${curSha ? `· 当前版本 <code class="text-[11px] text-slate-400">${esc(curSha.slice(0, 8))}</code>` : ''}</div>
+      </div>
+      <div class="text-[11px] text-slate-400 max-w-[280px]">三方技能无 git / 无灰度 staging，故无进化路径、晋升与灰度裁决版块。</div>
+    </div>
+
+    <div class="grid grid-cols-12 gap-4 mt-4">
+      <div class="col-span-12 lg:col-span-7">
+        <h3 class="font-semibold text-sm">版本统计 <span class="font-normal text-[11px] text-slate-400 ml-1">content_sha 聚合 · 样本 / UX / 首末打分</span></h3>
+        <div class="overflow-x-auto"><table class="w-full mt-1 text-[12.5px]">
+          <thead><tr class="text-[11px] text-slate-400 border-b border-slate-100"><th class="text-left font-medium py-2">版本</th><th class="text-right font-medium">样本</th><th class="text-right font-medium">UX</th><th class="text-left font-medium pl-4">首次</th><th class="text-left font-medium pl-4">末次</th></tr></thead>
+          <tbody class="divide-y divide-slate-50">${vrows}</tbody></table></div>
+      </div>
+      <div class="col-span-12 lg:col-span-5 rounded-2xl ring-1 ring-slate-200 p-5">
+        <h3 class="font-semibold text-sm">关联打分原子 <span class="font-normal text-[11px] text-slate-400 ml-1">${scores.length} 条</span></h3>
+        ${atomUnavailable ? '<div class="text-[11px] text-slate-400 mt-1">非团队服务器模式，原子内容不可反查（仅评分）</div>' : ''}
+        <div class="mt-1 divide-y divide-slate-100 max-h-80 overflow-y-auto">${arows}</div>
+      </div>
+    </div>
+  </div>`;
+  box.scrollIntoView({ behavior: 'smooth' });
 }
 
 // 离线探针触发率面板（描述质量信号；区别于"总触发"的线上真实使用率）

--- a/src/xskill/dashboard/static/app.js
+++ b/src/xskill/dashboard/static/app.js
@@ -1396,8 +1396,11 @@ async function openUserProfile(uid) {
   const skEls = (d.skills || []).map(s => {
     const c = sc(s);
     const short = s.name.length > 14 ? s.name.slice(0, 13) + '…' : s.name;
+    const hub = s.source === 'skillhub';         // 三方 skill 区分:琥珀色 ▲ + tooltip 标"第三方"
+    const fill = hub ? '#d97706' : '#0f172a';
+    const tip = `${hub ? '第三方 ' : ''}SKILL:${esc(s.name)} · 触发 ${esc(s.use_count)} 次`;
     return `<g class="skill-jump cursor-pointer" data-skill="${esc(s.name)}">
-      <path d="M${c.x.toFixed(1)} ${(c.y - 7).toFixed(1)} l6.2 11 h-12.4 z" fill="#0f172a"><title>SKILL:${esc(s.name)} · 触发 ${esc(s.use_count)} 次</title></path>
+      <path d="M${c.x.toFixed(1)} ${(c.y - 7).toFixed(1)} l6.2 11 h-12.4 z" fill="${fill}"><title>${tip}</title></path>
       <text x="${c.x.toFixed(1)}" y="${(c.y + 17).toFixed(1)}" font-size="9.5" font-weight="600" fill="#334155" text-anchor="middle">SKILL:${esc(short)}</text></g>`;
   }).join('');
   const legend = (d.clusters || []).map(cl =>

--- a/src/xskill/dashboard/static/app.js
+++ b/src/xskill/dashboard/static/app.js
@@ -175,6 +175,12 @@ const STATE_BADGE = {
 const stateBadge = s =>
   `<span class="px-2 py-0.5 rounded-md text-[11px] font-medium ${STATE_BADGE[s] || STATE_BADGE.unknown}">${esc(s)}</span>`;
 
+// 来源徽章：skillhub 三方技能标醒目的"第三方"并显示 hub 来源；自产技能标淡色"自产"。
+const sourceBadge = s => s.source === 'skillhub'
+  ? `<span class="ml-2 inline-block px-2 py-0.5 rounded-md text-[11px] font-medium bg-indigo-100 text-indigo-700">第三方 · skillhub</span>`
+    + (s.hub ? `<span class="ml-2 inline-block text-[11px] text-slate-400">${esc(s.hub)}</span>` : '')
+  : `<span class="ml-2 inline-block px-2 py-0.5 rounded-md text-[11px] font-medium bg-slate-100 text-slate-500">自产</span>`;
+
 async function loadSkills() {
   const d = await jc('api/v1/dashboard/skills');
   const bs = d.by_state || {};
@@ -182,7 +188,7 @@ async function loadSkills() {
   put('skills.summary', `共 ${d.total} 个${parts ? ' · ' + parts : ''}`);
   rows('skills-body', (d.skills || []).map(s =>
     `<tr class="hover:bg-slate-50 cursor-pointer" data-skill-row="${esc(s.name)}">`
-    + `<td class="py-2.5 font-medium text-teal-700">${esc(s.name)}</td>`
+    + `<td class="py-2.5 font-medium text-teal-700">${esc(s.name)}${sourceBadge(s)}</td>`
     + `<td>${stateBadge(s.state)}</td>`
     + `<td class="text-slate-500 max-w-[480px] truncate" title="${esc(s.description)}">${esc(s.description) || '—'}</td>`
     + `<td class="text-right tabular-nums">v${esc(s.version)}</td>`

--- a/src/xskill/pipeline/atom.py
+++ b/src/xskill/pipeline/atom.py
@@ -80,9 +80,10 @@ class AtomTaskStore:
     - **不用 SQLite**: traj 数量级 < 数千；文件读写直接、调试方便、跨平台兼容。
     - **每 traj 一个子目录**: 让 watcher 按 traj 粒度做增量处理，``list_by_traj``
       不需要全表扫。
-    - **向量索引整批重建**: TaskAgent 每给一条 traj 拆出新 atom 后由 watcher
-      触发一次 ``rebuild_vector_index``；增量重建对正确性没好处只增加复杂度，
-      暂不做（embed batch API 也支持千条以内的吞吐）。
+    - **向量索引增量重建**: TaskAgent 每给一条 traj 拆出新 atom 后由 watcher
+      触发一次 ``rebuild_vector_index``；按 ``atom_id`` 复用旧 index.pkl 中同
+      模型的向量，只对新原子调 embedding（换模型则整体重算，护栏见方法内），
+      避免攒了上万原子的 client 新增几条就全量重 embed。
     """
 
     INDEX_FILE = "index.pkl"
@@ -173,25 +174,64 @@ class AtomTaskStore:
 
     # ── vector index ──────────────────────────────────────────────
 
+    def _load_vector_cache(self, model: str) -> dict:
+        """增量 embedding 复用源：``{atom_id: 归一化向量(D,)}``。
+
+        仅当已落盘 index.pkl 的 ``model`` 字段与当前 ``model`` 一致才返回缓存
+        （换 embedding 模型 → 旧向量与当前模型不同源作废，返回空 dict 强制整体
+        重算，护栏在此不混用不同模型的向量）。无索引文件 / 结构缺字段 → 空 dict。
+        """
+        p = self._index_path()
+        if not p.is_file():
+            return {}
+        with open(p, "rb") as f:
+            data = pickle.load(f)
+        if (data.get("model") or "") != (model or ""):
+            return {}
+        atom_ids = data.get("atom_ids") or []
+        embeddings = data.get("embeddings")
+        if embeddings is None:
+            return {}
+        return {
+            aid: embeddings[i]
+            for i, aid in enumerate(atom_ids)
+            if i < len(embeddings) and aid
+        }
+
     def rebuild_vector_index(self, embed_client) -> None:
-        """整批 encode 所有 atom 的 ``summary or intent`` → L2 归一 → 落 index.pkl。
+        """增量重建索引：复用旧 index.pkl 中同模型的向量，只对新原子调 embedding。
+
+        - 旧索引 ``model`` 与当前 ``embed_client.model`` 一致时，按 ``atom_id``
+          复用其向量（atom 内容随 id 不可变，复用安全）；换模型则整体重算。
+        - 只对**没在缓存里的** atom_id 调 ``encode_batch``，其余复用缓存向量。
+        - 新索引只含当前 ``all_atoms()`` 的原子——被删除/reset 的原子自然不残留。
+        - 复用向量本就归一化落盘；新算向量照旧 L2 归一。最终 embeddings 行顺序
+          与 atom_ids、与 ``all_atoms()`` 顺序严格对齐。
 
         无 atom 时直接返回（不写空索引文件——``vector_search`` 自己处理无索引情况）。
         """
         atoms = list(self.all_atoms())
         if not atoms:
             return
-        texts = [a.summary or a.intent for a in atoms]
-        vecs = embed_client.encode_batch(texts)
-        norms = np.linalg.norm(vecs, axis=1, keepdims=True)
-        norms[norms == 0] = 1
-        vecs = vecs / norms
+        model = getattr(embed_client, "model", "")
+        cache = self._load_vector_cache(model)
+        missing = [a for a in atoms if a.atom_id not in cache]
+        if missing:
+            texts = [a.summary or a.intent for a in missing]
+            fresh = np.asarray(embed_client.encode_batch(texts))
+            norms = np.linalg.norm(fresh, axis=1, keepdims=True)
+            norms[norms == 0] = 1
+            fresh = fresh / norms
+            cache = dict(cache)
+            for a, v in zip(missing, fresh):
+                cache[a.atom_id] = v
+        vecs = np.asarray([cache[a.atom_id] for a in atoms])
         self.root.mkdir(parents=True, exist_ok=True)
         with open(self._index_path(), "wb") as f:
             pickle.dump({
                 "atom_ids": [a.atom_id for a in atoms],
                 "embeddings": vecs,
-                "model": getattr(embed_client, "model", ""),
+                "model": model,
                 "dim": int(vecs.shape[1]),
             }, f)
 

--- a/src/xskill/recommend/skillhub.py
+++ b/src/xskill/recommend/skillhub.py
@@ -11,11 +11,17 @@
 from __future__ import annotations
 
 import hashlib
+import pickle
 import re
 from datetime import datetime
 from pathlib import Path
 
 import numpy as np
+
+# dashboard 可读的三方 skill 向量缓存文件名（落在 skillhub 目录内，dot 前缀故不被
+# ``rglob("SKILL.md")`` 扫到）。dashboard 端无 embed_client，只能读此缓存把用户用过
+# 的三方 skill 画成散点 ▲（D6:不现算不造假）。结构对齐自产 ``.skill_index.pkl``。
+INDEX_CACHE_NAME = ".skillhub_index.pkl"
 
 from xskill.canary import aggregate_ux_by_version, load_ux_scores
 from xskill.config import skillhub_config
@@ -105,13 +111,40 @@ class SkillHub:
             for entry in self._entries(include_vec=False, require_description=True)
         )
 
+    @property
+    def index_cache_path(self) -> Path:
+        """dashboard 可读的三方 skill 向量缓存路径（``<skillhub_dir>/.skillhub_index.pkl``）。"""
+        return self.dir / INDEX_CACHE_NAME
+
     def index(self) -> list[dict]:
         """返回三方 skill 索引。禁用 → 空 list；启用但目录缺失 → raise。
 
         skill 以 ``skillhub.dir`` 下任意层级中包含 ``SKILL.md`` 的目录为单位。
         ``name`` / ``skill_id`` 是稳定分发身份，展示名放 ``display_name``。
+
+        算好向量的同时落盘一份 dashboard 可读缓存（画像散点靠它画三方 skill ▲，
+        dashboard 端无 embed_client 不能现算，D6）。只在启用且有三方 skill 时写。
         """
-        return self._entries(include_vec=True, require_description=True)
+        entries = self._entries(include_vec=True, require_description=True)
+        if entries:
+            self._persist_index(entries)
+        return entries
+
+    def _persist_index(self, entries: list[dict]) -> None:
+        """把已算好的三方 skill 向量落盘成 dashboard 可读缓存。
+
+        结构对齐自产 ``.skill_index.pkl``（``skill_names`` / ``embeddings`` /
+        ``model``），profile_viz 只读不写、读不到就不画（D6，不现算不造假）。
+        """
+        names = [entry["name"] for entry in entries]
+        embeddings = np.vstack([np.asarray(entry["vec"], dtype=float) for entry in entries])
+        data = {
+            "skill_names": names,
+            "embeddings": embeddings,
+            "model": getattr(self.embed_client, "model", None),
+        }
+        with open(self.index_cache_path, "wb") as index_file:
+            pickle.dump(data, index_file)
 
     def entry(self, name: str) -> dict | None:
         """按 skill_id / source_path / 唯一 display_name 找当前磁盘上的 skill。"""

--- a/tests/test_atom_task_store.py
+++ b/tests/test_atom_task_store.py
@@ -132,6 +132,118 @@ class TestVectorIndex:
         assert hits == []
 
 
+class _SpyEmbed(_FakeEmbed):
+    """记录每次 ``encode_batch`` 输入文本，用于断言增量复用只 embed 新原子。"""
+
+    def __init__(self, model: str = "fake"):
+        self.model = model
+        self.batches: list[list[str]] = []
+
+    def encode_batch(self, texts: list[str]) -> np.ndarray:
+        self.batches.append(list(texts))
+        return super().encode_batch(texts)
+
+
+def _read_index(tmp_path: Path) -> dict:
+    import pickle
+    with open(tmp_path / "cc-sessions" / "index.pkl", "rb") as f:
+        return pickle.load(f)
+
+
+class TestVectorIndexIncremental:
+    def test_first_rebuild_embeds_all(self, tmp_path):
+        store = _store(tmp_path)
+        embed = _SpyEmbed()
+        for i in range(3):
+            store.save(_atom(atom_id=f"atom_t_000{i}", traj_id="t",
+                             offset_start=i * 10, offset_end=(i + 1) * 10,
+                             summary=f"do thing {i}"))
+        store.rebuild_vector_index(embed)
+        # 首次：一次 batch 覆盖全部 3 个原子
+        assert embed.batches == [["do thing 0", "do thing 1", "do thing 2"]]
+        idx = _read_index(tmp_path)
+        assert idx["atom_ids"] == ["atom_t_0000", "atom_t_0001", "atom_t_0002"]
+
+    def test_added_atom_only_embeds_the_new_one(self, tmp_path):
+        store = _store(tmp_path)
+        embed = _SpyEmbed()
+        for i in range(2):
+            store.save(_atom(atom_id=f"atom_t_000{i}", traj_id="t",
+                             offset_start=i * 10, offset_end=(i + 1) * 10,
+                             summary=f"do thing {i}"))
+        store.rebuild_vector_index(embed)
+        embed.batches.clear()
+        # 新增第 3 个原子后再 rebuild：只 embed 新原子，其余复用缓存
+        store.save(_atom(atom_id="atom_t_0002", traj_id="t",
+                         offset_start=20, offset_end=30, summary="do thing 2"))
+        store.rebuild_vector_index(embed)
+        assert embed.batches == [["do thing 2"]]
+        idx = _read_index(tmp_path)
+        assert idx["atom_ids"] == [
+            "atom_t_0000", "atom_t_0001", "atom_t_0002"]
+
+    def test_reused_rows_match_full_rebuild(self, tmp_path):
+        # 增量拼出来的向量与整批重算逐行一致（行顺序对齐 all_atoms()）
+        store = _store(tmp_path)
+        for i in range(2):
+            store.save(_atom(atom_id=f"atom_t_000{i}", traj_id="t",
+                             offset_start=i * 10, offset_end=(i + 1) * 10,
+                             summary=f"do thing {i}"))
+        store.rebuild_vector_index(_SpyEmbed())
+        store.save(_atom(atom_id="atom_t_0002", traj_id="t",
+                         offset_start=20, offset_end=30, summary="do thing 2"))
+        store.rebuild_vector_index(_SpyEmbed())
+        incremental = _read_index(tmp_path)["embeddings"]
+
+        # 另建等价 store 一次性整批重建作为基准
+        ref_store = AtomTaskStore(root=tmp_path / "ref")
+        for i in range(3):
+            ref_store.save(_atom(atom_id=f"atom_t_000{i}", traj_id="t",
+                                 offset_start=i * 10, offset_end=(i + 1) * 10,
+                                 summary=f"do thing {i}"))
+        ref_store.rebuild_vector_index(_SpyEmbed())
+        import pickle
+        with open(tmp_path / "ref" / "index.pkl", "rb") as f:
+            full = pickle.load(f)["embeddings"]
+        assert np.allclose(incremental, full)
+
+    def test_model_change_reembeds_all(self, tmp_path):
+        store = _store(tmp_path)
+        for i in range(2):
+            store.save(_atom(atom_id=f"atom_t_000{i}", traj_id="t",
+                             offset_start=i * 10, offset_end=(i + 1) * 10,
+                             summary=f"do thing {i}"))
+        store.rebuild_vector_index(_SpyEmbed(model="fake"))
+        # 换 embedding 模型：旧向量作废，全部重算
+        embed2 = _SpyEmbed(model="other")
+        store.rebuild_vector_index(embed2)
+        assert embed2.batches == [["do thing 0", "do thing 1"]]
+        assert _read_index(tmp_path)["model"] == "other"
+
+    def test_deleted_atom_dropped_from_index(self, tmp_path):
+        store = _store(tmp_path)
+        for i in range(3):
+            store.save(_atom(atom_id=f"atom_t_000{i}", traj_id="t",
+                             offset_start=i * 10, offset_end=(i + 1) * 10,
+                             summary=f"do thing {i}"))
+        store.rebuild_vector_index(_SpyEmbed())
+        # 删掉一个原子文件后 rebuild：索引里不再有它
+        (tmp_path / "cc-sessions" / "t" / "tasks" /
+         "atom_t_0001.json").unlink()
+        embed = _SpyEmbed()
+        store.rebuild_vector_index(embed)
+        idx = _read_index(tmp_path)
+        assert idx["atom_ids"] == ["atom_t_0000", "atom_t_0002"]
+        # 复用命中，无需再 embed 任何原子
+        assert embed.batches == []
+        assert idx["embeddings"].shape[0] == 2
+
+    def test_empty_store_writes_no_file(self, tmp_path):
+        store = _store(tmp_path)
+        store.rebuild_vector_index(_SpyEmbed())
+        assert not (tmp_path / "cc-sessions" / "index.pkl").exists()
+
+
 class TestAllAtoms:
     def test_iterates_across_trajs(self, tmp_path):
         store = _store(tmp_path)

--- a/tests/test_dashboard_frontend_smoke.py
+++ b/tests/test_dashboard_frontend_smoke.py
@@ -38,3 +38,16 @@ def test_appjs_fetches_overview_endpoint():
     # 斜杠，对相对/绝对两种写法都成立。
     assert "api/v1/dashboard/overview" in js
     assert "api/v1/dashboard/by-domain" in js
+
+
+def test_appjs_routes_skillhub_detail_by_source():
+    """技能详情按 source 分流：三方(skillhub)技能调 skillhub ux 端点，
+    自产技能不受影响。断言存在 source==='skillhub' 分支与 skillhub ux
+    端点调用（版本聚合 + 关联原子）。"""
+    js = (STATIC / "app.js").read_text(encoding="utf-8")
+    # 基于 source 的分流判定
+    assert "source === 'skillhub'" in js
+    # 调三方 ux 端点(版本聚合分)与关联原子端点，而非自产 detail
+    assert "dashboard/skillhub/" in js
+    assert "/ux?days=" in js
+    assert "/ux/atoms?days=" in js

--- a/tests/test_dashboard_metrics.py
+++ b/tests/test_dashboard_metrics.py
@@ -171,6 +171,85 @@ def test_skills_catalog_empty_dir(tmp_path):
     assert skills_catalog(tmp_path / "nope") == []
 
 
+def test_skills_catalog_native_source_tag(tmp_path):
+    """向后兼容：不传 skillhub 时,自产条目统一带 source='native',无 skillhub 混入。"""
+    from xskill.skill.git import init_skill_repo_on_baby
+    sd = tmp_path / "skill"; sd.mkdir()
+    init_skill_repo_on_baby(str(sd / "wip-skill"), name="wip-skill", description="草稿")
+    cat = skills_catalog(sd)
+    assert len(cat) == 1
+    assert cat[0]["source"] == "native"
+    assert all(s.get("source") != "skillhub" for s in cat)
+
+
+def _make_skillhub(tmp_path, name, description, sub="vendor/tool"):
+    """构造启用态 SkillHub：hub_dir 下放一个三方 SKILL.md（embed_client 无需真实,
+    技能库列表走 include_vec=False 分支）。"""
+    from xskill.recommend.skillhub import SkillHub
+    hub_dir = tmp_path / "hub"
+    skdir = hub_dir / sub
+    skdir.mkdir(parents=True)
+    (skdir / "SKILL.md").write_text(
+        f"---\nname: {name}\ndescription: {description}\n---\n正文\n", encoding="utf-8")
+    return SkillHub(enabled=True, hub_dir=hub_dir, embed_client=None)
+
+
+def test_skills_catalog_merges_skillhub(tmp_path):
+    """技能库列表既含自产(native)又含三方(skillhub)条目,字段符合契约。"""
+    from xskill.skill.git import init_skill_repo_on_baby, commit_baby_to_main_branch
+    sd = tmp_path / "skill"; sd.mkdir()
+    init_skill_repo_on_baby(str(sd / "ready-skill"), name="ready-skill", description="正式描述")
+    commit_baby_to_main_branch(str(sd / "ready-skill"), "graduate")
+    hub = _make_skillhub(tmp_path, "vendor-skill", "三方能力描述", sub="vendor/tool")
+
+    cat = skills_catalog(sd, skillhub=hub)
+    by_source: dict = {}
+    for s in cat:
+        by_source.setdefault(s["source"], []).append(s)
+    assert set(by_source) == {"native", "skillhub"}
+
+    native = by_source["native"][0]
+    assert native["name"] == "ready-skill" and native["state"] == "main"
+
+    hub_row = by_source["skillhub"][0]
+    assert hub_row["name"] == "vendor-skill"          # 展示名取 display_name
+    assert hub_row["state"] == "skillhub"             # 无 git 分支
+    assert hub_row["hub"] == "vendor/tool"            # skillhub 目录下相对路径
+    assert hub_row["skill_id"].startswith("vendor-skill@")  # name@path_hash
+    assert "三方能力描述" in hub_row["description"]
+    assert hub_row["use_count"] == 0                  # 无使用记录 → 0
+    # 自产排在三方之前
+    assert cat.index(native) < cat.index(hub_row)
+
+
+def test_skills_catalog_skillhub_none_is_noop(tmp_path):
+    """skillhub=None（缺省/禁用）→ no-op：只有自产,不报错。"""
+    from xskill.skill.git import init_skill_repo_on_baby
+    sd = tmp_path / "skill"; sd.mkdir()
+    init_skill_repo_on_baby(str(sd / "wip"), name="wip", description="d")
+    assert skills_catalog(sd, skillhub=None) == skills_catalog(sd)
+    # 禁用态 SkillHub 也应 no-op（其 _entries 内部判 enabled）
+    from xskill.recommend.skillhub import SkillHub
+    disabled = SkillHub(enabled=False, hub_dir=tmp_path / "nohub", embed_client=None)
+    cat = skills_catalog(sd, skillhub=disabled)
+    assert all(s["source"] == "native" for s in cat)
+
+
+def test_skills_catalog_accepts_entry_list(tmp_path):
+    """skillhub 入参也可直接是条目列表（契约：SkillHub 对象或 entries）。"""
+    entries = [{
+        "source": "skillhub", "name": "x@abc123", "skill_id": "x@abc123",
+        "display_name": "x", "source_path": "team/x", "description": "e",
+        "use_count": 5,
+    }]
+    cat = skills_catalog(tmp_path / "nope", skillhub=entries)
+    assert len(cat) == 1
+    row = cat[0]
+    assert row["source"] == "skillhub" and row["hub"] == "team/x"
+    assert row["skill_id"] == "x@abc123" and row["use_count"] == 5
+    assert row["name"] == "x"
+
+
 def test_users_lists_team_clients(tmp_path):
     db = tmp_path / "u.db"
     conn = get_connection(db)

--- a/tests/test_dashboard_p3.py
+++ b/tests/test_dashboard_p3.py
@@ -351,6 +351,103 @@ def test_scatter_skill_vec_only_from_index(tmp_path):
     assert ProfileViz(pdb, skill_dir=skills).user_scatter("alice")["skills"] == []
 
 
+# ── 3.4bis 三方(skillhub)skill ▲ + source 契约 ────────────────────────
+
+class _FakeEmbed:
+    """dashboard 无 embed_client;这里只给 SkillHub 落盘缓存用(维度对齐 points=4)。"""
+
+    def __init__(self, dim=4):
+        self.dim = dim
+        self.model = "fake-embed"
+
+    def encode(self, text):
+        v = np.zeros(self.dim, dtype=float)
+        for i, ch in enumerate(text):
+            v[i % self.dim] += ord(ch) % 97
+        return v
+
+
+def _write_hub_skill(hub_dir: Path, rel: str, desc: str):
+    d = hub_dir / rel
+    d.mkdir(parents=True)
+    (d / "SKILL.md").write_text(
+        f"---\nname: {rel}\ndescription: {desc}\n---\n# {rel}\n", encoding="utf-8")
+
+
+def _seed_alice_with_skills(pdb: Path, used_skills: list[dict]):
+    """alice 两簇各 3 点(dim=4),used_skills 自定,便于挂三方 skill。"""
+    store = ProfileStore(pdb)
+    a = np.array([[1, 0.05 * i, 0, 0] for i in range(3)], dtype=float)
+    b = np.array([[0.05 * i, 1, 0, 0] for i in range(3)], dtype=float)
+    pts = np.vstack([a, b])
+    pts /= np.linalg.norm(pts, axis=1, keepdims=True)
+    centers = np.vstack([a.mean(0), b.mean(0)])
+    centers /= np.linalg.norm(centers, axis=1, keepdims=True)
+    meta = [{"atom_id": f"atom_{i}", "summary": f"s{i}", "ux": 8,
+             "tags": ["git"] if i < 3 else ["docker"]} for i in range(6)]
+    store.upsert("alice", feature_tensor=centers, mean_tensor=pts.mean(0),
+                 used_skills=used_skills, points=pts, point_meta=meta)
+
+
+def test_skillhub_index_for_locates_sibling(tmp_path):
+    """三方缓存旁推定位:registry 同级 skillhub_skills/.skillhub_index.pkl。"""
+    from xskill.dashboard.profile_viz import skillhub_index_for
+    p = skillhub_index_for(tmp_path / "registry.db")
+    assert p == tmp_path / "skillhub_skills" / ".skillhub_index.pkl"
+
+
+def test_scatter_marks_skillhub_source(tmp_path):
+    """SkillHub.index() 落盘缓存 → 用户用过的三方 skill 画成 ▲、带 source=skillhub、
+    有坐标;自产 skill 仍 source=native(不回归)。writer↔reader 契约端到端。"""
+    from xskill.recommend.skillhub import SkillHub
+    pdb = tmp_path / "p.db"
+    hub_dir = tmp_path / "hub"
+    _write_hub_skill(hub_dir, "linter", "python lint helper")
+    hub = SkillHub(enabled=True, hub_dir=hub_dir, embed_client=_FakeEmbed(dim=4))
+    hub_id = hub.index()[0]["name"]
+    assert hub.index_cache_path.is_file()  # 算向量的同时落盘缓存(供 dashboard 读)
+    _seed_alice_with_skills(pdb, [{"name": "sk1", "use_count": 3},
+                                  {"name": hub_id, "use_count": 5}])
+    skills = tmp_path / "skills"
+    skills.mkdir()
+    (skills / ".skill_index.pkl").write_bytes(pickle.dumps(
+        {"skill_names": ["sk1"], "embeddings": np.array([[0.7, 0.7, 0, 0]], dtype=float)}))
+    out = ProfileViz(pdb, skill_dir=skills,
+                     skillhub_index=hub.index_cache_path).user_scatter("alice")["skills"]
+    by = {s["name"]: s for s in out}
+    assert set(by) == {"sk1", hub_id}
+    assert by["sk1"]["source"] == "native"
+    assert by[hub_id]["source"] == "skillhub"
+    assert by[hub_id]["use_count"] == 5
+    for s in out:  # 都有坐标
+        assert isinstance(s["x"], float) and isinstance(s["y"], float)
+
+
+def test_scatter_skillhub_missing_cache_not_drawn(tmp_path):
+    """D6:三方缓存缺失 → 三方 skill 不出现、不报错、不现算;自产 ▲ 不回归。"""
+    pdb = tmp_path / "p.db"
+    _seed_alice_with_skills(pdb, [{"name": "sk1", "use_count": 3},
+                                  {"name": "ghosthub@zzz", "use_count": 2}])
+    skills = tmp_path / "skills"
+    skills.mkdir()
+    (skills / ".skill_index.pkl").write_bytes(pickle.dumps(
+        {"skill_names": ["sk1"], "embeddings": np.array([[0.7, 0.7, 0, 0]], dtype=float)}))
+    out = ProfileViz(pdb, skill_dir=skills,
+                     skillhub_index=tmp_path / "nope.pkl").user_scatter("alice")["skills"]
+    assert [s["name"] for s in out] == ["sk1"]
+    assert out[0]["source"] == "native"
+
+
+def test_scatter_skillhub_dim_mismatch_skipped(tmp_path):
+    """三方缓存维度与 points 不一致(换过 embedding 模型)→ 跳过,不画,不报错。"""
+    pdb = tmp_path / "p.db"
+    _seed_alice_with_skills(pdb, [{"name": "hub@x", "use_count": 1}])
+    cache = tmp_path / "hub.pkl"
+    cache.write_bytes(pickle.dumps(
+        {"skill_names": ["hub@x"], "embeddings": np.ones((1, 7)), "model": "m"}))
+    assert ProfileViz(pdb, skillhub_index=cache).user_scatter("alice")["skills"] == []
+
+
 # ── 3.5 聚类 graph ───────────────────────────────────────────────────
 
 def test_cluster_graph_edges_and_isolated(tmp_path):


### PR DESCRIPTION
## 概述 / Summary

四项工作,并行开发(4 个隔离 worktree 子代理)后整合。前三项让 **skillhub 第三方技能**在控制台前端完整可见,第四项修 ingest 的一处大规模浪费。base 指向 `feat/dashboard-console-p3`(PR #81),只展示本轮增量。

Four workstreams, developed in parallel (4 isolated-worktree subagents) then integrated. The first three surface **skillhub (third-party) skills** in the dashboard frontend; the fourth fixes a large-scale ingest waste. Based on `feat/dashboard-console-p3` (#81) so the diff shows only this round's delta.

## 改动 / Changes

**1. watcher/原子索引 增量 embedding**（`pipeline/atom.py`）
`rebuild_vector_index` 此前每拆出新原子就把该客户端全部原子重 embed 一遍(watcher/sync 4 处触发)。改为读旧 `index.pkl` 按 `atom_id` 复用,只 embed 新原子;`model` 字段做护栏(换模型全量重算);只含当前原子集,天然处理删除。

**2. skillhub 进技能库列表 + 来源徽章**（`metrics.py`、`router.py` skills 端点、`app.js` 列表）
`skills_catalog` 合入 skillhub 三方技能;统一数据契约 `source`(native/skillhub) + `hub` + `skill_id`;前端每行标来源徽章。skillhub 缺省禁用则 no-op。

**3. skillhub 评分 + 详情页**（`app.js` 详情段）
技能详情按 `source` 分流:三方技能改调后端已有的 `/skillhub/{name}/ux`、`/ux/atoms` 渲染版本聚合评分 + 关联原子,标注"无 git 灰度";自产路径不变。

**4. skillhub 散点画 ▲**（`profile_viz.py`、`skillhub.py`、`app.js` 散点段）
根因:三方技能向量只在引擎里临时算、不落盘,dashboard 无 embed_client(D6)读不到 → 用户用过的三方技能散点上不显示。`SkillHub.index()` 落盘 `.skillhub_index.pkl`,`profile_viz` 读入合并;散点 `skills[]` 带 `source`,三方 ▲ 用琥珀色区分。严守 D6:只读缓存,读不到不画,绝不现算。

## 测试 / Tests
- 全量 `pytest tests/ --ignore=tests/e2e`:**1254 passed**,1 failed = `test_canary_flip_promote_and_install_new_version`(全会话都红的既有环境 flaky,与本改动无关)。
- 新增单测:atom 增量索引(6) / skills_catalog skillhub 合入(5) / 前端 skillhub 详情分流 / 散点 skillhub ▲ 与 D6(4)。
- pylint 改动文件 10.00/10;`node --check app.js` 通过。

## 备注 / Notes
- `metrics._skillhub_entries` 调了 `SkillHub._entries`(私有,唯一提供 name+description 且不需 embed_client 的列举口径)——可后续在 SkillHub 加个公开 accessor 收紧。
- 依赖 #81 的 dashboard 代码,建议 #81 合入后再合本 MR。
