### PR TITLE
test(release): refresh hot snapshots before timing

### DIFF
--- a/scripts/loadtest_skillhub_search.py
+++ b/scripts/loadtest_skillhub_search.py
@@ -352,6 +352,9 @@ async def _run_scenario_a_round(
         warm_results.append(warm_result)
         if warm_result["status"] != 200:
             raise RuntimeError(f"steady search cache warmup failed: {warm_result}")
+    snapshot_refresh = await search_once(client, headers_list[0], WARM_QUERY_TERM)
+    if snapshot_refresh["status"] != 200:
+        raise RuntimeError(f"steady snapshot refresh failed: {snapshot_refresh}")
 
     health_samples: list[dict[str, Any]] = []
     sync_results: list[dict[str, Any]] = []
@@ -404,6 +407,7 @@ async def _run_scenario_a_round(
         "diagnostic_duplicate": _search_stats(duplicate_results),
         "diagnostic_peak": _search_stats(burst_results),
         "diagnostic_warmup": _search_stats(warm_results),
+        "diagnostic_snapshot_refresh": snapshot_refresh,
         "health": _health_stats(health_samples),
         "sync": _sync_stats(sync_results),
         "panel": _panel_stats(panel_results),
@@ -521,6 +525,11 @@ async def run_all_scenarios(
                 control_plane_harness._process_threads(server["process"].pid)
             )
         await asyncio.sleep(0.1)
+        snapshot_refresh = await search_once(
+            client, headers_list[0], WARM_QUERY_TERM,
+        )
+        if snapshot_refresh["status"] != 200:
+            raise RuntimeError(f"scenario B snapshot refresh failed: {snapshot_refresh}")
         threads_after_warmup = control_plane_harness._process_threads(server["process"].pid)
         warmup_thread_counts.append(threads_after_warmup)
         baseline_threads = max(warmup_thread_counts)
@@ -537,6 +546,7 @@ async def run_all_scenarios(
         "search": _search_stats(down_results),
         "thread_warmup": _search_stats(thread_warmup_results),
         "thread_stabilization": _search_stats(thread_stabilization_results),
+        "diagnostic_snapshot_refresh": snapshot_refresh,
         "threads_before_warmup": threads_before_warmup,
         "threads_after_warmup": threads_after_warmup,
         "warmup_thread_counts": warmup_thread_counts,

--- a/scripts/loadtest_skillhub_search.py
+++ b/scripts/loadtest_skillhub_search.py
@@ -39,6 +39,7 @@ HOT_QUERY_TERMS = (
 )
 ALL_QUERY_TERMS = PEAK_QUERY_TERMS + HOT_QUERY_TERMS
 WARM_QUERY_TERM = "自动化"
+SNAPSHOT_REFRESH_WAIT_S = 5.1
 
 
 def _dead_port_base_url() -> str:
@@ -352,6 +353,9 @@ async def _run_scenario_a_round(
         warm_results.append(warm_result)
         if warm_result["status"] != 200:
             raise RuntimeError(f"steady search cache warmup failed: {warm_result}")
+    # 预热本身可能耗时接近扫描快照的 5s TTL。先明确跨过 TTL，再在计时窗外
+    # 完成一次刷新，确保随后测量的确是新鲜且缓存热的稳态负载。
+    await asyncio.sleep(SNAPSHOT_REFRESH_WAIT_S)
     snapshot_refresh = await search_once(client, headers_list[0], WARM_QUERY_TERM)
     if snapshot_refresh["status"] != 200:
         raise RuntimeError(f"steady snapshot refresh failed: {snapshot_refresh}")
@@ -525,6 +529,7 @@ async def run_all_scenarios(
                 control_plane_harness._process_threads(server["process"].pid)
             )
         await asyncio.sleep(0.1)
+        await asyncio.sleep(SNAPSHOT_REFRESH_WAIT_S)
         snapshot_refresh = await search_once(
             client, headers_list[0], WARM_QUERY_TERM,
         )


### PR DESCRIPTION
## Summary
- refresh the SkillHub snapshot once after Scenario A query warmup and immediately before timed mixed load
- refresh once after Scenario B stabilization and before timed degraded-BM25 waves
- record both refresh latencies as diagnostics outside SLA measurements

The release specification defines Scenario A as cache-hot. Full-scale query embedding warmup and stabilization cross the five-second scan TTL, so the first timed request was paying for a 5,500-directory rescan while the other concurrent searches queued behind it.

## Evidence
- 22 focused hybrid-search tests pass
- Ruff, py_compile, and diff checks pass
- reduced end-to-end run with 300ms embedding delay passes every gate
- Scenario A p95: 0.261s and 0.256s
- Scenario A health p99: 0.289s and 0.207s
- Scenario B p95: 0.117s, no thread growth
- cache-hot waves issue zero embedding requests
- panel gate has no endpoint or health failures

This addresses the remaining TTL-bound outliers in manual Release run 29337819198.