### PR TITLE
feat(cli): xskill dashboard 免密一次性登录链接，点击即以自己身份进看板

### DIFF
--- a/src/xskill/cli.py
+++ b/src/xskill/cli.py
@@ -421,6 +421,56 @@ def cmd_update(args) -> int:
     return 0  # 不会到达这里
 
 
+def cmd_dashboard(args) -> int:
+    """向 server 要一条免密登录链接并打印：点开即以自己的身份进入看板。"""
+    import json
+    import urllib.error
+    import urllib.request
+    from xskill.config import get_team_client_state_path
+    from xskill.team.client.state import load_client_state
+
+    state_path = get_team_client_state_path()
+    if not state_path.is_file():
+        from xskill.runtime import read_status
+        status = read_status()
+        if status.get("running"):
+            print(f"本机看板: http://127.0.0.1:{status.get('port')}/")
+            return 0
+        print("error: 未连接 team server，本机也没有运行中的 serve。\n"
+              "  先跑：xskill connect <host:port> --token <t> --name <你的名字>",
+              file=sys.stderr)
+        return 1
+    state = load_client_state(state_path)
+    server_base = state.server_url.rstrip("/")
+    request = urllib.request.Request(
+        f"{server_base}/api/v1/team/dashboard_link",
+        method="POST",
+        headers={
+            "X-Xskill-Token": state.join_token,
+            "X-Xskill-Client": state.client_id,
+        },
+    )
+    try:
+        with urllib.request.urlopen(request, timeout=10) as response:
+            link_info = json.loads(response.read().decode("utf-8"))
+    except urllib.error.HTTPError as http_error:
+        detail = http_error.read().decode("utf-8", "replace")[:300]
+        if http_error.code == 404:
+            print("error: server 版本过旧，不支持免密链接（需 ≥0.6.14），"
+                  "请管理员先升级 server", file=sys.stderr)
+        else:
+            print(f"error: server 拒绝签发登录链接（HTTP {http_error.code}）: "
+                  f"{detail}", file=sys.stderr)
+        return 1
+    except Exception as network_error:
+        print(f"error: 连不上 server: {network_error}", file=sys.stderr)
+        return 1
+    print(f"身份: {link_info['user']}")
+    print("免密登录链接（10 分钟内有效，仅可用一次）:")
+    print(f"  {server_base}{link_info['path']}")
+    return 0
+
+
 def cmd_stop(args) -> int:
     """停止并撤销 connect 常驻任务。"""
     from xskill.team.client.service import ServiceError, get_backend
@@ -716,6 +766,11 @@ def build_parser() -> argparse.ArgumentParser:
     sub.add_parser("update", help="立即检查 PyPI 新版并升级（有新版则重启）")
     p_status.add_argument("--json", action="store_true", help="机读 JSON 输出")
 
+    sub.add_parser(
+        "dashboard",
+        help="打印免密登录链接，点击即以自己的身份进入 server 看板",
+    )
+
     p_stats = sub.add_parser(
         "stats", help="Show token usage & estimated cost (Issue #43)",
     )
@@ -814,6 +869,8 @@ def main() -> int:
         return cmd_status(args)
     if args.command == "update":
         return cmd_update(args)
+    if args.command == "dashboard":
+        return cmd_dashboard(args)
 
     # stats 只读 registry，不需要 config.yaml / llm.api_key / facade
     if args.command == "stats":

--- a/src/xskill/cli.py
+++ b/src/xskill/cli.py
@@ -468,6 +468,7 @@ def cmd_dashboard(args) -> int:
     print(f"身份: {link_info['user']}")
     print("免密登录链接（10 分钟内有效，仅可用一次）:")
     print(f"  {server_base}{link_info['path']}")
+    print("  （打不开时：需 server 看板允许远程访问，见 dashboard.public 配置）")
     return 0
 
 

--- a/src/xskill/dashboard/auth.py
+++ b/src/xskill/dashboard/auth.py
@@ -136,7 +136,9 @@ class _AuthContext:
         self.signer: SessionSigner | None = None
         self.admins: list[str] = []
         self.admin_password: str = ""
-        self.redeemed_link_ids: dict[str, float] = {}  # link_id → 过期时刻
+        # link_id → 过期时刻。单次性依赖单进程（uvicorn 单 worker）；重启清空
+        # 意味着已兑换链接在剩余时效内可再兑换一次，多 worker 部署前须挪持久层。
+        self.redeemed_link_ids: dict[str, float] = {}
         # 零参 callable → ClientRegistry | None。用 provider 而非实例:
         # mount_dashboard 在 create_app 时跑,而 ClientRegistry 在 app startup
         # 才创建(team ctx 初始化),登录时才解引用。

--- a/src/xskill/dashboard/auth.py
+++ b/src/xskill/dashboard/auth.py
@@ -27,12 +27,16 @@ from pathlib import Path
 from typing import Optional
 
 from fastapi import APIRouter, HTTPException, Request, Response
+from fastapi.responses import RedirectResponse
 from pydantic import BaseModel
 
 logger = logging.getLogger("xskill.dashboard.auth")
 
 SESSION_COOKIE = "xskill_session"
 SESSION_TTL_SECONDS = 7 * 24 * 3600
+
+# 免密登录链接的时效：够用户从终端复制点开，不够链接泄露后被长期滥用。
+LOGIN_LINK_TTL_SECONDS = 600
 
 
 # ---------------------------------------------------------------------------
@@ -73,24 +77,21 @@ class SessionSigner:
     def __init__(self, secret: str):
         self._key = secret.encode()
 
-    def sign(self, user: str, role: str, *, ttl: int = SESSION_TTL_SECONDS) -> str:
-        payload = json.dumps(
-            {"u": user, "r": role, "exp": int(time.time()) + ttl},
-            separators=(",", ":"),
-        ).encode()
-        sig = hmac.new(self._key, payload, hashlib.sha256).digest()
-        return f"{_b64e(payload)}.{_b64e(sig)}"
+    def _signed(self, payload_dict: dict) -> str:
+        payload = json.dumps(payload_dict, separators=(",", ":")).encode()
+        signature = hmac.new(self._key, payload, hashlib.sha256).digest()
+        return f"{_b64e(payload)}.{_b64e(signature)}"
 
-    def verify(self, token: str) -> Optional[dict]:
-        """合法且未过期 → {"user":…, "role":…}；否则 None。"""
+    def _verified(self, token: str) -> Optional[dict]:
+        """签名合法且未过期 → payload dict；否则 None。"""
         try:
             p64, s64 = token.split(".", 1)
             payload = _b64d(p64)
-            sig = _b64d(s64)
+            signature = _b64d(s64)
         except (ValueError, TypeError):
             return None
         want = hmac.new(self._key, payload, hashlib.sha256).digest()
-        if not hmac.compare_digest(sig, want):
+        if not hmac.compare_digest(signature, want):
             return None
         try:
             data = json.loads(payload)
@@ -98,7 +99,32 @@ class SessionSigner:
             return None
         if int(data.get("exp", 0)) < time.time():
             return None
+        return data
+
+    def sign(self, user: str, role: str, *, ttl: int = SESSION_TTL_SECONDS) -> str:
+        return self._signed({"u": user, "r": role, "exp": int(time.time()) + ttl})
+
+    def verify(self, token: str) -> Optional[dict]:
+        """合法且未过期 → {"user":…, "role":…}；否则 None。"""
+        data = self._verified(token)
+        # 一次性登录链接 token 不得当会话 cookie 用（未过兑换闸就无单次性保证）。
+        if data is None or data.get("ott"):
+            return None
         return {"user": data.get("u", ""), "role": data.get("r", "")}
+
+    def sign_login_link(self, user: str, *,
+                        ttl: int = LOGIN_LINK_TTL_SECONDS) -> str:
+        return self._signed({
+            "u": user, "r": "user", "ott": secrets.token_hex(8),
+            "exp": int(time.time()) + ttl,
+        })
+
+    def verify_login_link(self, token: str) -> Optional[dict]:
+        """合法、未过期且带 ott 标记 → {"user", "link_id"}；否则 None。"""
+        data = self._verified(token)
+        if data is None or not data.get("ott"):
+            return None
+        return {"user": data.get("u", ""), "link_id": str(data["ott"])}
 
 
 # ---------------------------------------------------------------------------
@@ -110,6 +136,7 @@ class _AuthContext:
         self.signer: SessionSigner | None = None
         self.admins: list[str] = []
         self.admin_password: str = ""
+        self.redeemed_link_ids: dict[str, float] = {}  # link_id → 过期时刻
         # 零参 callable → ClientRegistry | None。用 provider 而非实例:
         # mount_dashboard 在 create_app 时跑,而 ClientRegistry 在 app startup
         # 才创建(team ctx 初始化),登录时才解引用。
@@ -127,6 +154,17 @@ def configure_auth(*, secret: str, admins: list[str], admin_password: str,
     _ctx.admins = [a.strip() for a in admins if a and a.strip()]
     _ctx.admin_password = admin_password or ""
     _ctx.registry_provider = registry_provider
+
+
+def issue_login_link_token(user_name: str) -> Optional[str]:
+    """给命名用户签发一次性登录链接 token；auth 未配置（dashboard 关）→ None。
+
+    供 team server 的 ``/api/v1/team/dashboard_link`` 调用；角色恒 user——
+    admin 必须走口令登录（Q2a），免密链接不发放 admin 会话。
+    """
+    if _ctx.signer is None:
+        return None
+    return _ctx.signer.sign_login_link(user_name)
 
 
 def _identity_from_request(request: Request) -> Optional[dict]:
@@ -183,6 +221,35 @@ def build_auth_router() -> APIRouter:
             max_age=SESSION_TTL_SECONDS, httponly=True, samesite="lax",
         )
         return {"user": user, "role": role}
+
+    @router.get("/login/link")
+    def login_link(t: str):
+        """兑换一次性登录链接：种会话 cookie 并 303 跳看板首页。"""
+        if _ctx.signer is None:
+            raise HTTPException(status_code=503, detail="auth not configured")
+        link_data = _ctx.signer.verify_login_link(t)
+        if link_data is None:
+            raise HTTPException(
+                status_code=401,
+                detail="链接无效或已过期，请重新执行 xskill dashboard",
+            )
+        now = time.time()
+        _ctx.redeemed_link_ids = {
+            link_id: expiry
+            for link_id, expiry in _ctx.redeemed_link_ids.items() if expiry > now
+        }
+        if link_data["link_id"] in _ctx.redeemed_link_ids:
+            raise HTTPException(
+                status_code=401,
+                detail="链接已被使用，请重新执行 xskill dashboard",
+            )
+        _ctx.redeemed_link_ids[link_data["link_id"]] = now + LOGIN_LINK_TTL_SECONDS
+        redirect = RedirectResponse("/", status_code=303)
+        redirect.set_cookie(
+            SESSION_COOKIE, _ctx.signer.sign(link_data["user"], "user"),
+            max_age=SESSION_TTL_SECONDS, httponly=True, samesite="lax",
+        )
+        return redirect
 
     @router.post("/logout")
     def logout(response: Response):

--- a/src/xskill/team/server/api.py
+++ b/src/xskill/team/server/api.py
@@ -340,6 +340,35 @@ async def team_version(
     }
 
 
+@router.post("/dashboard_link")
+async def team_dashboard_link(
+    x_xskill_token: str | None = Header(default=None),
+    x_xskill_client: str | None = Header(default=None),
+) -> dict:
+    """给已命名 client 签发一次性看板登录链接（``xskill dashboard`` 用）。"""
+    client_id = _auth(x_xskill_token, x_xskill_client)
+    client_row = (
+        _ctx.client_registry.get(client_id)
+        if _ctx.client_registry is not None else None
+    )
+    user_name = str((client_row or {}).get("user_name") or "").strip()
+    if not user_name:
+        raise HTTPException(
+            status_code=400,
+            detail="匿名 client 无面板身份：先 `xskill connect <host:port> "
+                   "--token <t> --name <你的名字>` 注册命名身份",
+        )
+    from xskill.dashboard.auth import issue_login_link_token
+    link_token = issue_login_link_token(user_name)
+    if link_token is None:
+        raise HTTPException(status_code=503, detail="server 未启用 dashboard 登录")
+    logger.info("dashboard link issued: client=%s user=%s", client_id, user_name)
+    return {
+        "user": user_name,
+        "path": f"/api/v1/dashboard/login/link?t={link_token}",
+    }
+
+
 @router.get("/wheel")
 async def team_wheel(
     x_xskill_token: str | None = Header(default=None),

--- a/tests/test_dashboard_login_link.py
+++ b/tests/test_dashboard_login_link.py
@@ -1,0 +1,187 @@
+"""免密登录链接（xskill dashboard）：签发 / 兑换 / 单次性 / 不可冒充会话。"""
+from __future__ import annotations
+
+import time
+
+import pytest
+from fastapi import FastAPI
+from fastapi.testclient import TestClient
+
+from xskill.cli import build_parser, cmd_dashboard
+from xskill.dashboard.auth import (
+    SESSION_COOKIE,
+    build_auth_router,
+    configure_auth,
+    ensure_dashboard_secret,
+    issue_login_link_token,
+)
+from xskill.team.server import api as server_api
+from xskill.team.server.client_registry import ClientRegistry
+
+
+@pytest.fixture()
+def link_env(tmp_path):
+    registry = ClientRegistry(tmp_path / "c.db")
+    named_client_id = registry.register(user_name="alice")
+    anonymous_client_id = registry.register()
+    server_api.init_team_context(
+        join_token="jt", client_registry=registry,
+        skill_dir=tmp_path / "skills", traj_root=tmp_path / "traj",
+        probability=0.2, ranked_slots=2, total_slots=3,
+        register_dir=lambda p, l: None,
+    )
+    configure_auth(
+        secret=ensure_dashboard_secret(tmp_path / "sec.json"),
+        admins=[], admin_password="",
+        registry_provider=lambda: registry,
+    )
+    app = FastAPI()
+    app.include_router(build_auth_router())
+    app.include_router(server_api.router)
+    return {
+        "app": app,
+        "named_client_id": named_client_id,
+        "anonymous_client_id": anonymous_client_id,
+    }
+
+
+def _team_headers(client_id):
+    return {"X-Xskill-Token": "jt", "X-Xskill-Client": client_id}
+
+
+class TestIssueEndpoint:
+    def test_named_client_gets_link(self, link_env):
+        client = TestClient(link_env["app"])
+        r = client.post("/api/v1/team/dashboard_link",
+                        headers=_team_headers(link_env["named_client_id"]))
+        assert r.status_code == 200
+        assert r.json()["user"] == "alice"
+        assert r.json()["path"].startswith("/api/v1/dashboard/login/link?t=")
+
+    def test_anonymous_client_rejected(self, link_env):
+        client = TestClient(link_env["app"])
+        r = client.post("/api/v1/team/dashboard_link",
+                        headers=_team_headers(link_env["anonymous_client_id"]))
+        assert r.status_code == 400
+        assert "--name" in r.json()["detail"]
+
+    def test_bad_token_rejected(self, link_env):
+        client = TestClient(link_env["app"])
+        r = client.post("/api/v1/team/dashboard_link", headers={
+            "X-Xskill-Token": "wrong",
+            "X-Xskill-Client": link_env["named_client_id"],
+        })
+        assert r.status_code == 401
+
+
+class TestRedeem:
+    def _issue_path(self, link_env):
+        client = TestClient(link_env["app"])
+        r = client.post("/api/v1/team/dashboard_link",
+                        headers=_team_headers(link_env["named_client_id"]))
+        return r.json()["path"]
+
+    def test_link_logs_in_as_self_and_redirects(self, link_env):
+        path = self._issue_path(link_env)
+        client = TestClient(link_env["app"])
+
+        r = client.get(path, follow_redirects=False)
+
+        assert r.status_code == 303
+        assert r.headers["location"] == "/"
+        assert SESSION_COOKIE in r.cookies
+        me = client.get("/api/v1/dashboard/me")
+        assert me.status_code == 200
+        assert me.json() == {"user": "alice", "role": "user"}
+
+    def test_link_is_single_use(self, link_env):
+        path = self._issue_path(link_env)
+        first_client = TestClient(link_env["app"])
+        assert first_client.get(
+            path, follow_redirects=False,
+        ).status_code == 303
+
+        second_client = TestClient(link_env["app"])
+        r = second_client.get(path, follow_redirects=False)
+
+        assert r.status_code == 401
+        assert "已被使用" in r.json()["detail"]
+
+    def test_tampered_token_rejected(self, link_env):
+        path = self._issue_path(link_env)
+        client = TestClient(link_env["app"])
+
+        r = client.get(path[:-4] + "AAAA", follow_redirects=False)
+
+        assert r.status_code == 401
+
+    def test_expired_link_rejected(self, link_env, monkeypatch):
+        path = self._issue_path(link_env)
+        client = TestClient(link_env["app"])
+        real_time = time.time
+        monkeypatch.setattr(time, "time", lambda: real_time() + 601)
+
+        r = client.get(path, follow_redirects=False)
+
+        assert r.status_code == 401
+
+    def test_link_token_cannot_be_used_as_session_cookie(self, link_env):
+        link_token = issue_login_link_token("alice")
+        client = TestClient(link_env["app"], cookies={SESSION_COOKIE: link_token})
+
+        me = client.get("/api/v1/dashboard/me")
+
+        assert me.status_code == 401, "ott token 直接当会话 cookie 必须被拒"
+
+
+class TestCmdDashboard:
+    def test_prints_clickable_url(self, monkeypatch, tmp_path, capsys):
+        import json
+        state_file = tmp_path / "team_client.json"
+        state_file.write_text(json.dumps({
+            "server_url": "http://srv:8000",
+            "client_id": "cid",
+            "join_token": "jt",
+        }), encoding="utf-8")
+        monkeypatch.setattr(
+            "xskill.config.get_team_client_state_path", lambda: state_file,
+        )
+
+        class _FakeResponse:
+            def read(self):
+                return json.dumps({
+                    "user": "alice",
+                    "path": "/api/v1/dashboard/login/link?t=abc.def",
+                }).encode("utf-8")
+
+            def __enter__(self):
+                return self
+
+            def __exit__(self, *exc_info):
+                return False
+
+        captured_requests: list = []
+
+        def fake_urlopen(request, timeout=0):
+            captured_requests.append(request)
+            return _FakeResponse()
+
+        monkeypatch.setattr("urllib.request.urlopen", fake_urlopen)
+
+        args = build_parser().parse_args(["dashboard"])
+        assert cmd_dashboard(args) == 0
+        printed = capsys.readouterr().out
+        assert "http://srv:8000/api/v1/dashboard/login/link?t=abc.def" in printed
+        assert "alice" in printed
+        assert captured_requests[0].headers["X-xskill-token"] == "jt"
+
+    def test_no_state_and_no_local_serve_errors(self, monkeypatch, tmp_path, capsys):
+        monkeypatch.setattr(
+            "xskill.config.get_team_client_state_path",
+            lambda: tmp_path / "absent.json",
+        )
+        monkeypatch.setattr("xskill.runtime.read_status", lambda: {"running": False})
+
+        args = build_parser().parse_args(["dashboard"])
+        assert cmd_dashboard(args) == 1
+        assert "connect" in capsys.readouterr().err

--- a/tests/test_dashboard_login_link.py
+++ b/tests/test_dashboard_login_link.py
@@ -185,3 +185,14 @@ class TestCmdDashboard:
         args = build_parser().parse_args(["dashboard"])
         assert cmd_dashboard(args) == 1
         assert "connect" in capsys.readouterr().err
+
+
+def test_issue_endpoint_503_when_team_context_missing(link_env, monkeypatch):
+    """standalone（无 team ctx）：签发端点须 503 而非 500。"""
+    monkeypatch.setattr(server_api._ctx, "client_registry", None)
+    client = TestClient(link_env["app"])
+
+    r = client.post("/api/v1/team/dashboard_link",
+                    headers=_team_headers(link_env["named_client_id"]))
+
+    assert r.status_code == 503


### PR DESCRIPTION
Closes #95

## 用法

```
$ xskill dashboard
身份: alice
免密登录链接（10 分钟内有效，仅可用一次）:
  http://srv:8000/api/v1/dashboard/login/link?t=eyJ1IjoiYWxpY2Ui...
```

点开 → 种会话 cookie → 303 跳看板首页，身份 = 自己（ClientRegistry 里的 user_name）。

## 实现

- **签发**（server）：`POST /api/v1/team/dashboard_link`，走既有 team `_auth`（join_token + client_id），从 ClientRegistry 解析 user_name。匿名 client 400（引导 `connect --name`）；dashboard 未启用 503。签发留 `dashboard link issued: client=… user=…` 日志。
- **token**：复用 dashboard 会话 HMAC secret；`SessionSigner` 拆出 `_signed`/`_verified` 共用底座，新增 `sign_login_link`/`verify_login_link`——payload 带随机 `ott` id、时效 600s。
- **兑换**：`GET /api/v1/dashboard/login/link?t=`：验签 → 查已兑换表（内存 dict，随过期自清）→ 单次性（二次点击 401「已被使用」）→ 种 7 天会话 cookie → 303 `/`。**角色恒 user**：admin 会话必须走口令登录（沿用 Q2a 政策）。
- **防降级**：会话 `verify()` 显式拒绝带 `ott` 标记的 payload——链接 token 直接塞进 cookie 无效，必须过兑换闸（有测试锁死）。
- **client**：`xskill dashboard` 读 `team_client.json` 请求并打印完整 URL；未 connect 但本机有 serve → 打印本机看板地址；server 404 → 提示需先升级 server。

## 测试

`tests/test_dashboard_login_link.py` 10 例：命名/匿名/坏凭据签发、兑换登录（cookie + `/me` 身份 + 303）、单次性、篡改拒绝、过期拒绝、**ott 冒充会话 cookie 被拒**、CLI 打印与请求头、未连接报错。全量 1299 passed（canary e2e 存量失败已排除）。

🤖 Generated with [Claude Code](https://claude.com/claude-code)