### PR TITLE
fix(release): 迁移 v0.6.28a1 发布门禁到四池配置

### DIFF
--- a/scripts/bench/bench_cluster_batch.py
+++ b/scripts/bench/bench_cluster_batch.py
@@ -28,13 +28,22 @@ from pathlib import Path
 _REC = {"sessions": 0, "input_chars": 0}
 
 
+def _tool_name(tool) -> str:
+    return getattr(tool, "__name__", None) or getattr(tool, "name", "")
+
+
+def _call_tool(tool, *args):
+    entrypoint = tool if callable(tool) else getattr(tool, "entrypoint")
+    return entrypoint(*args)
+
+
 def _make_stub():
     import re
 
     class _Stub:
         def __init__(self, *, instructions, tools):
             self.instructions = instructions
-            self.tools = {getattr(t, "__name__", ""): t for t in tools}
+            self.tools = {_tool_name(t): t for t in tools}
 
         def run(self, user_msg, **kw):
             head = (self.instructions[0] if self.instructions else "")[:80]
@@ -47,13 +56,25 @@ def _make_stub():
                 # 真实输入 = system prompt（含 skill 路由表）+ user 消息
                 _REC["input_chars"] += len(self.instructions[0]) + len(user_msg)
                 atom_ids = re.findall(r"atom_id:\s*(\S+)", user_msg)
+                grouped: dict[str, list[str]] = {}
                 for aid in atom_ids:
                     # round-robin 路由到 8 个 skill，形成一个真实（小）的 catalog
                     sk = f"skill-{abs(hash(aid)) % 8}"
+                    grouped.setdefault(sk, []).append(aid)
+                for sk, grouped_atom_ids in grouped.items():
                     if "new_skill_folder" in self.tools:
-                        self.tools["new_skill_folder"](sk, "bench skill")
-                    if "add_task_to_skill" in self.tools:
-                        self.tools["add_task_to_skill"](sk, aid, 3)
+                        _call_tool(
+                            self.tools["new_skill_folder"], sk, "bench skill",
+                        )
+                    if "add_tasks_to_skill" in self.tools:
+                        _call_tool(
+                            self.tools["add_tasks_to_skill"],
+                            sk,
+                            [
+                                {"atom_id": aid, "weightscore": 3}
+                                for aid in grouped_atom_ids
+                            ],
+                        )
                 return _R()
             # split / edit / 其它：noop
             return _R()
@@ -73,8 +94,10 @@ def _run(traj_atoms: dict[str, int], batch_size: int):
     _REC["input_chars"] = 0
 
     tmp = Path(tempfile.mkdtemp(prefix="bench_cluster_"))
-    wd = tmp / "wd"; wd.mkdir()
-    skill_dir = tmp / "skill"; skill_dir.mkdir()
+    wd = tmp / "wd"
+    wd.mkdir()
+    skill_dir = tmp / "skill"
+    skill_dir.mkdir()
     db = tmp / "bench.db"
     store = AtomTaskStore(root=wd)
 
@@ -99,12 +122,18 @@ def _run(traj_atoms: dict[str, int], batch_size: int):
         config={"llm": {"base_url": "x", "model": "y", "api_key": "z"}},
         skill_dir=skill_dir,
         poll_interval=0.0,
-        max_concurrent=4,
+        pool_config={
+            "split": {"workers": 4, "llm_weight": 6},
+            "cluster": {
+                "workers": 4, "batch_size": batch_size, "llm_weight": 3,
+            },
+            "edit": {"workers": 4, "llm_weight": 1},
+            "embed": {"workers": 4},
+        },
         db_path=db,
         store=store,
         agno_agent_factory=_make_stub(),
         home_root=tmp,
-        cluster_batch_size=batch_size,
     )
 
     t0 = time.monotonic()
@@ -119,7 +148,7 @@ def _run(traj_atoms: dict[str, int], batch_size: int):
             break
     wall = time.monotonic() - t0
     done = len(get_trajs_by_status(wd_id, "done", db_path=db))
-    watcher._pool.shutdown(wait=False)
+    watcher.stop()
     return {"sessions": _REC["sessions"], "input_chars": _REC["input_chars"],
             "wall": wall, "done": done, "n_trajs": len(traj_atoms)}
 

--- a/scripts/loadtest_300_control_plane.py
+++ b/scripts/loadtest_300_control_plane.py
@@ -463,6 +463,11 @@ def prepare_home(
             "connect_timeout": 5,
             "client_max_retries": 0,
             "max_retries": 1,
+            "rate_limit": {
+                "rpm": 60000,
+                "request_burst": max_concurrent,
+                "max_inflight": max_concurrent,
+            },
         },
         "embedding": {
             "base_url": mock_base_url,
@@ -470,6 +475,7 @@ def prepare_home(
             "api_key": "mock-key",
             "dim": 8,
             "api": "openai",
+            "rate_limit": {"max_inflight": profile_refresh_workers},
         },
         "skill_opt": {"enabled": False},
         "canary": {
@@ -483,9 +489,17 @@ def prepare_home(
         },
         "watcher": {
             "poll_interval": 0.5,
-            "max_concurrent": max_concurrent,
-            "cluster_batch_size": 8,
         },
+        "agent_worker": {"pools": {
+            "split": {"workers": max_concurrent, "llm_weight": 6},
+            "cluster": {
+                "workers": max_concurrent,
+                "batch_size": 8,
+                "llm_weight": 3,
+            },
+            "edit": {"workers": max_concurrent, "llm_weight": 1},
+            "embed": {"workers": profile_refresh_workers},
+        }},
         "server": {
             "thread_pool_tokens": thread_pool_tokens,
             "team_sync_workers": team_sync_workers,
@@ -1519,7 +1533,7 @@ def validate_result(result: dict[str, Any]) -> list[str]:
         failures.append(f"LLM request split incorrect: {llm}")
     if llm.get("started") != 2 * skills or llm.get("completed") != 2 * skills:
         failures.append(f"LLM completion count incorrect: {llm}")
-    if int(llm.get("max_active", workers + 1)) > int(config["watcher_max_concurrent"]):
+    if int(llm.get("max_active", workers + 1)) > int(config["llm_max_inflight"]):
         failures.append(f"LLM active limit exceeded: {llm.get('max_active')}")
 
     embedding = mock.get("embedding", {})
@@ -1778,7 +1792,7 @@ def main() -> int:
         "config": {
             "skills": args.skills,
             "clients": args.clients,
-            "watcher_max_concurrent": args.max_concurrent,
+            "llm_max_inflight": args.max_concurrent,
             "thread_pool_tokens": args.thread_pool_tokens,
             "team_sync_workers": args.team_sync_workers,
             "skill_slots": args.skill_slots,

--- a/scripts/loadtest_skillhub_search.py
+++ b/scripts/loadtest_skillhub_search.py
@@ -130,15 +130,26 @@ def prepare_search_home(run_dir: Path, mock_base_url: str, args: argparse.Namesp
             "base_url": mock_base_url, "model": "mock-tool-model", "api_key": "mock-key",
             "max_context": 200000, "request_timeout": 120, "connect_timeout": 5,
             "client_max_retries": 0, "max_retries": 1,
+            "rate_limit": {"rpm": 240, "request_burst": 8, "max_inflight": 8},
         },
         "embedding": {
             "base_url": mock_base_url, "model": "mock-embed-model", "api_key": "mock-key",
             "dim": 8, "api": "openai",
             "max_embed": args.max_embed_low, "search_timeout_s": args.search_timeout_s,
+            # This smoke measures SkillHub's max_embed=1/4 semaphore while up
+            # to eight profile-refresh requests run beside it. Keep the shared
+            # endpoint gate large enough for both independently bounded paths.
+            "rate_limit": {"max_inflight": 8 + args.max_embed_high},
         },
         "skillhub": {"enabled": True, "dir": str(skillhub_dir)},
         "skill_opt": {"enabled": False},
-        "watcher": {"poll_interval": 0.5, "max_concurrent": 8, "cluster_batch_size": 8},
+        "watcher": {"poll_interval": 0.5},
+        "agent_worker": {"pools": {
+            "split": {"workers": 8, "llm_weight": 6},
+            "cluster": {"workers": 8, "batch_size": 8, "llm_weight": 3},
+            "edit": {"workers": 8, "llm_weight": 1},
+            "embed": {"workers": 8},
+        }},
         "server": {
             "thread_pool_tokens": 80, "team_sync_workers": args.team_sync_workers,
             "profile_refresh_workers": 8, "profile_refresh_queue_size": 1024,


### PR DESCRIPTION
## 修复

- 将 SkillHub 发布冒烟和 300 客户端压测配置迁移到 `agent_worker.pools`
- 为发布压测补齐 LLM 与 Embedding 请求限制
- 将 Cluster benchmark 迁移到四池构造参数和批量写入工具

## 验证

- `37 passed`：配置、迁移、限流与压测工具单测
- 小型真实进程 SkillHub 发布冒烟：`1 passed`
- Cluster benchmark：72 Atom，Cluster 会话 72 → 9
- Ruff 与 `git diff --check` 通过

修复 tag `v0.6.28a1` 首次发布门禁因旧 `watcher.max_concurrent` 配置启动失败的问题。首次工作流未创建 Release，也未上传 PyPI。