### PR TITLE
fix(install): 终结 Windows 无限黑窗风暴（skillhub 槽位无条件重装 × copy 模式无守卫 × mklink 缺 CREATE_NO_WINDOW）

### DIFF
--- a/src/xskill/ecosystems/_fallback.py
+++ b/src/xskill/ecosystems/_fallback.py
@@ -94,11 +94,30 @@ def _install_meta_path(dest: Path) -> Path:
     return dest.parent / f"{_INSTALL_META_PREFIX}{dest.name}.json"
 
 
+def _read_skill_head_sha(skill_path: Path) -> str:
+    """读 skill 仓当前 HEAD 的 sha。读不到（非 git 仓 / 没有 HEAD）就返回空串——
+    用于 install-meta 记录，缺失不影响 install 本身。
+    """
+    head = skill_path / ".git" / "HEAD"
+    if not head.is_file():
+        return ""
+    try:
+        ref = head.read_text(encoding="utf-8").strip()
+        if ref.startswith("ref: "):
+            ref_path = skill_path / ".git" / ref[5:]
+            if ref_path.is_file():
+                return ref_path.read_text(encoding="utf-8").strip()
+        return ref  # detached HEAD
+    except OSError:
+        return ""
+
+
 def _write_install_meta(dest: Path, source: Path, mode: InstallMode) -> None:
     """install_dir 落地成功后写一份 meta。失败仅 warn（meta 缺失不影响主流程）。"""
     meta = {
         "mode": mode,
         "source": str(source.resolve()),
+        "source_sha": _read_skill_head_sha(source),
         "installed_at": time.time(),
     }
     try:
@@ -135,6 +154,41 @@ def _is_link_or_junction(p: Path) -> bool:
     return False
 
 
+def _copy_install_is_current(src_dir: Path, dest: Path) -> bool:
+    """dest 已是同源且源内容未变的 copy 安装 → True（调用方可跳过重装）。
+
+    源未变的判定：git 源比 HEAD sha 与 meta 记录；skillhub 源比
+    ``.xskill_skillhub.json`` 的 sha；两者都不可用 → False（保守重装）。
+    """
+    meta_path = _install_meta_path(dest)
+    if not dest.is_dir() or not meta_path.is_file():
+        return False
+    try:
+        meta = json.loads(meta_path.read_text(encoding="utf-8"))
+    except (OSError, ValueError):
+        return False
+    if meta.get("mode") != "copy" or meta.get("source") != str(src_dir):
+        return False
+    if "source_sha" not in meta:
+        # 老版本 meta 没记 sha，无法判定源是否变过
+        return False
+    recorded_sha = meta["source_sha"]
+    if recorded_sha:
+        return _read_skill_head_sha(src_dir) == recorded_sha
+    source_hub_meta = src_dir / ".xskill_skillhub.json"
+    dest_hub_meta = dest / ".xskill_skillhub.json"
+    if not (source_hub_meta.is_file() and dest_hub_meta.is_file()):
+        return False
+    try:
+        source_hub_sha = json.loads(
+            source_hub_meta.read_text(encoding="utf-8")).get("sha")
+        dest_hub_sha = json.loads(
+            dest_hub_meta.read_text(encoding="utf-8")).get("sha")
+    except (OSError, ValueError):
+        return False
+    return bool(source_hub_sha) and source_hub_sha == dest_hub_sha
+
+
 def _try_symlink(src_dir: Path, dest: Path) -> bool:
     """尝试建目录 symlink。成功 True，失败（OSError/NotImplementedError）False。
 
@@ -160,6 +214,8 @@ def _try_junction(src_dir: Path, dest: Path) -> bool:
             ["cmd", "/c", "mklink", "/J", str(dest), str(src_dir)],
             check=True,
             capture_output=True,
+            # CREATE_NO_WINDOW：无 console 的父进程下不弹 cmd 黑窗
+            creationflags=subprocess.CREATE_NO_WINDOW,
         )
         return True
     except (subprocess.CalledProcessError, FileNotFoundError, OSError) as e:

--- a/src/xskill/ecosystems/_shared.py
+++ b/src/xskill/ecosystems/_shared.py
@@ -36,7 +36,8 @@ from typing import Callable, Iterable, Literal, Optional
 
 from xskill.config import get_traj_dir, ingest_config
 from xskill.ecosystems._fallback import (
-    InstallMode, _is_link_or_junction, install_dir,
+    InstallMode, _copy_install_is_current, _is_link_or_junction,
+    _read_skill_head_sha, install_dir,
 )
 
 logger = logging.getLogger("xskill.ecosystems")
@@ -335,6 +336,9 @@ def _install_skill_into(
         # （不递归动 target）
         dest.unlink()
     elif dest.exists():
+        # copy 模式且源未变：no-op——避免每轮 reconcile 重拷 + 重试 junction（Windows 弹 cmd 窗）
+        if _copy_install_is_current(src_dir, dest):
+            return dest / "SKILL.md"
         # 旧 install 留下的真实目录或文件 → 删（保留备份避免误删用户手写）。
         # ``.replaced-by-symlink`` 备份保留——这是用户手写 skill 目录的保护机制，
         # 不是 boilerplate；不能直接走 ``_reset_dest`` 删掉。
@@ -355,24 +359,6 @@ def _install_skill_into(
             ecosystem_label, name, dest,
         )
     return dest / "SKILL.md"
-
-
-def _read_skill_head_sha(skill_path: Path) -> str:
-    """读 skill 仓当前 HEAD 的 sha。读不到（非 git 仓 / 没有 HEAD）就返回空串——
-    用于 install-meta 记录，缺失不影响 install 本身。
-    """
-    head = skill_path / ".git" / "HEAD"
-    if not head.is_file():
-        return ""
-    try:
-        ref = head.read_text(encoding="utf-8").strip()
-        if ref.startswith("ref: "):
-            ref_path = skill_path / ".git" / ref[5:]
-            if ref_path.is_file():
-                return ref_path.read_text(encoding="utf-8").strip()
-        return ref  # detached HEAD
-    except OSError:
-        return ""
 
 
 def _install_all_with(

--- a/src/xskill/ecosystems/opencode.py
+++ b/src/xskill/ecosystems/opencode.py
@@ -36,7 +36,7 @@ from typing import Iterable
 
 from xskill._sqlite_connect import connect_with_lock
 from xskill.ecosystems._fallback import (
-    InstallMode, _is_link_or_junction, install_dir,
+    InstallMode, _copy_install_is_current, _is_link_or_junction, install_dir,
 )
 from xskill.ecosystems._shared import (
     SqliteEcosystemSpec,
@@ -525,6 +525,9 @@ def install_to_opencode(
             return dest / "SKILL.md"
         dest.unlink()
     elif dest.exists():
+        # copy 模式且源未变：no-op——避免每轮 reconcile 重拷 + 重试 junction（Windows 弹 cmd 窗）
+        if _copy_install_is_current(src_dir, dest):
+            return dest / "SKILL.md"
         if dest.is_dir():
             backup = skills_root / f".{name}.replaced-by-symlink"
             if backup.exists():

--- a/src/xskill/team/client/daemon.py
+++ b/src/xskill/team/client/daemon.py
@@ -178,12 +178,13 @@ class TeamClient:
                                slot.skill_name, r.status_code)
                 continue
             if getattr(slot, "source", "repo") == "skillhub":
-                self._apply_skillhub_archive(
+                # 与 repo slot 的 on_changed 语义对齐：内容没变不重装生态
+                if self._apply_skillhub_archive(
                     r.content, repo_dir, expected_sha=slot.sha,
                     display_name=slot.display_name,
                     source_path=slot.source_path,
-                )
-                self._install_to_ecosystems(repo_dir)
+                ):
+                    self._install_to_ecosystems(repo_dir)
                 continue
             apply_repo_bundle(r.content, repo_dir)
             # 步骤 1 = manifest 给的 (side, sha)；2/3/4 = 共享助手
@@ -196,8 +197,8 @@ class TeamClient:
     def _apply_skillhub_archive(
         self, archive_bytes: bytes, dest_dir: Path, *, expected_sha: str,
         display_name: str | None, source_path: str | None,
-    ) -> None:
-        apply_skillhub_archive(
+    ) -> bool:
+        return apply_skillhub_archive(
             archive_bytes, dest_dir, expected_sha=expected_sha,
             display_name=display_name, source_path=source_path,
         )
@@ -336,12 +337,14 @@ def apply_skillhub_archive(
     display_name: str | None, source_path: str | None,
     marker_name: str = ".xskill_skillhub.json",
     extra_meta: dict | None = None,
-) -> None:
+) -> bool:
     """把非 git 的 skillhub skill zip 原子落到本地目录（带路径穿越防护）。
 
     sync reconcile 与 `xskill search` 槽位共用；后者用 ``marker_name`` /
     ``extra_meta`` 换成自己的标记文件。安装判断使用实际 zip 内容哈希，而不是仅覆盖
     SKILL.md 的 ``expected_sha``，确保 scripts/references/assets 单独变化也会更新。
+
+    返回是否真正落了新内容——``False`` 表示 zip 哈希命中现有安装、盘上没动。
     """
     dest_dir = Path(dest_dir)
     meta_path = dest_dir / marker_name
@@ -350,7 +353,7 @@ def apply_skillhub_archive(
         try:
             meta = json.loads(meta_path.read_text(encoding="utf-8"))
             if meta.get("archive_sha") == archive_sha:
-                return
+                return False
         except (OSError, ValueError):
             pass
 
@@ -387,6 +390,7 @@ def apply_skillhub_archive(
     )
     shutil.rmtree(dest_dir, ignore_errors=True)
     tmp_dir.replace(dest_dir)
+    return True
 
 
 def _valid_skill_name(skill_name: str) -> bool:

--- a/tests/test_install_fallback.py
+++ b/tests/test_install_fallback.py
@@ -309,3 +309,116 @@ def test_install_dir_mode_matrix(tmp_path, monkeypatch, symlink_ok, junction_ok,
     mode = install_dir(src, dest)
     assert mode == expected_mode
     assert (dest / "SKILL.md").is_file()
+
+
+# ──────────────────────────────────────────────────────────────────
+# T10. copy 模式 no-op 守卫 —— 源未变不重装，源变了重装
+# ──────────────────────────────────────────────────────────────────
+
+
+def _force_copy_mode(monkeypatch):
+    """把 symlink/junction 都打成失败，逼 install 走 copy 模式。"""
+    monkeypatch.setattr(install_fallback, "_try_symlink", lambda s, d: False)
+    monkeypatch.setattr(install_fallback, "_try_junction", lambda s, d: False)
+
+
+def _count_do_copy(monkeypatch):
+    """包一层 _do_copy 计数，返回可变的计数容器。"""
+    copy_calls = []
+    original_do_copy = install_fallback._do_copy
+
+    def _counting_do_copy(src_dir, dest):
+        copy_calls.append((src_dir, dest))
+        original_do_copy(src_dir, dest)
+
+    monkeypatch.setattr(install_fallback, "_do_copy", _counting_do_copy)
+    return copy_calls
+
+
+def test_copy_reinstall_skipped_when_git_source_unchanged(tmp_path, monkeypatch):
+    """git 源 sha 未变时，第二次 install 应命中守卫直接 no-op。"""
+    from xskill import ecosystems
+
+    src = _make_src(tmp_path / "srcs")
+    (src / ".git").mkdir()
+    (src / ".git" / "HEAD").write_text("a" * 40, encoding="utf-8")
+    fake_home = tmp_path / "fake_home"
+    _force_copy_mode(monkeypatch)
+    copy_calls = _count_do_copy(monkeypatch)
+
+    first = ecosystems.install_to_claude_code(src, target_root=fake_home)
+    assert len(copy_calls) == 1
+    assert first.is_file()
+
+    second = ecosystems.install_to_claude_code(src, target_root=fake_home)
+    assert second == first
+    assert len(copy_calls) == 1  # 守卫命中，没有重新 copy
+    assert (first.parent / "scripts" / "run.sh").is_file()  # dest 内容还在
+
+
+def test_copy_reinstall_happens_when_git_source_changed(tmp_path, monkeypatch):
+    """git 源 sha 变了（模拟新 commit），第二次 install 必须重装。"""
+    from xskill import ecosystems
+
+    src = _make_src(tmp_path / "srcs")
+    (src / ".git").mkdir()
+    (src / ".git" / "HEAD").write_text("a" * 40, encoding="utf-8")
+    fake_home = tmp_path / "fake_home"
+    _force_copy_mode(monkeypatch)
+    copy_calls = _count_do_copy(monkeypatch)
+
+    ecosystems.install_to_claude_code(src, target_root=fake_home)
+    (src / ".git" / "HEAD").write_text("b" * 40, encoding="utf-8")
+    (src / "SKILL.md").write_text("---\nname: skill-x\n---\nv2\n", encoding="utf-8")
+
+    dest_md = ecosystems.install_to_claude_code(src, target_root=fake_home)
+    assert len(copy_calls) == 2
+    assert "v2" in dest_md.read_text(encoding="utf-8")
+
+
+def test_copy_reinstall_skipped_when_skillhub_sha_unchanged(tmp_path, monkeypatch):
+    """skillhub 源（非 git 仓）用 .xskill_skillhub.json 的 sha 判定未变 → no-op。
+
+    走 install_to_opencode 覆盖 opencode.py 里复制的那份守卫调用点。
+    """
+    from xskill import ecosystems
+
+    src = _make_src(tmp_path / "srcs")
+    (src / ".xskill_skillhub.json").write_text('{"sha": "hub-sha-1"}', encoding="utf-8")
+    fake_home = tmp_path / "fake_home"
+    _force_copy_mode(monkeypatch)
+    copy_calls = _count_do_copy(monkeypatch)
+
+    ecosystems.install_to_opencode(src, target_root=fake_home)
+    assert len(copy_calls) == 1
+
+    ecosystems.install_to_opencode(src, target_root=fake_home)
+    assert len(copy_calls) == 1  # sha 未变，守卫命中
+
+    (src / ".xskill_skillhub.json").write_text('{"sha": "hub-sha-2"}', encoding="utf-8")
+    ecosystems.install_to_opencode(src, target_root=fake_home)
+    assert len(copy_calls) == 2  # sha 变了，重装
+
+
+def test_copy_reinstall_happens_with_legacy_meta_without_sha(tmp_path, monkeypatch):
+    """老版本 meta 没有 source_sha 字段：无法判定 → 保守重装，且不崩。"""
+    import json as json_mod
+
+    from xskill import ecosystems
+    from xskill.ecosystems._fallback import _install_meta_path
+
+    src = _make_src(tmp_path / "srcs")
+    (src / ".git").mkdir()
+    (src / ".git" / "HEAD").write_text("a" * 40, encoding="utf-8")
+    fake_home = tmp_path / "fake_home"
+    _force_copy_mode(monkeypatch)
+    copy_calls = _count_do_copy(monkeypatch)
+
+    dest_md = ecosystems.install_to_claude_code(src, target_root=fake_home)
+    meta_path = _install_meta_path(dest_md.parent)
+    legacy_meta = json_mod.loads(meta_path.read_text(encoding="utf-8"))
+    legacy_meta.pop("source_sha")
+    meta_path.write_text(json_mod.dumps(legacy_meta), encoding="utf-8")
+
+    ecosystems.install_to_claude_code(src, target_root=fake_home)
+    assert len(copy_calls) == 2  # 老 meta 判不了，重装

--- a/tests/test_skillhub.py
+++ b/tests/test_skillhub.py
@@ -471,3 +471,110 @@ class TestSkillhubTeamPush:
         assert (installed / "SKILL.md").is_file()
         assert not (installed / ".git").exists()
         assert (installed / ".xskill_skillhub.json").is_file()
+
+    def test_skillhub_slot_skips_ecosystem_install_when_unchanged(
+        self, tmp_path, monkeypatch,
+    ):
+        hub_dir = tmp_path / "hub"
+        _write_hub_skill(hub_dir, "hub-a/foo", "django migration helper", name="foo")
+        hub = SkillHub(enabled=True, hub_dir=hub_dir, embed_client=FakeEmbed(dim=4))
+        entry = hub.index()[0]
+        reg = ClientRegistry(tmp_path / "clients.db")
+        client_id = reg.register(label="alice", hostname="host")
+        http = self._app(tmp_path, hub, reg)
+        state = ClientState(
+            server_url="http://testserver",
+            client_id=client_id,
+            join_token="tok",
+        )
+        client = TeamClient(
+            state=state,
+            http=http,
+            skill_dir=tmp_path / "client_home" / ".xskill" / "skill",
+            cursor_path=tmp_path / "cursor.json",
+            history_path=tmp_path / "history.jsonl",
+            home_root=tmp_path / "client_home",
+            min_change_interval=0,
+        )
+        manifest = SyncResponse(
+            server_time=1.0,
+            slots=[
+                SkillSlot(
+                    skill_name=entry["skill_id"],
+                    side="main",
+                    sha=entry["content_sha"],
+                    bucket="recommended",
+                    source="skillhub",
+                    display_name=entry["display_name"],
+                    source_path=entry["source_path"],
+                )
+            ],
+        )
+        install_calls = []
+        monkeypatch.setattr(
+            client, "_install_to_ecosystems",
+            lambda repo_dir: install_calls.append(repo_dir),
+        )
+
+        client.reconcile_skill_sides(manifest)
+        assert len(install_calls) == 1
+
+        # 第二轮 tick：zip 内容没变 → 不重装生态（黑窗风暴回归护栏）
+        client.reconcile_skill_sides(manifest)
+        assert len(install_calls) == 1
+
+    def test_skillhub_slot_reinstalls_ecosystems_when_content_changes(
+        self, tmp_path, monkeypatch,
+    ):
+        hub_dir = tmp_path / "hub"
+        _write_hub_skill(hub_dir, "hub-a/foo", "django migration helper", name="foo")
+        hub = SkillHub(enabled=True, hub_dir=hub_dir, embed_client=FakeEmbed(dim=4))
+        entry = hub.index()[0]
+        reg = ClientRegistry(tmp_path / "clients.db")
+        client_id = reg.register(label="alice", hostname="host")
+        http = self._app(tmp_path, hub, reg)
+        state = ClientState(
+            server_url="http://testserver",
+            client_id=client_id,
+            join_token="tok",
+        )
+        client = TeamClient(
+            state=state,
+            http=http,
+            skill_dir=tmp_path / "client_home" / ".xskill" / "skill",
+            cursor_path=tmp_path / "cursor.json",
+            history_path=tmp_path / "history.jsonl",
+            home_root=tmp_path / "client_home",
+            min_change_interval=0,
+        )
+        manifest = SyncResponse(
+            server_time=1.0,
+            slots=[
+                SkillSlot(
+                    skill_name=entry["skill_id"],
+                    side="main",
+                    sha=entry["content_sha"],
+                    bucket="recommended",
+                    source="skillhub",
+                    display_name=entry["display_name"],
+                    source_path=entry["source_path"],
+                )
+            ],
+        )
+        install_calls = []
+        monkeypatch.setattr(
+            client, "_install_to_ecosystems",
+            lambda repo_dir: install_calls.append(repo_dir),
+        )
+
+        client.reconcile_skill_sides(manifest)
+        assert len(install_calls) == 1
+
+        # 源 skill 内容变了 → server 出的 zip 哈希变 → 重装一次
+        skill_md = hub_dir / "hub-a" / "foo" / "SKILL.md"
+        skill_md.write_text(
+            skill_md.read_text(encoding="utf-8") + "\nupdated line\n",
+            encoding="utf-8",
+        )
+        client.reconcile_skill_sides(manifest)
+        assert len(install_calls) == 2


### PR DESCRIPTION
Fixes #125

## 因果链（一句话）

昨天发布的 v0.6.17 上线 skill_hub search/upload，manifest 首次出现 skillhub 槽位，激活 v0.6.5 起潜伏的"每 30s tick 无条件重装到所有生态"循环——junction 建不成落到 copy 模式的 Windows 机器上，copy dest 没有 no-op 守卫，每轮重装都重试一次从 v0.4.1 起就缺 `CREATE_NO_WINDOW` 的 `cmd /c mklink`，黑窗无限闪。

## 三层修复

| 层 | 文件 | 修复 |
|---|---|---|
| 触发循环 | `team/client/daemon.py` | `apply_skillhub_archive` 返回是否真落新内容；skillhub 槽位只在内容变更时 `_install_to_ecosystems`（与 repo 槽位 `on_changed` 语义对齐） |
| 重装风暴 | `ecosystems/_fallback.py` `_shared.py` `opencode.py` | install-meta 新记 `source_sha`；新增 `_copy_install_is_current` 守卫：copy 模式且同源未变（git HEAD sha / skillhub json sha 一致）→ no-op，不 rename 不重拷不重试 junction。老格式 meta（无 `source_sha`）保守重装 |
| 可见弹窗 | `ecosystems/_fallback.py` | `_try_junction` 的 mklink 加 `creationflags=subprocess.CREATE_NO_WINDOW` |

## 行为变化说明

copy 模式 dest 上的用户手改，在源未变期间不再每轮被挪进 `.replaced-by-symlink` 备份（此前每 30s 就被挪走一次）；源变更时 reverse-sync-before-overwrite 逻辑不变。

## 测试

- `test_skillhub.py` +2：sha 未变不装 / 变了装一次
- `test_install_fallback.py` +4（T10）：copy 同源 no-op、git sha 变重装、skillhub sha 变重装（经 `install_to_opencode` 覆盖第二个调用点）、老 meta 不崩
- 回归并集 221 passed：install_fallback(+revsync)、skillhub、team_client、reconcile_unified、canary_rotation、search_upload、openclaw/cursor/claude_code/codex/opencode/ngagent 适配器

🤖 Generated with [Claude Code](https://claude.com/claude-code)