### PR TITLE
SkillEditAgent: 大 buffer 分批+turn 分支渐进式消化，SkillEdit 移出扫描循环内联执行

### DIFF
--- a/src/xskill/agents/skill_edit_agent.py
+++ b/src/xskill/agents/skill_edit_agent.py
@@ -14,8 +14,20 @@ agent 写完 SKILL.md / scripts / references 后**必须**调以下两个 commit
   - baby 分支：调 ``commit_baby_to_main(skill_name, message)`` 完成首版
   - main 分支：调 ``commit_to_staging(skill_name, message)`` 产出灰度候选
 
-落盘成功（SKILL.md mtime 推进 + 非空）→ 清空 candidates buffer + 立即
-install_to_claude_code 让 CC 立刻看到新版本。
+落盘成功（SKILL.md mtime 推进 + 非空 + 分支真推进）→ 从 buffer 摘除本次
+快照到的 atom_id + 立即 install_to_claude_code 让 CC 立刻看到新版本。
+
+多轮渐进式消化（buffer 超过 ``SKILL_EDIT_BATCH_SIZE`` 条候选时）：
+一次 ``maybe_run`` 对 buffer 做一次快照,按 ``(weightscore 降序, atom_id 升序)``
+切成多批,每批一轮**全新上下文**的 ``agent.run()``（不带前一轮的对话历史，
+与 TaskAgent 弃窗单趟同一设计哲学，见 ``context_budget.py``）。除最后一轮外
+每轮结束后由**宿主 Python 代码**（不是 agent）把改动 commit 到一个新建的
+``<branch>_turn<N>`` 分支承接进度；中间轮的 agent 完全不会拿到任何终态
+commit 工具——分支推进对它不可见也不可调用，是结构性保证而非约定。最后一轮
+开跑前宿主代码把 HEAD 切回原分支（工作区不动），agent 此时才拿到终态 commit
+工具，一次 commit 落地全部批次的累计改动。成功后清理所有遗留 turn 分支；
+若发现残留 turn 分支（上次崩溃/失败），不续传，直接重置重来（详见
+``SkillEditAgent._recover_crashed_turns``）。
 """
 from __future__ import annotations
 
@@ -343,10 +355,13 @@ class SkillEditAgent:
              - .ux_scores.jsonl 必须至少有 1 条 side=main → 证明 main 真有人用
              - 否则保留 candidates 等用户用过 main 再触发
 
-        全过 → 跑 agent → 验证 SKILL.md mtime 推进 + 非空 → 清 candidates。
-        agent 没落盘 SKILL.md → 保留 candidates 等下轮重试（Bug 2 修复）。
+        全过 → 跑 agent（可能多轮渐进式） → 验证 SKILL.md mtime 推进 + 非空 +
+        分支真推进 → 从 buffer 摘除本次快照的 atom_id。
+        agent 没落盘 SKILL.md，或分支没真推进 → 保留 candidates 等下轮重试。
         """
         from xskill.skill.git import current_branch, run_git
+
+        self._recover_crashed_turns()
 
         # 守门 1（改）：staging 存在时，候选累计 ws ≥ jam_threshold 则越过灰度强砍；
         # 未达到阈值时维持原先 hold 行为。
@@ -396,10 +411,18 @@ class SkillEditAgent:
             if code == 0:
                 main_sha_before = out.strip()
 
+        # 快照：本次消化范围 = 当前 buffer 里的这些 atom_id。多轮渐进式消化
+        # 期间 cluster 并发 add 进来的新候选不在这个集合里，不受影响，留给
+        # 下一次 maybe_run 处理（避免竞争/饿死）。
+        snapshot_atom_ids = {
+            c.get("atom_id") for c in ready if c.get("atom_id")
+        }
+
         try:
-            self._run(ready, current_branch_name=cur, jam=jam)
+            run_ok = self._run(ready, current_branch_name=cur, jam=jam)
         except Exception:
             logger.exception("SkillEditAgent _run failed: %s", self.skill_dir.name)
+            run_ok = False
 
         # 实测落盘：mtime 推进 + 非空 = agent 真写了
         wrote = (
@@ -434,6 +457,15 @@ class SkillEditAgent:
             )
             return False
 
+        if not run_ok:
+            logger.warning(
+                "SkillEditAgent _run 未完整跑完终态提交（多轮渐进式消化中途失败/"
+                "崩溃）: %s — 保留 candidates，下轮 maybe_run 会清残留 turn 分支"
+                "重新开始",
+                self.skill_dir.name,
+            )
+            return False
+
         if jam:
             from xskill.canary import discard_staging
 
@@ -453,12 +485,14 @@ class SkillEditAgent:
                     self.skill_dir.name,
                 )
                 return False
+            self._cleanup_turn_branches("main")
 
         # commit 工具的成功效应（baby→main 或 main→staging）通过当前分支变化
-        # 自然反映，不需要在这里做额外检查
-        C.clear_candidates(self.skill_dir)
-        logger.info("SkillEditAgent done + candidates cleared: %s",
-                    self.skill_dir.name)
+        # 自然反映，不需要在这里做额外检查（非 jam 路径的 turn 分支已在
+        # ``_run`` 尾部的终态校验通过后就地清理）
+        C.remove_candidates(self.skill_dir, snapshot_atom_ids)
+        logger.info("SkillEditAgent done + %d candidate(s) removed: %s",
+                    len(snapshot_atom_ids), self.skill_dir.name)
         return True
 
     def _main_has_ux_score(self) -> bool:
@@ -473,96 +507,256 @@ class SkillEditAgent:
             return False
         return any(s.get("side") == "main" for s in scores)
 
-    def _run(self, ready: list[dict], current_branch_name: str, jam: bool = False) -> None:
+    # ───────────────────────────────────────────────────────────────
+    # 崩溃恢复 + turn 分支生命周期
+    # ───────────────────────────────────────────────────────────────
+
+    def _recover_crashed_turns(self) -> None:
+        """``maybe_run`` 入口第一件事：发现残留 turn 分支就判定上次跑到一半
+        崩溃/失败，简单粗暴重置——不续传。
+
+        buffer 从未在多轮消化中途被清空（只有全部批次成功才 remove），所以
+        重置只丢弃 turn 分支上的半成品工作区改动，不丢候选。
+        """
+        import re
+
+        from xskill.skill.git import current_branch, list_turn_branches, run_git
+
+        turn_branches = list_turn_branches(str(self.skill_dir), base_branch=None)
+        if not turn_branches:
+            return
+
+        cur = current_branch(str(self.skill_dir))
+        bases = {re.sub(r"_turn\d+$", "", b) for b in turn_branches}
+        reset_target = cur if cur in ("baby", "main") else (
+            sorted(bases)[0] if bases else "main"
+        )
+        logger.warning(
+            "SkillEditAgent 发现残留 turn 分支 %s（skill=%s）——判定上次崩溃/"
+            "失败，重置到 %r 重新开始整条链条",
+            turn_branches, self.skill_dir.name, reset_target,
+        )
+        run_git(["checkout", reset_target], cwd=str(self.skill_dir))
+        run_git(["branch", "-D", *turn_branches], cwd=str(self.skill_dir))
+
+    def _cleanup_turn_branches(self, base_branch: str) -> None:
+        """成功收尾后删除该 base 派生的所有遗留 turn 分支（空列表时零开销）。"""
+        from xskill.skill.git import list_turn_branches, run_git
+
+        turn_branches = list_turn_branches(str(self.skill_dir), base_branch)
+        if turn_branches:
+            run_git(["branch", "-D", *turn_branches], cwd=str(self.skill_dir))
+
+    # ───────────────────────────────────────────────────────────────
+    # 批次切分
+    # ───────────────────────────────────────────────────────────────
+
+    def _make_batches(self, ready: list[dict]) -> list[list[dict]]:
+        """按 (weightscore 降序, atom_id 升序) 稳定排序后,切成
+        ``SKILL_EDIT_BATCH_SIZE`` 条一批。"""
+        ordered = sorted(
+            ready,
+            key=lambda c: (-int(c.get("weightscore", 0) or 0), str(c.get("atom_id", ""))),
+        )
+        size = C.SKILL_EDIT_BATCH_SIZE
+        return [ordered[i:i + size] for i in range(0, len(ordered), size)]
+
+    def _round_info_lines(self, turn_idx: int, num_batches: int) -> list[str]:
+        """单批（num_batches<=1）不插入任何轮次说明——prompt 文本与消化前
+        逐字一致,零行为差异。"""
+        if num_batches <= 1:
+            return []
+        if turn_idx == 1:
+            note = (
+                f"这是渐进式编辑第 1/{num_batches} 轮：candidates buffer 过大，"
+                f"已按 {C.SKILL_EDIT_BATCH_SIZE} 条一批切分为 {num_batches} 轮处理，"
+                "本轮只处理下面列出的这一批候选。"
+            )
+        else:
+            note = (
+                f"这是渐进式编辑第 {turn_idx}/{num_batches} 轮：当前 SKILL.md 已经"
+                "融合了前面几批候选的内容，请先读现状（SkillRead / read_file）再"
+                "基于本轮候选继续编辑，不要覆盖丢弃前面几轮已经写好的内容。"
+            )
+        return ["", note]
+
+    def _trace_run(self, agent: Any, user_msg: str, *, log_suffix: str) -> None:
+        """跑一轮 agent.run() 并把逐轮 CoT/工具调用记到
+        logs/agents/skill_edit_agents/skills/<skill><suffix>_<ts>.log。"""
+        import time as _time
+        from xskill.agents.agent_trace import trace_to
+        from xskill.config import get_logs_dir
+
+        _ts = _time.strftime("%Y%m%d-%H%M%S")
+        sink = (
+            get_logs_dir() / "agents" / "skill_edit_agents" / "skills"
+            / f"{self.skill_dir.name}{log_suffix}_{_ts}.log"
+        )
+        with trace_to(sink):
+            agent.run(user_msg)
+
+    # ───────────────────────────────────────────────────────────────
+    # 多轮消化主循环
+    # ───────────────────────────────────────────────────────────────
+
+    def _run(self, ready: list[dict], current_branch_name: str, jam: bool = False) -> bool:
+        """跑完整条（可能多轮的）消化链。
+
+        返回 True = 终态 commit 完整跑完（baby→main / main 直接更新走
+        staging / jam 强砍合并）且 turn 分支已清理；False/异常 = 某一环节
+        失败——调用方保留 candidates，下轮 ``maybe_run`` 触发崩溃恢复重来。
+        """
+        from xskill.skill import git as skillgit
+        from xskill.skill.git import current_branch as _current_branch
+        from xskill.skill.git import run_git as _run_git
+
+        batches = self._make_batches(ready)
+        num_batches = len(batches)
+        if num_batches == 0:
+            return False
+
+        for turn_idx, batch in enumerate(batches, start=1):
+            is_last = turn_idx == num_batches
+            if is_last and num_batches > 1:
+                # 最后一轮开跑前把 HEAD 切回原分支（工作区不动，仍是最后一个
+                # turn 分支演化出的内容）——终态 commit 工具的分支校验才能过。
+                skillgit.checkout_head_ref_only(
+                    str(self.skill_dir), current_branch_name,
+                )
+            if jam:
+                self._run_jam_round(
+                    batch, turn_idx=turn_idx, num_batches=num_batches, is_last=is_last,
+                )
+            else:
+                self._run_normal_round(
+                    batch, current_branch_name=current_branch_name,
+                    turn_idx=turn_idx, num_batches=num_batches, is_last=is_last,
+                )
+            if not is_last:
+                turn_branch = f"{current_branch_name}_turn{turn_idx}"
+                skillgit.commit_progressive_turn(
+                    str(self.skill_dir), turn_branch,
+                    f"skilledit progressive turn {turn_idx}/{num_batches} "
+                    f"({len(batch)} atoms, not final)",
+                )
+
+        if jam:
+            # jam 的终态校验（main sha 是否真推进）+ discard_staging + turn 分支
+            # 清理都在 maybe_run 里做（它已经拿着 main_sha_before 了）。这里只
+            # 负责把多轮循环跑完，不重复判定。
+            return True
+
+        final_branch = _current_branch(str(self.skill_dir))
+        if current_branch_name == "baby":
+            ok = final_branch == "main"
+        else:
+            staging_ok = _run_git(
+                ["rev-parse", "--verify", "staging"], cwd=str(self.skill_dir),
+            )[0] == 0
+            ok = staging_ok and final_branch == "main"
+        if ok:
+            self._cleanup_turn_branches(current_branch_name)
+        return ok
+
+    def _run_jam_round(
+        self, batch: list[dict], *, turn_idx: int, num_batches: int, is_last: bool,
+    ) -> None:
+        from xskill.agents import agent_tools
+
+        skill_md = self.skill_dir / "SKILL.md"
+        staging_body = (
+            self.skill_dir.parent / ".canary" / self.skill_dir.name / "SKILL.md"
+        )
+        if not staging_body.is_file():
+            from xskill.canary import materialize_staging
+            materialize_staging(self.skill_dir, self.skill_dir.parent / ".canary")
+        if not staging_body.is_file():
+            raise RuntimeError(
+                f"jam-merge: staging body for {self.skill_dir.name} could not be "
+                "materialized; refusing to merge and discard"
+            )
+
+        lines = [
+            MERGE_DISCIPLINE_BLOCK,
+            *self._round_info_lines(turn_idx, num_batches),
+            "",
+            f"skill_name: {self.skill_dir.name}（**main 分支 · 轨迹堰塞强砍合并**）",
+            f"现有 main 正文：用 skill_read('{self.skill_dir.name}') 读。",
+            f"staging 正文路径（用 read_file 读）：{staging_body}",
+            *self._skill_tree_context_lines(),
+            "# 待合并候选（按 weightscore 倒序）",
+        ]
+        for c in sorted(batch, key=lambda x: x.get("weightscore", 0), reverse=True):
+            note = c.get("note", "")
+            lines.append(
+                f"- atom_id={c['atom_id']}  weightscore={c['weightscore']}"
+                + (f"  note: {note}" if note else "")
+            )
+        lines += [
+            "",
+            f"目标 skill 目录: {self.skill_dir}",
+            f"目标 SKILL.md 路径: {skill_md}",
+        ]
+        scenario_block = "\n".join(lines)
+        sysprompt = build_system_prompt(scenario_block=scenario_block, branch_now="main")
+
+        tools = [
+            agent_tools.atom_task_read,
+            agent_tools.read_traj,
+            agent_tools.skill_read,
+            agent_tools.read_file,
+            agent_tools.list_files,
+            agent_tools.write_file,
+        ]
+        if is_last:
+            tools.append(agent_tools.commit_update_main)
+
+        agent = self.agno_agent_factory(instructions=[sysprompt], tools=tools)
+        suffix = "_jam" if num_batches <= 1 else f"_jam_turn{turn_idx}"
+        self._trace_run(agent, scenario_block, log_suffix=suffix)
+
+    def _run_normal_round(
+        self, batch: list[dict], *, current_branch_name: str,
+        turn_idx: int, num_batches: int, is_last: bool,
+    ) -> None:
         from xskill.agents import agent_tools
         from xskill.skill.frontmatter import parse as fm_parse
 
-        if jam:
-            from xskill.canary import materialize_staging
-
-            skill_md = self.skill_dir / "SKILL.md"
-            staging_body = (
-                self.skill_dir.parent / ".canary" / self.skill_dir.name / "SKILL.md"
-            )
-            if not staging_body.is_file():
-                materialize_staging(self.skill_dir, self.skill_dir.parent / ".canary")
-            if not staging_body.is_file():
-                raise RuntimeError(
-                    f"jam-merge: staging body for {self.skill_dir.name} could not be "
-                    "materialized; refusing to merge and discard"
-                )
-
-            lines = [
-                MERGE_DISCIPLINE_BLOCK,
-                "",
-                f"skill_name: {self.skill_dir.name}（**main 分支 · 轨迹堰塞强砍合并**）",
-                f"现有 main 正文：用 skill_read('{self.skill_dir.name}') 读。",
-                f"staging 正文路径（用 read_file 读）：{staging_body}",
-                *self._skill_tree_context_lines(),
-                "# 待合并候选（按 weightscore 倒序）",
-            ]
-            for c in sorted(ready, key=lambda x: x.get("weightscore", 0), reverse=True):
-                note = c.get("note", "")
-                lines.append(
-                    f"- atom_id={c['atom_id']}  weightscore={c['weightscore']}"
-                    + (f"  note: {note}" if note else "")
-                )
-            lines += [
-                "",
-                f"目标 skill 目录: {self.skill_dir}",
-                f"目标 SKILL.md 路径: {skill_md}",
-            ]
-            scenario_block = "\n".join(lines)
-            sysprompt = build_system_prompt(
-                scenario_block=scenario_block,
-                branch_now="main",
-            )
-            agent = self.agno_agent_factory(
-                instructions=[sysprompt],
-                tools=[
-                    agent_tools.atom_task_read,
-                    agent_tools.read_traj,
-                    agent_tools.skill_read,
-                    agent_tools.read_file,
-                    agent_tools.list_files,
-                    agent_tools.write_file,
-                    agent_tools.commit_update_main,
-                ],
-            )
-            import time as _time
-            from xskill.agents.agent_trace import trace_to
-            from xskill.config import get_logs_dir
-
-            _ts = _time.strftime("%Y%m%d-%H%M%S")
-            sink = (
-                get_logs_dir() / "agents" / "skill_edit_agents" / "skills"
-                / f"{self.skill_dir.name}_jam_{_ts}.log"
-            )
-            with trace_to(sink):
-                agent.run(scenario_block)
-            return
-
-        # 构造 scenario_block + branch_now 给 prompt 用
         skill_md = self.skill_dir / "SKILL.md"
         scenario_lines: list[str] = []
         if current_branch_name == "baby":
             scenario_lines.append(
                 "skill_name: " + self.skill_dir.name + "（**baby 分支**——首次出版本）"
             )
-            scenario_lines.append(
-                "写完 SKILL.md 后调 ``commit_baby_to_main(skill_name, message)`` "
-                "graduate 到 main 分支。"
-            )
+            scenario_lines.extend(self._round_info_lines(turn_idx, num_batches))
+            if is_last:
+                scenario_lines.append(
+                    "写完 SKILL.md 后调 ``commit_baby_to_main(skill_name, message)`` "
+                    "graduate 到 main 分支。"
+                )
+            else:
+                scenario_lines.append(
+                    "本轮没有提供任何 commit 工具——分支推进由系统在全部批次渐进式"
+                    "消化完成后自动处理，你只需要把本轮候选编辑进 SKILL.md。"
+                )
         else:
             scenario_lines.append(
                 "skill_name: " + self.skill_dir.name + "（**main 分支** —— 更新现有 skill）"
             )
-            scenario_lines.append(
-                "写完 SKILL.md 后调 ``commit_to_staging(skill_name, message)`` "
-                "把更新作为灰度候选 commit 到 staging。"
-            )
+            scenario_lines.extend(self._round_info_lines(turn_idx, num_batches))
+            if is_last:
+                scenario_lines.append(
+                    "写完 SKILL.md 后调 ``commit_to_staging(skill_name, message)`` "
+                    "把更新作为灰度候选 commit 到 staging。"
+                )
+            else:
+                scenario_lines.append(
+                    "本轮没有提供任何 commit 工具——分支推进由系统在全部批次渐进式"
+                    "消化完成后自动处理，你只需要把本轮候选编辑进 SKILL.md。"
+                )
 
-        # 现有 SKILL.md 是 stub (baby 时) 或正式版 (main 时)
+        # 现有 SKILL.md 是 stub (baby 时) 或正式版 (main 时)；多轮消化中间态时
+        # 是前几轮已经融合过候选的正文。
         if skill_md.is_file():
             try:
                 fm, _ = fm_parse(skill_md.read_text(encoding="utf-8"))
@@ -576,9 +770,7 @@ class SkillEditAgent:
         scenario_lines.extend(self._skill_tree_context_lines())
         scenario_lines.append("")
         scenario_lines.append("# 待整理 candidates（按 weightscore 倒序）")
-        for c in sorted(
-            ready, key=lambda x: x.get("weightscore", 0), reverse=True,
-        ):
+        for c in sorted(batch, key=lambda x: x.get("weightscore", 0), reverse=True):
             note = c.get("note", "")
             ext = f"  note: {note}" if note else ""
             scenario_lines.append(
@@ -595,25 +787,20 @@ class SkillEditAgent:
         )
         user_msg = scenario_block  # 同时也作为 user 消息（agno 两端都看）
 
-        agent = self.agno_agent_factory(
-            instructions=[sysprompt],
-            tools=[
-                agent_tools.atom_task_read,
-                agent_tools.read_traj,
-                agent_tools.skill_read,
-                agent_tools.read_file,
-                agent_tools.list_files,
-                agent_tools.write_file,
-                agent_tools.commit_baby_to_main,
-                agent_tools.commit_to_staging,
-            ],
-        )
-        # 逐轮 CoT/工具调用 → logs/agents/skill_edit_agents/skills/<skill>_<ts>.log
-        import time as _time
-        from xskill.agents.agent_trace import trace_to
-        from xskill.config import get_logs_dir
-        _ts = _time.strftime("%Y%m%d-%H%M%S")
-        sink = (get_logs_dir() / "agents" / "skill_edit_agents" / "skills"
-                / f"{self.skill_dir.name}_{_ts}.log")
-        with trace_to(sink):
-            agent.run(user_msg)
+        tools = [
+            agent_tools.atom_task_read,
+            agent_tools.read_traj,
+            agent_tools.skill_read,
+            agent_tools.read_file,
+            agent_tools.list_files,
+            agent_tools.write_file,
+        ]
+        if is_last:
+            if current_branch_name == "baby":
+                tools.append(agent_tools.commit_baby_to_main)
+            else:
+                tools.append(agent_tools.commit_to_staging)
+
+        agent = self.agno_agent_factory(instructions=[sysprompt], tools=tools)
+        suffix = "" if num_batches <= 1 else f"_turn{turn_idx}"
+        self._trace_run(agent, user_msg, log_suffix=suffix)

--- a/src/xskill/pipeline/runner.py
+++ b/src/xskill/pipeline/runner.py
@@ -27,7 +27,7 @@ import asyncio
 import logging
 import threading
 import time
-from concurrent.futures import ThreadPoolExecutor, Future, as_completed
+from concurrent.futures import ThreadPoolExecutor, Future
 from pathlib import Path
 
 from xskill.config import (
@@ -321,7 +321,12 @@ class DirectoryWatcher:
         self._check_pending_skill_edits()
 
     def _cold_start_pipeline_idle(self) -> bool:
-        """当前 watcher 没有待处理轨迹或后台任务时，cold-start 可 flush。"""
+        """当前 watcher 没有待处理轨迹或后台任务时，cold-start 可 flush。
+
+        ``self._futures`` 是 split/embed/cluster/skill_edit 共用的同一个飞行
+        中任务表——非空即不空闲，天然把"有 SkillEdit future 在飞"也计入，
+        不需要对 stage="skill_edit" 单独判断。
+        """
         if self._futures:
             return False
         pending_statuses = (
@@ -388,7 +393,7 @@ class DirectoryWatcher:
         agent_tools.init_skill_authoring_tool_context(
             self.skill_dir, self.skill_dir, self.config,
         )
-        # ── 跨技能并行写正文 ──
+        # ── 跨技能并行写正文，且不阻塞扫描循环 ──
         # 每个 skill 文件夹是独立 git 仓（skill/git.py 各自 git init），仓锁
         # _repo_lock_for(repo_dir) 是 per-skill 的 → 不同技能 = 不同锁 = 零冲突，
         # 跨技能并发安全。agent_tools 的配置单例在循环外已用同一个 skill
@@ -397,9 +402,13 @@ class DirectoryWatcher:
         # 实参解析目标子目录（target = skill_dir / slug），不依赖任何 per-skill
         # 全局态。因此把每个技能的 maybe_run() 丢进线程池并发跑是安全的。
         #
-        # 仅并行 LLM 写正文（maybe_run）这一段；结果收齐后回主线程串行做
-        # _stats 自增 + 即时 install——避免对无锁的 self._stats 做并发自增，
-        # install 是廉价的文件系统活，串行无碍。
+        # 不在这里 as_completed 等待：SkillEditAgent 现在支持多轮渐进式消化，
+        # 单个 skill 的 maybe_run() 可能跑到小时级（buffer 攒了几十上百批候选
+        # 时）。像 split/cluster 一样把每个 skill 的 maybe_run() 提交进
+        # self._futures（stage="skill_edit"），本方法立即返回；结果由
+        # ``_harvest``（每轮 scan 开头）收割 + 做 _stats 自增/即时 install。
+        # 同一个 skill 同时只允许一个 skill_edit future 在飞，避免同一 skill
+        # 被并发跑两个 maybe_run（第二个进来时前一个多半仍在改 candidates/git）。
         skill_dirs = [
             d for d in sorted(self.skill_dir.iterdir())
             if d.is_dir() and not d.name.startswith(".")
@@ -427,24 +436,51 @@ class DirectoryWatcher:
                 logger.exception("SkillEditAgent failed: %s", d.name)
                 return d, False
 
-        futures = {self._pool.submit(_run_one, d): d for d in skill_dirs}
-        promoted: list = []
-        for fut in as_completed(futures):
-            d, ok = fut.result()
-            if ok:
-                promoted.append(d)
+        skill_edit_in_flight = {
+            info.get("skill_dir") for info in self._futures.values()
+            if info.get("stage") == "skill_edit"
+        }
+        for d in skill_dirs:
+            if d in skill_edit_in_flight:
+                continue
+            fut = self._pool.submit(_run_one, d)
+            self._futures[fut] = {"stage": "skill_edit", "skill_dir": d}
 
-        # 回主线程串行汇总：_stats 自增（无锁，必须单线程）+ 即时 install。
-        for d in promoted:
-            self._stats["skills_edited"] += 1
-            logger.info("SkillEditAgent promoted: %s", d.name)
-            # 即时 install 让 Claude Code 立刻看到新生成的 SKILL.md
-            # 不必等 daemon 重启。install_to_claude_code 现在走 symlink，
-            # 后续 xskill 改 SKILL.md 也会被 CC 立即感知。
-            try:
-                self._install_skill_to_all_detected(d)
-            except Exception:
-                logger.exception("install after SkillEdit failed: %s", d.name)
+    def _on_skill_edit_done(self, result) -> None:
+        """``_harvest`` 收割 stage="skill_edit" future 用：_stats 自增 + 即时
+        install。回主线程串行做（避免对无锁的 self._stats 并发自增）。"""
+        d, ok = result
+        if not ok:
+            return
+        self._stats["skills_edited"] += 1
+        logger.info("SkillEditAgent promoted: %s", d.name)
+        # 即时 install 让 Claude Code 立刻看到新生成的 SKILL.md，不必等
+        # daemon 重启。install_to_claude_code 现在走 symlink，后续 xskill
+        # 改 SKILL.md 也会被 CC 立即感知。
+        try:
+            self._install_skill_to_all_detected(d)
+        except Exception:
+            logger.exception("install after SkillEdit failed: %s", d.name)
+
+    def _drain_futures(self, stage: str | None = None, timeout: float = 30.0) -> None:
+        """阻塞等到 ``self._futures`` 里指定 stage（``None`` = 全部）的 future
+        都跑完并被 ``_harvest`` 收割。
+
+        生产扫描循环从不调用本方法——SkillEdit 移出内联执行就是为了不阻塞
+        扫描；这里存在纯粹是给测试/优雅关停一个"等它跑完"的钩子，不必重新
+        发明"轮询 self._futures 直到清空"这套逻辑。
+        """
+        deadline = time.time() + timeout
+        while True:
+            pending = [
+                fut for fut, info in self._futures.items()
+                if stage is None or info.get("stage") == stage
+            ]
+            if not pending:
+                return
+            for fut in pending:
+                fut.result(timeout=max(0.01, deadline - time.time()))
+            self._harvest()
 
     def _resolve_target_root(self):
         """target_root 优先级：
@@ -744,6 +780,18 @@ class DirectoryWatcher:
                         "cluster batch failed (%d atoms); atoms stay unlanded, "
                         "will re-pool next scan: %s",
                         len(info.get("atom_ids") or []), e,
+                    )
+                continue
+            if stage == "skill_edit":
+                # SkillEditAgent.maybe_run() 自己吞异常返回 (d, False)——正常
+                # 不会走到 except，这里兜底仅防池化层面的意外（cancel 等）。
+                try:
+                    self._on_skill_edit_done(fut.result(timeout=0))
+                except Exception:
+                    self._stats["errors"] += 1
+                    logger.exception(
+                        "skill_edit future failed: %s",
+                        info.get("skill_dir"),
                     )
                 continue
             wd_id, fname = info["wd_id"], info["fname"]

--- a/src/xskill/skill/candidates.py
+++ b/src/xskill/skill/candidates.py
@@ -39,6 +39,13 @@ FUZZY_PREFIX = 60
 # 单 atom 给 10 分立即触发——cluster agent 的提示词鼓励"非常确信时打高分"。
 ATOM_PROMOTION_THRESHOLD = 10
 
+# SkillEditAgent 单轮最多消化的候选数。buffer 攒满阈值时可能已经堆到几十上百
+# 条（xskill rebuild --force 重放全部历史 / 团队突然活跃），一次性塞进单个
+# agent.run() 会话会让证据读取/compact 无限拉长，且整条流水线扫描循环会被
+# 这一个技能的整理过程卡死。超过这个数就切成多批，每批一轮独立的 agent 会话，
+# 轮与轮之间用 git turn 分支承接进度（见 skill_edit_agent.py）。
+SKILL_EDIT_BATCH_SIZE = 20
+
 
 # ═══════════════════════════════════════════════════════════════════
 # I/O
@@ -212,6 +219,22 @@ def clear_candidates(skill_dir: Path) -> None:
     直接追加。
     """
     save_candidates(skill_dir, {"candidates": []})
+
+
+def remove_candidates(skill_dir: Path, atom_ids: set[str]) -> None:
+    """按 atom_id 集合从 buffer 中摘除条目,其余原样保留。
+
+    SkillEditAgent 多轮渐进式消化用：只摘除本次 maybe_run 开始时快照到的
+    atom_id,消化期间 cluster 并发 add 进来的新候选不受影响,留给下一次
+    maybe_run 处理。取代 ``clear_candidates`` 的整文件清空——那样会把消化
+    期间新增的候选一并静默丢掉。
+    """
+    data = load_candidates(skill_dir)
+    remaining = [
+        c for c in data.get("candidates", []) or []
+        if c.get("atom_id") not in atom_ids
+    ]
+    save_candidates(skill_dir, {**data, "candidates": remaining})
 
 
 def find_atom_in_any_skill(skill_dir: Path, atom_id: str) -> str | None:

--- a/src/xskill/skill/git.py
+++ b/src/xskill/skill/git.py
@@ -1667,6 +1667,66 @@ def commit_update_main_branch(skill_dir: str, message: str) -> bool:
     return True
 
 
+def commit_progressive_turn(skill_dir: str, turn_branch: str, message: str) -> bool:
+    """SkillEditAgent 多轮渐进式消化用：把当前工作区状态 commit 到一个新建的
+    turn 分支上（从当前 HEAD 派生,工作区不动——等价 ``checkout -b`` 无 sha 形态），
+    HEAD 落在新分支上供下一轮读取/续写。
+
+    与 ``commit_baby_to_main_branch`` 等终态 commit 的区别：turn 分支只是中间
+    态书签,不代表任何终态发布,也不做分支改名/校验当前分支必须是 baby/main。
+    该函数不检查当前分支——调用方（``SkillEditAgent._run``）负责保证时序正确。
+
+    返回 False 当且仅当 turn_branch 已存在（不应发生,调用方按递增 turn 号
+    生成分支名）。commit 本身允许空提交（本轮 agent 可能什么都没改）。
+    """
+    with skill_repo_lock(skill_dir):
+        with _open_repo(skill_dir) as repo:
+            if _has_branch(repo, turn_branch):
+                logger.warning("commit_progressive_turn 拒绝：分支已存在 %s", turn_branch)
+                return False
+            code, err = _checkout_branch(repo, turn_branch, create=True)
+            if code != 0:
+                logger.warning("commit_progressive_turn checkout 失败: %s", err)
+                return False
+            _stage_all(repo, Path(skill_dir))
+            sha, err = _do_commit(repo, message, allow_empty=True)
+            if sha is None:
+                logger.warning("commit_progressive_turn commit 失败: %s", err)
+                return False
+    return True
+
+
+def checkout_head_ref_only(skill_dir: str, branch: str) -> None:
+    """把 HEAD symbolic ref 指回 ``branch``,**不**动工作区/index。
+
+    多轮渐进式消化收尾用：最后一轮开跑前,把 HEAD 从最后一个 turn 分支切回
+    原始分支（baby/main），但保留 turn 分支演化出的工作区内容——这样现成的
+    终态 commit 工具（校验"当前必须在 baby/main"）可以原样调用,commit 时
+    ``_stage_all`` 会把 turn 分支上积累的全部改动当成"原分支的未提交改动"
+    一并收进这一次终态 commit。
+    """
+    with skill_repo_lock(skill_dir):
+        with _open_repo(skill_dir) as repo:
+            repo.refs.set_symbolic_ref(b"HEAD", _ref_for_branch(branch))
+
+
+def list_turn_branches(skill_dir: str, base_branch: str | None = None) -> list[str]:
+    """列出该 skill 仓库里的 turn 分支（形如 ``<base>_turn<N>``）。
+
+    ``base_branch`` 给定时只匹配该 base 派生的turn 分支；``None`` 时匹配任意
+    base 的 turn 分支——SkillEditAgent 崩溃恢复扫描用（不知道上次跑到哪个
+    base 就崩了）。
+    """
+    import re
+
+    pattern = (
+        re.compile(rf"^{re.escape(base_branch)}_turn\d+$")
+        if base_branch else re.compile(r"^.+_turn\d+$")
+    )
+    with _open_repo(skill_dir) as repo:
+        return [b for b in _list_branches(repo) if pattern.match(b)]
+
+
 def ensure_repo(skill_dir: str):
     """确保 skill_dir 是一个 git 仓库，在 main 分支上。"""
     p = Path(skill_dir)

--- a/tests/test_cold_start_signal.py
+++ b/tests/test_cold_start_signal.py
@@ -83,6 +83,7 @@ class TestColdStartFlush:
         watcher = _make_watcher(tmp_path, skill_root)
 
         watcher._run_skill_edit_step()
+        watcher._drain_futures(stage="skill_edit")
 
         assert current_branch(str(skill_directory)) == "baby"
         assert candidates.load_candidates(skill_directory)["candidates"]
@@ -96,11 +97,13 @@ class TestColdStartFlush:
 
         watcher._cold_start_pipeline_idle = lambda: False
         watcher._run_skill_edit_step()
+        watcher._drain_futures(stage="skill_edit")
         assert current_branch(str(skill_directory)) == "baby"
         assert candidates.load_candidates(skill_directory)["candidates"]
 
         watcher._cold_start_pipeline_idle = lambda: True
         watcher._run_skill_edit_step()
+        watcher._drain_futures(stage="skill_edit")
         assert current_branch(str(skill_directory)) == "main"
         assert candidates.load_candidates(skill_directory)["candidates"] == []
         assert not (tmp_path / COLD_START_FILENAME).exists()

--- a/tests/test_skill_edit_batch_turns.py
+++ b/tests/test_skill_edit_batch_turns.py
@@ -1,0 +1,488 @@
+"""SkillEditAgent 多轮渐进式消化（batch + turn 分支）验收单测
+================================================================
+
+背景：``.candidates.yml`` buffer 攒满阈值时曾经把全部候选一次性塞进单个
+``agent.run()``——``xskill rebuild --force`` 重放历史 / 团队突然活跃时 buffer
+可能攒到几十上百条，单次会话被拖到小时级,且落盘判定弱（agent 半途收笔也会
+被当成"成功"整批清空 buffer,未消化的候选静默丢失）。
+
+止血设计（用户拍板，见 PR 描述）：
+  1. ``maybe_run`` 对 buffer 做一次快照,按 ``(weightscore 降序, atom_id 升序)``
+     切成 ``SKILL_EDIT_BATCH_SIZE`` 条一批,每批一轮全新上下文的 agent.run()。
+  2. 除最后一轮外,每轮结束由宿主 Python 代码（不是 agent）commit 到
+     ``<branch>_turn<N>`` 分支承接进度；中间轮的 agent 完全拿不到任何终态
+     commit 工具——分支推进对它不可见也不可调用（结构性保证）。
+  3. 最后一轮开跑前宿主代码把 HEAD 切回原分支（工作区不动），agent 此时才
+     拿到终态 commit 工具，一次 commit 落地全部批次的累计改动。
+  4. 成功后清理所有 turn 分支；用快照的 atom_id 集合从 buffer 摘除（而非
+     清空整个文件）——消化期间新增的候选留给下一次 maybe_run。
+  5. 崩溃恢复：发现残留 ``*_turn*`` 分支就重置（不续传），buffer 未清过，
+     重新完整跑一遍不丢候选。
+
+本文件验收：
+  - 100+ 候选、真实 batch=20：多轮链条产出的 SKILL.md 融合全部批次内容，
+    turn 分支跑完后清理干净。
+  - 核心安全性质：中间轮不会推进 main / 不会创建 staging，只有最后一轮才推进。
+  - 四个终态落地场景（baby 毕业 / main 开 staging / jam 强砍合并——jam 内部
+    调用的 ``commit_update_main_branch`` 就是"main 直接更新"这第四种落地
+    方式，本仓库现状里它只在 jam 路径可达，因此用同一个 jam 多轮用例覆盖）
+    都各有一个多轮用例，共享同一套渐进式循环骨架。
+  - 崩溃恢复：残留 turn 分支被重置，重新完整跑一遍，候选不丢不重复消化。
+  - 快照语义：消化期间新增的候选本次不处理，运行结束后仍在 buffer 里。
+  - ``remove_candidates`` 只摘除快照里的 atom_id，其余原样保留。
+"""
+from __future__ import annotations
+
+import re
+from pathlib import Path
+
+import pytest
+
+from xskill.agents.skill_edit_agent import SkillEditAgent
+from xskill.skill import candidates as C
+from xskill.skill.git import (
+    commit_to_staging_branch,
+    current_branch,
+    init_skill_repo_on_baby,
+    list_turn_branches,
+    run_git,
+)
+
+
+def _tool_name(tool) -> str:
+    return getattr(tool, "__name__", None) or getattr(tool, "name", "")
+
+
+def _call_tool(tool, *args):
+    entrypoint = tool if callable(tool) else getattr(tool, "entrypoint")
+    return entrypoint(*args)
+
+
+@pytest.fixture(autouse=True)
+def _init_atom_task_tool_context(tmp_path):
+    """让 commit_baby_to_main / commit_to_staging / commit_update_main /
+    write_file 这些 agent 工具在测试里可用（同 test_skill_edit_agent.py）。"""
+    from xskill.agents import agent_tools
+    from xskill.pipeline.atom import AtomTaskStore
+
+    saved_context = agent_tools.agent_tool_config.snapshot()
+    (tmp_path / "skill").mkdir(parents=True, exist_ok=True)
+    (tmp_path / "store").mkdir(parents=True, exist_ok=True)
+    agent_tools.init_atom_task_tool_context(
+        skill_dir=tmp_path / "skill",
+        atom_store=AtomTaskStore(root=tmp_path / "store"),
+        default_traj_root=tmp_path / "store",
+    )
+    agent_tools.init_skill_authoring_tool_context(
+        tmp_path / "skill", tmp_path / "skill", {"skill_opt": {"enabled": False}},
+    )
+    yield
+    agent_tools.agent_tool_config.restore(saved_context)
+
+
+def _make_baby_skill(parent: Path, name: str, desc: str = "stub desc") -> Path:
+    sd = parent / name
+    init_skill_repo_on_baby(str(sd), name=name, description=desc)
+    return sd
+
+
+def _make_main_skill(parent: Path, name: str, desc: str = "stub desc") -> Path:
+    sd = _make_baby_skill(parent, name, desc)
+    run_git(["branch", "-m", "baby", "main"], cwd=str(sd))
+    return sd
+
+
+def _add_ux_score(skill_dir: Path, side: str = "main"):
+    import json
+    line = json.dumps({
+        "atom_id": "atom_seed_0001", "skill_name": skill_dir.name, "side": side,
+        "commit_sha": "abc", "score": 7, "reasons": "",
+        "scored_at": "2026-05-13T10:00:00+00:00",
+    })
+    (skill_dir / ".ux_scores.jsonl").write_text(line + "\n", encoding="utf-8")
+
+
+def _seed_candidates(skill_dir: Path, n: int, ws: int = 1) -> list[str]:
+    """灌 n 条候选,atom_id 形如 atom_0001.. ，weightscore 递增（1..n 或固定 ws）
+    保证总分轻松过 ATOM_PROMOTION_THRESHOLD。返回全部 atom_id 列表。"""
+    data = {"candidates": []}
+    atom_ids = []
+    for i in range(1, n + 1):
+        atom_id = f"atom_{i:04d}"
+        data, _ = C.add_atom_contribution(data, atom_id, ws)
+        atom_ids.append(atom_id)
+    C.save_candidates(skill_dir, data)
+    return atom_ids
+
+
+# ─────────────────────────────────────────────────────────────────────
+# stub agno 工厂：每轮把本轮 batch 的 atom_id 追加成 SKILL.md 正文里一行
+# "- round atoms: ..." 标记（累积——因为磁盘文件在轮次间不会被重置），
+# 最后一轮（且仅最后一轮）才会拿到终态 commit 工具并调用它。
+# 同时记录每轮开始时 base 分支的 git 状态,用于验证"中间轮不推进终态"。
+# ─────────────────────────────────────────────────────────────────────
+
+class _ProgressiveStub:
+    def __init__(self, *, instructions, tools, observed):
+        self.tools = {_tool_name(t): t for t in tools}
+        self.observed = observed
+
+    def run(self, user_msg, **_kw):
+        target = re.search(r"目标 SKILL\.md 路径:\s*(\S+)", user_msg).group(1)
+        skill = re.search(r"skill_name:\s*([\w-]+)", user_msg).group(1)
+        atom_ids = re.findall(r"atom_id=(\S+)\s+weightscore=", user_msg)
+        skill_dir = Path(target).parent
+
+        def _rev(ref):
+            code, out, _ = run_git(["rev-parse", ref], cwd=str(skill_dir))
+            return out.strip() if code == 0 else None
+
+        staging_ok = run_git(
+            ["rev-parse", "--verify", "staging"], cwd=str(skill_dir),
+        )[0] == 0
+        self.observed.append({
+            "atom_ids": list(atom_ids),
+            "baby_sha": _rev("baby"),
+            "main_sha": _rev("main"),
+            "staging_exists": staging_ok,
+            "has_commit_baby": "commit_baby_to_main" in self.tools,
+            "has_commit_staging": "commit_to_staging" in self.tools,
+            "has_commit_update_main": "commit_update_main" in self.tools,
+        })
+
+        existing = (
+            Path(target).read_text(encoding="utf-8") if Path(target).is_file() else ""
+        )
+        tail = existing.split("## 领域规则\n", 1)[1] if "## 领域规则\n" in existing else ""
+        marker = f"- round atoms: {','.join(atom_ids)}\n"
+        content = (
+            f"---\nname: {skill}\ndescription: progressive stub v{len(self.observed)}\n"
+            f"metadata:\n  version: {len(self.observed)}\n---\n\n"
+            f"# {skill}\n\n## 领域规则\n{tail}{marker}"
+        )
+        _call_tool(self.tools["write_file"], target, content)
+
+        if "commit_baby_to_main" in self.tools:
+            _call_tool(self.tools["commit_baby_to_main"], skill, "progressive graduate")
+        elif "commit_to_staging" in self.tools:
+            _call_tool(self.tools["commit_to_staging"], skill, "progressive staging")
+        elif "commit_update_main" in self.tools:
+            _call_tool(self.tools["commit_update_main"], skill, "progressive jam merge")
+
+        class _R:
+            pass
+        r = _R()
+        r.content = "done"
+        return r
+
+
+def _make_progressive_factory(observed: list):
+    def factory(*, instructions, tools):
+        return _ProgressiveStub(instructions=instructions, tools=tools, observed=observed)
+    return factory
+
+
+# ═══════════════════════════════════════════════════════════════════
+# 1. 100+ 候选、真实 batch=20：多轮链条 + 内容融合 + turn 分支清理
+# ═══════════════════════════════════════════════════════════════════
+
+class TestLargeBufferRealBatchSize:
+    def test_100_plus_candidates_batch_20_merges_all_and_cleans_turn_branches(
+        self, tmp_path,
+    ):
+        assert C.SKILL_EDIT_BATCH_SIZE == 20, "本用例故意验证真实默认 batch size"
+        skill_dir = _make_baby_skill(tmp_path / "skill", "huge-skill")
+        atom_ids = _seed_candidates(skill_dir, 100)
+
+        observed: list = []
+        agent = SkillEditAgent(
+            skill_dir=skill_dir, store=None,
+            agno_agent_factory=_make_progressive_factory(observed),
+            llm_cfg={}, traj_root=tmp_path,
+        )
+        assert agent.maybe_run() is True
+
+        # 5 轮（100/20）
+        assert len(observed) == 5, f"expected 5 turns, got {len(observed)}"
+
+        # 毕业到 main
+        assert current_branch(str(skill_dir)) == "main"
+
+        # 正文融合了全部 5 批的标记行，且每批 20 个 atom_id，并集 = 全部 100 个
+        body = (skill_dir / "SKILL.md").read_text(encoding="utf-8")
+        marker_lines = [ln for ln in body.splitlines() if ln.startswith("- round atoms:")]
+        assert len(marker_lines) == 5
+        seen_atoms: set[str] = set()
+        for ln in marker_lines:
+            ids = ln.split(":", 1)[1].strip().split(",")
+            assert len(ids) == 20
+            seen_atoms.update(ids)
+        assert seen_atoms == set(atom_ids)
+
+        # turn 分支跑完后清理干净
+        assert list_turn_branches(str(skill_dir)) == []
+        code, out, _ = run_git(["branch", "--list"], cwd=str(skill_dir))
+        assert "_turn" not in out
+
+        # buffer 清空（全部 atom_id 都被摘除）
+        assert C.load_candidates(skill_dir)["candidates"] == []
+
+
+# ═══════════════════════════════════════════════════════════════════
+# 2 & 3. 四个终态场景（baby / staging / jam）各一个多轮用例，
+#        共享同一套渐进式循环骨架 —— 核心安全性质：中间轮不推进终态。
+# ═══════════════════════════════════════════════════════════════════
+
+@pytest.fixture
+def small_batch(monkeypatch):
+    """把 batch size 调小,让"多轮"用例不需要真造 100+ 条候选就能跑多轮，
+    加速非"真实 batch size"的场景/安全性质测试。"""
+    monkeypatch.setattr(C, "SKILL_EDIT_BATCH_SIZE", 4)
+    return 4
+
+
+class TestFourTerminalScenariosMultiTurn:
+    def test_baby_graduate_multi_turn_only_final_round_advances(
+        self, tmp_path, small_batch,
+    ):
+        skill_dir = _make_baby_skill(tmp_path / "skill", "baby-multi")
+        _seed_candidates(skill_dir, 10)  # batch=4 → 3 轮 (4,4,2)
+        baby_sha_before = run_git(["rev-parse", "baby"], cwd=str(skill_dir))[1].strip()
+
+        observed: list = []
+        agent = SkillEditAgent(
+            skill_dir=skill_dir, store=None,
+            agno_agent_factory=_make_progressive_factory(observed),
+            llm_cfg={}, traj_root=tmp_path,
+        )
+        assert agent.maybe_run() is True
+        assert len(observed) == 3
+
+        # 安全性质：只有最后一轮拿到 commit_baby_to_main；baby ref 在此之前
+        # 全程原地不动（turn 分支不影响 baby 自己的 tip）。
+        for round_info in observed[:-1]:
+            assert round_info["has_commit_baby"] is False
+            assert round_info["baby_sha"] == baby_sha_before
+        assert observed[-1]["has_commit_baby"] is True
+
+        assert current_branch(str(skill_dir)) == "main"
+        assert list_turn_branches(str(skill_dir)) == []
+        assert C.load_candidates(skill_dir)["candidates"] == []
+
+    def test_main_open_staging_multi_turn_only_final_round_creates_staging(
+        self, tmp_path, small_batch,
+    ):
+        skill_dir = _make_main_skill(tmp_path / "skill", "staging-multi")
+        _add_ux_score(skill_dir)
+        _seed_candidates(skill_dir, 10)
+
+        observed: list = []
+        agent = SkillEditAgent(
+            skill_dir=skill_dir, store=None,
+            agno_agent_factory=_make_progressive_factory(observed),
+            llm_cfg={}, traj_root=tmp_path,
+        )
+        assert agent.maybe_run() is True
+        assert len(observed) == 3
+
+        for round_info in observed[:-1]:
+            assert round_info["has_commit_staging"] is False
+            assert round_info["staging_exists"] is False
+        assert observed[-1]["has_commit_staging"] is True
+
+        code, _, _ = run_git(["rev-parse", "--verify", "staging"], cwd=str(skill_dir))
+        assert code == 0
+        assert current_branch(str(skill_dir)) == "main"
+        assert list_turn_branches(str(skill_dir)) == []
+        assert C.load_candidates(skill_dir)["candidates"] == []
+
+    def test_jam_force_merge_multi_turn_only_final_round_updates_main(
+        self, tmp_path, small_batch,
+    ):
+        """jam 强砍合并场景：staging 已存在 + 候选累计 ≥ jam_threshold 时越过
+        灰度强砍。jam 内部调用 commit_update_main_branch——即"main 直接更新"
+        这第四种终态落地方式，本仓库现状里只在 jam 路径可达。"""
+        skill_dir = _make_main_skill(tmp_path / "skill", "jam-multi")
+        (skill_dir / "SKILL.md").write_text(
+            (skill_dir / "SKILL.md").read_text(encoding="utf-8") + "\n<!-- staging draft -->\n",
+            encoding="utf-8",
+        )
+        assert commit_to_staging_branch(str(skill_dir), "stub staging candidate") is True
+        _seed_candidates(skill_dir, 10, ws=6)  # 10*6=60 ≥ jam_threshold(50)
+
+        main_sha_before = run_git(["rev-parse", "main"], cwd=str(skill_dir))[1].strip()
+
+        observed: list = []
+        agent = SkillEditAgent(
+            skill_dir=skill_dir, store=None,
+            agno_agent_factory=_make_progressive_factory(observed),
+            llm_cfg={}, traj_root=tmp_path, jam_threshold=50,
+        )
+        assert agent.maybe_run() is True
+        assert len(observed) == 3
+
+        for round_info in observed[:-1]:
+            assert round_info["has_commit_update_main"] is False
+            assert round_info["main_sha"] == main_sha_before
+        assert observed[-1]["has_commit_update_main"] is True
+
+        # staging 被 discard，main 已推进
+        code, _, _ = run_git(["rev-parse", "--verify", "staging"], cwd=str(skill_dir))
+        assert code != 0
+        main_sha_after = run_git(["rev-parse", "main"], cwd=str(skill_dir))[1].strip()
+        assert main_sha_after != main_sha_before
+        assert current_branch(str(skill_dir)) == "main"
+        assert list_turn_branches(str(skill_dir)) == []
+        assert C.load_candidates(skill_dir)["candidates"] == []
+
+
+# ═══════════════════════════════════════════════════════════════════
+# 4. 崩溃恢复：残留 turn 分支 → 不续传，重置后完整重来一遍
+# ═══════════════════════════════════════════════════════════════════
+
+class TestCrashRecovery:
+    def test_leftover_turn_branch_is_reset_and_full_chain_reruns(
+        self, tmp_path, small_batch,
+    ):
+        skill_dir = _make_baby_skill(tmp_path / "skill", "crashed-skill")
+        atom_ids = _seed_candidates(skill_dir, 10)
+
+        # 模拟"上次跑到一半进程死了"：手工造一个 turn 分支，HEAD 停在那里，
+        # 且带着一份"半成品"改动（真实运行崩溃时 turn 分支也会带部分改动）。
+        run_git(["checkout", "-b", "baby_turn1"], cwd=str(skill_dir))
+        (skill_dir / "SKILL.md").write_text(
+            "---\nname: crashed-skill\ndescription: half-done crash artifact\n"
+            "metadata:\n  version: 1\n---\n\n# half\n\ncrash-marker-should-not-survive\n",
+            encoding="utf-8",
+        )
+        run_git(["add", "-A"], cwd=str(skill_dir))
+        run_git(["commit", "-m", "half-done turn (simulated crash)"], cwd=str(skill_dir))
+        assert current_branch(str(skill_dir)) == "baby_turn1"
+
+        observed: list = []
+        agent = SkillEditAgent(
+            skill_dir=skill_dir, store=None,
+            agno_agent_factory=_make_progressive_factory(observed),
+            llm_cfg={}, traj_root=tmp_path,
+        )
+        assert agent.maybe_run() is True
+
+        # 完整重新跑了一遍（3 轮：batch=4 → 4,4,2），没有续传半成品
+        assert len(observed) == 3
+        assert current_branch(str(skill_dir)) == "main"
+        assert list_turn_branches(str(skill_dir)) == []
+
+        body = (skill_dir / "SKILL.md").read_text(encoding="utf-8")
+        assert "crash-marker-should-not-survive" not in body
+        marker_lines = [ln for ln in body.splitlines() if ln.startswith("- round atoms:")]
+        assert len(marker_lines) == 3
+        seen_atoms: set[str] = set()
+        for ln in marker_lines:
+            seen_atoms.update(ln.split(":", 1)[1].strip().split(","))
+        assert seen_atoms == set(atom_ids), "候选没丢也没重复：全部 10 个原子都被消化一次"
+
+        # 候选没丢：全部被真正消化后摘除
+        assert C.load_candidates(skill_dir)["candidates"] == []
+
+    def test_recovery_does_not_lose_buffer_before_rerun(self, tmp_path, small_batch):
+        """崩溃残留 turn 分支时,候选此前从未被清过——重置动作本身不该动
+        .candidates.yml（只清 git 状态）。"""
+        skill_dir = _make_baby_skill(tmp_path / "skill", "crash-buffer-intact")
+        atom_ids = _seed_candidates(skill_dir, 10)
+
+        run_git(["checkout", "-b", "baby_turn1"], cwd=str(skill_dir))
+        run_git(["checkout", "-b", "baby_turn2"], cwd=str(skill_dir))
+
+        from xskill.agents.skill_edit_agent import SkillEditAgent as SEA
+        agent = SEA(
+            skill_dir=skill_dir, store=None,
+            agno_agent_factory=lambda **kw: (_ for _ in ()).throw(
+                RuntimeError("boom before recovery observed anything"),
+            ),
+            llm_cfg={}, traj_root=tmp_path,
+        )
+        # 崩溃恢复本身应该在 maybe_run 顶部无条件跑，即使 gating 因为其他原因
+        # 提前失败；这里我们只验证 recover 私有方法独立生效 + buffer 不受影响。
+        agent._recover_crashed_turns()
+        assert list_turn_branches(str(skill_dir)) == []
+        assert current_branch(str(skill_dir)) == "baby"
+        data = C.load_candidates(skill_dir)
+        assert {c["atom_id"] for c in data["candidates"]} == set(atom_ids)
+
+
+# ═══════════════════════════════════════════════════════════════════
+# 5. 快照语义：消化期间新增到 buffer 的候选,本次不处理,运行后仍在 buffer
+# ═══════════════════════════════════════════════════════════════════
+
+class TestSnapshotSemantics:
+    def test_candidates_added_during_run_are_not_consumed_this_round(self, tmp_path):
+        skill_dir = _make_baby_skill(tmp_path / "skill", "concurrent-add-skill")
+        snapshot_ids = _seed_candidates(skill_dir, 3, ws=4)  # 总分 12 ≥ 阈值 10
+
+        class _InjectingStub:
+            """写正文 + commit 之前,模拟 cluster 并发往 buffer 里加了条新候选。"""
+            def __init__(self, *, instructions, tools):
+                self.tools = {_tool_name(t): t for t in tools}
+
+            def run(self, user_msg, **_kw):
+                target = re.search(r"目标 SKILL\.md 路径:\s*(\S+)", user_msg).group(1)
+                skill = re.search(r"skill_name:\s*([\w-]+)", user_msg).group(1)
+
+                data = C.load_candidates(skill_dir)
+                data, _ = C.add_atom_contribution(data, "atom_injected_concurrently", 5)
+                C.save_candidates(skill_dir, data)
+
+                _call_tool(
+                    self.tools["write_file"], target,
+                    f"---\nname: {skill}\ndescription: v1\nmetadata:\n  version: 1\n---\n# body\n",
+                )
+                _call_tool(self.tools["commit_baby_to_main"], skill, "v1")
+                class _R:
+                    pass
+                r = _R(); r.content = "done"
+                return r
+
+        agent = SkillEditAgent(
+            skill_dir=skill_dir, store=None,
+            agno_agent_factory=lambda **kw: _InjectingStub(**kw),
+            llm_cfg={}, traj_root=tmp_path,
+        )
+        assert agent.maybe_run() is True
+
+        remaining = C.load_candidates(skill_dir)["candidates"]
+        remaining_ids = {c["atom_id"] for c in remaining}
+        # 快照里的 3 个已消化摘除；并发期间加进来的第 4 个还在,留给下次 maybe_run
+        assert remaining_ids == {"atom_injected_concurrently"}
+        assert not (remaining_ids & set(snapshot_ids))
+
+
+# ═══════════════════════════════════════════════════════════════════
+# 6. remove_candidates：只摘除给定 atom_id 集合，其余原样保留
+# ═══════════════════════════════════════════════════════════════════
+
+class TestRemoveCandidates:
+    def test_removes_only_given_atom_ids(self, tmp_path):
+        skill_dir = tmp_path / "skill" / "rc-target"
+        skill_dir.mkdir(parents=True)
+        data = {"candidates": []}
+        for atom_id, ws in (("a1", 3), ("a2", 5), ("a3", 7)):
+            data, _ = C.add_atom_contribution(data, atom_id, ws)
+        C.save_candidates(skill_dir, data)
+
+        C.remove_candidates(skill_dir, {"a1", "a3"})
+
+        remaining = C.load_candidates(skill_dir)["candidates"]
+        assert [c["atom_id"] for c in remaining] == ["a2"]
+        assert remaining[0]["weightscore"] == 5
+
+    def test_noop_when_atom_ids_not_present(self, tmp_path):
+        skill_dir = tmp_path / "skill" / "rc-noop"
+        skill_dir.mkdir(parents=True)
+        data = {"candidates": []}
+        data, _ = C.add_atom_contribution(data, "only-one", 10)
+        C.save_candidates(skill_dir, data)
+
+        C.remove_candidates(skill_dir, {"does-not-exist"})
+
+        remaining = C.load_candidates(skill_dir)["candidates"]
+        assert [c["atom_id"] for c in remaining] == ["only-one"]

--- a/tests/test_skilledit_parallel.py
+++ b/tests/test_skilledit_parallel.py
@@ -170,6 +170,7 @@ def test_runner_passes_jam_threshold(monkeypatch, tmp_path):
     }
     w = _make_watcher_with_config(tmp_path, skill_root, factory, config)
     w._check_pending_skill_edits()
+    w._drain_futures(stage="skill_edit")
 
     assert captured.get("jam_threshold") == 33, (
         f"jam_threshold was not wired from config; captured={captured!r}"
@@ -197,6 +198,9 @@ class TestSkillEditParallel:
 
         t0 = time.time()
         watcher._check_pending_skill_edits()
+        # SkillEdit 现在是像 split/cluster 一样的非阻塞 future 提交——
+        # _check_pending_skill_edits() 立即返回,真正的完成要 drain。
+        watcher._drain_futures(stage="skill_edit")
         elapsed = time.time() - t0
         # 若串行退化，barrier 永远凑不齐 → 每个 wait 撞 20s timeout → 远超阈值。
         # 真并发：一波凑齐后秒回。给宽松上限避免 CI 抖动误判。
@@ -237,6 +241,7 @@ class TestSkillEditParallel:
                 factory = _make_barrier_agno(1, noop)
             w = _make_watcher(sub, skill_root, factory, max_concurrent=max_conc)
             w._check_pending_skill_edits()
+            w._drain_futures(stage="skill_edit")
             graduated = {s: current_branch(str(d)) for s, d in dirs.items()}
             bodies = {s: (d / "SKILL.md").read_text(encoding="utf-8")
                       for s, d in dirs.items()}


### PR DESCRIPTION
## Why

`SkillEditAgent`（`skill_edit_agent.py`）在 `.candidates.yml` 累计 weightscore 过阈值时，把 buffer 里**全部**候选原子一次性塞进单次 `agent.run()`。`xskill rebuild --force`（重跑全部历史轨迹，可能耗时数天）或团队突然活跃时，短时间内一个 skill 的 buffer 可能攒到上百个候选原子，带来三个问题：

1. 单次会话要读几十上百次证据、反复触发 `context_budget.py` 的 compact，agno Agent 没有 `tool_call_limit` 硬顶，理论上可以跑极长时间。
2. `_run_skill_edit_step` 此前在 watcher 扫描循环里**同步内联执行**（`_check_pending_skill_edits` 提交到线程池后又用 `as_completed` 阻塞等全部完成）——这一步跑多久，整条流水线扫描（发现新轨迹/拆分/embedding/聚类）就停多久。
3. 落盘判定弱：只看 `SKILL.md` mtime/size 变化 + frontmatter 合法，agent 哪怕没调终态 commit 工具也可能被判定成功，buffer 被整体清空（`clear_candidates`），未消化的候选静默丢失。

这是与用户讨论后拍板的止血设计——用户原话：

> candidate.yaml被skilleditagent消费，然后skill下，20个消费一次，然后第二次运行在第一次的skill的main的产出的skill的基础上再次进行进化，直到消费完毕。（最后才是真正的main，之前都是main_turnx分支），我们这样来进行海量处理启动。

批准范围：分批消费（做）；状态用 git 分支本身承载，不在 `.candidates.yml` 里加状态字段（做）；给 agent 加 `tool_call_limit` 硬顶 / compact 次数计数中止（明确不做，未触碰 `context_budget.py`）；把 `_run_skill_edit_step` 从内联同步改成像 split/cluster 一样提交 future、由 `_harvest` 收割（必须项，已做）。

## What

### 1. 分批消费 + turn 分支链（`skill_edit_agent.py`）

`maybe_run()` 对 `.candidates.yml` 做**一次快照**（不在多轮期间重新读取——cluster 并发 add 的新候选不属于本次消化范围，留给下一次 `maybe_run` 处理），按 `(weightscore 降序, atom_id 升序)` 稳定排序，切成每批 `SKILL_EDIT_BATCH_SIZE`（20，`candidates.py`）条：

- 每批一轮**全新上下文**的 `agent.run()`（不带上一轮对话历史——与 TaskAgent"弃窗单趟"同一设计哲学，见 `context_budget.py` 模块头注释）。
- 除最后一轮外，每轮结束由**宿主 Python 代码**（不是 agent）把改动 commit 到新建的 `<branch>_turn<N>` 分支（`git.py` 新增 `commit_progressive_turn`）承接进度。**中间轮的 agent 完全拿不到任何终态 commit 工具**（`commit_baby_to_main` / `commit_to_staging` / `commit_update_main`）——分支推进对它不可见也不可调用，是结构性保证，不依赖 prompt 约定。
- 最后一轮开跑前，宿主代码把 HEAD 切回原分支（`git.py` 新增 `checkout_head_ref_only`：只动 symbolic ref，不碰工作区/index），让现成的三个终态 commit 工具（各自校验"当前必须在 baby/main"）原样调用，一次 commit 落地全部批次的累计改动。
- 成功后清理所有 `*_turn*` 分支（`git.py` 新增 `list_turn_branches`），并用快照的 atom_id 集合从 buffer 里**摘除**（`candidates.py` 新增 `remove_candidates`，替代整文件清空的 `clear_candidates`）——消化期间新增的候选不受影响。
- 落盘成功判定新增**分支真推进**校验（baby 场景验证真变成了 main；staging 场景验证 staging 真被创建且 HEAD 回到 main），作为 mtime/frontmatter 检查之外的额外闸——堵住"agent 忘记调终态工具但仍被判定成功"的既有缺口。

jam（轨迹堰塞强砍合并）与 baby 毕业 / main 开 staging 三个场景共享同一套批次循环骨架（`_run`），只有每轮 prompt 内容和终态动作不同。

**取舍说明**：用户列出的"四个场景"里，"main 直接更新"与"jam 强砍合并"在现状代码里是同一个机制——`commit_update_main_branch` 目前只在 jam 路径（staging 已存在 + 候选超 `jam_threshold`）可达，没有独立的"main 不开 staging 直接更新"触发路径。本 PR 没有新增这样一条独立触发路径（超出止血范围），所以用同一个 jam 多轮测试覆盖这第四种落地机制。

单批（buffer ≤ 20，即今天的全部现状用例）时，循环退化成一轮、不创建任何 turn 分支——与改动前逐字节等价，零行为差异。

### 2. 崩溃恢复（`skill_edit_agent.py`）

`maybe_run()` 入口第一件事：扫描该 skill 仓库是否有残留 `*_turn*` 分支。有 → 判定上次跑到一半崩溃/失败，**不续传**：`checkout` 回清洁的 base 分支（丢弃 turn 分支上的半成品工作区）+ 删除所有残留 turn 分支。buffer 从未在多轮消化中途清空，这次 `maybe_run` 直接从快照第 1 批重新开始整条链条，不丢候选。

### 3. SkillEdit 移出扫描循环内联执行（`runner.py`）

`_check_pending_skill_edits` 不再 `pool.submit` + `as_completed` 阻塞等全部技能的 `maybe_run()` 完成，而是像 split/cluster 一样把每个技能的 `maybe_run()` 提交进 `self._futures`（`stage="skill_edit"`）后立即返回；`_harvest()`（每轮 scan 开头已调用）收割完成的 future，做 `_stats["skills_edited"]` 自增 + 即时 `install_to_claude_code`。同一个 skill 同时只允许一个 `skill_edit` future 在飞。`_cold_start_pipeline_idle` 复用同一个 `self._futures` 表判断"是否空闲"，天然涵盖 SkillEdit 在飞的情况，不需要额外代码。

新增 `DirectoryWatcher._drain_futures(stage=None)`：纯测试/优雅关停用的"等某个 stage 跑完"钩子——生产扫描循环从不调用它。

## Tests

新增 `tests/test_skill_edit_batch_turns.py`：

- 100+ 候选、真实 `SKILL_EDIT_BATCH_SIZE=20`：验证最终 SKILL.md 融合全部 5 批内容，且 turn 分支运行后清理干净。
- 核心安全性质：中间轮**不会**拿到终态 commit 工具、**不会**推进 baby→main / 创建 staging / 推进 main（jam），只有最后一轮才推进——baby 毕业 / main 开 staging / jam 强砍合并三个场景各一个多轮用例。
- 崩溃恢复：残留 turn 分支被重置，链条从头完整重跑一遍，候选不丢不重复消化。
- 快照语义：消化期间新增到 buffer 的候选本次不处理，运行结束后仍在 buffer 里。
- `remove_candidates` 只摘除给定 atom_id 集合，其余原样保留。

调整 `test_skilledit_parallel.py` / `test_cold_start_signal.py`：`_check_pending_skill_edits` / `_run_skill_edit_step` 改成非阻塞提交后，这几个直接调用一次就断言完成的测试改用新增的 `_drain_futures(stage="skill_edit")` 等待。其余 watcher 测试本来就用"轮询 `self._futures` 直到清空"的写法，无需改动。

全套单测：`python3.11 -m pytest tests/ --ignore=tests/docker_e2e --ignore=tests/live --deselect tests/test_e2e_xskill_serve_auto.py::test_canary_flip_promote_and_install_new_version -q` → **1257 passed, 1 deselected**（`test_canary_flip_promote_and_install_new_version` 是 origin/main 上既有的、与本 PR 无关的失败，已 deselect）。

🤖 Generated with [Claude Code](https://claude.com/claude-code)
