### PR TITLE
perf(sqlite): 线程内复用 registry 连接，消除 finalize convoy（协程卡顿根治）

### DIFF
--- a/scripts/bench/bench_sqlite_finalize_convoy.py
+++ b/scripts/bench/bench_sqlite_finalize_convoy.py
@@ -1,0 +1,92 @@
+"""复现/度量 SQLite 连接 finalize convoy。
+
+模拟 embedding 高峰：N 个写线程持续打 ``record_usage``（每次 LLM/embedding
+调用的真实路径），同时一个"看板受害者"线程反复调 ``usage_summary`` 量延迟，
+并采样 ``/proc/self/task/*/wchan`` 统计 park 在 futex 上的线程数。
+
+用法（对比改造前后，用 PYTHONPATH 指向不同源码树跑两次）::
+
+    PYTHONPATH=src python3 scripts/bench/bench_sqlite_finalize_convoy.py
+"""
+from __future__ import annotations
+
+import json
+import os
+import statistics
+import tempfile
+import threading
+import time
+from pathlib import Path
+
+WRITER_THREADS = 16
+DURATION_SECONDS = 10.0
+
+
+def _wchan_futex_ratio() -> tuple[int, int]:
+    task_dir = Path(f"/proc/{os.getpid()}/task")
+    parked = total = 0
+    for task in task_dir.iterdir():
+        try:
+            channel = (task / "wchan").read_text()
+        except OSError:
+            continue
+        total += 1
+        if "futex" in channel:
+            parked += 1
+    return parked, total
+
+
+def main() -> None:
+    from xskill.pipeline.registry import record_usage, usage_summary
+
+    with tempfile.TemporaryDirectory(prefix="xskill-bench-") as tmp:
+        db_path = Path(tmp) / "registry.db"
+        stop = threading.Event()
+        write_counts = [0] * WRITER_THREADS
+
+        def writer(index: int) -> None:
+            while not stop.is_set():
+                record_usage(step="bench", model="m", prompt=10, completion=10,
+                             total=20, cost_usd=0.0, price_source="config",
+                             db_path=db_path)
+                write_counts[index] += 1
+
+        victim_latencies: list[float] = []
+        futex_samples: list[tuple[int, int]] = []
+
+        def victim() -> None:
+            while not stop.is_set():
+                started = time.perf_counter()
+                usage_summary(db_path=db_path)
+                victim_latencies.append(time.perf_counter() - started)
+                futex_samples.append(_wchan_futex_ratio())
+                time.sleep(0.05)
+
+        threads = [threading.Thread(target=writer, args=(i,), daemon=True)
+                   for i in range(WRITER_THREADS)]
+        threads.append(threading.Thread(target=victim, daemon=True))
+        for thread in threads:
+            thread.start()
+        time.sleep(DURATION_SECONDS)
+        stop.set()
+        for thread in threads:
+            thread.join(timeout=10)
+
+        ordered = sorted(victim_latencies)
+        peak_parked = max(sample[0] for sample in futex_samples)
+        print(json.dumps({
+            "writer_threads": WRITER_THREADS,
+            "duration_s": DURATION_SECONDS,
+            "record_usage_ops": sum(write_counts),
+            "record_usage_ops_per_s": round(sum(write_counts) / DURATION_SECONDS),
+            "victim_reads": len(ordered),
+            "victim_p50_ms": round(statistics.median(ordered) * 1000, 2),
+            "victim_p95_ms": round(ordered[int(len(ordered) * 0.95) - 1] * 1000, 2),
+            "victim_max_ms": round(ordered[-1] * 1000, 2),
+            "peak_futex_parked_threads": peak_parked,
+            "sampled_threads": futex_samples[-1][1],
+        }, indent=2))
+
+
+if __name__ == "__main__":
+    main()

--- a/src/xskill/api/app.py
+++ b/src/xskill/api/app.py
@@ -709,15 +709,14 @@ async def api_unregister_dir(req: dict):
 @router.get("/trajectories/logs")
 async def api_trajectory_logs(filename: str, dir: str = ""):
     """Return stored process logs for a trajectory."""
-    from xskill.pipeline.registry import list_watch_dirs, get_connection
+    from xskill.pipeline.registry import list_watch_dirs, pooled_connection
     import json as _json
 
     dirs = list_watch_dirs()
     for d in dirs:
         if dir and d["path"] != dir:
             continue
-        conn = get_connection()
-        try:
+        with pooled_connection() as conn:
             row = conn.execute(
                 "SELECT process_log FROM trajectories"
                 " WHERE watch_dir_id=? AND filename=?",
@@ -729,20 +728,17 @@ async def api_trajectory_logs(filename: str, dir: str = ""):
                 except Exception:
                     entries = [{"t": "", "tag": "raw", "msg": row["process_log"]}]
                 return {"logs": entries, "filename": filename}
-        finally:
-            conn.close()
     return {"logs": [], "filename": filename}
 
 
 @router.get("/trajectories/list")
 async def api_list_trajectories():
     """List all trajectories across registered directories with full status."""
-    from xskill.pipeline.registry import list_watch_dirs, get_connection, get_status_counts
+    from xskill.pipeline.registry import list_watch_dirs, pooled_connection, get_status_counts
     dirs = list_watch_dirs()
     all_trajs = []
     for d in dirs:
-        conn = get_connection()
-        try:
+        with pooled_connection() as conn:
             rows = conn.execute(
                 "SELECT filename, has_meta, has_embedding, status, process_action,"
                 " skill_generated, skill_used, canary_side, ux_score, error_msg,"
@@ -769,8 +765,6 @@ async def api_list_trajectories():
                     "indexed_at": r["indexed_at"],
                     "updated_at": r["updated_at"],
                 })
-        finally:
-            conn.close()
     status_counts = get_status_counts()
     return {"trajectories": all_trajs, "count": len(all_trajs), "status_counts": status_counts}
 

--- a/src/xskill/dashboard/console.py
+++ b/src/xskill/dashboard/console.py
@@ -21,7 +21,7 @@ from xskill.pipeline.registry import (
     PinQuotaExceeded,
     clear_skill_pref,
     effective_prefs,
-    get_connection,
+    pooled_connection,
     prefs_for,
     purge_skill_records,
     retire_skill,
@@ -54,12 +54,9 @@ def _total_slots() -> int:
 
 def _traj_user_map(db_path: Optional[Path]) -> dict[str, str]:
     """traj_id(stem) → user_key。直接读 trajectories.user_key（P2-2.1）。"""
-    conn = get_connection(db_path)
-    try:
+    with pooled_connection(db_path) as conn:
         rows = conn.execute(
             "SELECT filename fn, user_key uk FROM trajectories").fetchall()
-    finally:
-        conn.close()
     out: dict[str, str] = {}
     for r in rows:
         fn = r["fn"] or ""
@@ -99,12 +96,9 @@ def reco_trigger_for_users(*, db_path: Optional[Path], skill_dir: Path,
     from xskill.dashboard.metrics import load_usage_records
 
     c2u = _client_to_user(registry)
-    conn = get_connection(db_path)
-    try:
+    with pooled_connection(db_path) as conn:
         reco_rows = conn.execute(
             "SELECT client_id, skill, ts FROM recommendation_log").fetchall()
-    finally:
-        conn.close()
 
     exposures: dict[tuple, int] = {}
     for r in reco_rows:
@@ -302,8 +296,7 @@ def build_console_router(db_path: Optional[Path] = None) -> APIRouter:
         ctx = _require_team_ctx()
         from xskill.dashboard.metrics import load_usage_records
         user = ident["user"]
-        conn = get_connection(db_path)
-        try:
+        with pooled_connection(db_path) as conn:
             row = conn.execute(
                 "SELECT COUNT(*) n, COALESCE(SUM(tasks_extracted),0) atoms"
                 " FROM trajectories WHERE user_key=?", (user,)).fetchone()
@@ -317,8 +310,6 @@ def build_console_router(db_path: Optional[Path] = None) -> APIRouter:
             adoption = conn.execute(
                 "SELECT atom_id, skill, weightscore FROM atom_adoption"
             ).fetchall()
-        finally:
-            conn.close()
         # atom_id 内嵌 traj_id（atom_<traj_id>_NNNN）——按包含判定归属
         my_adopted = [dict(a) for a in adoption
                       if any(stem in (a["atom_id"] or "") for stem in my_stems)]

--- a/src/xskill/dashboard/explore.py
+++ b/src/xskill/dashboard/explore.py
@@ -12,7 +12,7 @@ from pathlib import Path
 from typing import Optional
 
 from xskill._sqlite_connect import connect_with_lock
-from xskill.pipeline.registry import get_connection
+from xskill.pipeline.registry import pooled_connection
 from xskill.dashboard.metrics import _resolve_local_root, load_usage_records
 
 
@@ -27,16 +27,13 @@ class TrajExplorer:
                         else get_registry_db_path().parent)
 
     def _traj_row(self, traj_id: str) -> dict:
-        conn = get_connection(self._db)
-        try:
+        with pooled_connection(self._db) as conn:
             row = conn.execute(
                 "SELECT t.*, w.path wpath, w.label wlabel, w.ecosystem eco"
                 " FROM trajectories t JOIN watch_dirs w ON t.watch_dir_id=w.id"
                 " WHERE t.filename=? OR t.filename=?",
                 (traj_id, f"{traj_id}.md"),
             ).fetchone()
-        finally:
-            conn.close()
         if row is None:
             raise KeyError(f"trajectory not found: {traj_id}")
         return dict(row)
@@ -119,13 +116,10 @@ class TrajExplorer:
     def _atom_destinations(self, atom_id: str) -> list[dict]:
         """该 atom 的去向：进入了哪些 skill（adoption 事件 + 在途 candidates）。"""
         out: list[dict] = []
-        conn = get_connection(self._db)
-        try:
+        with pooled_connection(self._db) as conn:
             rows = conn.execute(
                 "SELECT skill, weightscore, ts FROM atom_adoption WHERE atom_id=?"
                 " ORDER BY ts", (atom_id,)).fetchall()
-        finally:
-            conn.close()
         for r in rows:
             out.append({"skill": r["skill"], "weightscore": r["weightscore"],
                         "state": "adopted", "ts": r["ts"]})
@@ -151,8 +145,7 @@ def skill_lineage(skill_dir: Path, name: str,
     sub = Path(skill_dir) / name
     if not sub.is_dir():
         raise KeyError(f"skill not found: {name}")
-    conn = get_connection(db_path)
-    try:
+    with pooled_connection(db_path) as conn:
         adoption = conn.execute(
             "SELECT atom_id, weightscore, ts FROM atom_adoption WHERE skill=?"
             " ORDER BY ts", (name,)).fetchall()
@@ -160,8 +153,6 @@ def skill_lineage(skill_dir: Path, name: str,
             "SELECT t.filename fn, t.source_model model, w.label label,"
             " w.path wpath FROM trajectories t"
             " JOIN watch_dirs w ON t.watch_dir_id=w.id").fetchall()
-    finally:
-        conn.close()
     from xskill.config import get_registry_db_path
     db_dir = Path(db_path).parent if db_path else get_registry_db_path().parent
     traj_info: dict[str, dict] = {}
@@ -245,13 +236,10 @@ def skill_ux_daily(skill_dir: Path, name: str) -> list[dict]:
 def pipeline_progress(db_path: Optional[Path],
                       skill_dir: Optional[Path]) -> dict:
     """总览页蒸馏管线进度（图⑥）：状态计数 + 冷启动信号 + 候选孵化进度。"""
-    conn = get_connection(db_path)
-    try:
+    with pooled_connection(db_path) as conn:
         rows = dict(conn.execute(
             "SELECT status, COUNT(*) FROM trajectories GROUP BY status"
         ).fetchall())
-    finally:
-        conn.close()
     stages = {
         "pending_split": rows.get("discovered", 0) + rows.get("meta_done", 0),
         "splitting": rows.get("splitting", 0),
@@ -319,8 +307,7 @@ def users_status(db_path: Optional[Path], *,
     finally:
         cconn.close()
     # 轨迹/原子/harness/模型聚合（registry）：team_client 目录按 label 归 client
-    conn = get_connection(db_path)
-    try:
+    with pooled_connection(db_path) as conn:
         trows = conn.execute(
             "SELECT w.label label, COUNT(t.id) trajs,"
             " COALESCE(SUM(t.tasks_extracted),0) atoms"
@@ -336,8 +323,6 @@ def users_status(db_path: Optional[Path], *,
             " FROM trajectories t JOIN watch_dirs w ON t.watch_dir_id=w.id"
             " WHERE w.ecosystem='team_client' GROUP BY w.label, t.source_model"
         ).fetchall()
-    finally:
-        conn.close()
     stats = {r["label"]: {"trajs": r["trajs"], "atoms": r["atoms"]}
              for r in trows}
     harness: dict[str, list] = {}

--- a/src/xskill/dashboard/gitgraph.py
+++ b/src/xskill/dashboard/gitgraph.py
@@ -9,7 +9,7 @@ from __future__ import annotations
 from pathlib import Path
 from typing import Optional
 
-from xskill.pipeline.registry import get_connection
+from xskill.pipeline.registry import pooled_connection
 
 _MAX_COMMITS = 200
 
@@ -81,14 +81,11 @@ def skill_commit_graph(skill_dir: Path, name: str,
 
     decisions_by_sha: dict[str, dict] = {}
     unlocated: list[dict] = []
-    conn = get_connection(db_path)
-    try:
+    with pooled_connection(db_path) as conn:
         rows = conn.execute(
             "SELECT ts, action, main_avg, staging_avg, staging_sha, main_sha"
             " FROM canary_decision WHERE skill=? ORDER BY ts", (name,)
         ).fetchall()
-    finally:
-        conn.close()
     node_shas = {n["sha"] for n in nodes}
     for r in rows:
         d = {"ts": r["ts"], "action": r["action"],

--- a/src/xskill/dashboard/metrics.py
+++ b/src/xskill/dashboard/metrics.py
@@ -13,7 +13,7 @@ import time
 from pathlib import Path
 from typing import Optional
 
-from xskill.pipeline.registry import get_connection
+from xskill.pipeline.registry import pooled_connection
 
 
 def _pct(num: float, den: float) -> float:
@@ -439,13 +439,10 @@ class DashboardMetrics:
         P2-2.1 起直接读 ``trajectories.user_key``（team 桶入库时写、存量由
         scripts/backfill_user_key.py 回填），不再 JOIN ``watch_dirs.label``——
         source 唯一，不留两条归因链路。非 team 轨迹 user_key 为空 → '(local)'。"""
-        conn = get_connection(self._db)
-        try:
+        with pooled_connection(self._db) as conn:
             rows = conn.execute(
                 "SELECT filename fn, user_key uk FROM trajectories"
             ).fetchall()
-        finally:
-            conn.close()
         out: dict[str, str] = {}
         for r in rows:
             fn = r["fn"] or ""
@@ -454,8 +451,7 @@ class DashboardMetrics:
         return out
 
     def overview(self) -> dict:
-        conn = get_connection(self._db)
-        try:
+        with pooled_connection(self._db) as conn:
             r = conn.execute(
                 "SELECT COUNT(*) trajs, COALESCE(SUM(tasks_extracted),0) atoms,"
                 " SUM(CASE WHEN status='done' THEN 1 ELSE 0 END) done,"
@@ -464,8 +460,6 @@ class DashboardMetrics:
                 " SUM(CASE WHEN retry_count>0 THEN 1 ELSE 0 END) retried"
                 " FROM trajectories"
             ).fetchone()
-        finally:
-            conn.close()
         n = r["trajs"] or 0
         # 处理成功率按终态口径：done/(done+error+filtered)，在途轨迹不进分母
         # （否则新批入库时比率被瞬间稀释——审计 P2-10）。
@@ -499,8 +493,7 @@ class DashboardMetrics:
             " THEN COALESCE(NULLIF(t.source_harness,''),:hlabel)"
             " ELSE wd.ecosystem END"
         )
-        conn = get_connection(self._db)
-        try:
+        with pooled_connection(self._db) as conn:
             # HAVING 排除 0 轨迹幻影行（空 team_client 目录经 LEFT JOIN 出成
             # unknown 行——审计 P3-13）。
             rows = conn.execute(
@@ -510,21 +503,16 @@ class DashboardMetrics:
                 f" GROUP BY {eco_expr} HAVING COUNT(t.id)>0 ORDER BY trajs DESC",
                 {"hlabel": self._unknown_harness},
             ).fetchall()
-        finally:
-            conn.close()
         return [self._row(r, "ecosystem") for r in rows]
 
     def by_model(self) -> list[dict]:
-        conn = get_connection(self._db)
-        try:
+        with pooled_connection(self._db) as conn:
             rows = conn.execute(
                 "SELECT COALESCE(source_model,:mlabel) model, COUNT(*) trajs,"
                 " COALESCE(SUM(tasks_extracted),0) atoms FROM trajectories"
                 " GROUP BY COALESCE(source_model,:mlabel) ORDER BY trajs DESC",
                 {"mlabel": self._unknown_model},
             ).fetchall()
-        finally:
-            conn.close()
         return [self._row(r, "model") for r in rows]
 
     def users(self) -> list[dict]:
@@ -532,8 +520,7 @@ class DashboardMetrics:
         一个 ecosystem='team_client' 的 watch_dir(label=client_id)。按 client 聚合
         其轨迹数 / 原子数 / 最近活跃时间。非 team 部署无此类目录 → 返回 []。
         """
-        conn = get_connection(self._db)
-        try:
+        with pooled_connection(self._db) as conn:
             # last_active 用 discovered_at（用户轨迹产生时间），不用 updated_at
             # （那是流水线自己的写时间，rebuild 会把它全刷新——审计 P3-13）。
             rows = conn.execute(
@@ -544,8 +531,6 @@ class DashboardMetrics:
                 " WHERE wd.ecosystem='team_client' AND wd.label IS NOT NULL"
                 " AND wd.label!='' GROUP BY wd.label ORDER BY trajs DESC"
             ).fetchall()
-        finally:
-            conn.close()
         return [{"client_id": r["client_id"], "trajs": r["trajs"] or 0,
                  "atoms": r["atoms"] or 0, "last_active": r["last_active"] or ""}
                 for r in rows]
@@ -569,12 +554,9 @@ class DashboardMetrics:
         db_dir = Path(self._db).parent if self._db else get_registry_db_path().parent
         counter: Counter = Counter()
         tag_users: dict[str, set] = defaultdict(set)
-        conn = get_connection(self._db)
-        try:
+        with pooled_connection(self._db) as conn:
             wds = [(r["path"], r["label"], r["ecosystem"]) for r in conn.execute(
                 "SELECT path, label, ecosystem FROM watch_dirs").fetchall()]
-        finally:
-            conn.close()
         for wp, label, eco in wds:
             root = _resolve_local_root(wp, db_dir)
             client = label if (eco == "team_client" and label) else None
@@ -614,14 +596,11 @@ class DashboardMetrics:
 
     def adoption_rate(self) -> dict:
         """原子采纳率 = 采纳原子(atom_adoption 去重) / 总原子(tasks_extracted 求和)。"""
-        conn = get_connection(self._db)
-        try:
+        with pooled_connection(self._db) as conn:
             adopted = conn.execute(
                 "SELECT COUNT(DISTINCT atom_id) FROM atom_adoption").fetchone()[0]
             total = conn.execute(
                 "SELECT COALESCE(SUM(tasks_extracted),0) FROM trajectories").fetchone()[0]
-        finally:
-            conn.close()
         # 分子是历史累计事件、分母是当前存量，reset/unregister 已同步清理分子；
         # 仍封顶 100% 防残余时间窗错位读成 >100%（审计 P1-7）。
         return {"adopted": adopted, "total": total,
@@ -629,12 +608,9 @@ class DashboardMetrics:
 
     def promotion_rate(self) -> dict:
         """canary 晋升率 = 晋升数 / 已裁决数(晋升+拒绝+超时丢弃)。"""
-        conn = get_connection(self._db)
-        try:
+        with pooled_connection(self._db) as conn:
             rows = dict(conn.execute(
                 "SELECT action, COUNT(*) n FROM canary_decision GROUP BY action").fetchall())
-        finally:
-            conn.close()
         promoted = rows.get("promoted", 0)
         decided = promoted + rows.get("rejected", 0) + rows.get("timeout_discarded", 0)
         return {"promoted": promoted, "decided": decided, "rate": _pct(promoted, decided)}
@@ -648,14 +624,11 @@ class DashboardMetrics:
         单 skill 触发率 = 采用的曝光对 / 该 skill 曝光对，天然 ≤100%；
         总触发率 = 全部采用对 / 全部曝光对。
         """
-        conn = get_connection(self._db)
-        try:
+        with pooled_connection(self._db) as conn:
             exposures = conn.execute(
                 "SELECT client_id, skill, MIN(ts) ts FROM recommendation_log"
                 " WHERE client_id IS NOT NULL AND client_id!=''"
                 " GROUP BY client_id, skill").fetchall()
-        finally:
-            conn.close()
         traj_client = self._traj_client_map()
         # (client, skill) → 最早使用时间
         first_use: dict[tuple[str, str], str] = {}

--- a/src/xskill/events.py
+++ b/src/xskill/events.py
@@ -29,7 +29,7 @@ import logging
 from pathlib import Path
 from typing import Optional
 
-from xskill.pipeline.registry import get_connection
+from xskill.pipeline.registry import pooled_connection
 
 logger = logging.getLogger("xskill.events")
 
@@ -66,8 +66,7 @@ def skill_contributors(skill: str, *, min_weight: int = CONTRIBUTOR_MIN_WEIGHT,
     贡献关系 = ``atom_adoption``(atom 被聚进 skill) 经 atom_id 内嵌的
     traj_id 归到 ``trajectories.user_key``(D5 canonical 身份键)。
     """
-    conn = get_connection(db_path)
-    try:
+    with pooled_connection(db_path) as conn:
         traj_user = {
             (r["filename"][:-3] if r["filename"].endswith(".md")
              else r["filename"]): (r["user_key"] or "")
@@ -78,8 +77,6 @@ def skill_contributors(skill: str, *, min_weight: int = CONTRIBUTOR_MIN_WEIGHT,
             "SELECT atom_id, weightscore FROM atom_adoption WHERE skill=?",
             (skill,),
         ).fetchall()
-    finally:
-        conn.close()
     weights: dict[str, int] = {}
     for r in rows:
         user = traj_user.get(_traj_of_atom(r["atom_id"] or ""), "")
@@ -104,8 +101,7 @@ class EventStore:
 
         feedback 命中 (skill, traj_id) 去重索引时返回 None(已发过,不重发)。
         """
-        conn = get_connection(self._db_path)
-        try:
+        with pooled_connection(self._db_path) as conn:
             cur = conn.execute(
                 "INSERT OR IGNORE INTO events(kind,actor,skill,traj_id,payload)"
                 " VALUES(?,?,?,?,?)",
@@ -122,8 +118,6 @@ class EventStore:
                         " VALUES(?,?)", (event_id, user))
             conn.commit()
             return event_id
-        finally:
-            conn.close()
 
     def emit_feedback(self, *, actor: str, skill: str, traj_id: str,
                       score_avg: float, n_atoms: int, side: str,
@@ -180,8 +174,7 @@ class EventStore:
     def world_feed(self, *, limit: int = 50,
                    before_id: Optional[int] = None) -> list[dict]:
         """世界消息:全部事件,最新在前(Q6:登录可见;只读实例不挂该路由)。"""
-        conn = get_connection(self._db_path)
-        try:
+        with pooled_connection(self._db_path) as conn:
             sql = "SELECT * FROM events"
             params: list = []
             if before_id is not None:
@@ -191,14 +184,11 @@ class EventStore:
             params.append(max(1, min(int(limit), 200)))
             return [self._row_to_event(r)
                     for r in conn.execute(sql, params).fetchall()]
-        finally:
-            conn.close()
 
     def for_user(self, user_key: str, *, limit: int = 50,
                  before_id: Optional[int] = None) -> list[dict]:
         """发给我的通知,最新在前,带 ``read`` 标记(id ≤ 游标 = 已读)。"""
-        conn = get_connection(self._db_path)
-        try:
+        with pooled_connection(self._db_path) as conn:
             cursor_id = self._last_read_id(conn, user_key)
             sql = ("SELECT e.* FROM events e"
                    " JOIN event_targets t ON t.event_id=e.id"
@@ -215,12 +205,9 @@ class EventStore:
                 ev["read"] = ev["id"] <= cursor_id
                 out.append(ev)
             return out
-        finally:
-            conn.close()
 
     def unread_count(self, user_key: str) -> int:
-        conn = get_connection(self._db_path)
-        try:
+        with pooled_connection(self._db_path) as conn:
             cursor_id = self._last_read_id(conn, user_key)
             return conn.execute(
                 "SELECT COUNT(*) FROM event_targets t"
@@ -228,13 +215,10 @@ class EventStore:
                 " WHERE t.user_key=? AND e.id>?",
                 (user_key, cursor_id),
             ).fetchone()[0]
-        finally:
-            conn.close()
 
     def mark_read(self, user_key: str, last_id: int) -> None:
         """推进已读游标(只前进不后退——重复/乱序标记幂等)。"""
-        conn = get_connection(self._db_path)
-        try:
+        with pooled_connection(self._db_path) as conn:
             conn.execute(
                 "INSERT INTO event_reads(user_key,last_read_id) VALUES(?,?)"
                 " ON CONFLICT(user_key) DO UPDATE SET"
@@ -242,8 +226,6 @@ class EventStore:
                 (user_key, int(last_id)),
             )
             conn.commit()
-        finally:
-            conn.close()
 
     @staticmethod
     def _last_read_id(conn, user_key: str) -> int:

--- a/src/xskill/pipeline/registry.py
+++ b/src/xskill/pipeline/registry.py
@@ -20,10 +20,12 @@ import logging
 import sqlite3
 import threading
 import zlib
+from contextlib import contextmanager
 from datetime import datetime, timezone
 from enum import Enum
 from pathlib import Path
-from typing import Optional
+from types import SimpleNamespace
+from typing import Iterator, Optional
 
 from xskill._sqlite_connect import connect_with_lock
 from xskill.config import get_registry_db_path
@@ -35,6 +37,9 @@ _REGISTRY_DB_LOCKS_GUARD = threading.Lock()
 _REGISTRY_WAL_LOCKS: dict[Path, threading.Lock] = {}
 _REGISTRY_SCHEMA_LOCKS: dict[Path, threading.Lock] = {}
 _REGISTRY_WAL_READY: dict[Path, tuple[int, int]] = {}
+# 线程本地的按 DB 连接槽位（pooled_connection 用）；线程死亡随 GC 释放
+_REGISTRY_THREAD_POOL = threading.local()
+_REGISTRY_THREAD_POOL_CAPACITY = 4
 
 
 def _registry_db_lock(
@@ -282,6 +287,82 @@ def get_connection(db_path: Optional[Path] = None) -> sqlite3.Connection:
         raise
 
 
+@contextmanager
+def pooled_connection(db_path: Optional[Path] = None) -> Iterator[sqlite3.Connection]:
+    """线程内复用的 registry 连接；退出时回滚未提交事务，但不 close。
+
+    高频调用点（``record_usage`` 每次 LLM/embedding 调用一次）每次 open/close
+    会把连接 finalize 打成热事件，而 finalize 走 ``_SQLITE_CALL_GATE`` 独占侧，
+    高负载下整个进程的 SQLite 调用都会 park 在这把门后（futex convoy）。线程内
+    复用后 finalize 只发生在线程退出 / DB 重建 / 槽位淘汰这些低频时刻。
+
+    同线程重入（外层还没退出又请求同一 DB）退回一次性连接，保证两层事务互不
+    可见；DB 文件被删除重建（rebuild / 测试 tmp 目录）靠 inode 变化识别并重开。
+    """
+    if db_path is None:
+        db_path = get_registry_db_path()
+    db_key = db_path.expanduser().resolve()
+    slots = getattr(_REGISTRY_THREAD_POOL, "slots", None)
+    if slots is None:
+        slots = {}
+        _REGISTRY_THREAD_POOL.slots = slots
+    try:
+        identity = _registry_db_identity(db_key)
+    except OSError:
+        identity = None
+    slot = slots.get(db_key)
+    if slot is not None and slot.busy:
+        connection = get_connection(db_path)
+        try:
+            yield connection
+        finally:
+            connection.close()
+        return
+    if slot is not None and (identity is None or slot.identity != identity):
+        slots.pop(db_key, None)
+        try:
+            slot.conn.close()
+        except Exception:
+            logger.debug("closing stale pooled connection failed", exc_info=True)
+        slot = None
+    if slot is None:
+        connection = get_connection(db_path)
+        slot = SimpleNamespace(conn=connection,
+                               identity=_registry_db_identity(db_key),
+                               busy=False)
+        while len(slots) >= _REGISTRY_THREAD_POOL_CAPACITY:
+            _oldest_key, oldest_slot = next(iter(slots.items()))
+            slots.pop(_oldest_key)
+            try:
+                oldest_slot.conn.close()
+            except Exception:
+                logger.debug("evicting pooled connection failed", exc_info=True)
+        slots[db_key] = slot
+    else:
+        # 手动 LRU：命中的槽位挪到 dict 尾部，淘汰永远从头部取最旧
+        slots.pop(db_key)
+        slots[db_key] = slot
+    slot.busy = True
+    try:
+        yield slot.conn
+        if slot.conn.in_transaction:
+            slot.conn.rollback()
+    except Exception:
+        try:
+            if slot.conn.in_transaction:
+                slot.conn.rollback()
+        except Exception:
+            slots.pop(db_key, None)
+            try:
+                slot.conn.close()
+            except Exception:
+                logger.debug("closing broken pooled connection failed",
+                             exc_info=True)
+        raise
+    finally:
+        slot.busy = False
+
+
 def _migrate(conn: sqlite3.Connection) -> None:
     """Add columns missing from older schema versions."""
     # ── trajectories ──
@@ -380,8 +461,7 @@ def record_usage(*, step: str, model: str, prompt: int, completion: int,
                  total: int, cost_usd: float, price_source: str,
                  db_path: Optional[Path] = None) -> None:
     """追加一条 LLM/embedding 调用的 token+成本记录。旁路 telemetry。"""
-    conn = get_connection(db_path)
-    try:
+    with pooled_connection(db_path) as conn:
         conn.execute(
             "INSERT INTO llm_usage(step,model,prompt,completion,total,cost_usd,price_source)"
             " VALUES(?,?,?,?,?,?,?)",
@@ -389,8 +469,6 @@ def record_usage(*, step: str, model: str, prompt: int, completion: int,
              float(cost_usd), price_source),
         )
         conn.commit()
-    finally:
-        conn.close()
 
 
 # ---------------------------------------------------------------------------
@@ -419,8 +497,7 @@ def set_skill_pref(*, user_key: str, skill_name: str, pref: str, set_by: str,
         raise ValueError(f"pref 必须是 pinned|blocked,得到 {pref!r}")
     if not user_key or not skill_name:
         raise ValueError("user_key/skill_name 不能为空")
-    conn = get_connection(db_path)
-    try:
+    with pooled_connection(db_path) as conn:
         if pref == "pinned" and max_pinned is not None:
             _check_pin_quota(conn, user_key=user_key, skill_name=skill_name,
                              max_pinned=max_pinned)
@@ -433,8 +510,6 @@ def set_skill_pref(*, user_key: str, skill_name: str, pref: str, set_by: str,
             (user_key, skill_name, pref, set_by),
         )
         conn.commit()
-    finally:
-        conn.close()
 
 
 def _check_pin_quota(conn, *, user_key: str, skill_name: str,
@@ -470,29 +545,23 @@ def _check_pin_quota(conn, *, user_key: str, skill_name: str,
 def clear_skill_pref(*, user_key: str, skill_name: str,
                      db_path: Optional[Path] = None) -> bool:
     """删除一条偏好(pin 取消/屏蔽恢复)。返回是否真的删了行。"""
-    conn = get_connection(db_path)
-    try:
+    with pooled_connection(db_path) as conn:
         cur = conn.execute(
             "DELETE FROM skill_prefs WHERE user_key=? AND skill_name=?",
             (user_key, skill_name),
         )
         conn.commit()
         return cur.rowcount > 0
-    finally:
-        conn.close()
 
 
 def prefs_for(user_key: str, *, db_path: Optional[Path] = None) -> list[dict]:
     """某 user_key(或 '*global*')的全部偏好行。"""
-    conn = get_connection(db_path)
-    try:
+    with pooled_connection(db_path) as conn:
         return [dict(r) for r in conn.execute(
             "SELECT user_key, skill_name, pref, set_by, ts FROM skill_prefs"
             " WHERE user_key=? ORDER BY ts",
             (user_key,),
         ).fetchall()]
-    finally:
-        conn.close()
 
 
 def effective_prefs(user_key: str, *, db_path: Optional[Path] = None) -> dict:
@@ -503,16 +572,13 @@ def effective_prefs(user_key: str, *, db_path: Optional[Path] = None) -> dict:
     与全局行冲突时,**blocked 优先**(任何一侧屏蔽即不分发——全局屏蔽用户
     不能自行恢复;用户自己屏蔽的全局推荐仅对自己生效)。
     """
-    conn = get_connection(db_path)
-    try:
+    with pooled_connection(db_path) as conn:
         rows = [dict(r) for r in conn.execute(
             "SELECT user_key, skill_name, pref, set_by, ts FROM skill_prefs"
             " WHERE user_key IN (?, ?) ORDER BY CASE user_key WHEN ? THEN 0"
             " ELSE 1 END, ts",
             (GLOBAL_PREF_KEY, user_key, GLOBAL_PREF_KEY),
         ).fetchall()]
-    finally:
-        conn.close()
     blocked = {r["skill_name"] for r in rows if r["pref"] == "blocked"}
     pinned: list[str] = []
     pin_meta: dict = {}
@@ -531,8 +597,7 @@ def manifest_control_plane_snapshot(
     *, db_path: Optional[Path] = None,
 ) -> dict:
     """一次查询取得 manifest 所需的全部偏好和下线状态。"""
-    conn = get_connection(db_path)
-    try:
+    with pooled_connection(db_path) as conn:
         rows = [dict(row) for row in conn.execute(
             "SELECT user_key, skill_name, pref, set_by, ts FROM skill_prefs"
             " ORDER BY CASE user_key WHEN ? THEN 0 ELSE 1 END, ts",
@@ -543,8 +608,6 @@ def manifest_control_plane_snapshot(
                 "SELECT skill_name FROM skill_lifecycle WHERE state='retired'"
             ).fetchall()
         }
-    finally:
-        conn.close()
     return {"prefs": rows, "retired": retired}
 
 
@@ -581,8 +644,7 @@ def effective_prefs_from_snapshot(snapshot: dict, user_key: str) -> dict:
 def retire_skill(*, skill_name: str, set_by: str,
                  db_path: Optional[Path] = None) -> None:
     """下线:停止分发与推荐,数据与 git 历史保留。幂等。"""
-    conn = get_connection(db_path)
-    try:
+    with pooled_connection(db_path) as conn:
         conn.execute(
             "INSERT INTO skill_lifecycle(skill_name,state,set_by) VALUES(?,?,?)"
             " ON CONFLICT(skill_name) DO UPDATE SET state='retired',"
@@ -590,30 +652,22 @@ def retire_skill(*, skill_name: str, set_by: str,
             (skill_name, "retired", set_by),
         )
         conn.commit()
-    finally:
-        conn.close()
 
 
 def unretire_skill(*, skill_name: str, db_path: Optional[Path] = None) -> bool:
     """恢复在役。返回是否真的有行被删。"""
-    conn = get_connection(db_path)
-    try:
+    with pooled_connection(db_path) as conn:
         cur = conn.execute(
             "DELETE FROM skill_lifecycle WHERE skill_name=?", (skill_name,))
         conn.commit()
         return cur.rowcount > 0
-    finally:
-        conn.close()
 
 
 def retired_skills(*, db_path: Optional[Path] = None) -> set:
-    conn = get_connection(db_path)
-    try:
+    with pooled_connection(db_path) as conn:
         return {r["skill_name"] for r in conn.execute(
             "SELECT skill_name FROM skill_lifecycle WHERE state='retired'"
         ).fetchall()}
-    finally:
-        conn.close()
 
 
 def purge_skill_records(*, skill_name: str,
@@ -621,13 +675,10 @@ def purge_skill_records(*, skill_name: str,
     """删除 skill 时清掉它的 prefs/lifecycle 行——"删后同名 skill 再生"从
     零开始,不继承旧 pin/屏蔽/下线状态(语义拍板,见 tasks.md 2.4c)。
     评分/推荐等历史埋点(recommendation_log 等)保留作审计。"""
-    conn = get_connection(db_path)
-    try:
+    with pooled_connection(db_path) as conn:
         conn.execute("DELETE FROM skill_prefs WHERE skill_name=?", (skill_name,))
         conn.execute("DELETE FROM skill_lifecycle WHERE skill_name=?", (skill_name,))
         conn.commit()
-    finally:
-        conn.close()
 
 
 def record_recommendation(*, client_id: str, skill: str, side: str, bucket: str,
@@ -653,8 +704,7 @@ def record_recommendations(
     """在一个事务中记录同一用户的一批推荐曝光。"""
     if not records:
         return
-    conn = get_connection(db_path)
-    try:
+    with pooled_connection(db_path) as conn:
         conn.executemany(
             "INSERT OR IGNORE INTO recommendation_log(client_id,skill,side,bucket,sha)"
             " VALUES(?,?,?,?,?)",
@@ -662,22 +712,17 @@ def record_recommendations(
              for skill, side, bucket, sha in records],
         )
         conn.commit()
-    finally:
-        conn.close()
 
 
 def record_atom_adoption(*, atom_id: str, skill: str, weightscore: int,
                          was_new: bool, db_path: Optional[Path] = None) -> None:
     """记一次"某 atom 被聚进某 skill"。供算原子采纳率(采纳原子/总原子)。"""
-    conn = get_connection(db_path)
-    try:
+    with pooled_connection(db_path) as conn:
         conn.execute(
             "INSERT INTO atom_adoption(atom_id,skill,weightscore,was_new) VALUES(?,?,?,?)",
             (atom_id, skill, int(weightscore), 1 if was_new else 0),
         )
         conn.commit()
-    finally:
-        conn.close()
 
 
 def record_trigger_eval(*, skill: str, version_sha: Optional[str], exp_id: str,
@@ -689,8 +734,7 @@ def record_trigger_eval(*, skill: str, version_sha: Optional[str], exp_id: str,
     供看板展示 per-skill/版本"离线探针触发率"——区别于 mark_skill_used 记的
     线上真实使用频次,两者语义不同不可混。
     """
-    conn = get_connection(db_path)
-    try:
+    with pooled_connection(db_path) as conn:
         conn.execute(
             "INSERT INTO skill_trigger_eval"
             "(skill,version_sha,exp_id,train_score,test_score,n_cases,catalog_size)"
@@ -699,22 +743,17 @@ def record_trigger_eval(*, skill: str, version_sha: Optional[str], exp_id: str,
              int(n_cases), int(catalog_size)),
         )
         conn.commit()
-    finally:
-        conn.close()
 
 
 def trigger_eval_for_skill(skill: str, *, db_path: Optional[Path] = None) -> list:
     """取某 skill 的离线触发评测历史(按时间升序),供看板趋势图。"""
-    conn = get_connection(db_path)
-    try:
+    with pooled_connection(db_path) as conn:
         rows = conn.execute(
             "SELECT ts,version_sha,exp_id,train_score,test_score,n_cases,"
             "catalog_size FROM skill_trigger_eval WHERE skill=? ORDER BY id ASC",
             (skill,),
         ).fetchall()
         return [dict(r) for r in rows]
-    finally:
-        conn.close()
 
 
 def record_canary_decision(*, skill: str, action: str, main_avg: float,
@@ -727,8 +766,7 @@ def record_canary_decision(*, skill: str, action: str, main_avg: float,
     ``main_sha``/``staging_sha`` 是裁决时两侧 HEAD——进化图据此把裁决挂到
     具体 commit（D9）；存量无 sha 的历史裁决在图上显式标"无法定位"。
     """
-    conn = get_connection(db_path)
-    try:
+    with pooled_connection(db_path) as conn:
         conn.execute(
             "INSERT INTO canary_decision(skill,action,main_avg,staging_avg,"
             "main_samples,staging_samples,age_days,main_sha,staging_sha)"
@@ -738,8 +776,6 @@ def record_canary_decision(*, skill: str, action: str, main_avg: float,
              main_sha or "", staging_sha or ""),
         )
         conn.commit()
-    finally:
-        conn.close()
 
 
 def clear_rebuild_derived_state(
@@ -750,9 +786,8 @@ def clear_rebuild_derived_state(
     ``llm_usage`` is deliberately retained: it is cost accounting for already
     paid calls, not skill state derived from the current repository contents.
     """
-    connection = get_connection(registry_path)
     deleted_counts: dict[str, int] = {}
-    try:
+    with pooled_connection(registry_path) as connection:
         cursor = connection.execute("DELETE FROM recommendation_log")
         deleted_counts["recommendation_log"] = cursor.rowcount
         cursor = connection.execute("DELETE FROM atom_adoption")
@@ -763,14 +798,11 @@ def clear_rebuild_derived_state(
         deleted_counts["skill_trigger_eval"] = cursor.rowcount
         connection.commit()
         return deleted_counts
-    finally:
-        connection.close()
 
 
 def usage_summary(db_path: Optional[Path] = None) -> dict:
     """跨重启的持久汇总:累计 token/$、今日 $、按 step / model 分解。"""
-    conn = get_connection(db_path)
-    try:
+    with pooled_connection(db_path) as conn:
         tot = conn.execute(
             "SELECT COALESCE(SUM(total),0) t, COALESCE(SUM(cost_usd),0) c, COUNT(*) n"
             " FROM llm_usage"
@@ -797,8 +829,6 @@ def usage_summary(db_path: Optional[Path] = None) -> dict:
             "total_calls": tot["n"], "today_usd": round(today, 6),
             "estimated": estimated, "by_step": by_step, "by_model": by_model,
         }
-    finally:
-        conn.close()
 
 
 def _sidecar_field(md_path: Path, key: str) -> Optional[str]:
@@ -839,8 +869,7 @@ def harness_share(db_path: Optional[Path] = None, *,
     config 传入 dashboard.default_harness 覆盖；canary/stats 等调用不传，保持
     'unknown' 语义不变。
     """
-    conn = get_connection(db_path)
-    try:
+    with pooled_connection(db_path) as conn:
         rows = conn.execute(
             f"SELECT {_HARNESS_EXPR} AS harness, COUNT(*) AS trajs"
             " FROM trajectories t JOIN watch_dirs wd ON t.watch_dir_id=wd.id"
@@ -850,8 +879,6 @@ def harness_share(db_path: Optional[Path] = None, *,
         total = sum(r["trajs"] for r in rows) or 1
         return [{"harness": r["harness"], "trajs": r["trajs"],
                  "pct": round(100 * r["trajs"] / total, 1)} for r in rows]
-    finally:
-        conn.close()
 
 
 def model_share(db_path: Optional[Path] = None, *,
@@ -862,8 +889,7 @@ def model_share(db_path: Optional[Path] = None, *,
     注意：canary 的 ``eligible_models`` 把 'unknown' 当“未归属、留在 main”的哨兵，
     所以那条路径必须用默认 'unknown'——只有看板展示层才传入 config 的覆盖值。
     """
-    conn = get_connection(db_path)
-    try:
+    with pooled_connection(db_path) as conn:
         rows = conn.execute(
             "SELECT COALESCE(source_model,:mlabel) AS model, COUNT(*) AS trajs"
             " FROM trajectories GROUP BY COALESCE(source_model,:mlabel)"
@@ -873,8 +899,6 @@ def model_share(db_path: Optional[Path] = None, *,
         total = sum(r["trajs"] for r in rows) or 1
         return [{"model": r["model"], "trajs": r["trajs"],
                  "pct": round(100 * r["trajs"] / total, 1)} for r in rows]
-    finally:
-        conn.close()
 
 
 # ---------------------------------------------------------------------------
@@ -897,8 +921,7 @@ def register_dir(
       - 未来：``codex``、``opencode`` 等
     """
     dir_path = str(Path(dir_path).resolve())
-    conn = get_connection(db_path)
-    try:
+    with pooled_connection(db_path) as conn:
         conn.execute(
             "INSERT INTO watch_dirs (path, label, auto_index, ecosystem)"
             " VALUES (?, ?, ?, ?)"
@@ -911,8 +934,6 @@ def register_dir(
         conn.commit()
         row = conn.execute("SELECT id FROM watch_dirs WHERE path=?", (dir_path,)).fetchone()
         return row["id"]
-    finally:
-        conn.close()
 
 
 def unregister_dir(dir_path: str | Path, *, db_path: Optional[Path] = None) -> bool:
@@ -922,8 +943,7 @@ def unregister_dir(dir_path: str | Path, *, db_path: Optional[Path] = None) -> b
     分母被删小，比率虚高（审计 P1-7）。
     """
     dir_path = str(Path(dir_path).resolve())
-    conn = get_connection(db_path)
-    try:
+    with pooled_connection(db_path) as conn:
         stems = [
             (r["filename"][:-3] if r["filename"].endswith(".md") else r["filename"])
             for r in conn.execute(
@@ -938,14 +958,11 @@ def unregister_dir(dir_path: str | Path, *, db_path: Optional[Path] = None) -> b
         cur = conn.execute("DELETE FROM watch_dirs WHERE path=?", (dir_path,))
         conn.commit()
         return cur.rowcount > 0
-    finally:
-        conn.close()
 
 
 def list_watch_dirs(*, db_path: Optional[Path] = None) -> list[dict]:
     """返回所有注册目录及统计信息。"""
-    conn = get_connection(db_path)
-    try:
+    with pooled_connection(db_path) as conn:
         rows = conn.execute(
             "SELECT w.*, "
             "  (SELECT COUNT(*) FROM trajectories t WHERE t.watch_dir_id=w.id) AS traj_count,"
@@ -953,19 +970,14 @@ def list_watch_dirs(*, db_path: Optional[Path] = None) -> list[dict]:
             " FROM watch_dirs w ORDER BY w.id"
         ).fetchall()
         return [dict(r) for r in rows]
-    finally:
-        conn.close()
 
 
 def get_watch_dir(dir_path: str | Path, *, db_path: Optional[Path] = None) -> dict | None:
     """查询单个目录记录。"""
     dir_path = str(Path(dir_path).resolve())
-    conn = get_connection(db_path)
-    try:
+    with pooled_connection(db_path) as conn:
         row = conn.execute("SELECT * FROM watch_dirs WHERE path=?", (dir_path,)).fetchone()
         return dict(row) if row else None
-    finally:
-        conn.close()
 
 
 # ---------------------------------------------------------------------------
@@ -992,9 +1004,8 @@ def discover_trajectories(
     只拆新增内容。``updated`` 不计入返回的 new_files（只统计真·新文件）。
     """
     dir_path = Path(dir_path)
-    conn = get_connection(db_path)
     new_files: list[str] = []
-    try:
+    with pooled_connection(db_path) as conn:
         # P2-2.1 归因(D5):入库即把 watch_dir 的 label 写进 user_key,聚合层
         # 不再 JOIN watch_dirs.label——source 唯一。CS 模式各用户桶(label=
         # sessions 桶目录名=user_name/client_id)不论 ecosystem 是 team_client
@@ -1070,37 +1081,29 @@ def discover_trajectories(
 
         conn.commit()
         return new_files
-    finally:
-        conn.close()
 
 
 def mark_meta_done(
     watch_dir_id: int, filename: str, *, db_path: Optional[Path] = None
 ) -> None:
-    conn = get_connection(db_path)
-    try:
+    with pooled_connection(db_path) as conn:
         conn.execute(
             "UPDATE trajectories SET has_meta=1 WHERE watch_dir_id=? AND filename=?",
             (watch_dir_id, filename),
         )
         conn.commit()
-    finally:
-        conn.close()
 
 
 def mark_indexed(
     watch_dir_id: int, filename: str, *, db_path: Optional[Path] = None
 ) -> None:
-    conn = get_connection(db_path)
-    try:
+    with pooled_connection(db_path) as conn:
         conn.execute(
             "UPDATE trajectories SET has_embedding=1, indexed_at=?"
             " WHERE watch_dir_id=? AND filename=?",
             (datetime.now(timezone.utc).isoformat(timespec="seconds"), watch_dir_id, filename),
         )
         conn.commit()
-    finally:
-        conn.close()
 
 
 def mark_skill_used(
@@ -1118,24 +1121,20 @@ def mark_skill_used(
     watch_dirs.label 现算(用户)。与工具调用/ token 同属"按轨迹文本现算",保持
     "分析而非埋点"一致——免迁移、不改这条打分热路径的写入语义。
     """
-    conn = get_connection(db_path)
-    try:
+    with pooled_connection(db_path) as conn:
         conn.execute(
             "UPDATE trajectories SET skill_used=?, canary_side=?"
             " WHERE watch_dir_id=? AND filename=?",
             (skill_used, canary_side, watch_dir_id, filename),
         )
         conn.commit()
-    finally:
-        conn.close()
 
 
 def get_unindexed(
     watch_dir_id: int, *, db_path: Optional[Path] = None
 ) -> list[str]:
     """返回缺少 meta 或 embedding 的文件名。"""
-    conn = get_connection(db_path)
-    try:
+    with pooled_connection(db_path) as conn:
         rows = conn.execute(
             "SELECT filename FROM trajectories"
             " WHERE watch_dir_id=? AND (has_meta=0 OR has_embedding=0)"
@@ -1143,16 +1142,13 @@ def get_unindexed(
             (watch_dir_id,),
         ).fetchall()
         return [r["filename"] for r in rows]
-    finally:
-        conn.close()
 
 
 def get_needs_meta(
     watch_dir_id: int, *, db_path: Optional[Path] = None
 ) -> list[str]:
     """返回缺少 meta 的文件名。"""
-    conn = get_connection(db_path)
-    try:
+    with pooled_connection(db_path) as conn:
         rows = conn.execute(
             "SELECT filename FROM trajectories"
             " WHERE watch_dir_id=? AND has_meta=0"
@@ -1160,16 +1156,13 @@ def get_needs_meta(
             (watch_dir_id,),
         ).fetchall()
         return [r["filename"] for r in rows]
-    finally:
-        conn.close()
 
 
 def get_needs_embedding(
     watch_dir_id: int, *, db_path: Optional[Path] = None
 ) -> list[str]:
     """返回有 meta 但缺 embedding 的文件名。"""
-    conn = get_connection(db_path)
-    try:
+    with pooled_connection(db_path) as conn:
         rows = conn.execute(
             "SELECT filename FROM trajectories"
             " WHERE watch_dir_id=? AND has_meta=1 AND has_embedding=0"
@@ -1177,8 +1170,6 @@ def get_needs_embedding(
             (watch_dir_id,),
         ).fetchall()
         return [r["filename"] for r in rows]
-    finally:
-        conn.close()
 
 
 # ---------------------------------------------------------------------------
@@ -1187,8 +1178,7 @@ def get_needs_embedding(
 
 def all_index_paths(*, db_path: Optional[Path] = None) -> list[Path]:
     """返回所有注册目录中实际存在 index.pkl 的路径。"""
-    conn = get_connection(db_path)
-    try:
+    with pooled_connection(db_path) as conn:
         rows = conn.execute("SELECT path FROM watch_dirs ORDER BY id").fetchall()
         result = []
         for r in rows:
@@ -1196,8 +1186,6 @@ def all_index_paths(*, db_path: Optional[Path] = None) -> list[Path]:
             if (p / "index.pkl").is_file():
                 result.append(p)
         return result
-    finally:
-        conn.close()
 
 
 def find_traj_file(
@@ -1268,8 +1256,7 @@ def update_traj_status(
     会算好"重试次数 + 1"再回写，沿着 ``retry_count < max_retries``
     继续重试，超过门槛后兜底标 done + WARNING。
     """
-    conn = get_connection(db_path)
-    try:
+    with pooled_connection(db_path) as conn:
         sets = ["updated_at=datetime('now')"]
         vals: list = []
         if status is not None:
@@ -1297,8 +1284,6 @@ def update_traj_status(
             vals,
         )
         conn.commit()
-    finally:
-        conn.close()
 
 
 def get_traj_retry_count(
@@ -1310,8 +1295,7 @@ def get_traj_retry_count(
     ``update_traj_status(..., retry_count=N+1)``。和 ``increment_retry``
     的差异是这里**只读不写**，由调用方决定何时 +1。
     """
-    conn = get_connection(db_path)
-    try:
+    with pooled_connection(db_path) as conn:
         row = conn.execute(
             "SELECT retry_count FROM trajectories"
             " WHERE watch_dir_id=? AND filename=?",
@@ -1320,8 +1304,6 @@ def get_traj_retry_count(
         if row is None:
             return 0
         return int(row["retry_count"] or 0)
-    finally:
-        conn.close()
 
 
 def update_traj_log(
@@ -1332,16 +1314,13 @@ def update_traj_log(
     db_path: Optional[Path] = None,
 ) -> None:
     """Store process log (JSON string) for a trajectory."""
-    conn = get_connection(db_path)
-    try:
+    with pooled_connection(db_path) as conn:
         conn.execute(
             "UPDATE trajectories SET process_log=?, updated_at=datetime('now')"
             " WHERE watch_dir_id=? AND filename=?",
             (log_json, watch_dir_id, filename),
         )
         conn.commit()
-    finally:
-        conn.close()
 
 
 def get_traj_log(
@@ -1351,15 +1330,12 @@ def get_traj_log(
     db_path: Optional[Path] = None,
 ) -> str | None:
     """Retrieve the stored process log JSON for a trajectory."""
-    conn = get_connection(db_path)
-    try:
+    with pooled_connection(db_path) as conn:
         row = conn.execute(
             "SELECT process_log FROM trajectories WHERE watch_dir_id=? AND filename=?",
             (watch_dir_id, filename),
         ).fetchone()
         return row["process_log"] if row else None
-    finally:
-        conn.close()
 
 
 def update_traj_offset(
@@ -1377,8 +1353,7 @@ def update_traj_offset(
     ``last_atom_id`` 为 None 表示当前轨迹还没切出任何 atom（罕见——通常拆出
     至少 1 个）。
     """
-    conn = get_connection(db_path)
-    try:
+    with pooled_connection(db_path) as conn:
         conn.execute(
             "UPDATE trajectories SET last_offset=?, last_atom_id=?, "
             "tasks_extracted=?, updated_at=datetime('now')"
@@ -1387,8 +1362,6 @@ def update_traj_offset(
              watch_dir_id, filename),
         )
         conn.commit()
-    finally:
-        conn.close()
 
 
 def mark_not_fit(
@@ -1400,8 +1373,7 @@ def mark_not_fit(
     db_path: Optional[Path] = None,
 ) -> None:
     """Mark a trajectory as terminally filtered by the configured interests."""
-    conn = get_connection(db_path)
-    try:
+    with pooled_connection(db_path) as conn:
         conn.execute(
             "UPDATE trajectories SET status=?, process_action=?, error_msg=?, "
             "interest_fingerprint=?, updated_at=datetime('now')"
@@ -1416,8 +1388,6 @@ def mark_not_fit(
             ),
         )
         conn.commit()
-    finally:
-        conn.close()
 
 
 def reset_not_fit_for_interest_change(
@@ -1429,8 +1399,7 @@ def reset_not_fit_for_interest_change(
     """Reset only stale filtered/not_fit trajectories for re-evaluation."""
     if old_interest_fingerprint == new_interest_fingerprint:
         return 0
-    conn = get_connection(db_path)
-    try:
+    with pooled_connection(db_path) as conn:
         rows = conn.execute(
             "SELECT t.id, t.filename, w.path FROM trajectories t "
             "JOIN watch_dirs w ON t.watch_dir_id = w.id "
@@ -1468,8 +1437,6 @@ def reset_not_fit_for_interest_change(
             if index_path.is_file():
                 index_path.unlink()
         return len(rows)
-    finally:
-        conn.close()
 
 
 def reset_trajectories(
@@ -1499,8 +1466,7 @@ def reset_trajectories(
     Returns:
         被重置的轨迹 id 列表（cold-start 快照即由此而来）。
     """
-    conn = get_connection(db_path)
-    try:
+    with pooled_connection(db_path) as conn:
         query_text = (
             "SELECT t.id, t.filename, w.path FROM trajectories t "
             "JOIN watch_dirs w ON t.watch_dir_id = w.id WHERE 1=1"
@@ -1547,8 +1513,6 @@ def reset_trajectories(
             if index_path.is_file():
                 index_path.unlink()
         return [trajectory_row["id"] for trajectory_row in trajectory_rows]
-    finally:
-        conn.close()
 
 
 def get_trajs_by_status(
@@ -1560,8 +1524,7 @@ def get_trajs_by_status(
     db_path: Optional[Path] = None,
 ) -> list[str]:
     """按状态查询文件名。error 状态自动过滤超过 max_retries 的。"""
-    conn = get_connection(db_path)
-    try:
+    with pooled_connection(db_path) as conn:
         sql = "SELECT filename FROM trajectories WHERE watch_dir_id=? AND status=?"
         params: list = [watch_dir_id, status]
         if status == "error":
@@ -1572,8 +1535,6 @@ def get_trajs_by_status(
             sql += f" LIMIT {limit}"
         rows = conn.execute(sql, params).fetchall()
         return [r["filename"] for r in rows]
-    finally:
-        conn.close()
 
 
 def get_pending_traj_ids(
@@ -1586,8 +1547,7 @@ def get_pending_traj_ids(
     只计 ``auto_index=1`` 的 watch dir——watcher 不处理关闭索引的目录，其中
     的轨迹永远不会离开 pending，计入会让 cold-start 只能靠超时退出。
     """
-    conn = get_connection(db_path)
-    try:
+    with pooled_connection(db_path) as conn:
         status_placeholders = ",".join("?" * len(PENDING_TRAJECTORY_STATUSES))
         base_sql = (
             "SELECT t.id FROM trajectories t "
@@ -1608,31 +1568,25 @@ def get_pending_traj_ids(
             ).fetchall()
             pending_ids += [row["id"] for row in rows]
         return pending_ids
-    finally:
-        conn.close()
 
 
 def increment_retry(
     watch_dir_id: int, filename: str, *, db_path: Optional[Path] = None
 ) -> None:
-    conn = get_connection(db_path)
-    try:
+    with pooled_connection(db_path) as conn:
         conn.execute(
             "UPDATE trajectories SET retry_count = retry_count + 1"
             " WHERE watch_dir_id=? AND filename=?",
             (watch_dir_id, filename),
         )
         conn.commit()
-    finally:
-        conn.close()
 
 
 def get_status_counts(
     watch_dir_id: int | None = None, *, db_path: Optional[Path] = None
 ) -> dict[str, int]:
     """返回各状态的轨迹数量。watch_dir_id=None 时统计全部。"""
-    conn = get_connection(db_path)
-    try:
+    with pooled_connection(db_path) as conn:
         if watch_dir_id is not None:
             rows = conn.execute(
                 "SELECT status, COUNT(*) as cnt FROM trajectories"
@@ -1644,8 +1598,6 @@ def get_status_counts(
                 "SELECT status, COUNT(*) as cnt FROM trajectories GROUP BY status"
             ).fetchall()
         return {r["status"]: r["cnt"] for r in rows}
-    finally:
-        conn.close()
 
 
 # =============================================================================
@@ -1708,8 +1660,7 @@ class Registry:
         未找到返回 None。"""
         traj_path = Path(traj_path).resolve()
         wd_path = str(traj_path.parent)
-        conn = get_connection(self._db_path)
-        try:
+        with pooled_connection(self._db_path) as conn:
             row = conn.execute(
                 "SELECT t.* FROM trajectories t "
                 "JOIN watch_dirs w ON t.watch_dir_id = w.id "
@@ -1717,14 +1668,11 @@ class Registry:
                 (wd_path, traj_path.name),
             ).fetchone()
             return dict(row) if row else None
-        finally:
-            conn.close()
 
     def trajectories_using(self, skill_name: str) -> list[Path]:
         """反查：曾用过某个 skill 的所有轨迹路径。
         skill_used 字段是逗号分隔，故 LIKE 匹配。"""
-        conn = get_connection(self._db_path)
-        try:
+        with pooled_connection(self._db_path) as conn:
             rows = conn.execute(
                 "SELECT w.path AS wd_path, t.filename "
                 "FROM trajectories t JOIN watch_dirs w ON t.watch_dir_id=w.id "
@@ -1736,5 +1684,3 @@ class Registry:
                  f"%,{skill_name},%"),
             ).fetchall()
             return [Path(r["wd_path"]) / r["filename"] for r in rows]
-        finally:
-            conn.close()

--- a/src/xskill/pipeline/runner.py
+++ b/src/xskill/pipeline/runner.py
@@ -1433,15 +1433,12 @@ class DirectoryWatcher:
         """
         try:
             from xskill.events import EventStore
-            from xskill.pipeline.registry import get_connection
-            conn = get_connection(kw.get("db_path"))
-            try:
+            from xskill.pipeline.registry import pooled_connection
+            with pooled_connection(kw.get("db_path")) as conn:
                 row = conn.execute(
                     "SELECT user_key FROM trajectories"
                     " WHERE watch_dir_id=? AND filename=?",
                     (wd_id, fname)).fetchone()
-            finally:
-                conn.close()
             EventStore(kw.get("db_path")).emit_feedback(
                 actor=(row["user_key"] or "") if row else "",
                 skill=skill_name, traj_id=traj_id,

--- a/src/xskill/skill/skill.py
+++ b/src/xskill/skill/skill.py
@@ -348,8 +348,7 @@ class Skill:
             paths = self._registry.trajectories_using(self.name)  # 备选反查
             # 直接按 filename 找
             from xskill.pipeline import registry as _r
-            conn = _r.get_connection(self._registry._db_path)
-            try:
+            with _r.pooled_connection(self._registry._db_path) as conn:
                 rows = conn.execute(
                     "SELECT w.path, t.filename FROM trajectories t "
                     "JOIN watch_dirs w ON t.watch_dir_id=w.id "
@@ -359,8 +358,6 @@ class Skill:
                 for r in rows:
                     out.append(_Traj(path=Path(r["path"]) / r["filename"],
                                      registry=self._registry))
-            finally:
-                conn.close()
         return out
 
     def __repr__(self) -> str:

--- a/tests/test_pooled_connection.py
+++ b/tests/test_pooled_connection.py
@@ -1,0 +1,120 @@
+"""pooled_connection 线程内连接复用的行为契约。"""
+from __future__ import annotations
+
+import threading
+from concurrent.futures import ThreadPoolExecutor
+
+import pytest
+
+from xskill.pipeline import registry
+
+
+def _pool_slots():
+    return getattr(registry._REGISTRY_THREAD_POOL, "slots", {})
+
+
+def test_same_thread_reuses_one_connection(tmp_path):
+    db = tmp_path / "r.db"
+    with registry.pooled_connection(db) as first:
+        pass
+    with registry.pooled_connection(db) as second:
+        pass
+    assert first is second
+
+
+def test_threads_get_distinct_connections(tmp_path):
+    db = tmp_path / "r.db"
+    seen = {}
+
+    def grab(tag):
+        with registry.pooled_connection(db) as conn:
+            seen[tag] = id(conn)
+
+    grab("main")
+    worker = threading.Thread(target=grab, args=("worker",))
+    worker.start()
+    worker.join()
+    assert seen["main"] != seen["worker"]
+
+
+def test_record_usage_reuses_connection_and_persists(tmp_path):
+    db = tmp_path / "r.db"
+    for _ in range(3):
+        registry.record_usage(step="t", model="m", prompt=1, completion=1,
+                              total=2, cost_usd=0.0, price_source="config",
+                              db_path=db)
+    with registry.pooled_connection(db) as conn:
+        count = conn.execute("SELECT COUNT(*) FROM llm_usage").fetchone()[0]
+    assert count == 3
+    assert len(_pool_slots()) <= registry._REGISTRY_THREAD_POOL_CAPACITY
+
+
+def test_exception_rolls_back_but_keeps_connection(tmp_path):
+    db = tmp_path / "r.db"
+    with pytest.raises(RuntimeError):
+        with registry.pooled_connection(db) as conn:
+            conn.execute("INSERT INTO llm_usage(step,model,prompt,completion,"
+                         "total,cost_usd,price_source) VALUES('s','m',1,1,2,0,'x')")
+            raise RuntimeError("boom")
+    with registry.pooled_connection(db) as conn:
+        count = conn.execute("SELECT COUNT(*) FROM llm_usage").fetchone()[0]
+    assert count == 0  # 未提交的写被回滚
+    assert conn is not None
+
+
+def test_reentrant_acquire_falls_back_to_fresh_connection(tmp_path):
+    db = tmp_path / "r.db"
+    with registry.pooled_connection(db) as outer:
+        outer.execute("INSERT INTO llm_usage(step,model,prompt,completion,"
+                      "total,cost_usd,price_source) VALUES('s','m',1,1,2,0,'x')")
+        with registry.pooled_connection(db) as inner:
+            assert inner is not outer
+            # 外层未提交的事务对内层连接不可见
+            visible = inner.execute(
+                "SELECT COUNT(*) FROM llm_usage").fetchone()[0]
+            assert visible == 0
+        outer.commit()
+
+
+def test_deleted_db_file_triggers_reopen(tmp_path):
+    db = tmp_path / "r.db"
+    with registry.pooled_connection(db) as first:
+        first.execute("INSERT INTO llm_usage(step,model,prompt,completion,"
+                      "total,cost_usd,price_source) VALUES('s','m',1,1,2,0,'x')")
+        first.commit()
+    db.unlink()
+    for suffix in ("-wal", "-shm"):
+        sidecar = db.with_name(db.name + suffix)
+        if sidecar.exists():
+            sidecar.unlink()
+    with registry.pooled_connection(db) as reopened:
+        count = reopened.execute("SELECT COUNT(*) FROM llm_usage").fetchone()[0]
+    assert reopened is not first
+    assert count == 0  # 新库,旧连接没有被继续写
+
+
+def test_pool_capacity_evicts_oldest(tmp_path):
+    paths = [tmp_path / f"r{i}.db" for i in
+             range(registry._REGISTRY_THREAD_POOL_CAPACITY + 2)]
+    conns = []
+    for p in paths:
+        with registry.pooled_connection(p) as conn:
+            conns.append(conn)
+    slots = _pool_slots()
+    assert len(slots) == registry._REGISTRY_THREAD_POOL_CAPACITY
+    kept_keys = set(slots)
+    assert paths[0].resolve() not in kept_keys  # 最旧的被淘汰
+    assert paths[-1].resolve() in kept_keys
+
+
+def test_concurrent_record_usage_from_pool_threads(tmp_path):
+    db = tmp_path / "r.db"
+    def write(_i):
+        registry.record_usage(step="t", model="m", prompt=1, completion=1,
+                              total=2, cost_usd=0.0, price_source="config",
+                              db_path=db)
+    with ThreadPoolExecutor(max_workers=8) as pool:
+        list(pool.map(write, range(200)))
+    with registry.pooled_connection(db) as conn:
+        count = conn.execute("SELECT COUNT(*) FROM llm_usage").fetchone()[0]
+    assert count == 200


### PR DESCRIPTION
## 背景

生产容器看板在 embedding 高峰周期性整段卡死（~3-4 分钟一次）。定位结论：不是事件循环冻死、不是 WAL 锁竞争，而是 `record_usage`（**每次** LLM/embedding 调用触发）每次 open→INSERT→commit→close 一条 registry 连接——连接 finalize 走 `_SQLITE_CALL_GATE` 独占侧，高负载把"低频 finalize"打成高频事件，独占等待期间**全进程所有 SQLite 调用**（含看板只读请求）park 在同一个 Condition 上（futex convoy）。

## 方案

`registry.py` 新增 `pooled_connection()`：`threading.local` 按 (线程, DB) 缓存连接，退出时只回滚未提交事务、不 close。finalize 从每次调用降到线程退出 / DB 重建 / LRU 淘汰（容量 4）这些低频时刻。全部 46 处 `get_connection` 调用点机械替换；`get_connection` 保持公开、行为不变。

语义保障：同线程重入退回一次性连接（事务互不可见）；DB 删除重建靠 `(st_dev, st_ino)` 识别重开；异常回滚、回滚失败即丢弃连接；`check_same_thread` 语义不变，跨线程 GC finalize 由 `_LockedConnection.__del__` 兜底。

## 为什么不是 aiosqlite 全量异步化（设计文档 Phase 1/2）

设计文档基于 v0.6.15，其前提在 v0.6.16 已失效：同步写已移出响应路径（telemetry 有界队列）、热端点读已走专用 control-plane 池、看板已有 TTL 快照；且 `test_event_loop_safety` **显式断言** embed 端点与 `team_sync` 必须保持同步 `def`（半异步会把"阻塞一个线程"升级成"阻塞整个事件循环"）。剩余病根就是 finalize convoy，本补丁以 ~1/100 的改动面直接命中，不引入新依赖（Python 3.9 floor 不变）。

## 基准（同机前后对比，`scripts/bench/bench_sqlite_finalize_convoy.py`，16 写线程 × 10s）

| 指标 | before (v0.6.16) | after | 提升 |
|---|---|---|---|
| record_usage 吞吐 | 229 ops/s | 553 ops/s | **2.4×** |
| 看板读 p50 | 54 ms | 3.1 ms | **17×** |
| 看板读 p95 | 276 ms | 9.2 ms | **30×** |
| 看板读 max | 801 ms | 90 ms | **8.9×** |

300-client 控制面压测由 release CI 的 stress 门把关（`database_locked_count==0`、sync p95<4s、看板 SLA；对照基线 `docs/reports/2026-07-14-sync-control-plane-300-baseline.md`）。本机内存余量不足，未在本地跑 300 压测。

## 测试

- 新增 `tests/test_pooled_connection.py` 8 项：线程内复用 / 跨线程隔离 / 重入回退 / 异常回滚 / DB 重建重开 / 容量淘汰 / 8 线程×200 并发写。
- 全量 `pytest tests/`：**1418 passed**，唯一失败为 main 存量 `test_canary_flip_promote_and_install_new_version`（干净 origin/main 复现，无关）。

🤖 Generated with [Claude Code](https://claude.com/claude-code)