### PR TITLE
test(dashboard): UMAP 回归测试加码——6 簇不均匀、n=520、直调 _UMAP2D

### DIFF
--- a/tests/test_dashboard_p3.py
+++ b/tests/test_dashboard_p3.py
@@ -314,10 +314,7 @@ def test_scatter_umap_method(tmp_path):
 
 
 def test_scatter_umap_many_points_no_blowup(tmp_path):
-    """回归:全批斥力项数随点数线性增长,曾在 n≈300 时首轮步长爆炸,把布局
-    甩飞到初始尺度几十倍远、三簇挤成一团重叠——真实 qwen 向量画像上观察到
-    的现象。这里造 3×100=300 点(命中 _SCATTER_MAX_POINTS 上限,不触发抽样)
-    复现该规模,断言三簇仍分得开、坐标不发散。"""
+    """回归:3×100=300 点(命中 _SCATTER_MAX_POINTS 上限,不触发抽样)下 UMAP 布局不发散,三簇仍分得开。"""
     pdb = tmp_path / "p.db"
     store = ProfileStore(pdb)
     rng = np.random.default_rng(1)
@@ -349,6 +346,36 @@ def test_scatter_umap_many_points_no_blowup(tmp_path):
     # 爆炸时单点会被甩到离质心几十倍远;正常收敛的全体坐标半径应与簇间距同量级。
     overall_radius = np.linalg.norm(xy - xy.mean(axis=0), axis=1)
     assert overall_radius.max() < 20.0 * np.median(overall_radius)
+
+
+def test_umap_direct_fleet_scale_clusters_separate():
+    """直调 _UMAP2D(绕过看板 300 点抽样上限):6 簇不均匀、更高维、n=520,全批斥力不随规模爆炸。"""
+    from xskill.dashboard.profile_viz import _UMAP2D
+    cluster_sizes = [180, 130, 90, 60, 40, 20]
+    dim = 32
+    rng = np.random.default_rng(3)
+    cluster_centers = np.eye(len(cluster_sizes), dim)
+    points, labels = [], []
+    for cluster_id, size in enumerate(cluster_sizes):
+        for _ in range(size):
+            vector = cluster_centers[cluster_id] + 0.20 * rng.standard_normal(dim)
+            points.append(vector / np.linalg.norm(vector))
+            labels.append(cluster_id)
+    points = np.asarray(points)
+    labels = np.asarray(labels)
+    coords = _UMAP2D(n_epochs=250).fit(points)
+    radius = np.linalg.norm(coords - coords.mean(axis=0), axis=1)
+    assert radius.max() < 40.0  # 爆炸态观测半径达三百余,收敛态应在数十以内
+    cluster_means = [coords[labels == cluster_id].mean(axis=0)
+                     for cluster_id in range(len(cluster_sizes))]
+    cluster_spreads = [np.linalg.norm(coords[labels == cluster_id] - cluster_means[cluster_id],
+                                      axis=1).mean() for cluster_id in range(len(cluster_sizes))]
+    for i in range(len(cluster_sizes)):
+        for j in range(i + 1, len(cluster_sizes)):
+            between = np.linalg.norm(cluster_means[i] - cluster_means[j])
+            assert between > 3.0 * max(cluster_spreads[i], cluster_spreads[j])
+    coords_again = _UMAP2D(n_epochs=250).fit(points)
+    assert np.allclose(coords, coords_again)
 
 
 def test_scatter_unknown_method_rejected(tmp_path):


### PR DESCRIPTION
## Summary
- 跟进 #99(UMAP 全批斥力随点数膨胀爆炸的修复)。原回归测试 `test_scatter_umap_many_points_no_blowup` 走 `user_scatter`(3 簇均匀、n=300、dim=8),规模刚好卡在 `_SCATTER_MAX_POINTS=300` 边界,不能测更大规模。
- 新增 `test_umap_direct_fleet_scale_clusters_separate`:直调 `_UMAP2D` primitive(绕过看板抽样上限),6 簇不均匀(180/130/90/60/40/20=520 点)、dim=32、噪声更紧(0.20)。
- 已验证:在修复前的代码上跑这组参数,布局直接炸到半径 376(阈值 40),silhouette 转负(-0.16);修复后半径稳定在 ~16、簇间距/簇内散布最小比值 5.9(断言阈值 3.0),留了约 2× 安全边际。比原测试的信号强得多。
- 单次 fit 约 8s,两次(含确定性复验)约 16-18s,`test_dashboard_p3.py` 全量 33 个用例约 32s——CI 时间可控。
- 顺带把上一版回归测试的 4 行背景叙事注释精简为 1 行,合规仓库注释风格约定(事故背景放 PR 描述,不留在代码里)。

## Test plan
- [x] `pytest tests/test_dashboard_p3.py -q -k test_umap_direct_fleet_scale_clusters_separate` — 在修复前的 `profile_viz.py`(临时替换验证)上失败(`radius.max()=376 not < 40`),恢复后通过
- [x] `pytest tests/test_dashboard_p3.py -q` — 33 passed

CI 预期:ubuntu(py3.9-3.12)/CodeQL/verify-build 应全绿;macOS/Windows 上 `test_skill_tools_atom.py::TestReadFile` 的两个路径解析失败 + Windows 的 git 权限 flake 是已确认与本改动无关的预置问题(#99 review 时已核实,`main` 最近几次合并均带此失败),不需要重新排查。

🤖 Generated with [Claude Code](https://claude.com/claude-code)