### PR TITLE
perf(skillhub): make release smoke truly cache-hot

### DIFF
--- a/scripts/loadtest_skillhub_search.py
+++ b/scripts/loadtest_skillhub_search.py
@@ -344,6 +344,15 @@ async def _run_scenario_a_round(
     burst_results = await run_search_wave(client, headers_list[0], list(PEAK_QUERY_TERMS))
     observed_peak_embed = state.snapshot()["embedding"]["max_active"]
 
+    # 场景 A 的 SLA 是缓存热负载。峰值探测在 max_embed=1/4 时会让部分并发查询
+    # 立即走 BM25，因此这里逐个预热全部查询词，确保计时波次不再夹带 200ms embed。
+    warm_results: list[dict[str, Any]] = []
+    for query_term in ALL_QUERY_TERMS:
+        warm_result = await search_once(client, headers_list[0], query_term)
+        warm_results.append(warm_result)
+        if warm_result["status"] != 200:
+            raise RuntimeError(f"steady search cache warmup failed: {warm_result}")
+
     health_samples: list[dict[str, Any]] = []
     sync_results: list[dict[str, Any]] = []
     panel_results: list[dict[str, Any]] = []
@@ -394,6 +403,7 @@ async def _run_scenario_a_round(
         "search": _search_stats(wave_results),
         "diagnostic_duplicate": _search_stats(duplicate_results),
         "diagnostic_peak": _search_stats(burst_results),
+        "diagnostic_warmup": _search_stats(warm_results),
         "health": _health_stats(health_samples),
         "sync": _sync_stats(sync_results),
         "panel": _panel_stats(panel_results),
@@ -676,6 +686,10 @@ def validate_result(result: dict[str, Any], args: argparse.Namespace) -> list[st
             failures.append(f"{name}: panel probes={panel}")
         if int(wave["window_embed_calls"]) > int(wave["distinct_query_terms"]):
             failures.append(f"{name}: window embeds={wave['window_embed_calls']} > distinct terms")
+        if int(wave["throughput_wave_embed_calls"]) != 0:
+            failures.append(
+                f"{name}: cache-hot wave embeds={wave['throughput_wave_embed_calls']} != 0"
+            )
         if int(wave["duplicate_cold_embed_calls"]) != 1:
             failures.append(
                 f"{name}: same-query cold burst embeds={wave['duplicate_cold_embed_calls']} != 1"

--- a/src/xskill/recommend/skillhub.py
+++ b/src/xskill/recommend/skillhub.py
@@ -332,6 +332,14 @@ class SkillHub:
 
     def _bm25_ranks(self, index_bundle: dict, query_tokens: list[str]) -> dict[int, int]:
         """对命中文档按 BM25 分数降序给出 1-based 排名（k1=1.2, b=0.75）。"""
+        cache_key = tuple(sorted(set(query_tokens)))
+        rank_cache = index_bundle["bm25_rank_cache"]
+        rank_cache_lock = index_bundle["bm25_rank_cache_lock"]
+        with rank_cache_lock:
+            cached = rank_cache.get(cache_key)
+        if cached is not None:
+            return cached
+
         entries = index_bundle["entries"]
         term_postings = index_bundle["term_postings"]
         document_frequencies = index_bundle["document_frequencies"]
@@ -339,7 +347,7 @@ class SkillHub:
         average_document_length = index_bundle["average_document_length"]
         document_count = len(entries)
         scores: dict[int, float] = {}
-        for token in set(query_tokens):
+        for token in cache_key:
             document_frequency = document_frequencies.get(token, 0)
             if document_frequency == 0 or average_document_length == 0:
                 continue
@@ -359,7 +367,12 @@ class SkillHub:
         ranked = sorted(scores, key=lambda entry_index: (
             -scores[entry_index], entries[entry_index]["skill_id"],
         ))
-        return {entry_index: rank for rank, entry_index in enumerate(ranked, start=1)}
+        ranks = {
+            entry_index: rank
+            for rank, entry_index in enumerate(ranked, start=1)
+        }
+        with rank_cache_lock:
+            return rank_cache.setdefault(cache_key, ranks)
 
     def _semantic_ranks(self, index_bundle: dict,
                         normalized_query: str) -> dict[int, int]:
@@ -572,6 +585,8 @@ class SkillHub:
             "document_frequencies": document_frequencies,
             "document_lengths": document_lengths,
             "average_document_length": average_document_length,
+            "bm25_rank_cache": {},
+            "bm25_rank_cache_lock": threading.Lock(),
             "vector_present_indices": vector_present_indices,
             "corpus_matrix": corpus_matrix,
         }

--- a/src/xskill/recommend/skillhub.py
+++ b/src/xskill/recommend/skillhub.py
@@ -42,6 +42,7 @@ EMBED_CACHE_NAME = ".skillhub_embed_cache.pkl"
 
 BM25_K1 = 1.2
 BM25_B = 0.75
+BM25_RANK_CACHE_CAPACITY = 256
 RRF_RANK_CONSTANT = 60
 QUERY_VECTOR_CACHE_CAPACITY = 256
 QUERY_EMBED_FAILURE_COOLDOWN_SECONDS = 5.0
@@ -337,6 +338,8 @@ class SkillHub:
         rank_cache_lock = index_bundle["bm25_rank_cache_lock"]
         with rank_cache_lock:
             cached = rank_cache.get(cache_key)
+            if cached is not None:
+                rank_cache.move_to_end(cache_key)
         if cached is not None:
             return cached
 
@@ -372,7 +375,14 @@ class SkillHub:
             for rank, entry_index in enumerate(ranked, start=1)
         }
         with rank_cache_lock:
-            return rank_cache.setdefault(cache_key, ranks)
+            cached = rank_cache.get(cache_key)
+            if cached is not None:
+                rank_cache.move_to_end(cache_key)
+                return cached
+            rank_cache[cache_key] = ranks
+            while len(rank_cache) > BM25_RANK_CACHE_CAPACITY:
+                rank_cache.popitem(last=False)
+            return ranks
 
     def _semantic_ranks(self, index_bundle: dict,
                         normalized_query: str) -> dict[int, int]:
@@ -585,7 +595,7 @@ class SkillHub:
             "document_frequencies": document_frequencies,
             "document_lengths": document_lengths,
             "average_document_length": average_document_length,
-            "bm25_rank_cache": {},
+            "bm25_rank_cache": OrderedDict(),
             "bm25_rank_cache_lock": threading.Lock(),
             "vector_present_indices": vector_present_indices,
             "corpus_matrix": corpus_matrix,

--- a/tests/test_skillhub_hybrid_search.py
+++ b/tests/test_skillhub_hybrid_search.py
@@ -184,6 +184,20 @@ def test_search_hot_path_reuses_bm25_ranks(tmp_path, monkeypatch):
     assert first == second
 
 
+def test_bm25_rank_cache_is_bounded(tmp_path, monkeypatch):
+    hub_dir = tmp_path / "hub"
+    _write_hub_skill(hub_dir, "a", "alpha beta gamma", "shared")
+    hub = SkillHub(enabled=True, hub_dir=hub_dir, embed_client=None)
+    monkeypatch.setattr(skillhub_module, "BM25_RANK_CACHE_CAPACITY", 2)
+
+    hub.search("alpha", limit=5)
+    hub.search("beta", limit=5)
+    hub.search("gamma", limit=5)
+
+    rank_cache = hub._search_index_bundle()["bm25_rank_cache"]
+    assert list(rank_cache) == [("beta",), ("gamma",)]
+
+
 # ── 语义通道降级三条路 ─────────────────────────────────────────
 
 def test_semantic_degrades_when_embed_client_is_none(tmp_path):

--- a/tests/test_skillhub_hybrid_search.py
+++ b/tests/test_skillhub_hybrid_search.py
@@ -169,6 +169,21 @@ def test_search_hot_path_reuses_snapshot_index_without_recopying_entries(
     assert first == second
 
 
+def test_search_hot_path_reuses_bm25_ranks(tmp_path, monkeypatch):
+    hub_dir = tmp_path / "hub"
+    _write_hub_skill(hub_dir, "a", "alpha", "alpha shared")
+    hub = SkillHub(enabled=True, hub_dir=hub_dir, embed_client=None)
+    first = hub.search("alpha", limit=5)
+
+    def fail_log(*_args, **_kwargs):
+        raise AssertionError("hot search recomputed cached BM25 ranks")
+
+    monkeypatch.setattr(skillhub_module.math, "log", fail_log)
+    second = hub.search("alpha", limit=5)
+
+    assert first == second
+
+
 # ── 语义通道降级三条路 ─────────────────────────────────────────
 
 def test_semantic_degrades_when_embed_client_is_none(tmp_path):


### PR DESCRIPTION
The clean-runner release gate showed that Scenario A still issued 11/15 embedding requests inside its timed cache-hot waves, producing 1.34s p95 latency. Scenario B BM25 p95 was 0.238s.

This change:
- prewarms all 20 query terms after the cold concurrency diagnostics and before timed steady load;
- asserts zero embedding calls during cache-hot waves;
- caches BM25 ranks in the immutable search-index bundle, so an index refresh invalidates them automatically;
- adds a regression test proving repeated hot searches do not recompute BM25 ranks.

Validation:
- 19 hybrid search tests passed;
- Ruff and py_compile passed;
- reduced end-to-end smoke met every latency and functional gate; only the already-monitored thread-growth gate observed one late local worker on the saturated host. Search p95 was 0.173/0.280s, health p99 0.086/0.223s, and degraded BM25 p95 0.123s.