### PR TITLE
fix(updater): server 请求默认直连 + pip 升级闭环核验与回退（内网镜像滞后事故）

### DIFF
--- a/src/xskill/cli.py
+++ b/src/xskill/cli.py
@@ -299,6 +299,7 @@ def _run_team_client_forever(state, *, use_proxy: bool,
         cursor_path=get_team_client_cursor_path(state.server_url),
         history_path=get_team_client_history_path(state.server_url),
         auto_update=auto_update,
+        use_proxy=use_proxy,
     )
     client.run_forever()   # 阻塞
 
@@ -386,7 +387,7 @@ def cmd_update(args) -> int:
             # 连接信息坏了只影响回退通道，不该挡住 PyPI 主路径。
             print(f"warning: 读取 team 连接信息失败，禁用 server 回退（{state_error}）",
                   file=sys.stderr)
-    updater = AutoUpdater(**server_kwargs)
+    updater = AutoUpdater(**server_kwargs, use_proxy=args.use_proxy)
 
     print(f"当前版本: {current}")
     print("正在查询 PyPI...")
@@ -929,7 +930,11 @@ def build_parser() -> argparse.ArgumentParser:
 
     p_status = sub.add_parser("status", help="查看 connect 常驻任务状态")
 
-    sub.add_parser("update", help="立即检查 PyPI 新版并升级（有新版则重启）")
+    p_update = sub.add_parser("update", help="立即检查 PyPI 新版并升级（有新版则重启）")
+    p_update.add_argument(
+        "--use-proxy", action="store_true",
+        help="server wheel 回退经系统/环境代理拉取（默认直连，绕开公司 SWG 代理）。",
+    )
     p_status.add_argument("--json", action="store_true", help="机读 JSON 输出")
 
     sub.add_parser(

--- a/src/xskill/team/client/daemon.py
+++ b/src/xskill/team/client/daemon.py
@@ -94,6 +94,7 @@ class TeamClient:
         quiet_seconds: int = 180,
         min_change_interval: int = 600,
         auto_update: bool = True,
+        use_proxy: bool = False,
     ):
         self.state = state
         self.http = http
@@ -112,6 +113,8 @@ class TeamClient:
         )
         self._stop = threading.Event()
         self.auto_update = auto_update
+        # updater 的 server 方向请求跟随 connect 的 --use-proxy；默认直连内网 server。
+        self.use_proxy = use_proxy
 
     # ── HTTP 鉴权头 ──────────────────────────────────────────────
     def _hdr(self, extra: dict | None = None) -> dict:
@@ -304,6 +307,7 @@ class TeamClient:
             server_url=self.state.server_url,
             client_id=self.state.client_id,
             join_token=self.state.join_token,
+            use_proxy=self.use_proxy,
         ) if self.auto_update else None
         if updater:
             updater.start()

--- a/src/xskill/team/client/updater.py
+++ b/src/xskill/team/client/updater.py
@@ -78,6 +78,7 @@ def _server_version(
     server_url: str,
     join_token: str,
     client_id: str,
+    use_proxy: bool = False,
 ) -> dict[str, Any] | None:
     """从 team server 读取版本信息。网络/鉴权失败返回 None。"""
     import json
@@ -87,8 +88,11 @@ def _server_version(
         _team_api_url(server_url, "/version"),
         headers=_team_headers(join_token, client_id),
     )
+    # server 方向默认直连：ProxyHandler({}) 绕开环境代理，与 daemon httpx trust_env=False 对齐。
+    opener = (urllib.request.build_opener() if use_proxy
+              else urllib.request.build_opener(urllib.request.ProxyHandler({})))
     try:
-        with urllib.request.urlopen(req, timeout=10) as r:
+        with opener.open(req, timeout=10) as r:
             return json.loads(r.read().decode("utf-8"))
     except Exception:
         logger.debug("updater: 查询 server 版本失败", exc_info=True)
@@ -101,6 +105,7 @@ def _download_server_wheel(
     client_id: str,
     dest_dir: Path,
     filename: str | None,
+    use_proxy: bool = False,
 ) -> Path | None:
     """从 team server 下载 wheel 到临时目录。失败返回 None。"""
     import urllib.request
@@ -114,8 +119,11 @@ def _download_server_wheel(
         _team_api_url(server_url, "/wheel"),
         headers=_team_headers(join_token, client_id),
     )
+    # server 方向默认直连：ProxyHandler({}) 绕开环境代理，与 daemon httpx trust_env=False 对齐。
+    opener = (urllib.request.build_opener() if use_proxy
+              else urllib.request.build_opener(urllib.request.ProxyHandler({})))
     try:
-        with urllib.request.urlopen(req, timeout=60) as r:
+        with opener.open(req, timeout=60) as r:
             data = r.read()
         if not data:
             logger.warning("updater: server wheel 为空")
@@ -199,6 +207,7 @@ class AutoUpdater:
         server_url: str | None = None,
         client_id: str | None = None,
         join_token: str | None = None,
+        use_proxy: bool = False,
     ):
         # pypi_url 缺省 None = 不传 -i，尊重用户机器的 pip 配置（pip.ini /
         # pip.conf 的 index-url，内网通常配了企业镜像）。曾写死
@@ -210,6 +219,10 @@ class AutoUpdater:
         self.server_url = server_url
         self.client_id = client_id
         self.join_token = join_token
+        # server 方向请求默认直连；True 时走系统/环境代理（跟随 connect 的 --use-proxy）。
+        self.use_proxy = use_proxy
+        self._last_pip_failure_summary = ""
+        self._last_server_fallback_failure_summary = ""
         self._stop = threading.Event()
         self._thread: Optional[threading.Thread] = None
 
@@ -274,7 +287,13 @@ class AutoUpdater:
             _restart()   # 升级成功后重启，不会走到这行之后的代码
             # （_restart 在 Windows 上 os._exit；Linux 上 execv）
             return
-        self._check_server_fallback(current_str, current, reason="pypi_install_failed")
+        if not self._check_server_fallback(current_str, current,
+                                           reason="pypi_install_failed"):
+            logger.warning(
+                "updater: 升级到 %s 失败——pip 原因: %s；server 回退原因: %s",
+                latest_str,
+                self._last_pip_failure_summary or "未知",
+                self._last_server_fallback_failure_summary or "未知")
 
     # pip 卡死的硬上限。pip 自带的 socket timeout 只覆盖"完全无数据"，
     # 代理黑洞式的涓涓细流永远不触发；而 updater 是单线程循环，一次
@@ -294,19 +313,46 @@ class AutoUpdater:
         try:
             result = subprocess.run(cmd, capture_output=True, text=True,
                                     timeout=self._PIP_TIMEOUT)
-            if result.returncode == 0:
-                logger.info("updater: 升级到 %s 成功", target_version)
-                return True
+        except subprocess.TimeoutExpired:
+            self._last_pip_failure_summary = f"pip 超过 {self._PIP_TIMEOUT}s 未退出"
+            logger.warning("updater: %s，放弃本次升级", self._last_pip_failure_summary)
+            return False
+        except Exception as pip_error:
+            self._last_pip_failure_summary = f"执行 pip 异常: {pip_error}"
+            logger.warning("updater: 执行 pip 失败", exc_info=True)
+            return False
+        if result.returncode != 0:
+            self._last_pip_failure_summary = (
+                (result.stderr.strip() or result.stdout.strip()
+                 or "pip 返回非零退出码").splitlines()[-1])
             logger.warning("updater: pip 升级失败:\n%s",
                            result.stderr.strip() or result.stdout.strip())
             return False
-        except subprocess.TimeoutExpired:
-            logger.warning("updater: pip 超过 %ds 未退出，放弃本次升级",
-                           self._PIP_TIMEOUT)
-            return False
+        # pip 装完当前进程 metadata 不刷新，另起解释器核验实际落地版本。
+        installed_version = ""
+        try:
+            verify = subprocess.run(
+                [sys.executable, "-c",
+                 f"from importlib.metadata import version; print(version({self.package!r}))"],
+                capture_output=True, text=True, timeout=30)
+            installed_version = verify.stdout.strip()
         except Exception:
-            logger.warning("updater: 执行 pip 失败", exc_info=True)
-            return False
+            logger.debug("updater: 装后核验子进程失败，按 pip 退出码为准", exc_info=True)
+        # 只有拿到一个可解析且明确不同的版本才判失败；核验取不到版本则信任 pip 退出码。
+        if installed_version:
+            from packaging.version import Version
+            try:
+                reached_target = Version(installed_version) == Version(target_version)
+            except Exception:
+                reached_target = True
+            if not reached_target:
+                self._last_pip_failure_summary = (
+                    f"pip 装完核验版本 {installed_version} 未达目标 {target_version}")
+                logger.warning("updater: %s，改走 server 回退",
+                               self._last_pip_failure_summary)
+                return False
+        logger.info("updater: 升级到 %s 成功", target_version)
+        return True
 
     def _check_server_fallback(
         self, current_str: str, current, *, reason: str, restart: bool = True,
@@ -317,11 +363,14 @@ class AutoUpdater:
         CLI 进程重启只会重跑 update 命令本身，还会以报错收场。
         """
         if not (self.server_url and self.client_id and self.join_token):
+            self._last_server_fallback_failure_summary = "无 server 回退配置"
             logger.debug("updater: 无 server 回退配置，跳过（%s）", reason)
             return False
 
-        info = _server_version(self.server_url, self.join_token, self.client_id)
+        info = _server_version(self.server_url, self.join_token, self.client_id,
+                               self.use_proxy)
         if not info:
+            self._last_server_fallback_failure_summary = "查询 server 版本失败"
             return False
 
         server_version_str = str(info.get("version") or "")
@@ -329,15 +378,21 @@ class AutoUpdater:
             from packaging.version import Version
             server_version = Version(server_version_str)
         except Exception:
+            self._last_server_fallback_failure_summary = (
+                f"server 版本不可解析: {server_version_str}")
             logger.debug("updater: server 版本不可解析: %s",
                          server_version_str, exc_info=True)
             return False
 
         if server_version <= current:
+            self._last_server_fallback_failure_summary = (
+                f"server 版本 {server_version_str} 不高于当前 {current_str}")
             logger.debug("updater: server 版本 %s 不高于当前版本 %s",
                          server_version_str, current_str)
             return False
         if not info.get("wheel_available"):
+            self._last_server_fallback_failure_summary = (
+                f"server 版本 {server_version_str} 未提供 wheel")
             logger.warning("updater: server 版本 %s 可用，但未提供 wheel",
                            server_version_str)
             return False
@@ -349,8 +404,10 @@ class AutoUpdater:
                 self.client_id,
                 Path(td),
                 str(info.get("wheel_filename") or ""),
+                self.use_proxy,
             )
             if wheel is None:
+                self._last_server_fallback_failure_summary = "下载 server wheel 失败"
                 return False
             logger.info("updater: PyPI 不可用（%s），改用 server wheel 升级到 %s",
                         reason, server_version_str)
@@ -358,6 +415,7 @@ class AutoUpdater:
                 if restart:
                     _restart()
                 return True
+            self._last_server_fallback_failure_summary = "安装 server wheel 失败"
             return False
 
     def _install_wheel(self, wheel_path: Path) -> bool:

--- a/tests/test_team_client_updater.py
+++ b/tests/test_team_client_updater.py
@@ -82,7 +82,7 @@ def test_pypi_query_failure_falls_back_to_server_wheel(monkeypatch):
     monkeypatch.setattr(
         updater_mod,
         "_server_version",
-        lambda server_url, join_token, client_id: {
+        lambda server_url, join_token, client_id, use_proxy=False: {
             "version": "1.2.0",
             "wheel_available": True,
             "wheel_filename": "xskill-1.2.0-py3-none-any.whl",
@@ -95,6 +95,7 @@ def test_pypi_query_failure_falls_back_to_server_wheel(monkeypatch):
         client_id: str,
         dest_dir: Path,
         filename: str | None,
+        use_proxy: bool = False,
     ) -> Path:
         wheel = dest_dir / (filename or "xskill-1.2.0-py3-none-any.whl")
         wheel.write_bytes(b"wheel")
@@ -124,7 +125,7 @@ def test_pypi_install_failure_can_fallback_to_server_wheel(monkeypatch):
     monkeypatch.setattr(
         updater_mod,
         "_server_version",
-        lambda server_url, join_token, client_id: {
+        lambda server_url, join_token, client_id, use_proxy=False: {
             "version": "1.2.0",
             "wheel_available": True,
             "wheel_filename": "xskill-1.2.0-py3-none-any.whl",
@@ -137,6 +138,7 @@ def test_pypi_install_failure_can_fallback_to_server_wheel(monkeypatch):
         client_id: str,
         dest_dir: Path,
         filename: str | None,
+        use_proxy: bool = False,
     ) -> Path:
         wheel = dest_dir / (filename or "xskill-1.2.0-py3-none-any.whl")
         wheel.write_bytes(b"wheel")
@@ -166,7 +168,7 @@ def test_server_fallback_skips_non_newer_server_version(monkeypatch):
     monkeypatch.setattr(
         updater_mod,
         "_server_version",
-        lambda server_url, join_token, client_id: {
+        lambda server_url, join_token, client_id, use_proxy=False: {
             "version": "1.2.0",
             "wheel_available": True,
             "wheel_filename": "xskill-1.2.0-py3-none-any.whl",
@@ -201,9 +203,140 @@ def test_pip_respects_system_index_by_default(monkeypatch):
 
     monkeypatch.setattr(updater_mod.subprocess, "run", fake_run)
 
-    AutoUpdater()._install("1.2.3")
-    assert "-i" not in captured[-1], "缺省不许传 -i,必须尊重系统 pip 配置"
+    def pip_install_cmd(commands):
+        return next(c for c in commands
+                    if "install" in c and any("1.2.3" in part for part in c))
 
+    captured.clear()
+    AutoUpdater()._install("1.2.3")
+    assert "-i" not in pip_install_cmd(captured), "缺省不许传 -i,必须尊重系统 pip 配置"
+
+    captured.clear()
     AutoUpdater(pypi_url="https://mirror.example/simple/")._install("1.2.3")
-    idx = captured[-1].index("-i")
-    assert captured[-1][idx + 1] == "https://mirror.example/simple/"
+    install_cmd = pip_install_cmd(captured)
+    idx = install_cmd.index("-i")
+    assert install_cmd[idx + 1] == "https://mirror.example/simple/"
+
+
+def test_server_requests_default_to_no_proxy_opener(monkeypatch):
+    """回归(2026-07-14):server 方向 urllib 走默认 opener 会吃系统代理,内网 IP
+    被代理黑洞超时,PyPI 失败后的 server 回退也一起死。缺省必须用
+    ProxyHandler({}) 直连;use_proxy=True 才恢复走代理。"""
+    import json
+    import urllib.request
+
+    recorded_handlers: list[tuple] = []
+
+    class _FakeResponse:
+        def __enter__(self):
+            return self
+
+        def __exit__(self, *exc):
+            return False
+
+        def read(self):
+            return json.dumps({"version": "1.0.0"}).encode("utf-8")
+
+    class _FakeOpener:
+        def open(self, request, timeout=None):
+            return _FakeResponse()
+
+    def fake_build_opener(*handlers):
+        recorded_handlers.append(handlers)
+        return _FakeOpener()
+
+    monkeypatch.setattr(urllib.request, "build_opener", fake_build_opener)
+
+    updater_mod._server_version("http://server", "tok", "cid")
+    assert len(recorded_handlers[-1]) == 1
+    assert isinstance(recorded_handlers[-1][0], urllib.request.ProxyHandler)
+    assert recorded_handlers[-1][0].proxies == {}, "缺省必须注入空代理映射直连"
+
+    updater_mod._server_version("http://server", "tok", "cid", use_proxy=True)
+    assert recorded_handlers[-1] == (), "use_proxy=True 时不得注入 ProxyHandler,走系统代理"
+
+
+class _FakeProc:
+    def __init__(self, returncode: int, stdout: str = "", stderr: str = ""):
+        self.returncode = returncode
+        self.stdout = stdout
+        self.stderr = stderr
+
+
+def test_pip_success_but_wrong_version_falls_back_to_server(monkeypatch):
+    """回归(2026-07-14):镜像只同步到旧版时 pip 可能返回 0 却没把版本推到目标,
+    装后必须另起解释器核验;核验不符一律视为安装失败并走 server 回退。"""
+    installed_wheels: list[str] = []
+
+    monkeypatch.setattr(updater_mod, "_current_version", lambda package: "1.0.0")
+    monkeypatch.setattr(updater_mod, "_latest_pypi_version", lambda package: "1.2.0")
+    monkeypatch.setattr(
+        updater_mod,
+        "_server_version",
+        lambda server_url, join_token, client_id, use_proxy=False: {
+            "version": "1.2.0",
+            "wheel_available": True,
+            "wheel_filename": "xskill-1.2.0-py3-none-any.whl",
+        },
+    )
+
+    def fake_download(
+        server_url, join_token, client_id, dest_dir, filename, use_proxy=False,
+    ):
+        wheel = dest_dir / (filename or "xskill-1.2.0-py3-none-any.whl")
+        wheel.write_bytes(b"wheel")
+        return wheel
+
+    monkeypatch.setattr(updater_mod, "_download_server_wheel", fake_download)
+    monkeypatch.setattr(updater_mod, "_restart", lambda: None)
+
+    def fake_run(cmd, **kwargs):
+        if "install" in cmd:
+            return _FakeProc(returncode=0)
+        return _FakeProc(returncode=0, stdout="1.0.0\n")
+
+    monkeypatch.setattr(updater_mod.subprocess, "run", fake_run)
+
+    updater = AutoUpdater(server_url="http://server", client_id="cid", join_token="tok")
+    monkeypatch.setattr(
+        updater,
+        "_install_wheel",
+        lambda wheel: installed_wheels.append(wheel.name) or True,
+    )
+
+    updater._check_and_update()
+
+    assert installed_wheels == ["xskill-1.2.0-py3-none-any.whl"]
+
+
+def test_pip_and_server_fallback_both_fail_logs_warning(monkeypatch, caplog):
+    """回归(2026-07-14):pip 与 server 回退双双失败时,过去只在 DEBUG 记录,全链
+    静默。现在必须留一条 WARNING,一行含目标版本 + pip 失败摘要 + server 回退失败摘要。"""
+    import logging
+
+    monkeypatch.setattr(updater_mod, "_current_version", lambda package: "1.0.0")
+    monkeypatch.setattr(updater_mod, "_latest_pypi_version", lambda package: "1.2.0")
+    monkeypatch.setattr(
+        updater_mod,
+        "_server_version",
+        lambda server_url, join_token, client_id, use_proxy=False: None,
+    )
+
+    def fake_run(cmd, **kwargs):
+        return _FakeProc(returncode=1, stderr="ERROR: 镜像无 1.2.0")
+
+    monkeypatch.setattr(updater_mod.subprocess, "run", fake_run)
+
+    updater = AutoUpdater(server_url="http://server", client_id="cid", join_token="tok")
+    with caplog.at_level(logging.WARNING, logger="xskill.team.client.updater"):
+        updater._check_and_update()
+
+    combined = [
+        record.getMessage()
+        for record in caplog.records
+        if record.levelno == logging.WARNING
+        and "1.2.0" in record.getMessage()
+        and "镜像无 1.2.0" in record.getMessage()
+        and "查询 server 版本失败" in record.getMessage()
+    ]
+    assert combined, [r.getMessage() for r in caplog.records]


### PR DESCRIPTION
## 生产事故链（华为内网 Windows client 实盘复盘）

1. AutoUpdater 查 PyPI（外网经代理可达）得 0.6.17 > 本地 0.6.14 → `pip install --upgrade xskill==0.6.17`；
2. pip 尊重 pip.ini 的企业镜像，镜像只同步到 0.6.15 → 安装失败；
3. `_check_server_fallback` 的 urllib **默认 opener 吃系统代理** → 代理路由不到内网 server IP → 超时 → 回退也死；
4. 每小时循环，全部静默（关键日志 DEBUG 被吞）。

## 修复

- **server 方向请求默认直连**：`/team/version`、`/team/wheel` 两处 urllib 改 `build_opener(ProxyHandler({}))`（等价 daemon httpx 的 `trust_env=False` 语义）；`--use-proxy` 全链路透传（connect → TeamClient → AutoUpdater；`xskill update` 也新增该 flag）。查 PyPI 保持默认走代理（外网本该走）。
- **升级闭环**：pip 返回 0 后另起解释器核验落地版本，拿到明确不同的可解析版本 → 判失败 → 走 server wheel 回退（核验取不到版本时信任 pip 退出码，避免误杀）；
- **失败可见**：pip 失败 + server 回退失败 → 一条 WARNING 含目标版本 + 两段失败原因摘要（原 DEBUG 静默）。

## 测试

19 passed（含新增：no-proxy opener 断言 / 核验不符触发回退 / 双失败 WARNING 含两段原因）。

🤖 Generated with [Claude Code](https://claude.com/claude-code)