### PR TITLE
fix(dashboard): UMAP 散点全批斥力随点数膨胀致大样本布局爆炸重叠

### DIFF
--- a/src/xskill/dashboard/profile_viz.py
+++ b/src/xskill/dashboard/profile_viz.py
@@ -330,11 +330,17 @@ class _UMAP2D:
         return y / scale * 10.0  # 缩放到 ±10（umap 同款初始尺度）
 
     # ── 交叉熵布局（全批）────────────────────────────────────────
+    _MAX_STEP_NORM = 4.0  # 单点每轮位移范数上限(对齐 umap-learn 逐负样本 clip 的量级)
+
     def _optimize(self, y: np.ndarray, graph: np.ndarray,
                   a: float, b: float) -> np.ndarray:
         n = y.shape[0]
         neg = 1.0 - graph
         np.fill_diagonal(neg, 0.0)
+        # 全批斥力项数=n,随 n 线性膨胀;缩回 umap-learn 负采样等价量级(~5*k),避免大 n 时首轮步长爆炸把点甩飞。
+        neighbor_k = min(self._n_neighbors, n - 1)
+        neg_row_mass = float(neg.sum(axis=1).mean())
+        rep_scale = (5.0 * neighbor_k / neg_row_mass) if neg_row_mass > 0 else 1.0
         for epoch in range(self._n_epochs):
             alpha = self._init_alpha * (1.0 - epoch / self._n_epochs)
             diff = y[:, None, :] - y[None, :, :]     # (n,n,2)
@@ -346,11 +352,13 @@ class _UMAP2D:
             # 吸引力系数（沿边,权重=模糊隶属度）
             att = np.zeros((n, n))
             att[pos] = (-2.0 * a * b * np.power(d2[pos], b - 1.0)) / denom[pos]
-            # 斥力系数（负采样,权重=非隶属度）
+            # 斥力系数（负采样,权重=非隶属度,缩放见上）
             rep = np.zeros((n, n))
             rep[pos] = (2.0 * self._gamma * b) / ((0.001 + d2[pos]) * denom[pos])
-            coeff = graph * att + neg * rep          # (n,n)
+            coeff = graph * att + rep_scale * neg * rep  # (n,n)
             step = np.clip(coeff[:, :, None] * diff, -4.0, 4.0).sum(axis=1)
+            step_norm = np.linalg.norm(step, axis=1, keepdims=True)
+            step = step * np.minimum(1.0, self._MAX_STEP_NORM / np.maximum(step_norm, 1e-12))
             y = y + alpha * step
         return y - y.mean(axis=0)
 

--- a/tests/test_dashboard_p3.py
+++ b/tests/test_dashboard_p3.py
@@ -313,6 +313,44 @@ def test_scatter_umap_method(tmp_path):
     assert np.allclose(xy, xy2)
 
 
+def test_scatter_umap_many_points_no_blowup(tmp_path):
+    """回归:全批斥力项数随点数线性增长,曾在 n≈300 时首轮步长爆炸,把布局
+    甩飞到初始尺度几十倍远、三簇挤成一团重叠——真实 qwen 向量画像上观察到
+    的现象。这里造 3×100=300 点(命中 _SCATTER_MAX_POINTS 上限,不触发抽样)
+    复现该规模,断言三簇仍分得开、坐标不发散。"""
+    pdb = tmp_path / "p.db"
+    store = ProfileStore(pdb)
+    rng = np.random.default_rng(1)
+    dim = 8
+    centers = np.eye(3, dim)
+    points, point_meta = [], []
+    for cluster_id in range(3):
+        for atom_id in range(100):  # 3×100 = 300 == _SCATTER_MAX_POINTS,不抽样
+            vector = centers[cluster_id] + 0.15 * rng.standard_normal(dim)
+            vector = vector / np.linalg.norm(vector)
+            points.append(vector)
+            point_meta.append({"atom_id": f"a_{cluster_id}_{atom_id}",
+                               "summary": f"s{cluster_id}{atom_id}", "ux": 7,
+                               "tags": [f"t{cluster_id}"]})
+    points = np.asarray(points)
+    store.upsert("u", feature_tensor=centers, mean_tensor=points.mean(0),
+                 used_skills=[], points=points, point_meta=point_meta)
+    scatter = ProfileViz(pdb).user_scatter("u", method="umap")
+    assert scatter["sampled"] is False and scatter["total"] == 300
+    xy = np.array([[p["x"], p["y"]] for p in scatter["points"]])
+    assignment = np.array([p["cluster"] for p in scatter["points"]])
+    cluster_means = [xy[assignment == cluster_id].mean(axis=0) for cluster_id in range(3)]
+    cluster_spreads = [np.linalg.norm(xy[assignment == cluster_id] - cluster_means[cluster_id],
+                                      axis=1).mean() for cluster_id in range(3)]
+    for i in range(3):
+        for j in range(i + 1, 3):
+            between = np.linalg.norm(cluster_means[i] - cluster_means[j])
+            assert between > 2.0 * max(cluster_spreads[i], cluster_spreads[j])
+    # 爆炸时单点会被甩到离质心几十倍远;正常收敛的全体坐标半径应与簇间距同量级。
+    overall_radius = np.linalg.norm(xy - xy.mean(axis=0), axis=1)
+    assert overall_radius.max() < 20.0 * np.median(overall_radius)
+
+
 def test_scatter_unknown_method_rejected(tmp_path):
     pdb = tmp_path / "p.db"
     _seed_profile(pdb)


### PR DESCRIPTION
## Summary
- 用户反馈真实 qwen 向量画像上 UMAP 散点大量重叠;排查确认根因是 `_UMAP2D._optimize` 的全批斥力项数=n,总量随点数线性膨胀——n=300 时 epoch 0 首步单点位移达 119(初始谱布局半径才 ~10),点被甩飞后学习率线性衰减收不回来,表现为多簇挤成一团重叠 + 离群点把坐标系撑得巨大。用同一批构造语料测得 silhouette 0.225,而 umap-learn 参照实现是 0.726。
- `_preprocess_embeddings`(各向异性修正 + PCA 预降维,即用户怀疑的"embedding 正则化")经排查与此**无关且本身有益**——同一份数据上有它 t-SNE silhouette 更高(0.570 vs 0.500 raw),没有改动。
- 修复:斥力总量缩放到 umap-learn 负采样等价量级(`5 * n_neighbors`),并给每点每轮的位移加范数上限,对齐 umap-learn 的 clip 语义。全程仍无随机数,确定性不变。
- 新增回归测试 `test_scatter_umap_many_points_no_blowup`:3 簇 × 100 点(命中 `_SCATTER_MAX_POINTS=300` 上限、不触发抽样)复现该规模,断言簇间距 > 2× 簇内散布、坐标半径不发散。已验证该测试在修复前的代码上会失败(某簇散布达到与另一簇质心距离的 4 倍以上),修复后通过。

## Test plan
- [x] `pytest tests/test_dashboard_p3.py -q` — 32 passed(含新增回归用例,且已验证其在修复前失败)
- [x] `pytest tests/ -q --ignore=tests/e2e --deselect tests/test_e2e_xskill_serve_auto.py::test_canary_flip_promote_and_install_new_version` — 1300 passed(排除的 e2e 用例在本沙箱环境因执行 `claude` 二进制 `exec format error` 失败,与本改动无关,基线同样失败)

🤖 Generated with [Claude Code](https://claude.com/claude-code)