### PR TITLE
feat(cli): xskill init 一站式引导 + 收口全部 Windows 弹窗残留

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -11,6 +11,9 @@ skill/
 # 否则给它加新文件 git add 会被静默拒掉、得 -f 强加
 !src/xskill/skill/
 !src/xskill/skill/**
+# src/xskill/data/skill/ 是随包发布的官方 skill,同样不属于"生成 skill 仓库"
+!src/xskill/data/skill/
+!src/xskill/data/skill/**
 
 # 运行日志
 output/

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -70,6 +70,8 @@ xskill = [
     "data/*.json",            # vendored 价格表(Issue #43),随 wheel 发布
     "dashboard/static/*",     # 看板前端壳(index.html / app.js),随 wheel 发布
     "agents/prompts/*.txt",   # skill-creator 官方提示词(case生成/desc优化),随 wheel 发布
+    "data/skill/xskill/*",       # 捆绑的 xskill 使用指南 skill(xskill init 装到各生态)
+    "data/skill/xskill/**/*",    # 上者的子目录(references/scripts 等)一并打包
 ]
 
 [tool.setuptools.packages.find]

--- a/src/xskill/agents/agent_tools.py
+++ b/src/xskill/agents/agent_tools.py
@@ -23,6 +23,7 @@ from xskill.skill.frontmatter import (
     serialize as fm_serialize,
     FrontmatterError,
 )
+from xskill.utils.proc import windowless_subprocess_kwargs
 
 logger = logging.getLogger("xskill.agent_tools")
 
@@ -1061,6 +1062,7 @@ def grep_files(pattern: str, path: str = "", glob: str = "",
         try:
             completed = subprocess.run(
                 command, capture_output=True, text=True, timeout=30,
+                **windowless_subprocess_kwargs(),
             )
         except subprocess.TimeoutExpired:
             return "error: grep timed out after 30s — narrow path/glob"

--- a/src/xskill/cli.py
+++ b/src/xskill/cli.py
@@ -172,6 +172,120 @@ def cmd_registry_list_client() -> int:
     return 0
 
 
+def cmd_init(args) -> int:
+    """一站式引导：把 xskill 使用指南 skill 装进各 agent 生态 + 连上 team server。
+
+    交互式（默认）逐项询问缺失的 server/token/工号；带齐 flag 且 ``--yes`` 可无头执行。
+    """
+    from pathlib import Path
+
+    interactive = not args.yes
+    target_root = None
+    if args.target_root:
+        target_root = Path(args.target_root).expanduser().resolve()
+
+    if not args.no_skill:
+        from importlib.resources import files
+        from xskill.ecosystems import (
+            detect_known_ecosystems,
+            install_to_claude_code, install_to_codex, install_to_cursor,
+            install_to_nga3, install_to_ngagent, install_to_openclaw,
+            install_to_opencode, install_to_trae,
+        )
+        installer_by_eco = {
+            "claude_code": install_to_claude_code,
+            "codex": install_to_codex,
+            "nga3": install_to_nga3,
+            "opencode": install_to_opencode,
+            "ngagent": install_to_ngagent,
+            "openclaw": install_to_openclaw,
+            "cursor": install_to_cursor,
+            "trae": install_to_trae,
+        }
+        skill_source = Path(str(files("xskill") / "data" / "skill" / "xskill"))
+        if not (skill_source / "SKILL.md").is_file():
+            print(f"warning: 捆绑的 xskill skill 缺失（{skill_source}），跳过装 skill",
+                  file=sys.stderr)
+        else:
+            installed_ecosystems = []
+            for detection in detect_known_ecosystems(home_root=target_root):
+                install_fn = installer_by_eco.get(detection["ecosystem"])
+                if install_fn is None:
+                    continue
+                try:
+                    install_fn(skill_source, target_root=target_root, side="main")
+                    installed_ecosystems.append(detection["ecosystem"])
+                except Exception as install_error:  # noqa: BLE001
+                    print(f"warning: 装到 {detection['ecosystem']} 失败：{install_error}",
+                          file=sys.stderr)
+            if installed_ecosystems:
+                print(f"已把 xskill 使用指南装进 {'/'.join(installed_ecosystems)} 的 "
+                      f"skill 目录，在对应 agent 里可直接 /xskill 查用法。")
+            else:
+                print("未检测到已知 agent 生态（claude_code/codex/opencode/cursor/… "
+                      "均未发现），跳过装 skill。")
+
+    if args.skills_only:
+        return 0
+
+    from xskill.team.client.service import read_daemon_state
+    daemon_state = read_daemon_state()
+    if daemon_state.get("running"):
+        current_server = "?"
+        try:
+            from xskill.config import get_team_client_state_path
+            from xskill.team.client.state import load_client_state
+            current_server = load_client_state(get_team_client_state_path()).server_url
+        except Exception:  # noqa: BLE001
+            pass
+        print(f"检测到常驻连接正在运行：server={current_server}  "
+              f"pid={daemon_state.get('pid')}  backend={daemon_state.get('backend')}")
+        should_stop = args.force
+        if not args.force:
+            if not interactive:
+                print("已保留现有连接（加 --force 可停掉重新配置）。")
+                return 0
+            should_stop = input("停掉并重新配置？[y/N] ").strip().lower() in ("y", "yes")
+            if not should_stop:
+                print("保留现有连接，未改动。")
+                return 0
+        from xskill.team.client.service import (
+            ServiceError, clear_daemon_state, get_backend,
+        )
+        try:
+            get_backend().stop()
+        except ServiceError as stop_error:
+            print(f"warning: 停止旧常驻失败：{stop_error}", file=sys.stderr)
+        clear_daemon_state()
+
+    address = args.address
+    if not address and interactive:
+        address = input("server 地址 (host:port): ").strip()
+    if not address:
+        print("error: 缺少 server 地址（位置参数或交互输入）", file=sys.stderr)
+        return 2
+    token = args.token
+    if not token and interactive:
+        token = input("join token (server 启动时打印的 token): ").strip()
+    if not token:
+        print("error: 缺少 --token（首次连接必填）", file=sys.stderr)
+        return 2
+    name = args.name
+    if not name and interactive:
+        name = input("工号/用户 ID (推荐填，直接回车留空): ").strip() or None
+
+    connect_args = argparse.Namespace(
+        address=address, token=token, label=args.label, name=name,
+        use_proxy=args.use_proxy, foreground=args.foreground,
+        no_auto_update=args.no_auto_update,
+    )
+    exit_code = cmd_connect(connect_args)
+    if exit_code == 0:
+        print("\n后续：`xskill status` 看状态 · `xskill search <词>` 搜技能 · "
+              "`xskill update`／`pip install -U xskill` 升级 · `xskill stop` 停。")
+    return exit_code
+
+
 def cmd_connect(args) -> int:
     """team 瘦客户端：连上 server。
 
@@ -880,6 +994,35 @@ def build_parser() -> argparse.ArgumentParser:
     p_upload.add_argument("path", type=str, help="包含 SKILL.md 的 skill 目录")
     p_upload.add_argument("--json", action="store_true", help="机读 JSON 输出")
 
+    p_init = sub.add_parser(
+        "init",
+        help="一站式引导：装 xskill 使用指南 skill 到各 agent + 连上 team server",
+    )
+    p_init.add_argument("address", nargs="?", default=None,
+                        help="server 地址 host:port（交互模式留空会询问）")
+    p_init.add_argument("--token", default=None,
+                        help="join token（server 启动时打印；交互模式留空会询问）")
+    p_init.add_argument("--name", default=None, metavar="EMPLOYEE_ID",
+                        help="工号/用户 ID（推荐填，跨设备保持身份一致）")
+    p_init.add_argument("--label", default="",
+                        help="本 client 可读标签（默认主机名）")
+    p_init.add_argument("--use-proxy", action="store_true",
+                        help="经系统/环境代理连 server（默认直连，绕开公司 SWG 代理）")
+    p_init.add_argument("--foreground", action="store_true",
+                        help="前台阻塞跑守护循环（默认交给操作系统后台常驻）")
+    p_init.add_argument("--no-auto-update", action="store_true", dest="no_auto_update",
+                        help="禁用自动更新检查")
+    p_init.add_argument("--skills-only", action="store_true", dest="skills_only",
+                        help="只装 xskill skill，不配置连接")
+    p_init.add_argument("--no-skill", action="store_true", dest="no_skill",
+                        help="只配置连接，不装 xskill skill")
+    p_init.add_argument("--force", action="store_true",
+                        help="已有常驻连接时停掉并重新配置")
+    p_init.add_argument("-y", "--yes", action="store_true",
+                        help="非交互：缺必填项直接报错，不询问")
+    p_init.add_argument("--target-root", default=None,
+                        help="[测试/隔离] 安装与探测的 HOME 根（默认真实 HOME）")
+
     p_conn = sub.add_parser(
         "connect", help="Join a team server as a thin client",
     )
@@ -1018,6 +1161,10 @@ def main() -> int:
     if args.command == "registry" and args.registry_action in ("add", "remove"):
         if not args.path:
             parser.error(f"path is required for 'registry {args.registry_action}'")
+
+    # init 一站式引导：装 skill + connect，同样是瘦客户端侧，不碰 config.yaml。
+    if args.command == "init":
+        return cmd_init(args)
 
     # connect 是瘦客户端：不读 config.yaml / 不需要 llm.api_key / 不构造 XSkill 门面
     if args.command == "connect":

--- a/src/xskill/dashboard/router.py
+++ b/src/xskill/dashboard/router.py
@@ -385,10 +385,13 @@ def _file_tree(root: Path) -> list[dict]:
 
 def _git(root: Path, args: list[str]) -> str:
     import subprocess
+
+    from xskill.utils.proc import windowless_subprocess_kwargs
     try:
-        r = subprocess.run(["git", "-C", str(root)] + args,
-                           capture_output=True, text=True, timeout=10)
-        return r.stdout
+        result = subprocess.run(["git", "-C", str(root)] + args,
+                                capture_output=True, text=True, timeout=10,
+                                **windowless_subprocess_kwargs())
+        return result.stdout
     except (OSError, subprocess.SubprocessError):
         return ""
 

--- a/src/xskill/data/skill/xskill/SKILL.md
+++ b/src/xskill/data/skill/xskill/SKILL.md
@@ -1,0 +1,111 @@
+---
+name: xskill
+description: >-
+  How to run, connect, upgrade, debug, and search with the xskill CLI — the
+  team skill-distribution and trajectory-collection daemon. Use when a user
+  asks how to install or join an xskill team server, upgrade xskill, fix a
+  stuck/black-window/copy-mode install, run xskill in the background on
+  Windows/macOS/Linux/WSL, search or share team skills, or read the dashboard.
+---
+
+# xskill
+
+xskill is a thin client + background daemon that (1) mounts your team's shared
+Skills into every AI-agent tool you use (Claude Code, Codex, OpenCode, Cursor,
+Trae) and (2) quietly collects your agent trajectories and syncs them to a team
+server. You join a server once, then it keeps skills in sync and auto-updates
+itself.
+
+All state lives under `~/.xskill/`:
+
+| File | What |
+|---|---|
+| `~/.xskill/team_client.json` | connection **identity** (server_url, client_id, join_token) — survives restarts |
+| `~/.xskill/connect_daemon.json` | current background daemon (pid / host task) — used by `status`/`stop` |
+| `~/.xskill/logs/xskill.*.log` | split logs (one file per component) |
+| `~/.xskill/skill/` | the local skill repo everything is mounted from |
+
+## Getting started — `xskill init`
+
+`xskill init` is the interactive onboarding command. It:
+
+1. installs this xskill guide skill into every detected agent tool,
+2. asks which server to join, the join token, and your employee id,
+3. detects any already-running daemon and asks whether to keep or replace it,
+4. starts the background daemon.
+
+```bash
+xskill init                 # interactive: prompts for server / token / name
+```
+
+Headless / scripted (no prompts):
+
+```bash
+xskill init <host:port> --token <join-token> --name <employee-id> --yes
+```
+
+`init` is a convenience wrapper around `connect`. If you already know the flow,
+`xskill connect <host:port> --token <t> --name <id>` does the connect half
+directly. The **join token** is printed by the server operator when they run
+`xskill serve --server`.
+
+## Upgrading
+
+```bash
+pip install -U xskill        # manual upgrade to the latest PyPI release
+xskill update                # check PyPI now, upgrade + restart if newer exists
+```
+
+The daemon **auto-checks PyPI every hour** and upgrades itself when a newer
+version is out; disable with `xskill connect --no-auto-update`. Behind a
+corporate proxy, add `--use-proxy` (default is direct connection, bypassing the
+SWG proxy). Background hosting differs per platform — Windows uses a Scheduled
+Task, Linux/WSL uses a systemd **user** service. See
+[references/platforms.md](references/platforms.md).
+
+## Debugging
+
+The single most useful command when something is wrong:
+
+```bash
+xskill connect --foreground          # run the daemon loop in the foreground, live logs
+xskill connect --foreground --debug  # + verbose logging
+```
+
+| Symptom | Command | Expected |
+|---|---|---|
+| Is it running / connected? | `xskill status` | prints background task + pid, or "not running" |
+| Skills not updating | `xskill connect --foreground` | watch the reconcile loop; look for `copy-mode` / `fell back to copy` warnings |
+| Stop it | `xskill stop` | tears down the Scheduled Task / systemd unit |
+| Restart clean | `xskill stop` then `xskill connect` | re-handshakes and re-daemonizes |
+
+Logs are at `~/.xskill/logs/xskill.*.log`. See
+[references/troubleshooting.md](references/troubleshooting.md) for the
+black-window, copy-mode, and can't-connect issues in detail.
+
+## Searching & sharing team skills
+
+```bash
+xskill search <query...>       # search the team skillhub, pull hits into local slots
+xskill search auth retry -k 3  # top-3 results (max 10)
+xskill upload ./my-skill       # package a SKILL.md folder and share to the team
+xskill dashboard               # print a passwordless link into the server dashboard
+xskill stats                   # token usage & estimated cost (--watch for live)
+```
+
+## Where skills land per tool
+
+| Tool | Install dir | Mount |
+|---|---|---|
+| Claude Code | `~/.claude/skills/<name>/` | symlink → junction (Win) → copy |
+| Codex | `~/.agents/skills/<name>/` (shared) | same |
+| OpenCode | `~/.agents/skills/<name>/` (shared) | same |
+| Cursor | `~/.cursor/skills/<name>/` | same |
+| Trae | IDE workspace / `~/.trae-cn` (auto-detected) | same |
+
+**Live mount vs snapshot:** symlink/junction installs are live — server updates
+show up instantly and your edits round-trip back. A **copy**-mode install is a
+snapshot: it logs a warning, updates do NOT propagate live, and local edits do
+NOT round-trip. Copy mode only happens when neither symlink nor junction can be
+made (cross-drive, or non-NTFS). Fix: on Windows enable Developer Mode so
+symlinks work — see [references/platforms.md](references/platforms.md).

--- a/src/xskill/data/skill/xskill/references/platforms.md
+++ b/src/xskill/data/skill/xskill/references/platforms.md
@@ -1,0 +1,54 @@
+# xskill per-platform notes
+
+## Background hosting
+
+`xskill connect` (and `xskill init`) daemonize by handing the run loop to the
+OS's native service facility, then return. The foreground loop they run is
+`xskill connect --foreground`.
+
+| Platform | Background mechanism | Notes |
+|---|---|---|
+| Windows | Scheduled Task | starts at logon; console windows are suppressed |
+| Linux / WSL | systemd **user** service | needs `loginctl enable-linger` for run-at-boot without an active login (xskill sets this up) |
+| macOS | foreground fallback | if no native backend is available, `connect` runs the loop in the foreground |
+
+Manage the background task:
+
+```bash
+xskill start     # install as a background service (autostart + crash-restart)
+xskill status    # show task + pid
+xskill stop      # stop and remove the background task
+```
+
+## Skill mount behavior
+
+xskill mounts each skill with a three-tier fallback:
+
+1. **symlink** — Linux, macOS, and Windows with Developer Mode. Live: server
+   updates appear instantly, and your edits round-trip back to the source repo.
+2. **directory junction** (`mklink /J`) — Windows without Developer Mode. NTFS
+   reparse point; behaves like a symlink to readers, but only within one volume.
+3. **copy** — only when neither of the above works (cross-drive, or non-NTFS). A
+   snapshot: updates don't propagate live and edits don't round-trip. Logs a
+   warning.
+
+### Windows: prefer Developer Mode
+
+Enabling Developer Mode grants the symlink privilege, so installs use tier 1
+(fully live) instead of junctions or copies. It also avoids the junction code
+path entirely.
+
+Settings → Privacy & security → For developers → **Developer Mode: On**.
+
+## Install directories per tool
+
+| Tool | Discovery dir |
+|---|---|
+| Claude Code | `~/.claude/skills/` |
+| Codex | `~/.agents/skills/` (shared user scope) |
+| OpenCode | `~/.agents/skills/` (shared user scope) |
+| Cursor | `~/.cursor/skills/` |
+| Trae | IDE workspace storage, `~/.trae-cn`, or CLI trajectory dir (auto-detected) |
+
+Codex, OpenCode, and OpenClaw share `~/.agents/skills/`, so installing a skill
+once makes it visible to all three.

--- a/src/xskill/data/skill/xskill/references/troubleshooting.md
+++ b/src/xskill/data/skill/xskill/references/troubleshooting.md
@@ -1,0 +1,77 @@
+# xskill troubleshooting
+
+Each item: **symptom → cause → command/fix → expected**.
+
+## Windows: many `cmd` black windows flashing
+
+- **Symptom:** on Windows (non–Developer Mode), console windows flash
+  repeatedly — up to several per second — while the daemon runs.
+- **Cause:** historical bug. When symlinks aren't available xskill falls back to
+  `mklink /J` directory junctions; older versions spawned a visible console per
+  junction, and a reconcile loop retried them every ~30s.
+- **Fix:** upgrade — resolved in **0.6.19**.
+
+  ```bash
+  pip install -U xskill
+  xskill stop && xskill connect
+  ```
+- **Expected:** no more window flashes. `xskill status` shows the daemon running.
+
+## Skills install but never update ("copy mode")
+
+- **Symptom:** server-side skill changes don't show up locally; your edits to a
+  skill don't sync back. Foreground logs show `copy-mode install` /
+  `fell back to copy`.
+- **Cause:** neither a symlink nor a junction could be created for the install
+  target (cross-drive path, or a non-NTFS filesystem), so xskill copied the
+  files — a snapshot, not a live mount.
+- **Fix:** make symlinks work. On Windows, enable **Developer Mode**
+  (Settings → Privacy & security → For developers → Developer Mode), then
+  reconnect:
+
+  ```bash
+  xskill stop && xskill connect
+  ```
+- **Expected:** foreground logs no longer warn about copy mode; the install dir
+  becomes a link/junction and updates propagate live.
+
+## Can't connect to the server
+
+- **Symptom:** `connect` hangs or times out (often HTTP 504).
+- **Cause:** by default xskill connects **directly**, bypassing the corporate
+  SWG proxy. If your only route out is through a proxy, the direct attempt
+  fails; conversely, if you're on the internal network, going *through* the
+  proxy can 504.
+- **Fix / diagnose:**
+
+  ```bash
+  xskill connect <host:port> --token <t> --name <id>            # direct (default)
+  xskill connect <host:port> --token <t> --name <id> --use-proxy # via system/env proxy
+  ```
+- **Expected:** `reconnecting: client_id=... server=...` then a background task
+  starts. Use whichever of direct/`--use-proxy` reaches the server.
+
+## `403` on connect
+
+- **Cause:** the server has `allow_anonymous: false` and you didn't pass an
+  identity.
+- **Fix:** add `--name <employee-id>`. The server derives a stable `client_id`
+  from it, so your identity is consistent across devices and reinstalls.
+
+## "First connect must include --token"
+
+- **Cause:** the very first handshake needs the join token; only later reconnects
+  can omit it (they reuse `~/.xskill/team_client.json`).
+- **Fix:** get the token from whoever ran `xskill serve --server` and pass
+  `--token <t>` once.
+
+## Daemon isn't running after reboot / seems dead
+
+```bash
+xskill status                 # check task + pid liveness
+xskill connect --foreground   # run in foreground to see the real error
+xskill stop && xskill connect # rebuild the background task
+```
+
+Foreground mode is authoritative — it's exactly what the background task
+executes, so any error reproduces there with full logs (`--debug` for more).

--- a/src/xskill/runtime.py
+++ b/src/xskill/runtime.py
@@ -18,6 +18,8 @@ from typing import Optional
 
 import yaml
 
+from xskill.utils.proc import windowless_subprocess_kwargs
+
 from xskill.config import (
     CONFIG_PATH, XSKILL_HOME,
     get_team_client_state_path, get_team_server_state_path,
@@ -86,6 +88,7 @@ def _alive_windows(pid: int) -> bool:
         res = subprocess.run(
             ["tasklist", "/FI", f"PID eq {pid}", "/NH", "/FO", "CSV"],
             capture_output=True, text=True, timeout=2, check=False,
+            **windowless_subprocess_kwargs(),
         )
     except (OSError, subprocess.TimeoutExpired):
         return False

--- a/src/xskill/team/client/service.py
+++ b/src/xskill/team/client/service.py
@@ -41,6 +41,7 @@ from pathlib import Path
 from typing import Optional
 
 from xskill.config import get_connect_daemon_state_path
+from xskill.utils.proc import windowless_subprocess_kwargs
 
 logger = logging.getLogger("xskill.team.client.service")
 
@@ -83,6 +84,7 @@ def _pid_alive_windows(pid: int) -> bool:
         out = subprocess.run(
             ["tasklist", "/FI", f"PID eq {pid}", "/NH", "/FO", "CSV"],
             capture_output=True, text=True, check=False, timeout=2,
+            **windowless_subprocess_kwargs(),
         ).stdout
     except (OSError, subprocess.SubprocessError):
         return False
@@ -301,6 +303,7 @@ class WindowsTaskSchedulerBackend(ConnectServiceBackend):
         """跑一条 schtasks 子命令。text 模式拿输出，不 check（自行判 returncode）。"""
         return subprocess.run(
             ["schtasks", *args], capture_output=True, text=True, check=False,
+            **windowless_subprocess_kwargs(),
         )
 
     def install_and_start(self) -> dict:
@@ -371,13 +374,13 @@ class WindowsTaskSchedulerBackend(ConnectServiceBackend):
         except OSError as e:
             raise ServiceError(f"写开机启动脚本失败：{e}") from e
 
-        # 立即 detach 启动（CREATE_NO_WINDOW=0x08000000, DETACHED_PROCESS=0x00000008）
-        CREATE_NO_WINDOW = 0x08000000
+        # 立即 detach 启动：无窗 flag 叠加 DETACHED_PROCESS（0x00000008）
         DETACHED_PROCESS = 0x00000008
+        no_window = windowless_subprocess_kwargs()
         try:
             proc = subprocess.Popen(
                 argv,
-                creationflags=CREATE_NO_WINDOW | DETACHED_PROCESS,
+                creationflags=no_window.get("creationflags", 0) | DETACHED_PROCESS,
                 close_fds=True,
                 stdin=subprocess.DEVNULL,
                 stdout=subprocess.DEVNULL,
@@ -410,7 +413,8 @@ class WindowsTaskSchedulerBackend(ConnectServiceBackend):
             if pid and _pid_alive(pid):
                 try:
                     subprocess.run(["taskkill", "/PID", str(pid), "/F"],
-                                   capture_output=True, check=False)
+                                   capture_output=True, check=False,
+                                   **windowless_subprocess_kwargs())
                 except OSError:
                     pass
             clear_daemon_state()

--- a/src/xskill/team/client/updater.py
+++ b/src/xskill/team/client/updater.py
@@ -26,6 +26,8 @@ import tempfile
 import threading
 from typing import Any, Optional
 
+from xskill.utils.proc import windowless_subprocess_kwargs
+
 logger = logging.getLogger("xskill.team.client.updater")
 
 _PYPI_JSON_URL = "https://pypi.org/pypi/{package}/json"
@@ -158,11 +160,12 @@ def _restart() -> None:
         else:
             # startup_folder / 未知：.vbs 无重启能力，手动 spawn 新进程
             logger.info("updater: startup_folder 路径 — spawn 新进程后退出")
-            CREATE_NO_WINDOW = 0x08000000
             DETACHED_PROCESS = 0x00000008
+            no_window = windowless_subprocess_kwargs()
             subprocess.Popen(
                 sys.argv,
-                creationflags=CREATE_NO_WINDOW | DETACHED_PROCESS,
+                # 保持 detach 语义：无窗 flag 之外再叠加 DETACHED_PROCESS
+                creationflags=no_window.get("creationflags", 0) | DETACHED_PROCESS,
                 close_fds=True,
                 stdin=subprocess.DEVNULL,
                 stdout=subprocess.DEVNULL,
@@ -312,7 +315,8 @@ class AutoUpdater:
             cmd += ["-i", self.pypi_url]
         try:
             result = subprocess.run(cmd, capture_output=True, text=True,
-                                    timeout=self._PIP_TIMEOUT)
+                                    timeout=self._PIP_TIMEOUT,
+                                    **windowless_subprocess_kwargs())
         except subprocess.TimeoutExpired:
             self._last_pip_failure_summary = f"pip 超过 {self._PIP_TIMEOUT}s 未退出"
             logger.warning("updater: %s，放弃本次升级", self._last_pip_failure_summary)
@@ -334,7 +338,8 @@ class AutoUpdater:
             verify = subprocess.run(
                 [sys.executable, "-c",
                  f"from importlib.metadata import version; print(version({self.package!r}))"],
-                capture_output=True, text=True, timeout=30)
+                capture_output=True, text=True, timeout=30,
+                **windowless_subprocess_kwargs())
             installed_version = verify.stdout.strip()
         except Exception:
             logger.debug("updater: 装后核验子进程失败，按 pip 退出码为准", exc_info=True)
@@ -427,7 +432,8 @@ class AutoUpdater:
         ]
         try:
             result = subprocess.run(cmd, capture_output=True, text=True,
-                                    timeout=self._PIP_TIMEOUT)
+                                    timeout=self._PIP_TIMEOUT,
+                                    **windowless_subprocess_kwargs())
             if result.returncode == 0:
                 logger.info("updater: 安装 server wheel 成功: %s", wheel_path.name)
                 return True

--- a/src/xskill/utils/proc.py
+++ b/src/xskill/utils/proc.py
@@ -1,0 +1,17 @@
+"""子进程启动辅助：统一抑制 Windows 控制台黑窗。"""
+from __future__ import annotations
+
+import subprocess
+import sys
+
+
+def windowless_subprocess_kwargs() -> dict:
+    """返回可展开进 ``subprocess.run/Popen`` 的 kwargs，让控制台子进程在
+    Windows 上不弹黑窗；非 Windows 返回空 dict。
+
+    Windows 下父进程无 console 附着时（服务 / pythonw / detached daemon），
+    每次起 ``cmd`` / ``git`` / ``pip`` 等控制台程序都会闪一个可见窗口。
+    """
+    if sys.platform == "win32":
+        return {"creationflags": getattr(subprocess, "CREATE_NO_WINDOW", 0x08000000)}
+    return {}

--- a/tests/test_cli_init.py
+++ b/tests/test_cli_init.py
@@ -1,0 +1,152 @@
+"""`xskill init` 一站式引导命令的单元测试。
+
+装 skill 与 connect 都靠 monkeypatch 打桩——不真跑生态安装、不真握手 server，
+只验证 cmd_init 的分支（skills-only / no-skill / 已有常驻 / force / 缺必填项）。
+"""
+from __future__ import annotations
+
+import argparse
+import sys
+from pathlib import Path
+
+import pytest
+
+SRC = Path(__file__).resolve().parent.parent / "src"
+if str(SRC) not in sys.path:
+    sys.path.insert(0, str(SRC))
+
+import xskill.cli as cli  # noqa: E402
+
+
+def _args(**overrides) -> argparse.Namespace:
+    base = dict(
+        address=None, token=None, name=None, label="", use_proxy=False,
+        foreground=False, no_auto_update=False, skills_only=False,
+        no_skill=False, force=False, yes=False, target_root=None,
+    )
+    base.update(overrides)
+    return argparse.Namespace(**base)
+
+
+@pytest.fixture
+def bundled_skill(tmp_path, monkeypatch):
+    """让 ``files('xskill')`` 指向一个带 SKILL.md 的临时目录。"""
+    root = tmp_path / "pkgroot"
+    skill = root / "data" / "skill" / "xskill"
+    skill.mkdir(parents=True)
+    (skill / "SKILL.md").write_text("# xskill\n", encoding="utf-8")
+    monkeypatch.setattr("importlib.resources.files", lambda pkg: root)
+    return skill
+
+
+@pytest.fixture
+def install_recorder(monkeypatch):
+    """把所有 install_to_* 换成记录调用的桩，返回被安装到的生态列表。"""
+    installed = []
+    for eco in ("claude_code", "codex", "nga3", "opencode", "ngagent",
+                "openclaw", "cursor", "trae"):
+        def _make(eco_name):
+            def _fake(skill_path, target_root=None, side="main"):
+                installed.append(eco_name)
+                return Path(skill_path) / "SKILL.md"
+            return _fake
+        monkeypatch.setattr(f"xskill.ecosystems.install_to_{eco}", _make(eco))
+    return installed
+
+
+def test_skills_only_installs_without_connecting(
+        bundled_skill, install_recorder, monkeypatch):
+    monkeypatch.setattr(
+        "xskill.ecosystems.detect_known_ecosystems",
+        lambda home_root=None: [{"ecosystem": "claude_code",
+                                 "source": "/x", "bridge": "/y"}],
+    )
+    connect_called = []
+    monkeypatch.setattr(cli, "cmd_connect",
+                        lambda a: connect_called.append(a) or 0)
+
+    code = cli.cmd_init(_args(skills_only=True))
+
+    assert code == 0
+    assert install_recorder == ["claude_code"]
+    assert connect_called == []
+
+
+def test_no_skill_connects_without_installing(
+        bundled_skill, install_recorder, monkeypatch):
+    monkeypatch.setattr("xskill.team.client.service.read_daemon_state",
+                        lambda: {"running": False})
+    captured = {}
+    monkeypatch.setattr(cli, "cmd_connect",
+                        lambda a: captured.update(vars(a)) or 0)
+
+    code = cli.cmd_init(_args(no_skill=True, yes=True,
+                              address="1.2.3.4:8000", token="TOK", name="007"))
+
+    assert code == 0
+    assert install_recorder == []          # --no-skill：一个生态都没装
+    assert captured["address"] == "1.2.3.4:8000"
+    assert captured["token"] == "TOK"
+    assert captured["name"] == "007"
+
+
+def test_existing_daemon_kept_when_no_force_noninteractive(monkeypatch):
+    monkeypatch.setattr("xskill.team.client.service.read_daemon_state",
+                        lambda: {"running": True, "pid": 4321, "backend": "schtasks"})
+    monkeypatch.setattr(
+        "xskill.config.get_team_client_state_path",
+        lambda: Path("/nonexistent/team_client.json"),
+    )
+    connect_called = []
+    monkeypatch.setattr(cli, "cmd_connect",
+                        lambda a: connect_called.append(a) or 0)
+
+    code = cli.cmd_init(_args(no_skill=True, yes=True, force=False,
+                              address="h:1", token="T"))
+
+    assert code == 0
+    assert connect_called == []            # 保留现有，不重连
+
+
+def test_existing_daemon_force_stops_then_connects(monkeypatch):
+    monkeypatch.setattr("xskill.team.client.service.read_daemon_state",
+                        lambda: {"running": True, "pid": 4321, "backend": "systemd"})
+    monkeypatch.setattr(
+        "xskill.config.get_team_client_state_path",
+        lambda: Path("/nonexistent/team_client.json"),
+    )
+    stopped = []
+    cleared = []
+
+    class _Backend:
+        def stop(self):
+            stopped.append(True)
+            return {}
+    monkeypatch.setattr("xskill.team.client.service.get_backend",
+                        lambda: _Backend())
+    monkeypatch.setattr("xskill.team.client.service.clear_daemon_state",
+                        lambda: cleared.append(True))
+    connect_called = []
+    monkeypatch.setattr(cli, "cmd_connect",
+                        lambda a: connect_called.append(a) or 0)
+
+    code = cli.cmd_init(_args(no_skill=True, yes=True, force=True,
+                              address="h:1", token="T"))
+
+    assert code == 0
+    assert stopped == [True]
+    assert cleared == [True]
+    assert len(connect_called) == 1        # 停掉旧的后照常重连
+
+
+def test_noninteractive_missing_token_errors(monkeypatch):
+    monkeypatch.setattr("xskill.team.client.service.read_daemon_state",
+                        lambda: {"running": False})
+    connect_called = []
+    monkeypatch.setattr(cli, "cmd_connect",
+                        lambda a: connect_called.append(a) or 0)
+
+    code = cli.cmd_init(_args(no_skill=True, yes=True, address="h:1", token=None))
+
+    assert code == 2                       # 缺 token，非交互直接报错
+    assert connect_called == []

--- a/tests/test_windowless_proc.py
+++ b/tests/test_windowless_proc.py
@@ -1,0 +1,41 @@
+"""test_windowless_proc.py — 控制台子进程不弹 Windows 黑窗的统一 flag helper。
+
+平台无关：monkeypatch sys.platform，在 Linux CI 上验证两个分支。
+"""
+from __future__ import annotations
+
+import subprocess
+
+import xskill.utils.proc as proc
+import xskill.team.client.updater as updater
+
+
+def test_windowless_kwargs_on_windows(monkeypatch):
+    monkeypatch.setattr(proc.sys, "platform", "win32")
+    kwargs = proc.windowless_subprocess_kwargs()
+    assert "creationflags" in kwargs
+    assert kwargs["creationflags"] == getattr(subprocess, "CREATE_NO_WINDOW", 0x08000000)
+
+
+def test_windowless_kwargs_off_windows(monkeypatch):
+    monkeypatch.setattr(proc.sys, "platform", "linux")
+    assert proc.windowless_subprocess_kwargs() == {}
+
+
+def test_updater_pip_install_passes_no_window_on_windows(monkeypatch):
+    """updater 的 pip 升级子进程在 Windows 分支必须带 creationflags——否则每次
+    自动更新都会闪黑窗（issue #125 同源）。"""
+    monkeypatch.setattr(proc.sys, "platform", "win32")
+
+    captured_kwargs = {}
+
+    def fake_run(cmd, **kwargs):
+        captured_kwargs.update(kwargs)
+        return subprocess.CompletedProcess(cmd, 0, stdout="", stderr="")
+
+    monkeypatch.setattr(updater.subprocess, "run", fake_run)
+
+    client_updater = updater.AutoUpdater(package="xskill")
+    client_updater._install("9.9.9")
+
+    assert "creationflags" in captured_kwargs


### PR DESCRIPTION
承接 #125 / #126。分两块。

## 1. `xskill init` 一站式引导

新子命令,交互式 + 可无头:
- 把官方 **xskill 使用指南 skill** 装进本机检测到的所有 agent 生态(claude_code/codex/opencode/cursor/trae/ngagent/openclaw/nga3),并提醒可在对应 agent 里 `/xskill` 查用法
- 逐项询问缺失的 server / token / 工号,复用 `cmd_connect` 完成握手 + 后台常驻(不重抄)
- 检测到已有常驻连接 → 展示 server/pid/backend,交互问是否停掉重配;`--force` 直接替换;`--yes` 无 --force 则保留
- headless: `xskill init <host:port> --token <t> --name <工号> --force --yes`;`--skills-only` 只装 skill,`--no-skill` 只连

**随包官方 skill**:`src/xskill/data/skill/xskill/`(SKILL.md + references/{troubleshooting,platforms}.md),覆盖上手/升级/调试/搜索/各平台生态/常见问题(含黑窗历史、copy 模式快照说明、代理排障)。已过 `parse_strict` 校验,命令逐条对着 CLI 源码核实。pyproject package-data 纳入;`.gitignore` 的 `skill/` 宽规则曾误伤此目录,加负例外修正。

## 2. Windows 弹窗残留收口

#125 只修了 `_try_junction` 的 mklink。全仓扫描后发现其余控制台子进程调用同样缺 `CREATE_NO_WINDOW`,其中 **updater 的三处 pip/核验是周期性自动更新触发,每次发版全网 Windows 机器都会闪一轮**。

新增 `utils/proc.py::windowless_subprocess_kwargs()`(Windows 返回 flag,其它平台空 dict),统一接入:
| 文件 | 点 |
|---|---|
| updater.py | pip install / 装后核验 / server wheel(周期性) |
| runtime.py, service.py | tasklist / schtasks / taskkill |
| agent_tools.py | rg / grep |
| dashboard/router.py | git.exe |

并把 service/updater 两处手写的 `CREATE_NO_WINDOW = 0x08000000` 收敛到 helper。`run_git`(dulwich 纯 Python 不 shell out)与已带 flag 的 daemon Popen 无需改。

## 测试
- `test_cli_init.py`(5)、`test_windowless_proc.py`(3)新增;整合并集 **167 passed**
- 冒烟:init 解析、真装 skill 到临时 HOME、`python -m build` 确认 skill 进 wheel

🤖 Generated with [Claude Code](https://claude.com/claude-code)