### PR TITLE
fix(skillhub): 收紧搜索 embedding 并修复技能包分发

### DIFF
--- a/README.en.md
+++ b/README.en.md
@@ -140,11 +140,11 @@ On **macOS / Linux**, native persistence (launchd / systemd --user) is still on 
 #### Search / share skills on demand (skillhub)
 
 ```bash
-xskill search docker compose   # keyword-search the server skillhub; hits are pulled locally and installed
+xskill search docker compose   # BM25 + semantic search of the server skillhub; hits are installed locally
 xskill upload ./my-skill       # package & upload a skill folder (with SKILL.md); instantly searchable by the team
 ```
 
-`search` matches keywords only — independent of the recommendation profile — and prints each hit's name, description, and absolute local path. Pulled skills live in `~/.xskill/search_skills/` with a rolling cap of **10 slots** (least-recently-hit evicted). `upload` lands under `skillhub/user_skill_hub/<your-username>/` on the server. Local semantic search has been removed from the CLI (no more `xskill search traj|skill <query>`); use the dashboard or the API (`POST /api/v1/skills/search`) to search local trajectories/skills instead.
+`search` combines BM25 keyword and semantic-vector ranking, independently of the recommendation profile. If the embedding service is unavailable it automatically falls back to BM25, and it prints each hit's name, description, source, score, and absolute local path. Pulled skills live in `~/.xskill/search_skills/` with a rolling cap of **10 slots** (least-recently-hit evicted). `upload` lands under `skillhub/user_skill_hub/<your-username>/` on the server. Semantic search for local trajectories/skills has been removed from the CLI (no more `xskill search traj|skill <query>`); use the dashboard or the API (`POST /api/v1/skills/search`) instead.
 
 * * *
 

--- a/README.md
+++ b/README.md
@@ -153,11 +153,11 @@ xskill connect <服务器地址:端口> --token <TOKEN>   # 首次握手(macOS/L
 除了 server 按画像推送的技能,client 还可以主动搜 server 的 skillhub 并把命中的技能拉到本地:
 
 ```bash
-xskill search docker compose        # 关键词搜 skillhub,命中的直接拉到本地并装进各生态
+xskill search docker compose        # BM25+语义混合检索 skillhub,命中的直接拉到本地并安装
 xskill upload ./my-skill            # 打包上传一个 skill 目录(含 SKILL.md),全队立即可搜到
 ```
 
-- `search` 只按关键词匹配 skillhub 目录(含团队成员上传的技能),与推荐画像无关;输出每个命中技能的名字、描述和本机绝对路径。
+- `search` 使用 BM25 关键词+语义向量混合检索 skillhub 目录(含团队成员上传的技能),与推荐画像无关;语义服务不可用时自动退化为 BM25，并输出名字、描述、来源、评分和本机绝对路径。
 - 搜下来的技能落在 `~/.xskill/search_skills/`,本地最多保留 **10 个槽位**,按最近命中滚动淘汰,不受 sync 清理影响。
 - `upload` 会先校验 `SKILL.md` frontmatter,server 端落到 `skillhub/user_skill_hub/<你的用户名>/` 下。
 - 本机语义搜索已从 CLI 移除(不再有 `xskill search traj|skill <query>`);如需按语义检索本机轨迹/技能,请用 dashboard 或 API(`POST /api/v1/skills/search`)。

--- a/README.zh-CN.md
+++ b/README.zh-CN.md
@@ -100,11 +100,11 @@ macOS / Linux 的原生常驻（launchd / systemd --user）仍在路上，当前
 ### 按需搜索 / 分享技能（skillhub）
 
 ```bash
-xskill search docker compose        # 关键词搜 server 的 skillhub,命中的拉到本地并装进各生态
+xskill search docker compose        # BM25+语义混合检索 server skillhub，命中的拉到本地安装
 xskill upload ./my-skill            # 打包上传一个 skill 目录(含 SKILL.md),全队立即可搜到
 ```
 
-`search` 只按关键词匹配、与推荐画像无关，输出命中技能的名字、描述和本机绝对路径；本地最多保留 **10 个槽位**滚动淘汰。`upload` 在 server 端落到 `skillhub/user_skill_hub/<你的用户名>/` 下。本机语义搜索已从 CLI 移除（不再有 `xskill search traj|skill <query>`），改用 dashboard 或 API（`POST /api/v1/skills/search`）检索本机轨迹/技能。
+`search` 使用 BM25 关键词+语义向量混合检索、与推荐画像无关；语义服务不可用时自动退化为 BM25，并输出名字、描述、来源、评分和本机绝对路径。本地最多保留 **10 个槽位**滚动淘汰。`upload` 在 server 端落到 `skillhub/user_skill_hub/<你的用户名>/` 下。本机轨迹/技能的语义搜索已从 CLI 移除（不再有 `xskill search traj|skill <query>`），改用 dashboard 或 API（`POST /api/v1/skills/search`）。
 
 ## 架构图
 

--- a/src/xskill/cli.py
+++ b/src/xskill/cli.py
@@ -404,6 +404,11 @@ def cmd_update(args) -> int:
         return 1
     try:
         if current_version is not None and Version(latest) <= current_version:
+            if updater._check_server_fallback(
+                current, current_version, reason="pypi_not_ahead", restart=False,
+            ):
+                print("已通过 team server wheel 升级完成")
+                return 0
             print(f"已是最新版本 ({current})")
             return 0
     except Exception:
@@ -570,8 +575,9 @@ def _team_client_http_and_headers():
 def cmd_search_hub(args, http=None, headers=None) -> int:
     """`xskill search <query>` —— 搜 server skillhub，命中的拉到本地滚动槽位。
 
-    结果只按关键词匹配 skillhub 目录（含 user_skill_hub 上传件），与推荐画像
-    无关。每个命中 skill 下载解包到 ``~/.xskill/search_skills/<skill_id>/``、
+    结果由 BM25 关键词与语义向量混合检索 skillhub 目录（含 user_skill_hub 上传件），
+    与推荐画像无关；语义服务不可用时自动退化为 BM25。每个命中 skill 下载解包到
+    ``~/.xskill/search_skills/<skill_id>/``、
     打 ``.xskill_search.json`` 标记、装进本机生态；本地最多保留 10 个槽位，
     按最近命中滚动淘汰。``http``/``headers`` 参数仅测试注入用。
     """

--- a/src/xskill/recommend/skillhub.py
+++ b/src/xskill/recommend/skillhub.py
@@ -100,6 +100,8 @@ class SkillHub:
         self._query_embed_executor_lock = threading.Lock()
         self._query_vector_cache: OrderedDict[str, tuple[tuple, np.ndarray]] = OrderedDict()
         self._query_vector_cache_lock = threading.Lock()
+        self._query_embed_inflight: set[str] = set()
+        self._corpus_embed_inflight: set[str] = set()
 
     @classmethod
     def from_config(cls, config: dict, embed_client) -> "SkillHub":
@@ -378,15 +380,41 @@ class SkillHub:
                 return cached[1]
             elif cached is not None:
                 del self._query_vector_cache[normalized_query]
+            if normalized_query in self._query_embed_inflight:
+                return None
         if not self._query_embed_semaphore.acquire(blocking=False):
             return None
+        with self._query_vector_cache_lock:
+            # The cache or in-flight set may have changed between releasing the
+            # cache lock and acquiring the global embedding slot.
+            cached = self._query_vector_cache.get(normalized_query)
+            if cached is not None and cached[0] == fingerprint:
+                self._query_vector_cache.move_to_end(normalized_query)
+                self._query_embed_semaphore.release()
+                return cached[1]
+            if normalized_query in self._query_embed_inflight:
+                self._query_embed_semaphore.release()
+                return None
+            self._query_embed_inflight.add(normalized_query)
         # 超时后 embed 线程仍在跑（同步 60s httpx），信号量由该线程结束时释放，泄漏受 max_embed 约束。
-        future = self._query_embed_pool().submit(
-            self._encode_and_cache_query, normalized_query, fingerprint,
-        )
+        try:
+            future = self._query_embed_pool().submit(
+                self._encode_and_cache_query, normalized_query, fingerprint,
+            )
+        except Exception:
+            with self._query_vector_cache_lock:
+                self._query_embed_inflight.discard(normalized_query)
+            self._query_embed_semaphore.release()
+            logger.warning("skillhub semantic search degraded to BM25: submit failed",
+                           exc_info=True)
+            return None
         try:
             return future.result(timeout=self.search_timeout_s)
-        except Exception:  # 超时或 embed API 任何异常都只降级语义位，绝不冒泡到 search
+        except Exception as embed_error:  # 超时/API 异常只降级语义位，不冒泡到 search
+            logger.warning(
+                "skillhub semantic search degraded to BM25: query embedding %s: %s",
+                type(embed_error).__name__, embed_error,
+            )
             return None
 
     def _query_embed_pool(self) -> concurrent.futures.ThreadPoolExecutor:
@@ -413,6 +441,60 @@ class SkillHub:
                     self._query_vector_cache.popitem(last=False)
             return query_vector
         finally:
+            with self._query_vector_cache_lock:
+                self._query_embed_inflight.discard(normalized_query)
+            self._query_embed_semaphore.release()
+
+    def backfill_description_embedding(self, description: str) -> bool:
+        """Best-effort, bounded corpus-vector backfill used after an upload.
+
+        It shares the same configured embedding slots and executor as query
+        embeddings. If all slots are busy, the upload stays successful and the
+        skill remains available through BM25 until the normal index refresh
+        fills its vector.
+        """
+        if (not description or self.embed_client is None
+                or self.search_max_embed <= 0):
+            return False
+        description_key = hashlib.sha256(description.encode("utf-8")).hexdigest()
+        with self._query_vector_cache_lock:
+            if description_key in self._corpus_embed_inflight:
+                return True
+        if not self._query_embed_semaphore.acquire(blocking=False):
+            return False
+        with self._query_vector_cache_lock:
+            if description_key in self._corpus_embed_inflight:
+                self._query_embed_semaphore.release()
+                return True
+            self._corpus_embed_inflight.add(description_key)
+        try:
+            self._query_embed_pool().submit(
+                self._encode_corpus_description, description, description_key,
+            )
+        except Exception:
+            with self._query_vector_cache_lock:
+                self._corpus_embed_inflight.discard(description_key)
+            self._query_embed_semaphore.release()
+            logger.warning("skillhub upload embedding backfill submit failed",
+                           exc_info=True)
+            return False
+        return True
+
+    def _encode_corpus_description(self, description: str,
+                                   description_key: str) -> None:
+        try:
+            EmbedStore(self.dir / EMBED_CACHE_NAME, self.embed_client).encode_cached(
+                [description],
+            )
+            # A search may have built an index while this vector was absent.
+            # Rebuild lazily on the next request so the new vector is visible.
+            with self._search_index_lock:
+                self._search_index = None
+        except Exception as embed_error:
+            logger.warning("skill_hub upload embed backfill failed: %s", embed_error)
+        finally:
+            with self._query_vector_cache_lock:
+                self._corpus_embed_inflight.discard(description_key)
             self._query_embed_semaphore.release()
 
     def _search_index_bundle(self) -> dict:
@@ -485,7 +567,12 @@ class SkillHub:
         if not self.enabled:
             return None
         if force_refresh:
-            self._scan_snapshot_expires_at = 0.0
+            # Upload replacement must bypass both the L1 TTL snapshot and the
+            # L3 mtime/size memo. Preserved timestamps or coarse filesystems can
+            # otherwise hide a same-size SKILL.md replacement.
+            with self._scan_lock:
+                self._scan_snapshot_expires_at = 0.0
+                self._file_memo.clear()
         matches: list[dict] = []
         for entry in self._entries(include_vec=False, require_description=False):
             if name in {

--- a/src/xskill/team/client/daemon.py
+++ b/src/xskill/team/client/daemon.py
@@ -9,6 +9,7 @@ _tick 一轮：
 """
 from __future__ import annotations
 
+import hashlib
 import io
 import json
 import logging
@@ -336,14 +337,16 @@ def apply_skillhub_archive(
     """把非 git 的 skillhub skill zip 原子落到本地目录（带路径穿越防护）。
 
     sync reconcile 与 `xskill search` 槽位共用；后者用 ``marker_name`` /
-    ``extra_meta`` 换成自己的标记文件。marker sha 相同则跳过重写。
+    ``extra_meta`` 换成自己的标记文件。安装判断使用实际 zip 内容哈希，而不是仅覆盖
+    SKILL.md 的 ``expected_sha``，确保 scripts/references/assets 单独变化也会更新。
     """
     dest_dir = Path(dest_dir)
     meta_path = dest_dir / marker_name
+    archive_sha = hashlib.sha256(archive_bytes).hexdigest()
     if meta_path.is_file() and (dest_dir / "SKILL.md").is_file():
         try:
             meta = json.loads(meta_path.read_text(encoding="utf-8"))
-            if meta.get("sha") == expected_sha:
+            if meta.get("archive_sha") == archive_sha:
                 return
         except (OSError, ValueError):
             pass
@@ -370,6 +373,7 @@ def apply_skillhub_archive(
         raise RuntimeError("skillhub archive missing SKILL.md")
     meta = {
         "sha": expected_sha,
+        "archive_sha": archive_sha,
         "display_name": display_name,
         "source_path": source_path,
     }

--- a/src/xskill/team/server/api.py
+++ b/src/xskill/team/server/api.py
@@ -45,6 +45,10 @@ from xskill.utils.sanitize import sanitize_trajectory_text
 logger = logging.getLogger("xskill.team.server.api")
 router = APIRouter(prefix="/api/v1/team")
 
+_SKILL_ARCHIVE_MAX_FILES = 2048
+_SKILL_ARCHIVE_MAX_FILE_BYTES = 50 * 1024 * 1024
+_SKILL_ARCHIVE_MAX_TOTAL_BYTES = 100 * 1024 * 1024
+
 
 class _Ctx:
     """模块级上下文单例。init_team_context 填，端点读。"""
@@ -789,7 +793,7 @@ async def team_skill_hub_search(
     x_xskill_token: str | None = Header(default=None),
     x_xskill_client: str | None = Header(default=None),
 ) -> dict:
-    """关键词搜 skillhub（含 user_skill_hub 上传件）。与推荐画像完全无关。"""
+    """BM25 + 语义向量混合检索 skillhub；与推荐画像完全无关。"""
     _auth(x_xskill_token, x_xskill_client)
     hub = _ctx.skillhub
     if hub is None or not getattr(hub, "enabled", False):
@@ -863,9 +867,25 @@ def _store_user_skill(hub, owner_dir: str, payload: bytes) -> dict:
     except zipfile.BadZipFile as bad_zip:
         raise HTTPException(status_code=400, detail=f"invalid zip: {bad_zip}") from bad_zip
     with archive:
-        if "SKILL.md" not in archive.namelist():
+        members = archive.infolist()
+        files = [member for member in members if not member.is_dir()]
+        root_skill_files = [member for member in files if member.filename == "SKILL.md"]
+        if not root_skill_files:
             raise HTTPException(status_code=400,
                                 detail="SKILL.md missing at archive root")
+        if len(root_skill_files) != 1:
+            raise HTTPException(status_code=400,
+                                detail="archive contains duplicate SKILL.md entries")
+        if len(files) > _SKILL_ARCHIVE_MAX_FILES:
+            raise HTTPException(
+                status_code=413,
+                detail=f"skill archive contains more than {_SKILL_ARCHIVE_MAX_FILES} files",
+            )
+        if any(member.file_size > _SKILL_ARCHIVE_MAX_FILE_BYTES for member in files):
+            raise HTTPException(status_code=413, detail="skill archive contains an oversized file")
+        if sum(member.file_size for member in files) > _SKILL_ARCHIVE_MAX_TOTAL_BYTES:
+            raise HTTPException(status_code=413,
+                                detail="skill archive expands beyond 100MB")
         try:
             frontmatter, _body = parse_strict(
                 archive.read("SKILL.md").decode("utf-8"))
@@ -876,24 +896,47 @@ def _store_user_skill(hub, owner_dir: str, payload: bytes) -> dict:
         from xskill.recommend.skillhub import _safe_id_part
         dest_dir = (Path(hub.dir) / "user_skill_hub" / owner_dir
                     / _safe_id_part(display_name))
-        tmp_dir = dest_dir.with_name(f".{dest_dir.name}.tmp")
-        shutil.rmtree(tmp_dir, ignore_errors=True)
-        tmp_dir.mkdir(parents=True, exist_ok=True)
+        dest_dir.parent.mkdir(parents=True, exist_ok=True)
+        tmp_dir = Path(tempfile.mkdtemp(
+            prefix=f".{dest_dir.name}.tmp.", dir=dest_dir.parent,
+        ))
         extracted_root = tmp_dir.resolve()
-        for info in archive.infolist():
-            target = (tmp_dir / info.filename).resolve()
-            try:
-                target.relative_to(extracted_root)
-            except ValueError:
-                shutil.rmtree(tmp_dir, ignore_errors=True)
-                raise HTTPException(status_code=400,
-                                    detail=f"unsafe archive path: {info.filename}")
-            if info.is_dir():
-                target.mkdir(parents=True, exist_ok=True)
-                continue
-            target.parent.mkdir(parents=True, exist_ok=True)
-            with archive.open(info) as src, open(target, "wb") as dst:
-                shutil.copyfileobj(src, dst)
+        extracted_bytes = 0
+        try:
+            for info in members:
+                target = (tmp_dir / info.filename).resolve()
+                try:
+                    target.relative_to(extracted_root)
+                except ValueError:
+                    raise HTTPException(
+                        status_code=400, detail=f"unsafe archive path: {info.filename}",
+                    )
+                if info.is_dir():
+                    target.mkdir(parents=True, exist_ok=True)
+                    continue
+                target.parent.mkdir(parents=True, exist_ok=True)
+                file_bytes = 0
+                with archive.open(info) as src, open(target, "wb") as dst:
+                    while True:
+                        chunk = src.read(1024 * 1024)
+                        if not chunk:
+                            break
+                        file_bytes += len(chunk)
+                        extracted_bytes += len(chunk)
+                        if (file_bytes > _SKILL_ARCHIVE_MAX_FILE_BYTES
+                                or extracted_bytes > _SKILL_ARCHIVE_MAX_TOTAL_BYTES):
+                            raise HTTPException(
+                                status_code=413, detail="skill archive expands beyond limit",
+                            )
+                        dst.write(chunk)
+        except HTTPException:
+            shutil.rmtree(tmp_dir, ignore_errors=True)
+            raise
+        except (OSError, RuntimeError, zipfile.BadZipFile, EOFError) as extract_error:
+            shutil.rmtree(tmp_dir, ignore_errors=True)
+            raise HTTPException(
+                status_code=400, detail=f"invalid zip content: {extract_error}",
+            ) from extract_error
     shutil.rmtree(dest_dir, ignore_errors=True)
     tmp_dir.replace(dest_dir)
     source_path = dest_dir.relative_to(Path(hub.dir)).as_posix()
@@ -913,35 +956,28 @@ def _store_user_skill(hub, owner_dir: str, payload: bytes) -> dict:
 
 
 def _backfill_skill_embed(hub, description: str) -> None:
-    """上传成功后 fire-and-forget 对这一条 description 补一次 corpus embed（best-effort）。
-
-    单独 daemon 线程内写 EmbedStore，失败仅 log warning，绝不阻断 upload 响应；
-    下一次 search 重建索引时该向量即进语义通道。
-    """
-    if not description or getattr(hub, "embed_client", None) is None:
-        return
-    from xskill.recommend.skillhub import EMBED_CACHE_NAME
-    from xskill.utils.embed_store import EmbedStore
-
-    def _run() -> None:
-        try:
-            EmbedStore(Path(hub.dir) / EMBED_CACHE_NAME, hub.embed_client).encode_cached(
-                [description],
-            )
-        except Exception as embed_error:
-            logger.warning("skill_hub upload embed backfill failed: %s", embed_error)
-
-    threading.Thread(target=_run, name="skillhub-upload-embed", daemon=True).start()
+    """上传成功后有界、异步补这一条 corpus 向量；忙时保留 BM25 可用性。"""
+    if not hub.backfill_description_embedding(description):
+        logger.debug("skill_hub upload embed backfill skipped or semantic search disabled")
 
 
 def _make_skillhub_archive(skill_dir: Path) -> bytes:
-    """Pack a non-git skillhub directory as a zip archive for thin clients."""
+    """Pack a deterministic, content-addressable skill archive for thin clients."""
     skill_dir = Path(skill_dir)
     buf = io.BytesIO()
     with zipfile.ZipFile(buf, "w", compression=zipfile.ZIP_DEFLATED) as zf:
         for p in sorted(skill_dir.rglob("*")):
-            if p.is_file():
-                zf.write(p, p.relative_to(skill_dir).as_posix())
+            relative = p.relative_to(skill_dir)
+            if (p.is_symlink() or not p.is_file()
+                    or any(part in (".git", "__pycache__") for part in relative.parts)
+                    or p.name == ".ux_scores.jsonl"
+                    or p.name.startswith(".xskill_")):
+                continue
+            info = zipfile.ZipInfo(relative.as_posix(), date_time=(1980, 1, 1, 0, 0, 0))
+            info.compress_type = zipfile.ZIP_DEFLATED
+            info.create_system = 3
+            info.external_attr = (p.stat().st_mode & 0o777) << 16
+            zf.writestr(info, p.read_bytes())
     return buf.getvalue()
 
 

--- a/src/xskill/utils/embed_store.py
+++ b/src/xskill/utils/embed_store.py
@@ -13,6 +13,21 @@ from pathlib import Path
 import numpy as np
 
 
+_CACHE_LOCKS_GUARD = threading.Lock()
+_CACHE_LOCKS: dict[str, threading.RLock] = {}
+
+
+def _cache_lock(cache_path: Path) -> threading.RLock:
+    """Return one process-local lock for every normalized cache path."""
+    key = str(cache_path.expanduser().resolve())
+    with _CACHE_LOCKS_GUARD:
+        lock = _CACHE_LOCKS.get(key)
+        if lock is None:
+            lock = threading.RLock()
+            _CACHE_LOCKS[key] = lock
+        return lock
+
+
 class EmbedStore:
     """``cache_path`` 上的「文本哈希 → 向量」缓存，只对未命中文本现算。"""
 
@@ -24,8 +39,9 @@ class EmbedStore:
         self.model_id = str(getattr(embed_client, "model", "") or "")
         self._vectors: dict[str, np.ndarray] = {}
         self._touched: set[str] = set()
-        self._lock = threading.Lock()
-        self._load()
+        self._lock = _cache_lock(self.cache_path)
+        with self._lock:
+            self._load()
 
     def _load(self) -> None:
         try:
@@ -35,14 +51,17 @@ class EmbedStore:
             return
         # 缓存损坏或换了 embedding 模型 → 整体作废，从零重建。
         if not isinstance(data, dict) or data.get("model") != self.model_id:
+            self._vectors = {}
             return
         vectors = data.get("vectors")
         if isinstance(vectors, dict):
             self._vectors = vectors
 
     def _save(self) -> None:
-        # tmp 名带 pid：多进程写同一缓存时各写各的临时文件，replace 原子收尾。
-        temp_path = self.cache_path.with_suffix(f".tmp.{os.getpid()}")
+        # tmp 名带 pid + thread id：并发写各用独立临时文件，replace 原子收尾。
+        temp_path = self.cache_path.with_suffix(
+            f".tmp.{os.getpid()}.{threading.get_ident()}"
+        )
         with open(temp_path, "wb") as cache_file:
             pickle.dump(
                 {"model": self.model_id, "vectors": self._vectors}, cache_file,
@@ -54,6 +73,11 @@ class EmbedStore:
         if not texts:
             return np.empty((0, 0), dtype=np.float32)
         with self._lock:
+            # Another EmbedStore instance may have written this path since this
+            # instance was constructed. Reload under the shared path lock before
+            # the read/modify/write cycle so concurrent backfills cannot clobber
+            # each other's vectors.
+            self._load()
             text_hashes = [
                 hashlib.sha256(text.encode("utf-8")).hexdigest() for text in texts
             ]
@@ -79,6 +103,7 @@ class EmbedStore:
     def cached_vectors(self, texts: list[str]) -> list[np.ndarray | None]:
         """只读入口：返回每条文本已缓存的向量，未命中为 None，绝不触发 encode。"""
         with self._lock:
+            self._load()
             return [
                 self._vectors.get(
                     hashlib.sha256(text.encode("utf-8")).hexdigest()
@@ -93,6 +118,7 @@ class EmbedStore:
         调用方不要调，否则会把其他调用方的缓存修剪掉。
         """
         with self._lock:
+            self._load()
             self._vectors = {
                 text_hash: vector
                 for text_hash, vector in self._vectors.items()

--- a/tests/test_cli_update.py
+++ b/tests/test_cli_update.py
@@ -101,6 +101,38 @@ def test_manual_update_pip_failure_falls_back_to_server_wheel(monkeypatch, tmp_p
     }]
 
 
+def test_manual_update_checks_server_when_pypi_is_not_ahead(monkeypatch, tmp_path):
+    state_file = tmp_path / "team_client.json"
+    state_file.write_text(json.dumps({
+        "server_url": "http://srv:8000",
+        "client_id": "client-1",
+        "join_token": "tok",
+    }), encoding="utf-8")
+    monkeypatch.setattr(
+        "xskill.config.get_team_client_state_path", lambda: state_file,
+    )
+    monkeypatch.setattr(
+        "xskill.team.client.updater._current_version", lambda package: "1.0.0",
+    )
+    monkeypatch.setattr(
+        "xskill.team.client.updater._latest_pypi_version", lambda package: "1.0.0",
+    )
+    fallback_calls: list[tuple[str, bool]] = []
+
+    def fake_fallback(self, current_str, current, *, reason, restart=True):
+        fallback_calls.append((reason, restart))
+        return True
+
+    monkeypatch.setattr(
+        "xskill.team.client.updater.AutoUpdater._check_server_fallback",
+        fake_fallback,
+    )
+
+    args = build_parser().parse_args(["update"])
+    assert cmd_update(args) == 0
+    assert fallback_calls == [("pypi_not_ahead", False)]
+
+
 def test_manual_update_pypi_query_failure_tries_server_then_errors(monkeypatch, tmp_path):
     """
     PyPI 查询失败时也应先试 server 通道，server 也不可用才报错退出（#88）。

--- a/tests/test_embed_store.py
+++ b/tests/test_embed_store.py
@@ -9,6 +9,9 @@
 """
 from __future__ import annotations
 
+from concurrent.futures import ThreadPoolExecutor
+import threading
+
 import numpy as np
 import pytest
 
@@ -113,3 +116,25 @@ def test_corrupt_cache_file_is_ignored(tmp_path):
 
     assert result.shape == (1, 4)
     assert embed_client.encoded == ["aa"]
+
+
+def test_concurrent_instances_merge_updates_without_losing_vectors(tmp_path):
+    cache_path = tmp_path / "cache.pkl"
+    first = EmbedStore(cache_path, _CountingEmbed())
+    second = EmbedStore(cache_path, _CountingEmbed())
+    ready = threading.Barrier(2)
+
+    def encode(store, text):
+        ready.wait()
+        store.encode_cached([text])
+
+    with ThreadPoolExecutor(max_workers=2) as pool:
+        futures = [pool.submit(encode, first, "first"),
+                   pool.submit(encode, second, "second")]
+        for future in futures:
+            future.result()
+
+    verifier = _CountingEmbed()
+    result = EmbedStore(cache_path, verifier).encode_cached(["first", "second"])
+    assert result.shape == (2, 4)
+    assert verifier.encoded == []

--- a/tests/test_skill_hub_search_upload.py
+++ b/tests/test_skill_hub_search_upload.py
@@ -218,6 +218,39 @@ def test_upload_rejects_bad_archives(hub_env):
     assert not (hub_env.hub_dir.parent / "escape.txt").exists()
 
 
+def test_upload_rejects_archive_expanding_beyond_limit(hub_env, monkeypatch):
+    _cid, hdr = _register(hub_env.client)
+    monkeypatch.setattr(server_api, "_SKILL_ARCHIVE_MAX_TOTAL_BYTES", 64)
+    buf = io.BytesIO()
+    with zipfile.ZipFile(buf, "w", compression=zipfile.ZIP_DEFLATED) as zf:
+        zf.writestr("SKILL.md",
+                    "---\nname: bomb\ndescription: bomb\n---\n" + "x" * 128)
+    response = hub_env.client.post(
+        "/api/v1/team/skill_hub/upload",
+        files={"file": ("bomb.zip", buf.getvalue(), "application/zip")},
+        headers=hdr,
+    )
+    assert response.status_code == 413
+
+
+def test_skillhub_bundle_is_deterministic_and_excludes_server_ux_metadata(tmp_path):
+    skill_dir = _write_hub_skill(tmp_path / "hub", "pack", "pack", "desc")
+    (skill_dir / "references").mkdir()
+    asset = skill_dir / "references" / "note.md"
+    asset.write_text("stable", encoding="utf-8")
+    ux_file = skill_dir / ".ux_scores.jsonl"
+    ux_file.write_text("first", encoding="utf-8")
+    first = server_api._make_skillhub_archive(skill_dir)
+
+    ux_file.write_text("changed server metadata", encoding="utf-8")
+    asset.touch()
+    second = server_api._make_skillhub_archive(skill_dir)
+    assert second == first
+
+    asset.write_text("new package content", encoding="utf-8")
+    assert server_api._make_skillhub_archive(skill_dir) != first
+
+
 # ── client: SearchSlots 滚动槽位 ────────────────────────────────
 
 def _fake_result(name: str) -> dict:
@@ -263,6 +296,31 @@ def test_search_slots_rehit_moves_to_newest_without_duplicate(tmp_path):
         "b@0000000000ff", "c@0000000000ff", "a@0000000000ff"]
     assert len(ledger) == 3
     assert ledger[-1]["query"] == "again"
+
+
+def test_search_slots_refreshes_auxiliary_files_when_skill_md_sha_is_unchanged(tmp_path):
+    slots = SearchSlots(xskill_home=tmp_path / "xhome",
+                        home_root=tmp_path / "home", capacity=3)
+    result = _fake_result("aux-refresh")
+
+    def archive_with_note(note: str) -> bytes:
+        buf = io.BytesIO()
+        with zipfile.ZipFile(buf, "w") as zf:
+            zf.writestr("SKILL.md",
+                        "---\nname: aux-refresh\ndescription: d\n---\nbody\n")
+            zf.writestr("references/note.md", note)
+        return buf.getvalue()
+
+    installed = slots.install(result, archive_with_note("old"), query="q")
+    first_marker = json.loads((installed / ".xskill_search.json").read_text(
+        encoding="utf-8"))
+    slots.install(result, archive_with_note("new"), query="q")
+    second_marker = json.loads((installed / ".xskill_search.json").read_text(
+        encoding="utf-8"))
+
+    assert (installed / "references" / "note.md").read_text(encoding="utf-8") == "new"
+    assert first_marker["sha"] == second_marker["sha"] == result["content_sha"]
+    assert first_marker["archive_sha"] != second_marker["archive_sha"]
 
 
 def test_search_slots_default_capacity_is_ten(tmp_path):

--- a/tests/test_skillhub_hybrid_search.py
+++ b/tests/test_skillhub_hybrid_search.py
@@ -9,7 +9,9 @@ from __future__ import annotations
 import io
 import time
 import zipfile
+from concurrent.futures import ThreadPoolExecutor
 from pathlib import Path
+import threading
 from types import SimpleNamespace
 
 import numpy as np
@@ -165,6 +167,28 @@ def test_semantic_degrades_on_query_embed_timeout(tmp_path):
     assert results and all(result["semantic_rank"] is None for result in results)
 
 
+def test_concurrent_same_query_uses_one_embedding_request(tmp_path):
+    hub_dir = tmp_path / "hub"
+    _write_hub_skill(hub_dir, "a", "alpha", "gamma one")
+    client = ControlledEmbed({"gamma one": [1.0, 0.0], "alpha": [1.0, 0.0]},
+                             encode_delay=0.15)
+    hub = SkillHub(enabled=True, hub_dir=hub_dir, embed_client=client,
+                   search_max_embed=4)
+    _prime_corpus_cache(hub)
+    ready = threading.Barrier(8)
+
+    def search_once():
+        ready.wait()
+        return hub.search("alpha", limit=5)
+
+    with ThreadPoolExecutor(max_workers=8) as pool:
+        results = [future.result() for future in
+                   [pool.submit(search_once) for _ in range(8)]]
+
+    assert client.encode_calls == ["alpha"]
+    assert all(result for result in results)
+
+
 # ── query LRU：命中零调用 + fingerprint 失效 ────────────────────
 
 def test_query_lru_hit_then_invalidated_by_fingerprint(tmp_path):
@@ -298,3 +322,32 @@ def test_upload_backfills_corpus_embedding(tmp_path):
             break
         time.sleep(0.02)
     assert cached[0] is not None  # best-effort 补齐后向量进入 corpus 缓存
+
+
+def test_backfill_invalidates_search_index_built_before_vector_exists(tmp_path):
+    hub_dir = tmp_path / "hub"
+    _write_hub_skill(hub_dir, "a", "alpha", "gamma one")
+    client = ControlledEmbed({"gamma one": [1.0, 0.0], "alpha": [1.0, 0.0]})
+    hub = SkillHub(enabled=True, hub_dir=hub_dir, embed_client=client)
+
+    assert hub.search("alpha")[0]["semantic_rank"] is None
+    assert hub.backfill_description_embedding("gamma one") is True
+    for _attempt in range(100):
+        if hub._search_index is None:
+            break
+        time.sleep(0.02)
+
+    results = hub.search("alpha")
+    assert results[0]["semantic_rank"] == 1
+
+
+def test_upload_backfill_shares_configured_embedding_capacity(tmp_path):
+    hub_dir = tmp_path / "hub"
+    hub_dir.mkdir()
+    client = ControlledEmbed({"first": [1.0, 0.0], "second": [0.0, 1.0]},
+                             encode_delay=0.2)
+    hub = SkillHub(enabled=True, hub_dir=hub_dir, embed_client=client,
+                   search_max_embed=1)
+
+    assert hub.backfill_description_embedding("first") is True
+    assert hub.backfill_description_embedding("second") is False

--- a/tests/test_skillhub_scan_cache.py
+++ b/tests/test_skillhub_scan_cache.py
@@ -154,6 +154,23 @@ def test_force_refresh_bypasses_ttl(tmp_path):
     assert hub.entry("beta", force_refresh=True) is not None
 
 
+def test_force_refresh_bypasses_same_size_same_mtime_file_memo(tmp_path):
+    hub_dir = tmp_path / "hub"
+    skill_dir = _write_hub_skill(hub_dir, "alpha", "old")
+    hub = _make_hub(hub_dir, scan_ttl_seconds=60.0)
+    first = hub.entry("alpha")
+    skill_md = skill_dir / "SKILL.md"
+    original_stat = skill_md.stat()
+    replacement = skill_md.read_text(encoding="utf-8").replace("old", "new")
+    assert len(replacement.encode("utf-8")) == original_stat.st_size
+    skill_md.write_text(replacement, encoding="utf-8")
+    os.utime(skill_md, ns=(original_stat.st_atime_ns, original_stat.st_mtime_ns))
+
+    refreshed = hub.entry("alpha", force_refresh=True)
+    assert refreshed["description"] == "new"
+    assert refreshed["content_sha"] != first["content_sha"]
+
+
 def test_single_flight_concurrent_entry(tmp_path, monkeypatch):
     hub_dir = tmp_path / "hub"
     for index in range(5):


### PR DESCRIPTION
## 变更
- 同查询并发首波只发一次 embedding；上传补向量复用 `embedding.max_embed` 有界执行器
- EmbedStore 同路径线程安全合并，补向量完成后使搜索索引失效
- 上传强制刷新同时绕过 L1/L3 缓存
- 客户端按完整、确定性压缩包哈希更新，辅助文件变化不再被 `SKILL.md` SHA 掩盖
- 上传 zip 增加文件数、单文件、总展开大小限制并使用独立临时目录
- 手动 `xskill update` 在 PyPI 不领先时继续尝试 server wheel
- 文档改为 BM25 + 语义混合检索说明

## 验证
- 相关 69 项单测通过
- `git diff --check` 通过

这是 v0.6.18 发布阻断修复。