### PR TITLE
ci: move 300x300 stress to nightly / 将300x300压测迁移至夜间任务

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -1,7 +1,7 @@
 # CI workflow — see docs/dev-plan/ci-workflow-draft.yml and docs/dev-plan/testing-strategy.md
 #
 # Phase status:
-#   P1            — ut-it (3 OS × 2 py) + verify-build live.
+#   P1            — ut-it (3 OS × 4 py) + verify-build live.
 #   P2/P3         — Codex / OpenCode adapters add tests but don't change this file.
 #   P4 (this PR)  — smoke-e2e body filled: install codex/opencode CLI (real npm)
 #                   + run `pytest tests/e2e/test_smoke.py -k <agent>`.
@@ -11,9 +11,10 @@
 #                   secrets don't break the run).
 #
 # Trigger matrix:
-#   pull_request                  → ut-it + verify-build + smoke-e2e
-#   push to main                  → same + real-llm-e2e (graceful skip without secret)
-#   workflow_dispatch / schedule  → also live-agent-e2e (graceful skip without secret)
+#   pull_request         → ut-it + verify-build + smoke/connect/live-agent E2E
+#   push to main         → same + real-llm-e2e (graceful skip without secret)
+#   workflow_dispatch / schedule → same as push to main
+#   300×300 control-plane stress runs only in the dedicated nightly workflow.
 
 name: CI
 
@@ -102,34 +103,6 @@ jobs:
         run: pip install -e .[dev]
       - name: Connect lifecycle E2E (local stub, no network)
         run: pytest tests/e2e/test_connect_lifecycle_e2e.py -v
-
-  control-plane-stress:
-    name: control-plane stress (300x300, py3.11)
-    if: github.event_name != 'pull_request'
-    needs: ut-it
-    runs-on: ubuntu-latest
-    timeout-minutes: 25
-    steps:
-      - uses: actions/checkout@v4
-      - uses: actions/setup-python@v5
-        with:
-          python-version: "3.11"
-          cache: pip
-      - name: Install package with dev extras
-        run: pip install -e .[dev]
-      - name: Run 300x300 control-plane stress test
-        run: >-
-          pytest tests/stress/test_control_plane_300.py -v
-          --override-ini="addopts=" -m stress
-          --basetemp=.stress-artifacts
-      - name: Upload stress-test evidence
-        if: always()
-        uses: actions/upload-artifact@v4
-        with:
-          name: control-plane-stress-${{ github.run_id }}
-          path: .stress-artifacts/**
-          if-no-files-found: warn
-          retention-days: 14
 
   real-llm-e2e:
     name: real-llm-e2e (linux)

--- a/.github/workflows/nightly-control-plane-stress.yml
+++ b/.github/workflows/nightly-control-plane-stress.yml
@@ -1,0 +1,45 @@
+# Dedicated 300×300 control-plane stress workflow.
+# Runs daily at UTC 16:00 (Beijing time 00:00 the following day) and on demand.
+# It is intentionally independent of regular CI and the release publish gate.
+
+name: Nightly Control-Plane Stress
+
+on:
+  schedule:
+    - cron: '0 16 * * *'
+  workflow_dispatch:
+
+permissions:
+  contents: read
+
+concurrency:
+  group: nightly-control-plane-stress
+  cancel-in-progress: false
+
+jobs:
+  control-plane-stress:
+    name: control-plane stress (300x300, py3.11)
+    runs-on: ubuntu-latest
+    timeout-minutes: 25
+    steps:
+      - uses: actions/checkout@v4
+      - uses: actions/setup-python@v5
+        with:
+          python-version: "3.11"
+          cache: pip
+      - name: Install package with dev extras
+        run: pip install -e .[dev]
+      - name: Run 300x300 control-plane stress test
+        run: >-
+          pytest tests/stress/test_control_plane_300.py -v
+          --override-ini="addopts=" -m stress
+          --basetemp=.stress-artifacts
+      - name: Upload stress-test evidence
+        if: always()
+        uses: actions/upload-artifact@v4
+        with:
+          name: nightly-control-plane-stress-${{ github.run_id }}
+          path: .stress-artifacts/**
+          if-no-files-found: warn
+          include-hidden-files: true
+          retention-days: 30

--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -1,6 +1,8 @@
 # Release: triggered by pushing a version tag (v*).
 # Tag is the source of truth; setuptools-scm derives the package version from it.
 # Pre-release tags (e.g. v0.4.0a1, v0.4.0rc1) are supported.
+# Publishing is gated by the test matrix and SkillHub search smoke test.
+# The 300×300 control-plane stress test runs independently in the nightly workflow.
 
 name: Release
 
@@ -30,33 +32,6 @@ jobs:
         run: pip install -e .[dev]
       - name: Run pytest
         run: pytest tests/ -q
-
-  stress:
-    name: control-plane stress (300x300, py3.11)
-    runs-on: ubuntu-latest
-    timeout-minutes: 25
-    steps:
-      - uses: actions/checkout@v4
-      - uses: actions/setup-python@v5
-        with:
-          python-version: "3.11"
-          cache: pip
-      - name: Install package with dev extras
-        run: pip install -e .[dev]
-      - name: Run 300x300 control-plane stress test
-        run: >-
-          pytest tests/stress/test_control_plane_300.py -v
-          --override-ini="addopts=" -m stress
-          --basetemp=.stress-artifacts
-      - name: Upload stress-test evidence
-        if: always()
-        uses: actions/upload-artifact@v4
-        with:
-          name: release-control-plane-stress-${{ github.run_id }}
-          path: .stress-artifacts/**
-          if-no-files-found: warn
-          include-hidden-files: true
-          retention-days: 30
 
   skillhub-search-smoke:
     name: skillhub search smoke (py3.11)
@@ -88,7 +63,7 @@ jobs:
   publish:
     name: build and publish
     if: startsWith(github.ref, 'refs/tags/v')
-    needs: [test, stress, skillhub-search-smoke]
+    needs: [test, skillhub-search-smoke]
     runs-on: ubuntu-latest
     steps:
       - uses: actions/checkout@v4

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -88,7 +88,7 @@ markers = [
     # ``--ignore=tests/live``）；CI live-agent-e2e job + 本地手动跑用
     # ``pytest -m live_agent`` 触发。
     "live_agent: real codex/opencode process + mock LLM end-to-end (slow, optional)",
-    "stress: release-gating real-process load tests (slow, excluded by default)",
+    "stress: slow real-process load and smoke tests (excluded by default)",
 ]
 addopts = "--ignore=tests/live --ignore=tests/stress"
 asyncio_mode = "strict"

--- a/tests/stress/test_control_plane_300.py
+++ b/tests/stress/test_control_plane_300.py
@@ -1,8 +1,8 @@
-"""Release-gating 300x300 control-plane stress test.
+"""Nightly 300x300 control-plane stress test.
 
-The defaults are the release acceptance scale and real backend delays.  Local
-debugging may set the documented ``XSKILL_STRESS_*`` environment variables;
-CI and release workflows intentionally do not override them.
+The defaults are the production acceptance scale and real backend delays.
+Local debugging may set the documented ``XSKILL_STRESS_*`` environment
+variables; the nightly workflow intentionally does not override them.
 """
 from __future__ import annotations
 


### PR DESCRIPTION
## Summary / 摘要

- move the 300×300 control-plane stress test out of regular CI and the release publish gate
- add a dedicated daily nightly workflow at UTC 16:00 with manual dispatch
- retain failure artifacts for 30 days and prevent overlapping runs
- keep the SkillHub search smoke test as a release gate

- 将 300×300 控制面压测移出常规 CI 和发布门禁
- 新增每天 UTC 16:00 运行并支持手动触发的独立 nightly workflow
- 失败产物保留 30 天，并防止任务重叠
- SkillHub 搜索 smoke 继续作为发布门禁

## Verification / 验证

- actionlint: pass
- YAML trigger/dependency assertions: pass
- `tests/stress/test_loadtest_harness_unit.py`: 20 passed
- independent subagent review: PASS