### PR TITLE
feat(agent): SkillEditAgent 探索能力升级——读根扩到 ~/.xskill、grep_files、skill_read 文件树

### DIFF
--- a/src/xskill/agents/agent_tools.py
+++ b/src/xskill/agents/agent_tools.py
@@ -11,7 +11,7 @@ those from config at their own boundary.
 
 from __future__ import annotations
 
-import json, logging, tempfile
+import json, logging, re, shutil, subprocess, tempfile
 from datetime import date, datetime
 from pathlib import Path
 
@@ -37,6 +37,7 @@ class AgentToolConfig:
         self._atom_skill_dir: Path | None = None
         self._atom_store = None
         self._default_traj_root: Path | None = None
+        self.grep_fallback_warned = False
 
     def configure_skill_authoring(
         self, skill_dir, data_dir, config,
@@ -144,6 +145,33 @@ def _is_relative_to(path: Path, root: Path) -> bool:
         return False
 
 
+SENSITIVE_FILENAMES = {
+    "config.yaml", "team_client.json", "team_clients.db", "dashboard_secret.json",
+}
+SENSITIVE_NAME_TOKENS = {"secret", "token", "credential", "key", "password"}
+
+
+def _allowed_read_roots() -> list[Path]:
+    """探索类工具（read_file / list_files / grep_files）共用的只读根集合。"""
+    from xskill.config import XSKILL_HOME
+    roots: list[Path] = []
+    configured_root = agent_tool_config.skill_dir or agent_tool_config.atom_skill_dir
+    if configured_root is not None:
+        roots.append(Path(configured_root).parent.resolve())
+    roots.append(XSKILL_HOME.resolve())
+    roots.append((Path(tempfile.gettempdir()) / "xskill" / "skilleditagent").resolve())
+    return list(dict.fromkeys(roots))
+
+
+def _is_sensitive_file(path: Path) -> bool:
+    """密钥类文件不给 agent 读——skill 正文会分发全团队，蒸进去即泄密。"""
+    lower_name = path.name.lower()
+    if lower_name in SENSITIVE_FILENAMES:
+        return True
+    name_tokens = set(re.split(r"[^a-z0-9]+", lower_name))
+    return bool(name_tokens & SENSITIVE_NAME_TOKENS)
+
+
 def _sanitize_frontmatter_dates(fm: dict) -> dict:
     """不让 LLM 写的日期字段污染 frontmatter。
     - created: 必须是合法 ISO date 且 ≤ 今天；否则替换成今天（保留历史 created 优先）
@@ -226,15 +254,15 @@ def search_similar_trajs(query: str, top_k: int = 5, filter: str = "all") -> str
 
 @tool(name="read_file")
 def read_file(path: str, offset: int = 1, limit: int = 200) -> str:
-    """Read a file under the skill workspace or /tmp spill area.
+    """Read a file under the skill workspace, ~/.xskill, or the /tmp spill area.
 
-    SkillEditAgent may receive trimmed tool results that point at files under
-    /tmp/xskill/skilleditagent. Use read_file(spill_path, offset, limit) to
-    reload those raw tool results in line windows when the short placeholder is
-    insufficient.
+    Use with list_files / grep_files output: they return paths this tool can
+    read directly. Spill files under /tmp/xskill/skilleditagent hold trimmed
+    raw tool results; reload them in line windows when placeholders are not
+    enough. Secret-bearing files (config.yaml, *token*, *key*, ...) are refused.
 
     Args:
-        path: File path under the skill workspace or /tmp/xskill/skilleditagent (spill dir).
+        path: File path under an allowed read root.
         offset: 1-based start line.
         limit: Number of lines to read from offset.
     """
@@ -249,12 +277,7 @@ def read_file(path: str, offset: int = 1, limit: int = 200) -> str:
         return f"error: limit must be >= 1 (got {line_limit})"
 
     p = Path(path)
-    configured_root = agent_tool_config.skill_dir or agent_tool_config.atom_skill_dir
-    roots: list[Path] = []
-    if configured_root is not None:
-        roots.append(Path(configured_root).parent.resolve())
-    roots.append((Path(tempfile.gettempdir()) / "xskill" / "skilleditagent").resolve())
-    roots = list(dict.fromkeys(roots))
+    roots = _allowed_read_roots()
     resolved = p.resolve()
     try:
         allowed = any(_is_relative_to(resolved, root) for root in roots)
@@ -268,6 +291,8 @@ def read_file(path: str, offset: int = 1, limit: int = 200) -> str:
             f"resolved_path: {resolved}\n"
             f"allowed_roots:\n{allowed_block}"
         )
+    if _is_sensitive_file(resolved):
+        return f"error: sensitive file, not readable by agent ({path})"
 
     if not resolved.exists():
         return f"error: file not found ({path})"
@@ -703,15 +728,48 @@ def new_skill_folder(skill_name: str, description: str) -> str:
 
 @tool(name="skill_read")
 def skill_read(skill_name: str) -> str:
-    """读 skill 的 SKILL.md；没有则返回 placeholder 提示。"""
+    """读 skill 的 SKILL.md 正文 + 目录内其余文件树（路径可直接喂 read_file）。"""
     skill_dir = agent_tool_config.atom_skill_dir
     if skill_dir is None:
         return "error: atom task tool context not initialized"
     slug = _slugify(skill_name)
-    p = skill_dir / slug / "SKILL.md"
-    if not p.is_file():
-        return f"(skill {slug} has no SKILL.md yet — only candidates buffer)"
-    return p.read_text(encoding="utf-8")
+    skill_path = (skill_dir / slug).resolve()
+    header = f"skill_dir: {skill_path}"
+    try:
+        from xskill.skill.git import current_branch
+        header += f"   (branch: {current_branch(str(skill_path))})"
+    except Exception:
+        pass
+    markdown_path = skill_path / "SKILL.md"
+    if markdown_path.is_file():
+        markdown_text = markdown_path.read_text(encoding="utf-8")
+        body = (f"--- SKILL.md ({len(markdown_text.splitlines())} lines) ---\n"
+                f"{markdown_text}")
+    else:
+        body = f"(skill {slug} has no SKILL.md yet — only candidates buffer)"
+    tree_lines: list[str] = []
+    if skill_path.is_dir():
+        for file_path in sorted(skill_path.rglob("*")):
+            relative_path = file_path.relative_to(skill_path)
+            if relative_path.parts[0] == ".git" or len(relative_path.parts) > 4:
+                continue
+            if not file_path.is_file() or relative_path.as_posix() == "SKILL.md":
+                continue
+            size_kb = file_path.stat().st_size / 1024
+            annotation = ("  (用 list_candidates 读)"
+                          if relative_path.name == "candidates.yml" else "")
+            tree_lines.append(
+                f"{relative_path.as_posix()}  ({size_kb:.1f} KB){annotation}",
+            )
+            if len(tree_lines) >= 100:
+                tree_lines.append("(+more, use list_files)")
+                break
+    if not tree_lines:
+        return f"{header}\n{body}"
+    files_block = "\n".join(tree_lines)
+    return (f"{header}\n{body}\n"
+            f"--- other files（相对 {skill_path}；用 read_file(绝对路径) 精读）---\n"
+            f"{files_block}")
 
 
 @tool(name="add_task_to_skill")
@@ -932,26 +990,114 @@ def make_task_agent_tools(
 def list_files(path: str) -> str:
     """列目录下的文件 / 子目录，返回可直接传给 read_file 的完整路径。
 
-    给 SkillEditAgent 用来摸清当前 skill 已有什么文件（避免重复写、便于增量
-    更新）。路径必须在 skill_dir 范围内；越界返回 error。
+    可列 skill 仓、~/.xskill、/tmp spill 三个只读根内的任意目录——摸清 skill
+    已有文件、轨迹 / atom 数据布局都用它。越界返回 error。
     """
-    p = Path(path)
-    skill_root = agent_tool_config.atom_skill_dir if agent_tool_config.atom_skill_dir is not None else agent_tool_config.skill_dir
-    if skill_root is None:
-        return "error: skill_dir context not initialized"
-    try:
-        p.resolve().relative_to(skill_root.resolve())
-    except ValueError:
-        return f"error: list_files restricted to skill_dir (tried: {path})"
-    if not p.is_dir():
+    target_directory = Path(path).resolve()
+    roots = _allowed_read_roots()
+    if not any(_is_relative_to(target_directory, root) for root in roots):
+        allowed_block = ", ".join(str(root) for root in roots)
+        return f"error: list_files restricted to {allowed_block} (tried: {path})"
+    if not target_directory.is_dir():
         return f"error: not a directory: {path}"
-    entries = sorted(p.iterdir())
+    entries = sorted(target_directory.iterdir())
     if not entries:
         return "(empty)"
     return "\n".join(
         f"{'[dir] ' if e.is_dir() else '[file] '}{e.resolve()}{'/' if e.is_dir() else ''}"
         for e in entries
     )
+
+
+@tool(name="grep_files")
+def grep_files(pattern: str, path: str = "", glob: str = "",
+               max_results: int = 100) -> str:
+    """在允许的只读根内全文检索，返回「文件:行号:内容」，路径可直接喂 read_file。
+
+    Args:
+        pattern: 正则表达式（ripgrep / grep -E 语法）。
+        path: 检索根目录，缺省为 skill 仓所在根；须在允许的只读根内。
+        glob: 可选文件名过滤，如 "*.md"。
+        max_results: 命中行数上限（1-500）。
+    """
+    max_results = max(1, min(int(max_results), 500))
+    roots = _allowed_read_roots()
+    search_root = (Path(path) if path else roots[0]).resolve()
+    if not any(_is_relative_to(search_root, root) for root in roots):
+        allowed_block = ", ".join(str(root) for root in roots)
+        return f"error: grep_files restricted to {allowed_block} (tried: {path})"
+    if not search_root.exists():
+        return f"error: path not found ({path})"
+
+    if shutil.which("rg"):
+        engine = "rg"
+        command = ["rg", "-n", "--no-heading", "--color", "never", "--smart-case"]
+        if glob:
+            command += ["--glob", glob]
+        command += ["-e", pattern, str(search_root)]
+    elif shutil.which("grep"):
+        engine = "grep (ripgrep 不可用，已降级；建议安装 rg 提速)"
+        command = ["grep", "-rnIE"]
+        if glob:
+            command += [f"--include={glob}"]
+        command += ["-e", pattern, str(search_root)]
+    else:
+        engine = "python (ripgrep/grep 均不可用，已降级纯扫描)"
+        command = None
+    if command is None or engine != "rg":
+        if not agent_tool_config.grep_fallback_warned:
+            agent_tool_config.grep_fallback_warned = True
+            logger.warning("grep_files: ripgrep 不可用，降级为 %s",
+                           "grep" if command else "python 纯扫描")
+
+    if command is not None:
+        try:
+            completed = subprocess.run(
+                command, capture_output=True, text=True, timeout=30,
+            )
+        except subprocess.TimeoutExpired:
+            return "error: grep timed out after 30s — narrow path/glob"
+        # rg/grep 退出码：0=命中，1=无命中，≥2=真错误
+        if completed.returncode > 1:
+            return f"error: {engine} failed: {completed.stderr.strip()[:500]}"
+        output_lines = completed.stdout.splitlines()
+    else:
+        try:
+            compiled_pattern = re.compile(pattern)
+        except re.error as regex_error:
+            return f"error: invalid pattern: {regex_error}"
+        output_lines = []
+        scanned_count = 0
+        for file_path in search_root.rglob(glob or "*"):
+            if not file_path.is_file() or ".git" in file_path.parts:
+                continue
+            scanned_count += 1
+            if scanned_count > 2000 or len(output_lines) >= max_results:
+                break
+            try:
+                file_text = file_path.read_text(encoding="utf-8")
+            except (UnicodeDecodeError, OSError):
+                continue
+            for line_number, line_text in enumerate(file_text.splitlines(), 1):
+                if compiled_pattern.search(line_text):
+                    output_lines.append(f"{file_path}:{line_number}:{line_text}")
+
+    hit_line_pattern = re.compile(r"^(.*?):(\d+):")
+    filtered_lines: list[str] = []
+    for output_line in output_lines:
+        hit_match = hit_line_pattern.match(output_line)
+        if hit_match and _is_sensitive_file(Path(hit_match.group(1))):
+            continue
+        filtered_lines.append(output_line)
+        if len(filtered_lines) >= max_results:
+            break
+    header = f"engine: {engine}\nroot: {search_root}\n"
+    if not filtered_lines:
+        return header + f"(no matches for {pattern!r})"
+    body = "\n".join(filtered_lines)
+    if len(body) > 10000:
+        body = body[:10000] + "\n... (truncated — narrow pattern/glob or lower max_results)"
+    return header + body
 
 
 # ═══════════════════════════════════════════════════════════════════

--- a/src/xskill/agents/agent_tools.py
+++ b/src/xskill/agents/agent_tools.py
@@ -11,7 +11,7 @@ those from config at their own boundary.
 
 from __future__ import annotations
 
-import json, logging, re, shutil, subprocess, tempfile
+import json, logging, os, re, shutil, subprocess, tempfile
 from datetime import date, datetime
 from pathlib import Path
 
@@ -145,10 +145,13 @@ def _is_relative_to(path: Path, root: Path) -> bool:
         return False
 
 
-SENSITIVE_FILENAMES = {
-    "config.yaml", "team_client.json", "team_clients.db", "dashboard_secret.json",
-}
-SENSITIVE_NAME_TOKENS = {"secret", "token", "credential", "key", "password"}
+SENSITIVE_FILENAMES = frozenset({
+    "config.yaml", "team_client.json", "team_server.json", "team_clients.db",
+    "dashboard_secret.json",
+})
+SENSITIVE_NAME_TOKENS = frozenset({
+    "secret", "token", "credential", "key", "password",
+})
 
 
 def _allowed_read_roots() -> list[Path]:
@@ -749,21 +752,25 @@ def skill_read(skill_name: str) -> str:
         body = f"(skill {slug} has no SKILL.md yet — only candidates buffer)"
     tree_lines: list[str] = []
     if skill_path.is_dir():
-        for file_path in sorted(skill_path.rglob("*")):
-            relative_path = file_path.relative_to(skill_path)
-            if relative_path.parts[0] == ".git" or len(relative_path.parts) > 4:
-                continue
-            if not file_path.is_file() or relative_path.as_posix() == "SKILL.md":
-                continue
-            size_kb = file_path.stat().st_size / 1024
-            annotation = ("  (用 list_candidates 读)"
-                          if relative_path.name == "candidates.yml" else "")
-            tree_lines.append(
-                f"{relative_path.as_posix()}  ({size_kb:.1f} KB){annotation}",
+        for current_dir, dir_names, file_names in os.walk(skill_path):
+            walk_depth = len(Path(current_dir).relative_to(skill_path).parts)
+            # 剪枝进不去 .git / 第 4 层以下，避免白遍历上千 git 对象。
+            dir_names[:] = sorted(
+                name for name in dir_names if name != ".git" and walk_depth < 3
             )
-            if len(tree_lines) >= 100:
-                tree_lines.append("(+more, use list_files)")
-                break
+            for file_name in sorted(file_names):
+                file_path = Path(current_dir) / file_name
+                relative_path = file_path.relative_to(skill_path)
+                if relative_path.as_posix() == "SKILL.md":
+                    continue
+                size_kb = file_path.stat().st_size / 1024
+                annotation = ("  (用 list_candidates 读)"
+                              if relative_path.name == "candidates.yml" else "")
+                tree_lines.append(
+                    f"{relative_path.as_posix()}  ({size_kb:.1f} KB){annotation}",
+                )
+        if len(tree_lines) > 100:
+            tree_lines = tree_lines[:100] + ["(+more, use list_files)"]
     if not tree_lines:
         return f"{header}\n{body}"
     files_block = "\n".join(tree_lines)
@@ -1086,7 +1093,8 @@ def grep_files(pattern: str, path: str = "", glob: str = "",
     filtered_lines: list[str] = []
     for output_line in output_lines:
         hit_match = hit_line_pattern.match(output_line)
-        if hit_match and _is_sensitive_file(Path(hit_match.group(1))):
+        # resolve() 后再判敏感：防符号链接用无害文件名包装密钥文件绕过过滤。
+        if hit_match and _is_sensitive_file(Path(hit_match.group(1)).resolve()):
             continue
         filtered_lines.append(output_line)
         if len(filtered_lines) >= max_results:

--- a/src/xskill/agents/skill_edit_agent.py
+++ b/src/xskill/agents/skill_edit_agent.py
@@ -208,10 +208,12 @@ commit message 写明本次基于哪些 atom_id 整理，例如：
 # 可用工具
 - AtomTaskRead(atom_id) — 读 atom JSON
 - ReadTraj(traj_id, offset_start, offset_end) — 按行号取轨迹原文（offset 即 1-based 行号）
-- SkillRead(skill_name) — 读现有 SKILL.md（更新场景用）
-- read_file(path, offset=1, limit=200) — 按 1-based 行号窗口读取 skill workspace
-  或 /tmp 下的 spill 文件；trim 后的 ``spill_path`` 也用它分页回读
+- SkillRead(skill_name) — 读现有 SKILL.md + 该 skill 目录其余文件树（更新场景先看这个）
+- read_file(path, offset=1, limit=200) — 按 1-based 行号窗口读取 skill 仓 /
+  ~/.xskill / /tmp spill 下的文件；trim 后的 ``spill_path`` 也用它分页回读
 - list_files(path) — 列目录文件，返回可直接传给 read_file 的完整路径
+- grep_files(pattern, path="", glob="", max_results=100) — 全文检索（ripgrep），
+  返回「文件:行号:内容」；先检索定位、再 read_file 精读，别逐个翻文件
 - write_file(path, content) — 写任意文件到 skill_dir 下
 - commit_baby_to_main(skill_name, message) — 仅 baby 分支可用
 - commit_to_staging(skill_name, message) — 仅 main 分支可用
@@ -706,6 +708,7 @@ class SkillEditAgent:
             agent_tools.skill_read,
             agent_tools.read_file,
             agent_tools.list_files,
+            agent_tools.grep_files,
             agent_tools.write_file,
         ]
         if is_last:
@@ -793,6 +796,7 @@ class SkillEditAgent:
             agent_tools.skill_read,
             agent_tools.read_file,
             agent_tools.list_files,
+            agent_tools.grep_files,
             agent_tools.write_file,
         ]
         if is_last:

--- a/tests/test_agent_tools_explore.py
+++ b/tests/test_agent_tools_explore.py
@@ -45,7 +45,8 @@ class TestReadRoots:
     def test_read_file_denies_sensitive_files(self, tmp_path, monkeypatch):
         xskill_home, _skill_dir = _setup_home(tmp_path, monkeypatch)
         for sensitive_name in (
-            "config.yaml", "team_client.json", "my_api_key.txt", "join-token.log",
+            "config.yaml", "team_client.json", "team_server.json",
+            "my_api_key.txt", "join-token.log",
         ):
             sensitive_file = xskill_home / sensitive_name
             sensitive_file.write_text("s3cret\n", encoding="utf-8")
@@ -147,6 +148,24 @@ class TestGrepFiles:
         assert "engine: python" in out
         assert "traj_a.md:2:" in out
         assert "api_key.txt" not in out
+
+    def test_python_fallback_filters_symlinked_sensitive_file(
+        self, tmp_path, monkeypatch,
+    ):
+        xskill_home, _skill_dir = _setup_home(tmp_path, monkeypatch)
+        corpus_dir = xskill_home / "cc_sessions"
+        corpus_dir.mkdir()
+        secret_file = xskill_home / "config.yaml"
+        secret_file.write_text("llm_api_key: SECRET_VALUE\n", encoding="utf-8")
+        (corpus_dir / "notes.md").symlink_to(secret_file)
+        monkeypatch.setattr(agent_tools.shutil, "which", lambda name: None)
+
+        out = agent_tools.grep_files.entrypoint(
+            "SECRET_VALUE", path=str(corpus_dir),
+        )
+
+        assert "llm_api_key" not in out, "符号链接不得绕过敏感过滤"
+        assert "notes.md:1" not in out
 
     def test_no_matches_reports_engine(self, tmp_path, monkeypatch):
         xskill_home, _skill_dir = _setup_home(tmp_path, monkeypatch)

--- a/tests/test_agent_tools_explore.py
+++ b/tests/test_agent_tools_explore.py
@@ -1,0 +1,206 @@
+"""SkillEditAgent 探索工具（#91）：读根扩展 / 敏感文件 denylist / grep_files /
+skill_read 文件树。"""
+from __future__ import annotations
+
+from pathlib import Path
+
+from xskill.agents import agent_tools
+
+
+def _setup_home(tmp_path, monkeypatch):
+    xskill_home = tmp_path / ".xskill"
+    xskill_home.mkdir()
+    monkeypatch.setattr("xskill.config.XSKILL_HOME", xskill_home)
+    skill_dir = xskill_home / "skill"
+    skill_dir.mkdir()
+    agent_tools.init_atom_task_tool_context(
+        skill_dir=skill_dir, atom_store=None, default_traj_root=tmp_path,
+    )
+    agent_tools.init_skill_authoring_tool_context(
+        skill_dir, skill_dir, {"skill_opt": {"enabled": False}},
+    )
+    return xskill_home, skill_dir
+
+
+class TestReadRoots:
+    def test_read_file_allows_xskill_home(self, tmp_path, monkeypatch):
+        xskill_home, _skill_dir = _setup_home(tmp_path, monkeypatch)
+        trajectory_file = xskill_home / "cc_sessions" / "traj_a.md"
+        trajectory_file.parent.mkdir()
+        trajectory_file.write_text("trajectory evidence line\n", encoding="utf-8")
+
+        out = agent_tools.read_file.entrypoint(str(trajectory_file))
+
+        assert "trajectory evidence line" in out
+
+    def test_read_file_denies_outside_roots(self, tmp_path, monkeypatch):
+        _setup_home(tmp_path, monkeypatch)
+        outside_file = tmp_path / "outside.txt"
+        outside_file.write_text("nope\n", encoding="utf-8")
+
+        out = agent_tools.read_file.entrypoint(str(outside_file))
+
+        assert out.startswith("error: outside allowed read roots")
+
+    def test_read_file_denies_sensitive_files(self, tmp_path, monkeypatch):
+        xskill_home, _skill_dir = _setup_home(tmp_path, monkeypatch)
+        for sensitive_name in (
+            "config.yaml", "team_client.json", "my_api_key.txt", "join-token.log",
+        ):
+            sensitive_file = xskill_home / sensitive_name
+            sensitive_file.write_text("s3cret\n", encoding="utf-8")
+            out = agent_tools.read_file.entrypoint(str(sensitive_file))
+            assert out.startswith("error: sensitive file"), sensitive_name
+            assert "s3cret" not in out
+
+    def test_read_file_allows_benign_names_with_substring(self, tmp_path, monkeypatch):
+        xskill_home, _skill_dir = _setup_home(tmp_path, monkeypatch)
+        benign_file = xskill_home / "monkey_notes.md"
+        benign_file.write_text("monkey business\n", encoding="utf-8")
+
+        out = agent_tools.read_file.entrypoint(str(benign_file))
+
+        assert "monkey business" in out
+
+    def test_list_files_allows_xskill_home(self, tmp_path, monkeypatch):
+        xskill_home, _skill_dir = _setup_home(tmp_path, monkeypatch)
+        logs_dir = xskill_home / "logs"
+        logs_dir.mkdir()
+        (logs_dir / "watcher.log").write_text("log line\n", encoding="utf-8")
+
+        listing = agent_tools.list_files.entrypoint(str(logs_dir))
+
+        assert "watcher.log" in listing
+
+    def test_list_files_denies_outside_roots(self, tmp_path, monkeypatch):
+        _setup_home(tmp_path, monkeypatch)
+
+        listing = agent_tools.list_files.entrypoint("/etc")
+
+        assert listing.startswith("error: list_files restricted")
+
+
+class TestGrepFiles:
+    def _seed_corpus(self, xskill_home):
+        corpus_dir = xskill_home / "cc_sessions"
+        corpus_dir.mkdir(exist_ok=True)
+        (corpus_dir / "traj_a.md").write_text(
+            "line one\nDOCKER_RESTART needed here\n", encoding="utf-8")
+        (corpus_dir / "traj_b.md").write_text("nothing here\n", encoding="utf-8")
+        (corpus_dir / "api_key.txt").write_text(
+            "DOCKER_RESTART secret ctx\n", encoding="utf-8")
+        return corpus_dir
+
+    def test_finds_matches_with_paths_and_line_numbers(self, tmp_path, monkeypatch):
+        xskill_home, _skill_dir = _setup_home(tmp_path, monkeypatch)
+        corpus_dir = self._seed_corpus(xskill_home)
+
+        out = agent_tools.grep_files.entrypoint(
+            "DOCKER_RESTART", path=str(corpus_dir),
+        )
+
+        assert out.startswith("engine: ")
+        assert f"{corpus_dir}/traj_a.md:2:" in out
+
+    def test_sensitive_files_filtered_from_hits(self, tmp_path, monkeypatch):
+        xskill_home, _skill_dir = _setup_home(tmp_path, monkeypatch)
+        corpus_dir = self._seed_corpus(xskill_home)
+
+        out = agent_tools.grep_files.entrypoint(
+            "DOCKER_RESTART", path=str(corpus_dir),
+        )
+
+        assert "api_key.txt" not in out
+
+    def test_denies_path_outside_roots(self, tmp_path, monkeypatch):
+        _setup_home(tmp_path, monkeypatch)
+
+        out = agent_tools.grep_files.entrypoint("x", path="/etc")
+
+        assert out.startswith("error: grep_files restricted")
+
+    def test_falls_back_to_grep_when_rg_missing(self, tmp_path, monkeypatch):
+        xskill_home, _skill_dir = _setup_home(tmp_path, monkeypatch)
+        corpus_dir = self._seed_corpus(xskill_home)
+        real_which = agent_tools.shutil.which
+        monkeypatch.setattr(
+            agent_tools.shutil, "which",
+            lambda name: None if name == "rg" else real_which(name),
+        )
+
+        out = agent_tools.grep_files.entrypoint(
+            "DOCKER_RESTART", path=str(corpus_dir),
+        )
+
+        assert "engine: grep" in out
+        assert "traj_a.md:2:" in out
+
+    def test_falls_back_to_python_when_no_grep_either(self, tmp_path, monkeypatch):
+        xskill_home, _skill_dir = _setup_home(tmp_path, monkeypatch)
+        corpus_dir = self._seed_corpus(xskill_home)
+        monkeypatch.setattr(agent_tools.shutil, "which", lambda name: None)
+
+        out = agent_tools.grep_files.entrypoint(
+            "DOCKER_RESTART", path=str(corpus_dir),
+        )
+
+        assert "engine: python" in out
+        assert "traj_a.md:2:" in out
+        assert "api_key.txt" not in out
+
+    def test_no_matches_reports_engine(self, tmp_path, monkeypatch):
+        xskill_home, _skill_dir = _setup_home(tmp_path, monkeypatch)
+        corpus_dir = self._seed_corpus(xskill_home)
+
+        out = agent_tools.grep_files.entrypoint(
+            "NO_SUCH_TOKEN_ANYWHERE", path=str(corpus_dir),
+        )
+
+        assert "(no matches" in out
+
+
+class TestSkillReadTree:
+    def test_returns_body_and_auxiliary_file_tree(self, tmp_path, monkeypatch):
+        _xskill_home, skill_dir = _setup_home(tmp_path, monkeypatch)
+        skill_path = skill_dir / "my-skill"
+        (skill_path / "references").mkdir(parents=True)
+        (skill_path / "SKILL.md").write_text(
+            "---\nname: my-skill\n---\n# body here\n", encoding="utf-8")
+        (skill_path / "references" / "notes.md").write_text(
+            "ref note\n", encoding="utf-8")
+        (skill_path / "candidates.yml").write_text(
+            "candidates: []\n", encoding="utf-8")
+
+        out = agent_tools.skill_read.entrypoint("my-skill")
+
+        assert f"skill_dir: {skill_path.resolve()}" in out
+        assert "body here" in out
+        assert "references/notes.md" in out
+        assert "candidates.yml" in out and "list_candidates" in out
+        assert "read_file" in out
+
+    def test_git_internals_excluded_from_tree(self, tmp_path, monkeypatch):
+        _xskill_home, skill_dir = _setup_home(tmp_path, monkeypatch)
+        skill_path = skill_dir / "git-skill"
+        (skill_path / ".git" / "objects").mkdir(parents=True)
+        (skill_path / ".git" / "HEAD").write_text("ref: x\n", encoding="utf-8")
+        (skill_path / "SKILL.md").write_text(
+            "---\nname: git-skill\n---\n# g\n", encoding="utf-8")
+
+        out = agent_tools.skill_read.entrypoint("git-skill")
+
+        assert ".git" not in out.split("skill_dir:")[1]
+
+    def test_missing_skill_md_keeps_placeholder_but_lists_files(
+        self, tmp_path, monkeypatch,
+    ):
+        _xskill_home, skill_dir = _setup_home(tmp_path, monkeypatch)
+        skill_path = skill_dir / "baby-skill"
+        skill_path.mkdir()
+        (skill_path / "candidates.yml").write_text(
+            "candidates: []\n", encoding="utf-8")
+
+        out = agent_tools.skill_read.entrypoint("baby-skill")
+
+        assert "no SKILL.md" in out
+        assert "candidates.yml" in out


### PR DESCRIPTION
Closes #91（设计见该 Issue）

## 改动

1. **读权限**：`read_file`/`list_files` 允许根从「skill 仓上一级 + /tmp spill」扩为「skill 仓上一级 + `XSKILL_HOME` + /tmp spill」，三工具共用 `_allowed_read_roots()`。新增敏感文件 denylist：`config.yaml`（llm.api_key）、`team_client.json`/`team_clients.db`（join_token）、`dashboard_secret.json`，以及文件名分词后含 secret/token/key/credential/password 的文件——skill 正文会分发全团队，宁可误挡不可漏放。写权限不变。
2. **`grep_files(pattern, path, glob, max_results)`**：ripgrep 优先；无 rg 降级 `grep -rnIE` 并在结果头部注明 + logger.warning（每进程一次，状态挂在 agent_tool_config 单例上）；连 grep 都没有（Windows 单机）降级纯 Python 扫描（2000 文件上限）。同一套根判定 + 命中行过滤敏感文件 + 30s 超时 + 10k 字符截断。输出「文件:行号:内容」可直接喂 read_file。
3. **`skill_read`**：返回 skill_dir 绝对路径、当前分支、SKILL.md 正文（带行数），以及除 `.git` 外的其余文件树（相对路径 + 大小；`candidates.yml` 标注用 list_candidates 读；上限 100 条 / 4 层）。无 SKILL.md 保留原 placeholder 语义但仍列文件树。
4. SkillEditAgent 常规与 jam 两条路径的工具列表注册 `grep_files`；prompt 工具清单加「先检索定位、再精读」指引。

## 测试

新增 `tests/test_agent_tools_explore.py` 15 例：XSKILL_HOME 可读/越界拒绝/敏感文件拒绝（含误伤对照 monkey_notes.md）/list_files 扩根/grep 三引擎（rg 实测、monkeypatch which 强制 grep 与 python 兜底）/敏感命中过滤/skill_read 树与 placeholder。全量 1280 passed（canary e2e 为 main 存量失败，已排除）。

🤖 Generated with [Claude Code](https://claude.com/claude-code)