### PR TITLE
perf(dashboard): 画像散点事件触发物化 + multiprocessing 隔离（closes #106）

### DIFF
--- a/src/xskill/dashboard/profile_viz.py
+++ b/src/xskill/dashboard/profile_viz.py
@@ -11,6 +11,7 @@
 """
 from __future__ import annotations
 
+import hashlib
 import logging
 import pickle
 from collections import Counter
@@ -407,6 +408,95 @@ def _skillhub_index_vecs(cache_path: Optional[Path]) -> dict[str, np.ndarray]:
         return {}
 
 
+_PROJECTORS = {"tsne": _TSNE2D, "umap": _UMAP2D}
+
+
+def _file_signature(path: Optional[Path]) -> str:
+    """文件的廉价内容签名(size:mtime_ns);缺失/不可读 → '-'。只 stat,不读内容。"""
+    if not path:
+        return "-"
+    try:
+        st = Path(path).stat()
+    except OSError:
+        return "-"
+    return f"{st.st_size}:{st.st_mtime_ns}"
+
+
+def compute_scatter_payload(scatter_inputs: dict) -> dict:
+    """散点降维的纯计算核心（模块顶层、可 pickle）——进程池 worker 与直算共用。
+
+    入参为父进程取好的纯数据（向量矩阵 + 逐点/技能元数据），出参为前端契约的
+    坐标包 dict。子进程只做数学,不碰 SQLite/配置/文件（#106 multiprocessing 范式）。
+    """
+    if scatter_inputs.get("cold"):
+        return {"user": scatter_inputs["user"],
+                "updated_at": scatter_inputs["updated_at"],
+                "points": [], "centers": [], "skills": [], "clusters": [],
+                "method": scatter_inputs["method"],
+                "note": scatter_inputs["note"]}
+
+    method = scatter_inputs["method"]
+    combined = np.asarray(scatter_inputs["combined"], dtype=float)
+    n_points = scatter_inputs["n_points"]
+    n_centers = scatter_inputs["n_centers"]
+    coords_all = _PROJECTORS[method]().fit(combined)
+    coords = coords_all[:n_points]
+    center_coords = coords_all[n_points:n_points + n_centers]
+    skill_coords = coords_all[n_points + n_centers:]
+
+    meta = scatter_inputs["meta"]
+    assignment = scatter_inputs["assignment"]
+    out_points = []
+    cluster_tags: dict[int, Counter] = {}
+    for i, m in enumerate(meta):
+        cluster = int(assignment[i])
+        out_points.append({
+            "x": round(float(coords[i, 0]), 4),
+            "y": round(float(coords[i, 1]), 4),
+            "atom_id": m.get("atom_id") or "",
+            "summary": (m.get("summary") or "")[:200],
+            "ux": m.get("ux"),
+            "cluster": cluster,
+        })
+        tag_counter = cluster_tags.setdefault(cluster, Counter())
+        for tag in (m.get("tags") or []):
+            tag = str(tag).strip().lower()
+            if tag:
+                tag_counter[tag] += 1
+
+    clusters = [
+        {"cluster": c,
+         "label": (cluster_tags.get(c) or Counter()).most_common(1)[0][0]
+         if cluster_tags.get(c) else f"簇 {c}"}
+        for c in range(max(len(center_coords), 1))
+    ]
+
+    skills = [
+        {"name": name,
+         "x": round(float(skill_coords[i, 0]), 4),
+         "y": round(float(skill_coords[i, 1]), 4),
+         "use_count": use_count,
+         "source": source}
+        for i, (name, use_count, source) in enumerate(scatter_inputs["skill_meta"])
+    ]
+
+    return {
+        "user": scatter_inputs["user"],
+        "updated_at": scatter_inputs["updated_at"],
+        "points": out_points,
+        "centers": [{"cluster": i,
+                     "x": round(float(center_coords[i, 0]), 4),
+                     "y": round(float(center_coords[i, 1]), 4)}
+                    for i in range(len(center_coords))],
+        "clusters": clusters,
+        "skills": skills,
+        "method": method,
+        "total": scatter_inputs["total"],
+        "shown": len(out_points),
+        "sampled": scatter_inputs["sampled"],
+    }
+
+
 class ProfileViz:
     """画像可视化数据装配（读 ProfileStore + skill 索引,纯 numpy,无 LLM）。"""
 
@@ -420,28 +510,41 @@ class ProfileViz:
 
     # ── §2.3 画像散点 ────────────────────────────────────────────
 
-    _PROJECTORS = {"tsne": _TSNE2D, "umap": _UMAP2D}
+    def scatter_input_fingerprint(self, user_key: str) -> Optional[str]:
+        """散点输入的廉价内容指纹:画像修订(原子集+embedding 模型) + skill/skillhub
+        索引文件签名。只查一列 revision + stat 两个缓存文件,不做矩阵计算;输入不变
+        指纹不变。无画像行 → None（端点据此转 404,不入队）。"""
+        revision = self._store.get_revision(user_key)
+        if revision is None:
+            return None
+        skill_index = (Path(self._skill_dir) / ".skill_index.pkl"
+                       if self._skill_dir else None)
+        parts = [revision["source_revision"], revision["embed_model"],
+                 _file_signature(skill_index),
+                 _file_signature(self._skillhub_index)]
+        return hashlib.sha256("|".join(parts).encode()).hexdigest()
 
-    def user_scatter(self, user_key: str, method: str = "tsne") -> dict:
-        """降维 2D 散点数据。``method`` ∈ {tsne, umap}（默认 tsne）。无画像行 →
-        KeyError（端点转 404）;有行无点（冷启动）→ ``points=[]`` + ``note``,
-        显式标注不造假。
+    def gather_scatter_inputs(self, user_key: str, method: str = "tsne") -> dict:
+        """取数(读库/读 skill 索引)装配 ``compute_scatter_payload`` 的纯数据入参。
+
+        读侧全部留在此处（父进程）:返回的 dict 只含可 pickle 纯数据 + 内容指纹,
+        供进程池 worker 直接消费。无画像行 → KeyError（端点转 404）;有行无点
+        （冷启动）→ ``cold=True`` + ``note``,显式标注不造假。
 
         points/centers/skill 向量一次性联合投影（两种算法都没有 PCA 那种线性
-        basis 可以对新点复用——邻域结构必须从投影一开始就联合建立,分开投影
-        会让簇位置互相对不上）。
+        basis 可对新点复用——邻域结构必须从投影一开始就联合建立,分开投影会让
+        簇位置互相对不上）,故此处只组装 combined,不拆分。
         """
-        projector_cls = self._PROJECTORS.get(method)
-        if projector_cls is None:
+        if method not in _PROJECTORS:
             raise ValueError(f"未知投影算法 {method!r}（可选 tsne/umap）")
         profile = self._store.load(user_key)
         stored = self._store.load_points(user_key)
         if profile is None or stored is None:
             raise KeyError(f"用户 {user_key!r} 无画像")
+        fingerprint = self.scatter_input_fingerprint(user_key) or ""
         if stored["points"] is None or not len(stored["meta"]):
-            return {"user": user_key, "updated_at": stored["updated_at"],
-                    "points": [], "centers": [], "skills": [], "clusters": [],
-                    "method": method,
+            return {"cold": True, "user": user_key, "method": method,
+                    "updated_at": stored["updated_at"], "fingerprint": fingerprint,
                     "note": "画像冷启动:该用户还没有可投影的原子"}
 
         points = np.asarray(stored["points"], dtype=float)
@@ -488,60 +591,28 @@ class ProfileViz:
         if skill_entries:
             blocks.append(np.vstack([v for _, _, v, _ in skill_entries]))
         combined = np.vstack(blocks)
-        coords_all = projector_cls().fit(combined)
-        coords = coords_all[:len(points)]
-        center_coords = coords_all[len(points):len(points) + len(centers)]
-        skill_coords = coords_all[len(points) + len(centers):]
-
-        out_points = []
-        cluster_tags: dict[int, Counter] = {}
-        for i, m in enumerate(meta):
-            cluster = int(assignment[i])
-            out_points.append({
-                "x": round(float(coords[i, 0]), 4),
-                "y": round(float(coords[i, 1]), 4),
-                "atom_id": m.get("atom_id") or "",
-                "summary": (m.get("summary") or "")[:200],
-                "ux": m.get("ux"),
-                "cluster": cluster,
-            })
-            tag_counter = cluster_tags.setdefault(cluster, Counter())
-            for tag in (m.get("tags") or []):
-                tag = str(tag).strip().lower()
-                if tag:
-                    tag_counter[tag] += 1
-
-        clusters = [
-            {"cluster": c,
-             "label": (cluster_tags.get(c) or Counter()).most_common(1)[0][0]
-             if cluster_tags.get(c) else f"簇 {c}"}
-            for c in range(max(len(center_coords), 1))
-        ]
-
-        skills = [
-            {"name": name,
-             "x": round(float(skill_coords[i, 0]), 4),
-             "y": round(float(skill_coords[i, 1]), 4),
-             "use_count": use_count,
-             "source": source}  # 共同数据契约:native / skillhub(据向量来自哪个缓存)
-            for i, (name, use_count, _vec, source) in enumerate(skill_entries)
-        ]
 
         return {
+            "cold": False,
             "user": user_key,
-            "updated_at": stored["updated_at"],
-            "points": out_points,
-            "centers": [{"cluster": i,
-                         "x": round(float(center_coords[i, 0]), 4),
-                         "y": round(float(center_coords[i, 1]), 4)}
-                        for i in range(len(center_coords))],
-            "clusters": clusters,
-            "skills": skills,
             "method": method,
-            "total": total,          # 该用户原子总数
-            "shown": len(out_points),  # 实际投影/渲染的点数
-            "sampled": sampled,      # True → 已分层抽样,页面标注"显示 N/M"
+            "updated_at": stored["updated_at"],
+            "fingerprint": fingerprint,
+            "combined": combined,
+            "n_points": len(points),
+            "n_centers": len(centers),
+            "meta": meta,
+            "assignment": [int(cluster) for cluster in assignment],
+            "skill_meta": [(name, use_count, source)
+                           for name, use_count, _vec, source in skill_entries],
+            "total": total,
+            "sampled": sampled,
         }
+
+    def user_scatter(self, user_key: str, method: str = "tsne") -> dict:
+        """降维 2D 散点数据（gather → 纯计算）。保持既有契约,供无缓存/无进程池
+        时的直算回退与既有调用方使用。"""
+        return compute_scatter_payload(self.gather_scatter_inputs(user_key, method))
 
     # ── §2.5 admin 用户聚类 graph ────────────────────────────────
 

--- a/src/xskill/dashboard/router.py
+++ b/src/xskill/dashboard/router.py
@@ -5,6 +5,7 @@
 """
 from __future__ import annotations
 
+import json
 from pathlib import Path
 from typing import Optional
 
@@ -507,26 +508,32 @@ def _register_explorer_endpoints(router: APIRouter, db_path: Optional[Path],
 
     @router.get("/api/v1/dashboard/user/{user_key}/scatter")
     def user_scatter_ep(user_key: str, method: str = "tsne") -> dict:
-        """画像散点（图③,P3-3.4）:原子点降维投影 + 兴趣中心 + skill 向量。
-        ``method`` ∈ {tsne, umap}——同一批向量、同款前置,换降维算法对比效果。"""
+        """画像散点（图③,P3-3.4）:事件触发物化 + 端点只读（#106）。命中缓存直返
+        坐标包;未命中/指纹过期 → 入队一次重算并返回 ``{"status":"pending"}``(HTTP 200)。
+        无常驻服务的独立只读实例退化为直算并物化一次。"""
+        if method not in ("tsne", "umap"):
+            raise HTTPException(status_code=400,
+                                detail=f"未知投影算法 {method!r}（可选 tsne/umap）")
         from xskill.dashboard.profile_viz import (
             ProfileViz, profile_db_for, skillhub_index_for)
+        from xskill.pipeline.registry import (
+            read_scatter_cache, write_scatter_cache)
         pdb = profile_db_for(db_path)
         if not pdb.is_file():
             raise HTTPException(status_code=404,
                                 detail="画像库不存在(team 模式未启用或还没有画像)")
         profile_viz = ProfileViz(pdb, skill_dir=skill_dir, db_path=db_path,
                                  skillhub_index=skillhub_index_for(db_path))
-        try:
-            return profile_viz.user_scatter(user_key, method=method)
-        except ValueError as e:
-            raise HTTPException(status_code=400, detail=str(e)) from e
-        except KeyError as e:
-            # 画像按 client_id 存,而看板行的 uid 对命名用户是 user_name(#97)
-            # ——按名反查 client_id 重试,匿名/未知名字保持 404。
+
+        # 廉价内容指纹:输入不变则命中,不做投影。画像按 client_id 存,看板行的 uid
+        # 对命名用户是 user_name(#97)——首次拿不到指纹时按名反查 client_id 重试。
+        effective_key = user_key
+        fingerprint = profile_viz.scatter_input_fingerprint(user_key)
+        if fingerprint is None:
             from xskill.config import get_registry_db_path
             from xskill.team.server.client_registry import ClientRegistry
-            db_dir = Path(db_path).parent if db_path else get_registry_db_path().parent
+            db_dir = (Path(db_path).parent if db_path
+                      else get_registry_db_path().parent)
             clients_db = db_dir / "team_clients.db"
             resolved_client_id = None
             if clients_db.is_file():
@@ -535,10 +542,31 @@ def _register_explorer_endpoints(router: APIRouter, db_path: Optional[Path],
                         clients_db).find_by_user_name(user_key)
                 except ValueError:
                     resolved_client_id = None
-            if not resolved_client_id or resolved_client_id == user_key:
-                raise HTTPException(status_code=404, detail=str(e)) from e
-            try:
-                return profile_viz.user_scatter(resolved_client_id, method=method)
-            except KeyError as retry_error:
-                raise HTTPException(
-                    status_code=404, detail=str(retry_error)) from retry_error
+            if resolved_client_id and resolved_client_id != user_key:
+                fingerprint = profile_viz.scatter_input_fingerprint(
+                    resolved_client_id)
+                if fingerprint is not None:
+                    effective_key = resolved_client_id
+        if fingerprint is None:
+            raise HTTPException(status_code=404,
+                                detail=f"用户 {user_key!r} 无画像")
+
+        cached = read_scatter_cache(effective_key, method, db_path=db_path)
+        if cached is not None and cached["fingerprint"] == fingerprint:
+            return json.loads(cached["payload"])
+
+        service = None
+        try:
+            from xskill.api.app import _profile_refresh_ref
+            service = _profile_refresh_ref.get("instance")
+        except Exception:  # pylint: disable=broad-exception-caught
+            service = None
+        if service is not None and service.submit_scatter(effective_key, method):
+            return {"status": "pending", "user": effective_key, "method": method,
+                    "note": "画像散点计算中，请稍候…"}
+
+        # 独立只读实例(无常驻服务)或服务不收:直算并物化,下次即命中。
+        payload = profile_viz.user_scatter(effective_key, method=method)
+        write_scatter_cache(effective_key, method, fingerprint, payload,
+                            db_path=db_path)
+        return payload

--- a/src/xskill/dashboard/static/app.js
+++ b/src/xskill/dashboard/static/app.js
@@ -1434,7 +1434,7 @@ function convexHull(pts) {
 let SCATTER_METHOD = location.pathname.includes('umap') ? 'umap' : 'tsne';
 let _lastProfileUid = null;
 const METHOD_LABEL = { tsne: 't-SNE', umap: 'UMAP' };
-async function openUserProfile(uid) {
+async function openUserProfile(uid, isRetry) {
   _lastProfileUid = uid;
   const box = document.getElementById('user-profile');
   if (!box) return;
@@ -1443,6 +1443,12 @@ async function openUserProfile(uid) {
   try { d = await j('api/v1/dashboard/user/' + encodeURIComponent(uid) + '/scatter?method=' + SCATTER_METHOD); }
   catch (e) {
     box.innerHTML = `<div class="bg-white rounded-2xl ring-1 ring-slate-200 p-5 text-slate-400 text-xs">${esc(uid)}:${esc(e.message)}</div>`;
+    return;
+  }
+  // #106 端点只读:未物化时返回 pending,显示占位并在 5s 后自动重试一次(不做复杂轮询)。
+  if (d && d.status === 'pending') {
+    box.innerHTML = `<div class="bg-white rounded-2xl ring-1 ring-slate-200 p-5 text-slate-400 text-xs">${esc(uid)} 的画像散点计算中…${isRetry ? '' : '（约几秒后自动刷新）'}</div>`;
+    if (!isRetry) setTimeout(() => { if (_lastProfileUid === uid) openUserProfile(uid, true).catch(console.error); }, 5000);
     return;
   }
   if (!(d.points || []).length) {

--- a/src/xskill/pipeline/registry.py
+++ b/src/xskill/pipeline/registry.py
@@ -231,6 +231,17 @@ CREATE TABLE IF NOT EXISTS skill_trigger_eval (
     catalog_size INTEGER      -- 诱饵清单平均大小(竞争对手数)
 );
 CREATE INDEX IF NOT EXISTS idx_trig_skill ON skill_trigger_eval(skill);
+
+-- #106 画像散点物化缓存:事件触发重算落盘,scatter 端点退化为纯读。
+-- payload=JSON 坐标包;fingerprint=散点输入的廉价内容指纹(输入不变则命中不重算)。
+CREATE TABLE IF NOT EXISTS scatter_cache (
+    user_key    TEXT NOT NULL,
+    method      TEXT NOT NULL,
+    fingerprint TEXT NOT NULL,
+    payload     TEXT NOT NULL,
+    computed_at TEXT DEFAULT (datetime('now')),
+    PRIMARY KEY (user_key, method)
+);
 """
 
 
@@ -467,6 +478,42 @@ def record_usage(*, step: str, model: str, prompt: int, completion: int,
             " VALUES(?,?,?,?,?,?,?)",
             (step, model, int(prompt), int(completion), int(total),
              float(cost_usd), price_source),
+        )
+        conn.commit()
+
+
+# ---------------------------------------------------------------------------
+# #106 画像散点物化缓存 —— 事件触发重算写入，scatter 端点只读命中
+# ---------------------------------------------------------------------------
+
+def read_scatter_cache(user_key: str, method: str, *,
+                       db_path: Optional[Path] = None) -> Optional[dict]:
+    """返回某用户某算法的散点缓存 ``{payload, fingerprint, computed_at}``；无行 → None。"""
+    with pooled_connection(db_path) as conn:
+        row = conn.execute(
+            "SELECT payload, fingerprint, computed_at FROM scatter_cache"
+            " WHERE user_key=? AND method=?",
+            (user_key, method),
+        ).fetchone()
+        if row is None:
+            return None
+        return {"payload": row["payload"], "fingerprint": row["fingerprint"],
+                "computed_at": row["computed_at"]}
+
+
+def write_scatter_cache(user_key: str, method: str, fingerprint: str,
+                        payload: dict, *,
+                        db_path: Optional[Path] = None) -> None:
+    """物化一条散点坐标包（``payload`` dict → JSON 存储），覆盖旧值并刷新 computed_at。"""
+    payload_json = json.dumps(payload, ensure_ascii=False)
+    with pooled_connection(db_path) as conn:
+        conn.execute(
+            "INSERT INTO scatter_cache(user_key,method,fingerprint,payload)"
+            " VALUES(?,?,?,?)"
+            " ON CONFLICT(user_key,method) DO UPDATE SET"
+            " fingerprint=excluded.fingerprint, payload=excluded.payload,"
+            " computed_at=datetime('now')",
+            (user_key, method, fingerprint, payload_json),
         )
         conn.commit()
 

--- a/src/xskill/team/server/profile_refresh.py
+++ b/src/xskill/team/server/profile_refresh.py
@@ -3,16 +3,33 @@ from __future__ import annotations
 
 import logging
 import math
+import multiprocessing
 import queue
 import threading
 import time
-from typing import Callable
+from concurrent.futures import ProcessPoolExecutor
+from concurrent.futures.process import BrokenProcessPool
+from pathlib import Path
+from typing import Callable, Optional
 
 from xskill.recommend.client_interest import ClientInterest
 
 logger = logging.getLogger("xskill.team.server.profile_refresh")
 
 _STOP = object()
+
+
+def _shutdown_scatter_pool(pool) -> None:
+    """尽力关闭散点进程池（兼容假池/旧签名），不阻塞停机。"""
+    shutdown = getattr(pool, "shutdown", None)
+    if shutdown is None:
+        return
+    try:
+        shutdown(wait=False, cancel_futures=True)
+    except TypeError:
+        shutdown(wait=False)
+    except Exception:  # pylint: disable=broad-exception-caught
+        logger.debug("scatter pool shutdown failed", exc_info=True)
 
 
 class ProfileRefreshService:
@@ -31,6 +48,9 @@ class ProfileRefreshService:
         settle_delay: float = 0.0,
         interest_factory: Callable[[str], ClientInterest] = ClientInterest,
         autostart: bool = True,
+        scatter_materialize: bool = True,
+        scatter_pool_factory: Optional[Callable[[], object]] = None,
+        scatter_registry_db: Optional[Path] = None,
     ):
         if workers < 1:
             raise ValueError("workers 必须 >= 1")
@@ -70,7 +90,25 @@ class ProfileRefreshService:
             "embed_batches": 0,
             "embed_items": 0,
             "reused_vector_items": 0,
+            "scatter_submitted": 0,
+            "scatter_deduped": 0,
+            "scatter_materialized": 0,
         }
+        # #106 散点物化子系统:进程池 + 单派发线程懒创建,事件触发重算落盘。
+        # 引擎不具备取数属性(测试用假引擎)时整体关闭,不建线程/进程池。
+        self._scatter_enabled = (
+            scatter_materialize
+            and hasattr(engine, "skill_dir")
+            and hasattr(engine, "profile_store")
+        )
+        self._scatter_pool_factory = scatter_pool_factory
+        self._scatter_registry_db = scatter_registry_db
+        self._scatter_pool = None
+        self._scatter_pool_disabled = False
+        self._scatter_thread: Optional[threading.Thread] = None
+        self._scatter_queue: queue.Queue = queue.Queue()
+        self._scatter_inflight: set[tuple[str, str]] = set()
+        self._scatter_viz = None
         if autostart:
             self.start()
 
@@ -166,6 +204,16 @@ class ProfileRefreshService:
                 continue
             remaining = max(0.0, deadline - time.monotonic())
             thread.join(remaining)
+
+        # 散点子系统停机:停派发线程 + 关进程池（在 with 块已置 _stopping,不再建新的）。
+        scatter_thread = self._scatter_thread
+        if scatter_thread is not None:
+            self._scatter_queue.put(_STOP)
+            scatter_thread.join(max(0.0, deadline - time.monotonic()))
+        if self._scatter_pool is not None:
+            _shutdown_scatter_pool(self._scatter_pool)
+            self._scatter_pool = None
+
         return all(not thread.is_alive() for thread in threads)
 
     def _worker(self) -> None:
@@ -199,8 +247,9 @@ class ProfileRefreshService:
                 self._metrics["queued"] -= 1
                 self._metrics["running"] += 1
 
+            changed = False
             if self._wait_for_settle():
-                self._run_once(client_id)
+                changed = self._run_once(client_id)
 
             run_again = False
             with self._condition:
@@ -212,7 +261,13 @@ class ProfileRefreshService:
                     self._metrics["rerun"] += 1
                     run_again = True
             if run_again:
-                self._run_once(client_id)
+                changed = self._run_once(client_id) or changed
+
+            # 事件触发（在 finalize 之前,保证 wait_idle 解除时投递已发生）:画像真的
+            # 变了才投递该用户 tsne+umap 两个方法的散点重算,指纹未变的空转在重算侧跳过。
+            if changed and self._scatter_enabled:
+                for scatter_method in ("tsne", "umap"):
+                    self.submit_scatter(client_id, scatter_method)
 
             with self._condition:
                 self._states.pop(client_id, None)
@@ -230,7 +285,8 @@ class ProfileRefreshService:
                 self._condition.wait(timeout=remaining)
             return False
 
-    def _run_once(self, client_id: str) -> None:
+    def _run_once(self, client_id: str) -> bool:
+        """执行一次画像更新;返回是否产生了变更（供事件触发散点重算判定）。"""
         try:
             result = self.engine.update_user_interest(
                 self.interest_factory(client_id),
@@ -240,11 +296,13 @@ class ProfileRefreshService:
             with self._condition:
                 self._metrics["failed"] += 1
             logger.exception("profile refresh failed for client %s", client_id)
-            return
+            return False
+        cancelled = getattr(result, "cancelled", False)
+        changed = getattr(result, "changed", True)
         with self._condition:
-            if getattr(result, "cancelled", False):
+            if cancelled:
                 self._metrics["cancelled"] += 1
-            elif getattr(result, "changed", True):
+            elif changed:
                 self._metrics["completed"] += 1
             else:
                 self._metrics["unchanged"] += 1
@@ -257,8 +315,134 @@ class ProfileRefreshService:
             self._metrics["reused_vector_items"] += int(
                 getattr(result, "reused_vector_items", 0),
             )
+        return bool(changed and not cancelled)
 
     def _should_commit(self) -> bool:
         """供引擎在最终画像 upsert 前检查停机状态。"""
         with self._condition:
             return self._accepting
+
+    # ── #106 散点物化子系统 ──────────────────────────────────────
+
+    def submit_scatter(self, user_key: str, method: str) -> bool:
+        """投递一次散点物化重算;同 ``(user_key, method)`` 在飞则合并去重,不重复入队。
+        服务停止/未启用散点物化 → False。真正的重算在单派发线程上串行执行。"""
+        if not self._scatter_enabled:
+            return False
+        key = (user_key, method)
+        with self._condition:
+            if not self._accepting or self._stopping:
+                return False
+            if key in self._scatter_inflight:
+                self._metrics["scatter_deduped"] += 1
+                return True
+            self._scatter_inflight.add(key)
+            self._metrics["scatter_submitted"] += 1
+        self._ensure_scatter_dispatcher()
+        self._scatter_queue.put(key)
+        return True
+
+    def _ensure_scatter_dispatcher(self) -> None:
+        """懒启动单条散点派发线程（串行消费重算队列）。"""
+        with self._condition:
+            if self._scatter_thread is not None or self._stopping:
+                return
+            self._scatter_thread = threading.Thread(
+                target=self._scatter_dispatch_loop,
+                name="xskill-scatter-dispatch",
+                daemon=True,
+            )
+            self._scatter_thread.start()
+
+    def _scatter_dispatch_loop(self) -> None:
+        while True:
+            key = self._scatter_queue.get()
+            if key is _STOP:
+                return
+            user_key, method = key
+            try:
+                self._recompute_scatter(user_key, method)
+            except Exception:  # pylint: disable=broad-exception-caught
+                logger.warning("scatter recompute failed for %s/%s",
+                               user_key, method, exc_info=True)
+            finally:
+                with self._condition:
+                    self._scatter_inflight.discard(key)
+
+    def _recompute_scatter(self, user_key: str, method: str) -> None:
+        """取数(父进程)→ 指纹比对跳过空转 → 进程池纯数学 → 物化落盘。"""
+        from xskill.dashboard.profile_viz import compute_scatter_payload
+        from xskill.pipeline.registry import (
+            read_scatter_cache, write_scatter_cache)
+        viz = self._scatter_profile_viz()
+        fingerprint = viz.scatter_input_fingerprint(user_key)
+        if fingerprint is None:
+            return  # 无画像,不物化
+        cached = read_scatter_cache(user_key, method,
+                                    db_path=self._scatter_registry_db)
+        if cached is not None and cached["fingerprint"] == fingerprint:
+            return  # 指纹未变,事件触发的空转直接跳过
+        scatter_inputs = viz.gather_scatter_inputs(user_key, method)
+        payload = self._project_scatter(scatter_inputs, compute_scatter_payload)
+        if payload is None:
+            return  # 子进程异常,保留旧缓存
+        write_scatter_cache(user_key, method, fingerprint, payload,
+                            db_path=self._scatter_registry_db)
+        with self._condition:
+            self._metrics["scatter_materialized"] += 1
+
+    def _project_scatter(self, scatter_inputs: dict, worker) -> Optional[dict]:
+        """把 500 轮纯 Python 循环推到进程池(GIL 隔离);池不可用→线程内直算一次,
+        子进程异常→None(保留旧缓存)。``worker`` 为模块顶层可 pickle 的纯函数。"""
+        pool = self._acquire_scatter_pool()
+        if pool is None:
+            return worker(scatter_inputs)
+        try:
+            return pool.submit(worker, scatter_inputs).result()
+        except BrokenProcessPool:
+            with self._condition:
+                self._scatter_pool = None  # 池坏了,下次重建
+            logger.warning("scatter process pool broken; computing inline once")
+            return worker(scatter_inputs)
+        except Exception:  # pylint: disable=broad-exception-caught
+            logger.warning("scatter projection failed in subprocess", exc_info=True)
+            return None
+
+    def _acquire_scatter_pool(self):
+        """懒创建 spawn 单 worker 进程池;建池失败(极端环境)→ None,退回线程内直算。"""
+        with self._condition:
+            if self._stopping or self._scatter_pool_disabled:
+                return None
+            if self._scatter_pool is not None:
+                return self._scatter_pool
+        try:
+            if self._scatter_pool_factory is not None:
+                pool = self._scatter_pool_factory()
+            else:
+                context = multiprocessing.get_context("spawn")
+                pool = ProcessPoolExecutor(max_workers=1, mp_context=context)
+        except Exception:  # pylint: disable=broad-exception-caught
+            logger.warning("scatter process pool unavailable; inline fallback",
+                           exc_info=True)
+            with self._condition:
+                self._scatter_pool_disabled = True
+            return None
+        with self._condition:
+            if self._stopping:
+                _shutdown_scatter_pool(pool)
+                return None
+            self._scatter_pool = pool
+            return pool
+
+    def _scatter_profile_viz(self):
+        """懒构造读侧 ProfileViz（从引擎旁推 profile_db / skill_dir / skillhub 索引）。"""
+        if self._scatter_viz is None:
+            from xskill.dashboard.profile_viz import ProfileViz
+            engine = self.engine
+            self._scatter_viz = ProfileViz(
+                engine.profile_store.db_path,
+                skill_dir=engine.skill_dir,
+                skillhub_index=getattr(
+                    getattr(engine, "skillhub", None), "index_cache_path", None),
+            )
+        return self._scatter_viz

--- a/tests/test_scatter_materialize.py
+++ b/tests/test_scatter_materialize.py
@@ -1,0 +1,251 @@
+"""test_scatter_materialize.py —— #106 画像散点事件触发物化 + multiprocessing 隔离
+
+覆盖:registry 缓存读写往返/指纹语义、端点只读化(命中/未命中入队/去重)、纯 worker
+确定性、真 spawn 进程池冒烟、ProfileRefreshService 完成画像后投递散点重算。
+"""
+from __future__ import annotations
+
+import json
+import multiprocessing
+import pickle
+import threading
+import time
+from concurrent.futures import ProcessPoolExecutor
+from pathlib import Path
+from types import SimpleNamespace
+
+import numpy as np
+import pytest
+from fastapi import FastAPI
+from fastapi.testclient import TestClient
+
+from xskill.dashboard.profile_viz import (
+    ProfileViz, compute_scatter_payload, profile_db_for, skillhub_index_for)
+from xskill.dashboard.router import _skill_dir_for, build_dashboard_router
+from xskill.pipeline import registry as R
+from xskill.recommend.profile_store import ProfileStore
+from xskill.team.server.profile_refresh import ProfileRefreshService
+
+
+def _seed_alice(pdb: Path) -> ProfileStore:
+    """alice:两簇各 3 点(git/docker),供散点投影;source_revision 记一个稳定串。"""
+    store = ProfileStore(pdb)
+    a = np.array([[1, 0.05 * i, 0, 0] for i in range(3)], dtype=float)
+    b = np.array([[0.05 * i, 1, 0, 0] for i in range(3)], dtype=float)
+    pts = np.vstack([a, b])
+    pts /= np.linalg.norm(pts, axis=1, keepdims=True)
+    centers = np.vstack([a.mean(0), b.mean(0)])
+    centers /= np.linalg.norm(centers, axis=1, keepdims=True)
+    meta = [{"atom_id": f"atom_t_{i:04d}", "summary": f"s{i}", "ux": 8,
+             "tags": ["git"] if i < 3 else ["docker"]} for i in range(6)]
+    store.upsert("alice", feature_tensor=centers, mean_tensor=pts.mean(0),
+                 used_skills=[{"name": "sk1", "use_count": 3}],
+                 points=pts, point_meta=meta, source_revision="rev-1")
+    return store
+
+
+def _endpoint_fingerprint(registry_db: Path, user_key: str) -> str:
+    """按端点同款构造 ProfileViz 取指纹,保证测试与端点算出的指纹一致。"""
+    viz = ProfileViz(profile_db_for(registry_db),
+                     skill_dir=_skill_dir_for(registry_db), db_path=registry_db,
+                     skillhub_index=skillhub_index_for(registry_db))
+    return viz.scatter_input_fingerprint(user_key)
+
+
+# ── a. registry 缓存读写往返 + 指纹语义 ──────────────────────────────
+
+def test_scatter_cache_roundtrip_and_overwrite(tmp_path):
+    db = tmp_path / "r.db"
+    payload = {"points": [{"x": 1.0, "y": 2.0}], "method": "tsne"}
+    R.write_scatter_cache("alice", "tsne", "fp-1", payload, db_path=db)
+    got = R.read_scatter_cache("alice", "tsne", db_path=db)
+    assert got is not None
+    assert json.loads(got["payload"]) == payload
+    assert got["fingerprint"] == "fp-1" and got["computed_at"]
+    # 覆盖:同 (user,method) 更新指纹与坐标
+    R.write_scatter_cache("alice", "tsne", "fp-2", {"points": []}, db_path=db)
+    got2 = R.read_scatter_cache("alice", "tsne", db_path=db)
+    assert got2["fingerprint"] == "fp-2" and json.loads(got2["payload"]) == {"points": []}
+    # 不同 method / 缺失键
+    assert R.read_scatter_cache("alice", "umap", db_path=db) is None
+    assert R.read_scatter_cache("bob", "tsne", db_path=db) is None
+
+
+def test_fingerprint_mismatch_is_miss(tmp_path):
+    """缓存指纹与当前输入指纹不一致 → 视为未命中(端点会入队重算)。"""
+    db = tmp_path / "r.db"
+    _seed_alice(profile_db_for(db))
+    current = _endpoint_fingerprint(db, "alice")
+    R.write_scatter_cache("alice", "tsne", "stale-fp", {"points": []}, db_path=db)
+    cached = R.read_scatter_cache("alice", "tsne", db_path=db)
+    assert cached["fingerprint"] != current  # 命中判定 = 指纹相等,此处不等 → miss
+
+
+# ── b. 端点只读化 ───────────────────────────────────────────────────
+
+def _dashboard_client(registry_db: Path) -> TestClient:
+    app = FastAPI()
+    app.include_router(build_dashboard_router(db_path=registry_db))
+    return TestClient(app)
+
+
+def test_endpoint_returns_cached_payload_on_hit(tmp_path, monkeypatch):
+    db = tmp_path / "r.db"
+    _seed_alice(profile_db_for(db))
+    monkeypatch.setattr("xskill.api.app._profile_refresh_ref", {})  # 无常驻服务
+    fingerprint = _endpoint_fingerprint(db, "alice")
+    sentinel = {"points": [{"x": 9.0, "y": 9.0}], "method": "tsne", "marker": "cached"}
+    R.write_scatter_cache("alice", "tsne", fingerprint, sentinel, db_path=db)
+    resp = _dashboard_client(db).get("/api/v1/dashboard/user/alice/scatter?method=tsne")
+    assert resp.status_code == 200
+    assert resp.json() == sentinel  # 命中直返物化坐标包,未重算
+
+
+def test_endpoint_miss_returns_pending_and_enqueues_once(tmp_path, monkeypatch):
+    db = tmp_path / "r.db"
+    _seed_alice(profile_db_for(db))
+
+    class _RecordingService:
+        def __init__(self):
+            self.enqueued = []
+            self._inflight = set()
+
+        def submit_scatter(self, user_key, method):
+            key = (user_key, method)
+            if key in self._inflight:
+                return True
+            self._inflight.add(key)
+            self.enqueued.append(key)
+            return True
+
+    service = _RecordingService()
+    monkeypatch.setattr("xskill.api.app._profile_refresh_ref", {"instance": service})
+    client = _dashboard_client(db)
+    first = client.get("/api/v1/dashboard/user/alice/scatter?method=tsne")
+    assert first.status_code == 200 and first.json()["status"] == "pending"
+    # 同 (user,method) 再请求 → 仍 pending,但服务侧去重,不重复入队
+    second = client.get("/api/v1/dashboard/user/alice/scatter?method=tsne")
+    assert second.json()["status"] == "pending"
+    assert service.enqueued == [("alice", "tsne")]
+
+
+def test_endpoint_inline_materializes_without_service(tmp_path, monkeypatch):
+    """独立只读实例(无常驻服务):未命中 → 直算并物化,返回真实坐标包。"""
+    db = tmp_path / "r.db"
+    _seed_alice(profile_db_for(db))
+    monkeypatch.setattr("xskill.api.app._profile_refresh_ref", {})
+    resp = _dashboard_client(db).get("/api/v1/dashboard/user/alice/scatter?method=umap")
+    assert resp.status_code == 200
+    body = resp.json()
+    assert "status" not in body and len(body["points"]) == 6
+    # 已物化:缓存里出现指纹一致的坐标包
+    cached = R.read_scatter_cache("alice", "umap", db_path=db)
+    assert cached["fingerprint"] == _endpoint_fingerprint(db, "alice")
+
+
+def test_endpoint_unknown_method_and_missing_user(tmp_path, monkeypatch):
+    db = tmp_path / "r.db"
+    _seed_alice(profile_db_for(db))
+    monkeypatch.setattr("xskill.api.app._profile_refresh_ref", {})
+    client = _dashboard_client(db)
+    assert client.get("/api/v1/dashboard/user/alice/scatter?method=pca").status_code == 400
+    assert client.get("/api/v1/dashboard/user/ghost/scatter?method=tsne").status_code == 404
+
+
+# ── worker 纯函数:确定性 + 可 pickle ───────────────────────────────
+
+def test_worker_pure_function_deterministic(tmp_path):
+    db = tmp_path / "r.db"
+    _seed_alice(profile_db_for(db))
+    viz = ProfileViz(profile_db_for(db))
+    scatter_inputs = viz.gather_scatter_inputs("alice", method="umap")
+    # 纯数据可 pickle(跨进程边界前提);函数按引用可 pickle
+    pickle.loads(pickle.dumps(scatter_inputs))
+    pickle.loads(pickle.dumps(compute_scatter_payload))
+    first = compute_scatter_payload(scatter_inputs)
+    second = compute_scatter_payload(scatter_inputs)
+    xy1 = [(p["x"], p["y"]) for p in first["points"]]
+    xy2 = [(p["x"], p["y"]) for p in second["points"]]
+    assert xy1 == xy2 and len(xy1) == 6
+
+
+# ── c. 真 spawn 进程池冒烟 ──────────────────────────────────────────
+
+@pytest.mark.timeout(60)
+def test_spawn_process_pool_smoke(tmp_path):
+    db = tmp_path / "r.db"
+    _seed_alice(profile_db_for(db))
+    scatter_inputs = ProfileViz(profile_db_for(db)).gather_scatter_inputs(
+        "alice", method="tsne")
+    context = multiprocessing.get_context("spawn")
+    with ProcessPoolExecutor(max_workers=1, mp_context=context) as pool:
+        payload = pool.submit(compute_scatter_payload, scatter_inputs).result()
+    assert payload["method"] == "tsne" and len(payload["points"]) == 6
+
+
+# ── c. ProfileRefreshService 事件触发 + 去重 ────────────────────────
+
+class _FakeEngine:
+    """具备散点取数属性(skill_dir/profile_store)的假引擎,启用散点物化子系统。"""
+
+    def __init__(self, db_path: Path):
+        self.skill_dir = db_path.parent / "skill"
+        self.profile_store = SimpleNamespace(db_path=db_path)
+        self.skillhub = None
+        self.calls: list[str] = []
+
+    def update_user_interest(self, interest, *, should_commit=None):
+        self.calls.append(interest.user_id)
+        return SimpleNamespace(changed=True, cancelled=False, embed_items=1)
+
+
+def test_service_event_trigger_submits_both_methods(tmp_path):
+    engine = _FakeEngine(tmp_path / "team_profile.db")
+    service = ProfileRefreshService(engine, workers=1, queue_size=4)
+    recorder = _RecorderScatter()
+    service.submit_scatter = recorder.submit_scatter  # 只验证投递,不跑真重算
+    try:
+        assert service.request("client-x")
+        assert service.wait_idle(timeout=3)
+        time.sleep(0.05)  # 事件触发在 finalize 前,给投递一点点余量
+        assert recorder.enqueued == [("client-x", "tsne"), ("client-x", "umap")]
+    finally:
+        assert service.stop(timeout=3)
+
+
+def test_service_submit_scatter_dedup(tmp_path):
+    engine = _FakeEngine(tmp_path / "team_profile.db")
+    service = ProfileRefreshService(engine, workers=1, queue_size=4, autostart=False)
+    started = threading.Event()
+    release = threading.Event()
+    seen: list[tuple[str, str]] = []
+
+    def _blocking_recompute(user_key, method):
+        seen.append((user_key, method))
+        started.set()
+        assert release.wait(3)
+
+    service._recompute_scatter = _blocking_recompute
+    try:
+        assert service.submit_scatter("u", "tsne") is True
+        assert started.wait(3)  # 派发线程已取走并进入(阻塞的)重算
+        assert service.submit_scatter("u", "tsne") is True  # 在飞 → 去重
+        assert service.metrics["scatter_deduped"] == 1
+        release.set()
+    finally:
+        assert service.stop(timeout=3)
+    assert seen == [("u", "tsne")]  # 只重算一次
+
+
+class _RecorderScatter:
+    def __init__(self):
+        self.enqueued: list[tuple[str, str]] = []
+        self._inflight: set = set()
+
+    def submit_scatter(self, user_key, method):
+        key = (user_key, method)
+        if key in self._inflight:
+            return True
+        self._inflight.add(key)
+        self.enqueued.append(key)
+        return True

--- a/tests/test_team_sync_profile.py
+++ b/tests/test_team_sync_profile.py
@@ -121,7 +121,10 @@ def team_runtime(tmp_path):
         profile_db=tmp_path / "profile.db",
         client_registry=registry,
     )
-    service = ProfileRefreshService(engine, workers=2, queue_size=64)
+    # 本组测试只验画像刷新,不测散点物化——关掉散点子系统,避免事件触发派发线程/
+    # 进程池的异步副作用（#106 的散点路径由 test_scatter_materialize 专门覆盖）。
+    service = ProfileRefreshService(engine, workers=2, queue_size=64,
+                                    scatter_materialize=False)
     set_recommend_engine(engine)
     server_api.init_team_context(
         join_token="tok",
@@ -323,7 +326,8 @@ def test_thirty_clients_return_while_embedding_is_bounded(tmp_path, monkeypatch)
         profile_db=tmp_path / "profile.db",
         client_registry=registry,
     )
-    service = ProfileRefreshService(engine, workers=4, queue_size=64)
+    service = ProfileRefreshService(engine, workers=4, queue_size=64,
+                                    scatter_materialize=False)
     set_recommend_engine(engine)
     server_api.init_team_context(
         join_token="tok",


### PR DESCRIPTION
Closes #106。全仓第一个 multiprocessing 先例：纯 Python 重计算（t-SNE/UMAP 500 轮循环）从请求路径彻底移出。

## 三步落地

1. **物化存储**：registry 新表 `scatter_cache(user_key, method, fingerprint, payload, computed_at)`（schema 指纹机制自动迁移）；fingerprint = ProfileStore revision + embed model + 两个索引文件 stat 签名——全程只 stat/一列 SELECT，端点与服务共用同一指纹函数。
2. **端点只读**：`/dashboard/user/{key}/scatter` 命中直返；未命中/过期 → `{"status":"pending"}` + 入队一次（同 key 在飞去重）；前端占位 + 5s 自动重试一次。保留 #97 的 user_name→client_id 反查；无常驻服务的只读实例退化为直算并物化（首访一次）。
3. **进程隔离**：`ProcessPoolExecutor(max_workers=1, spawn)` 挂 ProfileRefreshService 实例懒创建；worker 为模块顶层纯函数（取数留父进程，子进程只做数学）；画像更新事件后自动投递 tsne+umap（指纹未变跳过）。兜底链：BrokenProcessPool → 重建+本次直算；建池失败 → 永久回退直算；子进程异常 → 保留旧缓存。`service.stop()` 停派发线程 + 关池。

## 内存/停机

单 worker 常驻子进程 RSS ≈ 100-200MB（14G 生产机可控）；停机依赖 supervisor `stopwaitsecs≥90`（既有要求）。

## 测试

新增 10 项（含真 spawn 进程池冒烟、事件触发投递、pending 去重、指纹 miss 语义）；本地 test_scatter_materialize + sync_profile + registry + pooled_connection + dashboard_router 全绿。

🤖 Generated with [Claude Code](https://claude.com/claude-code)