### PR TITLE
feat(skillhub): xskill search / xskill upload — 团队技能按需检索与分享

### DIFF
--- a/README.en.md
+++ b/README.en.md
@@ -137,6 +137,15 @@ xskill stop / xskill start                    # stop / re-start (must have conne
 
 On **macOS / Linux**, native persistence (launchd / systemd --user) is still on the way; for now run the foreground form `xskill connect --foreground` under your own init system.
 
+#### Search / share skills on demand (skillhub)
+
+```bash
+xskill search docker compose   # keyword-search the server skillhub; hits are pulled locally and installed
+xskill upload ./my-skill       # package & upload a skill folder (with SKILL.md); instantly searchable by the team
+```
+
+`search` matches keywords only — independent of the recommendation profile — and prints each hit's name, description, and absolute local path. Pulled skills live in `~/.xskill/search_skills/` with a rolling cap of **10 slots** (least-recently-hit evicted). `upload` lands under `skillhub/user_skill_hub/<your-username>/` on the server. The local index search is unchanged: `xskill search traj|skill <query>`.
+
 * * *
 
 ## 🔌 Works with your agents

--- a/README.md
+++ b/README.md
@@ -148,6 +148,20 @@ xskill connect <服务器地址:端口> --token <TOKEN>   # 首次握手(macOS/L
 
 > 把 `<服务器地址:端口>` 和 `<TOKEN>` 换成团队管理员给你的值(server 端 `xskill serve --server` 启动时会打印 token)。**切勿把真实 token 写进任何公开仓库或聊天记录。**
 
+#### 按需搜索 / 分享技能(skillhub)
+
+除了 server 按画像推送的技能,client 还可以主动搜 server 的 skillhub 并把命中的技能拉到本地:
+
+```bash
+xskill search docker compose        # 关键词搜 skillhub,命中的直接拉到本地并装进各生态
+xskill upload ./my-skill            # 打包上传一个 skill 目录(含 SKILL.md),全队立即可搜到
+```
+
+- `search` 只按关键词匹配 skillhub 目录(含团队成员上传的技能),与推荐画像无关;输出每个命中技能的名字、描述和本机绝对路径。
+- 搜下来的技能落在 `~/.xskill/search_skills/`,本地最多保留 **10 个槽位**,按最近命中滚动淘汰,不受 sync 清理影响。
+- `upload` 会先校验 `SKILL.md` frontmatter,server 端落到 `skillhub/user_skill_hub/<你的用户名>/` 下。
+- 本机原有的本地索引搜索保持不变:`xskill search traj|skill <query>`。
+
 * * *
 
 ## 🔌 与你的 agent 协同

--- a/README.zh-CN.md
+++ b/README.zh-CN.md
@@ -97,6 +97,15 @@ xskill stop / xskill start                     # 停止 / 重新拉起(需先 co
 
 macOS / Linux 的原生常驻（launchd / systemd --user）仍在路上，当前用自己的 init 系统托管 `xskill connect --foreground` 即可。
 
+### 按需搜索 / 分享技能（skillhub）
+
+```bash
+xskill search docker compose        # 关键词搜 server 的 skillhub,命中的拉到本地并装进各生态
+xskill upload ./my-skill            # 打包上传一个 skill 目录(含 SKILL.md),全队立即可搜到
+```
+
+`search` 只按关键词匹配、与推荐画像无关，输出命中技能的名字、描述和本机绝对路径；本地最多保留 **10 个槽位**滚动淘汰。`upload` 在 server 端落到 `skillhub/user_skill_hub/<你的用户名>/` 下。本机索引搜索保持原样：`xskill search traj|skill <query>`。
+
 ## 架构图
 
 <p align="center">

--- a/src/xskill/cli.py
+++ b/src/xskill/cli.py
@@ -544,7 +544,12 @@ def cmd_stats(args) -> int:
 
 
 def cmd_search(args, xskill) -> int:
-    target = args.search_target
+    target = args.terms[0]
+    query = " ".join(args.terms[1:]).strip()
+    if not query:
+        print(f"error: 用法 xskill search {target} <query>", file=sys.stderr)
+        return 2
+    args.query = query
     if target == "traj":
         hits = xskill.search_trajectories(args.query, top_k=args.top_k)
         for h in hits:
@@ -567,6 +572,153 @@ def cmd_search(args, xskill) -> int:
             print(f"{h.similarity:.3f}\t{s.name}\t{s.use_count}\t{ux_col}\t{canary_col}")
         return 0
     return 1
+
+
+def _team_client_http_and_headers():
+    """瘦客户端命令共用：读连接 state，返回 (httpx client, 鉴权头)。
+
+    未 connect 过返回 (None, None)（调用方打印引导后退出）。
+    """
+    from xskill.config import get_team_client_state_path
+    from xskill.team.client.state import load_client_state
+
+    state_path = get_team_client_state_path()
+    if not state_path.is_file():
+        print("error: 未连接 team server。先跑：\n"
+              "  xskill connect <host:port> --token <t> --name <你的名字>",
+              file=sys.stderr)
+        return None, None
+    state = load_client_state(state_path)
+    import httpx
+    http = httpx.Client(base_url=state.server_url, timeout=60.0, trust_env=False)
+    headers = {"X-Xskill-Token": state.join_token,
+               "X-Xskill-Client": state.client_id,
+               "X-Xskill-Version": __version__}
+    return http, headers
+
+
+def cmd_search_hub(args, http=None, headers=None) -> int:
+    """`xskill search <query>` —— 搜 server skillhub，命中的拉到本地滚动槽位。
+
+    结果只按关键词匹配 skillhub 目录（含 user_skill_hub 上传件），与推荐画像
+    无关。每个命中 skill 下载解包到 ``~/.xskill/search_skills/<skill_id>/``、
+    打 ``.xskill_search.json`` 标记、装进本机生态；本地最多保留 10 个槽位，
+    按最近命中滚动淘汰。``http``/``headers`` 参数仅测试注入用。
+    """
+    import json as _json
+    from xskill.config import XSKILL_HOME
+    from xskill.team.client.search_slots import SearchSlots
+
+    if http is None:
+        http, headers = _team_client_http_and_headers()
+        if http is None:
+            return 1
+    query = " ".join(args.terms).strip()
+    resp = http.get("/api/v1/team/skill_hub/search",
+                    params={"query": query, "limit": args.top_k},
+                    headers=headers)
+    if resp.status_code == 404:
+        print("error: server 版本过旧，不支持 skillhub 搜索（需 ≥0.6.17），"
+              "请管理员先升级 server", file=sys.stderr)
+        return 1
+    if resp.status_code != 200:
+        print(f"error: 搜索失败 HTTP {resp.status_code}: {resp.text[:300]}",
+              file=sys.stderr)
+        return 1
+    results = resp.json().get("results", [])
+    if not results:
+        print("skillhub 无匹配 skill")
+        return 0
+    slots = SearchSlots(xskill_home=XSKILL_HOME)
+    installed = []
+    for result in results:
+        bundle = http.get(f"/api/v1/team/skill/{result['skill_id']}/bundle",
+                          headers=headers)
+        if bundle.status_code != 200:
+            print(f"warning: 拉取 {result['skill_id']} 失败 "
+                  f"HTTP {bundle.status_code}", file=sys.stderr)
+            continue
+        local_path = slots.install(result, bundle.content, query=query)
+        installed.append({
+            "name": result["display_name"],
+            "skill_id": result["skill_id"],
+            "description": result["description"],
+            "path": str(local_path),
+        })
+    if args.json:
+        print(_json.dumps(installed, ensure_ascii=False, indent=2))
+        return 0
+    for row in installed:
+        print(f"{row['name']}  ({row['skill_id']})")
+        print(f"  {row['description']}")
+        print(f"  {row['path']}")
+    return 0
+
+
+def cmd_upload(args, http=None, headers=None) -> int:
+    """`xskill upload <dir>` —— 打包 skill 文件夹上传到 server 的 user skillhub。
+
+    server 落盘到 ``<skillhub>/user_skill_hub/<用户目录>/<skill名>/``，之后
+    团队成员可用 `xskill search` 搜到。``http``/``headers`` 仅测试注入用。
+    """
+    import io as _io
+    import json as _json
+    import zipfile as _zipfile
+    from pathlib import Path
+    from xskill.skill.frontmatter import FrontmatterError, parse_strict
+
+    skill_dir = Path(args.path).expanduser().resolve()
+    skill_md = skill_dir / "SKILL.md"
+    if not skill_md.is_file():
+        print(f"error: {skill_dir} 下没有 SKILL.md，不是合法 skill 目录",
+              file=sys.stderr)
+        return 2
+    try:
+        frontmatter, _body = parse_strict(skill_md.read_text(encoding="utf-8"))
+    except (FrontmatterError, UnicodeDecodeError) as bad_skill:
+        print(f"error: SKILL.md 校验失败: {bad_skill}", file=sys.stderr)
+        return 2
+
+    buffer = _io.BytesIO()
+    with _zipfile.ZipFile(buffer, "w", compression=_zipfile.ZIP_DEFLATED) as zf:
+        for file_path in sorted(skill_dir.rglob("*")):
+            rel_parts = file_path.relative_to(skill_dir).parts
+            if any(part in (".git", "__pycache__") or part.startswith(".xskill_")
+                   for part in rel_parts):
+                continue
+            if file_path.is_file():
+                zf.write(file_path, file_path.relative_to(skill_dir).as_posix())
+    payload = buffer.getvalue()
+    if len(payload) > 20 * 1024 * 1024:
+        print("error: 打包后超过 20MB，请清理 skill 目录里的大文件",
+              file=sys.stderr)
+        return 2
+
+    if http is None:
+        http, headers = _team_client_http_and_headers()
+        if http is None:
+            return 1
+    archive_name = f"{frontmatter['name']}.zip"
+    resp = http.post("/api/v1/team/skill_hub/upload",
+                     files={"file": (archive_name, payload, "application/zip")},
+                     headers=headers)
+    if resp.status_code == 404:
+        print("error: server 版本过旧，不支持 skill 上传（需 ≥0.6.17），"
+              "请管理员先升级 server", file=sys.stderr)
+        return 1
+    if resp.status_code != 200:
+        print(f"error: 上传失败 HTTP {resp.status_code}: {resp.text[:300]}",
+              file=sys.stderr)
+        return 1
+    stored = resp.json()
+    if args.json:
+        print(_json.dumps(stored, ensure_ascii=False, indent=2))
+        return 0
+    print(f"uploaded: {stored['display_name']}  ({stored['skill_id']})")
+    print(f"  server 路径: {stored['stored_path']}")
+    print("  团队成员现在可以: xskill search "
+          f"{stored['display_name']}")
+    return 0
 
 
 def cmd_read(args, xskill) -> int:
@@ -717,11 +869,23 @@ def build_parser() -> argparse.ArgumentParser:
                        help="human-friendly label (for add)")
 
     p_search = sub.add_parser(
-        "search", help="Search trajectories or skills (cross-registry)"
+        "search",
+        help="搜 team server 的 skillhub 并拉到本地槽位；"
+             "`search traj|skill <query>` 保持原本机索引搜索",
     )
-    p_search.add_argument("search_target", choices=["traj", "skill"])
-    p_search.add_argument("query", type=str)
-    p_search.add_argument("--top-k", "-k", type=int, default=5)
+    p_search.add_argument(
+        "terms", nargs="+", metavar="QUERY",
+        help="搜索词（可多个）。首词恰为 traj/skill 时视为本机索引搜索",
+    )
+    p_search.add_argument("--top-k", "-k", type=int, default=5,
+                          help="返回条数（skillhub 搜索最多 10）")
+    p_search.add_argument("--json", action="store_true", help="机读 JSON 输出")
+
+    p_upload = sub.add_parser(
+        "upload", help="打包一个 skill 文件夹上传到 team server 的 user skillhub",
+    )
+    p_upload.add_argument("path", type=str, help="包含 SKILL.md 的 skill 目录")
+    p_upload.add_argument("--json", action="store_true", help="机读 JSON 输出")
 
     p_conn = sub.add_parser(
         "connect", help="Join a team server as a thin client",
@@ -873,6 +1037,13 @@ def main() -> int:
         return cmd_update(args)
     if args.command == "dashboard":
         return cmd_dashboard(args)
+
+    # skillhub 搜索/上传是瘦客户端侧（走 team server），不碰 config.yaml。
+    # `search traj|skill <q>` 仍是本机索引搜索，走下面的 facade 路径。
+    if args.command == "search" and args.terms[0] not in ("traj", "skill"):
+        return cmd_search_hub(args)
+    if args.command == "upload":
+        return cmd_upload(args)
 
     # stats 只读 registry，不需要 config.yaml / llm.api_key / facade
     if args.command == "stats":

--- a/src/xskill/recommend/skillhub.py
+++ b/src/xskill/recommend/skillhub.py
@@ -158,6 +158,35 @@ class SkillHub:
         with open(self.index_cache_path, "wb") as index_file:
             pickle.dump(data, index_file)
 
+    def search(self, query: str, limit: int = 5) -> list[dict]:
+        """无画像关键词检索：只按 display_name/description 文本匹配打分。
+
+        与 ``SkillRecommendEngine`` 完全无关——不读画像、不算向量，结果只由
+        查询词与 skill 元数据的字面匹配决定（`xskill search` 的语义契约）。
+        """
+        needle = query.strip().lower()
+        if not needle:
+            return []
+        tokens = [token for token in re.split(r"[^0-9a-z一-鿿]+", needle) if token]
+        scored: list[tuple[float, dict]] = []
+        for entry in self._entries(include_vec=False, require_description=False):
+            name_text = str(entry["display_name"]).lower()
+            desc_text = str(entry["description"]).lower()
+            score = 0.0
+            if needle in name_text:
+                score += 6.0
+            elif needle in desc_text:
+                score += 3.0
+            for token in tokens:
+                if token in name_text:
+                    score += 2.0
+                if token in desc_text:
+                    score += 1.0
+            if score > 0:
+                scored.append((score, entry))
+        scored.sort(key=lambda pair: (-pair[0], pair[1]["skill_id"]))
+        return [entry for _score, entry in scored[:limit]]
+
     def entry(self, name: str) -> dict | None:
         """按 skill_id / source_path / 唯一 display_name 找当前磁盘上的 skill。"""
         if not self.enabled:

--- a/src/xskill/team/client/daemon.py
+++ b/src/xskill/team/client/daemon.py
@@ -192,83 +192,13 @@ class TeamClient:
         self, archive_bytes: bytes, dest_dir: Path, *, expected_sha: str,
         display_name: str | None, source_path: str | None,
     ) -> None:
-        """Install a non-git skillhub skill archive into the local skill directory."""
-        dest_dir = Path(dest_dir)
-        meta_path = dest_dir / ".xskill_skillhub.json"
-        if meta_path.is_file() and (dest_dir / "SKILL.md").is_file():
-            try:
-                meta = json.loads(meta_path.read_text(encoding="utf-8"))
-                if meta.get("sha") == expected_sha:
-                    return
-            except (OSError, ValueError):
-                pass
-
-        tmp_dir = dest_dir.with_name(f".{dest_dir.name}.tmp")
-        shutil.rmtree(tmp_dir, ignore_errors=True)
-        tmp_dir.mkdir(parents=True, exist_ok=True)
-        with zipfile.ZipFile(io.BytesIO(archive_bytes)) as zf:
-            root = tmp_dir.resolve()
-            for info in zf.infolist():
-                target = (tmp_dir / info.filename).resolve()
-                try:
-                    target.relative_to(root)
-                except ValueError:
-                    raise RuntimeError(f"unsafe skillhub archive path: {info.filename}")
-                if info.is_dir():
-                    target.mkdir(parents=True, exist_ok=True)
-                    continue
-                target.parent.mkdir(parents=True, exist_ok=True)
-                with zf.open(info) as src, open(target, "wb") as dst:
-                    shutil.copyfileobj(src, dst)
-        if not (tmp_dir / "SKILL.md").is_file():
-            shutil.rmtree(tmp_dir, ignore_errors=True)
-            raise RuntimeError("skillhub archive missing SKILL.md")
-        (tmp_dir / ".xskill_skillhub.json").write_text(
-            json.dumps({
-                "sha": expected_sha,
-                "display_name": display_name,
-                "source_path": source_path,
-            }, ensure_ascii=False),
-            encoding="utf-8",
+        apply_skillhub_archive(
+            archive_bytes, dest_dir, expected_sha=expected_sha,
+            display_name=display_name, source_path=source_path,
         )
-        shutil.rmtree(dest_dir, ignore_errors=True)
-        tmp_dir.replace(dest_dir)
 
     def _install_to_ecosystems(self, repo_dir: Path) -> None:
-        """把一个已 checkout 好的 skill working copy 装到本机所有生态。
-
-        working tree 已是 server 指定 side 的内容，所以一律用 side='main'
-        语义（= 链接 / 拷贝整个 working tree 目录）。
-
-        注意 openclaw 走 copy 不是 symlink（openclaw 拒收 escape-root 的
-        symlink，详见 docs/ecosystem/openclaw-install-fix.md）。其他生态保持
-        symlink-first 三阶 fallback。
-        """
-        from xskill.ecosystems import (
-            detect_known_ecosystems, install_to_claude_code,
-            install_to_codex, install_to_nga3, install_to_opencode, install_to_ngagent,
-            install_to_openclaw, install_to_cursor, install_to_trae,
-        )
-        installer = {
-            "claude_code": install_to_claude_code,
-            "codex": install_to_codex,
-            "nga3": install_to_nga3,
-            "opencode": install_to_opencode,
-            "ngagent": install_to_ngagent,
-            "openclaw": install_to_openclaw,
-            "cursor": install_to_cursor,
-            "trae": install_to_trae,
-        }
-        for det in detect_known_ecosystems(home_root=self.home_root):
-            fn = installer.get(det["ecosystem"])
-            if fn is None:
-                continue
-            try:
-                fn(repo_dir, target_root=self.home_root, side="main")
-                logger.info("installed %s to %s", repo_dir.name, det["ecosystem"])
-            except Exception:
-                logger.warning("install %s to %s failed",
-                               repo_dir.name, det["ecosystem"], exc_info=True)
+        install_skill_to_ecosystems(repo_dir, home_root=self.home_root)
 
     # ── ④ push 用户手改 ──────────────────────────────────────────
     def push_user_edits(self) -> int:
@@ -354,14 +284,7 @@ class TeamClient:
             logger.info("cleanup removed stale skill: %s", repo_dir.name)
 
     def _uninstall_from_ecosystems(self, skill_name: str) -> None:
-        from xskill.ecosystems import _cc_skills_path, _agents_skills_path
-        for root_fn in (_cc_skills_path, _agents_skills_path):
-            dest = root_fn(self.home_root) / skill_name
-            if dest.is_symlink():
-                try:
-                    dest.unlink()
-                except OSError:
-                    logger.warning("failed to unlink %s", dest, exc_info=True)
+        uninstall_skill_from_ecosystems(skill_name, home_root=self.home_root)
 
     # ── 守护循环 ─────────────────────────────────────────────────
     def _tick(self) -> None:
@@ -398,3 +321,105 @@ class TeamClient:
 
     def stop(self) -> None:
         self._stop.set()
+
+
+def apply_skillhub_archive(
+    archive_bytes: bytes, dest_dir: Path, *, expected_sha: str,
+    display_name: str | None, source_path: str | None,
+    marker_name: str = ".xskill_skillhub.json",
+    extra_meta: dict | None = None,
+) -> None:
+    """把非 git 的 skillhub skill zip 原子落到本地目录（带路径穿越防护）。
+
+    sync reconcile 与 `xskill search` 槽位共用；后者用 ``marker_name`` /
+    ``extra_meta`` 换成自己的标记文件。marker sha 相同则跳过重写。
+    """
+    dest_dir = Path(dest_dir)
+    meta_path = dest_dir / marker_name
+    if meta_path.is_file() and (dest_dir / "SKILL.md").is_file():
+        try:
+            meta = json.loads(meta_path.read_text(encoding="utf-8"))
+            if meta.get("sha") == expected_sha:
+                return
+        except (OSError, ValueError):
+            pass
+
+    tmp_dir = dest_dir.with_name(f".{dest_dir.name}.tmp")
+    shutil.rmtree(tmp_dir, ignore_errors=True)
+    tmp_dir.mkdir(parents=True, exist_ok=True)
+    with zipfile.ZipFile(io.BytesIO(archive_bytes)) as zf:
+        root = tmp_dir.resolve()
+        for info in zf.infolist():
+            target = (tmp_dir / info.filename).resolve()
+            try:
+                target.relative_to(root)
+            except ValueError:
+                raise RuntimeError(f"unsafe skillhub archive path: {info.filename}")
+            if info.is_dir():
+                target.mkdir(parents=True, exist_ok=True)
+                continue
+            target.parent.mkdir(parents=True, exist_ok=True)
+            with zf.open(info) as src, open(target, "wb") as dst:
+                shutil.copyfileobj(src, dst)
+    if not (tmp_dir / "SKILL.md").is_file():
+        shutil.rmtree(tmp_dir, ignore_errors=True)
+        raise RuntimeError("skillhub archive missing SKILL.md")
+    meta = {
+        "sha": expected_sha,
+        "display_name": display_name,
+        "source_path": source_path,
+    }
+    if extra_meta:
+        meta.update(extra_meta)
+    (tmp_dir / marker_name).write_text(
+        json.dumps(meta, ensure_ascii=False), encoding="utf-8",
+    )
+    shutil.rmtree(dest_dir, ignore_errors=True)
+    tmp_dir.replace(dest_dir)
+
+
+def install_skill_to_ecosystems(repo_dir: Path, *, home_root: Path) -> None:
+    """把一个已就位的 skill 目录装到本机所有检测到的生态。
+
+    working tree 已是最终内容，一律用 side='main' 语义（= 链接 / 拷贝整个
+    目录）。openclaw 走 copy 不是 symlink（openclaw 拒收 escape-root 的
+    symlink，详见 docs/ecosystem/openclaw-install-fix.md）；其他生态保持
+    symlink-first 三阶 fallback。
+    """
+    from xskill.ecosystems import (
+        detect_known_ecosystems, install_to_claude_code,
+        install_to_codex, install_to_nga3, install_to_opencode, install_to_ngagent,
+        install_to_openclaw, install_to_cursor, install_to_trae,
+    )
+    installer = {
+        "claude_code": install_to_claude_code,
+        "codex": install_to_codex,
+        "nga3": install_to_nga3,
+        "opencode": install_to_opencode,
+        "ngagent": install_to_ngagent,
+        "openclaw": install_to_openclaw,
+        "cursor": install_to_cursor,
+        "trae": install_to_trae,
+    }
+    for det in detect_known_ecosystems(home_root=home_root):
+        fn = installer.get(det["ecosystem"])
+        if fn is None:
+            continue
+        try:
+            fn(repo_dir, target_root=home_root, side="main")
+            logger.info("installed %s to %s", repo_dir.name, det["ecosystem"])
+        except Exception:
+            logger.warning("install %s to %s failed",
+                           repo_dir.name, det["ecosystem"], exc_info=True)
+
+
+def uninstall_skill_from_ecosystems(skill_name: str, *, home_root: Path) -> None:
+    """摘掉生态目录里指向该 skill 的 symlink（copy 型安装不动，保守起见）。"""
+    from xskill.ecosystems import _cc_skills_path, _agents_skills_path
+    for root_fn in (_cc_skills_path, _agents_skills_path):
+        dest = root_fn(home_root) / skill_name
+        if dest.is_symlink():
+            try:
+                dest.unlink()
+            except OSError:
+                logger.warning("failed to unlink %s", dest, exc_info=True)

--- a/src/xskill/team/client/search_slots.py
+++ b/src/xskill/team/client/search_slots.py
@@ -1,0 +1,85 @@
+"""search_slots.py — `xskill search` 拉取的 skillhub skill 的本地滚动槽位。
+
+search 命中的 skill 落 ``~/.xskill/search_skills/<skill_id>/``，与 sync 管理的
+``~/.xskill/skill/`` 分开——daemon 的 cleanup 按 manifest 清理那边，不碰这里。
+台账 ``~/.xskill/search_slots.json`` 按最近命中排序，超过容量淘汰最旧的
+（同时摘掉生态里的 symlink 安装）。每个槽位目录里有 ``.xskill_search.json``
+标记（sha / 查询词 / 时间），与 sync 的 ``.xskill_skillhub.json`` 区分来源。
+"""
+from __future__ import annotations
+
+import json
+import logging
+import shutil
+from datetime import datetime, timezone
+from pathlib import Path
+
+from xskill.team.client.daemon import (
+    apply_skillhub_archive,
+    install_skill_to_ecosystems,
+    uninstall_skill_from_ecosystems,
+)
+
+logger = logging.getLogger("xskill.team.client")
+
+SEARCH_SLOT_CAPACITY = 10
+SEARCH_MARKER_NAME = ".xskill_search.json"
+
+
+class SearchSlots:
+    """search 槽位管理：落盘、打标、按最近命中滚动淘汰。"""
+
+    def __init__(self, *, xskill_home: Path, home_root: Path | None = None,
+                 capacity: int = SEARCH_SLOT_CAPACITY):
+        self.slots_dir = Path(xskill_home) / "search_skills"
+        self.ledger_path = Path(xskill_home) / "search_slots.json"
+        self.home_root = Path(home_root) if home_root else Path.home()
+        self.capacity = capacity
+
+    def entries(self) -> list[dict]:
+        """台账内容（旧 → 新）。文件缺失或损坏按空处理。"""
+        try:
+            loaded = json.loads(self.ledger_path.read_text(encoding="utf-8"))
+        except (OSError, ValueError):
+            return []
+        return [slot for slot in loaded if isinstance(slot, dict)] \
+            if isinstance(loaded, list) else []
+
+    def install(self, result: dict, archive_bytes: bytes, *, query: str) -> Path:
+        """落盘一个 search 命中的 skill，装进生态并滚动淘汰。返回绝对路径。"""
+        dest_dir = self.slots_dir / result["skill_id"]
+        searched_at = datetime.now(timezone.utc).isoformat(timespec="seconds")
+        apply_skillhub_archive(
+            archive_bytes, dest_dir,
+            expected_sha=result["content_sha"],
+            display_name=result.get("display_name"),
+            source_path=result.get("source_path"),
+            marker_name=SEARCH_MARKER_NAME,
+            extra_meta={"query": query, "searched_at": searched_at},
+        )
+        install_skill_to_ecosystems(dest_dir, home_root=self.home_root)
+        slots = [slot for slot in self.entries()
+                 if slot.get("skill_id") != result["skill_id"]]
+        slots.append({
+            "skill_id": result["skill_id"],
+            "display_name": result.get("display_name"),
+            "description": result.get("description"),
+            "sha": result["content_sha"],
+            "query": query,
+            "searched_at": searched_at,
+        })
+        evicted, kept = slots[:-self.capacity], slots[-self.capacity:]
+        for stale in evicted:
+            stale_id = str(stale.get("skill_id") or "")
+            stale_dir = self.slots_dir / stale_id
+            # 台账损坏出来的空 id 会让 stale_dir == slots_dir，绝不能 rmtree
+            if not stale_id or stale_dir == self.slots_dir:
+                continue
+            uninstall_skill_from_ecosystems(stale_id, home_root=self.home_root)
+            shutil.rmtree(stale_dir, ignore_errors=True)
+            logger.info("search slot evicted: %s", stale_id)
+        self.ledger_path.parent.mkdir(parents=True, exist_ok=True)
+        self.ledger_path.write_text(
+            json.dumps(kept, ensure_ascii=False, indent=2), encoding="utf-8",
+        )
+        return dest_dir.resolve()

--- a/src/xskill/team/server/api.py
+++ b/src/xskill/team/server/api.py
@@ -20,6 +20,7 @@ import io
 import json
 import logging
 from pathlib import Path
+import shutil
 import tempfile
 import threading
 import time
@@ -779,6 +780,121 @@ async def team_skill_bundle(
         return Response(content=archive, media_type="application/zip")
     bundle = make_repo_bundle(repo_dir)
     return Response(content=bundle, media_type="application/octet-stream")
+
+
+@router.get("/skill_hub/search")
+async def team_skill_hub_search(
+    query: str,
+    limit: int = 5,
+    x_xskill_token: str | None = Header(default=None),
+    x_xskill_client: str | None = Header(default=None),
+) -> dict:
+    """关键词搜 skillhub（含 user_skill_hub 上传件）。与推荐画像完全无关。"""
+    _auth(x_xskill_token, x_xskill_client)
+    hub = _ctx.skillhub
+    if hub is None or not getattr(hub, "enabled", False):
+        raise HTTPException(status_code=503, detail="skillhub not enabled on server")
+    if not query.strip():
+        raise HTTPException(status_code=400, detail="empty query")
+    bounded_limit = max(1, min(int(limit), 10))
+    try:
+        matches = await run_in_threadpool(hub.search, query, bounded_limit)
+    except FileNotFoundError as missing_dir:
+        raise HTTPException(status_code=503, detail=str(missing_dir)) from missing_dir
+    return {"results": [
+        {
+            "skill_id": match["skill_id"],
+            "display_name": match["display_name"],
+            "description": match["description"],
+            "content_sha": match["content_sha"],
+            "source_path": match["source_path"],
+        }
+        for match in matches
+    ]}
+
+
+@router.post("/skill_hub/upload")
+async def team_skill_hub_upload(
+    file: UploadFile = File(...),
+    x_xskill_token: str | None = Header(default=None),
+    x_xskill_client: str | None = Header(default=None),
+) -> dict:
+    """收 client 打包的 skill 文件夹 zip，落到 user_skill_hub/<用户目录>/ 下。
+
+    落盘位置在 skillhub 目录树内，所以上传件天然进入 skillhub 扫描范围：
+    可被 `/skill_hub/search` 搜到、可经 `/skill/{id}/bundle` 分发。
+    """
+    client_id = _auth(x_xskill_token, x_xskill_client)
+    hub = _ctx.skillhub
+    if hub is None or not getattr(hub, "enabled", False):
+        raise HTTPException(status_code=503, detail="skillhub not enabled on server")
+    payload = await file.read()
+    if len(payload) > 20 * 1024 * 1024:
+        raise HTTPException(status_code=413, detail="skill archive exceeds 20MB")
+    from xskill.team.server.client_registry import safe_dir_name
+    registry_row = _ctx.client_registry.get(client_id)
+    owner_dir = safe_dir_name((registry_row or {}).get("user_name") or None, client_id)
+    stored = await run_in_threadpool(_store_user_skill, hub, owner_dir, payload)
+    logger.info("skill_hub upload from %s: %s -> %s",
+                client_id, stored["display_name"], stored["stored_path"])
+    return stored
+
+
+def _store_user_skill(hub, owner_dir: str, payload: bytes) -> dict:
+    """校验并解压上传的 skill zip 到 <skillhub>/user_skill_hub/<owner>/<name>/。"""
+    from xskill.skill.frontmatter import FrontmatterError, parse_strict
+
+    try:
+        archive = zipfile.ZipFile(io.BytesIO(payload))
+    except zipfile.BadZipFile as bad_zip:
+        raise HTTPException(status_code=400, detail=f"invalid zip: {bad_zip}") from bad_zip
+    with archive:
+        if "SKILL.md" not in archive.namelist():
+            raise HTTPException(status_code=400,
+                                detail="SKILL.md missing at archive root")
+        try:
+            frontmatter, _body = parse_strict(
+                archive.read("SKILL.md").decode("utf-8"))
+        except (FrontmatterError, UnicodeDecodeError) as bad_skill:
+            raise HTTPException(status_code=400,
+                                detail=f"invalid SKILL.md: {bad_skill}") from bad_skill
+        display_name = str(frontmatter["name"]).strip()
+        from xskill.recommend.skillhub import _safe_id_part
+        dest_dir = (Path(hub.dir) / "user_skill_hub" / owner_dir
+                    / _safe_id_part(display_name))
+        tmp_dir = dest_dir.with_name(f".{dest_dir.name}.tmp")
+        shutil.rmtree(tmp_dir, ignore_errors=True)
+        tmp_dir.mkdir(parents=True, exist_ok=True)
+        extracted_root = tmp_dir.resolve()
+        for info in archive.infolist():
+            target = (tmp_dir / info.filename).resolve()
+            try:
+                target.relative_to(extracted_root)
+            except ValueError:
+                shutil.rmtree(tmp_dir, ignore_errors=True)
+                raise HTTPException(status_code=400,
+                                    detail=f"unsafe archive path: {info.filename}")
+            if info.is_dir():
+                target.mkdir(parents=True, exist_ok=True)
+                continue
+            target.parent.mkdir(parents=True, exist_ok=True)
+            with archive.open(info) as src, open(target, "wb") as dst:
+                shutil.copyfileobj(src, dst)
+    shutil.rmtree(dest_dir, ignore_errors=True)
+    tmp_dir.replace(dest_dir)
+    source_path = dest_dir.relative_to(Path(hub.dir)).as_posix()
+    entry = hub.entry(source_path)
+    if entry is None:
+        raise HTTPException(status_code=500,
+                            detail="stored skill not visible in skillhub scan")
+    return {
+        "skill_id": entry["skill_id"],
+        "display_name": entry["display_name"],
+        "description": entry["description"],
+        "content_sha": entry["content_sha"],
+        "source_path": entry["source_path"],
+        "stored_path": str(dest_dir),
+    }
 
 
 def _make_skillhub_archive(skill_dir: Path) -> bytes:

--- a/tests/test_skill_hub_search_upload.py
+++ b/tests/test_skill_hub_search_upload.py
@@ -1,0 +1,322 @@
+"""`xskill search` / `xskill upload` 的 server 端点 + client 槽位测试。"""
+from __future__ import annotations
+
+import io
+import json
+import zipfile
+from pathlib import Path
+from types import SimpleNamespace
+
+import pytest
+from fastapi import FastAPI
+from fastapi.testclient import TestClient
+
+from xskill import cli
+from xskill.recommend.skillhub import SkillHub
+from xskill.team.client.search_slots import SearchSlots
+from xskill.team.server import api as server_api
+from xskill.team.server.client_registry import ClientRegistry, safe_dir_name
+
+TOKEN = "secret-token"
+
+
+def _write_hub_skill(hub_dir: Path, folder: str, name: str, description: str) -> Path:
+    d = hub_dir / folder
+    d.mkdir(parents=True)
+    (d / "SKILL.md").write_text(
+        f"---\nname: {name}\ndescription: {description}\n---\n# {name}\nbody\n",
+        encoding="utf-8")
+    return d
+
+
+def _zip_dir(src: Path) -> bytes:
+    buf = io.BytesIO()
+    with zipfile.ZipFile(buf, "w") as zf:
+        for p in sorted(src.rglob("*")):
+            if p.is_file():
+                zf.write(p, p.relative_to(src).as_posix())
+    return buf.getvalue()
+
+
+def _make_team_client(tmp_path: Path, *, skillhub) -> TestClient:
+    skill_dir = tmp_path / "skill"
+    skill_dir.mkdir(exist_ok=True)
+    server_api.init_team_context(
+        join_token=TOKEN,
+        client_registry=ClientRegistry(tmp_path / "clients.db"),
+        skill_dir=skill_dir,
+        traj_root=tmp_path / "team_traj",
+        probability=0.2, ranked_slots=80, total_slots=100,
+        register_dir=lambda path, label: None,
+        skillhub=skillhub,
+    )
+    app = FastAPI()
+    app.include_router(server_api.router)
+    return TestClient(app)
+
+
+def _register(client: TestClient, user_name: str | None = None) -> tuple[str, dict]:
+    body = {"token": TOKEN, "client_label": "t", "hostname": "h"}
+    if user_name:
+        body["user_name"] = user_name
+    r = client.post("/api/v1/team/register", json=body)
+    assert r.status_code == 200
+    cid = r.json()["client_id"]
+    return cid, {"X-Xskill-Token": TOKEN, "X-Xskill-Client": cid}
+
+
+@pytest.fixture
+def hub_env(tmp_path):
+    hub_dir = tmp_path / "skillhub_skills"
+    _write_hub_skill(hub_dir, "docker-helper", "docker-helper",
+                     "Manage docker containers and compose files")
+    _write_hub_skill(hub_dir, "k8s-deploy", "k8s-deploy",
+                     "Deploy workloads to kubernetes clusters")
+    _write_hub_skill(hub_dir, "unrelated", "poetry-writer",
+                     "Write beautiful poems")
+    hub = SkillHub(enabled=True, hub_dir=hub_dir, embed_client=None)
+    client = _make_team_client(tmp_path, skillhub=hub)
+    return SimpleNamespace(client=client, hub=hub, hub_dir=hub_dir,
+                           tmp_path=tmp_path)
+
+
+# ── server: search ──────────────────────────────────────────────
+
+def test_search_matches_by_keyword_without_profile(hub_env):
+    _cid, hdr = _register(hub_env.client)
+    r = hub_env.client.get("/api/v1/team/skill_hub/search",
+                           params={"query": "docker"}, headers=hdr)
+    assert r.status_code == 200
+    results = r.json()["results"]
+    assert [x["display_name"] for x in results] == ["docker-helper"]
+    top = results[0]
+    assert top["description"].startswith("Manage docker")
+    assert top["skill_id"] and top["content_sha"] and top["source_path"]
+
+
+def test_search_name_hit_outranks_description_hit(hub_env):
+    _cid, hdr = _register(hub_env.client)
+    r = hub_env.client.get("/api/v1/team/skill_hub/search",
+                           params={"query": "deploy"}, headers=hdr)
+    names = [x["display_name"] for x in r.json()["results"]]
+    assert names[0] == "k8s-deploy"
+
+
+def test_search_rejects_empty_query_and_requires_auth(hub_env):
+    _cid, hdr = _register(hub_env.client)
+    r = hub_env.client.get("/api/v1/team/skill_hub/search",
+                           params={"query": "  "}, headers=hdr)
+    assert r.status_code == 400
+    r = hub_env.client.get("/api/v1/team/skill_hub/search",
+                           params={"query": "docker"},
+                           headers={"X-Xskill-Token": "wrong",
+                                    "X-Xskill-Client": "ghost"})
+    assert r.status_code == 401
+
+
+def test_search_and_upload_503_when_skillhub_disabled(tmp_path):
+    client = _make_team_client(tmp_path, skillhub=None)
+    _cid, hdr = _register(client)
+    r = client.get("/api/v1/team/skill_hub/search",
+                   params={"query": "docker"}, headers=hdr)
+    assert r.status_code == 503
+    r = client.post("/api/v1/team/skill_hub/upload",
+                    files={"file": ("x.zip", b"zz", "application/zip")},
+                    headers=hdr)
+    assert r.status_code == 503
+
+
+# ── server: upload ──────────────────────────────────────────────
+
+def test_upload_stores_under_user_skill_hub_and_is_searchable(hub_env, tmp_path):
+    cid, hdr = _register(hub_env.client, user_name="alice")
+    src = tmp_path / "my-skill-src"
+    src.mkdir()
+    (src / "SKILL.md").write_text(
+        "---\nname: terraform-ops\ndescription: Provision cloud infra with terraform\n"
+        "---\n# terraform-ops\nbody\n", encoding="utf-8")
+    (src / "references").mkdir()
+    (src / "references" / "notes.md").write_text("extra", encoding="utf-8")
+
+    r = hub_env.client.post("/api/v1/team/skill_hub/upload",
+                            files={"file": ("s.zip", _zip_dir(src),
+                                            "application/zip")},
+                            headers=hdr)
+    assert r.status_code == 200, r.text
+    stored = r.json()
+    owner = safe_dir_name("alice", cid)
+    expected_dir = hub_env.hub_dir / "user_skill_hub" / owner / "terraform-ops"
+    assert Path(stored["stored_path"]) == expected_dir
+    assert (expected_dir / "SKILL.md").is_file()
+    assert (expected_dir / "references" / "notes.md").read_text(
+        encoding="utf-8") == "extra"
+    assert stored["source_path"] == f"user_skill_hub/{owner}/terraform-ops"
+
+    # 上传件立即可被搜索、可按 skill_id 拉 bundle（zip）
+    r = hub_env.client.get("/api/v1/team/skill_hub/search",
+                           params={"query": "terraform"}, headers=hdr)
+    hits = r.json()["results"]
+    assert [x["display_name"] for x in hits] == ["terraform-ops"]
+    assert hits[0]["skill_id"] == stored["skill_id"]
+    r = hub_env.client.get(f"/api/v1/team/skill/{stored['skill_id']}/bundle",
+                           headers=hdr)
+    assert r.status_code == 200
+    with zipfile.ZipFile(io.BytesIO(r.content)) as zf:
+        assert "SKILL.md" in zf.namelist()
+
+
+def test_upload_reupload_replaces_same_folder(hub_env, tmp_path):
+    _cid, hdr = _register(hub_env.client, user_name="bob")
+    src = tmp_path / "v1"
+    src.mkdir()
+    (src / "SKILL.md").write_text(
+        "---\nname: swiss-knife\ndescription: first version\n---\nbody\n",
+        encoding="utf-8")
+    (src / "old.txt").write_text("old", encoding="utf-8")
+    r1 = hub_env.client.post("/api/v1/team/skill_hub/upload",
+                             files={"file": ("s.zip", _zip_dir(src),
+                                             "application/zip")}, headers=hdr)
+    assert r1.status_code == 200
+    (src / "SKILL.md").write_text(
+        "---\nname: swiss-knife\ndescription: second version\n---\nbody\n",
+        encoding="utf-8")
+    (src / "old.txt").unlink()
+    r2 = hub_env.client.post("/api/v1/team/skill_hub/upload",
+                             files={"file": ("s.zip", _zip_dir(src),
+                                             "application/zip")}, headers=hdr)
+    assert r2.status_code == 200
+    stored_dir = Path(r2.json()["stored_path"])
+    assert stored_dir == Path(r1.json()["stored_path"])
+    assert not (stored_dir / "old.txt").exists()
+    assert r2.json()["content_sha"] != r1.json()["content_sha"]
+
+
+def test_upload_rejects_bad_archives(hub_env):
+    _cid, hdr = _register(hub_env.client)
+    post = lambda payload: hub_env.client.post(  # noqa: E731
+        "/api/v1/team/skill_hub/upload",
+        files={"file": ("s.zip", payload, "application/zip")}, headers=hdr)
+
+    assert post(b"not a zip").status_code == 400
+
+    buf = io.BytesIO()
+    with zipfile.ZipFile(buf, "w") as zf:
+        zf.writestr("README.md", "no skill here")
+    assert post(buf.getvalue()).status_code == 400  # 缺 SKILL.md
+
+    buf = io.BytesIO()
+    with zipfile.ZipFile(buf, "w") as zf:
+        zf.writestr("SKILL.md", "no frontmatter at all")
+    assert post(buf.getvalue()).status_code == 400  # frontmatter 非法
+
+    buf = io.BytesIO()
+    with zipfile.ZipFile(buf, "w") as zf:
+        zf.writestr("SKILL.md",
+                    "---\nname: evil\ndescription: evil\n---\nbody\n")
+        zf.writestr("../escape.txt", "evil")
+    assert post(buf.getvalue()).status_code == 400  # 路径穿越
+    assert not (hub_env.hub_dir.parent / "escape.txt").exists()
+
+
+# ── client: SearchSlots 滚动槽位 ────────────────────────────────
+
+def _fake_result(name: str) -> dict:
+    return {"skill_id": f"{name}@0000000000ff", "display_name": name,
+            "description": f"desc of {name}", "content_sha": "ab" * 8,
+            "source_path": name}
+
+
+def _fake_archive(name: str) -> bytes:
+    buf = io.BytesIO()
+    with zipfile.ZipFile(buf, "w") as zf:
+        zf.writestr("SKILL.md",
+                    f"---\nname: {name}\ndescription: d\n---\nbody\n")
+    return buf.getvalue()
+
+
+def test_search_slots_marker_ledger_and_rolling_eviction(tmp_path):
+    slots = SearchSlots(xskill_home=tmp_path / "xhome",
+                        home_root=tmp_path / "home", capacity=3)
+    for i in range(4):
+        path = slots.install(_fake_result(f"s{i}"), _fake_archive(f"s{i}"),
+                             query=f"q{i}")
+        assert path.is_file() is False and (path / "SKILL.md").is_file()
+        marker = json.loads((path / ".xskill_search.json").read_text(
+            encoding="utf-8"))
+        assert marker["query"] == f"q{i}" and marker["searched_at"]
+
+    ledger = slots.entries()
+    assert [s["skill_id"] for s in ledger] == [
+        "s1@0000000000ff", "s2@0000000000ff", "s3@0000000000ff"]
+    assert not (slots.slots_dir / "s0@0000000000ff").exists()  # 最旧被淘汰
+    assert (slots.slots_dir / "s3@0000000000ff" / "SKILL.md").is_file()
+
+
+def test_search_slots_rehit_moves_to_newest_without_duplicate(tmp_path):
+    slots = SearchSlots(xskill_home=tmp_path / "xhome",
+                        home_root=tmp_path / "home", capacity=3)
+    for name in ("a", "b", "c"):
+        slots.install(_fake_result(name), _fake_archive(name), query="q")
+    slots.install(_fake_result("a"), _fake_archive("a"), query="again")
+    ledger = slots.entries()
+    assert [s["skill_id"] for s in ledger] == [
+        "b@0000000000ff", "c@0000000000ff", "a@0000000000ff"]
+    assert len(ledger) == 3
+    assert ledger[-1]["query"] == "again"
+
+
+def test_search_slots_default_capacity_is_ten(tmp_path):
+    slots = SearchSlots(xskill_home=tmp_path / "xhome",
+                        home_root=tmp_path / "home")
+    assert slots.capacity == 10
+
+
+# ── client: CLI 端到端（TestClient 注入） ───────────────────────
+
+def test_cmd_search_hub_installs_and_prints_paths(hub_env, tmp_path,
+                                                  monkeypatch, capsys):
+    _cid, hdr = _register(hub_env.client)
+    xhome = tmp_path / "cli-xhome"
+    monkeypatch.setattr(
+        "xskill.team.client.search_slots.SearchSlots",
+        lambda **kw: SearchSlots(xskill_home=xhome,
+                                 home_root=tmp_path / "cli-home"))
+    args = SimpleNamespace(terms=["docker"], top_k=5, json=True)
+    assert cli.cmd_search_hub(args, http=hub_env.client, headers=hdr) == 0
+    rows = json.loads(capsys.readouterr().out)
+    assert len(rows) == 1
+    assert rows[0]["name"] == "docker-helper"
+    installed = Path(rows[0]["path"])
+    assert (installed / "SKILL.md").is_file()
+    assert installed.is_absolute()
+    assert (installed / ".xskill_search.json").is_file()
+
+
+def test_cmd_search_hub_no_match_returns_zero(hub_env, capsys):
+    _cid, hdr = _register(hub_env.client)
+    args = SimpleNamespace(terms=["nonexistent-topic-xyz"], top_k=5, json=False)
+    assert cli.cmd_search_hub(args, http=hub_env.client, headers=hdr) == 0
+    assert "无匹配" in capsys.readouterr().out
+
+
+def test_cmd_upload_end_to_end(hub_env, tmp_path, capsys):
+    _cid, hdr = _register(hub_env.client, user_name="carol")
+    src = tmp_path / "upload-src"
+    src.mkdir()
+    (src / "SKILL.md").write_text(
+        "---\nname: rust-review\ndescription: Review rust code\n---\nbody\n",
+        encoding="utf-8")
+    (src / ".git").mkdir()
+    (src / ".git" / "HEAD").write_text("ref", encoding="utf-8")
+    args = SimpleNamespace(path=str(src), json=True)
+    assert cli.cmd_upload(args, http=hub_env.client, headers=hdr) == 0
+    stored = json.loads(capsys.readouterr().out)
+    stored_dir = Path(stored["stored_path"])
+    assert (stored_dir / "SKILL.md").is_file()
+    assert not (stored_dir / ".git").exists()  # 打包时剔除 .git
+
+
+def test_cmd_upload_rejects_non_skill_dir(tmp_path, capsys):
+    args = SimpleNamespace(path=str(tmp_path), json=False)
+    assert cli.cmd_upload(args) == 2
+    assert "SKILL.md" in capsys.readouterr().err


### PR DESCRIPTION
## 做什么

- **`xskill search <query...>`**：关键词搜 team server 的 skillhub（含成员上传件），命中的 skill 拉到本地 `~/.xskill/search_skills/<skill_id>/`、打 `.xskill_search.json` 标记、装进本机全部生态，输出 name / description / 本机绝对路径。本地固定 **10 个滚动槽位**（台账 `search_slots.json`，按最近命中淘汰，摘生态 symlink + 删目录）。
- **`xskill upload <dir>`**：本地 `parse_strict` 校验 SKILL.md 后打 zip（剔 `.git`/`__pycache__`/`.xskill_*`，20MB 上限）上传；server 落到 `<skillhub>/user_skill_hub/<safe_dir_name(user_name, client_id)>/<skill名>/`。
- `xskill search traj|skill <q>`（本机索引搜索）行为不变。

## 关键设计

- **与推荐画像完全无关**：搜索端点只做 name/description 关键词打分（`SkillHub.search`），不经 `SkillRecommendEngine`、不读 client 画像。
- **上传件落在 skillhub 目录树内** → 天然进入既有扫描：立即可搜、可走既有 `/skill/{id}/bundle` 分发、推荐引擎 fingerprint 自动失效，零新增分发通路。
- **search 槽位放独立目录**：daemon 的 cleanup 按 manifest 清 `~/.xskill/skill/`，search 拉下的 skill 不受 sync 周期清理影响。
- daemon 的 zip 落盘 / 生态安装 / 生态摘除提为模块级函数复用，行为不变。
- 两个新端点鉴权与现有 team 端点一致（`_auth`）；上传有路径穿越防护 + zip/frontmatter 校验；skillhub 未启用时 503。

## 测试

- 新增 `tests/test_skill_hub_search_upload.py` 14 项：端点鉴权 / 评分序 / 503 降级 / 落盘路径与重传覆盖 / 坏包与穿越拒收 / 槽位滚动淘汰与重复命中去重 / CLI 端到端（TestClient 注入）。
- 全量 `pytest tests/`：**1432 passed**，唯一失败 `test_canary_flip_promote_and_install_new_version` 为 main 存量（已在干净 origin/main 复现，与本改动无关）。

🤖 Generated with [Claude Code](https://claude.com/claude-code)