### PR TITLE
fix(config): 兼容 v0.6.27 旧配置

### DIFF
--- a/src/xskill/config.py
+++ b/src/xskill/config.py
@@ -7,6 +7,7 @@ config.py — 全局路径与配置加载
 
 from __future__ import annotations
 
+import copy
 import hashlib
 import json
 import logging
@@ -26,6 +27,19 @@ LOGS_DIR = XSKILL_HOME / "logs"
 
 _config: dict = {}
 _overrides: dict = {}
+
+DEFAULT_AGENT_WORKER_POOLS = {
+    "split": {"workers": 24, "llm_weight": 6},
+    "cluster": {"workers": 8, "batch_size": 8, "llm_weight": 3},
+    "edit": {"workers": 4, "llm_weight": 1},
+    "embed": {"workers": 4},
+}
+DEFAULT_LLM_RATE_LIMIT = {
+    "rpm": 240,
+    "request_burst": 8,
+    "max_inflight": 8,
+}
+DEFAULT_EMBEDDING_MAX_INFLIGHT = 4
 
 
 def set_overrides(**kwargs):
@@ -278,87 +292,162 @@ def _positive_int(value, path: str) -> int:
     return value
 
 
-def agent_worker_config(config_data: dict) -> dict:
-    """Validate and normalize the v0.6.28 four-pool configuration."""
+def _positive_int_or_default(value, path: str, default: int) -> int:
+    if value is None:
+        return default
+    return _positive_int(value, path)
+
+
+def normalize_runtime_config(config_data: dict) -> dict:
+    """Return a validated runtime copy compatible with v0.6.27 configs.
+
+    Compatibility defaults are deliberately applied in memory.  The user's
+    YAML remains untouched, while every runtime consumer sees the canonical
+    four-pool and request-limit shape introduced in v0.6.28.
+    """
     if not isinstance(config_data, dict):
         raise ValueError("config.yaml 顶层必须是 mapping")
-    watcher = config_data.get("watcher") or {}
+    runtime_config = copy.deepcopy(config_data)
+
+    watcher = runtime_config.get("watcher") or {}
     if not isinstance(watcher, dict):
         raise ValueError("watcher 必须是 mapping")
+    legacy_max_concurrent = None
     if "max_concurrent" in watcher:
-        raise ValueError(
-            "旧配置 watcher.max_concurrent 已移除；请分别配置 "
-            "agent_worker.pools.split/cluster/edit/embed.workers"
+        legacy_max_concurrent = _positive_int(
+            watcher["max_concurrent"], "watcher.max_concurrent",
         )
+    legacy_batch_size = None
     if "cluster_batch_size" in watcher:
-        raise ValueError(
-            "旧配置 watcher.cluster_batch_size 已移至 "
-            "agent_worker.pools.cluster.batch_size"
+        legacy_batch_size = _positive_int(
+            watcher["cluster_batch_size"], "watcher.cluster_batch_size",
         )
+    watcher.pop("max_concurrent", None)
+    watcher.pop("cluster_batch_size", None)
+    runtime_config["watcher"] = watcher
 
-    for llm_path, llm_cfg in (
-        ("llm", config_data.get("llm") or {}),
-        ("llm_skill", config_data.get("llm_skill") or {}),
-    ):
-        if not isinstance(llm_cfg, dict):
-            raise ValueError(f"{llm_path} 必须是 mapping")
-        rate_cfg = llm_cfg.get("rate_limit") or {}
-        if not isinstance(rate_cfg, dict):
-            raise ValueError(f"{llm_path}.rate_limit 必须是 mapping")
-        if "burst" in rate_cfg:
-            raise ValueError(
-                f"旧配置 {llm_path}.rate_limit.burst 已移除；请求突发量改用 "
-                f"{llm_path}.rate_limit.request_burst，TPM 突发量单独使用 "
-                f"{llm_path}.rate_limit.token_burst"
-            )
-
-    worker = config_data.get("agent_worker")
-    if not isinstance(worker, dict) or not isinstance(worker.get("pools"), dict):
-        raise ValueError(
-            "缺少 agent_worker.pools；请配置 split、cluster、edit、embed 四个池"
-        )
-    pools = worker["pools"]
-    normalized: dict[str, dict] = {}
-    for name in ("split", "cluster", "edit", "embed"):
+    worker = runtime_config.get("agent_worker")
+    if worker is None:
+        worker = {}
+    if not isinstance(worker, dict):
+        raise ValueError("agent_worker 必须是 mapping")
+    pools = worker.get("pools")
+    if pools is None:
+        pools = {}
+    if not isinstance(pools, dict):
+        raise ValueError("agent_worker.pools 必须是 mapping")
+    normalized_pools: dict[str, dict] = {}
+    for name, defaults in DEFAULT_AGENT_WORKER_POOLS.items():
         pool = pools.get(name)
+        if pool is None:
+            pool = {}
         if not isinstance(pool, dict):
-            raise ValueError(f"缺少 agent_worker.pools.{name}")
+            raise ValueError(f"agent_worker.pools.{name} 必须是 mapping")
         if "queue_size" in pool:
             raise ValueError(
                 f"不接受 agent_worker.pools.{name}.queue_size；等待容量自动为 workers × 2"
             )
-        normalized[name] = dict(pool)
-        normalized[name]["workers"] = _positive_int(
-            pool.get("workers"), f"agent_worker.pools.{name}.workers"
+        normalized_pool = {**defaults, **pool}
+        normalized_pool["workers"] = _positive_int(
+            normalized_pool["workers"], f"agent_worker.pools.{name}.workers"
         )
         if name in ("split", "cluster", "edit"):
-            normalized[name]["llm_weight"] = _positive_int(
-                pool.get("llm_weight"),
+            normalized_pool["llm_weight"] = _positive_int(
+                normalized_pool["llm_weight"],
                 f"agent_worker.pools.{name}.llm_weight",
             )
-    normalized["cluster"]["batch_size"] = _positive_int(
-        pools["cluster"].get("batch_size"),
+        normalized_pools[name] = normalized_pool
+    cluster_batch_size = normalized_pools["cluster"].get("batch_size")
+    if "cluster" not in pools or "batch_size" not in pools["cluster"]:
+        cluster_batch_size = (
+            legacy_batch_size
+            if legacy_batch_size is not None
+            else DEFAULT_AGENT_WORKER_POOLS["cluster"]["batch_size"]
+        )
+    normalized_pools["cluster"]["batch_size"] = _positive_int(
+        cluster_batch_size,
         "agent_worker.pools.cluster.batch_size",
     )
+    worker = dict(worker)
+    worker["pools"] = normalized_pools
+    runtime_config["agent_worker"] = worker
 
-    llm_rate = (config_data.get("llm") or {}).get("rate_limit")
+    llm = runtime_config.get("llm") or {}
+    if not isinstance(llm, dict):
+        raise ValueError("llm 必须是 mapping")
+    llm = dict(llm)
+    llm_rate = llm.get("rate_limit") or {}
     if not isinstance(llm_rate, dict):
-        raise ValueError("缺少 llm.rate_limit")
-    for key in ("rpm", "request_burst", "max_inflight"):
-        _positive_int(llm_rate.get(key), f"llm.rate_limit.{key}")
+        raise ValueError("llm.rate_limit 必须是 mapping")
+    llm_rate = dict(llm_rate)
+    legacy_burst = llm_rate.pop("burst", None)
+    if legacy_burst is not None:
+        legacy_burst = _positive_int(legacy_burst, "llm.rate_limit.burst")
+    llm_rate["rpm"] = _positive_int_or_default(
+        llm_rate.get("rpm"), "llm.rate_limit.rpm",
+        DEFAULT_LLM_RATE_LIMIT["rpm"],
+    )
+    llm_rate["request_burst"] = _positive_int_or_default(
+        llm_rate.get("request_burst"), "llm.rate_limit.request_burst",
+        legacy_burst or DEFAULT_LLM_RATE_LIMIT["request_burst"],
+    )
+    llm_rate["max_inflight"] = _positive_int_or_default(
+        llm_rate.get("max_inflight"), "llm.rate_limit.max_inflight",
+        legacy_max_concurrent or DEFAULT_LLM_RATE_LIMIT["max_inflight"],
+    )
     if "tpm" in llm_rate:
-        _positive_int(llm_rate["tpm"], "llm.rate_limit.tpm")
+        tpm = _positive_int(llm_rate["tpm"], "llm.rate_limit.tpm")
+        llm_rate["token_burst"] = _positive_int_or_default(
+            llm_rate.get("token_burst"), "llm.rate_limit.token_burst",
+            legacy_burst or max(1, tpm // 6),
+        )
     if "token_burst" in llm_rate:
         _positive_int(llm_rate["token_burst"], "llm.rate_limit.token_burst")
+    llm["rate_limit"] = llm_rate
+    runtime_config["llm"] = llm
 
-    embedding_rate = (config_data.get("embedding") or {}).get("rate_limit")
+    llm_skill = runtime_config.get("llm_skill")
+    if llm_skill is not None:
+        if not isinstance(llm_skill, dict):
+            raise ValueError("llm_skill 必须是 mapping")
+        llm_skill = dict(llm_skill)
+        if "rate_limit" in llm_skill:
+            skill_rate = llm_skill.get("rate_limit") or {}
+            if not isinstance(skill_rate, dict):
+                raise ValueError("llm_skill.rate_limit 必须是 mapping")
+            skill_rate = dict(skill_rate)
+            skill_burst = skill_rate.pop("burst", None)
+            if skill_burst is not None:
+                skill_burst = _positive_int(
+                    skill_burst, "llm_skill.rate_limit.burst",
+                )
+                skill_rate.setdefault("request_burst", skill_burst)
+                if "tpm" in skill_rate:
+                    skill_rate.setdefault("token_burst", skill_burst)
+            llm_skill["rate_limit"] = skill_rate
+        runtime_config["llm_skill"] = llm_skill
+
+    embedding = runtime_config.get("embedding") or {}
+    if not isinstance(embedding, dict):
+        raise ValueError("embedding 必须是 mapping")
+    embedding = dict(embedding)
+    embedding_rate = embedding.get("rate_limit") or {}
     if not isinstance(embedding_rate, dict):
-        raise ValueError("缺少 embedding.rate_limit.max_inflight")
-    _positive_int(
+        raise ValueError("embedding.rate_limit 必须是 mapping")
+    embedding_rate = dict(embedding_rate)
+    embedding_rate["max_inflight"] = _positive_int_or_default(
         embedding_rate.get("max_inflight"),
         "embedding.rate_limit.max_inflight",
+        DEFAULT_EMBEDDING_MAX_INFLIGHT,
     )
-    return {"pools": normalized}
+    embedding["rate_limit"] = embedding_rate
+    runtime_config["embedding"] = embedding
+    return runtime_config
+
+
+def agent_worker_config(config_data: dict) -> dict:
+    """Return the validated four-pool config, including legacy defaults."""
+    return normalize_runtime_config(config_data)["agent_worker"]
 
 
 def load_config(path: Optional[Path] = None) -> dict:
@@ -376,8 +465,8 @@ def load_config(path: Optional[Path] = None) -> dict:
             f"or call config.ensure_config_exists()."
         )
     with open(cfg_path, encoding="utf-8") as f:
-        _config = yaml.safe_load(f) or {}
-    agent_worker_config(_config)
+        raw_config = yaml.safe_load(f) or {}
+    _config = normalize_runtime_config(raw_config)
     if not _config.get("llm", {}).get("api_key"):
         raise KeyError(f"llm.api_key missing in {cfg_path}")
     if not _config.get("embedding", {}).get("api_key"):

--- a/src/xskill/pipeline/watcher_factory.py
+++ b/src/xskill/pipeline/watcher_factory.py
@@ -27,14 +27,15 @@ def build_watcher(config: dict, *, home_root: Path | None = None,
     """
     from xskill.config import (
         XSKILL_HOME,
-        agent_worker_config,
         get_registry_db_path,
         get_skill_dir,
+        normalize_runtime_config,
     )
     from xskill.pipeline.runner import DirectoryWatcher
     from xskill.usage import UsageLedger, load_price_table
     from xskill.utils.llm import create_embed_client, create_llm_client
 
+    config = normalize_runtime_config(config)
     state_root = (
         Path(xskill_home) if xskill_home is not None else XSKILL_HOME
     ).expanduser().resolve()
@@ -71,7 +72,7 @@ def build_watcher(config: dict, *, home_root: Path | None = None,
         db_path=resolved_db_path,
     )
     watcher_cfg = config.get("watcher", {})
-    worker_cfg = agent_worker_config(config)
+    worker_cfg = config["agent_worker"]
     return DirectoryWatcher(
         llm=create_llm_client(config, usage_ledger=usage_ledger),
         embed_client=create_embed_client(

--- a/src/xskill/utils/llm.py
+++ b/src/xskill/utils/llm.py
@@ -434,6 +434,11 @@ def create_llm_client(
     if role in ("skill", "eval"):
         override_cfg = config.get("llm_skill", {}) or {}
         merged = {**base_cfg, **{k: v for k, v in override_cfg.items() if v}}
+        if override_cfg.get("rate_limit"):
+            merged["rate_limit"] = {
+                **(base_cfg.get("rate_limit") or {}),
+                **override_cfg["rate_limit"],
+            }
     else:
         merged = base_cfg
 

--- a/tests/test_agent_worker.py
+++ b/tests/test_agent_worker.py
@@ -305,14 +305,9 @@ def test_build_watcher_defaults_and_history_stay_in_explicit_instance(
 
     watcher = watcher_factory.build_watcher(
         {
-            "watcher": {},
-            "agent_worker": {"pools": pool_config()},
-            "llm": {"rate_limit": {
-                "rpm": 240,
-                "request_burst": 8,
-                "max_inflight": 8,
-            }},
-            "embedding": {"rate_limit": {"max_inflight": 4}},
+            "watcher": {"max_concurrent": 6, "cluster_batch_size": 3},
+            "llm": {"rate_limit": {"burst": 5}},
+            "embedding": {},
         },
         xskill_home=instance_xskill_home,
         server_mode=True,
@@ -337,6 +332,23 @@ def test_build_watcher_defaults_and_history_stay_in_explicit_instance(
             instance_xskill_home / "tmp" / "spill"
         ).resolve()
         assert watcher.usage_ledger.db_path == watcher.db_path
+        assert watcher.pool_config == pool_config(
+            workers=2,
+            split_workers=24,
+            cluster_workers=8,
+            edit_workers=4,
+            embed_workers=4,
+            batch_size=3,
+        )
+        effective_config = create_llm_client.call_args.args[0]
+        assert effective_config["llm"]["rate_limit"] == {
+            "rpm": 240,
+            "request_burst": 5,
+            "max_inflight": 6,
+        }
+        assert create_embed_client.call_args.args[0]["embedding"] == {
+            "rate_limit": {"max_inflight": 4},
+        }
         assert (
             create_llm_client.call_args.kwargs["usage_ledger"]
             is watcher.usage_ledger

--- a/tests/test_agent_worker_runtime.py
+++ b/tests/test_agent_worker_runtime.py
@@ -1,6 +1,7 @@
 """v0.6.28 four-pool runtime and Cluster write-queue acceptance tests."""
 from __future__ import annotations
 
+import copy
 import threading
 import time
 from concurrent.futures import ThreadPoolExecutor
@@ -8,7 +9,7 @@ from concurrent.futures import ThreadPoolExecutor
 import pytest
 
 from tests.pool_helpers import pool_config
-from xskill.config import agent_worker_config
+from xskill.config import agent_worker_config, load_config, normalize_runtime_config
 from xskill.pipeline.atom import AtomTask, AtomTaskStore
 from xskill.pipeline.runner import DirectoryWatcher, process_atom_batch
 from xskill.pipeline.worker_runtime import BoundedExecutor, ClusterWriteQueue
@@ -19,18 +20,6 @@ from xskill.utils.rate_limit import SharedRequestLimiter
 
 def _thread_name():
     return threading.current_thread().name
-
-
-def _set_legacy_max_concurrent(config):
-    config["watcher"]["max_concurrent"] = 4
-
-
-def _set_legacy_cluster_batch_size(config):
-    config["watcher"]["cluster_batch_size"] = 8
-
-
-def _set_legacy_burst(config):
-    config["llm"]["rate_limit"]["burst"] = 4
 
 
 def _set_explicit_queue_size(config):
@@ -177,32 +166,123 @@ def test_embedding_client_uses_its_independent_inflight_limit(monkeypatch):
     executor.shutdown(wait=True)
 
 
+def _legacy_config() -> dict:
+    return {
+        "llm": {
+            "api_key": "llm-secret",
+            "rate_limit": {"rpm": 120, "tpm": 6000, "burst": 12},
+        },
+        "embedding": {"api_key": "embed-secret"},
+        "dashboard": {"password": "admin-secret"},
+        "watcher": {
+            "poll_interval": 7,
+            "max_concurrent": 32,
+            "cluster_batch_size": 5,
+        },
+    }
+
+
+def test_v0627_config_gets_runtime_defaults_without_mutating_user_input():
+    original = _legacy_config()
+    before = copy.deepcopy(original)
+
+    effective = normalize_runtime_config(original)
+
+    assert original == before
+    assert effective["watcher"] == {"poll_interval": 7}
+    assert effective["agent_worker"]["pools"] == {
+        "split": {"workers": 24, "llm_weight": 6},
+        "cluster": {"workers": 8, "batch_size": 5, "llm_weight": 3},
+        "edit": {"workers": 4, "llm_weight": 1},
+        "embed": {"workers": 4},
+    }
+    assert effective["llm"]["rate_limit"] == {
+        "rpm": 120,
+        "tpm": 6000,
+        "request_burst": 12,
+        "max_inflight": 32,
+        "token_burst": 12,
+    }
+    assert effective["embedding"]["rate_limit"] == {"max_inflight": 4}
+    assert effective["llm"]["api_key"] == "llm-secret"
+    assert effective["embedding"]["api_key"] == "embed-secret"
+    assert effective["dashboard"]["password"] == "admin-secret"
+
+
+def test_explicit_new_values_win_and_missing_pool_fields_get_defaults():
+    config = _legacy_config()
+    config["llm"]["rate_limit"].update({
+        "request_burst": 3,
+        "max_inflight": 11,
+    })
+    config["agent_worker"] = {
+        "pools": {
+            "split": {"workers": 9},
+            "cluster": {"workers": 3, "batch_size": 2},
+        },
+    }
+
+    effective = normalize_runtime_config(config)
+    pools = effective["agent_worker"]["pools"]
+
+    assert pools["split"] == {"workers": 9, "llm_weight": 6}
+    assert pools["cluster"] == {
+        "workers": 3, "batch_size": 2, "llm_weight": 3,
+    }
+    assert pools["edit"] == {"workers": 4, "llm_weight": 1}
+    assert pools["embed"] == {"workers": 4}
+    assert effective["llm"]["rate_limit"]["request_burst"] == 3
+    assert effective["llm"]["rate_limit"]["max_inflight"] == 11
+    assert agent_worker_config(config)["pools"] == pools
+
+
+def test_missing_new_sections_use_release_defaults():
+    effective = normalize_runtime_config({"llm": {}, "embedding": {}})
+
+    assert effective["llm"]["rate_limit"] == {
+        "rpm": 240,
+        "request_burst": 8,
+        "max_inflight": 8,
+    }
+    assert effective["embedding"]["rate_limit"] == {"max_inflight": 4}
+    assert effective["agent_worker"]["pools"]["cluster"]["batch_size"] == 8
+
+
+def test_load_config_accepts_old_yaml_without_rewriting_it(tmp_path):
+    path = tmp_path / "config.yaml"
+    old_yaml = """\
+llm:
+  api_key: llm-secret
+embedding:
+  api_key: embed-secret
+watcher:
+  poll_interval: 30
+  max_concurrent: 6
+"""
+    path.write_text(old_yaml, encoding="utf-8")
+
+    effective = load_config(path)
+
+    assert path.read_text(encoding="utf-8") == old_yaml
+    assert effective["llm"]["rate_limit"]["max_inflight"] == 6
+    assert effective["agent_worker"]["pools"]["split"]["workers"] == 24
+
+
 @pytest.mark.parametrize(
     ("mutate", "message"),
     [
-        (
-            _set_legacy_max_concurrent,
-            "agent_worker.pools",
-        ),
-        (
-            _set_legacy_cluster_batch_size,
-            "agent_worker.pools.cluster.batch_size",
-        ),
-        (
-            _set_legacy_burst,
-            "request_burst",
-        ),
-        (
-            _set_explicit_queue_size,
-            "等待容量自动",
-        ),
+        (lambda config: config["watcher"].update(max_concurrent=0),
+         "watcher.max_concurrent"),
+        (lambda config: config["watcher"].update(cluster_batch_size=False),
+         "watcher.cluster_batch_size"),
+        (_set_explicit_queue_size, "等待容量自动"),
     ],
 )
-def test_legacy_config_paths_fail_with_migration_hint(mutate, message):
+def test_invalid_legacy_or_unsupported_values_still_fail(mutate, message):
     config = _valid_config()
     mutate(config)
     with pytest.raises(ValueError, match=message):
-        agent_worker_config(config)
+        normalize_runtime_config(config)
 
 
 def test_cluster_write_queue_serializes_same_slug_creation(tmp_path):

--- a/tests/test_llm_client.py
+++ b/tests/test_llm_client.py
@@ -15,7 +15,13 @@ from __future__ import annotations
 
 import pytest
 
-from xskill.utils.llm import LLMClient, EmbedClient, _resolve_embed_api_style
+from xskill.config import normalize_runtime_config
+from xskill.utils.llm import (
+    EmbedClient,
+    LLMClient,
+    _resolve_embed_api_style,
+    create_llm_client,
+)
 
 
 class TestLLMClientDefaults:
@@ -65,6 +71,33 @@ class TestLLMClientFromConfig:
     def test_missing_model_raises(self):
         with pytest.raises(ValueError):
             LLMClient.from_config({"base_url": "http://x", "api_key": "k"})
+
+    def test_skill_override_inherits_legacy_concurrency_and_pool_weights(self):
+        config = normalize_runtime_config({
+            "llm": {
+                "base_url": "http://x",
+                "model": "base",
+                "api_key": "k",
+                "rate_limit": {"burst": 5},
+            },
+            "llm_skill": {
+                "model": "skill",
+                "rate_limit": {"rpm": 60},
+            },
+            "embedding": {},
+            "watcher": {"max_concurrent": 7},
+        })
+
+        client = create_llm_client(config, role="skill")
+
+        assert client is not None
+        assert client.model == "skill"
+        assert client.rate_limit_cfg == {
+            "rpm": 60,
+            "request_burst": 5,
+            "max_inflight": 7,
+            "_pool_weights": {"split": 6, "cluster": 3, "edit": 1},
+        }
 
 
 class TestEmbedApiStyle:


### PR DESCRIPTION
## 目标

让 v0.6.27 用户无需手工改写 config.yaml 即可启动 v0.6.28 四池 agent-worker。

## 兼容规则

- `watcher.max_concurrent` 作为 `llm.rate_limit.max_inflight` 的默认值
- `watcher.cluster_batch_size` 作为 cluster pool 的 `batch_size` 默认值
- `rate_limit.burst` 兼容为 `request_burst`，配置 TPM 时同时补 `token_burst`
- 缺失四池时补 24/8/4/4 和 6/3/1 权重
- embedding 缺失 rate_limit 时补 `max_inflight: 4`
- 显式新配置优先；只生成内存配置，不改写用户 YAML
- 非法值与显式 queue_size 仍然拒绝

## 验证

- 聚焦配置、LLM、watcher 测试：53 passed
- v0.6.27 server 示例配置直接兼容检查通过
- 当前 v0.6.28 配置归一化前后完全相同
- ruff / git diff --check 通过
- 本机全量：1922 passed，灰度 E2E 1 个本地 fake tool schema/时序失败，交由本 PR 干净 CI 复核