### PR TITLE
feat: v0.6.28 四池并行 agent-worker

### DIFF
--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -1,6 +1,8 @@
 # Release: triggered by pushing a version tag (v*).
 # Tag is the source of truth; setuptools-scm derives the package version from it.
-# Pre-release tags (e.g. v0.4.0a1, v0.4.0rc1) are supported.
+# Pre-release tags (e.g. v0.6.28a1, v0.6.28rc1) create a GitHub Prerelease
+# only. They deliberately do not upload to PyPI, so existing clients cannot
+# auto-install an observation build.
 # Publishing is gated by the test matrix and SkillHub search smoke test.
 # The 300×300 control-plane stress test runs independently in the nightly workflow.
 
@@ -79,6 +81,7 @@ jobs:
         run: pip install build twine setuptools-scm
 
       - name: Assert tag matches setuptools-scm derived version
+        id: release_kind
         run: |
           TAG_VERSION="${GITHUB_REF_NAME#v}"
           BUILD_VERSION=$(python -m setuptools_scm)
@@ -87,6 +90,14 @@ jobs:
             echo "::error::Tag ($TAG_VERSION) != setuptools_scm version ($BUILD_VERSION). Working tree may be dirty or commits exist after the tag."
             exit 1
           fi
+          python - "$TAG_VERSION" "$GITHUB_OUTPUT" <<'PY'
+          import sys
+          from packaging.version import Version
+
+          version = Version(sys.argv[1])
+          with open(sys.argv[2], "a", encoding="utf-8") as output:
+              output.write(f"prerelease={'true' if version.is_prerelease else 'false'}\n")
+          PY
 
       - name: Build sdist and wheel
         run: python -m build
@@ -106,6 +117,7 @@ jobs:
 
           required = {
               "xskill/__init__.py",
+              "xskill/pipeline/worker_runtime.py",
               "xskill/team/client/updater.py",
               "xskill/team/server/api.py",
           }
@@ -123,7 +135,12 @@ jobs:
       - name: Twine check
         run: twine check dist/*
 
+      - name: Stage pre-release migration utility
+        if: github.ref_name == 'v0.6.28a1'
+        run: cp scripts/xskill_v0_6_28a1_migrate.py dist/x.py
+
       - name: Publish to PyPI
+        if: steps.release_kind.outputs.prerelease != 'true'
         uses: pypa/gh-action-pypi-publish@release/v1
         with:
           password: ${{ secrets.PYPI_API_TOKEN }}
@@ -140,7 +157,16 @@ jobs:
             echo "release $GITHUB_REF_NAME already exists, skipping"
             exit 0
           fi
+          prerelease_args=()
+          assets=(dist/*.whl dist/*.tar.gz)
+          if [ "${{ steps.release_kind.outputs.prerelease }}" = "true" ]; then
+            prerelease_args+=(--prerelease)
+          fi
+          if [ "$GITHUB_REF_NAME" = "v0.6.28a1" ]; then
+            assets+=(dist/x.py)
+          fi
           gh release create "$GITHUB_REF_NAME" \
-            dist/*.whl dist/*.tar.gz \
+            "${assets[@]}" \
             --title "$GITHUB_REF_NAME" \
-            --generate-notes
+            --generate-notes \
+            "${prerelease_args[@]}"

--- a/config.yaml.server.example
+++ b/config.yaml.server.example
@@ -9,7 +9,8 @@ llm:
   max_context: 131071                   # 模型上下文窗口大小（token），按实际填写
   rate_limit:
     rpm: 240                            # 每分钟最大请求数，按你的账号配额填
-    burst: 100                          # 突发上限
+    request_burst: 8                    # 短时请求突发量
+    max_inflight: 8                     # split/cluster/edit 合计 HTTP 并发上限
 
 embedding:
   base_url: https://dashscope.aliyuncs.com/compatible-mode/v1  # 任何 OpenAI 兼容 embedding 端点
@@ -18,6 +19,8 @@ embedding:
   model: text-embedding-v4              # 换成你的 embedding 模型名
   api_key: PUT_YOUR_EMBEDDING_API_KEY_HERE
   dim: 1024                             # embedding 维度，填 0 则首次调用时自动探测
+  rate_limit:
+    max_inflight: 4                     # embedding 独立 HTTP 并发上限
 
 # ===== Server runtime =====
 server:
@@ -43,8 +46,21 @@ canary:
 watcher:
   poll_interval: 30      # 每隔 30 秒扫描一次所有 watch_dir，检测新轨迹
                          # 调小加快入库，但会增加 LLM 调用频率
-  max_concurrent: 4      # 每轮扫描最多同时跑 4 个 LLM 调用
-                         # 自建 vLLM 无并发限制时可调到 20~30
+
+agent_worker:
+  pools:
+    split:
+      workers: 24
+      llm_weight: 6
+    cluster:
+      workers: 8
+      batch_size: 8
+      llm_weight: 3
+    edit:
+      workers: 4
+      llm_weight: 1
+    embed:
+      workers: 4
 
 dashboard:
   enabled: true

--- a/scripts/xskill_v0_6_28a1_migrate.py
+++ b/scripts/xskill_v0_6_28a1_migrate.py
@@ -1,0 +1,430 @@
+#!/usr/bin/env python3
+"""Install the v0.6.28a1 wheel, migrate four-pool config, and verify it.
+
+Copy this file to ``/tmp/x.py`` on the target host, then run:
+
+    python3 /tmp/x.py --wheel /tmp/xskill-0.6.28a1-py3-none-any.whl
+    python3 /tmp/x.py --rollback
+
+The script never prints config values, API keys, process environments, or
+dashboard credentials.  It is intentionally Linux-specific because the
+pre-release observation host uses ``/proc`` for process discovery.
+"""
+from __future__ import annotations
+
+import argparse
+import importlib.metadata
+import json
+import os
+import shutil
+import signal
+import subprocess
+import sys
+import tempfile
+import time
+import urllib.error
+import urllib.request
+from pathlib import Path
+
+import yaml
+
+
+TARGET_VERSION = "0.6.28a1"
+ROLLBACK_VERSION = "0.6.27"
+POOL_DEFAULTS = {
+    "split": {"workers": 24, "llm_weight": 6},
+    "cluster": {"workers": 8, "batch_size": 8, "llm_weight": 3},
+    "edit": {"workers": 4, "llm_weight": 1},
+    "embed": {"workers": 4},
+}
+
+
+def _positive_int(value, default):
+    if isinstance(value, bool) or not isinstance(value, int) or value <= 0:
+        return default
+    return value
+
+
+def migrate_config(config):
+    """Return a migrated copy without exposing or changing secret fields."""
+    if not isinstance(config, dict):
+        raise ValueError("config.yaml 顶层必须是 mapping")
+    migrated = dict(config)
+
+    watcher = dict(migrated.get("watcher") or {})
+    legacy_batch_size = watcher.pop("cluster_batch_size", None)
+    watcher.pop("max_concurrent", None)
+    watcher["poll_interval"] = watcher.get("poll_interval", 5)
+    migrated["watcher"] = watcher
+
+    pools = {name: dict(values) for name, values in POOL_DEFAULTS.items()}
+    pools["cluster"]["batch_size"] = _positive_int(
+        legacy_batch_size,
+        pools["cluster"]["batch_size"],
+    )
+    migrated["agent_worker"] = {"pools": pools}
+
+    llm = dict(migrated.get("llm") or {})
+    rate = dict(llm.get("rate_limit") or {})
+    legacy_burst = rate.pop("burst", None)
+    rate["rpm"] = _positive_int(rate.get("rpm"), 240)
+    rate["request_burst"] = _positive_int(
+        rate.get("request_burst"),
+        _positive_int(legacy_burst, 8),
+    )
+    rate["max_inflight"] = _positive_int(rate.get("max_inflight"), 8)
+    if "tpm" in rate:
+        rate["token_burst"] = _positive_int(
+            rate.get("token_burst"),
+            _positive_int(legacy_burst, max(1, int(rate["tpm"]) // 6)),
+        )
+    llm["rate_limit"] = rate
+    migrated["llm"] = llm
+
+    llm_skill = migrated.get("llm_skill")
+    if isinstance(llm_skill, dict) and isinstance(llm_skill.get("rate_limit"), dict):
+        llm_skill = dict(llm_skill)
+        skill_rate = dict(llm_skill["rate_limit"])
+        skill_burst = skill_rate.pop("burst", None)
+        if "request_burst" not in skill_rate and skill_burst is not None:
+            skill_rate["request_burst"] = skill_burst
+        if "tpm" in skill_rate and "token_burst" not in skill_rate:
+            skill_rate["token_burst"] = _positive_int(
+                skill_burst,
+                max(1, int(skill_rate["tpm"]) // 6),
+            )
+        llm_skill["rate_limit"] = skill_rate
+        migrated["llm_skill"] = llm_skill
+
+    embedding = dict(migrated.get("embedding") or {})
+    embedding_rate = dict(embedding.get("rate_limit") or {})
+    embedding_rate["max_inflight"] = _positive_int(
+        embedding_rate.get("max_inflight"), 4,
+    )
+    embedding["rate_limit"] = embedding_rate
+    migrated["embedding"] = embedding
+    return migrated
+
+
+def _atomic_write_yaml(path, config):
+    path.parent.mkdir(parents=True, exist_ok=True)
+    original_mode = path.stat().st_mode & 0o777 if path.exists() else 0o600
+    handle = tempfile.NamedTemporaryFile(
+        mode="w",
+        encoding="utf-8",
+        dir=str(path.parent),
+        prefix=f".{path.name}.",
+        suffix=".tmp",
+        delete=False,
+    )
+    temporary = Path(handle.name)
+    try:
+        with handle:
+            yaml.safe_dump(
+                config,
+                handle,
+                allow_unicode=True,
+                sort_keys=False,
+            )
+            handle.flush()
+            os.fsync(handle.fileno())
+        os.chmod(temporary, original_mode)
+        os.replace(temporary, path)
+    finally:
+        temporary.unlink(missing_ok=True)
+
+
+def _package_version():
+    try:
+        return importlib.metadata.version("xskill")
+    except importlib.metadata.PackageNotFoundError:
+        return "not-installed"
+
+
+def _run_pip(*arguments):
+    subprocess.run(
+        [sys.executable, "-m", "pip", *arguments],
+        check=True,
+    )
+
+
+def _prepare_rollback_wheel(backup_dir):
+    backup_dir.mkdir(parents=True, exist_ok=True)
+    wheels = sorted(backup_dir.glob(f"xskill-{ROLLBACK_VERSION}-*.whl"))
+    if wheels:
+        return wheels[-1]
+    _run_pip(
+        "download", "--only-binary=:all:", "--no-deps",
+        "--dest", str(backup_dir), f"xskill=={ROLLBACK_VERSION}",
+    )
+    wheels = sorted(backup_dir.glob(f"xskill-{ROLLBACK_VERSION}-*.whl"))
+    if not wheels:
+        raise RuntimeError("未能准备 v0.6.27 回退 wheel")
+    return wheels[-1]
+
+
+def _read_cmdline(pid):
+    try:
+        raw = (Path("/proc") / str(pid) / "cmdline").read_bytes()
+    except OSError:
+        return []
+    return [part.decode("utf-8", errors="surrogateescape") for part in raw.split(b"\0") if part]
+
+
+def _serve_processes():
+    processes = []
+    proc_root = Path("/proc")
+    if not proc_root.is_dir():
+        raise RuntimeError("预发布迁移脚本需要 Linux /proc")
+    for entry in proc_root.iterdir():
+        if not entry.name.isdigit() or int(entry.name) == os.getpid():
+            continue
+        argv = _read_cmdline(int(entry.name))
+        if "serve" not in argv:
+            continue
+        if not any("xskill" in part for part in argv):
+            continue
+        try:
+            cwd = Path(os.readlink(entry / "cwd"))
+            environ = {}
+            for item in (entry / "environ").read_bytes().split(b"\0"):
+                if b"=" not in item:
+                    continue
+                key, value = item.split(b"=", 1)
+                environ[key.decode(errors="surrogateescape")] = value.decode(
+                    errors="surrogateescape",
+                )
+        except OSError:
+            cwd = Path.cwd()
+            environ = dict(os.environ)
+        processes.append({
+            "pid": int(entry.name),
+            "argv": argv,
+            "cwd": cwd,
+            "environ": environ,
+        })
+    return processes
+
+
+def _agent_worker_pids():
+    pids = []
+    for entry in Path("/proc").iterdir():
+        if not entry.name.isdigit():
+            continue
+        argv = _read_cmdline(int(entry.name))
+        if "agent-worker" in argv and any("xskill._workers" in part for part in argv):
+            pids.append(int(entry.name))
+    return pids
+
+
+def _port_from_argv(argv):
+    if "--port" in argv:
+        index = argv.index("--port")
+        if index + 1 < len(argv):
+            return int(argv[index + 1])
+    return 8000
+
+
+def _pid_alive(pid):
+    try:
+        os.kill(pid, 0)
+    except ProcessLookupError:
+        return False
+    except PermissionError:
+        return True
+    return True
+
+
+def _restart_serve(captured, log_path):
+    if not captured:
+        raise RuntimeError("未发现正在运行的 xskill serve；未擅自改变启动参数")
+    if len(captured) != 1:
+        raise RuntimeError(f"发现 {len(captured)} 个 xskill serve，拒绝不明确的重启")
+    old = captured[0]
+    os.kill(old["pid"], signal.SIGTERM)
+    deadline = time.time() + 30
+    while _pid_alive(old["pid"]) and time.time() < deadline:
+        time.sleep(0.2)
+    if _pid_alive(old["pid"]):
+        raise RuntimeError("xskill serve 在 30 秒内未响应 SIGTERM")
+
+    # A system supervisor may already have restarted it.  If not, relaunch the
+    # exact captured argv/cwd/environment without printing any environment.
+    deadline = time.time() + 5
+    while time.time() < deadline:
+        replacements = _serve_processes()
+        if replacements:
+            return replacements[0]
+        time.sleep(0.2)
+    log_path.parent.mkdir(parents=True, exist_ok=True)
+    with log_path.open("ab") as log_handle:
+        process = subprocess.Popen(
+            old["argv"],
+            cwd=str(old["cwd"]),
+            env=old["environ"],
+            stdin=subprocess.DEVNULL,
+            stdout=log_handle,
+            stderr=subprocess.STDOUT,
+            start_new_session=True,
+        )
+    return {**old, "pid": process.pid}
+
+
+def _get_json(url, timeout=3):
+    request = urllib.request.Request(url, headers={"Accept": "application/json"})
+    with urllib.request.urlopen(request, timeout=timeout) as response:
+        return json.loads(response.read().decode("utf-8"))
+
+
+def _verify(port, timeout=120):
+    base_url = f"http://127.0.0.1:{port}"
+    deadline = time.time() + timeout
+    last_error = None
+    while time.time() < deadline:
+        try:
+            worker_payload = _get_json(f"{base_url}/api/v1/agent-worker/status")
+            watcher_payload = _get_json(f"{base_url}/api/v1/watcher/status")
+            worker = worker_payload.get("stats", worker_payload)
+            watcher = watcher_payload.get("stats", watcher_payload)
+            pools = worker.get("pools") or {}
+            if set(pools) != {"split", "cluster", "edit", "embed"}:
+                raise RuntimeError("状态接口尚未报告四个池")
+            for name, pool in pools.items():
+                required = {
+                    "workers", "queue_capacity", "running", "queued",
+                    "completed", "failed", "occupancy",
+                }
+                if not required.issubset(pool):
+                    raise RuntimeError(f"{name} 池状态字段不完整")
+                if pool["queue_capacity"] != pool["workers"] * 2:
+                    raise RuntimeError(f"{name} 池等待容量不是 workers × 2")
+            if not worker.get("pid") or "scans" not in watcher:
+                raise RuntimeError("agent-worker 或 watcher 状态尚未就绪")
+            process_pids = _agent_worker_pids()
+            if int(worker["pid"]) not in process_pids:
+                raise RuntimeError("状态 PID 与 agent-worker 进程不一致")
+            return worker
+        except (OSError, ValueError, RuntimeError, urllib.error.URLError) as error:
+            last_error = error
+            time.sleep(1)
+    raise RuntimeError(f"服务健康检查超时: {last_error}")
+
+
+def _write_manifest(path, payload):
+    path.parent.mkdir(parents=True, exist_ok=True)
+    temporary = path.with_suffix(".tmp")
+    temporary.write_text(json.dumps(payload, ensure_ascii=False, indent=2), encoding="utf-8")
+    os.chmod(temporary, 0o600)
+    os.replace(temporary, path)
+
+
+def _load_manifest(path):
+    payload = json.loads(path.read_text(encoding="utf-8"))
+    if not isinstance(payload, dict):
+        raise RuntimeError("迁移记录格式无效")
+    return payload
+
+
+def install(args):
+    config_path = args.config.expanduser().resolve()
+    if not config_path.is_file():
+        raise RuntimeError(f"配置文件不存在: {config_path}")
+    wheel = args.wheel
+    if wheel is None:
+        matches = sorted(Path("/tmp").glob("xskill-0.6.28a1-*.whl"))
+        if len(matches) != 1:
+            raise RuntimeError("请用 --wheel 指定唯一的 v0.6.28a1 wheel")
+        wheel = str(matches[0])
+
+    state_dir = config_path.parent
+    timestamp = time.strftime("%Y%m%d-%H%M%S")
+    backup_path = state_dir / f"config.yaml.v0.6.27.bak.{timestamp}"
+    rollback_dir = state_dir / "rollback" / TARGET_VERSION
+    captured = _serve_processes()
+    port = _port_from_argv(captured[0]["argv"]) if len(captured) == 1 else 8000
+
+    config = yaml.safe_load(config_path.read_text(encoding="utf-8"))
+    migrated = migrate_config(config)
+    if args.dry_run:
+        print("配置迁移预检通过；未写文件、未安装、未重启。")
+        return
+
+    rollback_wheel = _prepare_rollback_wheel(rollback_dir)
+    shutil.copy2(config_path, backup_path)
+    _atomic_write_yaml(config_path, migrated)
+    _run_pip("install", "--no-deps", "--force-reinstall", wheel)
+    installed = _package_version()
+    if installed != args.expected_version:
+        raise RuntimeError(
+            f"安装版本不符: expected={args.expected_version} actual={installed}",
+        )
+    _write_manifest(args.manifest.expanduser(), {
+        "target_version": args.expected_version,
+        "rollback_version": ROLLBACK_VERSION,
+        "config_path": str(config_path),
+        "config_backup": str(backup_path),
+        "rollback_wheel": str(rollback_wheel),
+        "port": port,
+        "created_at": int(time.time()),
+    })
+    _restart_serve(captured, state_dir / "logs" / "v0.6.28a1-restart.log")
+    worker = _verify(port)
+    pool_summary = ", ".join(
+        f"{name}={values['workers']}"
+        for name, values in worker["pools"].items()
+    )
+    print(f"v{installed} 已安装并通过检查；agent-worker PID={worker['pid']}；{pool_summary}")
+    print("回退命令: python3 /tmp/x.py --rollback")
+
+
+def rollback(args):
+    manifest = _load_manifest(args.manifest.expanduser())
+    config_path = Path(manifest["config_path"])
+    backup_path = Path(manifest["config_backup"])
+    rollback_wheel = Path(manifest["rollback_wheel"])
+    if not backup_path.is_file() or not rollback_wheel.is_file():
+        raise RuntimeError("回退所需的配置备份或 v0.6.27 wheel 不存在")
+    captured = _serve_processes()
+    shutil.copy2(backup_path, config_path)
+    _run_pip("install", "--no-deps", "--force-reinstall", str(rollback_wheel))
+    installed = _package_version()
+    if installed != ROLLBACK_VERSION:
+        raise RuntimeError(f"回退版本不符: expected={ROLLBACK_VERSION} actual={installed}")
+    _restart_serve(captured, config_path.parent / "logs" / "v0.6.27-rollback.log")
+    print(f"已恢复 v{installed} 和原 watcher 配置。")
+
+
+def parse_args(argv=None):
+    parser = argparse.ArgumentParser()
+    parser.add_argument("--wheel", help="v0.6.28a1 wheel 的本地路径或 pip 可识别 URL")
+    parser.add_argument("--rollback", action="store_true")
+    parser.add_argument("--dry-run", action="store_true")
+    parser.add_argument("--expected-version", default=TARGET_VERSION)
+    parser.add_argument(
+        "--config",
+        type=Path,
+        default=Path.home() / ".xskill" / "config.yaml",
+    )
+    parser.add_argument(
+        "--manifest",
+        type=Path,
+        default=Path.home() / ".xskill" / "v0.6.28a1-migration.json",
+    )
+    return parser.parse_args(argv)
+
+
+def main(argv=None):
+    args = parse_args(argv)
+    try:
+        if args.rollback:
+            rollback(args)
+        else:
+            install(args)
+    except Exception as error:  # deployment boundary: concise, no secret values
+        print(f"失败: {error}", file=sys.stderr)
+        return 1
+    return 0
+
+
+if __name__ == "__main__":
+    raise SystemExit(main())

--- a/src/xskill/_workers.py
+++ b/src/xskill/_workers.py
@@ -1,13 +1,13 @@
 """内部子进程 worker(**非用户 CLI**)。
 
-watcher 是常驻子进程；画像重计算仍是短命子进程。web 进程的
+agent-worker 是常驻子进程；画像重计算仍是短命子进程。web 进程的
 ``IntervalSubprocessScheduler`` 用
 ``[sys.executable, "-m", "xskill._workers", <kind>]`` 启动它们，重计算与 web
 事件循环保持 GIL 隔离。
 
 这些是**内部管道**,刻意不注册进 ``xskill`` 用户 CLI(``cli.build_parser``)——用户
 ``xskill --help`` 看不到它们。调度器直接调本模块的 SDK 函数
-(``run_watcher_forever`` / ``run_profile_refresh_once``),或经
+(``run_agent_worker_forever`` / ``run_profile_refresh_once``),或经
 ``python -m xskill._workers`` 入口。
 """
 from __future__ import annotations
@@ -45,14 +45,14 @@ def _restore_signal_handlers(previous) -> None:
         signal.signal(signum, handler)
 
 
-def run_watcher_forever(
+def run_agent_worker_forever(
     *,
     server: bool = False,
     home: str | None = None,
     stop_event=None,
     status_interval: float = 5.0,
 ) -> int:
-    """构造一次 watcher 并常驻运行，直到收到 TERM/INT。
+    """构造四池 agent worker 并常驻运行，直到收到 TERM/INT。
 
     ``DirectoryWatcher.start()`` 的扫描线程每个 poll 都继续提交和收割
     任务，Future 跨轮保留；LLM 长尾任务不会阻止后续扫描。
@@ -70,7 +70,11 @@ def run_watcher_forever(
         build_watcher,
         ingest_detected_ecosystems_once,
     )
-    from xskill.utils.status_file import WATCHER_STATUS_FILE, write_status_file
+    from xskill.utils.status_file import (
+        AGENT_WORKER_STATUS_FILE,
+        WATCHER_STATUS_FILE,
+        write_status_file,
+    )
 
     if status_interval <= 0:
         raise ValueError("status_interval 必须 > 0")
@@ -78,6 +82,7 @@ def run_watcher_forever(
     config = load_config()
     home_root = Path(home).expanduser().resolve() if home else Path.home()
     status_path = XSKILL_HOME / WATCHER_STATUS_FILE
+    worker_status_path = XSKILL_HOME / AGENT_WORKER_STATUS_FILE
     event = stop_event if stop_event is not None else threading.Event()
     previous_handlers = _install_stop_signal_handlers(event)
     watcher = None
@@ -121,17 +126,27 @@ def run_watcher_forever(
         )
         watcher.start()
         write_status_file(status_path, watcher.stats, ok=True)
+        write_status_file(
+            worker_status_path,
+            getattr(watcher, "agent_worker_status", watcher.stats),
+            ok=True,
+        )
 
         while not event.wait(status_interval):
             if not watcher.is_running:
                 raise RuntimeError("watcher thread exited unexpectedly")
             write_status_file(status_path, watcher.stats, ok=True)
+            write_status_file(
+                worker_status_path,
+                getattr(watcher, "agent_worker_status", watcher.stats),
+                ok=True,
+            )
 
         ok = True
         return 0
     except Exception as exc:  # noqa: BLE001 — 常驻 worker 顶层边界
         error = str(exc)
-        logger.exception("persistent watcher failed")
+        logger.exception("persistent agent worker failed")
         return 1
     finally:
         if watcher is not None:
@@ -142,6 +157,16 @@ def run_watcher_forever(
         write_status_file(
             status_path,
             watcher.stats if watcher is not None else {},
+            ok=ok,
+            error=error,
+        )
+        write_status_file(
+            worker_status_path,
+            (
+                getattr(watcher, "agent_worker_status", watcher.stats)
+                if watcher is not None
+                else {}
+            ),
             ok=ok,
             error=error,
         )
@@ -325,9 +350,9 @@ def main(argv: list[str] | None = None) -> int:
 
     parser = argparse.ArgumentParser(prog="xskill._workers")
     sub = parser.add_subparsers(dest="kind", required=True)
-    p_watcher = sub.add_parser("watcher")
-    p_watcher.add_argument("--server", action="store_true")
-    p_watcher.add_argument("--home", default=None)
+    p_worker = sub.add_parser("agent-worker")
+    p_worker.add_argument("--server", action="store_true")
+    p_worker.add_argument("--home", default=None)
     p_ingest = sub.add_parser("ecosystem-ingest")
     p_ingest.add_argument("--home", default=None)
     p_ingest.add_argument("--loop", action="store_true")
@@ -336,8 +361,8 @@ def main(argv: list[str] | None = None) -> int:
     args = parser.parse_args(argv)
 
     configure_logging(get_logs_dir(), debug=False, quiet=False, stdout=True)
-    if args.kind == "watcher":
-        return run_watcher_forever(server=args.server, home=args.home)
+    if args.kind == "agent-worker":
+        return run_agent_worker_forever(server=args.server, home=args.home)
     if args.kind == "ecosystem-ingest":
         if args.loop:
             return run_ecosystem_ingest_loop(

--- a/src/xskill/agents/agent_tools.py
+++ b/src/xskill/agents/agent_tools.py
@@ -77,6 +77,8 @@ class AgentToolContext:
     default_traj_root: Path | None = None
     spill_root: Path | None = None
     usage_ledger: Any = None
+    cluster_write_queue: Any = None
+    cluster_result_recorder: Any = None
     grep_fallback_warned: bool = False
 
     def __post_init__(self) -> None:
@@ -106,6 +108,8 @@ def create_agent_tool_context(
     default_traj_root=None,
     spill_root=None,
     usage_ledger=None,
+    cluster_write_queue=None,
+    cluster_result_recorder=None,
 ) -> AgentToolContext:
     """Create an immutable context without changing the current task."""
     return AgentToolContext(
@@ -124,6 +128,8 @@ def create_agent_tool_context(
         ),
         spill_root=Path(spill_root) if spill_root is not None else None,
         usage_ledger=usage_ledger,
+        cluster_write_queue=cluster_write_queue,
+        cluster_result_recorder=cluster_result_recorder,
     )
 
 
@@ -207,6 +213,8 @@ class AgentToolConfig:
             "default_traj_root": current.default_traj_root,
             "spill_root": current.spill_root,
             "usage_ledger": current.usage_ledger,
+            "cluster_write_queue": current.cluster_write_queue,
+            "cluster_result_recorder": current.cluster_result_recorder,
             "grep_fallback_warned": current.grep_fallback_warned,
         }
 
@@ -220,6 +228,8 @@ class AgentToolConfig:
             default_traj_root=snapshot.get("default_traj_root"),
             spill_root=snapshot.get("spill_root"),
             usage_ledger=snapshot.get("usage_ledger"),
+            cluster_write_queue=snapshot.get("cluster_write_queue"),
+            cluster_result_recorder=snapshot.get("cluster_result_recorder"),
         ))
         if not snapshot.get("configured", True):
             current = _AGENT_TOOL_CONTEXT.get()
@@ -289,6 +299,26 @@ class AgentToolConfig:
 
 
 agent_tool_config = AgentToolConfig()
+
+
+def _run_cluster_mutation(operation):
+    """Run one ClusterAgent filesystem mutation in queue order."""
+    context = current_agent_tool_context()
+    queue = context.cluster_write_queue
+    if queue is None:
+        return operation()
+
+    def run_bound():
+        with use_agent_tool_context(context):
+            return operation()
+
+    return queue.call(run_bound)
+
+
+def _record_cluster_result(atom_id: str, skill_name: str, weightscore: int) -> None:
+    recorder = current_agent_tool_context().cluster_result_recorder
+    if recorder is not None:
+        recorder.record(atom_id, skill_name, weightscore)
 
 
 def init_atom_task_tool_context(
@@ -921,12 +951,15 @@ def new_skill_folder(skill_name: str, description: str) -> str:
                 "（2-3 句中文，让后续 cluster agent 能判断同类）")
     slug = _slugify(skill_name)
     target = skill_dir / slug
-    if target.exists():
-        return f"already exists: {target}"
-    # 初始化 git + baby 分支 + stub SKILL.md
-    from xskill.skill.git import init_skill_repo_on_baby
-    init_skill_repo_on_baby(str(target), name=slug, description=desc)
-    return f"created on baby branch: {target}  desc={desc[:60]!r}"
+
+    def mutate():
+        if target.exists():
+            return f"already exists: {target}"
+        from xskill.skill.git import init_skill_repo_on_baby
+        init_skill_repo_on_baby(str(target), name=slug, description=desc)
+        return f"created on baby branch: {target}  desc={desc[:60]!r}"
+
+    return _run_cluster_mutation(mutate)
 
 
 @tool(name="skill_read")
@@ -1003,17 +1036,21 @@ def add_task_to_skill(skill_name: str, atom_id: str, weightscore: int) -> str:
             "error: weightscore must be 1..10 "
             f"(got {weightscore_value})"
         )
-    new_flags, buffer_total = C.add_atom_contributions(
-        target,
-        [(atom_id, weightscore_value, "")],
-    )
-    was_new = new_flags[0]
-    verb = "new" if was_new else "overwrite"
-    return (
-        f"{verb}: skill={slug} atom={atom_id} "
-        f"weightscore={weightscore_value} "
-        f"buffer_total={buffer_total}/10"
-    )
+    def mutate():
+        new_flags, buffer_total = C.add_atom_contributions(
+            target,
+            [(atom_id, weightscore_value, "")],
+        )
+        _record_cluster_result(atom_id, slug, weightscore_value)
+        was_new = new_flags[0]
+        verb = "new" if was_new else "overwrite"
+        return (
+            f"{verb}: skill={slug} atom={atom_id} "
+            f"weightscore={weightscore_value} "
+            f"buffer_total={buffer_total}/10"
+        )
+
+    return _run_cluster_mutation(mutate)
 
 
 class CandidateTaskInput(BaseModel):
@@ -1094,17 +1131,24 @@ def add_tasks_to_skill(
             return "error: each task.note must be a string"
         contributions.append((atom_id, weightscore_value, note))
 
-    new_flags, buffer_total = C.add_atom_contributions(
-        target,
-        contributions,
-    )
-    new_count = sum(new_flags)
-    overwrite_count = len(new_flags) - new_count
-    return (
-        f"batched: skill={slug} atoms={len(new_flags)} "
-        f"new={new_count} overwrite={overwrite_count} "
-        f"buffer_total={buffer_total}/10"
-    )
+    def mutate():
+        new_flags, buffer_total = C.add_atom_contributions(
+            target,
+            contributions,
+        )
+        for contribution_atom_id, contribution_score, _note in contributions:
+            _record_cluster_result(
+                contribution_atom_id, slug, contribution_score,
+            )
+        new_count = sum(new_flags)
+        overwrite_count = len(new_flags) - new_count
+        return (
+            f"batched: skill={slug} atoms={len(new_flags)} "
+            f"new={new_count} overwrite={overwrite_count} "
+            f"buffer_total={buffer_total}/10"
+        )
+
+    return _run_cluster_mutation(mutate)
 
 
 @tool(name="score_task")
@@ -1119,13 +1163,16 @@ def score_task(atom_id: str, score: int) -> str:
         return f"error: score must be int 1..10 (got {score!r})"
     if not (1 <= sc <= 10):
         return f"error: score must be 1..10 (got {sc})"
-    try:
-        a = store.load(atom_id)
-    except FileNotFoundError as e:
-        return f"error: {e}"
-    a.ux_score = sc
-    store.save(a)
-    return f"scored: {atom_id} → {sc}"
+    def mutate():
+        try:
+            atom = store.load(atom_id)
+        except FileNotFoundError as error:
+            return f"error: {error}"
+        atom.ux_score = sc
+        store.save(atom)
+        return f"scored: {atom_id} → {sc}"
+
+    return _run_cluster_mutation(mutate)
 
 
 @tool(name="add_task")
@@ -1747,19 +1794,22 @@ def move_task_to(skill_from: str, skill_to: str, atom_id: str) -> str:
         return f"noop: 源和目标是同一 skill ({from_slug})"
     from_path = skill_dir / from_slug
     to_path = skill_dir / to_slug
-    if not from_path.is_dir():
-        return f"error: source skill {from_slug} not found"
-    if not to_path.is_dir():
-        return f"error: target skill {to_slug} not found"
 
-    weightscore = C.move_atom_contribution(
-        from_path,
-        to_path,
-        atom_id,
-    )
-    if weightscore is None:
-        return f"error: atom_id {atom_id} 不在 {from_slug} buffer 中"
+    def mutate():
+        if not from_path.is_dir():
+            return f"error: source skill {from_slug} not found"
+        if not to_path.is_dir():
+            return f"error: target skill {to_slug} not found"
+        weightscore = C.move_atom_contribution(
+            from_path,
+            to_path,
+            atom_id,
+        )
+        if weightscore is None:
+            return f"error: atom_id {atom_id} 不在 {from_slug} buffer 中"
+        _record_cluster_result(atom_id, to_slug, weightscore)
+        logger.info(f"moved task: atom={atom_id} {from_slug} → {to_slug}")
+        return (f"moved: atom={atom_id} from {from_slug} to {to_slug} "
+                f"(weightscore={weightscore})")
 
-    logger.info(f"moved task: atom={atom_id} {from_slug} → {to_slug}")
-    return (f"moved: atom={atom_id} from {from_slug} to {to_slug} "
-            f"(weightscore={weightscore})")
+    return _run_cluster_mutation(mutate)

--- a/src/xskill/agents/agno_factory.py
+++ b/src/xskill/agents/agno_factory.py
@@ -17,6 +17,7 @@ from __future__ import annotations
 import inspect
 import logging
 import os
+from functools import partial
 from typing import Any, Callable
 
 from xskill.utils.logging import StreamLog
@@ -113,32 +114,27 @@ def _wrap_with_rate_limit(
         model.invoke = record_only_invoke
         return model
 
-    from xskill.utils.rate_limit import (
-        get_or_create_bucket, estimate_tokens, extract_total_tokens,
-    )
-    bucket = get_or_create_bucket(
+    from xskill.utils.rate_limit import get_or_create_request_limiter
+    limiter = get_or_create_request_limiter(
+        "llm",
         llm_cfg.get("base_url", ""),
         rpm=rl_cfg.get("rpm"),
         tpm=rl_cfg.get("tpm"),
-        burst=rl_cfg.get("burst"),
+        request_burst=rl_cfg.get("request_burst", rl_cfg.get("burst")),
+        token_burst=rl_cfg.get("token_burst", rl_cfg.get("burst")),
+        max_inflight=rl_cfg.get("max_inflight"),
+        weights=llm_cfg.get("_pool_weights"),
     )
 
     def rate_limited_invoke(messages, **kwargs):
-        # agno 把 messages 列表传进来,估算用拼起来的总字符
         prompt_text = "\n".join(
             getattr(m, "content", str(m)) or "" for m in (messages or [])
         )
-        wait = bucket.acquire_rpm(timeout=60)
-        if wait > 0:
-            raise RuntimeError(f"RPM exhausted, wait {wait:.1f}s")
-        estimated = estimate_tokens(prompt_text)
-        wait = bucket.acquire_tpm(estimated, timeout=60)
-        if wait > 0:
-            raise RuntimeError(f"TPM exhausted, wait {wait:.1f}s")
-        resp = original_invoke(messages, **kwargs)
-        actual = extract_total_tokens(resp)
-        if actual is not None:
-            bucket.reconcile_tpm(estimated=estimated, actual=actual)
+        resp = limiter.call(
+            prompt=prompt_text,
+            inner_call=partial(original_invoke, messages, **kwargs),
+            timeout=60,
+        )
         # 旁路记账;record_llm 内部 best-effort,绝不抛。
         ledger.record_llm(current_step(), model_name, resp)
         return resp
@@ -269,6 +265,7 @@ def _wrap_with_retry(model, llm_cfg: dict):
     base = float(llm_cfg.get("retry_base_delay", 2.0) or 2.0)
     cap = float(llm_cfg.get("retry_max_delay", 60.0) or 60.0)
     original_invoke = model.invoke
+    base_url = llm_cfg.get("base_url", "")
 
     def retrying_invoke(messages, **kwargs):
         attempt = 0
@@ -286,8 +283,13 @@ def _wrap_with_retry(model, llm_cfg: dict):
                     attempt, max_retries, delay, str(exc)[:160])
                 # 用 Event.wait 代替 time.sleep：进程优雅退出时立即放弃重试，
                 # 否则退避睡眠会把 worker join 拖到分钟级 → supervisor SIGKILL
-                if SHUTTING_DOWN.wait(delay):
-                    raise
+                from xskill.utils.rate_limit import begin_retry_wait, end_retry_wait
+                begin_retry_wait("llm", base_url)
+                try:
+                    if SHUTTING_DOWN.wait(delay):
+                        raise
+                finally:
+                    end_retry_wait("llm", base_url)
 
     model.invoke = retrying_invoke
     return model
@@ -327,6 +329,11 @@ def make_default_factory(
     base_cfg = config.get("llm", {}) or {}
     override_cfg = config.get("llm_skill", {}) or {}
     llm_cfg = {**base_cfg, **{k: v for k, v in override_cfg.items() if v}}
+    pool_cfg = (config.get("agent_worker", {}) or {}).get("pools", {}) or {}
+    llm_cfg["_pool_weights"] = {
+        name: int((pool_cfg.get(name, {}) or {}).get("llm_weight", 1))
+        for name in ("split", "cluster", "edit")
+    }
 
     def factory(*, instructions, tools, **kwargs):
         model = build_chat_model(

--- a/src/xskill/agents/task_cluster_agent.py
+++ b/src/xskill/agents/task_cluster_agent.py
@@ -158,11 +158,8 @@ NewSkillFolder 再添加）。**每个 AtomTask 都必须通过添加工具落�
 - add_tasks_to_skill(skill_name, tasks) — 同一批有多个 atom 归入同一个 skill
   时优先使用；tasks 每项含 atom_id、weightscore，可选 note。整批只读写一次
   candidates 文件，不能把不同目标 skill 混进同一次调用。
-- RenameSkill(old_name, new_name) — **仅 baby 状态可改名**。合并近义 slug 的关键
-  工具：发现两个 baby 同义但 new_name 还没存在 → 把 less-specific 的改成
-  more-specific。如果 new_name 已存在 → 用 MoveTaskTo 而不是 RenameSkill。
 - MoveTaskTo(skill_from, skill_to, atom_id) — 把 atom 从一个 buffer 移到另一个。
-  合并近义 baby 的第二步：两个 baby 都已存在 → MoveTaskTo 把 atom 全搬到主 slug。
+  合并近义 baby 时用 MoveTaskTo 把 atom 全搬到主 slug。
   之后 from baby 空 buffer 但仍存在（保留以防后续 cluster 又往里写）。
 - score_task(atom_id, score) — 修改 atom 自身的 ux_score
 
@@ -202,7 +199,7 @@ NewSkillFolder 再添加）。**每个 AtomTask 都必须通过添加工具落�
   1   atom 跟路由表所有 skill 都没明显交叉。挑 desc 最不远的那个强 add，
       weightscore=1。不要为 ws=1 atom 新开 skill（守住"≥7 才新建"门槛）。
 
-# 处理流程（v2.2 重点：复用 > 整合 > 新建）
+# 处理流程（复用 > 整合 > 新建）
 
 ## Step 1: 看路由表
 - 路由表里所有 baby/main/staging skill 全看一遍，重点找 desc 同类的
@@ -212,12 +209,11 @@ NewSkillFolder 再添加）。**每个 AtomTask 都必须通过添加工具落�
 - 找到 ≥2 个 desc 同类的 baby（近义 slug 泛滥）→ 进入"整合"步骤
 - 没找到合适候选 → 跳到 Step 4
 
-## Step 3: 整合近义 baby（用 RenameSkill / MoveTaskTo）
+## Step 3: 整合近义 baby（用 MoveTaskTo）
 - ReadSkillTasks 查每个 baby 的 buffer 里都有什么 atom——判断哪个 slug 是"主"
 - 选 desc 最精准的 baby 当主 slug
-- **场景 A**：主 slug 名字还不存在 → 把次要 baby 用 RenameSkill 改成主 slug
-- **场景 B**：主 slug 名字已被另一个 baby 占用 → 用 MoveTaskTo 把次要 baby
-  的 atom 全搬到主 slug。次要 baby 留下空 buffer（不删，避免后续 cluster
+- 用 MoveTaskTo 把次要 baby 的 atom 全搬到主 slug。次要 baby 留下空 buffer
+  （不删，避免后续 cluster
   又往里塞重复 atom）
 - 整合完再 add_task_to_skill 把当前 atom 加进主 slug
 
@@ -234,17 +230,16 @@ NewSkillFolder 再添加）。**每个 AtomTask 都必须通过添加工具落�
 
 # 渐进收敛策略
 
-cluster 在 watcher 层**始终串行**（同一目录同时只跑一个 batch），所以你**逐批**
-看到 catalog 演化，每一批都能看见前一批 cluster 的产物。这避免了并发创建近义
-slug。同一批里如给了多个 atom，仍要逐个判断、彼此独立；判断完成后，将归入
-同一个 skill 的 atom 合并成一次 add_tasks_to_skill 调用。
+多个 ClusterAgent 可以并行推理；所有目录修改会进入单线程写入队列。相同 slug 的
+并发创建会按顺序处理，后续请求复用已经创建的目录。同一批里如给了多个 atom，
+仍要逐个判断、彼此独立；判断完成后，将归入同一个 skill 的 atom 合并成一次
+add_tasks_to_skill 调用。
 
 # 硬禁止
 - 不要为了"做点事"乱打高分。低质 atom 就别加，会污染 candidates 触发劣质 skill。
 - 不要伪造 atom_id；只用我给的真实 id。
 - 不要直接写 SKILL.md——那是 SkillEditAgent 的职责。
-- RenameSkill 只对 baby 用；main/staging 工具会拒绝。
-- 两个 baby 都已存在时 → 用 MoveTaskTo 而不是 RenameSkill（避免冲突）。
+- 使用 MoveTaskTo 整合已有 baby；ClusterAgent 暂不提供 rename_skill。
 """
 
 

--- a/src/xskill/api/app.py
+++ b/src/xskill/api/app.py
@@ -937,15 +937,37 @@ def create_app(home_root: Path | str | None = None,
             return {"running": False, "message": "watcher has not started yet"}
         return status
 
+    @app.get("/api/v1/agent-worker/status")
+    async def api_agent_worker_status():
+        from xskill.config import XSKILL_HOME
+        from xskill.utils.status_file import (
+            AGENT_WORKER_STATUS_FILE,
+            read_status_file,
+        )
+
+        status = read_status_file(XSKILL_HOME / AGENT_WORKER_STATUS_FILE)
+        if status is None:
+            return {
+                "running": False,
+                "message": "agent-worker has not started yet",
+            }
+        return status
+
     # -- Usage / cost stats (Issue #43) --
     @app.get("/api/v1/stats")
     async def api_stats():
         # watcher 读常驻子进程心跳；画像仍读短命子进程的最近一轮状态。
         from xskill.config import XSKILL_HOME
         from xskill.utils.status_file import (
-            PROFILE_STATUS_FILE, WATCHER_STATUS_FILE, read_status_file,
+            AGENT_WORKER_STATUS_FILE,
+            PROFILE_STATUS_FILE,
+            WATCHER_STATUS_FILE,
+            read_status_file,
         )
         watcher = read_status_file(XSKILL_HOME / WATCHER_STATUS_FILE)
+        agent_worker = read_status_file(
+            XSKILL_HOME / AGENT_WORKER_STATUS_FILE,
+        )
         profile_refresh = read_status_file(XSKILL_HOME / PROFILE_STATUS_FILE)
 
         def _read_registry_stats():
@@ -957,7 +979,8 @@ def create_app(home_root: Path | str | None = None,
             "role": "server" if _config.get("team", {}).get("server") else "client",
             "cost": cost,
             "models": models,
-            "pipeline": watcher,
+            "pipeline": agent_worker,
+            "watcher": watcher,
             "profile_refresh": profile_refresh,
         }
 
@@ -1150,27 +1173,29 @@ def create_app(home_root: Path | str | None = None,
                 logger.exception("team server context init failed")
                 raise
 
-        # watcher 在常驻子进程中持续运行(python -m xskill._workers watcher)。web
+        # agent-worker 在常驻子进程中持续运行。
         # 进程只留一个轻量守护线程，负责启动、监测和异常退出后重启子进程；重计算
         # 仍与 web 事件循环保持 GIL 隔离。DirectoryWatcher 自己按 poll_interval
         # 持续扫描，Future 跨轮保留，不再等待一批全部结束后才启动下一轮。
         from xskill.pipeline.scheduler import IntervalSubprocessScheduler as _WorkerSched
-        poll_interval = float(_config.get("watcher", {}).get("poll_interval", 30))
-        watcher_command = [_sys.executable, "-m", "xskill._workers", "watcher"]
+        poll_interval = float(_config.get("watcher", {}).get("poll_interval", 5))
+        agent_worker_command = [
+            _sys.executable, "-m", "xskill._workers", "agent-worker",
+        ]
         if team_server:
-            watcher_command.append("--server")
+            agent_worker_command.append("--server")
         else:
-            watcher_command.extend(["--home", str(ecosystem_home_root)])
-        watcher_scheduler = _WorkerSched(
-            "watcher", watcher_command,
+            agent_worker_command.extend(["--home", str(ecosystem_home_root)])
+        agent_worker_scheduler = _WorkerSched(
+            "agent-worker", agent_worker_command,
             interval=poll_interval,
             timeout=5.0,
             persistent=True,
         )
-        watcher_scheduler.start()
-        _schedulers.append(watcher_scheduler)
+        agent_worker_scheduler.start()
+        _schedulers.append(agent_worker_scheduler)
         logger.info(
-            "persistent watcher worker started (team_server=%s, poll every %.0fs)",
+            "persistent agent worker started (team_server=%s, poll every %.0fs)",
             team_server,
             poll_interval,
         )

--- a/src/xskill/config.py
+++ b/src/xskill/config.py
@@ -80,10 +80,12 @@ llm:
   # client_max_retries: 0 # optional; openai-SDK client retries (default 0 —
                          # transient-error retries are handled by xskill's own
                          # retry wrapper; client retries would multiply).
-  # rate_limit:          # optional; absent = unlimited (good for self-hosted)
-  #   rpm: 60            # requests per minute; match your provider plan
-  #   tpm: 100000        # tokens per minute (optional within rate_limit)
-  #   burst: 10          # optional; default = ceil(rate/6)
+  rate_limit:
+    rpm: 240             # requests per minute shared by split/cluster/edit
+    request_burst: 8     # short request burst capacity
+    max_inflight: 8      # simultaneous LLM HTTP requests across all three pools
+    # tpm: 100000        # optional tokens per minute
+    # token_burst: 20000 # optional token burst capacity (separate from requests)
   # See docs/adr/0001-rate-limit-diy-not-litellm.md for the design rationale.
 
 # ===== Embedding (vector retrieval) =====
@@ -99,6 +101,8 @@ embedding:
   model:    text-embedding-v4
   api_key:  PUT_YOUR_EMBEDDING_API_KEY_HERE
   dim:      0
+  rate_limit:
+    max_inflight: 4      # embedding HTTP concurrency, independent from LLM
   # api: openai | multimodal   # optional; default openai. "multimodal" for
                                # vision-style embedding endpoints.
   # max_embed: 2               # optional; skill_hub/search 语义通道的全局并发上限
@@ -172,25 +176,27 @@ server:
   profile_refresh_interval: 600    # 画像短命子进程调度周期(秒;画像变化慢,默认 10min,与 watcher 解耦)
   profile_refresh_timeout: 1800    # 单轮画像子进程硬上限(秒;冷启动大量 client 兜底)
 
-# ===== Watcher (the directory poller inside `serve`) =====
+# ===== Watcher (scan scheduling only) =====
 watcher:
-  poll_interval:  30            # seconds between scans of every watch_dir
-  max_concurrent: 4             # parallel LLM calls per scan. Conservative
-                                # placeholder that pairs with llm.rate_limit
-                                # above. Raise to 20-30 for self-hosted vLLM
-                                # or accounts with no concurrency cap. See
-                                # docs/adr/0001-rate-limit-diy-not-litellm.md
-  # cluster_batch_size: 8       # atoms consumed per ClusterAgent call. The
-                                # watcher pools un-clustered atoms ACROSS all
-                                # indexed trajectories, drops those already in a
-                                # skill's .candidates.yml, then feeds up to N at
-                                # a time to ONE ClusterAgent (one LLM round-trip
-                                # handles N atom positions instead of one). The
-                                # agent still reads each atom's content on demand
-                                # via tools — only the positions are batched.
-                                # Clustering stays serial (one batch in flight per
-                                # watch dir). Default 8; set 1 for the old
-                                # one-atom-per-call behavior.
+  poll_interval: 5              # seconds between scans of every watch_dir
+
+# ===== Persistent agent worker =====
+# Every pool has an automatic waiting capacity of workers * 2. Running plus
+# waiting capacity is workers * 3; a full pool never blocks the watcher.
+agent_worker:
+  pools:
+    split:
+      workers: 24
+      llm_weight: 6
+    cluster:
+      workers: 8
+      batch_size: 8
+      llm_weight: 3
+    edit:
+      workers: 4
+      llm_weight: 1
+    embed:
+      workers: 4
 
 # ===== Ingest (bridging native agent sessions into traj_*.md) =====
 # 各生态 session ingester（claude_code / codex / openclaw / cursor 的 JSONL
@@ -266,6 +272,95 @@ def ensure_config_exists(path: Optional[Path] = None) -> bool:
     return False
 
 
+def _positive_int(value, path: str) -> int:
+    if isinstance(value, bool) or not isinstance(value, int) or value <= 0:
+        raise ValueError(f"{path} 必须是正整数")
+    return value
+
+
+def agent_worker_config(config_data: dict) -> dict:
+    """Validate and normalize the v0.6.28 four-pool configuration."""
+    if not isinstance(config_data, dict):
+        raise ValueError("config.yaml 顶层必须是 mapping")
+    watcher = config_data.get("watcher") or {}
+    if not isinstance(watcher, dict):
+        raise ValueError("watcher 必须是 mapping")
+    if "max_concurrent" in watcher:
+        raise ValueError(
+            "旧配置 watcher.max_concurrent 已移除；请分别配置 "
+            "agent_worker.pools.split/cluster/edit/embed.workers"
+        )
+    if "cluster_batch_size" in watcher:
+        raise ValueError(
+            "旧配置 watcher.cluster_batch_size 已移至 "
+            "agent_worker.pools.cluster.batch_size"
+        )
+
+    for llm_path, llm_cfg in (
+        ("llm", config_data.get("llm") or {}),
+        ("llm_skill", config_data.get("llm_skill") or {}),
+    ):
+        if not isinstance(llm_cfg, dict):
+            raise ValueError(f"{llm_path} 必须是 mapping")
+        rate_cfg = llm_cfg.get("rate_limit") or {}
+        if not isinstance(rate_cfg, dict):
+            raise ValueError(f"{llm_path}.rate_limit 必须是 mapping")
+        if "burst" in rate_cfg:
+            raise ValueError(
+                f"旧配置 {llm_path}.rate_limit.burst 已移除；请求突发量改用 "
+                f"{llm_path}.rate_limit.request_burst，TPM 突发量单独使用 "
+                f"{llm_path}.rate_limit.token_burst"
+            )
+
+    worker = config_data.get("agent_worker")
+    if not isinstance(worker, dict) or not isinstance(worker.get("pools"), dict):
+        raise ValueError(
+            "缺少 agent_worker.pools；请配置 split、cluster、edit、embed 四个池"
+        )
+    pools = worker["pools"]
+    normalized: dict[str, dict] = {}
+    for name in ("split", "cluster", "edit", "embed"):
+        pool = pools.get(name)
+        if not isinstance(pool, dict):
+            raise ValueError(f"缺少 agent_worker.pools.{name}")
+        if "queue_size" in pool:
+            raise ValueError(
+                f"不接受 agent_worker.pools.{name}.queue_size；等待容量自动为 workers × 2"
+            )
+        normalized[name] = dict(pool)
+        normalized[name]["workers"] = _positive_int(
+            pool.get("workers"), f"agent_worker.pools.{name}.workers"
+        )
+        if name in ("split", "cluster", "edit"):
+            normalized[name]["llm_weight"] = _positive_int(
+                pool.get("llm_weight"),
+                f"agent_worker.pools.{name}.llm_weight",
+            )
+    normalized["cluster"]["batch_size"] = _positive_int(
+        pools["cluster"].get("batch_size"),
+        "agent_worker.pools.cluster.batch_size",
+    )
+
+    llm_rate = (config_data.get("llm") or {}).get("rate_limit")
+    if not isinstance(llm_rate, dict):
+        raise ValueError("缺少 llm.rate_limit")
+    for key in ("rpm", "request_burst", "max_inflight"):
+        _positive_int(llm_rate.get(key), f"llm.rate_limit.{key}")
+    if "tpm" in llm_rate:
+        _positive_int(llm_rate["tpm"], "llm.rate_limit.tpm")
+    if "token_burst" in llm_rate:
+        _positive_int(llm_rate["token_burst"], "llm.rate_limit.token_burst")
+
+    embedding_rate = (config_data.get("embedding") or {}).get("rate_limit")
+    if not isinstance(embedding_rate, dict):
+        raise ValueError("缺少 embedding.rate_limit.max_inflight")
+    _positive_int(
+        embedding_rate.get("max_inflight"),
+        "embedding.rate_limit.max_inflight",
+    )
+    return {"pools": normalized}
+
+
 def load_config(path: Optional[Path] = None) -> dict:
     """加载 ~/.xskill/config.yaml；不存在直接抛 FileNotFoundError。
 
@@ -282,6 +377,7 @@ def load_config(path: Optional[Path] = None) -> dict:
         )
     with open(cfg_path, encoding="utf-8") as f:
         _config = yaml.safe_load(f) or {}
+    agent_worker_config(_config)
     if not _config.get("llm", {}).get("api_key"):
         raise KeyError(f"llm.api_key missing in {cfg_path}")
     if not _config.get("embedding", {}).get("api_key"):

--- a/src/xskill/dashboard/console.py
+++ b/src/xskill/dashboard/console.py
@@ -219,9 +219,11 @@ class ConfigPayload(BaseModel):
 
 
 # 热加载范围显式声明(2.9):这些段改完即生效(读方每次现取);
-# llm/watch_dirs 涉及进程级资源(client 连接池/watcher 注册),改动需重启 serve。
+# llm/embedding/agent_worker/watcher 涉及进程级资源，改动需重启 serve。
 HOT_RELOAD_SECTIONS = ("dashboard", "canary", "recommend", "skillhub")
-RESTART_SECTIONS = ("llm", "llm_skill", "embedding", "watcher", "team")
+RESTART_SECTIONS = (
+    "llm", "llm_skill", "embedding", "watcher", "agent_worker", "team",
+)
 # team 段整体是重启域(join_token/路径/registry 接线),但这几个子键是纯调优数字,
 # 由 api.live_manifest_tuning() 每请求现取 → 改它们不需要重启。只有改到 team
 # 下的其它子键才真要重启,否则 needs_restart 会把已经热的改动误标成要重启。

--- a/src/xskill/ecosystems/claude_code.py
+++ b/src/xskill/ecosystems/claude_code.py
@@ -479,9 +479,9 @@ def _prepend_xskill_header(
 ) -> bool:
     """把 ``<!-- xskill:skill=X side=Y sha=Z -->`` 注到 traj_*.md 顶部。
 
-    watcher._score_new 通过 parse_traj_header 抽这个 marker 来决定要不要给
-    这条 traj 跑 LLM ux 评分。CC native 桥过来的 traj 默认没有 header，
-    ingester 在确认 session 应当被哪 side 标注后补上。
+    watcher 通过 parse_traj_header 抽这个 marker 来决定 TaskAgent 生成的
+    atom ux_score 应归因到哪个 side。CC native 桥过来的 traj 默认没有
+    header，ingester 在确认 session 应当被哪 side 标注后补上。
     """
     header = f"<!-- xskill:skill={skill} side={side} sha={sha} -->\n"
     text = traj_md_path.read_text(encoding="utf-8")
@@ -879,7 +879,7 @@ class CCSessionIngester:
     3. 对每条新桥的 traj：用 ``install_history.lookup(session_start_t)``
        倒查"那一刻 daemon 给这个 skill 装的是哪 side"，把
        ``<!-- xskill:skill=X side=Y sha=Z -->`` 注到 traj_*.md 顶部——
-       这是 watcher._score_new 触发 LLM ux 评分的唯一门槛。
+       这是 watcher 将 TaskAgent ux_score 归因到对应 side 的唯一门槛。
     4. **翻牌子**：对每个 staging-active 的 skill，往 history 查当前 side，
        下次装 install_to_claude_code(side=opposite) + history.record。
 
@@ -1535,7 +1535,7 @@ class CCSessionIngester:
                 rec["xskill_used_skill"] = False
                 continue
 
-            # 真用了 → 打 header 让 watcher._score_new 触发 ux 评分员
+            # 真用了 → 打 header，让 watcher 归因 TaskAgent 已生成的 ux_score
             traj_md = Path(rec["path"])
             _prepend_xskill_header(traj_md, skill=canary_skill, side=side, sha=sha)
             rec["xskill_used_skill"] = True

--- a/src/xskill/pipeline/runner.py
+++ b/src/xskill/pipeline/runner.py
@@ -2,7 +2,7 @@
 pipeline/runner.py -- 流水线式目录监听器 + AtomTask 流水线核心入口
 ====================================================================
 
-每条轨迹独立流转，不分批不阻塞：
+每条轨迹独立流转，四类任务互不占用线程：
 
   discovered → meta_extracting → meta_done → indexed → processing → done
 
@@ -11,10 +11,10 @@ pipeline/runner.py -- 流水线式目录监听器 + AtomTask 流水线核心入�
   2. 对每条 discovered 提交 meta 提取任务（不等待）
   3. 对每条 meta_done 提交 embedding 任务（不等待）
   4. 对每条 indexed 提交 process_traj 任务（不等待）
-  5. 收割已完成的 futures，更新状态
+  5. 提交全局 Cluster batch、收割已完成的 futures
   6. 解析 xskill header → ux_score
 
-所有耗时操作都在 ThreadPoolExecutor 中异步执行，扫描本身秒完。
+split / cluster / edit / embed 各自在独立的有界线程池中异步执行。
 
 本模块还含 AtomTask 流水线核心入口 ``process_atom_task``（原 process.py）：
 v2 (AtomTask) 流水线下，对一个 atom 的"cluster → 触发 SkillEdit"是单一原子
@@ -26,9 +26,11 @@ from __future__ import annotations
 import asyncio
 import hashlib
 import logging
+import os
 import threading
 import time
-from concurrent.futures import Future, ThreadPoolExecutor
+from collections import deque
+from concurrent.futures import Future
 from pathlib import Path
 
 from xskill.config import (
@@ -85,14 +87,13 @@ class DirectoryWatcher:
     - splitting 阶段调 TaskAgent 拆 AtomTask，落盘到 ``<traj_root>/<traj_id>/tasks/``
     - indexed 阶段以 AtomTask 为单位整批重建 ``<traj_root>/index.pkl``
     - cluster 阶段**跨轨迹池化**：把所有 indexed 轨迹里尚未落地的 atom 汇成一池，
-      按 ``cluster_batch_size`` 分批，逐批喂**一个** ClusterAgent（串行，同 wd
-      同时只一个 batch future），一次 LLM 往返处理多个 atom 的位置。
-    - indexed → done 由 ``_sweep_done_trajs`` 标：一条轨迹的 atom 全部落进某个
+      按 ``cluster.batch_size`` 分批，提交给全局 cluster pool。
+    - indexed → done 由 ``_finalize_completed_trajs`` 标：一条轨迹的 atom 全部落进某个
       skill 的 ``.candidates.yml`` 时才 done（文件系统即队列，天然去重+断点续传）。
     """
 
     def __init__(self, *, llm=None, embed_client=None, config=None,
-                 skill_dir=None, poll_interval=30.0, max_concurrent=30,
+                 skill_dir=None, poll_interval=5.0, pool_config=None,
                  max_retries=3, db_path=None,
                  store=None, agno_agent_factory=None, home_root=None,
                  xskill_home=None, config_path=None,
@@ -100,7 +101,7 @@ class DirectoryWatcher:
                  spill_root=None,
                  usage_ledger=None,
                  server_mode=False, install_history_path=None,
-                 on_poll_hook=None, cluster_batch_size=8):
+                 on_poll_hook=None):
         self.llm = llm
         self.embed_client = embed_client
         self.usage_ledger = usage_ledger
@@ -146,7 +147,6 @@ class DirectoryWatcher:
             else xskill_state_root / "tmp" / "spill"
         ).expanduser().resolve()
         self.poll_interval = poll_interval
-        self.max_concurrent = max_concurrent
         self.max_retries = max_retries
         self.db_path = db_path
         # 每轮 _loop 在 _scan_once 之前调一次的钩子，用来让 server 端的"生态
@@ -155,12 +155,14 @@ class DirectoryWatcher:
         # 钩子抛异常不应导致 watcher 死循环退出——catch 后只记日志。
         self.on_poll_hook = on_poll_hook
 
-        # 每次 ClusterAgent 调用消费的 atom 数（位置批量，非内容）。watcher 把所有
-        # indexed 轨迹里"尚未落进任何 skill .candidates.yml"的 atom 汇成一个跨轨迹
-        # 池，每批取 ≤ cluster_batch_size 条喂一个 ClusterAgent——一次 LLM 往返处理
-        # 多个 atom 的位置，减少往返次数提速。聚类仍串行（同 wd 同时只一个 batch
-        # future）。1 = 退回逐 atom 一次往返的旧行为。
-        self.cluster_batch_size = max(1, int(cluster_batch_size))
+        default_pools = {
+            "split": {"workers": 24, "llm_weight": 6},
+            "cluster": {"workers": 8, "batch_size": 8, "llm_weight": 3},
+            "edit": {"workers": 4, "llm_weight": 1},
+            "embed": {"workers": 4},
+        }
+        self.pool_config = pool_config or default_pools
+        self.cluster_batch_size = int(self.pool_config["cluster"]["batch_size"])
         self.interests = interests_config(self.config)
         self.interest_fingerprint = interests_fingerprint(self.interests)
 
@@ -172,10 +174,19 @@ class DirectoryWatcher:
         self._stop = threading.Event()
         self._pause = threading.Event()
         self._thread: threading.Thread | None = None
-        self._pool = ThreadPoolExecutor(
-            max_workers=max_concurrent, initializer=_install_thread_event_loop)
+        from xskill.pipeline.worker_runtime import BoundedExecutor, ClusterWriteQueue
+        self._pools = {
+            name: BoundedExecutor(name, int(self.pool_config[name]["workers"]))
+            for name in ("split", "cluster", "edit", "embed")
+        }
+        self.cluster_write_queue = ClusterWriteQueue()
         self._futures: dict[Future, dict] = {}
+        # Only the watcher thread mutates these scheduling collections.
+        self.pending_atoms: deque[str] = deque()
+        self.claimed_atoms: set[str] = set()
+        self.cluster_futures: set[Future] = set()
         self._last_poll: float | None = None
+        self._started_at = time.time()
         # 单机 canary 轮转节流：上次真跑 _reconcile_skill_sides 的时间戳。
         # None = 从未跑过（首轮 scan 必跑一次）。
         self._last_rotate_ts: float | None = None
@@ -194,7 +205,7 @@ class DirectoryWatcher:
         self._stop.clear()
         self._thread = threading.Thread(target=self._loop, daemon=True, name="xskill-watcher")
         self._thread.start()
-        logger.info("watcher started (interval=%.1fs, concurrent=%d)", self.poll_interval, self.max_concurrent)
+        logger.info("watcher started (interval=%.1fs, four independent pools)", self.poll_interval)
 
     def stop(self):
         self._stop.set()
@@ -204,7 +215,9 @@ class DirectoryWatcher:
             self._thread.join(timeout=5)
         # cancel_futures：排队未跑的任务直接丢弃。在跑的 worker 由
         # SHUTTING_DOWN 事件叫停（agno_factory 重试循环），不在这里等。
-        self._pool.shutdown(wait=False, cancel_futures=True)
+        for pool in self._pools.values():
+            pool.shutdown(wait=False, cancel_futures=True)
+        self.cluster_write_queue.shutdown(wait=False)
         logger.info("watcher stopped")
 
     def pause(self):
@@ -225,12 +238,33 @@ class DirectoryWatcher:
 
     @property
     def stats(self):
+        """Watcher-only scan state retained by ``/watcher/status``."""
         return {
             **self._stats,
-            "last_poll": self._last_poll,
+            "last_scan": self._last_poll,
+            "scans": self._stats["polls"],
             "running": self.is_running,
             "paused": self.is_paused,
-            "in_flight": len(self._futures),
+        }
+
+    @property
+    def agent_worker_status(self):
+        from xskill.utils.rate_limit import request_limiter_status
+
+        return {
+            "pid": os.getpid(),
+            "started_at": self._started_at,
+            "heartbeat_at": time.time(),
+            "watcher": self.stats,
+            "pools": {name: pool.status for name, pool in self._pools.items()},
+            "cluster": {
+                "pending_atoms": len(self.pending_atoms),
+                "claimed_atoms": len(self.claimed_atoms),
+                "running_batches": len(self.cluster_futures),
+            },
+            "cluster_write_queue": self.cluster_write_queue.status,
+            "llm": request_limiter_status("llm"),
+            "embedding": request_limiter_status("embedding"),
         }
 
     def _db_kw(self):
@@ -294,13 +328,29 @@ class DirectoryWatcher:
         from xskill.skill.candidates import LazyConsumedIndex
         consumed_index = LazyConsumedIndex(self.skill_dir)
 
-        # ── Step 1-4: 对每个目录扫描 + 提交任务 ──
-        for wd in list_watch_dirs(**kw):
+        # ── Step 1-4: 对每个目录扫描 + 提交 split/embed + 收集 cluster atom ──
+        watch_dirs = list_watch_dirs(**kw)
+        active_watch_dirs = []
+        for wd in watch_dirs:
             if self._stop.is_set():
                 break
             if not wd.get("auto_index"):
                 continue
+            active_watch_dirs.append(wd)
             self._scan_dir(wd, consumed_index, **kw)
+
+        # 全部 watch_dir 共用一个 pending/claimed 队列；持续提交到 cluster 池满。
+        # 最后不足 batch_size 的尾批也立即提交。
+        self._submit_cluster_batches()
+
+        # 已完成归类的轨迹在下一次 durable atom 检查中进入 done。
+        if self.skill_dir:
+            for wd in active_watch_dirs:
+                dir_path = Path(wd["path"])
+                if dir_path.is_dir():
+                    self._finalize_completed_trajs(
+                        wd["id"], dir_path, consumed_index, **kw,
+                    )
 
         # ── Step 5: 独立扫所有 skill 目录的 candidates buffer ──
         # 这步与具体 atom 处理解耦：即便某些 atom cluster 失败，buffer
@@ -482,7 +532,9 @@ class DirectoryWatcher:
         for d in skill_dirs:
             if d in skill_edit_in_flight:
                 continue
-            fut = self._pool.submit(_run_one, d)
+            fut = self._pools["edit"].submit(_run_one, d)
+            if fut is None:
+                break
             self._futures[fut] = {"stage": "skill_edit", "skill_dir": d}
 
     def _on_skill_edit_done(self, result) -> None:
@@ -1782,7 +1834,7 @@ class DirectoryWatcher:
 
         cluster batch 与 split/embed 不同：一个 batch future 覆盖一批跨轨迹的
         atom，没有单一 fname。它只负责"把 atom 写进 candidates"（agent 用工具
-        完成）+ 记日志；轨迹 done 由 ``_sweep_done_trajs`` 独立核对落地情况后标。
+        完成）+ 记日志；轨迹 done 由 ``_finalize_completed_trajs`` 独立核对落地情况后标。
         batch 整体抛异常（如 LLM 余额耗尽）时，atom 留在未落地池，下一轮 scan
         重新进池重试——无单独重试计数，靠重池化自愈（cluster prompt 要求每个
         atom 必落地，永久失败不会发生，失败都是瞬时的）。
@@ -1793,6 +1845,8 @@ class DirectoryWatcher:
             stage = info["stage"]
             kw = self._db_kw()
             if stage == "cluster":
+                atom_ids = list(info.get("atom_ids") or [])
+                self.cluster_futures.discard(fut)
                 try:
                     self._on_cluster_batch_done(fut.result(timeout=0))
                 except Exception as e:
@@ -1800,8 +1854,12 @@ class DirectoryWatcher:
                     logger.warning(
                         "cluster batch failed (%d atoms); atoms stay unlanded, "
                         "will re-pool next scan: %s",
-                        len(info.get("atom_ids") or []), e,
+                        len(atom_ids), e,
                     )
+                finally:
+                    # Successful writes now have durable ``clustered`` markers;
+                    # failures and silent drops are eligible for the next scan.
+                    self.claimed_atoms.difference_update(atom_ids)
                 continue
             if stage == "skill_edit":
                 # SkillEditAgent.maybe_run() 自己吞异常返回 (d, False)——正常
@@ -1852,7 +1910,7 @@ class DirectoryWatcher:
                 update_traj_status(wd_id, fname, "discovered", **kw)
 
         # 跨轨迹批处理下 watcher 不再把轨迹置 "clustering"（done 由
-        # _sweep_done_trajs 按 atom 落地情况标）。任何遗留的 "clustering"
+        # _finalize_completed_trajs 按 atom 落地情况标）。任何遗留的 "clustering"
         # （旧 daemon 升级残留 / 历史数据）一律回退 "indexed" 让其重新进池——
         # 已落地的 atom 会在 _collect_cluster_batch 被去重跳过，不会重复消费。
         for fname in get_trajs_by_status(wd_id, "clustering", **kw):
@@ -1877,10 +1935,10 @@ class DirectoryWatcher:
         if self.llm is not None:
             for status in ("discovered", "updated"):
                 for fname in get_trajs_by_status(
-                    wd_id, status, limit=self.max_concurrent * 2, **kw,
+                    wd_id, status,
+                    limit=self._pools["split"].total_capacity,
+                    **kw,
                 ):
-                    if self._too_many_in_flight():
-                        break
                     validation = validate_trajectory_source(dir_path / fname)
                     if not validation.valid:
                         update_traj_status(
@@ -1893,8 +1951,12 @@ class DirectoryWatcher:
                             fname, validation.reason,
                         )
                         continue
+                    fut = self._pools["split"].submit(
+                        self._do_split, dir_path, fname,
+                    )
+                    if fut is None:
+                        break
                     update_traj_status(wd_id, fname, "splitting", **kw)
-                    fut = self._pool.submit(self._do_split, dir_path, fname)
                     self._futures[fut] = {
                         "wd_id": wd_id, "fname": fname, "stage": "split",
                     }
@@ -1905,42 +1967,21 @@ class DirectoryWatcher:
             if split_done_files and not any(
                 i["stage"] == "embed" and i["wd_id"] == wd_id for i in self._futures.values()
             ):
-                fut = self._pool.submit(self._do_atom_index, dir_path, wd_id,
-                                         split_done_files)
-                self._futures[fut] = {"wd_id": wd_id, "fname": "_batch_embed", "stage": "embed"}
-
-        # ── Cluster：跨轨迹池化 + 单批串行 ──
-        # 把所有 indexed 轨迹里"尚未落进任何 skill .candidates.yml"的 atom 汇成
-        # 一个跨轨迹池，取 ≤ cluster_batch_size 条喂给**一个** ClusterAgent 调用
-        # （一次 LLM 往返处理多个 atom 的位置）。同 wd 同时只允许一个 cluster
-        # batch future 在飞（串行——逐批让 catalog 演化可见，避免并发 agent 各自
-        # 创建近义 baby slug）。轨迹 done 不在这里标，交给 _sweep_done_trajs。
-        if self.skill_dir:
-            cluster_in_flight = any(
-                i["stage"] == "cluster" and i["wd_id"] == wd_id
-                for i in self._futures.values()
-            )
-            if not cluster_in_flight and not self._too_many_in_flight():
-                batch = self._collect_cluster_batch(dir_path, wd_id, consumed_index, **kw)
-                if batch:
-                    fut = self._pool.submit(self._do_cluster_batch, dir_path, batch)
+                fut = self._pools["embed"].submit(
+                    self._do_atom_index, dir_path, wd_id, split_done_files,
+                )
+                if fut is not None:
                     self._futures[fut] = {
-                        "wd_id": wd_id, "stage": "cluster", "atom_ids": batch,
+                        "wd_id": wd_id,
+                        "fname": "_batch_embed",
+                        "stage": "embed",
                     }
-                    cluster_in_flight = True
 
-            # ── done 标记：轨迹的 atom 全部落地 → done（+ 触发 ux 打分）──
-            # Windows 对正在被 cluster future 原子替换的 atom JSON 会报
-            # PermissionError；等 future 被 harvest 后下一轮再扫描。
-            if not cluster_in_flight:
-                self._sweep_done_trajs(wd_id, dir_path, consumed_index, **kw)
-
-        # ── ux_score（对有 xskill header 的新轨迹）──
-        if self.llm and self.skill_dir and new:
-            self._score_new(wd_id, dir_path, new, **kw)
-
-    def _too_many_in_flight(self):
-        return len(self._futures) >= self.max_concurrent * 3
+        # ── Cluster：只收集到全局 pending，不在目录循环内等待或串行 ──
+        if self.skill_dir:
+            self._collect_cluster_atoms(
+                dir_path, wd_id, consumed_index, **kw,
+            )
 
     # ───────────────────────────────────────────────────────────
     # Helpers: store / agno factory 按需获取
@@ -2066,9 +2107,8 @@ class DirectoryWatcher:
         store.rebuild_vector_index(self.embed_client)
         return (wd_id, filenames)
 
-    def _collect_cluster_batch(self, dir_path, wd_id, consumed_index, **kw):
-        """跨所有 indexed 轨迹收集"尚未落进任何 skill .candidates.yml"的 atom，
-        按 ``cluster_batch_size`` 截断，返回 atom_id 列表（≤ batch_size）。
+    def _collect_cluster_atoms(self, dir_path, wd_id, consumed_index, **kw):
+        """Collect every new unclustered atom into the global pending queue.
 
         过滤靠 atom 的耐久 ``clustered`` 标记——已消费 atom（含上一批刚写入的、
         以及进程被 kill 前已消费的）一律跳过。这从机制上同时实现了**去重**与
@@ -2077,19 +2117,37 @@ class DirectoryWatcher:
         ``.candidates.yml`` 成员判定——后者会被 SkillEdit 晋升清空，会让已消费
         atom 看起来又"未消费"而被重复送 LLM。
 
-        "待消费 ≥ batch_size 取 batch_size，< batch_size 全取"。
+        ``claimed_atoms`` covers both pending and running batches, so repeated
+        scans never enqueue the same atom twice.
         """
         store = self._store_for(dir_path)
-        batch: list[str] = []
         for fname in get_trajs_by_status(wd_id, "indexed", **kw):
             traj_id = (dir_path / fname).stem
             for atom in store.list_by_traj(traj_id):
                 if self._atom_consumed(atom, consumed_index):
                     continue  # 已消费 → 跳过（去重 + 断点续传）
-                batch.append(atom.atom_id)
-                if len(batch) >= self.cluster_batch_size:
-                    return batch
-        return batch
+                if atom.atom_id in self.claimed_atoms:
+                    continue
+                self.claimed_atoms.add(atom.atom_id)
+                self.pending_atoms.append(atom.atom_id)
+
+    def _submit_cluster_batches(self) -> None:
+        """Fill the cluster pool without ever waiting in the watcher thread."""
+        while self.pending_atoms:
+            batch_size = min(self.cluster_batch_size, len(self.pending_atoms))
+            atom_ids = list(self.pending_atoms)[:batch_size]
+            future = self._pools["cluster"].submit(
+                self._do_cluster_batch, atom_ids,
+            )
+            if future is None:
+                return
+            for _ in atom_ids:
+                self.pending_atoms.popleft()
+            self._futures[future] = {
+                "stage": "cluster",
+                "atom_ids": atom_ids,
+            }
+            self.cluster_futures.add(future)
 
     def _atom_consumed(self, atom, consumed_index) -> bool:
         """atom 是否已被 cluster 消费。耐久标记 ``clustered`` 为主（O(1)，扛得住
@@ -2101,7 +2159,7 @@ class DirectoryWatcher:
             return True
         return consumed_index.contains(atom.atom_id)
 
-    def _do_cluster_batch(self, dir_path, atom_ids):
+    def _do_cluster_batch(self, atom_ids):
         """对一批（可能跨多条轨迹）atom 调**一个** ClusterAgent，只跑 cluster。
 
         把"逐 atom 一次 LLM 往返"压成"一批一次往返"。edit 触发独立由
@@ -2112,7 +2170,16 @@ class DirectoryWatcher:
 
         返回 ``[result_dict, ...]``（顺序同 atom_ids）。
         """
-        store = self._store_for(dir_path)
+        from xskill.pipeline.atom import MultiAtomTaskStore
+
+        stores = [
+            self._store_for(Path(wd["path"]))
+            for wd in list_watch_dirs(**self._db_kw())
+            if wd.get("auto_index") and Path(wd["path"]).is_dir()
+        ]
+        if not stores:
+            raise RuntimeError("cluster batch has no active AtomTaskStore")
+        store = stores[0] if len(stores) == 1 else MultiAtomTaskStore(stores)
         factory = self._factory()
         return process_atom_batch(
             atom_ids=atom_ids,
@@ -2125,6 +2192,7 @@ class DirectoryWatcher:
             usage_ledger=self.usage_ledger,
             logs_dir=self.logs_dir,
             spill_root=self.spill_root,
+            cluster_write_queue=self.cluster_write_queue,
         )
 
     # ───────────────────────────────────────────────────────────
@@ -2185,7 +2253,7 @@ class DirectoryWatcher:
         轨迹状态。
 
         轨迹 done 与具体 batch 解耦——一个 batch 跨多条轨迹，done 由
-        ``_sweep_done_trajs`` 按"该轨迹 atom 是否全落地"独立判定。
+        ``_finalize_completed_trajs`` 按"该轨迹 atom 是否全落地"独立判定。
         """
         n_total = len(results)
         in_skills = [r for r in results if r.get("skill_name")]
@@ -2215,7 +2283,7 @@ class DirectoryWatcher:
             )
         self._stats["atoms_clustered"] += len(in_skills)
 
-    def _sweep_done_trajs(self, wd_id, dir_path, consumed_index, **kw):
+    def _finalize_completed_trajs(self, wd_id, dir_path, consumed_index, **kw):
         """把"所有 atom 都已落进某个 skill .candidates.yml"的 indexed 轨迹标
         done，并触发该轨迹的 ux 打分。
 
@@ -2247,15 +2315,6 @@ class DirectoryWatcher:
     # ux_score
     # ───────────────────────────────────────────────────────────
 
-    def _score_new(self, _watch_dir_id, _dir_path, _filenames, **_kwargs):
-        """v2: 不在发现新 traj 时打分（那时 atom 还没拆）。
-
-        实际打分在 ``_sweep_done_trajs`` → ``_score_atoms_for_traj`` 触发。
-        此方法保留 hook 兼容 ``_scan_dir`` 末尾的调用；只在 traj 没有
-        ``xskill:`` header 时早返回，避免无谓 IO。
-        """
-        return  # noop: 打分时机改到 cluster 完成后
-
     def _score_atoms_for_traj(self, wd_id, fname, **kw):
         """对一条已跑完 cluster 的 traj 扫所有 atom 打 ux_score。
 
@@ -2263,7 +2322,8 @@ class DirectoryWatcher:
         - traj.md 顶部含 ``<!-- xskill:skill=X side=Y sha=Z -->`` header
         - 该 traj 已拆出 atom
 
-        每个 atom 独立调 ``score_atom`` + ``AtomCanary.append``。同一 atom
+        每个 atom 直接使用 TaskAgent 拆分时生成的 ``ux_score``，再调
+        ``AtomCanary.append``。同一 atom
         在同 (skill, side) 上幂等：``AtomCanary.append`` 自带去重。
         所有 atom 处理完调一次 ``check_and_decide`` 让 staging 该升的升 /
         该弃的弃。
@@ -2273,9 +2333,8 @@ class DirectoryWatcher:
         sha = ``SKILL.md`` 内容哈希前 16 位）。两处都无 → 该 skill 未装/未索引，
         跳过（不报错）。
         """
-        if self.llm is None or self.skill_dir is None:
+        if self.skill_dir is None:
             return
-        from xskill.pipeline.atom import score_atom
         from xskill.canary import AtomCanary
         # 找到该 wd 的 dir_path
         for wd in list_watch_dirs(**kw):
@@ -2305,18 +2364,16 @@ class DirectoryWatcher:
         new_scores: list[float] = []
         for atom in atoms:
             try:
-                result = score_atom(
-                    llm=self.llm, atom=atom, side=side,
-                )
-                if result["score"] is None:
+                if atom.ux_score is None:
                     continue
                 if ac.append(
                     atom_id=atom.atom_id, skill_name=skill_name,
                     side=side, commit_sha=commit_sha,
-                    score=result["score"], reasons=result["reasons"],
+                    score=atom.ux_score,
+                    reasons=["TaskAgent split ux_score"],
                     user_model=atom.source_model,
                 ):
-                    new_scores.append(float(result["score"]))
+                    new_scores.append(float(atom.ux_score))
                 self._stats["scores"] += 1
             except Exception:
                 logger.exception("score_atom failed: %s/%s",
@@ -2366,11 +2423,10 @@ class DirectoryWatcher:
         路由），未命中再查三方 ``skillhub_dir/<name>``（无 git → side 恒 ``main``、
         sha = 内容哈希）。两处都无 → 跳过该 skill（不报错）。
         """
-        if self.llm is None or self.skill_dir is None:
+        if self.skill_dir is None:
             return
         from xskill.canary import AtomCanary
         from xskill.canary import CanaryConfig, eligible_models
-        from xskill.pipeline.atom import score_atom
         from xskill.pipeline.registry import model_share
         from xskill.recommend.skillhub import SkillHub
 
@@ -2408,19 +2464,19 @@ class DirectoryWatcher:
                 if skill_sub is None:
                     continue
                 try:
-                    result = score_atom(llm=self.llm, atom=atom, side=side)
-                    if result["score"] is None:
+                    if atom.ux_score is None:
                         continue
                     if AtomCanary(skill_dir=skill_sub).append(
                         atom_id=atom.atom_id, skill_name=skill_name,
                         side=side, commit_sha=sha,
-                        score=result["score"], reasons=result["reasons"],
+                        score=atom.ux_score,
+                        reasons=["TaskAgent split ux_score"],
                         user_model=atom.source_model,
                     ):
                         entry = new_by_skill.setdefault(
                             skill_name,
                             {"scores": [], "side": side, "sha": sha})
-                        entry["scores"].append(float(result["score"]))
+                        entry["scores"].append(float(atom.ux_score))
                     self._stats["scores"] += 1
                     used_any = True
                 except Exception:
@@ -2505,10 +2561,13 @@ def process_atom_task(*, atom_id: str, config: dict, skill_dir: Path,
                       db_path: Path | None = None,
                       usage_ledger=None,
                       logs_dir: Path | None = None,
-                      spill_root: Path | None = None) -> dict:
+                      spill_root: Path | None = None,
+                      cluster_write_queue=None) -> dict:
     """Run one atom with an isolated AgentToolContext."""
     from xskill.agents import agent_tools
 
+    from xskill.pipeline.worker_runtime import ClusterResultRecorder
+    recorder = ClusterResultRecorder()
     tool_context = agent_tools.create_agent_tool_context(
         skill_dir=skill_dir,
         data_dir=skill_dir,
@@ -2518,6 +2577,8 @@ def process_atom_task(*, atom_id: str, config: dict, skill_dir: Path,
         default_traj_root=store.root,
         spill_root=spill_root,
         usage_ledger=usage_ledger,
+        cluster_write_queue=cluster_write_queue,
+        cluster_result_recorder=recorder,
     )
     with agent_tools.use_agent_tool_context(tool_context):
         return _process_atom_task_bound(
@@ -2529,6 +2590,7 @@ def process_atom_task(*, atom_id: str, config: dict, skill_dir: Path,
             agno_agent_factory=agno_agent_factory,
             db_path=db_path,
             logs_dir=logs_dir,
+            cluster_result_recorder=recorder,
         )
 
 
@@ -2536,7 +2598,8 @@ def _process_atom_task_bound(*, atom_id: str, config: dict,
                              skill_dir: Path, store, embed_client,
                              agno_agent_factory,
                              db_path: Path | None = None,
-                             logs_dir: Path | None = None) -> dict:
+                             logs_dir: Path | None = None,
+                             cluster_result_recorder=None) -> dict:
     """处理一个 AtomTask：只跑 cluster，**不跑 edit**。
 
     edit 触发由 watcher 每轮独立扫描所有 skill 目录完成（见
@@ -2574,25 +2637,32 @@ def _process_atom_task_bound(*, atom_id: str, config: dict,
             agent_tools.atom_task_read, agent_tools.read_traj,
             agent_tools.skill_read, agent_tools.read_skill_tasks,
             agent_tools.new_skill_folder, agent_tools.add_task_to_skill,
-            agent_tools.rename_skill, agent_tools.move_task_to,
+            agent_tools.move_task_to,
             agent_tools.score_task,
         ],
     )
-    cluster_content = cluster.process(atom)
+    cluster_error = None
+    cluster_content = ""
+    try:
+        cluster_content = cluster.process(atom)
+    except BaseException as error:  # preserve successful tool writes before failure
+        cluster_error = (error, error.__traceback__)
 
-    # cluster 跑完后回查 .candidates.yml 看 atom 实际落到了哪个 skill。
-    # 新 prompt 要求"任何分数都必须 add_task_to_skill"，正常情况下应该总能
-    # 找到；找不到 (skill_name=None) 即为 silent drop，被上层 logger 升 WARN。
-    from xskill.skill.candidates import find_atom_entry_in_any_skill
-    hit = find_atom_entry_in_any_skill(skill_dir, atom_id)
+    hit = (
+        cluster_result_recorder.get(atom_id)
+        if cluster_result_recorder is not None
+        else None
+    )
     skill_name = hit[0] if hit else None
     weightscore = hit[1] if hit else None
 
     # 落地即打耐久消费标记（与批量版 process_atom_batch 一致），让 watcher 的
     # 去重/done 判定不依赖会被 SkillEdit 晋升清空的 .candidates.yml。
-    if skill_name and not atom.clustered:
-        atom.clustered = True
-        store.save(atom)
+    if skill_name:
+        latest_atom = store.load(atom_id)
+        if not latest_atom.clustered:
+            latest_atom.clustered = True
+            store.save(latest_atom)
 
     # 埋点：atom 实际落到某 skill = 一次采纳(best-effort，失败不阻断)。
     # 在 cluster(大模型调用,按秒)之后,这条数据库写入(毫秒级)可忽略——和
@@ -2605,6 +2675,10 @@ def _process_atom_task_bound(*, atom_id: str, config: dict,
                                  db_path=db_path)
         except Exception:  # pylint: disable=broad-exception-caught
             logger.debug("atom adoption telemetry skipped", exc_info=True)
+
+    if cluster_error is not None:
+        error, traceback = cluster_error
+        raise error.with_traceback(traceback)
 
     return {
         "action": "clustered",
@@ -2620,10 +2694,13 @@ def process_atom_batch(*, atom_ids: list[str], config: dict, skill_dir: Path,
                        db_path: Path | None = None,
                        usage_ledger=None,
                        logs_dir: Path | None = None,
-                       spill_root: Path | None = None) -> list[dict]:
+                       spill_root: Path | None = None,
+                       cluster_write_queue=None) -> list[dict]:
     """Run one atom batch with an isolated AgentToolContext."""
     from xskill.agents import agent_tools
 
+    from xskill.pipeline.worker_runtime import ClusterResultRecorder
+    recorder = ClusterResultRecorder()
     tool_context = agent_tools.create_agent_tool_context(
         skill_dir=skill_dir,
         data_dir=skill_dir,
@@ -2633,6 +2710,8 @@ def process_atom_batch(*, atom_ids: list[str], config: dict, skill_dir: Path,
         default_traj_root=store.root,
         spill_root=spill_root,
         usage_ledger=usage_ledger,
+        cluster_write_queue=cluster_write_queue,
+        cluster_result_recorder=recorder,
     )
     with agent_tools.use_agent_tool_context(tool_context):
         return _process_atom_batch_bound(
@@ -2644,6 +2723,7 @@ def process_atom_batch(*, atom_ids: list[str], config: dict, skill_dir: Path,
             agno_agent_factory=agno_agent_factory,
             db_path=db_path,
             logs_dir=logs_dir,
+            cluster_result_recorder=recorder,
         )
 
 
@@ -2651,13 +2731,14 @@ def _process_atom_batch_bound(*, atom_ids: list[str], config: dict,
                               skill_dir: Path, store, embed_client,
                               agno_agent_factory,
                               db_path: Path | None = None,
-                              logs_dir: Path | None = None) -> list[dict]:
+                              logs_dir: Path | None = None,
+                              cluster_result_recorder=None) -> list[dict]:
     """批量版 ``process_atom_task``：一次 LLM 会话覆盖**多个 atom 的位置**，只跑 cluster。
 
     与单 atom 版语义等价，只是把"逐 atom 一次往返"压成"一批一次往返"——
-    ``atom_ids`` 可能跨多条轨迹（watcher 跨轨迹池化后传入）。batch 跑完后逐个回查
-    各 atom 的 ``.candidates.yml`` 落点，构造与单 atom 版同形的 result dict 列表
-    （顺序同 ``atom_ids``）。
+    ``atom_ids`` 可能跨多条轨迹（watcher 跨轨迹池化后传入）。batch 跑完后直接读取
+    当前执行上下文的写入结果，构造与单 atom 版同形的 result dict 列表（顺序同
+    ``atom_ids``），不再遍历所有 candidates 文件反查落点。
 
     Args 同 ``process_atom_task``，只是 ``atom_id`` → ``atom_ids``（list）。
 
@@ -2667,7 +2748,6 @@ def _process_atom_batch_bound(*, atom_ids: list[str], config: dict,
     """
     from xskill.agents.task_cluster_agent import TaskClusterAgent
     from xskill.agents import agent_tools
-    from xskill.skill.candidates import find_atom_entry_in_any_skill
 
     del embed_client  # kept for API compatibility; cluster tools no longer use it
 
@@ -2683,22 +2763,33 @@ def _process_atom_batch_bound(*, atom_ids: list[str], config: dict,
             agent_tools.atom_task_read, agent_tools.read_traj,
             agent_tools.skill_read, agent_tools.read_skill_tasks,
             agent_tools.new_skill_folder, agent_tools.add_tasks_to_skill,
-            agent_tools.rename_skill, agent_tools.move_task_to,
+            agent_tools.move_task_to,
             agent_tools.score_task,
         ],
     )
-    cluster_content = cluster.process_batch(atoms)
+    cluster_error = None
+    cluster_content = ""
+    try:
+        cluster_content = cluster.process_batch(atoms)
+    except BaseException as error:  # tools may already have committed part of the batch
+        cluster_error = (error, error.__traceback__)
 
     results: list[dict] = []
     for aid in atom_ids:
-        hit = find_atom_entry_in_any_skill(skill_dir, aid)
+        hit = (
+            cluster_result_recorder.get(aid)
+            if cluster_result_recorder is not None
+            else None
+        )
         skill_name = hit[0] if hit else None
         weightscore = hit[1] if hit else None
         # 落地即打耐久消费标记（在 SkillEdit 可能清空 .candidates.yml 之前完成
         # 这次回查），让 watcher 的去重/done 判定不受后续 skill 晋升影响。
-        if skill_name and aid in atom_by_id and not atom_by_id[aid].clustered:
-            atom_by_id[aid].clustered = True
-            store.save(atom_by_id[aid])
+        if skill_name and aid in atom_by_id:
+            latest_atom = store.load(aid)
+            if not latest_atom.clustered:
+                latest_atom.clustered = True
+                store.save(latest_atom)
         # 埋点：atom 落到某 skill = 一次采纳（best-effort，失败不阻断）。
         if skill_name:
             try:
@@ -2715,4 +2806,7 @@ def _process_atom_batch_bound(*, atom_ids: list[str], config: dict,
             "weightscore": weightscore,
             "cluster_log": (cluster_content or "")[:500],
         })
+    if cluster_error is not None:
+        error, traceback = cluster_error
+        raise error.with_traceback(traceback)
     return results

--- a/src/xskill/pipeline/watcher_factory.py
+++ b/src/xskill/pipeline/watcher_factory.py
@@ -1,4 +1,4 @@
-"""watcher 构造 + 生态一次性入库，供常驻 watcher worker 使用。
+"""watcher 构造 + 生态一次性入库，供常驻 agent-worker 使用。
 
 web startup 原有的生态检测闭包收敛为
 ``ingest_detected_ecosystems_once``：watcher 每次 poll 对检测到的生态调
@@ -27,6 +27,7 @@ def build_watcher(config: dict, *, home_root: Path | None = None,
     """
     from xskill.config import (
         XSKILL_HOME,
+        agent_worker_config,
         get_registry_db_path,
         get_skill_dir,
     )
@@ -70,6 +71,7 @@ def build_watcher(config: dict, *, home_root: Path | None = None,
         db_path=resolved_db_path,
     )
     watcher_cfg = config.get("watcher", {})
+    worker_cfg = agent_worker_config(config)
     return DirectoryWatcher(
         llm=create_llm_client(config, usage_ledger=usage_ledger),
         embed_client=create_embed_client(
@@ -77,9 +79,8 @@ def build_watcher(config: dict, *, home_root: Path | None = None,
         ),
         config=config,
         skill_dir=resolved_skill_dir,
-        poll_interval=float(watcher_cfg.get("poll_interval", 30)),
-        max_concurrent=int(watcher_cfg.get("max_concurrent", 30)),
-        cluster_batch_size=int(watcher_cfg.get("cluster_batch_size", 8)),
+        poll_interval=float(watcher_cfg.get("poll_interval", 5)),
+        pool_config=worker_cfg["pools"],
         server_mode=server_mode,
         home_root=home_root,
         xskill_home=state_root,

--- a/src/xskill/pipeline/worker_runtime.py
+++ b/src/xskill/pipeline/worker_runtime.py
@@ -1,0 +1,208 @@
+"""Agent worker concurrency primitives.
+
+The watcher owns four independent bounded executors.  Each executor accepts at
+most ``workers`` running calls plus ``workers * 2`` waiting calls and rejects
+additional submissions without blocking the watcher thread.
+
+Cluster agents perform model inference concurrently, but their filesystem
+mutations are funneled through :class:`ClusterWriteQueue` so candidate files and
+new skill repositories are changed in a deterministic order.
+"""
+from __future__ import annotations
+
+import threading
+from concurrent.futures import Future, ThreadPoolExecutor
+from dataclasses import dataclass
+from typing import Any, Callable
+
+
+def _install_worker_context() -> None:
+    """Install the asyncio loop required by agno on Python 3.9 workers."""
+    import asyncio
+
+    asyncio.set_event_loop(asyncio.new_event_loop())
+
+
+@dataclass
+class _SubmissionState:
+    started: bool = False
+
+
+class BoundedExecutor:
+    """A non-blocking, observable ``ThreadPoolExecutor``.
+
+    ``ThreadPoolExecutor`` itself has an unbounded waiting queue.  A semaphore
+    reserves one slot before submission, giving this wrapper a hard total
+    capacity of ``workers * 3``.  Rejected work is never submitted and the
+    caller can leave its durable DB/file state untouched for the next scan.
+    """
+
+    def __init__(self, name: str, workers: int):
+        if isinstance(workers, bool) or not isinstance(workers, int) or workers <= 0:
+            raise ValueError(f"{name}.workers 必须是正整数")
+        self.name = name
+        self.workers = workers
+        self.queue_capacity = workers * 2
+        self.total_capacity = workers * 3
+        self._slots = threading.BoundedSemaphore(self.total_capacity)
+        self._lock = threading.Lock()
+        self._running = 0
+        self._queued = 0
+        self._completed = 0
+        self._failed = 0
+        self._executor = ThreadPoolExecutor(
+            max_workers=workers,
+            thread_name_prefix=f"xskill-{name}",
+            initializer=_install_worker_context,
+        )
+
+    def submit(self, function: Callable[..., Any], /, *args, **kwargs) -> Future | None:
+        """Submit immediately or return ``None`` when this pool is full."""
+        if not self._slots.acquire(blocking=False):
+            return None
+        state = _SubmissionState()
+        state_lock = threading.Lock()
+        with self._lock:
+            self._queued += 1
+
+        def run():
+            with state_lock:
+                state.started = True
+            with self._lock:
+                self._queued -= 1
+                self._running += 1
+            try:
+                from xskill.utils.rate_limit import request_source
+
+                with request_source(self.name):
+                    result = function(*args, **kwargs)
+            except BaseException:
+                with self._lock:
+                    self._failed += 1
+                raise
+            else:
+                with self._lock:
+                    self._completed += 1
+                return result
+            finally:
+                with self._lock:
+                    self._running -= 1
+                self._slots.release()
+
+        try:
+            future = self._executor.submit(run)
+        except BaseException:
+            with self._lock:
+                self._queued -= 1
+            self._slots.release()
+            raise
+
+        def release_cancelled(_future: Future) -> None:
+            if not _future.cancelled():
+                return
+            with state_lock:
+                if state.started:
+                    return
+                state.started = True
+            with self._lock:
+                self._queued -= 1
+            self._slots.release()
+
+        future.add_done_callback(release_cancelled)
+        return future
+
+    @property
+    def available_capacity(self) -> int:
+        with self._lock:
+            return self.total_capacity - self._running - self._queued
+
+    @property
+    def status(self) -> dict[str, int | float]:
+        with self._lock:
+            occupied = self._running + self._queued
+            return {
+                "workers": self.workers,
+                "queue_capacity": self.queue_capacity,
+                "total_capacity": self.total_capacity,
+                "running": self._running,
+                "queued": self._queued,
+                "completed": self._completed,
+                "failed": self._failed,
+                "occupancy": occupied / self.total_capacity,
+            }
+
+    def shutdown(self, *, wait: bool = False, cancel_futures: bool = True) -> None:
+        self._executor.shutdown(wait=wait, cancel_futures=cancel_futures)
+
+
+class ClusterResultRecorder:
+    """Thread-safe record of successful writes made for one ClusterAgent call."""
+
+    def __init__(self):
+        self._lock = threading.Lock()
+        self._results: dict[str, tuple[str, int]] = {}
+
+    def record(self, atom_id: str, skill_name: str, weightscore: int) -> None:
+        with self._lock:
+            self._results[atom_id] = (skill_name, int(weightscore))
+
+    def get(self, atom_id: str) -> tuple[str, int] | None:
+        with self._lock:
+            return self._results.get(atom_id)
+
+    def snapshot(self) -> dict[str, tuple[str, int]]:
+        with self._lock:
+            return dict(self._results)
+
+
+class ClusterWriteQueue:
+    """Single-thread queue for ClusterAgent filesystem mutations."""
+
+    def __init__(self):
+        self._lock = threading.Lock()
+        self._queued = 0
+        self._running = 0
+        self._completed = 0
+        self._failed = 0
+        self._executor = ThreadPoolExecutor(
+            max_workers=1,
+            thread_name_prefix="xskill-cluster-write",
+            initializer=_install_worker_context,
+        )
+
+    def call(self, function: Callable[[], Any]) -> Any:
+        with self._lock:
+            self._queued += 1
+
+        def run():
+            with self._lock:
+                self._queued -= 1
+                self._running += 1
+            try:
+                result = function()
+            except BaseException:
+                with self._lock:
+                    self._failed += 1
+                raise
+            else:
+                with self._lock:
+                    self._completed += 1
+                return result
+            finally:
+                with self._lock:
+                    self._running -= 1
+
+        return self._executor.submit(run).result()
+
+    @property
+    def status(self) -> dict[str, int]:
+        with self._lock:
+            return {
+                "queued": self._queued,
+                "running": self._running,
+                "completed": self._completed,
+                "failed": self._failed,
+            }
+
+    def shutdown(self, *, wait: bool = False) -> None:
+        self._executor.shutdown(wait=wait, cancel_futures=True)

--- a/src/xskill/skill/candidates.py
+++ b/src/xskill/skill/candidates.py
@@ -497,7 +497,7 @@ class LazyConsumedIndex:
 
     watcher 一轮 scan 里,只要 atom 都已打 ``clustered`` 快标记(稳态),就完全不碰
     磁盘;唯有冷启动那种存量未打标 atom 才触发一次 ``build_atom_consumed_index``。
-    这避免了"1 万 skill 下每轮 sweep 无条件读 1 万个 .candidates.yml"的纯浪费。
+    这避免了"1 万 skill 下每轮扫描无条件读 1 万个 .candidates.yml"的纯浪费。
     """
 
     def __init__(self, skill_dir):

--- a/src/xskill/utils/llm.py
+++ b/src/xskill/utils/llm.py
@@ -21,6 +21,7 @@ from __future__ import annotations
 import logging
 import os
 from dataclasses import dataclass, field
+from functools import partial
 from typing import Any, Literal, Optional
 
 import numpy as np
@@ -60,7 +61,7 @@ class LLMClient:
     # 里可覆盖；缩小可省 token 费但要承担更高 fallback 率。
     max_tokens: int = 10000
     temperature: float = 0.0
-    # 限流配置；None = 不限流(快路径)。结构: {rpm, tpm, burst} 任一可缺。
+    # 限流配置；None = 不限流(快路径)。
     # 详见 src/xskill/utils/rate_limit.py 与 docs/adr/0001。
     rate_limit_cfg: "Optional[dict]" = field(default=None)
     usage_ledger: Any = field(default=None, repr=False)
@@ -112,15 +113,23 @@ class LLMClient:
         if self.rate_limit_cfg:
             # 走限流 wrapper —— 共享按 base_url 注册的桶
             from xskill.utils.rate_limit import (
-                RateLimitedLLM, get_or_create_bucket,
+                RateLimitedLLM, get_or_create_request_limiter,
             )
-            bucket = get_or_create_bucket(
+            limiter = get_or_create_request_limiter(
+                "llm",
                 self.base_url,
                 rpm=self.rate_limit_cfg.get("rpm"),
                 tpm=self.rate_limit_cfg.get("tpm"),
-                burst=self.rate_limit_cfg.get("burst"),
+                request_burst=self.rate_limit_cfg.get(
+                    "request_burst", self.rate_limit_cfg.get("burst"),
+                ),
+                token_burst=self.rate_limit_cfg.get(
+                    "token_burst", self.rate_limit_cfg.get("burst"),
+                ),
+                max_inflight=self.rate_limit_cfg.get("max_inflight"),
+                weights=self.rate_limit_cfg.get("_pool_weights"),
             )
-            wrapper = RateLimitedLLM(bucket=bucket, inner_call=self._raw_chat)
+            wrapper = RateLimitedLLM(limiter=limiter, inner_call=self._raw_chat)
             resp = wrapper.call(prompt=prompt, system=system, timeout=60.0)
             self._record(resp)
             return resp.choices[0].message.content
@@ -218,6 +227,7 @@ class EmbedClient:
     api_key: str
     dim: int = 0  # 0 = 未探测
     api_style: EmbedApiStyle = "openai"
+    rate_limit_cfg: "Optional[dict]" = field(default=None, repr=False)
     usage_ledger: Any = field(default=None, repr=False)
     _client: Any = field(default=None, repr=False)
 
@@ -242,6 +252,7 @@ class EmbedClient:
             api_key=api_key,
             dim=dim,
             api_style=api_style,
+            rate_limit_cfg=cfg.get("rate_limit"),
             usage_ledger=usage_ledger,
         )
         return inst
@@ -293,10 +304,25 @@ class EmbedClient:
             raise ValueError(f"embedding response missing data: {data!r}")
         return items[0]["embedding"]
 
-    def _call_api_single(self, text: str) -> list[float]:
+    def _call_api_single_unlimited(self, text: str) -> list[float]:
         if self.api_style == "multimodal":
             return self._call_api_multimodal(text)
         return self._call_api_openai(text)
+
+    def _call_api_single(self, text: str) -> list[float]:
+        if not self.rate_limit_cfg:
+            return self._call_api_single_unlimited(text)
+        from xskill.utils.rate_limit import get_or_create_request_limiter
+
+        limiter = get_or_create_request_limiter(
+            "embedding",
+            self.base_url,
+            max_inflight=self.rate_limit_cfg.get("max_inflight"),
+        )
+        return limiter.call(
+            prompt="",
+            inner_call=partial(self._call_api_single_unlimited, text),
+        )
 
     def probe_dim(self) -> int:
         """发送测试文本，探测 embedding 维度"""
@@ -395,7 +421,16 @@ def create_llm_client(
         model: "doubao-seed-2-0-pro-260215"    # agent + eval 换大模型
         # base_url / api_key 缺省 → 继承 llm.*
     """
-    base_cfg = config.get("llm", {}) or {}
+    base_cfg = dict(config.get("llm", {}) or {})
+    pool_cfg = (config.get("agent_worker", {}) or {}).get("pools", {}) or {}
+    if base_cfg.get("rate_limit"):
+        base_cfg["rate_limit"] = {
+            **base_cfg["rate_limit"],
+            "_pool_weights": {
+                name: int((pool_cfg.get(name, {}) or {}).get("llm_weight", 1))
+                for name in ("split", "cluster", "edit")
+            },
+        }
     if role in ("skill", "eval"):
         override_cfg = config.get("llm_skill", {}) or {}
         merged = {**base_cfg, **{k: v for k, v in override_cfg.items() if v}}

--- a/src/xskill/utils/rate_limit.py
+++ b/src/xskill/utils/rate_limit.py
@@ -9,12 +9,35 @@ DIY 实现,零额外依赖。设计基线:
 from __future__ import annotations
 
 import math
+import contextlib
+import contextvars
 import threading
 import time
 import unicodedata
+from collections import defaultdict, deque
+from functools import partial
 from typing import Any, Callable, Dict, Optional
 
 from xskill.utils.shutdown import SHUTTING_DOWN
+
+
+_REQUEST_SOURCE: contextvars.ContextVar[str] = contextvars.ContextVar(
+    "xskill_request_source", default="other",
+)
+
+
+@contextlib.contextmanager
+def request_source(source: str):
+    """Identify the agent-worker pool issuing requests in this context."""
+    token = _REQUEST_SOURCE.set(source)
+    try:
+        yield
+    finally:
+        _REQUEST_SOURCE.reset(token)
+
+
+def current_request_source() -> str:
+    return _REQUEST_SOURCE.get()
 
 
 def estimate_tokens(text: str) -> int:
@@ -50,13 +73,28 @@ class TokenBucket:
         rpm: Optional[int] = None,
         tpm: Optional[int] = None,
         burst: Optional[int] = None,
+        request_burst: Optional[int] = None,
+        token_burst: Optional[int] = None,
         clock: Optional[Callable[[], float]] = None,
     ):
         self.rpm = rpm
         self.tpm = tpm
-        # burst 默认 = ceil(rate/6),约 10 秒预算的瞬时突发
-        self._rpm_burst = burst if burst is not None else (max(1, rpm // 6) if rpm else 0)
-        self._tpm_burst = burst if burst is not None else (max(1, tpm // 6) if tpm else 0)
+        # ``burst`` is retained for the public Python API.  Config validation
+        # rejects it and requires the unambiguous request/token names.
+        if request_burst is None:
+            request_burst = burst
+        if token_burst is None:
+            token_burst = burst
+        self._rpm_burst = (
+            request_burst
+            if request_burst is not None
+            else (max(1, rpm // 6) if rpm else 0)
+        )
+        self._tpm_burst = (
+            token_burst
+            if token_burst is not None
+            else (max(1, tpm // 6) if tpm else 0)
+        )
         self._clock = clock or time.monotonic
 
         self._rpm_tokens = float(self._rpm_burst)
@@ -154,6 +192,160 @@ class RateLimitExhausted(RuntimeError):
     """限流桶在 timeout 内仍取不到 token —— 上层应捕获或选择降级。"""
 
 
+class _WeightedInflightGate:
+    """Weighted, work-conserving semaphore for LLM HTTP calls."""
+
+    def __init__(self, limit: int, weights: Optional[dict[str, int]] = None):
+        self.limit = int(limit)
+        self.weights = {
+            name: max(1, int(weight))
+            for name, weight in (weights or {}).items()
+        }
+        self._condition = threading.Condition()
+        self._waiting: dict[str, deque[threading.Event]] = defaultdict(deque)
+        self._scores: dict[str, int] = defaultdict(int)
+        self._active = 0
+
+    def _select_locked(self) -> str:
+        active_sources = [name for name, queue in self._waiting.items() if queue]
+        total_weight = sum(self.weights.get(name, 1) for name in active_sources)
+        for name in active_sources:
+            self._scores[name] += self.weights.get(name, 1)
+        selected = max(active_sources, key=self._scores.__getitem__)
+        self._scores[selected] -= total_weight
+        return selected
+
+    def _grant_locked(self) -> None:
+        while self._active < self.limit and any(self._waiting.values()):
+            source = self._select_locked()
+            ticket = self._waiting[source].popleft()
+            self._active += 1
+            ticket.set()
+
+    def acquire(self, source: str) -> None:
+        ticket = threading.Event()
+        with self._condition:
+            self._waiting[source].append(ticket)
+            self._grant_locked()
+        # Wait on a ticket rather than polling the watcher; no HTTP slot is
+        # counted as in flight until this admission has also passed RPM/TPM.
+        ticket.wait()
+
+    def release(self) -> None:
+        with self._condition:
+            self._active -= 1
+            self._grant_locked()
+
+    @property
+    def active(self) -> int:
+        with self._condition:
+            return self._active
+
+    @property
+    def waiting(self) -> int:
+        with self._condition:
+            return sum(len(queue) for queue in self._waiting.values())
+
+
+class SharedRequestLimiter:
+    """Shared RPM/TPM and weighted in-flight limit for one endpoint."""
+
+    def __init__(
+        self,
+        *,
+        bucket: TokenBucket | None = None,
+        rpm: Optional[int] = None,
+        tpm: Optional[int] = None,
+        request_burst: Optional[int] = None,
+        token_burst: Optional[int] = None,
+        max_inflight: Optional[int] = None,
+        weights: Optional[dict[str, int]] = None,
+    ):
+        self.bucket = bucket or TokenBucket(
+            rpm=rpm, tpm=tpm,
+            request_burst=request_burst, token_burst=token_burst,
+        )
+        self._gate = (
+            _WeightedInflightGate(int(max_inflight), weights)
+            if max_inflight
+            else None
+        )
+        self._lock = threading.Lock()
+        self._inflight = 0
+        self._rate_limit_waiting = 0
+        self._retry_waiting = 0
+
+    def call(
+        self,
+        *,
+        prompt: str,
+        inner_call: Callable[[], Any],
+        timeout: float = 60.0,
+    ) -> Any:
+        estimated = estimate_tokens(prompt)
+        gate_acquired = False
+        if self._gate is not None:
+            # Admission happens before RPM/TPM acquisition so the configured
+            # pool weights govern request opportunities, not only calls that
+            # happened to obtain a token first.
+            self._gate.acquire(current_request_source())
+            gate_acquired = True
+        with self._lock:
+            self._rate_limit_waiting += 1
+        try:
+            wait = self.bucket.acquire_rpm(timeout=timeout)
+            if wait > 0:
+                raise RateLimitExhausted(
+                    f"RPM bucket exhausted, need wait {wait:.1f}s"
+                )
+            wait = self.bucket.acquire_tpm(estimated, timeout=timeout)
+            if wait > 0:
+                raise RateLimitExhausted(
+                    f"TPM bucket exhausted, need wait {wait:.1f}s"
+                )
+        except BaseException:
+            if gate_acquired:
+                self._gate.release()
+            raise
+        finally:
+            with self._lock:
+                self._rate_limit_waiting -= 1
+        with self._lock:
+            self._inflight += 1
+        try:
+            response = inner_call()
+        finally:
+            with self._lock:
+                self._inflight -= 1
+            if gate_acquired:
+                self._gate.release()
+        actual = extract_total_tokens(response)
+        if actual is not None:
+            self.bucket.reconcile_tpm(estimated=estimated, actual=actual)
+        return response
+
+    def begin_retry_wait(self) -> None:
+        with self._lock:
+            self._retry_waiting += 1
+
+    def end_retry_wait(self) -> None:
+        with self._lock:
+            self._retry_waiting -= 1
+
+    @property
+    def status(self) -> dict[str, int]:
+        with self._lock:
+            inflight = self._inflight
+            rate_waiting = self._rate_limit_waiting
+            retry_waiting = self._retry_waiting
+        return {
+            "inflight": inflight,
+            "waiting": self._gate.waiting if self._gate is not None else 0,
+            "rate_limit_waiting": rate_waiting,
+            "retry_waiting": retry_waiting,
+        }
+
+
 def extract_total_tokens(resp: Any) -> Optional[int]:
     """从 OpenAI 兼容 response 提取 total_tokens,缺失返 None。
 
@@ -191,15 +383,32 @@ class RateLimitedLLM:
     不假设 inner 的内部实现,只检查 response.usage.total_tokens 做 reconcile。
     """
 
-    def __init__(self, *, bucket: TokenBucket, inner_call: Callable[..., Any]):
+    def __init__(
+        self,
+        *,
+        bucket: TokenBucket | None = None,
+        limiter: SharedRequestLimiter | None = None,
+        inner_call: Callable[..., Any],
+    ):
+        if bucket is None and limiter is None:
+            raise ValueError("bucket 或 limiter 至少提供一个")
         self.bucket = bucket
+        self.limiter = limiter
         self.inner_call = inner_call
 
     def call(self, *, prompt: str, timeout: float = 30.0, **kwargs) -> Any:
         """执行受限流的 LLM 调用。流程: acquire_rpm → estimate → acquire_tpm
         → inner_call(**kw) → reconcile_tpm by response.usage(缺失则保留估算)。
         """
-        # 1) RPM acquire
+        if self.limiter is not None:
+            return self.limiter.call(
+                prompt=prompt,
+                inner_call=partial(self.inner_call, prompt=prompt, **kwargs),
+                timeout=timeout,
+            )
+
+        # Backward-compatible direct bucket path.
+        assert self.bucket is not None
         wait = self.bucket.acquire_rpm(timeout=timeout)
         if wait > 0:
             raise RateLimitExhausted(f"RPM bucket exhausted, need wait {wait:.1f}s")
@@ -226,6 +435,8 @@ class RateLimitedLLM:
 # 导致同 API key 的额度被双重消耗。
 _BUCKETS: Dict[str, TokenBucket] = {}
 _BUCKETS_LOCK = threading.Lock()
+_LIMITERS: Dict[tuple[str, str], SharedRequestLimiter] = {}
+_LIMITERS_LOCK = threading.Lock()
 
 
 def get_or_create_bucket(
@@ -234,16 +445,89 @@ def get_or_create_bucket(
     rpm: Optional[int] = None,
     tpm: Optional[int] = None,
     burst: Optional[int] = None,
+    request_burst: Optional[int] = None,
+    token_burst: Optional[int] = None,
 ) -> TokenBucket:
     """按 base_url 取桶,不存在则新建。线程安全。"""
     with _BUCKETS_LOCK:
         if base_url not in _BUCKETS:
-            _BUCKETS[base_url] = TokenBucket(rpm=rpm, tpm=tpm, burst=burst)
+            _BUCKETS[base_url] = TokenBucket(
+                rpm=rpm,
+                tpm=tpm,
+                burst=burst,
+                request_burst=request_burst,
+                token_burst=token_burst,
+            )
         return _BUCKETS[base_url]
+
+
+def get_or_create_request_limiter(
+    kind: str,
+    base_url: str,
+    *,
+    rpm: Optional[int] = None,
+    tpm: Optional[int] = None,
+    request_burst: Optional[int] = None,
+    token_burst: Optional[int] = None,
+    max_inflight: Optional[int] = None,
+    weights: Optional[dict[str, int]] = None,
+) -> SharedRequestLimiter:
+    """Return the process-wide limiter shared by one request endpoint."""
+    key = (kind, base_url)
+    with _LIMITERS_LOCK:
+        if key not in _LIMITERS:
+            bucket = None
+            if kind == "llm":
+                bucket = get_or_create_bucket(
+                    base_url,
+                    rpm=rpm,
+                    tpm=tpm,
+                    request_burst=request_burst,
+                    token_burst=token_burst,
+                )
+            _LIMITERS[key] = SharedRequestLimiter(
+                bucket=bucket,
+                rpm=rpm,
+                tpm=tpm,
+                request_burst=request_burst,
+                token_burst=token_burst,
+                max_inflight=max_inflight,
+                weights=weights,
+            )
+        return _LIMITERS[key]
+
+
+def request_limiter_status(kind: str) -> dict[str, int]:
+    """Aggregate live counters for status endpoints."""
+    with _LIMITERS_LOCK:
+        limiters = [
+            limiter
+            for (limiter_kind, _), limiter in _LIMITERS.items()
+            if limiter_kind == kind
+        ]
+    statuses = [limiter.status for limiter in limiters]
+    keys = ("inflight", "waiting", "rate_limit_waiting", "retry_waiting")
+    return {key: sum(status.get(key, 0) for status in statuses) for key in keys}
+
+
+def begin_retry_wait(kind: str, base_url: str) -> None:
+    with _LIMITERS_LOCK:
+        limiter = _LIMITERS.get((kind, base_url))
+    if limiter is not None:
+        limiter.begin_retry_wait()
+
+
+def end_retry_wait(kind: str, base_url: str) -> None:
+    with _LIMITERS_LOCK:
+        limiter = _LIMITERS.get((kind, base_url))
+    if limiter is not None:
+        limiter.end_retry_wait()
 
 
 def reset_buckets_for_testing() -> None:
     """测试用 —— 清空注册表,各测试间隔离。"""
+    with _LIMITERS_LOCK:
+        _LIMITERS.clear()
     with _BUCKETS_LOCK:
         _BUCKETS.clear()
 

--- a/src/xskill/utils/status_file.py
+++ b/src/xskill/utils/status_file.py
@@ -1,7 +1,7 @@
-"""跨进程状态文件:常驻 watcher 定期写心跳，短命 profile-refresh 写一轮结果，
-常驻 api 进程的 /watcher/status、/stats 端点读它们派生状态。
+"""跨进程状态文件:常驻 agent-worker 定期写心跳，短命 profile-refresh 写一轮结果，
+常驻 api 进程的 /agent-worker/status、/watcher/status、/stats 端点读取状态。
 
-watcher / 画像拆成独立子进程后,api 进程不再持有它们的内存对象(原来
+agent-worker / 画像拆成独立子进程后,api 进程不再持有它们的内存对象(原来
 ``_watcher_ref["instance"].stats`` / ``_profile_refresh_ref["instance"].metrics``),
 故改经磁盘 JSON 通信。写为原子(临时文件 + os.replace),避免读到半截 JSON。
 """
@@ -17,6 +17,7 @@ from typing import Optional
 logger = logging.getLogger("xskill.utils.status_file")
 
 WATCHER_STATUS_FILE = "watcher_status.json"
+AGENT_WORKER_STATUS_FILE = "agent_worker_status.json"
 PROFILE_STATUS_FILE = "profile_refresh_status.json"
 
 

--- a/tests/docker_e2e/openclaw_real_llm/xskill_config.yaml
+++ b/tests/docker_e2e/openclaw_real_llm/xskill_config.yaml
@@ -5,13 +5,21 @@ llm:
   base_url: http://127.0.0.1:19999
   model: fake-llm
   api_key: fake-key
+  rate_limit: {rpm: 240, request_burst: 8, max_inflight: 8}
 embedding:
   base_url: http://127.0.0.1:19999
   model: fake-embed
   api_key: fake-key
   dim: 0
+  rate_limit: {max_inflight: 4}
 watcher:
   poll_interval: 3
+agent_worker:
+  pools:
+    split: {workers: 2, llm_weight: 6}
+    cluster: {workers: 2, batch_size: 8, llm_weight: 3}
+    edit: {workers: 1, llm_weight: 1}
+    embed: {workers: 1}
 candidates:
   threshold: 3
   stale_days: 60

--- a/tests/docker_e2e/scenarios/runtime_ecosystem_detect/pre_state/.xskill/config.yaml
+++ b/tests/docker_e2e/scenarios/runtime_ecosystem_detect/pre_state/.xskill/config.yaml
@@ -6,13 +6,21 @@ llm:
   base_url: http://127.0.0.1:19999
   model: fake-llm
   api_key: fake-key
+  rate_limit: {rpm: 240, request_burst: 8, max_inflight: 8}
 embedding:
   base_url: http://127.0.0.1:19999
   model: fake-embed
   api_key: fake-key
   dim: 0
+  rate_limit: {max_inflight: 4}
 watcher:
   poll_interval: 3      # 短 poll 让 scenario 不用等太久
+agent_worker:
+  pools:
+    split: {workers: 2, llm_weight: 6}
+    cluster: {workers: 2, batch_size: 8, llm_weight: 3}
+    edit: {workers: 1, llm_weight: 1}
+    embed: {workers: 1}
 candidates:
   threshold: 3
   stale_days: 60

--- a/tests/docker_e2e/scenarios/runtime_openclaw_detect/pre_state/.xskill/config.yaml
+++ b/tests/docker_e2e/scenarios/runtime_openclaw_detect/pre_state/.xskill/config.yaml
@@ -5,13 +5,21 @@ llm:
   base_url: http://127.0.0.1:19999
   model: fake-llm
   api_key: fake-key
+  rate_limit: {rpm: 240, request_burst: 8, max_inflight: 8}
 embedding:
   base_url: http://127.0.0.1:19999
   model: fake-embed
   api_key: fake-key
   dim: 0
+  rate_limit: {max_inflight: 4}
 watcher:
   poll_interval: 3
+agent_worker:
+  pools:
+    split: {workers: 2, llm_weight: 6}
+    cluster: {workers: 2, batch_size: 8, llm_weight: 3}
+    edit: {workers: 1, llm_weight: 1}
+    embed: {workers: 1}
 candidates:
   threshold: 3
   stale_days: 60

--- a/tests/e2e/test_team_cs_e2e.py
+++ b/tests/e2e/test_team_cs_e2e.py
@@ -207,12 +207,23 @@ def team_server(tmp_path, fake_server):
     config_yaml = {
         "skill_dir": str(skill_dir),
         "llm": {"base_url": fake_server.base_url, "model": "fake-llm",
-                "api_key": "fake-key"},
+                "api_key": "fake-key",
+                "rate_limit": {"rpm": 240, "request_burst": 8,
+                               "max_inflight": 8}},
         "embedding": {"base_url": fake_server.base_url, "model": "fake-embed",
-                      "api_key": "fake-key", "dim": 0},
+                      "api_key": "fake-key", "dim": 0,
+                      "rate_limit": {"max_inflight": 4}},
         "canary": {"enabled": True, "probability": 0.5, "min_samples": 5,
                    "max_days_hold": 14, "rotate_interval": 300},
         "watcher": {"poll_interval": 2},
+        "agent_worker": {
+            "pools": {
+                "split": {"workers": 4, "llm_weight": 6},
+                "cluster": {"workers": 4, "batch_size": 4, "llm_weight": 3},
+                "edit": {"workers": 2, "llm_weight": 1},
+                "embed": {"workers": 2},
+            },
+        },
         "team": {"server": {"skill_slots": 100, "ranked_slots": 80}},
     }
     (xhome / "config.yaml").write_text(

--- a/tests/pool_helpers.py
+++ b/tests/pool_helpers.py
@@ -1,0 +1,22 @@
+"""Small four-pool configs for focused unit tests."""
+
+
+def pool_config(
+    workers: int = 2,
+    *,
+    batch_size: int = 8,
+    split_workers: int | None = None,
+    cluster_workers: int | None = None,
+    edit_workers: int | None = None,
+    embed_workers: int | None = None,
+) -> dict:
+    return {
+        "split": {"workers": split_workers or workers, "llm_weight": 6},
+        "cluster": {
+            "workers": cluster_workers or workers,
+            "batch_size": batch_size,
+            "llm_weight": 3,
+        },
+        "edit": {"workers": edit_workers or workers, "llm_weight": 1},
+        "embed": {"workers": embed_workers or workers},
+    }

--- a/tests/pool_helpers.py
+++ b/tests/pool_helpers.py
@@ -1,5 +1,7 @@
 """Small four-pool configs for focused unit tests."""
 
+from __future__ import annotations
+
 
 def pool_config(
     workers: int = 2,

--- a/tests/test_agent_tool_context_isolation.py
+++ b/tests/test_agent_tool_context_isolation.py
@@ -14,6 +14,7 @@ from xskill.agents import agent_tools
 from xskill.pipeline.atom import AtomTask, AtomTaskStore
 from xskill.pipeline.runner import DirectoryWatcher, process_atom_batch
 from xskill.usage import PriceTable, UsageLedger
+from tests.pool_helpers import pool_config
 
 
 def _tool_name(tool) -> str:
@@ -343,7 +344,7 @@ def _build_skill_edit_watcher(
     return DirectoryWatcher(
         config={"skill_opt": {"enabled": False}},
         skill_dir=skill_dir,
-        max_concurrent=1,
+        pool_config=pool_config(workers=1),
         db_path=db_path,
         store=AtomTaskStore(root=watch_dir),
         agno_agent_factory=_unused_agent_factory,
@@ -396,7 +397,7 @@ def test_skill_edit_workers_bind_each_instance_and_reset_after_completion(
             assert _usage_models(
                 tmp_path / suffix / "registry.db"
             ) == [f"edit-model-{suffix}"]
-            assert watcher._pool.submit(
+            assert watcher._pools["edit"].submit(
                 _current_atom_skill_dir
             ).result(timeout=5) is None
     finally:

--- a/tests/test_agent_worker.py
+++ b/tests/test_agent_worker.py
@@ -1,4 +1,4 @@
-"""常驻 watcher worker：生命周期、server 隔离、心跳和生态入库。"""
+"""常驻 agent-worker：生命周期、server 隔离、心跳和生态入库。"""
 from __future__ import annotations
 
 import threading
@@ -10,6 +10,7 @@ import pytest
 from xskill import _workers
 from xskill.pipeline import watcher_factory
 from xskill.utils.status_file import WATCHER_STATUS_FILE, read_status_file
+from tests.pool_helpers import pool_config
 
 
 class _FakeWatcher:
@@ -92,7 +93,7 @@ def test_watcher_server_mode_starts_and_stops_persistent_instance(
     stop_event = threading.Event()
     stop_event.set()
 
-    rc = _workers.run_watcher_forever(server=True, stop_event=stop_event)
+    rc = _workers.run_agent_worker_forever(server=True, stop_event=stop_event)
 
     assert rc == 0
     assert ingest_calls == []
@@ -109,7 +110,7 @@ def test_watcher_standalone_ingests_on_each_poll(tmp_path, monkeypatch):
     stop_event = threading.Event()
     stop_event.set()
 
-    rc = _workers.run_watcher_forever(server=False, stop_event=stop_event)
+    rc = _workers.run_agent_worker_forever(server=False, stop_event=stop_event)
 
     assert rc == 0
     assert ingest_calls == []
@@ -119,15 +120,15 @@ def test_watcher_standalone_ingests_on_each_poll(tmp_path, monkeypatch):
 
 
 def test_internal_cli_dispatches_to_persistent_watcher(monkeypatch, tmp_path):
-    run_watcher = Mock(return_value=0)
-    monkeypatch.setattr(_workers, "run_watcher_forever", run_watcher)
+    run_worker = Mock(return_value=0)
+    monkeypatch.setattr(_workers, "run_agent_worker_forever", run_worker)
     monkeypatch.setattr("xskill.utils.logging.configure_logging", Mock())
     monkeypatch.setattr("xskill.config.get_logs_dir", Mock(return_value=tmp_path))
 
     assert _workers.main([
-        "watcher", "--server", "--home", str(tmp_path),
+        "agent-worker", "--server", "--home", str(tmp_path),
     ]) == 0
-    run_watcher.assert_called_once_with(server=True, home=str(tmp_path))
+    run_worker.assert_called_once_with(server=True, home=str(tmp_path))
 
 
 def test_watcher_build_failure_writes_error_status(tmp_path, monkeypatch):
@@ -136,7 +137,7 @@ def test_watcher_build_failure_writes_error_status(tmp_path, monkeypatch):
         tmp_path,
         build_exception=RuntimeError("llm down"),
     )
-    rc = _workers.run_watcher_forever(
+    rc = _workers.run_agent_worker_forever(
         server=True,
         stop_event=threading.Event(),
         status_interval=0.01,
@@ -156,7 +157,7 @@ def test_watcher_thread_exit_is_reported_and_preserves_stats(
         running_after_start=False,
     )
 
-    return_code = _workers.run_watcher_forever(
+    return_code = _workers.run_agent_worker_forever(
         server=True,
         stop_event=threading.Event(),
         status_interval=0.01,
@@ -175,7 +176,10 @@ def test_persistent_watcher_starts_next_poll_while_future_is_still_running(
     """长尾 Future 不得阻塞下一轮扫描。"""
     from xskill.pipeline.runner import DirectoryWatcher
 
-    watcher = DirectoryWatcher(poll_interval=0.01, max_concurrent=1)
+    watcher = DirectoryWatcher(
+        poll_interval=0.01,
+        pool_config=pool_config(workers=1),
+    )
     release_slow = threading.Event()
     second_poll = threading.Event()
     poll_count = 0
@@ -184,7 +188,7 @@ def test_persistent_watcher_starts_next_poll_while_future_is_still_running(
         nonlocal poll_count
         poll_count += 1
         if poll_count == 1:
-            future = watcher._pool.submit(release_slow.wait, 2.0)
+            future = watcher._pools["split"].submit(release_slow.wait, 2.0)
             watcher._futures[future] = {"stage": "test"}
         elif poll_count == 2:
             second_poll.set()
@@ -238,7 +242,7 @@ def test_worker_passes_ecosystem_home_separately_from_xskill_home(
     stop_event = threading.Event()
     stop_event.set()
 
-    assert _workers.run_watcher_forever(
+    assert _workers.run_agent_worker_forever(
         home=home_argument,
         stop_event=stop_event,
     ) == 0
@@ -300,7 +304,16 @@ def test_build_watcher_defaults_and_history_stay_in_explicit_instance(
     )
 
     watcher = watcher_factory.build_watcher(
-        {"watcher": {}},
+        {
+            "watcher": {},
+            "agent_worker": {"pools": pool_config()},
+            "llm": {"rate_limit": {
+                "rpm": 240,
+                "request_burst": 8,
+                "max_inflight": 8,
+            }},
+            "embedding": {"rate_limit": {"max_inflight": 4}},
+        },
         xskill_home=instance_xskill_home,
         server_mode=True,
     )

--- a/tests/test_agent_worker_runtime.py
+++ b/tests/test_agent_worker_runtime.py
@@ -1,0 +1,414 @@
+"""v0.6.28 four-pool runtime and Cluster write-queue acceptance tests."""
+from __future__ import annotations
+
+import threading
+import time
+from concurrent.futures import ThreadPoolExecutor
+
+import pytest
+
+from tests.pool_helpers import pool_config
+from xskill.config import agent_worker_config
+from xskill.pipeline.atom import AtomTask, AtomTaskStore
+from xskill.pipeline.runner import DirectoryWatcher, process_atom_batch
+from xskill.pipeline.worker_runtime import BoundedExecutor, ClusterWriteQueue
+from xskill.skill.git import init_skill_repo_on_baby
+from xskill.utils.llm import EmbedClient
+from xskill.utils.rate_limit import SharedRequestLimiter
+
+
+def _thread_name():
+    return threading.current_thread().name
+
+
+def _set_legacy_max_concurrent(config):
+    config["watcher"]["max_concurrent"] = 4
+
+
+def _set_legacy_cluster_batch_size(config):
+    config["watcher"]["cluster_batch_size"] = 8
+
+
+def _set_legacy_burst(config):
+    config["llm"]["rate_limit"]["burst"] = 4
+
+
+def _set_explicit_queue_size(config):
+    config["agent_worker"]["pools"]["split"]["queue_size"] = 1
+
+
+def _valid_config() -> dict:
+    return {
+        "llm": {
+            "rate_limit": {
+                "rpm": 240,
+                "request_burst": 8,
+                "max_inflight": 8,
+            },
+        },
+        "embedding": {"rate_limit": {"max_inflight": 4}},
+        "agent_worker": {"pools": pool_config()},
+        "watcher": {"poll_interval": 5},
+    }
+
+
+def test_pool_capacity_is_workers_times_three_and_other_pools_keep_running():
+    release = threading.Event()
+    started = threading.Event()
+
+    def block():
+        started.set()
+        release.wait(5)
+
+    edit = BoundedExecutor("edit", 1)
+    split = BoundedExecutor("split", 1)
+    try:
+        futures = [edit.submit(block) for _ in range(3)]
+        assert all(future is not None for future in futures)
+        assert started.wait(1)
+        assert edit.submit(block) is None
+        assert edit.status["queue_capacity"] == 2
+        assert edit.status["total_capacity"] == 3
+        assert edit.status["running"] == 1
+        assert edit.status["queued"] == 2
+
+        thread_name = split.submit(_thread_name).result(1)
+        assert thread_name.startswith("xskill-split_")
+        assert split.status["completed"] == 1
+    finally:
+        release.set()
+        edit.shutdown(wait=True)
+        split.shutdown(wait=True)
+
+
+def test_all_pool_thread_names_are_visible():
+    pools = {
+        name: BoundedExecutor(name, 1)
+        for name in ("split", "cluster", "edit", "embed")
+    }
+    try:
+        for name, pool in pools.items():
+            thread_name = pool.submit(
+                _thread_name,
+            ).result(1)
+            assert thread_name.startswith(f"xskill-{name}_")
+    finally:
+        for pool in pools.values():
+            pool.shutdown(wait=True)
+
+
+def test_shared_request_limiter_caps_real_http_inflight():
+    limiter = SharedRequestLimiter(
+        max_inflight=2,
+        weights={"split": 6, "cluster": 3, "edit": 1},
+    )
+    release = threading.Event()
+    lock = threading.Lock()
+    active = 0
+    maximum = 0
+
+    def inner():
+        nonlocal active, maximum
+        with lock:
+            active += 1
+            maximum = max(maximum, active)
+        release.wait(5)
+        with lock:
+            active -= 1
+        return {}
+
+    executor = ThreadPoolExecutor(max_workers=8)
+    futures = [
+        executor.submit(limiter.call, prompt="x", inner_call=inner)
+        for _ in range(8)
+    ]
+    deadline = time.time() + 2
+    while limiter.status["inflight"] < 2 and time.time() < deadline:
+        time.sleep(0.01)
+    assert limiter.status["inflight"] == 2
+    assert limiter.status["waiting"] == 6
+    release.set()
+    assert [future.result(2) for future in futures] == [{}] * 8
+    executor.shutdown(wait=True)
+    assert maximum == 2
+
+
+def test_embedding_client_uses_its_independent_inflight_limit(monkeypatch):
+    release = threading.Event()
+    lock = threading.Lock()
+    active = 0
+    maximum = 0
+
+    def fake_call(_self, _text):
+        nonlocal active, maximum
+        with lock:
+            active += 1
+            maximum = max(maximum, active)
+        release.wait(5)
+        with lock:
+            active -= 1
+        return [1.0]
+
+    client = EmbedClient(
+        base_url="https://embedding-limit.example.test",
+        model="embed",
+        api_key="test",
+        dim=1,
+        rate_limit_cfg={"max_inflight": 2},
+    )
+    monkeypatch.setattr(
+        EmbedClient, "_call_api_single_unlimited", fake_call,
+    )
+    executor = ThreadPoolExecutor(max_workers=6)
+    futures = [executor.submit(client._call_api_single, "x") for _ in range(6)]
+    deadline = time.time() + 2
+    while maximum < 2 and time.time() < deadline:
+        time.sleep(0.01)
+    assert maximum == 2
+    release.set()
+    assert [future.result(2) for future in futures] == [[1.0]] * 6
+    executor.shutdown(wait=True)
+
+
+@pytest.mark.parametrize(
+    ("mutate", "message"),
+    [
+        (
+            _set_legacy_max_concurrent,
+            "agent_worker.pools",
+        ),
+        (
+            _set_legacy_cluster_batch_size,
+            "agent_worker.pools.cluster.batch_size",
+        ),
+        (
+            _set_legacy_burst,
+            "request_burst",
+        ),
+        (
+            _set_explicit_queue_size,
+            "等待容量自动",
+        ),
+    ],
+)
+def test_legacy_config_paths_fail_with_migration_hint(mutate, message):
+    config = _valid_config()
+    mutate(config)
+    with pytest.raises(ValueError, match=message):
+        agent_worker_config(config)
+
+
+def test_cluster_write_queue_serializes_same_slug_creation(tmp_path):
+    from tests.test_cluster_batch import _call_tool
+    from xskill.agents import agent_tools
+
+    skill_root = tmp_path / "skills"
+    skill_root.mkdir()
+    queue = ClusterWriteQueue()
+    context = agent_tools.create_agent_tool_context(
+        atom_skill_dir=skill_root,
+        cluster_write_queue=queue,
+    )
+
+    def create():
+        with agent_tools.use_agent_tool_context(context):
+            return _call_tool(
+                agent_tools.new_skill_folder,
+                "same-slug",
+                "same description",
+            )
+
+    with ThreadPoolExecutor(max_workers=2) as executor:
+        results = [future.result(5) for future in [
+            executor.submit(create), executor.submit(create),
+        ]]
+    queue.shutdown(wait=True)
+    assert sum("created on baby" in result for result in results) == 1
+    assert sum("already exists" in result for result in results) == 1
+    assert [
+        path.name for path in skill_root.iterdir()
+        if not path.name.startswith(".")
+    ] == ["same-slug"]
+
+
+def test_candidate_writes_follow_cluster_queue_order(tmp_path):
+    from tests.test_cluster_batch import _call_tool
+    from xskill.agents import agent_tools
+    from xskill.skill.candidates import load_candidates
+
+    skill_root = tmp_path / "skills"
+    skill_root.mkdir()
+    init_skill_repo_on_baby(
+        str(skill_root / "target"),
+        name="target",
+        description="target description",
+    )
+    queue = ClusterWriteQueue()
+    context = agent_tools.create_agent_tool_context(
+        atom_skill_dir=skill_root,
+        cluster_write_queue=queue,
+    )
+    release = threading.Event()
+    executor = ThreadPoolExecutor(max_workers=3)
+
+    def block_write():
+        return release.wait(5)
+
+    blocker = executor.submit(queue.call, block_write)
+    deadline = time.time() + 1
+    while queue.status["running"] != 1 and time.time() < deadline:
+        time.sleep(0.01)
+
+    def add(atom_id):
+        with agent_tools.use_agent_tool_context(context):
+            return _call_tool(
+                agent_tools.add_task_to_skill, "target", atom_id, 5,
+            )
+
+    first = executor.submit(add, "atom-a")
+    deadline = time.time() + 1
+    while queue.status["queued"] != 1 and time.time() < deadline:
+        time.sleep(0.01)
+    second = executor.submit(add, "atom-b")
+    deadline = time.time() + 1
+    while queue.status["queued"] != 2 and time.time() < deadline:
+        time.sleep(0.01)
+    release.set()
+    blocker.result(2)
+    first.result(2)
+    second.result(2)
+    executor.shutdown(wait=True)
+    queue.shutdown(wait=True)
+
+    candidates = load_candidates(skill_root / "target")["candidates"]
+    assert [item["atom_id"] for item in candidates] == ["atom-a", "atom-b"]
+
+
+def test_clustered_marker_rereads_atom_and_preserves_queued_score(tmp_path):
+    from tests.test_cluster_batch import _call_tool, _tool_name
+
+    skill_root = tmp_path / "skills"
+    skill_root.mkdir()
+    init_skill_repo_on_baby(
+        str(skill_root / "target"),
+        name="target",
+        description="target description",
+    )
+    store = AtomTaskStore(root=tmp_path / "watch")
+    store.root.mkdir()
+    atom = AtomTask(
+        atom_id="atom_traj_x_0000",
+        traj_id="traj_x",
+        offset_start=1,
+        offset_end=2,
+        intent="intent",
+        summary="summary",
+        tags=[],
+        used_skills=[],
+        ux_score=1,
+    )
+    store.save(atom)
+
+    class Agent:
+        def __init__(self, *, instructions, tools):
+            del instructions
+            self.tools = {_tool_name(tool): tool for tool in tools}
+
+        def run(self, _message):
+            _call_tool(self.tools["score_task"], atom.atom_id, 9)
+            _call_tool(
+                self.tools["add_tasks_to_skill"],
+                "target",
+                [{"atom_id": atom.atom_id, "weightscore": 7}],
+            )
+            return type("Result", (), {"content": "ok"})()
+
+    queue = ClusterWriteQueue()
+    result = process_atom_batch(
+        atom_ids=[atom.atom_id],
+        config={"llm": {}},
+        skill_dir=skill_root,
+        store=store,
+        embed_client=None,
+        agno_agent_factory=Agent,
+        cluster_write_queue=queue,
+    )
+    queue.shutdown(wait=True)
+    latest = store.load(atom.atom_id)
+    assert result[0]["skill_name"] == "target"
+    assert result[0]["weightscore"] == 7
+    assert latest.clustered is True
+    assert latest.ux_score == 9
+
+
+def test_successful_cluster_write_is_marked_when_agent_fails_later(tmp_path):
+    from tests.test_cluster_batch import _call_tool, _tool_name
+
+    skill_root = tmp_path / "skills"
+    skill_root.mkdir()
+    init_skill_repo_on_baby(
+        str(skill_root / "target"),
+        name="target",
+        description="target description",
+    )
+    store = AtomTaskStore(root=tmp_path / "watch")
+    store.root.mkdir()
+    atom = AtomTask(
+        atom_id="atom_traj_partial_0000",
+        traj_id="traj_partial",
+        offset_start=1,
+        offset_end=2,
+        intent="intent",
+        summary="summary",
+        tags=[],
+        used_skills=[],
+        ux_score=7,
+    )
+    store.save(atom)
+
+    class Agent:
+        def __init__(self, *, instructions, tools):
+            del instructions
+            self.tools = {_tool_name(tool): tool for tool in tools}
+
+        def run(self, _message):
+            _call_tool(
+                self.tools["add_tasks_to_skill"],
+                "target",
+                [{"atom_id": atom.atom_id, "weightscore": 6}],
+            )
+            raise RuntimeError("later model failure")
+
+    queue = ClusterWriteQueue()
+    with pytest.raises(RuntimeError, match="later model failure"):
+        process_atom_batch(
+            atom_ids=[atom.atom_id],
+            config={"llm": {}},
+            skill_dir=skill_root,
+            store=store,
+            embed_client=None,
+            agno_agent_factory=Agent,
+            cluster_write_queue=queue,
+        )
+    queue.shutdown(wait=True)
+    assert store.load(atom.atom_id).clustered is True
+
+
+def test_agent_worker_status_exposes_all_four_pools(tmp_path):
+    watcher = DirectoryWatcher(
+        skill_dir=tmp_path,
+        pool_config=pool_config(workers=1),
+    )
+    try:
+        status = watcher.agent_worker_status
+        assert set(status["pools"]) == {"split", "cluster", "edit", "embed"}
+        assert status["cluster"] == {
+            "pending_atoms": 0,
+            "claimed_atoms": 0,
+            "running_batches": 0,
+        }
+        assert "failed" in status["cluster_write_queue"]
+        assert "inflight" in status["llm"]
+        assert "inflight" in status["embedding"]
+    finally:
+        watcher.stop()

--- a/tests/test_agent_worker_runtime.py
+++ b/tests/test_agent_worker_runtime.py
@@ -122,12 +122,19 @@ def test_shared_request_limiter_caps_real_http_inflight():
         executor.submit(limiter.call, prompt="x", inner_call=inner)
         for _ in range(8)
     ]
-    deadline = time.time() + 2
-    while limiter.status["inflight"] < 2 and time.time() < deadline:
-        time.sleep(0.01)
-    assert limiter.status["inflight"] == 2
-    assert limiter.status["waiting"] == 6
-    release.set()
+    try:
+        deadline = time.time() + 2
+        status = limiter.status
+        while (
+            (status["inflight"] < 2 or status["waiting"] < 6)
+            and time.time() < deadline
+        ):
+            time.sleep(0.01)
+            status = limiter.status
+        assert status["inflight"] == 2
+        assert status["waiting"] == 6
+    finally:
+        release.set()
     assert [future.result(2) for future in futures] == [{}] * 8
     executor.shutdown(wait=True)
     assert maximum == 2

--- a/tests/test_cluster_batch.py
+++ b/tests/test_cluster_batch.py
@@ -1,13 +1,13 @@
 """跨轨迹批量聚类（cluster batch）验收单测
 ================================================
 
-ClusterAgent 由"每次消费 1 个 atom"改为"每次消费 cluster_batch_size 个 atom 的
+ClusterAgent 由"每次消费 1 个 atom"改为"每次消费 cluster batch_size 个 atom 的
 位置（非内容）"。本文件三组验收对应需求三条：
 
 1. **批量生效**：构造 N 条 indexed 轨迹（N > batch_size），观察 ClusterAgent
    调用次数 == ceil(总未归类 atom 数 / batch_size)，而**非** == 总 atom 数。
 2. **已落地过滤**：构造已在某 skill ``.candidates.yml`` 的 atom，确认被
-   ``_collect_cluster_batch`` 过滤、永不进入任何 batch、不送 LLM。
+   ``_collect_cluster_atoms`` 过滤、永不进入任何 batch、不送 LLM。
 3. **断点续传**：消费中途"kill 进程"（丢弃 watcher + 线程池），重启（新 watcher
    同一 wd/db/skill_dir/store）后从断点继续，已落地 atom 不重复消费。
 
@@ -32,6 +32,7 @@ from xskill.skill import candidates as C
 
 from tests.test_atom_task_store import _FakeEmbed
 from tests.test_task_agent import _TRAJ_MD, _AutoSplitLLM
+from tests.pool_helpers import pool_config
 
 
 def _tool_name(tool) -> str:
@@ -134,12 +135,15 @@ def _build_watcher(wd: Path, skill_dir: Path, db: Path, store: AtomTaskStore,
         config={"llm": {"base_url": "x", "model": "y", "api_key": "z"}},
         skill_dir=skill_dir,
         poll_interval=0.0,
-        max_concurrent=4,
+        pool_config=pool_config(
+            workers=4,
+            cluster_workers=8,
+            batch_size=batch_size,
+        ),
         db_path=db,
         store=store,
         agno_agent_factory=_BatchCountingStub,
         home_root=wd.parent,
-        cluster_batch_size=batch_size,
     )
 
 
@@ -283,21 +287,17 @@ class TestResumeAfterKill:
         total = n_trajs * k
         wd_id = _seed_indexed_trajs(wd, store, db, n_trajs, k)
 
-        # ── 进程 1：只跑到落地一批（4 个）就"被 kill" ──
+        # ── 进程 1：完成一批（4 个）后退出 ──
         w1 = _build_watcher(wd, skill_dir, db, store, batch_size=4)
-        for _ in range(30):
-            w1._scan_once()
-            for _ in range(40):
-                if not w1._futures:
-                    break
-                time.sleep(0.02)
-                w1._harvest()
-            if _BatchCountingStub.cluster_calls >= 1 and not w1._futures:
-                break
+        first_batch = [
+            f"atom_traj_{traj_index}_{atom_index:04d}"
+            for traj_index in range(2)
+            for atom_index in range(2)
+        ]
+        w1._do_cluster_batch(first_batch)
         landed_after_kill = list(_BatchCountingStub.sent_atoms)
         assert len(landed_after_kill) == 4, "进程 1 应恰好落地一批 4 个"
-        # 模拟 kill：丢弃线程池，不再用 w1
-        w1._pool.shutdown(wait=False)
+        w1.stop()
 
         # ── 进程 2：新 watcher 同一 wd/db/skill_dir/store，从断点继续 ──
         w2 = _build_watcher(wd, skill_dir, db, store, batch_size=4)

--- a/tests/test_cluster_retry_dedup.py
+++ b/tests/test_cluster_retry_dedup.py
@@ -23,6 +23,7 @@ from xskill.skill import candidates as C
 
 from tests.test_atom_task_store import _FakeEmbed
 from tests.test_task_agent import _TRAJ_MD, _AutoSplitLLM, autosplit_submit
+from tests.pool_helpers import pool_config
 
 
 def _tool_name(tool) -> str:
@@ -146,13 +147,12 @@ def _build_watcher(tmp_path: Path, db: Path, factory, *, batch_size=8):
         config={"llm": {"base_url": "x", "model": "y", "api_key": "z"}},
         skill_dir=skill_dir,
         poll_interval=0.0,
-        max_concurrent=2,
+        pool_config=pool_config(workers=2, batch_size=batch_size),
         db_path=db,
         max_retries=0,
         store=store,
         agno_agent_factory=factory,
         home_root=tmp_path,
-        cluster_batch_size=batch_size,
     ), wd, skill_dir
 
 

--- a/tests/test_cold_start_signal.py
+++ b/tests/test_cold_start_signal.py
@@ -20,6 +20,7 @@ from xskill.pipeline.cold_start import (
 )
 from xskill.pipeline.registry import get_connection, register_dir
 from xskill.pipeline.runner import DirectoryWatcher
+from tests.pool_helpers import pool_config
 from xskill.skill import candidates
 from xskill.skill.git import init_skill_repo_on_baby, current_branch
 from tests.test_atom_task_store import _FakeEmbed
@@ -54,7 +55,7 @@ def _make_watcher(tmp_path, skill_root):
         config=config,
         skill_dir=skill_root,
         poll_interval=0.0,
-        max_concurrent=4,
+        pool_config=pool_config(workers=4),
         db_path=database_path,
         store=atom_store,
         agno_agent_factory=_make_barrier_agno(1, threading.Barrier(1)),

--- a/tests/test_config_autoinit.py
+++ b/tests/test_config_autoinit.py
@@ -46,7 +46,9 @@ def test_noop_when_already_exists(tmp_path):
 def test_template_is_valid_yaml_with_required_sections():
     parsed = yaml.safe_load(CONFIG_TEMPLATE)
     # 必填段都在
-    for key in ("skill_dir", "llm", "embedding", "canary", "watcher"):
+    for key in (
+        "skill_dir", "llm", "embedding", "canary", "watcher", "agent_worker",
+    ):
         assert key in parsed, f"template missing {key}"
     # llm / embedding 带 api_key 占位符（用户要填）
     assert parsed["llm"]["api_key"] == "PUT_YOUR_LLM_API_KEY_HERE"
@@ -61,7 +63,8 @@ def test_template_top_level_keys_are_exactly_live_set():
     """
     parsed = yaml.safe_load(CONFIG_TEMPLATE)
     assert set(parsed.keys()) == {
-        "skill_dir", "llm", "embedding", "canary", "watcher", "team", "dashboard",
+        "skill_dir", "llm", "embedding", "canary", "watcher", "agent_worker",
+        "team", "dashboard",
         "skill_opt", "ingest", "interests", "server",
         # ingest 段由 config.ingest_config 消费（settle 屏障/去壳掩码）
         # recommend 段由 config.recommend_config 消费（推荐引擎参数）

--- a/tests/test_e2e_xskill_serve_auto.py
+++ b/tests/test_e2e_xskill_serve_auto.py
@@ -688,12 +688,16 @@ def sandbox(tmp_path, fake_server):
             "base_url": fake_server.base_url,
             "model": "fake-llm",
             "api_key": "fake-key",
+            "rate_limit": {
+                "rpm": 240, "request_burst": 8, "max_inflight": 8,
+            },
         },
         "embedding": {
             "base_url": fake_server.base_url,
             "model": "fake-embed",
             "api_key": "fake-key",
             "dim": 0,
+            "rate_limit": {"max_inflight": 4},
         },
         "canary": {
             "enabled": True, "probability": 0.5,
@@ -704,6 +708,14 @@ def sandbox(tmp_path, fake_server):
             "total_samples": CANARY_MIN_SAMPLES,
         },
         "watcher": {"poll_interval": 2},
+        "agent_worker": {
+            "pools": {
+                "split": {"workers": 4, "llm_weight": 6},
+                "cluster": {"workers": 4, "batch_size": 4, "llm_weight": 3},
+                "edit": {"workers": 2, "llm_weight": 1},
+                "embed": {"workers": 2},
+            },
+        },
         # 入库完成屏障（settle barrier，src/xskill 的 ingest 路径，默认 120s）
         # 会把"刚写完即扫描"的 session 全挡在窗口外 → daemon 子进程读本
         # config.yaml 拿到默认值，E2E 等不到桥接而超时。评测场景里 session

--- a/tests/test_no_real_home_pollution.py
+++ b/tests/test_no_real_home_pollution.py
@@ -28,6 +28,7 @@ from xskill.pipeline.runner import DirectoryWatcher
 from tests.test_atom_task_store import _FakeEmbed
 from tests.test_task_agent import _TRAJ_MD, _AutoSplitLLM
 from tests.test_watcher_atom import _StubAgno
+from tests.pool_helpers import pool_config
 
 
 REAL_HOME = Path(os.path.expanduser("~"))
@@ -79,7 +80,7 @@ class TestNoRealHomePollution:
             config={"llm": {"base_url": "x", "model": "y", "api_key": "z"}},
             skill_dir=skill_dir,
             poll_interval=0.0,
-            max_concurrent=4,
+            pool_config=pool_config(workers=4),
             db_path=db,
             store=store,
             agno_agent_factory=_StubAgno,
@@ -96,7 +97,7 @@ class TestNoRealHomePollution:
                 watcher._harvest()
             if get_status_counts(db_path=db).get("done"):
                 break
-        watcher._pool.shutdown(wait=False)
+        watcher.stop()
 
         # 关键断言 1：真 ~/.claude/skills/ 子项 + mtime 必须完全没变
         after = _real_skills_snapshot()

--- a/tests/test_profile_refresh_service.py
+++ b/tests/test_profile_refresh_service.py
@@ -139,9 +139,11 @@ def test_worker_concurrency_is_fixed_and_threads_are_daemon():
 
 def test_settle_delay_keeps_profile_work_behind_sync_burst():
     entered = threading.Event()
+    entered_at: list[float] = []
 
     class Engine:
         def update_user_interest(self, _interest, *, should_commit=None):
+            entered_at.append(time.monotonic())
             entered.set()
             return _Result()
 
@@ -151,9 +153,8 @@ def test_settle_delay_keeps_profile_work_behind_sync_burst():
     started = time.monotonic()
     assert service.request("u1")
     assert service.request("u2")
-    assert not entered.wait(0.05)
     assert entered.wait(1)
-    assert time.monotonic() - started >= 0.14
+    assert entered_at[0] - started >= 0.14
     assert service.wait_idle(timeout=2)
     assert service.stop(timeout=2)
 

--- a/tests/test_rebuild_resplit_repro.py
+++ b/tests/test_rebuild_resplit_repro.py
@@ -41,6 +41,7 @@ from xskill.pipeline.runner import DirectoryWatcher
 
 from tests.test_task_agent import _TRAJ_MD, _AutoSplitLLM
 from tests.test_watcher_atom import _StubAgno
+from tests.pool_helpers import pool_config
 from tests.test_atom_task_store import _FakeEmbed
 
 
@@ -55,7 +56,7 @@ def _make_watcher(*, db, wd, skill_dir, store, server_mode):
         config={"llm": {"base_url": "x", "model": "y", "api_key": "z"}},
         skill_dir=skill_dir,
         poll_interval=0.0,
-        max_concurrent=4,
+        pool_config=pool_config(workers=4),
         db_path=db,
         store=store,
         agno_agent_factory=_StubAgno,

--- a/tests/test_server_no_llm_fallback.py
+++ b/tests/test_server_no_llm_fallback.py
@@ -127,9 +127,9 @@ def test_standalone_worker_commands_share_resolved_ecosystem_home(
         "--home",
         str(ecosystem_home.resolve()),
     ]
-    assert set(records_by_name) == {"watcher", "ecosystem-ingest"}
-    assert records_by_name["watcher"].command[-2:] == expected_home_arguments
-    assert records_by_name["watcher"].keyword_arguments["persistent"] is True
+    assert set(records_by_name) == {"agent-worker", "ecosystem-ingest"}
+    assert records_by_name["agent-worker"].command[-2:] == expected_home_arguments
+    assert records_by_name["agent-worker"].keyword_arguments["persistent"] is True
     ingest_command = records_by_name["ecosystem-ingest"].command
     home_argument_index = ingest_command.index("--home")
     assert ingest_command[
@@ -238,11 +238,11 @@ def test_team_server_schedules_only_server_watcher(
     records_by_name = {
         record.name: record for record in scheduler_records
     }
-    assert set(records_by_name) == {"profile-refresh", "watcher"}
-    watcher_command = records_by_name["watcher"].command
+    assert set(records_by_name) == {"profile-refresh", "agent-worker"}
+    watcher_command = records_by_name["agent-worker"].command
     assert watcher_command[-1] == "--server"
     assert "--home" not in watcher_command
-    assert records_by_name["watcher"].keyword_arguments["persistent"] is True
+    assert records_by_name["agent-worker"].keyword_arguments["persistent"] is True
     assert "persistent" not in records_by_name["profile-refresh"].keyword_arguments
     assert "ecosystem-ingest" not in records_by_name
     assert all(record.stopped for record in scheduler_records)

--- a/tests/test_server_watcher_startup.py
+++ b/tests/test_server_watcher_startup.py
@@ -1,4 +1,4 @@
-"""server 启动必起常驻 watcher worker —— 即便 registry 为空。
+"""server 启动必起常驻 agent-worker —— 即便 registry 为空。
 
 回归锚点:web startup 无条件启动常驻 watcher 子进程，即便空 home /
 空 registry。历史上 watcher 启动
@@ -9,7 +9,7 @@ from __future__ import annotations
 from unittest.mock import MagicMock, patch
 
 
-def test_persistent_watcher_starts_even_with_empty_registry(tmp_path):
+def test_persistent_agent_worker_starts_even_with_empty_registry(tmp_path):
     from xskill.api import app as srv
     from starlette.testclient import TestClient
 
@@ -30,12 +30,12 @@ def test_persistent_watcher_starts_even_with_empty_registry(tmp_path):
             app = create_app()
             # 进入 context = startup 事件已跑完;退出 = shutdown 停掉调度器
             with TestClient(app):
-                names = [scheduler._name for scheduler in srv._schedulers]
-                watcher = next(
+                worker = next(
                     scheduler for scheduler in srv._schedulers
-                    if scheduler._name == "watcher"
+                    if scheduler._name == "agent-worker"
                 )
-                assert watcher._persistent is True
+                assert worker._persistent is True
+                assert worker._command[3] == "agent-worker"
     finally:
         srv._schedulers.clear()
         srv._config = None

--- a/tests/test_skilledit_parallel.py
+++ b/tests/test_skilledit_parallel.py
@@ -2,7 +2,7 @@
 
 修复对象：DirectoryWatcher._check_pending_skill_edits 原来用同步 for 循环
 顺序对每个 skill 调 SkillEditAgent.maybe_run()（每个 ~LLM 一次写正文，串行
-= N×耗时）。修复把每个 skill 的 maybe_run() 提交到 self._pool 并发跑，结果
+= N×耗时）。修复把每个 skill 的 maybe_run() 提交到 edit pool 并发跑，结果
 收齐后回主线程串行做 _stats 自增 + install。
 
 本测试验证：
@@ -23,6 +23,7 @@ from xskill.pipeline.atom import AtomTaskStore
 from xskill.pipeline.registry import register_dir
 from xskill.pipeline.runner import DirectoryWatcher
 from xskill.skill import candidates as C
+from tests.pool_helpers import pool_config
 from xskill.skill.git import init_skill_repo_on_baby, current_branch
 from tests.test_atom_task_store import _FakeEmbed
 from tests.test_task_agent import _AutoSplitLLM
@@ -106,7 +107,7 @@ def _make_barrier_agno(expected_workers, barrier):
     return barrier_agent_factory
 
 
-def _make_watcher(tmp_path, skill_root, factory, max_concurrent):
+def _make_watcher(tmp_path, skill_root, factory, edit_workers):
     db = tmp_path / "test.db"
     wd = tmp_path / "wd"
     wd.mkdir(exist_ok=True)
@@ -118,7 +119,7 @@ def _make_watcher(tmp_path, skill_root, factory, max_concurrent):
         config={"llm": {"base_url": "x", "model": "y", "api_key": "z"}},
         skill_dir=skill_root,
         poll_interval=0.0,
-        max_concurrent=max_concurrent,
+        pool_config=pool_config(workers=1, edit_workers=edit_workers),
         db_path=db,
         store=store,
         agno_agent_factory=factory,
@@ -139,7 +140,7 @@ def _make_watcher_with_config(tmp_path, skill_root, factory, config):
         config=config,
         skill_dir=skill_root,
         poll_interval=0.0,
-        max_concurrent=1,
+        pool_config=pool_config(workers=1),
         db_path=db,
         store=store,
         agno_agent_factory=factory,
@@ -190,11 +191,11 @@ class TestSkillEditParallel:
         for s, sd in skill_dirs.items():
             assert current_branch(str(sd)) == "baby"
 
-        # barrier 需要凑齐 N 个并发线程才放行 → 必须 max_concurrent>=N 且真并发
+        # barrier 需要凑齐 N 个并发线程才放行 → edit workers 必须足够且真并发
         barrier = threading.Barrier(N_SKILLS)
         factory = _make_barrier_agno(N_SKILLS, barrier)
         watcher = _make_watcher(tmp_path, skill_root, factory,
-                                max_concurrent=N_SKILLS)
+                                edit_workers=N_SKILLS)
 
         t0 = time.time()
         watcher._check_pending_skill_edits()
@@ -223,7 +224,7 @@ class TestSkillEditParallel:
         assert watcher._stats["skills_edited"] == N_SKILLS
 
     def test_equivalent_to_serial(self, tmp_path):
-        """并行版毕业结果与串行版（max_concurrent=1, 无 barrier）等价：
+        """并行版毕业结果与单 edit worker（无 barrier）等价：
         同一组 baby skill，两种执行模式下毕业集合 + 正文内容一致。"""
         def _run(max_conc, use_barrier):
             sub = tmp_path / f"root_{max_conc}_{int(use_barrier)}"
@@ -236,10 +237,10 @@ class TestSkillEditParallel:
                 barrier = threading.Barrier(len(slugs))
                 factory = _make_barrier_agno(len(slugs), barrier)
             else:
-                # 串行版不用 barrier（max_conc=1 时 barrier 会死锁）
+                # 单 worker 版不用 barrier（否则会死锁）
                 noop = threading.Barrier(1)
                 factory = _make_barrier_agno(1, noop)
-            w = _make_watcher(sub, skill_root, factory, max_concurrent=max_conc)
+            w = _make_watcher(sub, skill_root, factory, edit_workers=max_conc)
             w._check_pending_skill_edits()
             w._drain_futures(stage="skill_edit")
             graduated = {s: current_branch(str(d)) for s, d in dirs.items()}

--- a/tests/test_skillhub_ux.py
+++ b/tests/test_skillhub_ux.py
@@ -129,18 +129,10 @@ class TestSingleMachineScoresSkillhub:
         store.save(AtomTask(
             atom_id="atom_traj_t_0001", traj_id="traj_t",
             offset_start=0, offset_end=2, intent="i", summary="s",
-            tags=[], used_skills=["extfoo"], ux_score=None,
+            tags=[], used_skills=["extfoo"], ux_score=9,
             pre_atom_id=None, post_atom_id=None,
             context_prefix="", raw_segment="# body",
         ))
-
-        scored = []
-
-        def _fake_score_atom(*, llm, atom, side):
-            scored.append((atom.atom_id, side))
-            return {"score": 9, "reasons": "ok"}
-
-        monkeypatch.setattr("xskill.pipeline.atom.score_atom", _fake_score_atom)
 
         w = DirectoryWatcher(
             llm=object(), skill_dir=skill_dir, store=store,
@@ -153,7 +145,6 @@ class TestSingleMachineScoresSkillhub:
         w._score_atoms_for_traj(1, "traj_t.md")
 
         # side 被强制成 main（三方无 staging），sha = 内容哈希
-        assert scored == [("atom_traj_t_0001", "main")]
         rows = load_ux_scores(sub)
         assert len(rows) == 1
         assert rows[0]["side"] == "main"
@@ -175,14 +166,10 @@ class TestSingleMachineScoresSkillhub:
         store.save(AtomTask(
             atom_id="atom_traj_t_0001", traj_id="traj_t",
             offset_start=0, offset_end=2, intent="i", summary="s",
-            tags=[], used_skills=["dup"], ux_score=None,
+            tags=[], used_skills=["dup"], ux_score=7,
             pre_atom_id=None, post_atom_id=None,
             context_prefix="", raw_segment="# body",
         ))
-
-        monkeypatch.setattr(
-            "xskill.pipeline.atom.score_atom",
-            lambda *, llm, atom, side: {"score": 7, "reasons": "ok"})
 
         w = DirectoryWatcher(
             llm=object(), skill_dir=skill_dir, store=store,
@@ -245,18 +232,10 @@ class TestServerScoresSkillhub:
         store.save(AtomTask(
             atom_id="atom_traj_cc_x_001_0001", traj_id="traj_cc_x_001",
             offset_start=0, offset_end=6, intent="i", summary="s",
-            tags=[], used_skills=["extfoo"], ux_score=None,
+            tags=[], used_skills=["extfoo"], ux_score=8,
             pre_atom_id=None, post_atom_id=None,
             context_prefix="", raw_segment="# body",
         ))
-
-        scored = []
-
-        def _fake_score_atom(*, llm, atom, side):
-            scored.append((atom.atom_id, side))
-            return {"score": 8, "reasons": "ok"}
-
-        monkeypatch.setattr("xskill.pipeline.atom.score_atom", _fake_score_atom)
 
         w = DirectoryWatcher(
             llm=object(), skill_dir=skill_dir, store=store,
@@ -271,7 +250,6 @@ class TestServerScoresSkillhub:
             "xskill.pipeline.registry.model_share", lambda **kw: [])
         w._score_atoms_for_traj_server(1, "traj_cc_x_001.md")
 
-        assert scored == [("atom_traj_cc_x_001_0001", "main")]
         rows = load_ux_scores(sub)
         assert len(rows) == 1
         assert rows[0]["side"] == "main"
@@ -291,14 +269,10 @@ class TestServerScoresSkillhub:
         store.save(AtomTask(
             atom_id="atom_traj_cc_0001", traj_id="traj_cc",
             offset_start=0, offset_end=6, intent="i", summary="s",
-            tags=[], used_skills=["fix-foo"], ux_score=None,
+            tags=[], used_skills=["fix-foo"], ux_score=8,
             pre_atom_id=None, post_atom_id=None,
             context_prefix="", raw_segment="# body",
         ))
-
-        monkeypatch.setattr(
-            "xskill.pipeline.atom.score_atom",
-            lambda *, llm, atom, side: {"score": 8, "reasons": "ok"})
 
         w = DirectoryWatcher(
             llm=object(), skill_dir=skill_dir, store=store,

--- a/tests/test_task_agent.py
+++ b/tests/test_task_agent.py
@@ -139,9 +139,7 @@ Editing CSS...
 class _AutoSplitLLM:
     """``.chat`` 形态的 LLM 占位（watcher 的 ``llm=`` 参数用）。
 
-    弃窗后 split 走 agno 工厂,``llm`` 只用于 ``score_atom`` 闸门。watcher 等
-    下游测试把它注入当 ``llm=`` 占位——保留 ``.chat`` 行为,返回一个合法的
-    ux_score JSON,避免 score_atom 解析失败。
+    弃窗后 split 走 agno 工厂；watcher 下游测试仍把它注入为 ``llm=`` 占位。
     """
     model = "stub-autosplit"
 

--- a/tests/test_team_cs_attribution.py
+++ b/tests/test_team_cs_attribution.py
@@ -36,18 +36,9 @@ def test_server_mode_scores_each_used_skill(tmp_path, monkeypatch):
     store.save(AtomTask(
         atom_id="atom_traj_cc_x_001_0001", traj_id="traj_cc_x_001",
         offset_start=0, offset_end=6, intent="i", summary="s",
-        tags=[], used_skills=["fix-foo"], ux_score=None,
+        tags=[], used_skills=["fix-foo"], ux_score=8,
         pre_atom_id=None, post_atom_id=None, context_prefix="", raw_segment="# body",
     ))
-
-    # 桩掉 score_atom，断言它对 fix-foo 被调用、side=main（无 staging）
-    scored = []
-
-    def _fake_score_atom(*, llm, atom, side):
-        scored.append((atom.atom_id, side))
-        return {"score": 8, "reasons": "ok"}
-
-    monkeypatch.setattr("xskill.pipeline.atom.score_atom", _fake_score_atom)
 
     w = DirectoryWatcher(llm=object(), skill_dir=skill_dir, store=store,
                          config={"canary": {"probability": 0.2}}, server_mode=True)
@@ -56,6 +47,5 @@ def test_server_mode_scores_each_used_skill(tmp_path, monkeypatch):
                         lambda **kw: [{"id": 1, "path": str(sessions), "label": "cid-1"}])
     w._score_atoms_for_traj_server(1, "traj_cc_x_001.md")
 
-    assert scored == [("atom_traj_cc_x_001_0001", "main")]
     rows = load_ux_scores(skill_dir / "fix-foo")
     assert len(rows) == 1 and rows[0]["side"] == "main" and rows[0]["score"] == 8.0

--- a/tests/test_v0_6_28a1_migration.py
+++ b/tests/test_v0_6_28a1_migration.py
@@ -1,0 +1,190 @@
+"""Pre-release host migration script config tests."""
+from __future__ import annotations
+
+import importlib.util
+import json
+from pathlib import Path
+
+import yaml
+
+
+SCRIPT = Path(__file__).parents[1] / "scripts" / "xskill_v0_6_28a1_migrate.py"
+SPEC = importlib.util.spec_from_file_location("xskill_v0_6_28a1_migrate", SCRIPT)
+MODULE = importlib.util.module_from_spec(SPEC)
+assert SPEC.loader is not None
+SPEC.loader.exec_module(MODULE)
+
+
+def test_migration_preserves_secrets_and_creates_four_pools():
+    original = {
+        "llm": {
+            "api_key": "llm-secret",
+            "rate_limit": {"rpm": 120, "tpm": 6000, "burst": 12},
+        },
+        "embedding": {"api_key": "embed-secret"},
+        "dashboard": {"password": "admin-secret"},
+        "watcher": {
+            "poll_interval": 7,
+            "max_concurrent": 32,
+            "cluster_batch_size": 5,
+        },
+    }
+    migrated = MODULE.migrate_config(original)
+
+    assert migrated["llm"]["api_key"] == "llm-secret"
+    assert migrated["embedding"]["api_key"] == "embed-secret"
+    assert migrated["dashboard"]["password"] == "admin-secret"
+    assert migrated["watcher"] == {"poll_interval": 7}
+    assert set(migrated["agent_worker"]["pools"]) == {
+        "split", "cluster", "edit", "embed",
+    }
+    assert migrated["agent_worker"]["pools"]["cluster"]["batch_size"] == 5
+    assert migrated["llm"]["rate_limit"] == {
+        "rpm": 120,
+        "tpm": 6000,
+        "request_burst": 12,
+        "max_inflight": 8,
+        "token_burst": 12,
+    }
+    assert migrated["embedding"]["rate_limit"] == {"max_inflight": 4}
+    assert "agent_worker" not in original
+    assert "burst" in original["llm"]["rate_limit"]
+
+
+def test_migration_uses_release_defaults_for_missing_legacy_values():
+    migrated = MODULE.migrate_config({"llm": {}, "embedding": {}})
+    pools = migrated["agent_worker"]["pools"]
+    assert pools["split"] == {"workers": 24, "llm_weight": 6}
+    assert pools["cluster"] == {
+        "workers": 8, "batch_size": 8, "llm_weight": 3,
+    }
+    assert pools["edit"] == {"workers": 4, "llm_weight": 1}
+    assert pools["embed"] == {"workers": 4}
+
+
+def test_install_backs_up_migrates_restarts_and_never_prints_secrets(
+    tmp_path, monkeypatch, capsys,
+):
+    state_dir = tmp_path / ".xskill"
+    state_dir.mkdir()
+    config_path = state_dir / "config.yaml"
+    config_path.write_text(yaml.safe_dump({
+        "llm": {
+            "api_key": "never-print-llm-key",
+            "rate_limit": {"rpm": 60, "burst": 4},
+        },
+        "embedding": {"api_key": "never-print-embed-key"},
+        "dashboard": {"password": "never-print-password"},
+        "watcher": {"max_concurrent": 4, "cluster_batch_size": 3},
+    }), encoding="utf-8")
+    rollback_wheel = tmp_path / "xskill-0.6.27-py3-none-any.whl"
+    rollback_wheel.write_bytes(b"wheel")
+    manifest = state_dir / "migration.json"
+    calls = []
+
+    def prepare_rollback_wheel(_directory):
+        return rollback_wheel
+
+    def run_pip(*arguments):
+        calls.append(arguments)
+
+    def package_version():
+        return "0.6.28a1"
+
+    def serve_processes():
+        return [{
+            "pid": 123,
+            "argv": ["python", "-m", "xskill", "serve", "--port", "8123"],
+            "cwd": tmp_path,
+            "environ": {},
+        }]
+
+    def restart_serve(captured, log_path):
+        calls.append(("restart", captured, log_path))
+
+    def verify(_port):
+        return {
+            "pid": 456,
+            "pools": {
+                name: {"workers": values["workers"]}
+                for name, values in MODULE.POOL_DEFAULTS.items()
+            },
+        }
+
+    monkeypatch.setattr(
+        MODULE, "_prepare_rollback_wheel", prepare_rollback_wheel,
+    )
+    monkeypatch.setattr(MODULE, "_run_pip", run_pip)
+    monkeypatch.setattr(MODULE, "_package_version", package_version)
+    monkeypatch.setattr(MODULE, "_serve_processes", serve_processes)
+    monkeypatch.setattr(MODULE, "_restart_serve", restart_serve)
+    monkeypatch.setattr(MODULE, "_verify", verify)
+    args = MODULE.parse_args([
+        "--wheel", str(tmp_path / "xskill-0.6.28a1.whl"),
+        "--config", str(config_path),
+        "--manifest", str(manifest),
+    ])
+    MODULE.install(args)
+
+    migrated = yaml.safe_load(config_path.read_text(encoding="utf-8"))
+    assert set(migrated["agent_worker"]["pools"]) == {
+        "split", "cluster", "edit", "embed",
+    }
+    assert migrated["agent_worker"]["pools"]["cluster"]["batch_size"] == 3
+    payload = json.loads(manifest.read_text(encoding="utf-8"))
+    assert Path(payload["config_backup"]).is_file()
+    assert payload["port"] == 8123
+    assert calls[0][:3] == ("install", "--no-deps", "--force-reinstall")
+    output = capsys.readouterr().out
+    for secret in (
+        "never-print-llm-key", "never-print-embed-key", "never-print-password",
+    ):
+        assert secret not in output
+        assert secret not in manifest.read_text(encoding="utf-8")
+
+
+def test_rollback_restores_v0627_package_and_original_config(
+    tmp_path, monkeypatch,
+):
+    state_dir = tmp_path / ".xskill"
+    state_dir.mkdir()
+    config_path = state_dir / "config.yaml"
+    backup_path = state_dir / "config.yaml.v0.6.27.bak"
+    rollback_wheel = state_dir / "xskill-0.6.27-py3-none-any.whl"
+    manifest = state_dir / "migration.json"
+    original = "watcher:\n  max_concurrent: 4\n"
+    config_path.write_text("agent_worker:\n  pools: {}\n", encoding="utf-8")
+    backup_path.write_text(original, encoding="utf-8")
+    rollback_wheel.write_bytes(b"wheel")
+    manifest.write_text(json.dumps({
+        "config_path": str(config_path),
+        "config_backup": str(backup_path),
+        "rollback_wheel": str(rollback_wheel),
+    }), encoding="utf-8")
+    calls = []
+
+    def serve_processes():
+        return [{"pid": 1}]
+
+    def run_pip(*arguments):
+        calls.append(arguments)
+
+    def package_version():
+        return "0.6.27"
+
+    def restart_serve(captured, log_path):
+        calls.append(("restart", captured, log_path))
+
+    monkeypatch.setattr(MODULE, "_serve_processes", serve_processes)
+    monkeypatch.setattr(MODULE, "_run_pip", run_pip)
+    monkeypatch.setattr(MODULE, "_package_version", package_version)
+    monkeypatch.setattr(MODULE, "_restart_serve", restart_serve)
+
+    args = MODULE.parse_args(["--rollback", "--manifest", str(manifest)])
+    MODULE.rollback(args)
+
+    assert config_path.read_text(encoding="utf-8") == original
+    assert calls[0] == (
+        "install", "--no-deps", "--force-reinstall", str(rollback_wheel),
+    )
+    assert calls[1][0] == "restart"

--- a/tests/test_watcher.py
+++ b/tests/test_watcher.py
@@ -24,7 +24,7 @@ from xskill.pipeline.runner import DirectoryWatcher
 
 
 def _drain(watcher: DirectoryWatcher) -> None:
-    """等所有提交到 watcher._pool 的 future 跑完，再触发一次 _harvest 把
+    """等所有提交到 watcher pools 的 future 跑完，再触发一次 _harvest 把
     收割回调（更新 DB 状态、移除 future 记录）跑齐。供测试用。
     """
     for fut in list(watcher._futures):

--- a/tests/test_watcher_atom.py
+++ b/tests/test_watcher_atom.py
@@ -2,6 +2,7 @@
 from __future__ import annotations
 
 from concurrent.futures import Future
+import threading
 import time
 from unittest.mock import Mock
 
@@ -14,6 +15,7 @@ from xskill.config import interests_fingerprint
 from xskill.pipeline.runner import DirectoryWatcher
 from tests.test_atom_task_store import _FakeEmbed
 from tests.test_task_agent import _TRAJ_MD, _AutoSplitLLM, autosplit_submit
+from tests.pool_helpers import pool_config
 
 
 def _tool_name(tool) -> str:
@@ -143,7 +145,7 @@ class TestZombieCleanup:
             config={"llm": {"base_url": "x", "model": "y", "api_key": "z"}},
             skill_dir=skill_dir,
             poll_interval=0.0,
-            max_concurrent=2,
+            pool_config=pool_config(workers=2),
             db_path=db,
             store=store,
             agno_agent_factory=_StubAgno,
@@ -178,7 +180,7 @@ class TestZombieCleanup:
             config={},
             skill_dir=skill_directory,
             poll_interval=0.0,
-            max_concurrent=2,
+            pool_config=pool_config(workers=2),
             db_path=database_path,
             home_root=tmp_path,
         )
@@ -195,7 +197,7 @@ class TestZombieCleanup:
             watch_dir_id, "discovered", db_path=database_path,
         )
         assert watcher._futures[cluster_future]["stage"] == "cluster"
-        watcher._pool.shutdown(wait=False)
+        watcher.stop()
 
     def test_clustering_zombie_rolls_back_to_indexed(self, tmp_path):
         db = tmp_path / "test.db"
@@ -214,7 +216,7 @@ class TestZombieCleanup:
             config={"llm": {"base_url": "x", "model": "y", "api_key": "z"}},
             skill_dir=skill_dir,
             poll_interval=0.0,
-            max_concurrent=2,
+            pool_config=pool_config(workers=2),
             db_path=db,
             store=store,
             agno_agent_factory=_StubAgno,
@@ -244,30 +246,30 @@ def _seed_indexed_with_atoms(wd, store, db, n_trajs, atoms_per_traj):
     return wd_id
 
 
-class TestClusterSerial:
-    """聚类始终串行：同 wd 同时只允许一个 cluster batch future 在飞——逐批让
-    catalog 演化可见，避免并发 cluster agent 创建近义 baby slug。"""
+class TestClusterParallel:
+    """Cluster batch 填满独立池，同一 Atom 在重复扫描中只认领一次。"""
 
-    def _blocking_factory(self):
+    def _blocking_factory(self, started, release):
         class _BlockingStub:
             def __init__(self, **kw):
                 pass
 
             def run(self, _message, **_keyword_arguments):
-                import time
-                time.sleep(5)  # 模拟 cluster 长时间运行，让 future 留在飞
+                started.append(threading.current_thread().name)
+                release.wait(5)
                 class _R: pass
                 r = _R(); r.content = ""; return r
         return lambda **k: _BlockingStub(**k)
 
-    def test_only_one_cluster_batch_in_flight(self, tmp_path):
+    def test_cluster_batches_fill_independent_pool(self, tmp_path):
         db = tmp_path / "test.db"
         wd = tmp_path / "wd"; wd.mkdir()
         skill_dir = tmp_path / "skill"; skill_dir.mkdir()
         store = AtomTaskStore(root=wd)
-        # 4 条 indexed 轨迹 × 2 atom，batch_size=2 → 即便有 8 个待消费 atom、
-        # 4 个批次的量，同 wd 也只起 1 个 batch future（串行）。
-        _seed_indexed_with_atoms(wd, store, db, n_trajs=4, atoms_per_traj=2)
+        # 8 条 indexed 轨迹 × 2 atom，batch_size=2 → 8 个 Agent 同时运行。
+        _seed_indexed_with_atoms(wd, store, db, n_trajs=8, atoms_per_traj=2)
+        started = []
+        release = threading.Event()
 
         watcher = DirectoryWatcher(
             llm=_AutoSplitLLM(),
@@ -275,27 +277,34 @@ class TestClusterSerial:
             config={"llm": {"base_url": "x", "model": "y", "api_key": "z"}},
             skill_dir=skill_dir,
             poll_interval=0.0,
-            max_concurrent=30,
+            pool_config=pool_config(
+                workers=2, cluster_workers=8, batch_size=2,
+            ),
             db_path=db,
             store=store,
-            agno_agent_factory=self._blocking_factory(),
+            agno_agent_factory=self._blocking_factory(started, release),
             home_root=tmp_path,
-            cluster_batch_size=2,
         )
         watcher._scan_once()
         cluster_in_flight = sum(
             1 for i in watcher._futures.values() if i["stage"] == "cluster"
         )
-        assert cluster_in_flight == 1, (
-            f"cluster 应串行（1 batch in-flight），实际 {cluster_in_flight}"
+        deadline = time.time() + 2
+        while len(started) < 8 and time.time() < deadline:
+            time.sleep(0.01)
+        assert cluster_in_flight == 8, (
+            f"cluster 应同时提交 8 个 batch，实际 {cluster_in_flight}"
         )
-        # 再 scan 一次：上一个 batch 还在飞 → 不应再提交新的
+        assert len(started) == 8
+        assert all(name.startswith("xskill-cluster_") for name in started)
+        # 再 scan 一次：claimed atoms 不应重复提交。
         watcher._scan_once()
         cluster_in_flight = sum(
             1 for i in watcher._futures.values() if i["stage"] == "cluster"
         )
-        assert cluster_in_flight == 1, "batch 在飞时第二轮 scan 不应再起新 batch"
-        watcher._pool.shutdown(wait=False)
+        assert cluster_in_flight == 8, "第二轮 scan 不应重复提交 claimed atoms"
+        release.set()
+        watcher.stop()
 
 
 class TestClusterAllFailed:
@@ -332,7 +341,7 @@ class TestClusterAllFailed:
             config={"llm": {"base_url": "x", "model": "y", "api_key": "z"}},
             skill_dir=skill_dir,
             poll_interval=0.0,
-            max_concurrent=2,
+            pool_config=pool_config(workers=2),
             db_path=db,
             store=store,
             max_retries=0,
@@ -416,7 +425,7 @@ class TestIndependentSkillEditScan:
             config={"llm": {"base_url": "x", "model": "y", "api_key": "z"}},
             skill_dir=skill_dir,
             poll_interval=0.0,
-            max_concurrent=2,
+            pool_config=pool_config(workers=2),
             db_path=db,
             store=store,
             agno_agent_factory=lambda **kw: _MixedStub(**kw),
@@ -446,10 +455,9 @@ class TestIndependentSkillEditScan:
 
 
 class TestUxScoreAtomLevel:
-    """cluster 完成后该 traj 的所有 atom 应被逐个调 score_atom + AtomCanary.append。"""
+    """cluster 完成后复用 TaskAgent 的 atom ux_score 写入 AtomCanary。"""
 
     def test_with_header_triggers_atom_scoring(self, tmp_path):
-        from unittest.mock import patch
         db = tmp_path / "test.db"
         wd = tmp_path / "wd"; wd.mkdir()
         skill_dir = tmp_path / "skill"; skill_dir.mkdir()
@@ -478,31 +486,22 @@ class TestUxScoreAtomLevel:
             config={"llm": {"base_url": "x", "model": "y", "api_key": "z"}},
             skill_dir=skill_dir,
             poll_interval=0.0,
-            max_concurrent=2,
+            pool_config=pool_config(workers=2),
             db_path=db,
             store=store,
             agno_agent_factory=_StubAgno,
             home_root=tmp_path,
         )
-        # mock score_atom 返回固定分数
-        with patch("xskill.pipeline.atom.score_atom",
-                   return_value={"score": 8, "reasons": "ok"}) as mock_score:
-            # 多轮推进到 done
-            for _ in range(20):
-                watcher._scan_once()
-                for _ in range(30):
-                    if not watcher._futures:
-                        break
-                    time.sleep(0.05)
-                    watcher._harvest()
-                counts = get_status_counts(db_path=db)
-                if counts.get("done"):
+        for _ in range(20):
+            watcher._scan_once()
+            for _ in range(30):
+                if not watcher._futures:
                     break
-            # _TRAJ_MD 有 2 个 ## User → 2 个 atom → score_atom 调 2 次
-            assert mock_score.call_count == 2
-            # 验证传给 score_atom 的 side 来自 header
-            call_kw = mock_score.call_args[1]
-            assert call_kw["side"] == "staging"
+                time.sleep(0.05)
+                watcher._harvest()
+            counts = get_status_counts(db_path=db)
+            if counts.get("done"):
+                break
 
         # 落盘到 .ux_scores.jsonl，主键是 atom_id
         import json
@@ -515,6 +514,7 @@ class TestUxScoreAtomLevel:
             assert rec["atom_id"].startswith("atom_traj_z_")
             assert rec["side"] == "staging"
             assert rec["commit_sha"] == "abc123"
+            assert rec["score"] == 7
 
     def test_no_header_no_scoring(self, tmp_path):
         from unittest.mock import patch
@@ -531,7 +531,7 @@ class TestUxScoreAtomLevel:
             config={"llm": {"base_url": "x", "model": "y", "api_key": "z"}},
             skill_dir=skill_dir,
             poll_interval=0.0,
-            max_concurrent=2,
+            pool_config=pool_config(workers=2),
             db_path=db,
             store=store,
             agno_agent_factory=_StubAgno,
@@ -581,7 +581,7 @@ class TestContinuationResplit:
             config={"llm": {"base_url": "x", "model": "y", "api_key": "z"}},
             skill_dir=skill_dir,
             poll_interval=0.0,
-            max_concurrent=4,
+            pool_config=pool_config(workers=4),
             db_path=db,
             store=store,
             agno_agent_factory=_StubAgno,
@@ -654,7 +654,7 @@ class TestInterestFiltering:
             },
             skill_dir=skill_directory,
             poll_interval=0.0,
-            max_concurrent=1,
+            pool_config=pool_config(workers=1),
             db_path=db_path,
             store=AtomTaskStore(root=watch_directory),
             agno_agent_factory=_NotFitAgno,
@@ -711,7 +711,7 @@ class TestInterestFiltering:
             },
             skill_dir=skill_directory,
             poll_interval=0.0,
-            max_concurrent=1,
+            pool_config=pool_config(workers=1),
             db_path=db_path,
             store=AtomTaskStore(root=watch_directory),
             agno_agent_factory=_StubAgno,
@@ -747,7 +747,7 @@ class TestPipelineRun:
             config={"llm": {"base_url": "test://", "model": "stub", "api_key": "k"}},
             skill_dir=skill_dir,
             poll_interval=0.0,
-            max_concurrent=4,
+            pool_config=pool_config(workers=4),
             db_path=db,
             store=store,
             agno_agent_factory=_StubAgno,


### PR DESCRIPTION
## 变更

- 将常驻子进程迁移为 `agent-worker`，拆分 split、cluster、edit、embed 四个独立线程池
- 实现 Cluster 全局并行调度、Atom 去重/恢复和单线程文件写入队列
- 增加共享 LLM 限流与独立 Embedding 并发限制
- 增加严格配置迁移校验及 `/api/v1/agent-worker/status`
- 清理管线中的历史 sweep 命名
- 增加 v0.6.28a1 GitHub Prerelease 工作流与可回滚迁移脚本

## 验证

- `1919 passed`（完整测试集）
- Docker E2E 两个场景通过
- Python 3.11 wheel/sdist、twine、隔离安装验证通过
- v0.6.28a1 wheel 构建与内容检查通过
- py-spy 已识别四个固定前缀线程池
- Ruff、变更范围 Semgrep、`git diff --check` 通过

## 发布约束

预发布 tag 仅创建 GitHub Prerelease，不上传 PyPI；稳定版需在远程负载观察完成后另行发布。