### PR TITLE
fix(cli): 手动 xskill update 接入 team server wheel 回退，与后台 updater 对齐

### DIFF
--- a/src/xskill/cli.py
+++ b/src/xskill/cli.py
@@ -354,7 +354,9 @@ def cmd_start(args) -> int:
 
 
 def cmd_update(args) -> int:
-    """立即检查 PyPI 是否有新版 xskill，有则升级并重启。"""
+    """立即检查 PyPI 是否有新版 xskill；PyPI 通道失败时走 team server wheel 回退。"""
+    from packaging.version import Version
+    from xskill.config import get_team_client_state_path
     from xskill.team.client.updater import (
         AutoUpdater, _current_version, _latest_pypi_version, _restart,
     )
@@ -362,21 +364,50 @@ def cmd_update(args) -> int:
     if not current:
         print("error: 无法读取当前版本", file=sys.stderr)
         return 1
+    try:
+        current_version = Version(current)
+    except Exception:
+        current_version = None
+
+    # 已 connect 过 team server 时带上连接信息，PyPI 失败可回退 server wheel。
+    updater = AutoUpdater()
+    client_state_path = get_team_client_state_path()
+    if client_state_path.is_file():
+        from xskill.team.client.state import load_client_state
+        client_state = load_client_state(client_state_path)
+        updater = AutoUpdater(
+            server_url=client_state.server_url,
+            client_id=client_state.client_id,
+            join_token=client_state.join_token,
+        )
+
     print(f"当前版本: {current}")
     print("正在查询 PyPI...")
     latest = _latest_pypi_version("xskill")
     if not latest:
-        print("error: 查询 PyPI 失败，请检查网络", file=sys.stderr)
+        print("查询 PyPI 失败，尝试 team server 通道...")
+        if current_version is not None and updater._check_server_fallback(
+            current, current_version, reason="pypi_query_failed",
+        ):
+            print("已通过 team server wheel 升级，正在重启...")
+            return 0
+        print("error: 查询 PyPI 失败且 server 通道不可用，请检查网络",
+              file=sys.stderr)
         return 1
     try:
-        from packaging.version import Version
-        if Version(latest) <= Version(current):
+        if current_version is not None and Version(latest) <= current_version:
             print(f"已是最新版本 ({current})")
             return 0
     except Exception:
         pass
     print(f"发现新版本: {latest}，开始升级...")
-    if not AutoUpdater()._install(latest):
+    if not updater._install(latest):
+        print("pip 升级失败，尝试 team server 通道...")
+        if current_version is not None and updater._check_server_fallback(
+            current, current_version, reason="pypi_install_failed",
+        ):
+            print("已通过 team server wheel 升级，正在重启...")
+            return 0
         print("error: 升级失败，请检查 pip 配置和日志", file=sys.stderr)
         return 1
     print(f"升级到 {latest} 成功，正在重启...")

--- a/src/xskill/cli.py
+++ b/src/xskill/cli.py
@@ -370,16 +370,22 @@ def cmd_update(args) -> int:
         current_version = None
 
     # 已 connect 过 team server 时带上连接信息，PyPI 失败可回退 server wheel。
-    updater = AutoUpdater()
+    server_kwargs: dict = {}
     client_state_path = get_team_client_state_path()
     if client_state_path.is_file():
         from xskill.team.client.state import load_client_state
-        client_state = load_client_state(client_state_path)
-        updater = AutoUpdater(
-            server_url=client_state.server_url,
-            client_id=client_state.client_id,
-            join_token=client_state.join_token,
-        )
+        try:
+            client_state = load_client_state(client_state_path)
+            server_kwargs = {
+                "server_url": client_state.server_url,
+                "client_id": client_state.client_id,
+                "join_token": client_state.join_token,
+            }
+        except Exception as state_error:
+            # 连接信息坏了只影响回退通道，不该挡住 PyPI 主路径。
+            print(f"warning: 读取 team 连接信息失败，禁用 server 回退（{state_error}）",
+                  file=sys.stderr)
+    updater = AutoUpdater(**server_kwargs)
 
     print(f"当前版本: {current}")
     print("正在查询 PyPI...")
@@ -387,9 +393,9 @@ def cmd_update(args) -> int:
     if not latest:
         print("查询 PyPI 失败，尝试 team server 通道...")
         if current_version is not None and updater._check_server_fallback(
-            current, current_version, reason="pypi_query_failed",
+            current, current_version, reason="pypi_query_failed", restart=False,
         ):
-            print("已通过 team server wheel 升级，正在重启...")
+            print("已通过 team server wheel 升级完成")
             return 0
         print("error: 查询 PyPI 失败且 server 通道不可用，请检查网络",
               file=sys.stderr)
@@ -404,9 +410,9 @@ def cmd_update(args) -> int:
     if not updater._install(latest):
         print("pip 升级失败，尝试 team server 通道...")
         if current_version is not None and updater._check_server_fallback(
-            current, current_version, reason="pypi_install_failed",
+            current, current_version, reason="pypi_install_failed", restart=False,
         ):
-            print("已通过 team server wheel 升级，正在重启...")
+            print("已通过 team server wheel 升级完成")
             return 0
         print("error: 升级失败，请检查 pip 配置和日志", file=sys.stderr)
         return 1

--- a/src/xskill/team/client/updater.py
+++ b/src/xskill/team/client/updater.py
@@ -308,11 +308,13 @@ class AutoUpdater:
             logger.warning("updater: 执行 pip 失败", exc_info=True)
             return False
 
-    def _check_server_fallback(self, current_str: str, current, *, reason: str) -> bool:
-        """PyPI 不可用时，从 team server 下载同版本 wheel 回退升级。
+    def _check_server_fallback(
+        self, current_str: str, current, *, reason: str, restart: bool = True,
+    ) -> bool:
+        """PyPI 不可用时从 server 下载 wheel 回退升级，返回是否成功。
 
-        返回是否升级成功。生产环境成功路径 ``_restart`` 不返回；返回值
-        服务手动 ``xskill update`` 的结果提示与测试。
+        ``restart=False`` 供一次性 CLI 用：装完直接返回，不 ``_restart``——
+        CLI 进程重启只会重跑 update 命令本身，还会以报错收场。
         """
         if not (self.server_url and self.client_id and self.join_token):
             logger.debug("updater: 无 server 回退配置，跳过（%s）", reason)
@@ -353,7 +355,8 @@ class AutoUpdater:
             logger.info("updater: PyPI 不可用（%s），改用 server wheel 升级到 %s",
                         reason, server_version_str)
             if self._install_wheel(wheel):
-                _restart()
+                if restart:
+                    _restart()
                 return True
             return False
 

--- a/src/xskill/team/client/updater.py
+++ b/src/xskill/team/client/updater.py
@@ -308,15 +308,19 @@ class AutoUpdater:
             logger.warning("updater: 执行 pip 失败", exc_info=True)
             return False
 
-    def _check_server_fallback(self, current_str: str, current, *, reason: str) -> None:
-        """PyPI 不可用时，从 team server 下载同版本 wheel 回退升级。"""
+    def _check_server_fallback(self, current_str: str, current, *, reason: str) -> bool:
+        """PyPI 不可用时，从 team server 下载同版本 wheel 回退升级。
+
+        返回是否升级成功。生产环境成功路径 ``_restart`` 不返回；返回值
+        服务手动 ``xskill update`` 的结果提示与测试。
+        """
         if not (self.server_url and self.client_id and self.join_token):
             logger.debug("updater: 无 server 回退配置，跳过（%s）", reason)
-            return
+            return False
 
         info = _server_version(self.server_url, self.join_token, self.client_id)
         if not info:
-            return
+            return False
 
         server_version_str = str(info.get("version") or "")
         try:
@@ -325,16 +329,16 @@ class AutoUpdater:
         except Exception:
             logger.debug("updater: server 版本不可解析: %s",
                          server_version_str, exc_info=True)
-            return
+            return False
 
         if server_version <= current:
             logger.debug("updater: server 版本 %s 不高于当前版本 %s",
                          server_version_str, current_str)
-            return
+            return False
         if not info.get("wheel_available"):
             logger.warning("updater: server 版本 %s 可用，但未提供 wheel",
                            server_version_str)
-            return
+            return False
 
         with tempfile.TemporaryDirectory(prefix="xskill-update-") as td:
             wheel = _download_server_wheel(
@@ -345,11 +349,13 @@ class AutoUpdater:
                 str(info.get("wheel_filename") or ""),
             )
             if wheel is None:
-                return
+                return False
             logger.info("updater: PyPI 不可用（%s），改用 server wheel 升级到 %s",
                         reason, server_version_str)
             if self._install_wheel(wheel):
                 _restart()
+                return True
+            return False
 
     def _install_wheel(self, wheel_path: Path) -> bool:
         """用 pip 安装 server 下载的 wheel。返回是否成功。"""

--- a/tests/test_cli_update.py
+++ b/tests/test_cli_update.py
@@ -38,3 +38,96 @@ def test_manual_update_respects_system_pip_index(monkeypatch):
     assert cmd_update(args) == 0
     assert captured
     assert "-i" not in captured[0]
+
+
+def _write_client_state(tmp_path):
+    import json
+    state_file = tmp_path / "team_client.json"
+    state_file.write_text(json.dumps({
+        "server_url": "http://srv:8000",
+        "client_id": "client-1",
+        "join_token": "tok",
+    }), encoding="utf-8")
+    return state_file
+
+
+def test_manual_update_pip_failure_falls_back_to_server_wheel(monkeypatch, tmp_path):
+    """
+    手动 update 与后台 updater 对齐：pip 失败要走 team server wheel 回退（#88）。
+    @category: integration
+    @lane: integration
+    @dependency: updater server fallback
+    @complexity: medium
+    ROI: 70
+    """
+    state_file = _write_client_state(tmp_path)
+    monkeypatch.setattr(
+        "xskill.config.get_team_client_state_path", lambda: state_file,
+    )
+    monkeypatch.setattr(
+        "xskill.team.client.updater._current_version", lambda package: "1.0.0",
+    )
+    monkeypatch.setattr(
+        "xskill.team.client.updater._latest_pypi_version", lambda package: "1.1.0",
+    )
+    monkeypatch.setattr(
+        "xskill.team.client.updater.AutoUpdater._install",
+        lambda self, target_version: False,
+    )
+    fallback_calls: list[dict] = []
+
+    def fake_fallback(self, current_str, current, *, reason):
+        fallback_calls.append({
+            "server_url": self.server_url,
+            "client_id": self.client_id,
+            "reason": reason,
+        })
+        return True
+
+    monkeypatch.setattr(
+        "xskill.team.client.updater.AutoUpdater._check_server_fallback",
+        fake_fallback,
+    )
+
+    args = build_parser().parse_args(["update"])
+    assert cmd_update(args) == 0
+    assert fallback_calls == [{
+        "server_url": "http://srv:8000",
+        "client_id": "client-1",
+        "reason": "pypi_install_failed",
+    }]
+
+
+def test_manual_update_pypi_query_failure_tries_server_then_errors(monkeypatch, tmp_path):
+    """
+    PyPI 查询失败时也应先试 server 通道，server 也不可用才报错退出（#88）。
+    @category: integration
+    @lane: integration
+    @dependency: updater server fallback
+    @complexity: low
+    ROI: 66
+    """
+    state_file = _write_client_state(tmp_path)
+    monkeypatch.setattr(
+        "xskill.config.get_team_client_state_path", lambda: state_file,
+    )
+    monkeypatch.setattr(
+        "xskill.team.client.updater._current_version", lambda package: "1.0.0",
+    )
+    monkeypatch.setattr(
+        "xskill.team.client.updater._latest_pypi_version", lambda package: None,
+    )
+    fallback_reasons: list[str] = []
+
+    def fake_fallback(self, current_str, current, *, reason):
+        fallback_reasons.append(reason)
+        return False
+
+    monkeypatch.setattr(
+        "xskill.team.client.updater.AutoUpdater._check_server_fallback",
+        fake_fallback,
+    )
+
+    args = build_parser().parse_args(["update"])
+    assert cmd_update(args) == 1
+    assert fallback_reasons == ["pypi_query_failed"]

--- a/tests/test_cli_update.py
+++ b/tests/test_cli_update.py
@@ -1,9 +1,11 @@
 from __future__ import annotations
 
+import json
+
 from xskill.cli import build_parser, cmd_update
 
 
-def test_manual_update_respects_system_pip_index(monkeypatch):
+def test_manual_update_respects_system_pip_index(monkeypatch, tmp_path):
     """
     手动 update 与自动 updater 一样，不得绕过企业 pip 配置。
     @category: integration
@@ -19,6 +21,10 @@ def test_manual_update_respects_system_pip_index(monkeypatch):
         stdout = ""
         stderr = ""
 
+    monkeypatch.setattr(
+        "xskill.config.get_team_client_state_path",
+        lambda: tmp_path / "team_client.json",
+    )
     monkeypatch.setattr(
         "xskill.team.client.updater._current_version", lambda package: "1.0.0",
     )
@@ -40,27 +46,22 @@ def test_manual_update_respects_system_pip_index(monkeypatch):
     assert "-i" not in captured[0]
 
 
-def _write_client_state(tmp_path):
-    import json
-    state_file = tmp_path / "team_client.json"
-    state_file.write_text(json.dumps({
-        "server_url": "http://srv:8000",
-        "client_id": "client-1",
-        "join_token": "tok",
-    }), encoding="utf-8")
-    return state_file
-
-
 def test_manual_update_pip_failure_falls_back_to_server_wheel(monkeypatch, tmp_path):
     """
-    手动 update 与后台 updater 对齐：pip 失败要走 team server wheel 回退（#88）。
+    手动 update 与后台 updater 对齐：pip 失败要走 team server wheel 回退，
+    且 CLI 路径不重启（execv 重跑 update 会以报错收场）（#88）。
     @category: integration
     @lane: integration
     @dependency: updater server fallback
     @complexity: medium
     ROI: 70
     """
-    state_file = _write_client_state(tmp_path)
+    state_file = tmp_path / "team_client.json"
+    state_file.write_text(json.dumps({
+        "server_url": "http://srv:8000",
+        "client_id": "client-1",
+        "join_token": "tok",
+    }), encoding="utf-8")
     monkeypatch.setattr(
         "xskill.config.get_team_client_state_path", lambda: state_file,
     )
@@ -76,11 +77,12 @@ def test_manual_update_pip_failure_falls_back_to_server_wheel(monkeypatch, tmp_p
     )
     fallback_calls: list[dict] = []
 
-    def fake_fallback(self, current_str, current, *, reason):
+    def fake_fallback(self, current_str, current, *, reason, restart=True):
         fallback_calls.append({
             "server_url": self.server_url,
             "client_id": self.client_id,
             "reason": reason,
+            "restart": restart,
         })
         return True
 
@@ -95,6 +97,7 @@ def test_manual_update_pip_failure_falls_back_to_server_wheel(monkeypatch, tmp_p
         "server_url": "http://srv:8000",
         "client_id": "client-1",
         "reason": "pypi_install_failed",
+        "restart": False,
     }]
 
 
@@ -107,7 +110,12 @@ def test_manual_update_pypi_query_failure_tries_server_then_errors(monkeypatch, 
     @complexity: low
     ROI: 66
     """
-    state_file = _write_client_state(tmp_path)
+    state_file = tmp_path / "team_client.json"
+    state_file.write_text(json.dumps({
+        "server_url": "http://srv:8000",
+        "client_id": "client-1",
+        "join_token": "tok",
+    }), encoding="utf-8")
     monkeypatch.setattr(
         "xskill.config.get_team_client_state_path", lambda: state_file,
     )
@@ -119,7 +127,7 @@ def test_manual_update_pypi_query_failure_tries_server_then_errors(monkeypatch, 
     )
     fallback_reasons: list[str] = []
 
-    def fake_fallback(self, current_str, current, *, reason):
+    def fake_fallback(self, current_str, current, *, reason, restart=True):
         fallback_reasons.append(reason)
         return False
 
@@ -131,3 +139,33 @@ def test_manual_update_pypi_query_failure_tries_server_then_errors(monkeypatch, 
     args = build_parser().parse_args(["update"])
     assert cmd_update(args) == 1
     assert fallback_reasons == ["pypi_query_failed"]
+
+
+def test_manual_update_corrupt_state_file_keeps_pypi_path(monkeypatch, tmp_path):
+    """
+    team_client.json 损坏只应禁用 server 回退，不得挡住 PyPI 主路径。
+    @category: integration
+    @lane: integration
+    @dependency: updater server fallback
+    @complexity: low
+    ROI: 60
+    """
+    state_file = tmp_path / "team_client.json"
+    state_file.write_text("{broken json", encoding="utf-8")
+    monkeypatch.setattr(
+        "xskill.config.get_team_client_state_path", lambda: state_file,
+    )
+    monkeypatch.setattr(
+        "xskill.team.client.updater._current_version", lambda package: "1.0.0",
+    )
+    monkeypatch.setattr(
+        "xskill.team.client.updater._latest_pypi_version", lambda package: "1.1.0",
+    )
+    monkeypatch.setattr(
+        "xskill.team.client.updater.AutoUpdater._install",
+        lambda self, target_version: True,
+    )
+    monkeypatch.setattr("xskill.team.client.updater._restart", lambda: None)
+
+    args = build_parser().parse_args(["update"])
+    assert cmd_update(args) == 0


### PR DESCRIPTION
Closes #88

## 问题

后台 AutoUpdater 在 PyPI 查询失败 / pip 安装失败 / PyPI 无新版时都会走 `_check_server_fallback`（team server 的 `/version` + `/wheel` 通道）；手动 `xskill update` 只走 PyPI 路径，pip 失败直接报错退出。0.6.7 内网用户（该版还写死 `-i https://pypi.org/simple/`）手动重试也无法自愈。

## 改动

- `cmd_update` 读 `~/.xskill/team_client.json`，存在则构造带 server 连接信息的 AutoUpdater；PyPI 查询失败、pip 安装失败两个分支均尝试 server wheel 回退，带用户可读输出。
- `_check_server_fallback` 返回 bool（生产成功路径 `_restart` 不返回，返回值服务 CLI 提示与测试）。

## 测试

`tests/test_cli_update.py` 新增两例：pip 失败走回退（校验 reason 与 server 连接信息注入）、PyPI 查询失败先试 server 再报错。updater 既有 8 例全过。

🤖 Generated with [Claude Code](https://claude.com/claude-code)