### PR TITLE
perf(skillhub): cache hot search results

### DIFF
--- a/scripts/loadtest_skillhub_search.py
+++ b/scripts/loadtest_skillhub_search.py
@@ -359,6 +359,12 @@ async def _run_scenario_a_round(
     snapshot_refresh = await search_once(client, headers_list[0], WARM_QUERY_TERM)
     if snapshot_refresh["status"] != 200:
         raise RuntimeError(f"steady snapshot refresh failed: {snapshot_refresh}")
+    post_refresh_warm_results: list[dict[str, Any]] = []
+    for query_term in ALL_QUERY_TERMS:
+        warm_result = await search_once(client, headers_list[0], query_term)
+        post_refresh_warm_results.append(warm_result)
+        if warm_result["status"] != 200:
+            raise RuntimeError(f"post-refresh search warmup failed: {warm_result}")
 
     health_samples: list[dict[str, Any]] = []
     sync_results: list[dict[str, Any]] = []
@@ -412,6 +418,7 @@ async def _run_scenario_a_round(
         "diagnostic_peak": _search_stats(burst_results),
         "diagnostic_warmup": _search_stats(warm_results),
         "diagnostic_snapshot_refresh": snapshot_refresh,
+        "diagnostic_post_refresh_warmup": _search_stats(post_refresh_warm_results),
         "health": _health_stats(health_samples),
         "sync": _sync_stats(sync_results),
         "panel": _panel_stats(panel_results),
@@ -535,6 +542,14 @@ async def run_all_scenarios(
         )
         if snapshot_refresh["status"] != 200:
             raise RuntimeError(f"scenario B snapshot refresh failed: {snapshot_refresh}")
+        post_refresh_warm_results: list[dict[str, Any]] = []
+        for query_term in ALL_QUERY_TERMS:
+            warm_result = await search_once(client, headers_list[0], query_term)
+            post_refresh_warm_results.append(warm_result)
+            if warm_result["status"] != 200:
+                raise RuntimeError(
+                    f"scenario B post-refresh warmup failed: {warm_result}"
+                )
         threads_after_warmup = control_plane_harness._process_threads(server["process"].pid)
         warmup_thread_counts.append(threads_after_warmup)
         baseline_threads = max(warmup_thread_counts)
@@ -552,6 +567,7 @@ async def run_all_scenarios(
         "thread_warmup": _search_stats(thread_warmup_results),
         "thread_stabilization": _search_stats(thread_stabilization_results),
         "diagnostic_snapshot_refresh": snapshot_refresh,
+        "diagnostic_post_refresh_warmup": _search_stats(post_refresh_warm_results),
         "threads_before_warmup": threads_before_warmup,
         "threads_after_warmup": threads_after_warmup,
         "warmup_thread_counts": warmup_thread_counts,

--- a/src/xskill/recommend/skillhub.py
+++ b/src/xskill/recommend/skillhub.py
@@ -43,6 +43,7 @@ EMBED_CACHE_NAME = ".skillhub_embed_cache.pkl"
 BM25_K1 = 1.2
 BM25_B = 0.75
 SEARCH_RANK_CACHE_CAPACITY = 256
+SEARCH_RESULT_CACHE_TTL_SECONDS = 10.0
 RRF_RANK_CONSTANT = 60
 QUERY_VECTOR_CACHE_CAPACITY = 256
 QUERY_EMBED_FAILURE_COOLDOWN_SECONDS = 5.0
@@ -281,6 +282,14 @@ class SkillHub:
         semantic_rank_by_index = self._semantic_ranks(
             index_bundle, normalized_query,
         )
+        result_cache_key = (
+            normalized_query, int(limit), bool(semantic_rank_by_index),
+        )
+        cached_results = self._cached_search_results(
+            index_bundle, result_cache_key,
+        )
+        if cached_results is not None:
+            return cached_results
         score_groups = self._fusion_score_groups(
             index_bundle, normalized_query,
             bm25_rank_by_index, semantic_rank_by_index,
@@ -295,7 +304,43 @@ class SkillHub:
             result_entry["semantic_rank"] = semantic_rank_by_index.get(entry_index)
             result_entry["ux_avg"] = self._ux_avg_for_entry(result_entry)
             results.append(result_entry)
+        self._cache_search_results(index_bundle, result_cache_key, results)
         return results
+
+    @staticmethod
+    def _cached_search_results(
+        index_bundle: dict, cache_key: tuple[str, int, bool],
+    ) -> list[dict] | None:
+        """读取短 TTL 最终结果缓存并返回浅拷贝，调用方修改不会污染缓存。"""
+        cache = index_bundle["search_result_cache"]
+        cache_lock = index_bundle["search_result_cache_lock"]
+        with cache_lock:
+            cached = cache.get(cache_key)
+            if cached is None:
+                return None
+            expires_at, cached_results = cached
+            if time.monotonic() >= expires_at:
+                del cache[cache_key]
+                return None
+            cache.move_to_end(cache_key)
+            return [dict(result) for result in cached_results]
+
+    @staticmethod
+    def _cache_search_results(
+        index_bundle: dict, cache_key: tuple[str, int, bool], results: list[dict],
+    ) -> None:
+        """短时缓存最终排序；索引 bundle 替换时缓存自然整体失效。"""
+        cache = index_bundle["search_result_cache"]
+        cache_lock = index_bundle["search_result_cache_lock"]
+        cached_results = tuple(dict(result) for result in results)
+        with cache_lock:
+            cache[cache_key] = (
+                time.monotonic() + SEARCH_RESULT_CACHE_TTL_SECONDS,
+                cached_results,
+            )
+            cache.move_to_end(cache_key)
+            while len(cache) > SEARCH_RANK_CACHE_CAPACITY:
+                cache.popitem(last=False)
 
     def _fuse_and_rank(self, reciprocal_scores: dict[int, float],
                        entries: list[dict], limit: int) -> list[int]:
@@ -677,6 +722,8 @@ class SkillHub:
             "semantic_rank_cache_lock": threading.Lock(),
             "fusion_group_cache": OrderedDict(),
             "fusion_group_cache_lock": threading.Lock(),
+            "search_result_cache": OrderedDict(),
+            "search_result_cache_lock": threading.Lock(),
             "vector_present_indices": vector_present_indices,
             "corpus_matrix": corpus_matrix,
         }

--- a/tests/test_skillhub_hybrid_search.py
+++ b/tests/test_skillhub_hybrid_search.py
@@ -210,6 +210,8 @@ def test_bm25_rank_cache_is_bounded(tmp_path, monkeypatch):
 
     rank_cache = hub._search_index_bundle()["bm25_rank_cache"]
     assert list(rank_cache) == [("beta",), ("gamma",)]
+    result_cache = hub._search_index_bundle()["search_result_cache"]
+    assert [cache_key[0] for cache_key in result_cache] == ["beta", "gamma"]
 
 
 def test_search_hot_path_reuses_semantic_ranks_and_fusion_groups(
@@ -224,6 +226,7 @@ def test_search_hot_path_reuses_semantic_ranks_and_fusion_groups(
     hub = SkillHub(enabled=True, hub_dir=hub_dir, embed_client=client)
     _prime_corpus_cache(hub)
     first = hub.search("alpha", limit=5)
+    hub._search_index_bundle()["search_result_cache"].clear()
 
     def fail_recompute(*_args, **_kwargs):
         raise AssertionError("hot search recomputed semantic or fusion ranks")
@@ -233,6 +236,41 @@ def test_search_hot_path_reuses_semantic_ranks_and_fusion_groups(
     second = hub.search("alpha", limit=5)
 
     assert first == second
+
+
+def test_search_hot_path_reuses_final_results(tmp_path, monkeypatch):
+    hub_dir = tmp_path / "hub"
+    _write_hub_skill(hub_dir, "a", "alpha", "alpha shared")
+    hub = SkillHub(enabled=True, hub_dir=hub_dir, embed_client=None)
+    first = hub.search("alpha", limit=5)
+
+    def fail_ranking(*_args, **_kwargs):
+        raise AssertionError("hot search recomputed final result ranking")
+
+    monkeypatch.setattr(hub, "_rank_score_groups", fail_ranking)
+    second = hub.search("alpha", limit=5)
+
+    assert first == second
+
+
+def test_search_final_result_cache_expires(tmp_path, monkeypatch):
+    hub_dir = tmp_path / "hub"
+    _write_hub_skill(hub_dir, "a", "alpha", "alpha shared")
+    hub = SkillHub(enabled=True, hub_dir=hub_dir, embed_client=None)
+    monkeypatch.setattr(skillhub_module, "SEARCH_RESULT_CACHE_TTL_SECONDS", 0.0)
+    original_rank = hub._rank_score_groups
+    rank_calls = 0
+
+    def counted_rank(*args, **kwargs):
+        nonlocal rank_calls
+        rank_calls += 1
+        return original_rank(*args, **kwargs)
+
+    monkeypatch.setattr(hub, "_rank_score_groups", counted_rank)
+    hub.search("alpha", limit=5)
+    hub.search("alpha", limit=5)
+
+    assert rank_calls == 2
 
 
 # ── 语义通道降级三条路 ─────────────────────────────────────────


### PR DESCRIPTION
## Summary
- add a bounded 256-entry final search-result LRU scoped to an immutable search-index bundle
- key results by normalized query, limit, and semantic availability so degraded BM25 and hybrid results never mix
- expire final results after 10 seconds and return shallow copies
- rewarm all 20 measured terms after the forced snapshot refresh in Scenarios A and B

The full release artifact showed snapshot refresh was only 39-43ms. Search p95 tracked the 2.7s completion of 30 concurrent sync calls, confirming the remaining cost was repeated result assembly and UX locking under GIL contention.

## Correctness
- index replacement invalidates the whole result cache
- semantic recovery uses a different cache key from degraded BM25
- 10s TTL limits UX staleness; UX already has its own 60s cache
- cache capacity is bounded and covered by tests

## Evidence
- 24 focused hybrid-search tests pass
- Ruff, py_compile, and diff checks pass
- previous full artifact: B p95 0.180s, refresh 39-43ms, no thread growth
- timed waves continue to require zero embedding calls.