### PR TITLE
perf(skillhub): yield during hot search bursts

### DIFF
--- a/src/xskill/team/server/api.py
+++ b/src/xskill/team/server/api.py
@@ -805,12 +805,18 @@ async def team_skill_hub_search(
     # loop instead of creating 50 short-lived AnyIO worker jobs beside CPU-heavy
     # /sync work; misses and expired snapshots still run entirely off-loop.
     matches = hub.cached_search(query, bounded_limit)
-    if matches is None:
+    hot_cache_hit = matches is not None
+    if hot_cache_hit:
+        # Fifty cache-hit handlers otherwise contain no suspension point and can
+        # monopolize one event-loop turn.  Yield around result assembly so health
+        # and dashboard requests keep their latency budget during a search burst.
+        await asyncio.sleep(0)
+    else:
         try:
             matches = await run_in_threadpool(hub.search, query, bounded_limit)
         except FileNotFoundError as missing_dir:
             raise HTTPException(status_code=503, detail=str(missing_dir)) from missing_dir
-    return {"results": [
+    payload = {"results": [
         {
             "skill_id": match["skill_id"],
             "display_name": match["display_name"],
@@ -826,6 +832,9 @@ async def team_skill_hub_search(
         }
         for match in matches
     ]}
+    if hot_cache_hit:
+        await asyncio.sleep(0)
+    return payload
 
 
 def _skillhub_result_source(source_path: str) -> str:

--- a/tests/test_skillhub_hybrid_search.py
+++ b/tests/test_skillhub_hybrid_search.py
@@ -6,12 +6,14 @@ max_embed=0 关闭语义、端点新字段（source/ux_avg/match）、upload 后
 """
 from __future__ import annotations
 
+import asyncio
 import io
 import time
 import zipfile
 from concurrent.futures import ThreadPoolExecutor
 from pathlib import Path
 import threading
+from unittest.mock import AsyncMock
 
 import numpy as np
 from fastapi import FastAPI
@@ -481,6 +483,16 @@ def test_endpoint_serves_hot_result_without_anyio_worker(tmp_path, monkeypatch):
                       params={"query": "docker"}, headers=headers)
     assert second.status_code == 200
     assert second.json() == first.json()
+
+    cooperative_yield = AsyncMock()
+    monkeypatch.setattr(server_api.asyncio, "sleep", cooperative_yield)
+    direct = asyncio.run(server_api.team_skill_hub_search(
+        query="docker",
+        x_xskill_token=headers["X-Xskill-Token"],
+        x_xskill_client=headers["X-Xskill-Client"],
+    ))
+    assert direct == first.json()
+    assert cooperative_yield.await_count == 2
 
 
 def test_endpoint_source_marks_uploader(tmp_path):


### PR DESCRIPTION
## Summary
- add cooperative event-loop yields before and after assembling a hot SkillHub search response
- preserve the no-threadpool cache-hit path while allowing health/dashboard requests to run during 50-request bursts
- add a regression assertion that hot hits skip the AnyIO worker pool and yield exactly twice

## Evidence
- tag run 29344822291 failed only scenario_a_max_embed_4 health p99=0.3763s; all other SkillHub assertions passed
- after this change, the noisy local full-size smoke measured health p99 0.195s / 0.294s with zero timed embedding calls
- 49 focused tests, Ruff, py_compile, and diff check passed