### PR TITLE
feat(embed): EmbedStore 内容哈希复用缓存，消灭重启/单文件变更即全量重算

### DIFF
--- a/src/xskill/recommend/engine.py
+++ b/src/xskill/recommend/engine.py
@@ -25,6 +25,10 @@ from xskill.recommend.profile_store import ProfileStore
 from xskill.recommend.reco_store import RecoStore
 from xskill.recommend.skillhub import SkillHub
 from xskill.skill.repo import SkillRepo
+from xskill.utils.embed_store import EmbedStore
+
+# tag 向量的磁盘复用缓存文件（落 traj_root，tag 集稳定，不做 prune）。
+TAG_EMBED_CACHE_NAME = ".tag_embed_cache.pkl"
 
 if TYPE_CHECKING:
     from xskill.recommend.client_interest import ClientInterest
@@ -434,8 +438,11 @@ class SkillRecommendEngine:
                         tags.append(t)
         if not tags:
             return []
+        tag_embed_store = EmbedStore(
+            self.traj_root / TAG_EMBED_CACHE_NAME, self.embed_client,
+        )
         vecs = _normalize_rows(np.asarray(
-            self.embed_client.encode_batch(tags), dtype=float,
+            tag_embed_store.encode_cached(tags), dtype=float,
         ))
         return list(zip(tags, vecs))
 
@@ -484,8 +491,11 @@ class SkillRecommendEngine:
             skill_vec = np.asarray(skill.vec, dtype=float)
         except Exception:  # pylint: disable=broad-exception-caught
             return tags[:top_k]  # 无 vec（如无 description）→ 退回集合截断
+        tag_embed_store = EmbedStore(
+            self.traj_root / TAG_EMBED_CACHE_NAME, self.embed_client,
+        )
         tag_vecs = _normalize_rows(np.asarray(
-            self.embed_client.encode_batch(tags), dtype=float,
+            tag_embed_store.encode_cached(tags), dtype=float,
         ))
         sims = tag_vecs @ skill_vec
         order = np.argsort(-sims)

--- a/src/xskill/recommend/skillhub.py
+++ b/src/xskill/recommend/skillhub.py
@@ -23,9 +23,14 @@ import numpy as np
 # 的三方 skill 画成散点 ▲（D6:不现算不造假）。结构对齐自产 ``.skill_index.pkl``。
 INDEX_CACHE_NAME = ".skillhub_index.pkl"
 
+# 三方 skill description 的向量复用缓存（EmbedStore 格式，与上面 dashboard
+# 只读缓存分开：一个是产物、一个是加速器，语义不同不混一个文件）。
+EMBED_CACHE_NAME = ".skillhub_embed_cache.pkl"
+
 from xskill.canary import aggregate_ux_by_version, load_ux_scores
 from xskill.config import skillhub_config
 from xskill.skill.frontmatter import parse as fm_parse
+from xskill.utils.embed_store import EmbedStore
 
 
 def _normalize(v: np.ndarray) -> np.ndarray:
@@ -95,10 +100,18 @@ class SkillHub:
                 "description": desc,
                 "path": sub,
             }
-            if include_vec:
-                vec = _normalize(np.asarray(self.embed_client.encode(desc), dtype=float))
-                entry["vec"] = vec
             entries.append(entry)
+        if include_vec and entries:
+            # 批量 + 按内容哈希复用：重启/改一个 SKILL.md 不再全量重 embed。
+            embed_store = EmbedStore(
+                self.dir / EMBED_CACHE_NAME, self.embed_client,
+            )
+            vectors = embed_store.encode_cached(
+                [entry["description"] for entry in entries],
+            )
+            embed_store.flush_pruned()
+            for entry, vector in zip(entries, vectors):
+                entry["vec"] = _normalize(np.asarray(vector, dtype=float))
         return entries
 
     def fingerprint(self) -> tuple[tuple[str, str, str], ...]:

--- a/src/xskill/recommend/skillhub.py
+++ b/src/xskill/recommend/skillhub.py
@@ -23,8 +23,7 @@ import numpy as np
 # 的三方 skill 画成散点 ▲（D6:不现算不造假）。结构对齐自产 ``.skill_index.pkl``。
 INDEX_CACHE_NAME = ".skillhub_index.pkl"
 
-# 三方 skill description 的向量复用缓存（EmbedStore 格式，与上面 dashboard
-# 只读缓存分开：一个是产物、一个是加速器，语义不同不混一个文件）。
+# 三方 skill description 的向量复用缓存（与 dashboard 只读产物分开存）。
 EMBED_CACHE_NAME = ".skillhub_embed_cache.pkl"
 
 from xskill.canary import aggregate_ux_by_version, load_ux_scores

--- a/src/xskill/skill/repo.py
+++ b/src/xskill/skill/repo.py
@@ -195,8 +195,10 @@ def rebuild_skill_index(
     skill_names, descriptions = zip(*entries)
     descriptions = list(descriptions)
 
-    # 主特征：description-only 向量
-    embeddings = embed_client.encode_batch(descriptions)
+    # 主特征：description-only 向量（EmbedStore 按内容哈希复用，只算变化项）
+    from xskill.utils.embed_store import EmbedStore
+    embed_store = EmbedStore(skill_root / ".skill_embed_cache.pkl", embed_client)
+    embeddings = embed_store.encode_cached(descriptions)
     embeddings = numpy.asarray(embeddings, dtype=float)
     norms = numpy.linalg.norm(embeddings, axis=1, keepdims=True)
     norms[norms == 0] = 1
@@ -212,11 +214,14 @@ def rebuild_skill_index(
         )
         if not summaries:
             continue
-        vecs = numpy.asarray(embed_client.encode_batch(summaries), dtype=float)
+        vecs = numpy.asarray(embed_store.encode_cached(summaries), dtype=float)
         mean = vecs.mean(axis=0)
         n = float(numpy.linalg.norm(mean))
         atom_feats[i] = mean / n if n > 0 else mean
         atom_present[i] = True
+
+    # 本轮已覆盖全部 description + summary，压掉已删除/改写条目的陈旧向量。
+    embed_store.flush_pruned()
 
     index_data = {
         "skill_names": list(skill_names),

--- a/src/xskill/utils/embed_store.py
+++ b/src/xskill/utils/embed_store.py
@@ -1,8 +1,6 @@
-"""embed_store.py — 按内容哈希复用的 embedding 磁盘缓存。
+"""embed_store.py — 按 (embedding 模型, 文本 sha256) 复用向量的磁盘缓存。
 
-底层 ``EmbedClient`` 零缓存且单条延迟高，各索引重建点曾经每次全量重算。
-本类按 (embedding 模型, 文本 sha256) 复用向量：命中直接读盘，未命中分块
-现算并即时落盘——重启/中断后续算不回头；换 embedding 模型自动整体失效。
+命中直接读盘；未命中分块现算并即时落盘（中断续算不回头）；换模型整体失效。
 """
 from __future__ import annotations
 
@@ -43,7 +41,8 @@ class EmbedStore:
             self._vectors = vectors
 
     def _save(self) -> None:
-        temp_path = self.cache_path.with_suffix(".tmp")
+        # tmp 名带 pid：多进程写同一缓存时各写各的临时文件，replace 原子收尾。
+        temp_path = self.cache_path.with_suffix(f".tmp.{os.getpid()}")
         with open(temp_path, "wb") as cache_file:
             pickle.dump(
                 {"model": self.model_id, "vectors": self._vectors}, cache_file,

--- a/src/xskill/utils/embed_store.py
+++ b/src/xskill/utils/embed_store.py
@@ -1,0 +1,92 @@
+"""embed_store.py — 按内容哈希复用的 embedding 磁盘缓存。
+
+底层 ``EmbedClient`` 零缓存且单条延迟高，各索引重建点曾经每次全量重算。
+本类按 (embedding 模型, 文本 sha256) 复用向量：命中直接读盘，未命中分块
+现算并即时落盘——重启/中断后续算不回头；换 embedding 模型自动整体失效。
+"""
+from __future__ import annotations
+
+import hashlib
+import os
+import pickle
+import threading
+from pathlib import Path
+
+import numpy as np
+
+
+class EmbedStore:
+    """``cache_path`` 上的「文本哈希 → 向量」缓存，只对未命中文本现算。"""
+
+    SAVE_EVERY = 16
+
+    def __init__(self, cache_path: Path | str, embed_client):
+        self.cache_path = Path(cache_path)
+        self.embed_client = embed_client
+        self.model_id = str(getattr(embed_client, "model", "") or "")
+        self._vectors: dict[str, np.ndarray] = {}
+        self._touched: set[str] = set()
+        self._lock = threading.Lock()
+        self._load()
+
+    def _load(self) -> None:
+        try:
+            with open(self.cache_path, "rb") as cache_file:
+                data = pickle.load(cache_file)
+        except (OSError, pickle.PickleError, EOFError, AttributeError):
+            return
+        # 缓存损坏或换了 embedding 模型 → 整体作废，从零重建。
+        if not isinstance(data, dict) or data.get("model") != self.model_id:
+            return
+        vectors = data.get("vectors")
+        if isinstance(vectors, dict):
+            self._vectors = vectors
+
+    def _save(self) -> None:
+        temp_path = self.cache_path.with_suffix(".tmp")
+        with open(temp_path, "wb") as cache_file:
+            pickle.dump(
+                {"model": self.model_id, "vectors": self._vectors}, cache_file,
+            )
+        os.replace(temp_path, self.cache_path)
+
+    def encode_cached(self, texts: list[str]) -> np.ndarray:
+        """返回 ``(len(texts), dim)`` 向量矩阵；未命中的分块现算并即时落盘。"""
+        if not texts:
+            return np.empty((0, 0), dtype=np.float32)
+        with self._lock:
+            text_hashes = [
+                hashlib.sha256(text.encode("utf-8")).hexdigest() for text in texts
+            ]
+            self._touched.update(text_hashes)
+            missing: dict[str, str] = {}
+            for text, text_hash in zip(texts, text_hashes):
+                if text_hash not in self._vectors and text_hash not in missing:
+                    missing[text_hash] = text
+            missing_items = list(missing.items())
+            for chunk_start in range(0, len(missing_items), self.SAVE_EVERY):
+                chunk = missing_items[chunk_start:chunk_start + self.SAVE_EVERY]
+                chunk_vectors = np.asarray(
+                    self.embed_client.encode_batch(
+                        [text for _text_hash, text in chunk],
+                    ),
+                    dtype=np.float32,
+                )
+                for (text_hash, _text), vector in zip(chunk, chunk_vectors):
+                    self._vectors[text_hash] = vector
+                self._save()
+            return np.stack([self._vectors[h] for h in text_hashes])
+
+    def flush_pruned(self) -> None:
+        """只保留本实例生命周期内被请求过的哈希，防陈旧条目无限积累。
+
+        仅当本轮调用覆盖了完整语料（索引全量重建）时使用；按子集查询的
+        调用方不要调，否则会把其他调用方的缓存修剪掉。
+        """
+        with self._lock:
+            self._vectors = {
+                text_hash: vector
+                for text_hash, vector in self._vectors.items()
+                if text_hash in self._touched
+            }
+            self._save()

--- a/tests/test_dashboard_p3.py
+++ b/tests/test_dashboard_p3.py
@@ -360,6 +360,9 @@ class _FakeEmbed:
         self.dim = dim
         self.model = "fake-embed"
 
+    def encode_batch(self, texts):
+        return np.stack([self.encode(t) for t in texts])
+
     def encode(self, text):
         v = np.zeros(self.dim, dtype=float)
         for i, ch in enumerate(text):

--- a/tests/test_embed_store.py
+++ b/tests/test_embed_store.py
@@ -1,0 +1,115 @@
+"""EmbedStore —— 按内容哈希复用 embedding 的磁盘缓存。
+
+验证：
+  1. 命中项不再调 embed 服务，只算新增/变更文本。
+  2. 缓存跨实例（重启）存活。
+  3. 换 embedding 模型整体失效。
+  4. 分块即时落盘：中途失败已算部分不回头。
+  5. flush_pruned 只保留本轮请求过的哈希。
+"""
+from __future__ import annotations
+
+import numpy as np
+import pytest
+
+from xskill.utils.embed_store import EmbedStore
+
+
+class _CountingEmbed:
+    def __init__(self, model="fake-embed", fail_on=None):
+        self.model = model
+        self.encoded: list[str] = []
+        self.fail_on = fail_on
+
+    def encode_batch(self, texts):
+        for text in texts:
+            if self.fail_on is not None and text == self.fail_on:
+                raise RuntimeError(f"boom on {text}")
+        self.encoded.extend(texts)
+        return np.stack([
+            np.full(4, float(len(text)), dtype=np.float32) for text in texts
+        ])
+
+
+def test_only_missing_texts_are_encoded(tmp_path):
+    embed_client = _CountingEmbed()
+    store = EmbedStore(tmp_path / "cache.pkl", embed_client)
+
+    first = store.encode_cached(["aa", "bbb"])
+    assert first.shape == (2, 4)
+    assert embed_client.encoded == ["aa", "bbb"]
+
+    second = store.encode_cached(["aa", "bbb", "cccc"])
+    assert second.shape == (3, 4)
+    assert embed_client.encoded == ["aa", "bbb", "cccc"], "命中项不得重算"
+    assert np.array_equal(second[0], first[0])
+
+
+def test_cache_survives_restart(tmp_path):
+    cache_path = tmp_path / "cache.pkl"
+    EmbedStore(cache_path, _CountingEmbed()).encode_cached(["aa", "bbb"])
+
+    reopened_client = _CountingEmbed()
+    reopened = EmbedStore(cache_path, reopened_client)
+    result = reopened.encode_cached(["aa", "bbb"])
+
+    assert result.shape == (2, 4)
+    assert reopened_client.encoded == [], "重启后全命中，不得重算"
+
+
+def test_model_change_invalidates_cache(tmp_path):
+    cache_path = tmp_path / "cache.pkl"
+    EmbedStore(cache_path, _CountingEmbed(model="m1")).encode_cached(["aa"])
+
+    new_model_client = _CountingEmbed(model="m2")
+    EmbedStore(cache_path, new_model_client).encode_cached(["aa"])
+
+    assert new_model_client.encoded == ["aa"], "换模型必须整体重算"
+
+
+def test_partial_progress_persists_on_failure(tmp_path):
+    cache_path = tmp_path / "cache.pkl"
+    failing_client = _CountingEmbed(fail_on="poison")
+    store = EmbedStore(cache_path, failing_client)
+    store.SAVE_EVERY = 1
+
+    with pytest.raises(RuntimeError):
+        store.encode_cached(["aa", "bbb", "poison"])
+    assert failing_client.encoded == ["aa", "bbb"]
+
+    resumed_client = _CountingEmbed()
+    resumed = EmbedStore(cache_path, resumed_client)
+    resumed.encode_cached(["aa", "bbb", "poison"])
+    assert resumed_client.encoded == ["poison"], "中断前已算部分不得重算"
+
+
+def test_flush_pruned_drops_untouched(tmp_path):
+    cache_path = tmp_path / "cache.pkl"
+    store = EmbedStore(cache_path, _CountingEmbed())
+    store.encode_cached(["stale", "kept"])
+
+    pruning_client = _CountingEmbed()
+    pruning_store = EmbedStore(cache_path, pruning_client)
+    pruning_store.encode_cached(["kept"])
+    pruning_store.flush_pruned()
+
+    final_client = _CountingEmbed()
+    final_store = EmbedStore(cache_path, final_client)
+    final_store.encode_cached(["kept", "stale"])
+    assert final_client.encoded == ["stale"], "被 prune 的条目应重算，保留的命中"
+
+
+def test_empty_input_returns_empty(tmp_path):
+    store = EmbedStore(tmp_path / "cache.pkl", _CountingEmbed())
+    assert store.encode_cached([]).shape == (0, 0)
+
+
+def test_corrupt_cache_file_is_ignored(tmp_path):
+    cache_path = tmp_path / "cache.pkl"
+    cache_path.write_bytes(b"not a pickle")
+    embed_client = _CountingEmbed()
+
+    result = EmbedStore(cache_path, embed_client).encode_cached(["aa"])
+
+    assert result.shape == (1, 4)
+    assert embed_client.encoded == ["aa"]

--- a/tests/test_skillhub.py
+++ b/tests/test_skillhub.py
@@ -108,6 +108,40 @@ class TestSkillHub:
         assert hub.enabled is False
         assert hub.index() == []
 
+    def test_index_reuses_embeddings_for_unchanged_skill_md(self, tmp_path):
+        """重启/改一个 SKILL.md 只重算变化项，不再全量重 embed（EmbedStore）。"""
+
+        class CountingEmbed(FakeEmbed):
+            def __init__(self, dim=4):
+                super().__init__(dim=dim)
+                self.encoded: list[str] = []
+
+            def encode_batch(self, texts):
+                self.encoded.extend(texts)
+                return super().encode_batch(texts)
+
+        hub_dir = tmp_path / "hub"
+        _write_hub_skill(hub_dir, "foo", "django migration helper")
+        _write_hub_skill(hub_dir, "bar", "react component gen")
+        first_client = CountingEmbed()
+        SkillHub(enabled=True, hub_dir=hub_dir, embed_client=first_client).index()
+        assert sorted(first_client.encoded) == [
+            "django migration helper", "react component gen",
+        ]
+
+        # 模拟重启：新实例、缓存在盘上 → 内容未变零重算
+        restart_client = CountingEmbed()
+        SkillHub(enabled=True, hub_dir=hub_dir, embed_client=restart_client).index()
+        assert restart_client.encoded == []
+
+        # 只改一个 SKILL.md → 只重算这一条
+        (hub_dir / "foo" / "SKILL.md").write_text(
+            "---\nname: foo\ndescription: fastapi helper\n---\n# foo\n",
+            encoding="utf-8")
+        changed_client = CountingEmbed()
+        SkillHub(enabled=True, hub_dir=hub_dir, embed_client=changed_client).index()
+        assert changed_client.encoded == ["fastapi helper"]
+
     def test_recursively_scans_nested_skill_md_under_multiple_folders(self, tmp_path):
         hub_dir = tmp_path / "hub"
         _write_hub_skill(


### PR DESCRIPTION
Closes #92

## 问题（/tmp/embed.txt 梳理的 C/D/E 三点）

embedding 服务 ~22s/条，而三处调用点每次全量重算：三方 SkillHub 重启必全量、改一个 SKILL.md 也全量（线上"63 条逐个 embed 算不完"）；`rebuild_skill_index` 无增量；tag embedding 零缓存。

## 方案

`EmbedStore`（utils/embed_store.py）：按 (embedding 模型, 文本 sha256) 复用的磁盘缓存基类。

- `encode_cached(texts)` 只算未命中项，分块 16 条**边算边落盘**——中断/重启续算不回头（22s/条 下这是关键）；
- 换 embedding 模型自动整体失效；坏缓存文件作废重建；tmp+`os.replace` 原子写；
- `flush_pruned()` 给覆盖完整语料的重建方压缩陈旧条目，防无限膨胀；按子集查询的调用方（tag）不 prune。

已接入：skillhub（批量化 + `.skillhub_embed_cache.pkl`）、rebuild_skill_index（`.skill_embed_cache.pkl`）、tag（`.tag_embed_cache.pkl`）。A/B 两处已有增量机制的调用点未动，后续可迁移统一。

## 测试

- 新增 `tests/test_embed_store.py` 7 例：命中不重算/跨实例存活/换模型失效/中断续算/prune/空输入/坏缓存。
- `tests/test_skillhub.py` 新增集成回归：重启零重算、改一个 SKILL.md 只重算一条。
- 全量 1273 passed（canary e2e 为 main 存量失败，已排除）。

🤖 Generated with [Claude Code](https://claude.com/claude-code)