### PR TITLE
fix: clean owned search slot installations

### DIFF
--- a/src/xskill/team/client/daemon.py
+++ b/src/xskill/team/client/daemon.py
@@ -13,6 +13,7 @@ import hashlib
 import io
 import json
 import logging
+import os
 import shutil
 import threading
 import zipfile
@@ -282,13 +283,15 @@ class TeamClient:
         for repo_dir in sorted(self.skill_dir.iterdir()):
             if not repo_dir.is_dir() or repo_dir.name in keep:
                 continue
-            # 先摘生态里的安装（symlink），再删本地仓
-            self._uninstall_from_ecosystems(repo_dir.name)
+            # 先摘掉仍指向该 working copy 的生态安装，再删本地仓
+            self._uninstall_from_ecosystems(repo_dir)
             shutil.rmtree(repo_dir, ignore_errors=True)
             logger.info("cleanup removed stale skill: %s", repo_dir.name)
 
-    def _uninstall_from_ecosystems(self, skill_name: str) -> None:
-        uninstall_skill_from_ecosystems(skill_name, home_root=self.home_root)
+    def _uninstall_from_ecosystems(self, repo_dir: Path) -> None:
+        uninstall_skill_from_ecosystems(
+            repo_dir.name, home_root=self.home_root, source_dir=repo_dir,
+        )
 
     # ── 守护循环 ─────────────────────────────────────────────────
     def _tick(self) -> None:
@@ -386,7 +389,84 @@ def apply_skillhub_archive(
     tmp_dir.replace(dest_dir)
 
 
-def install_skill_to_ecosystems(repo_dir: Path, *, home_root: Path) -> None:
+def _valid_skill_name(skill_name: str) -> bool:
+    """安装目标名必须是单个路径段，不能逃出各生态的 skills 根目录。"""
+    return bool(skill_name) and skill_name not in {".", ".."} \
+        and "/" not in skill_name and "\\" not in skill_name \
+        and "\x00" not in skill_name
+
+
+def _targets_for_ecosystem(ecosystem: str, skill_name: str,
+                           home_root: Path) -> list[Path]:
+    """返回一个安装器本次可能写入的全部目标（Trae 可能有两个）。"""
+    from xskill.ecosystems import (
+        _agents_skills_path, _cc_skills_path, _cursor_skills_path,
+        _nga3_skills_path, _ngagent_skills_path, _trae_skills_roots,
+    )
+
+    shared = _agents_skills_path(home_root) / skill_name
+    roots = {
+        "claude_code": [_cc_skills_path(home_root) / skill_name],
+        "codex": [shared],
+        "opencode": [shared],
+        "openclaw": [shared],
+        "ngagent": [_ngagent_skills_path(home_root) / skill_name],
+        "nga3": [_nga3_skills_path(home_root) / skill_name],
+        "cursor": [_cursor_skills_path(home_root) / skill_name],
+        "trae": [root / skill_name for root in _trae_skills_roots(home_root)],
+    }
+    return roots.get(ecosystem, [])
+
+
+def _all_install_targets(skill_name: str, home_root: Path) -> list[Path]:
+    """返回当前所有安装器使用的目标；不依赖生态当前是否仍可探测。"""
+    from xskill.ecosystems import (
+        _agents_skills_path, _cc_skills_path, _cursor_skills_path,
+        _nga3_skills_path, _ngagent_skills_path,
+    )
+
+    roots = [
+        _cc_skills_path(home_root),
+        _agents_skills_path(home_root),
+        _nga3_skills_path(home_root),
+        _ngagent_skills_path(home_root),
+        _cursor_skills_path(home_root),
+        home_root / ".trae-cn" / "skills",
+        home_root / ".trae" / "skills",
+    ]
+    return [root / skill_name for root in roots]
+
+
+def _lexical_path_key(path: Path) -> str:
+    """不跟随 symlink 的绝对路径键，用于目标 allowlist 和去重。"""
+    return os.path.normcase(os.path.abspath(os.path.normpath(str(path))))
+
+
+def _source_path_key(path: Path) -> str:
+    """跟随 link 后的源路径键；Windows 上同时折叠大小写。"""
+    return os.path.normcase(str(path.resolve(strict=False)))
+
+
+def _installed_mode(dest: Path) -> str | None:
+    from xskill.ecosystems._fallback import (
+        _install_meta_path, _is_link_or_junction,
+    )
+
+    if dest.is_symlink():
+        return "symlink"
+    if _is_link_or_junction(dest):
+        return "junction"
+    if not dest.exists():
+        return None
+    try:
+        meta = json.loads(_install_meta_path(dest).read_text(encoding="utf-8"))
+    except (OSError, ValueError):
+        meta = {}
+    mode = meta.get("mode") if isinstance(meta, dict) else None
+    return mode if mode in {"symlink", "junction", "copy"} else "copy"
+
+
+def install_skill_to_ecosystems(repo_dir: Path, *, home_root: Path) -> list[dict]:
     """把一个已就位的 skill 目录装到本机所有检测到的生态。
 
     working tree 已是最终内容，一律用 side='main' 语义（= 链接 / 拷贝整个
@@ -399,6 +479,11 @@ def install_skill_to_ecosystems(repo_dir: Path, *, home_root: Path) -> None:
         install_to_codex, install_to_nga3, install_to_opencode, install_to_ngagent,
         install_to_openclaw, install_to_cursor, install_to_trae,
     )
+    repo_dir = Path(repo_dir).resolve()
+    home_root = Path(home_root).resolve(strict=False)
+    if not _valid_skill_name(repo_dir.name):
+        raise ValueError(f"invalid skill directory name: {repo_dir.name!r}")
+
     installer = {
         "claude_code": install_to_claude_code,
         "codex": install_to_codex,
@@ -409,25 +494,143 @@ def install_skill_to_ecosystems(repo_dir: Path, *, home_root: Path) -> None:
         "cursor": install_to_cursor,
         "trae": install_to_trae,
     }
+    installed: dict[str, dict] = {}
     for det in detect_known_ecosystems(home_root=home_root):
-        fn = installer.get(det["ecosystem"])
+        ecosystem = det["ecosystem"]
+        fn = installer.get(ecosystem)
         if fn is None:
             continue
         try:
             fn(repo_dir, target_root=home_root, side="main")
-            logger.info("installed %s to %s", repo_dir.name, det["ecosystem"])
+            for target in _targets_for_ecosystem(
+                ecosystem, repo_dir.name, home_root,
+            ):
+                mode = _installed_mode(target)
+                if mode is None:
+                    continue
+                key = _lexical_path_key(target)
+                installed[key] = {
+                    "ecosystem": ecosystem,
+                    "target": str(Path(key)),
+                    "mode": mode,
+                    "source": str(repo_dir),
+                }
+            logger.info("installed %s to %s", repo_dir.name, ecosystem)
         except Exception:
             logger.warning("install %s to %s failed",
-                           repo_dir.name, det["ecosystem"], exc_info=True)
+                           repo_dir.name, ecosystem, exc_info=True)
+    return list(installed.values())
 
 
-def uninstall_skill_from_ecosystems(skill_name: str, *, home_root: Path) -> None:
-    """摘掉生态目录里指向该 skill 的 symlink（copy 型安装不动，保守起见）。"""
-    from xskill.ecosystems import _cc_skills_path, _agents_skills_path
-    for root_fn in (_cc_skills_path, _agents_skills_path):
-        dest = root_fn(home_root) / skill_name
-        if dest.is_symlink():
-            try:
-                dest.unlink()
-            except OSError:
-                logger.warning("failed to unlink %s", dest, exc_info=True)
+def _matching_copied_marker(dest: Path, source_dir: Path) -> bool:
+    """兼容旧 copy 安装：源和目标的来源标记完全一致才视为仍属该源。"""
+    for marker_name in (".xskill_search.json", ".xskill_skillhub.json"):
+        source_marker = source_dir / marker_name
+        dest_marker = dest / marker_name
+        if not source_marker.is_file() or not dest_marker.is_file():
+            continue
+        try:
+            source_meta = json.loads(source_marker.read_text(encoding="utf-8"))
+            dest_meta = json.loads(dest_marker.read_text(encoding="utf-8"))
+        except (OSError, ValueError):
+            continue
+        if isinstance(source_meta, dict) and source_meta == dest_meta:
+            return True
+    return False
+
+
+def _target_owned_by_source(dest: Path, source_dir: Path) -> bool:
+    """根据当前文件系统状态判断目标是否仍由指定源安装。"""
+    from xskill.ecosystems._fallback import (
+        _install_meta_path, _is_link_or_junction,
+    )
+
+    if _is_link_or_junction(dest):
+        try:
+            return _source_path_key(dest) == _source_path_key(source_dir)
+        except OSError:
+            return False
+    if not dest.is_dir():
+        return False
+
+    meta_path = _install_meta_path(dest)
+    if meta_path.exists():
+        try:
+            meta = json.loads(meta_path.read_text(encoding="utf-8"))
+        except (OSError, ValueError):
+            return False
+        if not isinstance(meta, dict) or meta.get("mode") != "copy":
+            return False
+        raw_source = meta.get("source")
+        if not isinstance(raw_source, str) or not Path(raw_source).is_absolute():
+            return False
+        return _source_path_key(Path(raw_source)) == _source_path_key(source_dir)
+
+    return _matching_copied_marker(dest, source_dir)
+
+
+def _remove_owned_install_target(dest: Path) -> bool:
+    """junction-aware 删除目标；成功后才删除相邻 install meta。"""
+    from xskill.ecosystems._fallback import (
+        _install_meta_path, _is_link_or_junction,
+    )
+
+    try:
+        if _is_link_or_junction(dest) or dest.is_file():
+            dest.unlink()
+        elif dest.is_dir():
+            shutil.rmtree(dest)
+        else:
+            return False
+    except OSError:
+        logger.warning("failed to remove owned install target %s", dest,
+                       exc_info=True)
+        return False
+
+    if dest.exists() or _is_link_or_junction(dest):
+        logger.warning("owned install target still exists after removal: %s", dest)
+        return False
+    try:
+        _install_meta_path(dest).unlink(missing_ok=True)
+    except OSError:
+        logger.warning("failed to remove install metadata for %s", dest,
+                       exc_info=True)
+    return True
+
+
+def uninstall_skill_from_ecosystems(
+    skill_name: str, *, home_root: Path, source_dir: Path | None = None,
+    installations: list[dict] | None = None,
+) -> list[Path]:
+    """仅清理当前仍由 ``source_dir`` 拥有的所有生态安装目标。
+
+    ``installations`` 是 search 台账里的实际安装快照。当前安装器目标仍会完整
+    扫描，以兼容没有该字段的旧台账；快照中的目标必须命中 allowlist，不能把
+    损坏或篡改的台账路径变成删除入口。
+    """
+    if not _valid_skill_name(skill_name) or source_dir is None:
+        return []
+    home_root = Path(home_root).resolve(strict=False)
+    source_dir = Path(source_dir).resolve(strict=False)
+    allowed = {
+        _lexical_path_key(path): path
+        for path in _all_install_targets(skill_name, home_root)
+    }
+    if isinstance(installations, list):
+        for record in installations:
+            if not isinstance(record, dict) or not isinstance(
+                record.get("target"), str,
+            ):
+                continue
+            key = _lexical_path_key(Path(record["target"]))
+            if key not in allowed:
+                logger.warning("ignored install target outside ecosystem roots: %s",
+                               record["target"])
+
+    removed: list[Path] = []
+    for dest in allowed.values():
+        if not _target_owned_by_source(dest, source_dir):
+            continue
+        if _remove_owned_install_target(dest):
+            removed.append(dest)
+    return removed

--- a/src/xskill/team/client/search_slots.py
+++ b/src/xskill/team/client/search_slots.py
@@ -3,7 +3,7 @@
 search 命中的 skill 落 ``~/.xskill/search_skills/<skill_id>/``，与 sync 管理的
 ``~/.xskill/skill/`` 分开——daemon 的 cleanup 按 manifest 清理那边，不碰这里。
 台账 ``~/.xskill/search_slots.json`` 按最近命中排序，超过容量淘汰最旧的
-（同时摘掉生态里的 symlink 安装）。每个槽位目录里有 ``.xskill_search.json``
+（同时摘掉仍由该槽位拥有的生态安装）。每个槽位目录里有 ``.xskill_search.json``
 标记（sha / 查询词 / 时间），与 sync 的 ``.xskill_skillhub.json`` 区分来源。
 """
 from __future__ import annotations
@@ -24,6 +24,13 @@ logger = logging.getLogger("xskill.team.client")
 
 SEARCH_SLOT_CAPACITY = 10
 SEARCH_MARKER_NAME = ".xskill_search.json"
+
+
+def _valid_slot_id(skill_id: str) -> bool:
+    """槽位 id 必须是单个路径段。"""
+    return bool(skill_id) and skill_id not in {".", ".."} \
+        and "/" not in skill_id and "\\" not in skill_id \
+        and "\x00" not in skill_id
 
 
 class SearchSlots:
@@ -47,7 +54,10 @@ class SearchSlots:
 
     def install(self, result: dict, archive_bytes: bytes, *, query: str) -> Path:
         """落盘一个 search 命中的 skill，装进生态并滚动淘汰。返回绝对路径。"""
-        dest_dir = self.slots_dir / result["skill_id"]
+        skill_id = result.get("skill_id")
+        if not isinstance(skill_id, str) or not _valid_slot_id(skill_id):
+            raise ValueError(f"invalid search skill_id: {skill_id!r}")
+        dest_dir = self.slots_dir / skill_id
         searched_at = datetime.now(timezone.utc).isoformat(timespec="seconds")
         apply_skillhub_archive(
             archive_bytes, dest_dir,
@@ -57,25 +67,33 @@ class SearchSlots:
             marker_name=SEARCH_MARKER_NAME,
             extra_meta={"query": query, "searched_at": searched_at},
         )
-        install_skill_to_ecosystems(dest_dir, home_root=self.home_root)
+        installations = install_skill_to_ecosystems(
+            dest_dir, home_root=self.home_root,
+        )
         slots = [slot for slot in self.entries()
-                 if slot.get("skill_id") != result["skill_id"]]
+                 if slot.get("skill_id") != skill_id]
         slots.append({
-            "skill_id": result["skill_id"],
+            "skill_id": skill_id,
             "display_name": result.get("display_name"),
             "description": result.get("description"),
             "sha": result["content_sha"],
             "query": query,
             "searched_at": searched_at,
+            "installations": installations,
         })
         evicted, kept = slots[:-self.capacity], slots[-self.capacity:]
         for stale in evicted:
-            stale_id = str(stale.get("skill_id") or "")
-            stale_dir = self.slots_dir / stale_id
-            # 台账损坏出来的空 id 会让 stale_dir == slots_dir，绝不能 rmtree
-            if not stale_id or stale_dir == self.slots_dir:
+            stale_id = stale.get("skill_id")
+            if not isinstance(stale_id, str) or not _valid_slot_id(stale_id):
+                logger.warning("ignored invalid search slot id: %r", stale_id)
                 continue
-            uninstall_skill_from_ecosystems(stale_id, home_root=self.home_root)
+            stale_dir = self.slots_dir / stale_id
+            uninstall_skill_from_ecosystems(
+                stale_id,
+                home_root=self.home_root,
+                source_dir=stale_dir,
+                installations=stale.get("installations"),
+            )
             shutil.rmtree(stale_dir, ignore_errors=True)
             logger.info("search slot evicted: %s", stale_id)
         self.ledger_path.parent.mkdir(parents=True, exist_ok=True)

--- a/tests/test_skill_hub_search_upload.py
+++ b/tests/test_skill_hub_search_upload.py
@@ -12,6 +12,7 @@ from fastapi import FastAPI
 from fastapi.testclient import TestClient
 
 from xskill import cli
+from xskill.ecosystems._fallback import _install_meta_path, install_dir
 from xskill.recommend.skillhub import SkillHub
 from xskill.team.client.search_slots import SearchSlots
 from xskill.team.server import api as server_api
@@ -267,6 +268,12 @@ def _fake_archive(name: str) -> bytes:
     return buf.getvalue()
 
 
+def _enable_link_and_copy_ecosystems(home: Path) -> None:
+    """启用 Claude Code（link）和 OpenClaw（copy）检测。"""
+    (home / ".claude" / "projects").mkdir(parents=True)
+    (home / ".openclaw" / "agents").mkdir(parents=True)
+
+
 def test_search_slots_marker_ledger_and_rolling_eviction(tmp_path):
     slots = SearchSlots(xskill_home=tmp_path / "xhome",
                         home_root=tmp_path / "home", capacity=3)
@@ -283,6 +290,135 @@ def test_search_slots_marker_ledger_and_rolling_eviction(tmp_path):
         "s1@0000000000ff", "s2@0000000000ff", "s3@0000000000ff"]
     assert not (slots.slots_dir / "s0@0000000000ff").exists()  # 最旧被淘汰
     assert (slots.slots_dir / "s3@0000000000ff" / "SKILL.md").is_file()
+
+
+def test_search_slot_eviction_records_and_removes_link_and_copy_targets(tmp_path):
+    home = tmp_path / "home"
+    _enable_link_and_copy_ecosystems(home)
+    slots = SearchSlots(xskill_home=tmp_path / "xhome",
+                        home_root=home, capacity=1)
+
+    old = slots.install(_fake_result("old"), _fake_archive("old"), query="q")
+    old_id = old.name
+    link_dest = home / ".claude" / "skills" / old_id
+    copy_dest = home / ".agents" / "skills" / old_id
+
+    records = slots.entries()[0]["installations"]
+    assert {(Path(r["target"]), r["mode"], Path(r["source"])) for r in records} == {
+        (link_dest, "symlink", old),
+        (copy_dest, "copy", old),
+    }
+
+    slots.install(_fake_result("new"), _fake_archive("new"), query="q")
+
+    assert not link_dest.exists() and not link_dest.is_symlink()
+    assert not copy_dest.exists()
+    assert not _install_meta_path(link_dest).exists()
+    assert not _install_meta_path(copy_dest).exists()
+
+
+def test_search_slot_eviction_supports_legacy_ledger_without_installations(tmp_path):
+    home = tmp_path / "home"
+    _enable_link_and_copy_ecosystems(home)
+    slots = SearchSlots(xskill_home=tmp_path / "xhome",
+                        home_root=home, capacity=1)
+
+    old = slots.install(_fake_result("legacy"), _fake_archive("legacy"), query="q")
+    old_id = old.name
+    ledger = slots.entries()
+    ledger[0].pop("installations", None)
+    slots.ledger_path.write_text(json.dumps(ledger), encoding="utf-8")
+    _install_meta_path(home / ".agents" / "skills" / old_id).unlink()
+
+    slots.install(_fake_result("new"), _fake_archive("new"), query="q")
+
+    assert not (home / ".claude" / "skills" / old_id).exists()
+    assert not (home / ".agents" / "skills" / old_id).exists()
+
+
+def test_search_slot_eviction_preserves_targets_taken_over_by_another_source(tmp_path):
+    home = tmp_path / "home"
+    _enable_link_and_copy_ecosystems(home)
+    slots = SearchSlots(xskill_home=tmp_path / "xhome",
+                        home_root=home, capacity=1)
+
+    old = slots.install(_fake_result("shared"), _fake_archive("shared"), query="q")
+    old_id = old.name
+    link_dest = home / ".claude" / "skills" / old_id
+    copy_dest = home / ".agents" / "skills" / old_id
+    takeover = tmp_path / "sync" / old_id
+    takeover.mkdir(parents=True)
+    (takeover / "SKILL.md").write_text("owned by sync\n", encoding="utf-8")
+    install_dir(takeover, link_dest, force_mode="symlink", auto_reset=True)
+    install_dir(takeover, copy_dest, force_mode="copy", auto_reset=True)
+
+    slots.install(_fake_result("new"), _fake_archive("new"), query="q")
+
+    assert link_dest.resolve() == takeover.resolve()
+    assert (copy_dest / "SKILL.md").read_text(encoding="utf-8") == "owned by sync\n"
+    assert json.loads(_install_meta_path(link_dest).read_text(encoding="utf-8"))[
+        "source"
+    ] == str(takeover.resolve())
+    assert json.loads(_install_meta_path(copy_dest).read_text(encoding="utf-8"))[
+        "source"
+    ] == str(takeover.resolve())
+
+
+def test_search_slot_records_every_detected_ecosystem_target(tmp_path):
+    home = tmp_path / "home"
+    _enable_link_and_copy_ecosystems(home)
+    (home / ".codex" / "sessions").mkdir(parents=True)
+    (home / ".cac" / "projects").mkdir(parents=True)
+    (home / ".cursor" / "projects").mkdir(parents=True)
+    opencode_db = home / ".local" / "share" / "opencode" / "opencode.db"
+    opencode_db.parent.mkdir(parents=True)
+    opencode_db.touch()
+    ngagent_db = opencode_db.parent / "db" / "ngagent.db"
+    ngagent_db.parent.mkdir()
+    ngagent_db.touch()
+    (home / ".trae-cn").mkdir()
+    (home / ".trae").mkdir()
+    slots = SearchSlots(xskill_home=tmp_path / "xhome", home_root=home)
+
+    installed = slots.install(
+        _fake_result("all-targets"), _fake_archive("all-targets"), query="q",
+    )
+
+    records = slots.entries()[0]["installations"]
+    by_target = {Path(r["target"]): (r["mode"], Path(r["source"])) for r in records}
+    skill_id = installed.name
+    assert by_target == {
+        home / ".claude" / "skills" / skill_id: ("symlink", installed),
+        home / ".agents" / "skills" / skill_id: ("copy", installed),
+        home / ".cac" / "skills" / skill_id: ("symlink", installed),
+        home / ".config" / "opencode" / "skills" / skill_id: ("copy", installed),
+        home / ".cursor" / "skills" / skill_id: ("symlink", installed),
+        home / ".trae-cn" / "skills" / skill_id: ("symlink", installed),
+        home / ".trae" / "skills" / skill_id: ("symlink", installed),
+    }
+
+
+def test_search_slot_trae_windows_copy_targets_are_recorded_and_evicted(
+    tmp_path, monkeypatch,
+):
+    home = tmp_path / "home"
+    (home / ".trae-cn").mkdir(parents=True)
+    (home / ".trae").mkdir()
+    monkeypatch.setattr("xskill.ecosystems.trae.sys.platform", "win32")
+    slots = SearchSlots(xskill_home=tmp_path / "xhome",
+                        home_root=home, capacity=1)
+
+    old = slots.install(_fake_result("win"), _fake_archive("win"), query="q")
+    records = slots.entries()[0]["installations"]
+    assert {(Path(r["target"]), r["mode"], Path(r["source"])) for r in records} == {
+        (home / ".trae-cn" / "skills" / old.name, "copy", old),
+        (home / ".trae" / "skills" / old.name, "copy", old),
+    }
+
+    slots.install(_fake_result("new"), _fake_archive("new"), query="q")
+
+    assert not (home / ".trae-cn" / "skills" / old.name).exists()
+    assert not (home / ".trae" / "skills" / old.name).exists()
 
 
 def test_search_slots_rehit_moves_to_newest_without_duplicate(tmp_path):


### PR DESCRIPTION
Record actual ecosystem install targets, modes, and sources for search slots. Eviction now removes only targets still owned by that slot across Claude Code, Codex, OpenCode, OpenClaw, ngagent, nga3, Cursor, and both Trae roots; it preserves targets later taken over by sync or another source and remains compatible with old ledgers. Validation: 173 related tests passed, including 9 new search-slot regressions.