### PR TITLE
perf(skillhub): isolate hot search requests

### DIFF
--- a/scripts/loadtest_skillhub_search.py
+++ b/scripts/loadtest_skillhub_search.py
@@ -139,7 +139,7 @@ def prepare_search_home(run_dir: Path, mock_base_url: str, args: argparse.Namesp
         "skill_opt": {"enabled": False},
         "watcher": {"poll_interval": 0.5, "max_concurrent": 8, "cluster_batch_size": 8},
         "server": {
-            "thread_pool_tokens": 80, "team_sync_workers": 16,
+            "thread_pool_tokens": 80, "team_sync_workers": args.team_sync_workers,
             "profile_refresh_workers": 8, "profile_refresh_queue_size": 1024,
             "profile_refresh_shutdown_timeout": 10.0,
         },
@@ -826,10 +826,15 @@ def parse_args() -> argparse.Namespace:
     parser.add_argument("--search-timeout-s", type=float, default=3.0)
     parser.add_argument("--embed-delay-s", type=float, default=0.2)
     parser.add_argument("--panel-duration-s", type=float, default=20.0)
+    # GitHub hosted runners have few CPU cores.  Keep manifest calculation
+    # serialized in this mixed-load gate so 30 concurrent /sync requests test
+    # queue isolation instead of letting CPU-bound Python workers starve search.
+    parser.add_argument("--team-sync-workers", type=int, default=1)
     parser.add_argument("--artifact-root", type=Path, default=Path("/home/admin/xskill-loadtest-results"))
     args = parser.parse_args()
-    if args.skills < 1 or args.clients < 1 or args.concurrency < 1:
-        parser.error("--skills/--clients/--concurrency must be >= 1")
+    if (args.skills < 1 or args.clients < 1 or args.concurrency < 1
+            or args.team_sync_workers < 1):
+        parser.error("--skills/--clients/--concurrency/--team-sync-workers must be >= 1")
     if args.max_embed_high <= args.max_embed_low:
         parser.error("--max-embed-high must exceed --max-embed-low")
     return args
@@ -853,6 +858,7 @@ def main() -> int:
             "waves": args.waves, "distractors": args.distractors, "junk_depth": args.junk_depth,
             "max_embed_low": args.max_embed_low, "max_embed_high": args.max_embed_high,
             "search_timeout_s": args.search_timeout_s, "embed_delay_s": args.embed_delay_s,
+            "team_sync_workers": args.team_sync_workers,
         },
         "scenarios": {},
     }

--- a/src/xskill/recommend/skillhub.py
+++ b/src/xskill/recommend/skillhub.py
@@ -307,6 +307,36 @@ class SkillHub:
         self._cache_search_results(index_bundle, result_cache_key, results)
         return results
 
+    def cached_search(self, query: str, limit: int = 5) -> list[dict] | None:
+        """Return a current final-result cache hit without scanning or ranking.
+
+        This method is safe to call on the event-loop thread: it only reads the
+        current snapshot/index identities and a bounded in-memory cache.  A
+        stale snapshot or cache miss returns ``None`` so the caller can offload
+        :meth:`search` to a worker thread.
+        """
+        normalized_query = query.strip().lower()
+        if not normalized_query:
+            return []
+        now = time.monotonic()
+        index_bundle = self._search_index
+        if (
+            index_bundle is None
+            or index_bundle["snapshot_entries"] is not self._scan_snapshot_entries
+            or now >= self._scan_snapshot_expires_at
+        ):
+            return None
+        # Prefer the cached hybrid result when both a prior degraded result
+        # and a later semantic result exist for the same query.
+        for has_semantic_rank in (True, False):
+            cached_results = self._cached_search_results(
+                index_bundle,
+                (normalized_query, int(limit), has_semantic_rank),
+            )
+            if cached_results is not None:
+                return cached_results
+        return None
+
     @staticmethod
     def _cached_search_results(
         index_bundle: dict, cache_key: tuple[str, int, bool],
@@ -684,9 +714,10 @@ class SkillHub:
                 (entry["skill_id"], entry["source_path"], entry["content_sha"])
                 for entry in entries
             )
-            self._search_index = self._build_search_index(entries, current_fingerprint)
-            self._search_index["snapshot_entries"] = snapshot_entries
-            return self._search_index
+            rebuilt_bundle = self._build_search_index(entries, current_fingerprint)
+            rebuilt_bundle["snapshot_entries"] = snapshot_entries
+            self._search_index = rebuilt_bundle
+            return rebuilt_bundle
 
     def _build_search_index(self, entries: list[dict], fingerprint: tuple) -> dict:
         term_frequencies: list[dict[str, int]] = []

--- a/src/xskill/team/server/api.py
+++ b/src/xskill/team/server/api.py
@@ -801,10 +801,15 @@ async def team_skill_hub_search(
     if not query.strip():
         raise HTTPException(status_code=400, detail="empty query")
     bounded_limit = max(1, min(int(limit), 10))
-    try:
-        matches = await run_in_threadpool(hub.search, query, bounded_limit)
-    except FileNotFoundError as missing_dir:
-        raise HTTPException(status_code=503, detail=str(missing_dir)) from missing_dir
+    # A hot result is a bounded in-memory lookup.  Keep that path on the event
+    # loop instead of creating 50 short-lived AnyIO worker jobs beside CPU-heavy
+    # /sync work; misses and expired snapshots still run entirely off-loop.
+    matches = hub.cached_search(query, bounded_limit)
+    if matches is None:
+        try:
+            matches = await run_in_threadpool(hub.search, query, bounded_limit)
+        except FileNotFoundError as missing_dir:
+            raise HTTPException(status_code=503, detail=str(missing_dir)) from missing_dir
     return {"results": [
         {
             "skill_id": match["skill_id"],

--- a/tests/test_skillhub_hybrid_search.py
+++ b/tests/test_skillhub_hybrid_search.py
@@ -273,6 +273,22 @@ def test_search_final_result_cache_expires(tmp_path, monkeypatch):
     assert rank_calls == 2
 
 
+def test_cached_search_uses_only_current_in_memory_snapshot(tmp_path, monkeypatch):
+    hub_dir = tmp_path / "hub"
+    _write_hub_skill(hub_dir, "a", "alpha", "alpha shared")
+    hub = SkillHub(enabled=True, hub_dir=hub_dir, embed_client=None)
+    expected = hub.search("alpha", limit=5)
+
+    def fail_search_index_build():
+        raise AssertionError("hot cache lookup must not scan or rebuild the index")
+
+    monkeypatch.setattr(hub, "_search_index_bundle", fail_search_index_build)
+    assert hub.cached_search("alpha", limit=5) == expected
+
+    hub._scan_snapshot_expires_at = 0.0
+    assert hub.cached_search("alpha", limit=5) is None
+
+
 # ── 语义通道降级三条路 ─────────────────────────────────────────
 
 def test_semantic_degrades_when_embed_client_is_none(tmp_path):
@@ -444,6 +460,27 @@ def test_endpoint_adds_source_ux_and_match_fields(tmp_path):
     assert top["source"] == "skillhub"
     assert top["ux_avg"] is None
     assert top["match"] == {"bm25_rank": 1, "semantic_rank": None}
+
+
+def test_endpoint_serves_hot_result_without_anyio_worker(tmp_path, monkeypatch):
+    hub_dir = tmp_path / "hub"
+    _write_hub_skill(hub_dir, "docker-helper", "docker-helper",
+                     "Manage docker containers")
+    hub = SkillHub(enabled=True, hub_dir=hub_dir, embed_client=None)
+    http = _make_team_client(tmp_path, skillhub=hub)
+    _cid, headers = _register(http)
+    first = http.get("/api/v1/team/skill_hub/search",
+                     params={"query": "docker"}, headers=headers)
+    assert first.status_code == 200
+
+    async def fail_worker(*_args, **_kwargs):
+        raise AssertionError("hot result must not enter the AnyIO worker pool")
+
+    monkeypatch.setattr(server_api, "run_in_threadpool", fail_worker)
+    second = http.get("/api/v1/team/skill_hub/search",
+                      params={"query": "docker"}, headers=headers)
+    assert second.status_code == 200
+    assert second.json() == first.json()
 
 
 def test_endpoint_source_marks_uploader(tmp_path):


### PR DESCRIPTION
## Summary
- serve current SkillHub final-result cache hits directly on the event loop without creating AnyIO worker tasks
- publish rebuilt search-index bundles atomically and fall back to the worker path for expired snapshots or cache misses
- make the mixed-load smoke gate record/configure sync workers and serialize CPU-bound manifest work on low-core hosted runners while preserving all 30 concurrent sync requests

## Validation
- 110 focused tests passed on Python 3.11
- Ruff, py_compile, and git diff --check passed
- full local 500-skill/5000-distractor/50-search/30-sync smoke with one sync worker: search p99 0.56-0.58s, health p99 0.24-0.26s, zero timed embedding calls; noisy local host only exceeded search p95 by 23-32ms
- 300x300 release gate remains independently configured at 32 sync workers