### PR TITLE
refactor(cli): search 只保留 skillhub 形态 + 网络异常兜底 + 来源/评分展示

### DIFF
--- a/README.en.md
+++ b/README.en.md
@@ -144,7 +144,7 @@ xskill search docker compose   # keyword-search the server skillhub; hits are pu
 xskill upload ./my-skill       # package & upload a skill folder (with SKILL.md); instantly searchable by the team
 ```
 
-`search` matches keywords only — independent of the recommendation profile — and prints each hit's name, description, and absolute local path. Pulled skills live in `~/.xskill/search_skills/` with a rolling cap of **10 slots** (least-recently-hit evicted). `upload` lands under `skillhub/user_skill_hub/<your-username>/` on the server. The local index search is unchanged: `xskill search traj|skill <query>`.
+`search` matches keywords only — independent of the recommendation profile — and prints each hit's name, description, and absolute local path. Pulled skills live in `~/.xskill/search_skills/` with a rolling cap of **10 slots** (least-recently-hit evicted). `upload` lands under `skillhub/user_skill_hub/<your-username>/` on the server. Local semantic search has been removed from the CLI (no more `xskill search traj|skill <query>`); use the dashboard or the API (`POST /api/v1/skills/search`) to search local trajectories/skills instead.
 
 * * *
 

--- a/README.md
+++ b/README.md
@@ -160,7 +160,7 @@ xskill upload ./my-skill            # 打包上传一个 skill 目录(含 SKILL.
 - `search` 只按关键词匹配 skillhub 目录(含团队成员上传的技能),与推荐画像无关;输出每个命中技能的名字、描述和本机绝对路径。
 - 搜下来的技能落在 `~/.xskill/search_skills/`,本地最多保留 **10 个槽位**,按最近命中滚动淘汰,不受 sync 清理影响。
 - `upload` 会先校验 `SKILL.md` frontmatter,server 端落到 `skillhub/user_skill_hub/<你的用户名>/` 下。
-- 本机原有的本地索引搜索保持不变:`xskill search traj|skill <query>`。
+- 本机语义搜索已从 CLI 移除(不再有 `xskill search traj|skill <query>`);如需按语义检索本机轨迹/技能,请用 dashboard 或 API(`POST /api/v1/skills/search`)。
 
 * * *
 

--- a/README.zh-CN.md
+++ b/README.zh-CN.md
@@ -104,7 +104,7 @@ xskill search docker compose        # 关键词搜 server 的 skillhub,命中的
 xskill upload ./my-skill            # 打包上传一个 skill 目录(含 SKILL.md),全队立即可搜到
 ```
 
-`search` 只按关键词匹配、与推荐画像无关，输出命中技能的名字、描述和本机绝对路径；本地最多保留 **10 个槽位**滚动淘汰。`upload` 在 server 端落到 `skillhub/user_skill_hub/<你的用户名>/` 下。本机索引搜索保持原样：`xskill search traj|skill <query>`。
+`search` 只按关键词匹配、与推荐画像无关，输出命中技能的名字、描述和本机绝对路径；本地最多保留 **10 个槽位**滚动淘汰。`upload` 在 server 端落到 `skillhub/user_skill_hub/<你的用户名>/` 下。本机语义搜索已从 CLI 移除（不再有 `xskill search traj|skill <query>`），改用 dashboard 或 API（`POST /api/v1/skills/search`）检索本机轨迹/技能。
 
 ## 架构图
 

--- a/src/xskill/cli.py
+++ b/src/xskill/cli.py
@@ -5,7 +5,7 @@ cli.py — xskill 紧凑 CLI
 仅 5 个子命令（无 --no-watch / --no-ui / --skill-dir / --llm-* 这类散 flag）：
     xskill serve [--host] [--port]
     xskill registry add|remove|list <path>
-    xskill search traj|skill <query> [--top-k]
+    xskill search <关键词...> [--top-k]
 
 所有筛选/格式化交给 shell（grep/awk）。状态/配置全在 ~/.xskill/。
 """
@@ -543,37 +543,6 @@ def cmd_stats(args) -> int:
     return 0
 
 
-def cmd_search(args, xskill) -> int:
-    target = args.terms[0]
-    query = " ".join(args.terms[1:]).strip()
-    if not query:
-        print(f"error: 用法 xskill search {target} <query>", file=sys.stderr)
-        return 2
-    args.query = query
-    if target == "traj":
-        hits = xskill.search_trajectories(args.query, top_k=args.top_k)
-        for h in hits:
-            traj = h.trajectory
-            status = traj.status or "-"
-            skill_used = traj.skill_used or "-"
-            side = traj.canary_side or "-"
-            print(f"{h.similarity:.3f}\t{status}\t{skill_used}\t{side}\t{traj.path}")
-        return 0
-    if target == "skill":
-        hits = xskill.search_skills(args.query, top_k=args.top_k)
-        for h in hits:
-            s = h.skill
-            avg = s.ux_avg(side="main", days=30)
-            n = len([x for x in s.recent_ux_scores(side="main", days=30)
-                     if x.get("score") is not None])
-            ux_col = f"{avg:.1f}({n})" if avg is not None else "-"
-            canary = s.canary_status()
-            canary_col = "staging" if canary == "staging_active" else "-"
-            print(f"{h.similarity:.3f}\t{s.name}\t{s.use_count}\t{ux_col}\t{canary_col}")
-        return 0
-    return 1
-
-
 def _team_client_http_and_headers():
     """瘦客户端命令共用：读连接 state，返回 (httpx client, 鉴权头)。
 
@@ -606,6 +575,7 @@ def cmd_search_hub(args, http=None, headers=None) -> int:
     按最近命中滚动淘汰。``http``/``headers`` 参数仅测试注入用。
     """
     import json as _json
+    import httpx
     from xskill.config import XSKILL_HOME
     from xskill.team.client.search_slots import SearchSlots
 
@@ -614,42 +584,52 @@ def cmd_search_hub(args, http=None, headers=None) -> int:
         if http is None:
             return 1
     query = " ".join(args.terms).strip()
-    resp = http.get("/api/v1/team/skill_hub/search",
-                    params={"query": query, "limit": args.top_k},
-                    headers=headers)
-    if resp.status_code == 404:
-        print("error: server 版本过旧，不支持 skillhub 搜索（需 ≥0.6.17），"
-              "请管理员先升级 server", file=sys.stderr)
-        return 1
-    if resp.status_code != 200:
-        print(f"error: 搜索失败 HTTP {resp.status_code}: {resp.text[:300]}",
+    try:
+        resp = http.get("/api/v1/team/skill_hub/search",
+                        params={"query": query, "limit": args.top_k},
+                        headers=headers)
+        if resp.status_code == 404:
+            print("error: server 版本过旧，不支持 skillhub 搜索（需 ≥0.6.17），"
+                  "请管理员先升级 server", file=sys.stderr)
+            return 1
+        if resp.status_code != 200:
+            print(f"error: 搜索失败 HTTP {resp.status_code}: {resp.text[:300]}",
+                  file=sys.stderr)
+            return 1
+        results = resp.json().get("results", [])
+        if not results:
+            print("skillhub 无匹配 skill")
+            return 0
+        slots = SearchSlots(xskill_home=XSKILL_HOME)
+        installed = []
+        for result in results:
+            bundle = http.get(f"/api/v1/team/skill/{result['skill_id']}/bundle",
+                              headers=headers)
+            if bundle.status_code != 200:
+                print(f"warning: 拉取 {result['skill_id']} 失败 "
+                      f"HTTP {bundle.status_code}", file=sys.stderr)
+                continue
+            local_path = slots.install(result, bundle.content, query=query)
+            # 原样透传 server 返回的所有字段，再补本机安装信息
+            installed_entry = dict(result)
+            installed_entry["name"] = result["display_name"]
+            installed_entry["path"] = str(local_path)
+            installed.append(installed_entry)
+    except (httpx.HTTPError, OSError) as network_error:
+        print(f"error: 无法连接 team server（{type(network_error).__name__}: "
+              f"{network_error}），server 可能未响应，请检查网络或联系管理员",
               file=sys.stderr)
         return 1
-    results = resp.json().get("results", [])
-    if not results:
-        print("skillhub 无匹配 skill")
-        return 0
-    slots = SearchSlots(xskill_home=XSKILL_HOME)
-    installed = []
-    for result in results:
-        bundle = http.get(f"/api/v1/team/skill/{result['skill_id']}/bundle",
-                          headers=headers)
-        if bundle.status_code != 200:
-            print(f"warning: 拉取 {result['skill_id']} 失败 "
-                  f"HTTP {bundle.status_code}", file=sys.stderr)
-            continue
-        local_path = slots.install(result, bundle.content, query=query)
-        installed.append({
-            "name": result["display_name"],
-            "skill_id": result["skill_id"],
-            "description": result["description"],
-            "path": str(local_path),
-        })
     if args.json:
         print(_json.dumps(installed, ensure_ascii=False, indent=2))
         return 0
     for row in installed:
-        print(f"{row['name']}  ({row['skill_id']})")
+        name_line = f"{row['name']}  ({row['skill_id']})"
+        if row.get("ux_avg") is not None:
+            name_line += f" ux {row['ux_avg']}"
+        if row.get("source"):
+            name_line += f" 来源: {row['source']}"
+        print(name_line)
         print(f"  {row['description']}")
         print(f"  {row['path']}")
     return 0
@@ -664,6 +644,7 @@ def cmd_upload(args, http=None, headers=None) -> int:
     import io as _io
     import json as _json
     import zipfile as _zipfile
+    import httpx
     from pathlib import Path
     from xskill.skill.frontmatter import FrontmatterError, parse_strict
 
@@ -699,18 +680,24 @@ def cmd_upload(args, http=None, headers=None) -> int:
         if http is None:
             return 1
     archive_name = f"{frontmatter['name']}.zip"
-    resp = http.post("/api/v1/team/skill_hub/upload",
-                     files={"file": (archive_name, payload, "application/zip")},
-                     headers=headers)
-    if resp.status_code == 404:
-        print("error: server 版本过旧，不支持 skill 上传（需 ≥0.6.17），"
-              "请管理员先升级 server", file=sys.stderr)
-        return 1
-    if resp.status_code != 200:
-        print(f"error: 上传失败 HTTP {resp.status_code}: {resp.text[:300]}",
+    try:
+        resp = http.post("/api/v1/team/skill_hub/upload",
+                         files={"file": (archive_name, payload, "application/zip")},
+                         headers=headers)
+        if resp.status_code == 404:
+            print("error: server 版本过旧，不支持 skill 上传（需 ≥0.6.17），"
+                  "请管理员先升级 server", file=sys.stderr)
+            return 1
+        if resp.status_code != 200:
+            print(f"error: 上传失败 HTTP {resp.status_code}: {resp.text[:300]}",
+                  file=sys.stderr)
+            return 1
+        stored = resp.json()
+    except (httpx.HTTPError, OSError) as network_error:
+        print(f"error: 无法连接 team server（{type(network_error).__name__}: "
+              f"{network_error}），server 可能未响应，请检查网络或联系管理员",
               file=sys.stderr)
         return 1
-    stored = resp.json()
     if args.json:
         print(_json.dumps(stored, ensure_ascii=False, indent=2))
         return 0
@@ -870,12 +857,11 @@ def build_parser() -> argparse.ArgumentParser:
 
     p_search = sub.add_parser(
         "search",
-        help="搜 team server 的 skillhub 并拉到本地槽位；"
-             "`search traj|skill <query>` 保持原本机索引搜索",
+        help="搜 team server 的 skillhub 并把命中 skill 拉到本地槽位",
     )
     p_search.add_argument(
         "terms", nargs="+", metavar="QUERY",
-        help="搜索词（可多个）。首词恰为 traj/skill 时视为本机索引搜索",
+        help="搜索词（可多个，拼成一个 skillhub 查询）",
     )
     p_search.add_argument("--top-k", "-k", type=int, default=5,
                           help="返回条数（skillhub 搜索最多 10）")
@@ -1039,8 +1025,7 @@ def main() -> int:
         return cmd_dashboard(args)
 
     # skillhub 搜索/上传是瘦客户端侧（走 team server），不碰 config.yaml。
-    # `search traj|skill <q>` 仍是本机索引搜索，走下面的 facade 路径。
-    if args.command == "search" and args.terms[0] not in ("traj", "skill"):
+    if args.command == "search":
         return cmd_search_hub(args)
     if args.command == "upload":
         return cmd_upload(args)
@@ -1066,7 +1051,7 @@ def main() -> int:
                 and _standalone_watch_dir_count() == 0):
             return cmd_registry_list_client()
 
-    # 首次运行 auto-init：serve / registry / search 都需要 config.yaml。
+    # 首次运行 auto-init：serve / registry 都需要 config.yaml。
     # 不存在就写一份模板并要求用户填 key 后重跑——比直接抛 traceback 友好。
     from xskill.config import CONFIG_PATH, ensure_config_exists
     if not ensure_config_exists():
@@ -1084,7 +1069,6 @@ def main() -> int:
     handler = {
         "serve":    cmd_serve,
         "registry": cmd_registry,
-        "search":   cmd_search,
     }.get(args.command)
     return handler(args, xskill) if handler else (parser.print_help() or 1)
 

--- a/src/xskill/utils/logging.py
+++ b/src/xskill/utils/logging.py
@@ -42,7 +42,7 @@ stdout 保留简略输出（只 xskill.* INFO+），日常 ``xskill serve`` 终�
 
 调用约定：``cli.py`` 在 ``cmd_serve`` 前调一次 ``configure_logging(...)``
 即可——它 hooks Python ``logging`` 全局配置，所有 logger 自动 inherit。
-``cmd_search`` / ``cmd_registry`` 这种短命令不需要文件 handler，保留
+``cmd_stats`` / ``cmd_registry`` 这种短命令不需要文件 handler，保留
 stdout-only basicConfig 即可。
 """
 from __future__ import annotations

--- a/tests/test_skill_hub_search_upload.py
+++ b/tests/test_skill_hub_search_upload.py
@@ -320,3 +320,106 @@ def test_cmd_upload_rejects_non_skill_dir(tmp_path, capsys):
     args = SimpleNamespace(path=str(tmp_path), json=False)
     assert cli.cmd_upload(args) == 2
     assert "SKILL.md" in capsys.readouterr().err
+
+
+# ── client: 网络异常兜底 + 展示字段 ─────────────────────────────
+
+class _FakeResp:
+    def __init__(self, status_code, *, json_data=None, content=b""):
+        self.status_code = status_code
+        self._json = json_data
+        self.content = content
+
+    def json(self):
+        return self._json
+
+
+def test_cmd_search_hub_network_error_returns_one_without_traceback(capsys):
+    import httpx
+
+    class _BoomHttp:
+        def get(self, *args, **kwargs):
+            raise httpx.ConnectError("connection refused")
+
+    args = SimpleNamespace(terms=["docker"], top_k=5, json=False)
+    rc = cli.cmd_search_hub(args, http=_BoomHttp(), headers={})
+    err = capsys.readouterr().err
+    assert rc == 1
+    assert "Traceback" not in err
+    assert "ConnectError" in err
+    assert "管理员" in err or "网络" in err
+
+
+def test_cmd_upload_network_error_returns_one_without_traceback(tmp_path, capsys):
+    import httpx
+
+    class _BoomHttp:
+        def post(self, *args, **kwargs):
+            raise httpx.ConnectTimeout("timed out")
+
+    src = tmp_path / "up-src"
+    src.mkdir()
+    (src / "SKILL.md").write_text(
+        "---\nname: net-skill\ndescription: d\n---\nbody\n", encoding="utf-8")
+    args = SimpleNamespace(path=str(src), json=False)
+    rc = cli.cmd_upload(args, http=_BoomHttp(), headers={})
+    err = capsys.readouterr().err
+    assert rc == 1
+    assert "Traceback" not in err
+    assert "ConnectTimeout" in err
+    assert "管理员" in err or "网络" in err
+
+
+def test_cmd_search_hub_renders_source_and_ux_defensively(tmp_path, monkeypatch,
+                                                          capsys):
+    class _FakeHttp:
+        def get(self, path, **kwargs):
+            if "search" in path:
+                return _FakeResp(200, json_data={"results": [
+                    {"skill_id": "with@ff", "display_name": "with-meta",
+                     "description": "has metadata", "content_sha": "aa",
+                     "source_path": "p1", "source": "上传者:alice",
+                     "ux_avg": 4.2, "match": {"field": "name"}},
+                    {"skill_id": "bare@ff", "display_name": "bare-meta",
+                     "description": "no metadata", "content_sha": "bb",
+                     "source_path": "p2"},
+                ]})
+            return _FakeResp(200, content=_fake_archive("x"))
+
+    monkeypatch.setattr(
+        "xskill.team.client.search_slots.SearchSlots",
+        lambda **kw: SearchSlots(xskill_home=tmp_path / "xh",
+                                 home_root=tmp_path / "h"))
+    args = SimpleNamespace(terms=["anything"], top_k=5, json=False)
+    assert cli.cmd_search_hub(args, http=_FakeHttp(), headers={}) == 0
+    out = capsys.readouterr().out
+    assert "ux 4.2" in out
+    assert "来源: 上传者:alice" in out
+    # 缺 source/ux_avg 的命中正常渲染，其名字行不带 ux/来源 后缀，不报错
+    bare_line = next(line for line in out.splitlines() if "bare-meta" in line)
+    assert "ux" not in bare_line and "来源" not in bare_line
+
+
+def test_cmd_search_hub_json_passes_through_all_fields(tmp_path, monkeypatch,
+                                                       capsys):
+    class _FakeHttp:
+        def get(self, path, **kwargs):
+            if "search" in path:
+                return _FakeResp(200, json_data={"results": [
+                    {"skill_id": "j@ff", "display_name": "json-skill",
+                     "description": "d", "content_sha": "cc", "source_path": "p",
+                     "source": "skillhub", "ux_avg": None,
+                     "match": {"field": "description"}},
+                ]})
+            return _FakeResp(200, content=_fake_archive("x"))
+
+    monkeypatch.setattr(
+        "xskill.team.client.search_slots.SearchSlots",
+        lambda **kw: SearchSlots(xskill_home=tmp_path / "xh",
+                                 home_root=tmp_path / "h"))
+    args = SimpleNamespace(terms=["anything"], top_k=5, json=True)
+    assert cli.cmd_search_hub(args, http=_FakeHttp(), headers={}) == 0
+    row = json.loads(capsys.readouterr().out)[0]
+    assert row["source"] == "skillhub"
+    assert row["match"] == {"field": "description"}
+    assert row["name"] == "json-skill" and row["path"]


### PR DESCRIPTION
## 改动

- **BREAKING**：移除 `xskill search traj|skill <query>` 本机索引搜索 CLI 形态（产品拍板：客户端不需要 traj 搜索；本机语义搜索仍可走 dashboard 或 `POST /api/v1/skills/search`）。`xskill search <关键词...>` 现在无条件 = skillhub 搜索。
- `cmd_search_hub` / `cmd_upload` 全部网络调用包 `httpx.HTTPError/OSError` 兜底：一行中文友好错误 + return 1，不再有 traceback 直出（华为内网 Windows client 实际踩过 ConnectTimeout 整屏 traceback）。
- CLI 防御性展示 server 即将新增的可选字段：`ux_avg`（评分）、`source`（来源），`--json` 原样透传全部字段；字段缺失不显示不报错。
- README ×3 同步；清理 utils/logging.py 对已删函数的陈旧 docstring 引用。

## 测试

针对性 28 passed（含 4 个新增：网络异常无 traceback ×2、来源/评分渲染、json 透传）。全量套件在集成阶段统一跑。

🤖 Generated with [Claude Code](https://claude.com/claude-code)