### PR TITLE
fix(dashboard): 命名用户画像散点 404——scatter 端点按 user_name 反查 client_id

### DIFF
--- a/src/xskill/dashboard/router.py
+++ b/src/xskill/dashboard/router.py
@@ -515,11 +515,30 @@ def _register_explorer_endpoints(router: APIRouter, db_path: Optional[Path],
         if not pdb.is_file():
             raise HTTPException(status_code=404,
                                 detail="画像库不存在(team 模式未启用或还没有画像)")
+        profile_viz = ProfileViz(pdb, skill_dir=skill_dir, db_path=db_path,
+                                 skillhub_index=skillhub_index_for(db_path))
         try:
-            return ProfileViz(pdb, skill_dir=skill_dir, db_path=db_path,
-                              skillhub_index=skillhub_index_for(db_path)
-                              ).user_scatter(user_key, method=method)
-        except KeyError as e:
-            raise HTTPException(status_code=404, detail=str(e)) from e
+            return profile_viz.user_scatter(user_key, method=method)
         except ValueError as e:
             raise HTTPException(status_code=400, detail=str(e)) from e
+        except KeyError as e:
+            # 画像按 client_id 存,而看板行的 uid 对命名用户是 user_name(#97)
+            # ——按名反查 client_id 重试,匿名/未知名字保持 404。
+            from xskill.config import get_registry_db_path
+            from xskill.team.server.client_registry import ClientRegistry
+            db_dir = Path(db_path).parent if db_path else get_registry_db_path().parent
+            clients_db = db_dir / "team_clients.db"
+            resolved_client_id = None
+            if clients_db.is_file():
+                try:
+                    resolved_client_id = ClientRegistry(
+                        clients_db).find_by_user_name(user_key)
+                except ValueError:
+                    resolved_client_id = None
+            if not resolved_client_id or resolved_client_id == user_key:
+                raise HTTPException(status_code=404, detail=str(e)) from e
+            try:
+                return profile_viz.user_scatter(resolved_client_id, method=method)
+            except KeyError as retry_error:
+                raise HTTPException(
+                    status_code=404, detail=str(retry_error)) from retry_error

--- a/tests/test_dashboard_p3.py
+++ b/tests/test_dashboard_p3.py
@@ -612,3 +612,37 @@ def test_cluster_graph_endpoint_admin_only(console_env):
     r = boss.get("/api/v1/dashboard/admin/cluster-graph")
     assert r.status_code == 200
     assert {n["user"] for n in r.json()["nodes"]} == {"alice", "bob", "carol"}
+
+
+def test_scatter_endpoint_resolves_user_name_to_client_id(tmp_path):
+    """#97:画像按 client_id 存,看板行 uid 对命名用户是 user_name——端点须按名回退。"""
+    from fastapi import FastAPI
+    from fastapi.testclient import TestClient
+    from xskill.dashboard.router import build_dashboard_router
+    from xskill.team.server.client_registry import ClientRegistry
+
+    registry_db = tmp_path / "registry.db"
+    registry_db.touch()
+    named_client_id = ClientRegistry(
+        tmp_path / "team_clients.db").register(user_name="m00947023")
+    profile_store = ProfileStore(tmp_path / "team_profile.db")
+    pts = np.eye(4, dtype=float)[:3]
+    meta = [{"atom_id": f"atom_x_{i:04d}", "summary": "s", "traj_id": "x",
+             "ts": ""} for i in range(3)]
+    profile_store.upsert(named_client_id, feature_tensor=pts[:1],
+                         mean_tensor=pts.mean(0),
+                         used_skills=[], points=pts, point_meta=meta)
+
+    app = FastAPI()
+    app.include_router(build_dashboard_router(db_path=registry_db))
+    client = TestClient(app)
+
+    by_name = client.get("/api/v1/dashboard/user/m00947023/scatter?method=tsne")
+    assert by_name.status_code == 200, by_name.text
+    assert len(by_name.json()["points"]) == 3
+
+    by_client_id = client.get(f"/api/v1/dashboard/user/{named_client_id}/scatter")
+    assert by_client_id.status_code == 200
+
+    unknown = client.get("/api/v1/dashboard/user/nobody/scatter")
+    assert unknown.status_code == 404


### PR DESCRIPTION
Closes #97

企业用户上报：`GET /api/v1/dashboard/user/m00947023/scatter?method=tsne` → 404。

根因是键不一致：画像库按 **client_id** 存（`/sync` → `update_user_interest(ClientInterest(client_id))`），看板行 uid 对命名用户是 **user_name**——所有 `connect --name` 用户的画像散点都 404，只有匿名 client 能用。

修复：端点 KeyError 时按 `ClientRegistry.find_by_user_name`（与注册同套 `_normalize_user_name` 口径）解析成 client_id 重试；独立只读实例沿用 users_status 的 team_clients.db 同目录推导；未知名字保持 404。

测试：`test_scatter_endpoint_resolves_user_name_to_client_id`（按名 200 / 按 client_id 200 / 未知 404）。全量 1290 passed（canary e2e 存量失败已排除）。

🤖 Generated with [Claude Code](https://claude.com/claude-code)