### PR TITLE
perf(skillhub): 三层扫描缓存，根治全盘扫描风暴（面板冻结事故修复）

### DIFF
--- a/src/xskill/dashboard/metrics.py
+++ b/src/xskill/dashboard/metrics.py
@@ -141,6 +141,27 @@ _skills_catalog_cache: dict[tuple, tuple[float, list[dict]]] = {}
 _skills_catalog_flights: dict[tuple, "_CatalogFlight"] = {}
 _skills_catalog_cache_lock = threading.Lock()
 
+_TAG_CLOUD_TTL_SECONDS = 5.0
+_TAG_CLOUD_CACHE_MAX_ENTRIES = 64
+_tag_cloud_cache: dict[tuple, tuple[float, list[dict]]] = {}
+_tag_cloud_cache_lock = threading.Lock()
+
+
+def _prune_tag_cloud_cache(now: float) -> None:
+    """在持锁状态下清理过期项并限制不同 registry.db/top_n 组合的缓存数量。"""
+    for stale_key, (expires_at, _rows) in list(_tag_cloud_cache.items()):
+        if expires_at <= now:
+            _tag_cloud_cache.pop(stale_key, None)
+    limit = max(0, int(_TAG_CLOUD_CACHE_MAX_ENTRIES))
+    overflow = len(_tag_cloud_cache) - limit
+    if overflow > 0:
+        oldest = sorted(
+            _tag_cloud_cache,
+            key=lambda cache_key: _tag_cloud_cache[cache_key][0],
+        )[:overflow]
+        for stale_key in oldest:
+            _tag_cloud_cache.pop(stale_key, None)
+
 
 class _CatalogFlight:
     """同一个清单缓存键只允许一个线程扫描磁盘。"""
@@ -551,6 +572,13 @@ class DashboardMetrics:
         from collections import Counter, defaultdict
         from xskill.pipeline.atom import AtomTaskStore
         from xskill.config import get_registry_db_path
+        cache_key = (str(self._db), int(top_n))
+        now = time.monotonic()
+        with _tag_cloud_cache_lock:
+            _prune_tag_cloud_cache(now)
+            cached = _tag_cloud_cache.get(cache_key)
+            if cached is not None:
+                return copy.deepcopy(cached[1])
         db_dir = Path(self._db).parent if self._db else get_registry_db_path().parent
         counter: Counter = Counter()
         tag_users: dict[str, set] = defaultdict(set)
@@ -572,8 +600,13 @@ class DashboardMetrics:
                                 tag_users[t].add(client)
             except OSError:
                 continue  # 某个目录不可读/路径异常,跳过不阻断整体聚合
-        return [{"tag": t, "count": n, "users": sorted(tag_users.get(t, ()))}
-                for t, n in counter.most_common(top_n)]
+        result = [{"tag": t, "count": n, "users": sorted(tag_users.get(t, ()))}
+                  for t, n in counter.most_common(top_n)]
+        with _tag_cloud_cache_lock:
+            _tag_cloud_cache[cache_key] = (
+                time.monotonic() + _TAG_CLOUD_TTL_SECONDS, copy.deepcopy(result))
+            _prune_tag_cloud_cache(time.monotonic())
+        return result
 
     def canary_sides(self) -> list[dict]:
         """灰度分桶分布：使用打分记录按 side 聚合（与 check_and_decide 裁决同源）。

--- a/src/xskill/recommend/skillhub.py
+++ b/src/xskill/recommend/skillhub.py
@@ -11,8 +11,11 @@
 from __future__ import annotations
 
 import hashlib
+import os
 import pickle
 import re
+import threading
+import time
 from datetime import datetime
 from pathlib import Path
 
@@ -42,10 +45,6 @@ def _safe_id_part(value: str) -> str:
     return safe or "skill"
 
 
-def _content_sha(md: Path) -> str:
-    return hashlib.sha256(md.read_bytes()).hexdigest()[:16]
-
-
 def _path_hash(source_path: str) -> str:
     return hashlib.sha256(source_path.encode("utf-8")).hexdigest()[:12]
 
@@ -53,15 +52,87 @@ def _path_hash(source_path: str) -> str:
 class SkillHub:
     """三方 skill 扫描器 + ux 查询。``enabled=False``（缺省）时为 no-op。"""
 
-    def __init__(self, *, enabled: bool, hub_dir: Path | str, embed_client):
+    def __init__(self, *, enabled: bool, hub_dir: Path | str, embed_client,
+                 scan_ttl_seconds: float = 5.0):
         self.enabled = bool(enabled)
         self.dir = Path(hub_dir)
         self.embed_client = embed_client
+        self.scan_ttl_seconds = float(scan_ttl_seconds)
+        # L3 备忘录：SKILL.md 路径 → (st_mtime_ns, st_size, sha16, display_name, description)。
+        self._file_memo: dict[Path, tuple[int, int, str, str, str]] = {}
+        # L1 快照：require_description=False 的全集（不含 vec），single-flight 保护。
+        self._scan_snapshot_entries: list[dict] | None = None
+        self._scan_snapshot_expires_at: float = 0.0
+        self._scan_lock = threading.Lock()
 
     @classmethod
     def from_config(cls, config: dict, embed_client) -> "SkillHub":
         cfg = skillhub_config(config)
         return cls(enabled=cfg["enabled"], hub_dir=cfg["dir"], embed_client=embed_client)
+
+    def _walk_snapshot(self) -> list[dict]:
+        """L2 剪枝遍历 + L3 备忘录，产出 require_description=False 的全集（无 vec）。"""
+        entries: list[dict] = []
+        seen_paths: set[Path] = set()
+        for dirpath, dirnames, filenames in os.walk(self.dir):
+            dirnames[:] = [name for name in dirnames if not name.startswith(".")]
+            if "SKILL.md" not in filenames:
+                continue
+            sub = Path(dirpath)
+            md = sub / "SKILL.md"
+            try:
+                rel = sub.relative_to(self.dir).as_posix()
+            except ValueError:
+                continue
+            if any(part.startswith(".") for part in Path(rel).parts):
+                continue
+            stat_result = md.stat()
+            seen_paths.add(md)
+            memo = self._file_memo.get(md)
+            if (memo is not None and memo[0] == stat_result.st_mtime_ns
+                    and memo[1] == stat_result.st_size):
+                _mtime, _size, content_sha, display_name, description = memo
+            else:
+                raw_bytes = md.read_bytes()
+                content_sha = hashlib.sha256(raw_bytes).hexdigest()[:16]
+                frontmatter, _body = fm_parse(raw_bytes.decode("utf-8"))
+                raw_name = frontmatter.get("name") or sub.name
+                display_name = str(raw_name).strip() or sub.name
+                description = (frontmatter.get("description") or "").strip()
+                self._file_memo[md] = (
+                    stat_result.st_mtime_ns, stat_result.st_size,
+                    content_sha, display_name, description,
+                )
+            path_hash = _path_hash(rel)
+            skill_id = f"{_safe_id_part(display_name)}@{path_hash}"
+            entries.append({
+                "source": "skillhub",
+                "name": skill_id,
+                "skill_id": skill_id,
+                "display_name": display_name,
+                "source_path": rel,
+                "path_hash": path_hash,
+                "content_sha": content_sha,
+                "description": description,
+                "path": sub,
+            })
+        for stale_path in [path for path in self._file_memo if path not in seen_paths]:
+            del self._file_memo[stale_path]
+        entries.sort(key=lambda entry: entry["source_path"])
+        return entries
+
+    def _snapshot(self) -> list[dict]:
+        """L1 TTL 快照 + single-flight：过期时只有一个线程真扫盘。"""
+        now = time.monotonic()
+        if self._scan_snapshot_entries is not None and now < self._scan_snapshot_expires_at:
+            return self._scan_snapshot_entries
+        with self._scan_lock:
+            now = time.monotonic()
+            if self._scan_snapshot_entries is not None and now < self._scan_snapshot_expires_at:
+                return self._scan_snapshot_entries
+            self._scan_snapshot_entries = self._walk_snapshot()
+            self._scan_snapshot_expires_at = time.monotonic() + self.scan_ttl_seconds
+            return self._scan_snapshot_entries
 
     def _entries(self, *, include_vec: bool, require_description: bool) -> list[dict]:
         if not self.enabled:
@@ -70,36 +141,10 @@ class SkillHub:
             raise FileNotFoundError(
                 f"skillhub.dir 不存在: {self.dir}（启用 skillhub 前请放置三方 skill）"
             )
-        entries: list[dict] = []
-        for md in sorted(self.dir.rglob("SKILL.md")):
-            sub = md.parent
-            try:
-                rel = sub.relative_to(self.dir).as_posix()
-            except ValueError:
-                continue
-            if any(part.startswith(".") for part in Path(rel).parts):
-                continue
-            fm, _body = fm_parse(md.read_text(encoding="utf-8"))
-            raw_name = fm.get("name") or sub.name
-            display_name = str(raw_name).strip() or sub.name
-            desc = (fm.get("description") or "").strip()
-            if require_description and not desc:
-                continue
-            content_sha = _content_sha(md)
-            path_hash = _path_hash(rel)
-            skill_id = f"{_safe_id_part(display_name)}@{path_hash}"
-            entry = {
-                "source": "skillhub",
-                "name": skill_id,
-                "skill_id": skill_id,
-                "display_name": display_name,
-                "source_path": rel,
-                "path_hash": path_hash,
-                "content_sha": content_sha,
-                "description": desc,
-                "path": sub,
-            }
-            entries.append(entry)
+        entries = [
+            dict(entry) for entry in self._snapshot()
+            if not require_description or entry["description"]
+        ]
         if include_vec and entries:
             # 批量 + 按内容哈希复用：重启/改一个 SKILL.md 不再全量重 embed。
             embed_store = EmbedStore(
@@ -187,10 +232,15 @@ class SkillHub:
         scored.sort(key=lambda pair: (-pair[0], pair[1]["skill_id"]))
         return [entry for _score, entry in scored[:limit]]
 
-    def entry(self, name: str) -> dict | None:
-        """按 skill_id / source_path / 唯一 display_name 找当前磁盘上的 skill。"""
+    def entry(self, name: str, *, force_refresh: bool = False) -> dict | None:
+        """按 skill_id / source_path / 唯一 display_name 找当前磁盘上的 skill。
+
+        ``force_refresh=True`` 跳过 TTL 立即重扫（single-flight 内），供上传后即时可见。
+        """
         if not self.enabled:
             return None
+        if force_refresh:
+            self._scan_snapshot_expires_at = 0.0
         matches: list[dict] = []
         for entry in self._entries(include_vec=False, require_description=False):
             if name in {

--- a/src/xskill/team/server/api.py
+++ b/src/xskill/team/server/api.py
@@ -883,7 +883,7 @@ def _store_user_skill(hub, owner_dir: str, payload: bytes) -> dict:
     shutil.rmtree(dest_dir, ignore_errors=True)
     tmp_dir.replace(dest_dir)
     source_path = dest_dir.relative_to(Path(hub.dir)).as_posix()
-    entry = hub.entry(source_path)
+    entry = hub.entry(source_path, force_refresh=True)
     if entry is None:
         raise HTTPException(status_code=500,
                             detail="stored skill not visible in skillhub scan")

--- a/tests/test_skillhub.py
+++ b/tests/test_skillhub.py
@@ -267,6 +267,7 @@ class TestEngineSkillhubPool:
         entries = sorted(eng._skillhub_entries(), key=lambda e: e["source_path"])
         stale_id = entries[0]["skill_id"]
         shutil.rmtree(first)
+        eng.skillhub._scan_snapshot_expires_at = 0.0  # 模拟 TTL 到期：增删最迟 5s 后被扫到
 
         q = FakeEmbed(dim=4).encode("django migration helper")
         q = q / np.linalg.norm(q)
@@ -369,6 +370,7 @@ class TestEngineSkillhubPool:
             _write_hub_skill(
                 hub_dir, "hub-a/foo", "django migration helper", name="foo",
             )
+            eng.skillhub._scan_snapshot_expires_at = 0.0  # 模拟 TTL 到期：增删最迟 5s 后被扫到
             second = build_manifest(
                 client_id="client-one",
                 skill_dir=skill_dir,

--- a/tests/test_skillhub_scan_cache.py
+++ b/tests/test_skillhub_scan_cache.py
@@ -1,0 +1,226 @@
+"""test_skillhub_scan_cache.py —— skillhub 三层扫描缓存（L1 TTL 快照 / L2 剪枝 / L3 备忘录）。
+
+覆盖：TTL 内不重扫；内容不变零重读；改内容/删文件被反映；点目录不遍历；
+force_refresh 绕过 TTL；single-flight 并发只扫一次；目录缺失 raise 且补齐后恢复；
+以及 dashboard tag_cloud 的 TTL 缓存命中。
+"""
+from __future__ import annotations
+
+import os
+import pathlib
+import threading
+import time
+from concurrent.futures import ThreadPoolExecutor
+from pathlib import Path
+
+import pytest
+
+import xskill.recommend.skillhub as skillhub_module
+from xskill.recommend.skillhub import SkillHub
+
+
+def _write_hub_skill(hub_dir: Path, rel_path: str, description: str) -> Path:
+    skill_dir = hub_dir / rel_path
+    skill_dir.mkdir(parents=True)
+    (skill_dir / "SKILL.md").write_text(
+        f"---\nname: {skill_dir.name}\ndescription: {description}\n---\n# {skill_dir.name}\n",
+        encoding="utf-8")
+    return skill_dir
+
+
+def _make_hub(hub_dir: Path, *, scan_ttl_seconds: float = 5.0) -> SkillHub:
+    return SkillHub(enabled=True, hub_dir=hub_dir, embed_client=None,
+                    scan_ttl_seconds=scan_ttl_seconds)
+
+
+def _count_walks(monkeypatch, *, delay: float = 0.0) -> list[int]:
+    walk_calls: list[int] = []
+    real_walk = os.walk
+
+    def counting_walk(top, *args, **kwargs):
+        walk_calls.append(1)
+        if delay:
+            time.sleep(delay)
+        return real_walk(top, *args, **kwargs)
+
+    monkeypatch.setattr(skillhub_module.os, "walk", counting_walk)
+    return walk_calls
+
+
+def test_ttl_snapshot_scans_disk_once(tmp_path, monkeypatch):
+    hub_dir = tmp_path / "hub"
+    _write_hub_skill(hub_dir, "alpha", "django migration helper")
+    hub = _make_hub(hub_dir)
+    walk_calls = _count_walks(monkeypatch)
+
+    hub.entry("alpha")
+    hub.fingerprint()
+    hub.entry("alpha")
+
+    assert len(walk_calls) == 1
+
+
+def test_unchanged_files_are_not_reread(tmp_path, monkeypatch):
+    hub_dir = tmp_path / "hub"
+    _write_hub_skill(hub_dir, "alpha", "one")
+    _write_hub_skill(hub_dir, "nested/beta", "two")
+    hub = _make_hub(hub_dir, scan_ttl_seconds=0.0)  # 每次调用都真扫，检验 L3 备忘录
+
+    read_calls: list[str] = []
+    real_read_bytes = pathlib.Path.read_bytes
+
+    def counting_read_bytes(self):
+        read_calls.append(str(self))
+        return real_read_bytes(self)
+
+    monkeypatch.setattr(pathlib.Path, "read_bytes", counting_read_bytes)
+
+    hub.fingerprint()
+    assert len(read_calls) == 2  # 首轮每个 SKILL.md 读一次
+    read_calls.clear()
+
+    hub.fingerprint()
+    assert read_calls == []  # mtime/size 未变 → 零重读
+
+
+def test_changed_content_is_reflected(tmp_path):
+    hub_dir = tmp_path / "hub"
+    skill_dir = _write_hub_skill(hub_dir, "alpha", "old description")
+    hub = _make_hub(hub_dir, scan_ttl_seconds=0.0)
+
+    first = hub.entry("alpha")
+    old_sha = first["content_sha"]
+
+    (skill_dir / "SKILL.md").write_text(
+        "---\nname: alpha\ndescription: brand new much longer description\n---\n# alpha\n",
+        encoding="utf-8")
+    future = time.time() + 5
+    os.utime(skill_dir / "SKILL.md", (future, future))
+
+    updated = hub.entry("alpha")
+    assert updated["content_sha"] != old_sha
+    assert updated["description"] == "brand new much longer description"
+
+
+def test_deleted_skill_disappears(tmp_path):
+    hub_dir = tmp_path / "hub"
+    skill_dir = _write_hub_skill(hub_dir, "alpha", "one")
+    _write_hub_skill(hub_dir, "beta", "two")
+    hub = _make_hub(hub_dir, scan_ttl_seconds=0.0)
+
+    assert hub.entry("alpha") is not None
+    import shutil
+    shutil.rmtree(skill_dir)
+
+    assert hub.entry("alpha") is None
+    assert (skill_dir / "SKILL.md") not in hub._file_memo
+
+
+def test_dot_directories_are_not_traversed(tmp_path, monkeypatch):
+    hub_dir = tmp_path / "hub"
+    _write_hub_skill(hub_dir, "alpha", "visible")
+    deep_git_skill = hub_dir / ".git" / "objects" / "hidden"
+    deep_git_skill.mkdir(parents=True)
+    (deep_git_skill / "SKILL.md").write_text(
+        "---\nname: hidden\ndescription: buried in git\n---\n", encoding="utf-8")
+    hub = _make_hub(hub_dir)
+
+    visited_dirs: list[str] = []
+    real_walk = os.walk
+
+    def recording_walk(top, *args, **kwargs):
+        for dirpath, dirnames, filenames in real_walk(top, *args, **kwargs):
+            visited_dirs.append(dirpath)
+            yield dirpath, dirnames, filenames
+
+    monkeypatch.setattr(skillhub_module.os, "walk", recording_walk)
+
+    entries = hub._entries(include_vec=False, require_description=False)
+    names = {entry["display_name"] for entry in entries}
+    assert names == {"alpha"}
+    assert not any(".git" in visited for visited in visited_dirs)
+    assert (deep_git_skill / "SKILL.md") not in hub._file_memo
+
+
+def test_force_refresh_bypasses_ttl(tmp_path):
+    hub_dir = tmp_path / "hub"
+    _write_hub_skill(hub_dir, "alpha", "one")
+    hub = _make_hub(hub_dir, scan_ttl_seconds=5.0)
+
+    assert hub.entry("alpha") is not None
+    _write_hub_skill(hub_dir, "beta", "two")
+
+    assert hub.entry("beta") is None  # TTL 内旧快照看不到新 skill
+    assert hub.entry("beta", force_refresh=True) is not None
+
+
+def test_single_flight_concurrent_entry(tmp_path, monkeypatch):
+    hub_dir = tmp_path / "hub"
+    for index in range(5):
+        _write_hub_skill(hub_dir, f"skill_{index}", f"desc {index}")
+    hub = _make_hub(hub_dir)
+    walk_calls = _count_walks(monkeypatch, delay=0.05)
+
+    barrier = threading.Barrier(8)
+
+    def call_entry():
+        barrier.wait()
+        return hub.entry("skill_0")
+
+    with ThreadPoolExecutor(max_workers=8) as pool:
+        results = [future.result() for future in
+                   [pool.submit(call_entry) for _ in range(8)]]
+
+    assert all(result is not None for result in results)
+    assert len(walk_calls) == 1
+
+
+def test_missing_dir_raises_then_recovers(tmp_path):
+    hub_dir = tmp_path / "hub"
+    hub = _make_hub(hub_dir)
+
+    with pytest.raises(FileNotFoundError):
+        hub.entry("alpha")
+    with pytest.raises(FileNotFoundError):
+        hub.fingerprint()
+
+    _write_hub_skill(hub_dir, "alpha", "now here")
+    assert hub.entry("alpha") is not None
+
+
+def test_tag_cloud_ttl_cache_hit(tmp_path, monkeypatch):
+    from xskill.pipeline.atom import AtomTask, AtomTaskStore
+    from xskill.pipeline.registry import get_connection
+    from xskill.dashboard.metrics import DashboardMetrics
+    import xskill.dashboard.metrics as dashboard_metrics
+
+    watch_dir = tmp_path / "wd"
+    watch_dir.mkdir()
+    store = AtomTaskStore(root=watch_dir)
+    store.save(AtomTask(
+        atom_id="atom_t_0000", traj_id="t", offset_start=1, offset_end=2,
+        intent="i", summary="s", tags=["django", "nginx"], used_skills=[], ux_score=7,
+        pre_atom_id=None, post_atom_id=None, context_prefix="", raw_segment=""))
+    db_path = tmp_path / "tg.db"
+    conn = get_connection(db_path)
+    conn.execute("INSERT INTO watch_dirs(path,label,ecosystem) VALUES(?,?,?)",
+                 (str(watch_dir), "w", "claude_code"))
+    conn.commit()
+    conn.close()
+
+    dashboard_metrics._tag_cloud_cache.clear()
+    traversal_calls: list[int] = []
+    real_all_atoms = AtomTaskStore.all_atoms
+
+    def counting_all_atoms(self):
+        traversal_calls.append(1)
+        yield from real_all_atoms(self)
+
+    monkeypatch.setattr(AtomTaskStore, "all_atoms", counting_all_atoms)
+
+    metrics = DashboardMetrics(db_path=db_path)
+    first = {row["tag"]: row["count"] for row in metrics.tag_cloud()}
+    second = {row["tag"]: row["count"] for row in metrics.tag_cloud()}
+
+    assert first == second == {"django": 1, "nginx": 1}
+    assert len(traversal_calls) == 1


### PR DESCRIPTION
## 背景（生产事故）

v0.6.17 生产容器：面板打开后全端点（含纯 async 的 /health）约每 5 分钟足额 5s 超时。py-spy 定罪：`SkillHub.entry()` 每次调用 = 全树 rglob（钻 .git）+ 每个 SKILL.md read_bytes+sha256；`_pick_recommended` 每个 /sync 逐候选调它，30 并发 sync worker 把 GIL 打满 → 事件循环饿死。engine 既有的 fingerprint-keyed 缓存无效：`fingerprint()` 本身就是一次全盘扫描（校验成本=被缓存物），且 `entry()` 根本不走它。

## 方案（详见 /tmp/scan.md 设计，全部状态挂 SkillHub 实例）

- **L1** TTL 快照（5s，构造参数可调）+ single-flight：并发调用共享一次真扫；
- **L2** os.walk 剪枝遍历：点目录不下钻，只 stat 不读文件；
- **L3** 文件备忘录 `path → (mtime_ns, size, sha16, name, description)`：mtime+size 未变零 read 零哈希零解析；变更文件单次 read_bytes 同产 sha 与 frontmatter。

`entry()/fingerprint()/search()/index()` 全走快照；`entry(force_refresh=True)` 供上传后即时可见（api.py 已接）。`tag_cloud` 的逐 atom 目录遍历按 `_skills_catalog_cache` 同款模式加 5s TTL（deepcopy 进出防污染）。

稳态成本：单次 entry() 从 O(全树读+哈希) → O(1) 字典查；每 5s 全局一次纯 stat 遍历。语义变化仅一处：skillhub 目录增删改最迟一个 TTL（5s）后可见（上传路径 force_refresh 即时）。

## 测试

新增 tests/test_skillhub_scan_cache.py 9 项（TTL 内单次扫盘 / 未变更零重读 / 变更与删除反映 / .git 不遍历 / force_refresh / 8 线程 single-flight / dir 缺失恢复 / tag_cloud 命中）；test_skillhub.py 两个引擎用例按 TTL 语义补模拟到期（保留原安全断言）。本地回归 86 passed（skillhub/engine/manifest/team_server/sync_profile 全套）。

🤖 Generated with [Claude Code](https://claude.com/claude-code)