### PR TITLE
fix(cold-start): flush 判定改为「rebuild 快照终态」，活跃团队下冷启动可收敛

### DIFF
--- a/src/xskill/cli.py
+++ b/src/xskill/cli.py
@@ -559,15 +559,18 @@ def cmd_rebuild(args, _xskill) -> int:
         else:
             print("--force: 安装历史为空")
 
-    trajectory_count = reset_trajectories(eco=args.eco, traj_id=args.traj)
-    print(f"rebuild: 重置 {trajectory_count} 条轨迹（已删 atom + index.pkl，将从头重拆）")
+    reset_trajectory_ids = reset_trajectories(eco=args.eco, traj_id=args.traj)
+    print(
+        f"rebuild: 重置 {len(reset_trajectory_ids)} 条轨迹"
+        "（已删 atom + index.pkl，将从头重拆）"
+    )
 
     from xskill.pipeline.cold_start import ColdStartSignal
     cold_start_signal = ColdStartSignal(XSKILL_HOME)
-    signal_path = cold_start_signal.create()
+    cold_start_signal.create(reset_trajectory_ids)
     print(
-        "cold-start: 已写入内部信号文件，watcher 会在本次 rebuild 处理完成后 flush "
-        f"({signal_path})"
+        "cold-start: 已写入本批轨迹快照信号，watcher 会在这批轨迹处理完成后 flush "
+        f"({cold_start_signal.file_path})"
     )
 
     if read_status().get("running"):

--- a/src/xskill/ecosystems/_shared.py
+++ b/src/xskill/ecosystems/_shared.py
@@ -937,11 +937,11 @@ class JsonlIngester:
                 # 旧残骸轨迹拆出的 atom / 索引 / DB 状态作废，从头重拆。
                 # 函数内 import：registry 依赖 config，模块级 import 会成环。
                 from xskill.pipeline.registry import reset_trajectories
-                n = reset_trajectories(traj_id=traj_id)
+                reset_row_ids = reset_trajectories(traj_id=traj_id)
                 logger.info(
                     "JsonlIngester(%s): source grew after bridge, re-bridged "
                     "%s (reset %d trajectory row(s))",
-                    self.spec.name, traj_id, n,
+                    self.spec.name, traj_id, len(reset_row_ids),
                 )
             submitted.append(result)
             seen.add(sid)

--- a/src/xskill/pipeline/cold_start.py
+++ b/src/xskill/pipeline/cold_start.py
@@ -1,16 +1,22 @@
 """冷启动一次性批量 flush 信号。
 
-冷启动不是可配置的线上状态机，也没有多轮概念。``xskill rebuild`` 写
-``~/.xskill/COLD_START``，watcher 等 rebuild 触发的轨迹重新拆分/聚类完成后，
-按既有 ``ATOM_PROMOTION_THRESHOLD`` 做一次 SkillEdit 扫描并删除该文件。
+冷启动不是可配置的线上状态机，也没有多轮概念。``xskill rebuild`` 把本批被
+重置的轨迹 id 快照写进 ``~/.xskill/COLD_START``，watcher 只等这批轨迹全部
+到达终态（离开 pending 状态）就按既有 ``ATOM_PROMOTION_THRESHOLD`` 做一次
+SkillEdit 扫描并删除该文件——rebuild 之后新进的轨迹不延长等待。
 """
 from __future__ import annotations
 
+import json
+import time
 from dataclasses import dataclass
 from pathlib import Path
 
 
 COLD_START_FILENAME = "COLD_START"
+
+# 快照内个别轨迹卡死时的安全网：超过该时长强制 flush，不再 hold。
+COLD_START_MAX_HOLD_SECONDS = 24 * 3600
 
 
 @dataclass(frozen=True)
@@ -27,13 +33,26 @@ class ColdStartSignal:
     def exists(self) -> bool:
         return self.file_path.exists()
 
-    def create(self) -> Path:
+    def create(self, trajectory_ids: list[int]) -> dict:
         self.file_path.parent.mkdir(parents=True, exist_ok=True)
-        self.file_path.touch()
-        return self.file_path
+        payload = {
+            "trajectory_ids": list(trajectory_ids),
+            "created_at": time.time(),
+        }
+        self.file_path.write_text(json.dumps(payload), encoding="utf-8")
+        return payload
 
-    def ready_to_flush(self, *, pipeline_idle: bool) -> bool:
-        return self.exists and pipeline_idle
+    def snapshot(self) -> dict | None:
+        """读快照。≤0.6.11 的空 touch 文件/坏 JSON 返回 None，调用方补录。"""
+        try:
+            payload = json.loads(self.file_path.read_text(encoding="utf-8"))
+        except (OSError, ValueError):
+            return None
+        if not isinstance(payload, dict):
+            return None
+        if not isinstance(payload.get("trajectory_ids"), list):
+            return None
+        return payload
 
     def consume(self) -> None:
         if self.exists:

--- a/src/xskill/pipeline/cold_start.py
+++ b/src/xskill/pipeline/cold_start.py
@@ -8,6 +8,7 @@ SkillEdit 扫描并删除该文件——rebuild 之后新进的轨迹不延长�
 from __future__ import annotations
 
 import json
+import os
 import time
 from dataclasses import dataclass
 from pathlib import Path
@@ -39,7 +40,10 @@ class ColdStartSignal:
             "trajectory_ids": list(trajectory_ids),
             "created_at": time.time(),
         }
-        self.file_path.write_text(json.dumps(payload), encoding="utf-8")
+        # 原子写：CLI 与 watcher 补录跨进程双写，不能让对方读到半截 JSON。
+        temp_path = self.file_path.with_suffix(".tmp")
+        temp_path.write_text(json.dumps(payload), encoding="utf-8")
+        os.replace(temp_path, self.file_path)
         return payload
 
     def snapshot(self) -> dict | None:

--- a/src/xskill/pipeline/registry.py
+++ b/src/xskill/pipeline/registry.py
@@ -47,6 +47,17 @@ class ProcessAction(str, Enum):
     CLUSTERED = "clustered"
     NOT_FIT = "not_fit"
 
+
+# 流水线尚未处理完的状态；不含 error（重试由 max_retries 有界，耗尽即终态）。
+PENDING_TRAJECTORY_STATUSES = (
+    TrajectoryStatus.DISCOVERED.value,
+    TrajectoryStatus.UPDATED.value,
+    TrajectoryStatus.SPLITTING.value,
+    TrajectoryStatus.SPLIT_DONE.value,
+    TrajectoryStatus.INDEXED.value,
+    TrajectoryStatus.CLUSTERING.value,
+)
+
 # ---------------------------------------------------------------------------
 # Connection
 # ---------------------------------------------------------------------------
@@ -1347,7 +1358,7 @@ def reset_trajectories(
     eco: Optional[str] = None,
     traj_id: Optional[str] = None,
     db_path: Optional[Path] = None,
-) -> int:
+) -> list[int]:
     """删除已拆 atom + 重置状态，让 watcher 从头重拆（``xskill rebuild`` 用）。
 
     **关键正确性点**：TaskAgent 的续接点取自 atom **文件**
@@ -1367,7 +1378,7 @@ def reset_trajectories(
         traj_id: 只重置该轨迹（按文件名 stem 匹配）；None=不按轨迹过滤。
 
     Returns:
-        被重置的轨迹行数。
+        被重置的轨迹 id 列表（cold-start 快照即由此而来）。
     """
     conn = get_connection(db_path)
     try:
@@ -1416,7 +1427,7 @@ def reset_trajectories(
             index_path = Path(directory_path) / "index.pkl"
             if index_path.is_file():
                 index_path.unlink()
-        return len(trajectory_rows)
+        return [trajectory_row["id"] for trajectory_row in trajectory_rows]
     finally:
         conn.close()
 
@@ -1442,6 +1453,36 @@ def get_trajs_by_status(
             sql += f" LIMIT {limit}"
         rows = conn.execute(sql, params).fetchall()
         return [r["filename"] for r in rows]
+    finally:
+        conn.close()
+
+
+def get_pending_traj_ids(
+    trajectory_ids: Optional[list[int]] = None,
+    *,
+    db_path: Optional[Path] = None,
+) -> list[int]:
+    """返回处于 pending 状态的轨迹 id；``trajectory_ids=None`` 时查全库。"""
+    conn = get_connection(db_path)
+    try:
+        status_placeholders = ",".join("?" * len(PENDING_TRAJECTORY_STATUSES))
+        base_sql = (
+            f"SELECT id FROM trajectories WHERE status IN ({status_placeholders})"
+        )
+        if trajectory_ids is None:
+            rows = conn.execute(base_sql, PENDING_TRAJECTORY_STATUSES).fetchall()
+            return [row["id"] for row in rows]
+        pending_ids: list[int] = []
+        # 分块进 IN 子句：老版本 SQLite 绑定变量上限只有 999。
+        for chunk_start in range(0, len(trajectory_ids), 500):
+            chunk = trajectory_ids[chunk_start:chunk_start + 500]
+            id_placeholders = ",".join("?" * len(chunk))
+            rows = conn.execute(
+                base_sql + f" AND id IN ({id_placeholders})",
+                (*PENDING_TRAJECTORY_STATUSES, *chunk),
+            ).fetchall()
+            pending_ids += [row["id"] for row in rows]
+        return pending_ids
     finally:
         conn.close()
 

--- a/src/xskill/pipeline/registry.py
+++ b/src/xskill/pipeline/registry.py
@@ -1462,12 +1462,18 @@ def get_pending_traj_ids(
     *,
     db_path: Optional[Path] = None,
 ) -> list[int]:
-    """返回处于 pending 状态的轨迹 id；``trajectory_ids=None`` 时查全库。"""
+    """返回处于 pending 状态的轨迹 id；``trajectory_ids=None`` 时查全库。
+
+    只计 ``auto_index=1`` 的 watch dir——watcher 不处理关闭索引的目录，其中
+    的轨迹永远不会离开 pending，计入会让 cold-start 只能靠超时退出。
+    """
     conn = get_connection(db_path)
     try:
         status_placeholders = ",".join("?" * len(PENDING_TRAJECTORY_STATUSES))
         base_sql = (
-            f"SELECT id FROM trajectories WHERE status IN ({status_placeholders})"
+            "SELECT t.id FROM trajectories t "
+            "JOIN watch_dirs w ON t.watch_dir_id = w.id "
+            f"WHERE w.auto_index=1 AND t.status IN ({status_placeholders})"
         )
         if trajectory_ids is None:
             rows = conn.execute(base_sql, PENDING_TRAJECTORY_STATUSES).fetchall()
@@ -1478,7 +1484,7 @@ def get_pending_traj_ids(
             chunk = trajectory_ids[chunk_start:chunk_start + 500]
             id_placeholders = ",".join("?" * len(chunk))
             rows = conn.execute(
-                base_sql + f" AND id IN ({id_placeholders})",
+                base_sql + f" AND t.id IN ({id_placeholders})",
                 (*PENDING_TRAJECTORY_STATUSES, *chunk),
             ).fetchall()
             pending_ids += [row["id"] for row in rows]

--- a/src/xskill/pipeline/runner.py
+++ b/src/xskill/pipeline/runner.py
@@ -302,11 +302,7 @@ class DirectoryWatcher:
             self._reconcile_skill_sides()
 
     def _run_skill_edit_step(self):
-        """Step 5 的冷启动感知封装。
-
-        hold 判定是「rebuild 快照内的轨迹全部到达终态」，不是全局队列空闲——
-        活跃团队持续上传新轨迹时后者永远不成立（#87）。
-        """
+        """Step 5 的冷启动感知封装：hold 只等 rebuild 快照内轨迹到终态。"""
         from xskill.pipeline.cold_start import COLD_START_MAX_HOLD_SECONDS
         cold_start_signal = self._cold_start_signal
         if not cold_start_signal.exists:

--- a/src/xskill/pipeline/runner.py
+++ b/src/xskill/pipeline/runner.py
@@ -40,6 +40,7 @@ from xskill.pipeline.registry import (
     TrajectoryStatus,
     list_watch_dirs,
     discover_trajectories,
+    get_pending_traj_ids,
     get_trajs_by_status,
     mark_indexed,
     mark_skill_used,
@@ -301,46 +302,49 @@ class DirectoryWatcher:
             self._reconcile_skill_sides()
 
     def _run_skill_edit_step(self):
-        """Step 5 的冷启动感知封装。"""
-        cold_start_signal = self._cold_start_signal
-        if cold_start_signal.exists:
-            if cold_start_signal.ready_to_flush(
-                pipeline_idle=self._cold_start_pipeline_idle(),
-            ):
-                from xskill.skill import candidates
-                logger.info(
-                    "冷启动批量 flush 触发 → SkillEdit (threshold=%d)",
-                    candidates.ATOM_PROMOTION_THRESHOLD,
-                )
-                self._check_pending_skill_edits(
-                    threshold=candidates.ATOM_PROMOTION_THRESHOLD,
-                )
-                cold_start_signal.consume()
-            # COLD_START 已到但流水线尚未空闲：hold，本轮不写正文。
-            return
-        self._check_pending_skill_edits()
+        """Step 5 的冷启动感知封装。
 
-    def _cold_start_pipeline_idle(self) -> bool:
-        """当前 watcher 没有待处理轨迹或后台任务时，cold-start 可 flush。
-
-        ``self._futures`` 是 split/embed/cluster/skill_edit 共用的同一个飞行
-        中任务表——非空即不空闲，天然把"有 SkillEdit future 在飞"也计入，
-        不需要对 stage="skill_edit" 单独判断。
+        hold 判定是「rebuild 快照内的轨迹全部到达终态」，不是全局队列空闲——
+        活跃团队持续上传新轨迹时后者永远不成立（#87）。
         """
-        if self._futures:
-            return False
-        pending_statuses = (
-            "discovered", "updated", "splitting", "split_done",
-            "indexed", "clustering",
+        from xskill.pipeline.cold_start import COLD_START_MAX_HOLD_SECONDS
+        cold_start_signal = self._cold_start_signal
+        if not cold_start_signal.exists:
+            self._check_pending_skill_edits()
+            return
+        snapshot_payload = cold_start_signal.snapshot()
+        if snapshot_payload is None:
+            # ≤0.6.11 的空 touch 信号文件：现场补录快照，存量 rebuild 照样收敛。
+            snapshot_payload = cold_start_signal.create(
+                get_pending_traj_ids(**self._db_kw()),
+            )
+            logger.info(
+                "冷启动遗留信号无快照，已按当前 pending 轨迹补录（%d 条）",
+                len(snapshot_payload["trajectory_ids"]),
+            )
+        snapshot_pending_ids = get_pending_traj_ids(
+            snapshot_payload["trajectory_ids"], **self._db_kw(),
         )
-        for watch_dir_entry in list_watch_dirs(**self._db_kw()):
-            watch_dir_id = watch_dir_entry["id"]
-            for status in pending_statuses:
-                if get_trajs_by_status(
-                    watch_dir_id, status, limit=1, **self._db_kw(),
-                ):
-                    return False
-        return True
+        hold_age_seconds = (
+            time.time() - float(snapshot_payload.get("created_at", 0.0))
+        )
+        if snapshot_pending_ids and hold_age_seconds <= COLD_START_MAX_HOLD_SECONDS:
+            return
+        if snapshot_pending_ids:
+            logger.warning(
+                "冷启动 hold 超过 %ds 仍有 %d 条快照轨迹未到终态，强制 flush",
+                COLD_START_MAX_HOLD_SECONDS, len(snapshot_pending_ids),
+            )
+        from xskill.skill import candidates
+        logger.info(
+            "冷启动批量 flush 触发 → SkillEdit (threshold=%d, snapshot=%d 条)",
+            candidates.ATOM_PROMOTION_THRESHOLD,
+            len(snapshot_payload["trajectory_ids"]),
+        )
+        self._check_pending_skill_edits(
+            threshold=candidates.ATOM_PROMOTION_THRESHOLD,
+        )
+        cold_start_signal.consume()
 
     def _check_pending_skill_edits(self, threshold=None):
         """遍历每个 skill 目录调 SkillEditAgent.maybe_run()。

--- a/tests/test_cold_start_signal.py
+++ b/tests/test_cold_start_signal.py
@@ -76,18 +76,6 @@ def _insert_trajectory(database_path, filename, status):
         connection.close()
 
 
-def _set_trajectory_status(database_path, trajectory_id, status):
-    connection = get_connection(database_path)
-    try:
-        connection.execute(
-            "UPDATE trajectories SET status=? WHERE id=?",
-            (status, trajectory_id),
-        )
-        connection.commit()
-    finally:
-        connection.close()
-
-
 class TestColdStartSignal:
     def test_signal_path_is_fixed_under_home(self, tmp_path):
         cold_start_signal = ColdStartSignal(tmp_path)
@@ -183,7 +171,29 @@ class TestColdStartFlush:
         assert adopted["trajectory_ids"] == [legacy_trajectory_id]
         assert current_branch(str(skill_directory)) == "baby"
 
-        _set_trajectory_status(database_path, legacy_trajectory_id, "done")
+        connection = get_connection(database_path)
+        connection.execute(
+            "UPDATE trajectories SET status='done' WHERE id=?",
+            (legacy_trajectory_id,),
+        )
+        connection.commit()
+        connection.close()
+        watcher._run_skill_edit_step()
+        watcher._drain_futures(stage="skill_edit")
+
+        assert current_branch(str(skill_directory)) == "main"
+        assert not (tmp_path / COLD_START_FILENAME).exists()
+
+    def test_error_status_counts_as_terminal(self, tmp_path):
+        skill_root = tmp_path / "skill"
+        skill_root.mkdir()
+        skill_directory = _seed_baby_skill(skill_root, "sk-cold", [4, 4, 4])
+        watcher = _make_watcher(tmp_path, skill_root)
+        failed_trajectory_id = _insert_trajectory(
+            tmp_path / "test.db", "traj_failed.md", "error",
+        )
+        ColdStartSignal(tmp_path).create([failed_trajectory_id])
+
         watcher._run_skill_edit_step()
         watcher._drain_futures(stage="skill_edit")
 

--- a/tests/test_cold_start_signal.py
+++ b/tests/test_cold_start_signal.py
@@ -1,17 +1,24 @@
-"""冷启动 COLD_START 信号回归测试。
+"""冷启动 COLD_START 信号回归测试（#87 快照终态语义）。
 
 验证：
-  1. rebuild 写入的单一 ``COLD_START`` 文件是唯一触发入口。
-  2. 信号存在时 watcher hold 增量 SkillEdit，直到流水线空闲才按既有
-     ATOM_PROMOTION_THRESHOLD flush。
+  1. rebuild 写入的 ``COLD_START`` 携带本批轨迹 id 快照。
+  2. hold 只看快照内轨迹是否到终态——rebuild 之后新进的轨迹不延长等待。
+  3. ≤0.6.11 的空 touch 信号文件被现场补录成快照（存量 rebuild 兼容）。
+  4. 超过最长持有时限强制 flush（快照内个别轨迹卡死的安全网）。
 """
 from __future__ import annotations
 
+import json
 import threading
+import time
 
 from xskill.pipeline.atom import AtomTaskStore
-from xskill.pipeline.cold_start import COLD_START_FILENAME, ColdStartSignal
-from xskill.pipeline.registry import register_dir
+from xskill.pipeline.cold_start import (
+    COLD_START_FILENAME,
+    COLD_START_MAX_HOLD_SECONDS,
+    ColdStartSignal,
+)
+from xskill.pipeline.registry import get_connection, register_dir
 from xskill.pipeline.runner import DirectoryWatcher
 from xskill.skill import candidates
 from xskill.skill.git import init_skill_repo_on_baby, current_branch
@@ -55,6 +62,32 @@ def _make_watcher(tmp_path, skill_root):
     )
 
 
+def _insert_trajectory(database_path, filename, status):
+    connection = get_connection(database_path)
+    try:
+        cursor = connection.execute(
+            "INSERT INTO trajectories (watch_dir_id, filename, status) "
+            "VALUES (1, ?, ?)",
+            (filename, status),
+        )
+        connection.commit()
+        return cursor.lastrowid
+    finally:
+        connection.close()
+
+
+def _set_trajectory_status(database_path, trajectory_id, status):
+    connection = get_connection(database_path)
+    try:
+        connection.execute(
+            "UPDATE trajectories SET status=? WHERE id=?",
+            (status, trajectory_id),
+        )
+        connection.commit()
+    finally:
+        connection.close()
+
+
 class TestColdStartSignal:
     def test_signal_path_is_fixed_under_home(self, tmp_path):
         cold_start_signal = ColdStartSignal(tmp_path)
@@ -62,17 +95,24 @@ class TestColdStartSignal:
         assert cold_start_signal.file_path == tmp_path / COLD_START_FILENAME
         assert cold_start_signal.exists is False
 
-    def test_signal_waits_for_pipeline_idle(self, tmp_path):
+    def test_create_writes_snapshot_payload(self, tmp_path):
         cold_start_signal = ColdStartSignal(tmp_path)
-        created_path = cold_start_signal.create()
+        payload = cold_start_signal.create([11, 22, 33])
 
-        assert created_path == tmp_path / COLD_START_FILENAME
         assert cold_start_signal.exists is True
-        assert cold_start_signal.ready_to_flush(pipeline_idle=False) is False
-        assert cold_start_signal.ready_to_flush(pipeline_idle=True) is True
+        assert payload["trajectory_ids"] == [11, 22, 33]
+        on_disk = cold_start_signal.snapshot()
+        assert on_disk is not None
+        assert on_disk["trajectory_ids"] == [11, 22, 33]
+        assert on_disk["created_at"] > 0
 
         cold_start_signal.consume()
         assert cold_start_signal.exists is False
+
+    def test_legacy_empty_touch_file_has_no_snapshot(self, tmp_path):
+        (tmp_path / COLD_START_FILENAME).touch()
+
+        assert ColdStartSignal(tmp_path).snapshot() is None
 
 
 class TestColdStartFlush:
@@ -88,22 +128,85 @@ class TestColdStartFlush:
         assert current_branch(str(skill_directory)) == "baby"
         assert candidates.load_candidates(skill_directory)["candidates"]
 
-    def test_signal_holds_until_idle_then_flushes_at_existing_threshold(self, tmp_path):
+    def test_holds_while_snapshot_trajectory_pending(self, tmp_path):
         skill_root = tmp_path / "skill"
         skill_root.mkdir()
         skill_directory = _seed_baby_skill(skill_root, "sk-cold", [4, 4, 4])
         watcher = _make_watcher(tmp_path, skill_root)
-        ColdStartSignal(tmp_path).create()
+        snapshot_trajectory_id = _insert_trajectory(
+            tmp_path / "test.db", "traj_snap.md", "splitting",
+        )
+        ColdStartSignal(tmp_path).create([snapshot_trajectory_id])
 
-        watcher._cold_start_pipeline_idle = lambda: False
         watcher._run_skill_edit_step()
         watcher._drain_futures(stage="skill_edit")
+
         assert current_branch(str(skill_directory)) == "baby"
         assert candidates.load_candidates(skill_directory)["candidates"]
+        assert (tmp_path / COLD_START_FILENAME).exists()
 
-        watcher._cold_start_pipeline_idle = lambda: True
+    def test_flushes_when_snapshot_settled_despite_new_traffic(self, tmp_path):
+        skill_root = tmp_path / "skill"
+        skill_root.mkdir()
+        skill_directory = _seed_baby_skill(skill_root, "sk-cold", [4, 4, 4])
+        watcher = _make_watcher(tmp_path, skill_root)
+        database_path = tmp_path / "test.db"
+        snapshot_trajectory_id = _insert_trajectory(
+            database_path, "traj_snap.md", "done",
+        )
+        # 活跃团队语义：快照之外一直有新轨迹在 pending，不得延长等待。
+        _insert_trajectory(database_path, "traj_new_arrival.md", "discovered")
+        ColdStartSignal(tmp_path).create([snapshot_trajectory_id])
+
         watcher._run_skill_edit_step()
         watcher._drain_futures(stage="skill_edit")
+
         assert current_branch(str(skill_directory)) == "main"
         assert candidates.load_candidates(skill_directory)["candidates"] == []
+        assert not (tmp_path / COLD_START_FILENAME).exists()
+
+    def test_legacy_signal_adopts_snapshot_then_converges(self, tmp_path):
+        skill_root = tmp_path / "skill"
+        skill_root.mkdir()
+        skill_directory = _seed_baby_skill(skill_root, "sk-cold", [4, 4, 4])
+        watcher = _make_watcher(tmp_path, skill_root)
+        database_path = tmp_path / "test.db"
+        legacy_trajectory_id = _insert_trajectory(
+            database_path, "traj_legacy.md", "indexed",
+        )
+        (tmp_path / COLD_START_FILENAME).touch()
+
+        watcher._run_skill_edit_step()
+        watcher._drain_futures(stage="skill_edit")
+        adopted = ColdStartSignal(tmp_path).snapshot()
+        assert adopted is not None, "空信号文件应被补录成快照"
+        assert adopted["trajectory_ids"] == [legacy_trajectory_id]
+        assert current_branch(str(skill_directory)) == "baby"
+
+        _set_trajectory_status(database_path, legacy_trajectory_id, "done")
+        watcher._run_skill_edit_step()
+        watcher._drain_futures(stage="skill_edit")
+
+        assert current_branch(str(skill_directory)) == "main"
+        assert not (tmp_path / COLD_START_FILENAME).exists()
+
+    def test_max_hold_deadline_forces_flush(self, tmp_path):
+        skill_root = tmp_path / "skill"
+        skill_root.mkdir()
+        skill_directory = _seed_baby_skill(skill_root, "sk-cold", [4, 4, 4])
+        watcher = _make_watcher(tmp_path, skill_root)
+        stuck_trajectory_id = _insert_trajectory(
+            tmp_path / "test.db", "traj_stuck.md", "splitting",
+        )
+        cold_start_signal = ColdStartSignal(tmp_path)
+        payload = cold_start_signal.create([stuck_trajectory_id])
+        payload["created_at"] = time.time() - COLD_START_MAX_HOLD_SECONDS - 60
+        cold_start_signal.file_path.write_text(
+            json.dumps(payload), encoding="utf-8",
+        )
+
+        watcher._run_skill_edit_step()
+        watcher._drain_futures(stage="skill_edit")
+
+        assert current_branch(str(skill_directory)) == "main"
         assert not (tmp_path / COLD_START_FILENAME).exists()

--- a/tests/test_rebuild.py
+++ b/tests/test_rebuild.py
@@ -65,9 +65,9 @@ def test_reset_flips_status_to_discovered_and_zeros_offset(tmp_path, db_path):
     _d, wid = _seed_done_traj(tmp_path, db_path)
     assert "traj_ng_x.md" not in get_trajs_by_status(wid, "discovered", db_path=db_path)
 
-    n = reset_trajectories(eco="ngagent", db_path=db_path)
+    reset_ids = reset_trajectories(eco="ngagent", db_path=db_path)
 
-    assert n == 1
+    assert len(reset_ids) == 1
     assert "traj_ng_x.md" in get_trajs_by_status(wid, "discovered", db_path=db_path)
 
 
@@ -81,9 +81,9 @@ def test_reset_eco_filter_skips_other_ecosystems(tmp_path, db_path):
     discover_trajectories(wid2, other, db_path=db_path)
     update_traj_status(wid2, "traj_cc_y.md", "done", db_path=db_path)
 
-    n = reset_trajectories(eco="ngagent", db_path=db_path)
+    reset_ids = reset_trajectories(eco="ngagent", db_path=db_path)
 
-    assert n == 1
+    assert len(reset_ids) == 1
     assert "traj_cc_y.md" not in get_trajs_by_status(wid2, "discovered", db_path=db_path)
 
 
@@ -120,9 +120,9 @@ def test_reset_requeues_not_fit_and_clears_interest_fields(tmp_path, db_path):
         db_path=db_path,
     )
 
-    reset_count = reset_trajectories(eco="ngagent", db_path=db_path)
+    reset_ids = reset_trajectories(eco="ngagent", db_path=db_path)
 
-    assert reset_count == 1
+    assert len(reset_ids) == 1
     assert "traj_ng_x.md" in get_trajs_by_status(
         watch_dir_id, "discovered", db_path=db_path)
     conn = get_connection(db_path)
@@ -250,7 +250,7 @@ def test_rebuild_force_clears_derived_state_and_install_history(
             "skill_trigger_eval": 4,
         }
     )
-    reset_mock = Mock(return_value=0)
+    reset_mock = Mock(return_value=[])
     monkeypatch.setattr("xskill.config.XSKILL_HOME", tmp_path)
     monkeypatch.setattr("xskill.config.get_skill_dir", Mock(return_value=skill_root))
     monkeypatch.setattr("xskill.runtime.read_status", Mock(return_value={"running": False}))
@@ -295,7 +295,7 @@ def test_rebuild_proceeds_when_models_match(monkeypatch):
     monkeypatch.setattr("xskill.runtime.config_models",
                         lambda: {"llm_model": "m"})
     monkeypatch.setattr("xskill.pipeline.registry.reset_trajectories",
-                        lambda **_ignored_keyword_arguments: 0)
+                        lambda **_ignored_keyword_arguments: [])
 
     assert cmd_rebuild(_rebuild_args(), None) == 0
 
@@ -306,7 +306,7 @@ def test_rebuild_ignore_flag_bypasses_mismatch(monkeypatch):
     monkeypatch.setattr("xskill.runtime.config_models",
                         lambda: {"llm_model": "new"})
     monkeypatch.setattr("xskill.pipeline.registry.reset_trajectories",
-                        lambda **_ignored_keyword_arguments: 0)
+                        lambda **_ignored_keyword_arguments: [])
 
     assert cmd_rebuild(_rebuild_args(ignore_model_mismatch=True), None) == 0
 
@@ -318,7 +318,7 @@ def test_rebuild_no_guard_when_daemon_not_running(monkeypatch):
     monkeypatch.setattr("xskill.runtime.config_models",
                         lambda: {"llm_model": "new"})
     monkeypatch.setattr("xskill.pipeline.registry.reset_trajectories",
-                        lambda **_ignored_keyword_arguments: 0)
+                        lambda **_ignored_keyword_arguments: [])
 
     assert cmd_rebuild(_rebuild_args(), None) == 0
 
@@ -330,10 +330,14 @@ def test_rebuild_writes_single_cold_start_signal(monkeypatch, tmp_path):
         lambda: {"running": False, "role": "server", "mode": "server"},
     )
     monkeypatch.setattr("xskill.pipeline.registry.reset_trajectories",
-                        lambda **_ignored_keyword_arguments: 0)
+                        lambda **_ignored_keyword_arguments: [7, 8])
 
     assert cmd_rebuild(_rebuild_args(), None) == 0
 
     assert (tmp_path / "COLD_START").exists()
     assert not (tmp_path / "COLD_START_REQUEST").exists()
     assert not (tmp_path / "COLD_START_FLUSH").exists()
+    from xskill.pipeline.cold_start import ColdStartSignal
+    snapshot_payload = ColdStartSignal(tmp_path).snapshot()
+    assert snapshot_payload is not None
+    assert snapshot_payload["trajectory_ids"] == [7, 8]

--- a/tests/test_rebuild_resplit_repro.py
+++ b/tests/test_rebuild_resplit_repro.py
@@ -100,7 +100,7 @@ def _full_cycle(tmp_path, *, server_mode, eco):
     assert len(store.list_by_traj("traj_x")) == 2
 
     # Pass 2: rebuild --force core
-    assert reset_trajectories(eco=eco, db_path=db) == 1
+    assert len(reset_trajectories(eco=eco, db_path=db)) == 1
     assert store.list_by_traj("traj_x") == [], "reset deletes atom files"
 
     # Pass 3: re-scan -> SHOULD re-split


### PR DESCRIPTION
Closes #87

## 问题

冷启动 flush 的触发条件是「全部 watch dir 无任何 pending 轨迹」（全局队列干涸）。活跃团队下 client 每 30s 持续上传、错误轨迹每轮重试翻回 discovered，idle 永远不成立：

- 冷启动 flush 永远不触发，COLD_START 永远删不掉；
- hold 期间 `_run_skill_edit_step` 直接 return，**常规 SkillEdit 也全程停摆**。

企业用户全量蒸馏「冷启动退不出去」的线上事故即此。#86 只解决了 flush 触发后的有界消费，没有动触发条件。

## 改动

1. **快照语义**：`rebuild` 把本批被重置的轨迹 id 写进 COLD_START（JSON：`trajectory_ids` + `created_at`）；`reset_trajectories` 改为返回 id 列表。
2. **hold 判定**：watcher 只等快照内轨迹全部离开 pending 态（discovered/updated/splitting/split_done/indexed/clustering）即 flush——rebuild 之后新进的轨迹不延长等待。error 重试由 max_retries 有界，耗尽停在 error 即终态。
3. **安全网**：`COLD_START_MAX_HOLD_SECONDS`（24h）超时强制 flush 并 warning，防快照内个别轨迹卡死导致无限 hold。
4. **向后兼容（企业 0.6.8 存量任务）**：0.6.8–0.6.11 的 COLD_START 是空 touch 文件。新 watcher 遇到无快照的遗留信号时，现场按「当前全部 pending 轨迹」补录快照——长跑中的 rebuild 升级后任务接着跑、直接获得有界收敛，不用重来。
5. 新增 `registry.get_pending_traj_ids`（IN 子句按 500 分块，兼容老 SQLite 变量数上限）；删除 `_cold_start_pipeline_idle`。

## 测试

- `tests/test_cold_start_signal.py` 重写：快照 hold / 快照终态但有新流量仍 flush / 遗留空文件补录后收敛 / 超时强制 flush。
- 全量：1263 passed（`test_e2e_xskill_serve_auto.py::test_canary_flip_promote_and_install_new_version` 在干净 main 上同样失败，属存量问题，已排除）。

🤖 Generated with [Claude Code](https://claude.com/claude-code)