### PR TITLE
fix: unify generated and SkillHub team search

### DIFF
--- a/src/xskill/recommend/engine.py
+++ b/src/xskill/recommend/engine.py
@@ -28,7 +28,7 @@ from xskill.config import recommend_config
 from xskill.pipeline.atom import AtomTaskStore
 from xskill.recommend.profile_store import ProfileStore
 from xskill.recommend.reco_store import RecoStore
-from xskill.recommend.skillhub import SkillHub
+from xskill.recommend.skillhub import SearchCorpus, SkillHub
 from xskill.skill.repo import SkillRepo
 from xskill.utils.embed_store import EmbedStore
 
@@ -92,6 +92,8 @@ class SkillRecommendEngine:
         # 一次万行矩阵,不再每请求每 worker 各拼一遍。invalidate_cache 清空。
         self._combined_pool_cache: Optional[tuple] = None
         self._combined_pool_lock = threading.Lock()
+        self._repo_search_corpus_cache: Optional[tuple] = None
+        self._repo_search_corpus_lock = threading.Lock()
         self._profile_row_cache: dict[str, dict | None] = {}
         self._profile_cache_generation: dict[str, int] = {}
         self._profile_cache_lock = threading.Lock()
@@ -210,6 +212,99 @@ class SkillRecommendEngine:
         self._skill_index_cache = None
         self._skillhub_cache = None
         self._combined_pool_cache = None
+        with self._repo_search_corpus_lock:
+            self._repo_search_corpus_cache = None
+
+    def repo_search_corpus(self, catalog) -> SearchCorpus:
+        """把可分发 repo skill 投影为 hybrid search 补充语料。
+
+        文档始终进入 BM25；只有 ``.skill_index.pkl`` 中 name/text/vec 同代且
+        结构有效时才附加语义向量。
+        """
+        with self._repo_search_corpus_lock:
+            index_path = self.skill_dir / ".skill_index.pkl"
+            index = self._skill_index() if index_path.is_file() else None
+            cache = self._repo_search_corpus_cache
+            if cache is not None and cache[0] is catalog and cache[1] is index:
+                return cache[3]
+
+            skills = tuple(catalog.search_by_id.values())
+            documents = tuple((
+                skill,
+                catalog.refs[skill.name][0],
+                (skill.description or "").strip(),
+            ) for skill in skills)
+            fingerprint = tuple(
+                (skill.name, main_ref, description)
+                for skill, main_ref, description in documents
+            )
+            if (
+                cache is not None and cache[1] is index
+                and cache[2] == fingerprint
+            ):
+                self._repo_search_corpus_cache = (
+                    catalog, index, fingerprint, cache[3],
+                )
+                return cache[3]
+
+            vectors_by_name: dict[str, tuple[str, np.ndarray]] = {}
+            current_model = str(getattr(self.embed_client, "model", "") or "")
+            if index is not None and index.get("model") == current_model:
+                names = list(index.get("skill_names") or [])
+                texts = list(index.get("texts") or [])
+                raw_vectors = index.get("embeddings")
+                try:
+                    vectors = (
+                        np.asarray(raw_vectors, dtype=float)
+                        if raw_vectors is not None else np.empty((0, 0))
+                    )
+                except (TypeError, ValueError):
+                    vectors = np.empty((0, 0))
+                if (
+                    vectors.ndim == 2
+                    and len(names) == len(texts) == vectors.shape[0]
+                ):
+                    vectors_by_name = {
+                        name: (str(text), vectors[row])
+                        for row, (name, text) in enumerate(zip(names, texts))
+                        if isinstance(name, str)
+                    }
+                elif names or texts or raw_vectors is not None:
+                    logger.warning(
+                        "repo skill index shape mismatch; hybrid search uses BM25 only"
+                    )
+
+            entries: list[dict] = []
+            for skill, main_ref, description in documents:
+                entry = {
+                    "source": "repo",
+                    "name": f"repo:{skill.name}",
+                    "skill_id": f"repo:{skill.name}",
+                    "repo_name": skill.name,
+                    "display_name": str(
+                        skill.frontmatter.get("name") or skill.name
+                    ),
+                    "description": description,
+                    "source_path": skill.name,
+                    "content_sha": main_ref,
+                    "path": skill.path,
+                    "ux_side": "main",
+                }
+                indexed = vectors_by_name.get(skill.name)
+                if indexed is not None and indexed[0].strip() == description:
+                    entry["vec"] = indexed[1]
+                entries.append(entry)
+
+            corpus = tuple(entries)
+            self._repo_search_corpus_cache = (
+                catalog, index, fingerprint, corpus,
+            )
+            return corpus
+
+    def search_team_skills(self, query: str, limit: int, catalog) -> list[dict]:
+        """在自产 + SkillHub 的统一 BM25/semantic/RRF corpus 中搜索。"""
+        corpus = self.repo_search_corpus(catalog)
+        return self.skillhub.search(query, limit, supplemental=corpus)
 
     def _skill_index(self) -> dict:
         if self._skill_index_cache is None:

--- a/src/xskill/recommend/skillhub.py
+++ b/src/xskill/recommend/skillhub.py
@@ -57,6 +57,9 @@ class SkillFileSchemaError(TypeError):
     """A SKILL.md frontmatter field has a known-invalid type."""
 
 
+SearchCorpus = tuple[dict, ...]
+
+
 def _normalize(v: np.ndarray) -> np.ndarray:
     n = float(np.linalg.norm(v))
     return v / n if n > 0 else v
@@ -140,7 +143,7 @@ class SkillHub:
         self._corpus_embed_inflight: set[str] = set()
         self._query_embed_retry_after = 0.0
         self._ux_avg_cache: dict[
-            tuple[str, int], tuple[float, str, float | None]
+            tuple[str, int, str | None], tuple[float, str, float | None]
         ] = {}
         self._ux_avg_cache_lock = threading.Lock()
 
@@ -510,7 +513,13 @@ class SkillHub:
         with open(self.index_cache_path, "wb") as index_file:
             pickle.dump(data, index_file)
 
-    def search(self, query: str, limit: int = 5) -> list[dict]:
+    def search(
+        self,
+        query: str,
+        limit: int = 5,
+        *,
+        supplemental: SearchCorpus | None = None,
+    ) -> list[dict]:
         """BM25 关键词 + 语义向量 RRF 融合检索（无画像，query↔description）。
 
         与 ``SkillRecommendEngine`` 完全无关——不读画像。语义通道只读 ``EmbedStore``
@@ -520,7 +529,13 @@ class SkillHub:
         normalized_query = query.strip().lower()
         if not normalized_query:
             return []
-        index_bundle = self._search_index_bundle()
+        index_bundle = self._search_index_bundle(supplemental=supplemental)
+        return self._search_bundle(normalized_query, int(limit), index_bundle)
+
+    def _search_bundle(
+        self, normalized_query: str, limit: int, index_bundle: dict,
+    ) -> list[dict]:
+        """在已构建的统一索引上复用 BM25、semantic、RRF 与结果缓存。"""
         entries = index_bundle["entries"]
         if not entries:
             return []
@@ -571,6 +586,7 @@ class SkillHub:
             index_bundle is None
             or index_bundle["snapshot_entries"] is not self._scan_snapshot_entries
             or now >= self._scan_snapshot_expires_at
+            or index_bundle.get("supplemental") is not None
         ):
             return None
         # Prefer the cached hybrid result when both a prior degraded result
@@ -942,27 +958,48 @@ class SkillHub:
                 self._corpus_embed_inflight.discard(description_key)
             self._query_embed_semaphore.release()
 
-    def _search_index_bundle(self) -> dict:
+    def _search_index_bundle(
+        self, *, supplemental: SearchCorpus | None = None,
+    ) -> dict:
         """随内容 fingerprint 变化整体重建 BM25 倒排 + 只读 corpus 向量，几百 skill <10ms。"""
-        if not self.dir.is_dir():
+        if self.enabled and not self.dir.is_dir():
             raise FileNotFoundError(
                 f"skillhub.dir 不存在: {self.dir}（启用 skillhub 前请放置三方 skill）"
             )
-        snapshot_entries = self._snapshot()
+        snapshot_entries = self._snapshot() if self.enabled else None
         bundle = self._search_index
-        if bundle is not None and bundle["snapshot_entries"] is snapshot_entries:
+        if (
+            bundle is not None
+            and bundle["snapshot_entries"] is snapshot_entries
+            and bundle.get("supplemental") is supplemental
+        ):
             return bundle
         with self._search_index_lock:
             bundle = self._search_index
-            if bundle is not None and bundle["snapshot_entries"] is snapshot_entries:
+            if (
+                bundle is not None
+                and bundle["snapshot_entries"] is snapshot_entries
+                and bundle.get("supplemental") is supplemental
+            ):
                 return bundle
-            entries = [dict(entry) for entry in snapshot_entries]
-            current_fingerprint = tuple(
+            native_entries = snapshot_entries or ()
+            supplemental_entries = supplemental or ()
+            supplemental_ids = {
+                entry["skill_id"] for entry in supplemental_entries
+            }
+            entries = [
+                dict(entry) for entry in native_entries
+                if entry["skill_id"] not in supplemental_ids
+            ]
+            entries.extend(dict(entry) for entry in supplemental_entries)
+            native_fingerprint = tuple(
                 (entry["skill_id"], entry["source_path"], entry["content_sha"])
-                for entry in entries
+                for entry in native_entries
+                if entry["skill_id"] not in supplemental_ids
             )
-            rebuilt_bundle = self._build_search_index(entries, current_fingerprint)
+            rebuilt_bundle = self._build_search_index(entries, native_fingerprint)
             rebuilt_bundle["snapshot_entries"] = snapshot_entries
+            rebuilt_bundle["supplemental"] = supplemental
             self._search_index = rebuilt_bundle
             return rebuilt_bundle
 
@@ -987,6 +1024,8 @@ class SkillHub:
             sum(document_lengths) / len(document_lengths) if document_lengths else 0.0
         )
         vector_present_indices, corpus_matrix = self._read_cached_corpus_vectors(entries)
+        for entry in entries:
+            entry.pop("vec", None)
         return {
             "fingerprint": fingerprint,
             "entries": entries,
@@ -1011,16 +1050,75 @@ class SkillHub:
         if self.embed_client is None or self.search_max_embed <= 0 or not entries:
             return [], np.empty((0, 0), dtype=float)
         embed_store = EmbedStore(self.dir / EMBED_CACHE_NAME, self.embed_client)
-        cached = embed_store.cached_vectors([entry["description"] for entry in entries])
-        present_indices = [
-            entry_index for entry_index, vector in enumerate(cached) if vector is not None
+        vectors: list[np.ndarray | None] = [None] * len(entries)
+        cache_lookup_indices = [
+            entry_index for entry_index, entry in enumerate(entries)
+            if entry.get("vec") is None and entry.get("source") != "repo"
         ]
-        if not present_indices:
-            return [], np.empty((0, 0), dtype=float)
-        corpus_matrix = np.vstack([
-            _normalize(np.asarray(cached[entry_index], dtype=float))
-            for entry_index in present_indices
+        cached = embed_store.cached_vectors([
+            entries[entry_index]["description"]
+            for entry_index in cache_lookup_indices
         ])
+        for entry_index, vector in zip(cache_lookup_indices, cached):
+            if vector is not None:
+                try:
+                    vectors[entry_index] = np.asarray(vector, dtype=float)
+                except (TypeError, ValueError):
+                    pass
+        inline_indices: list[int] = []
+        for entry_index, entry in enumerate(entries):
+            if entry.get("vec") is not None:
+                inline_indices.append(entry_index)
+                try:
+                    vectors[entry_index] = np.asarray(entry["vec"], dtype=float)
+                except (TypeError, ValueError):
+                    vectors[entry_index] = None
+
+        # SkillHub EmbedStore 的当前模型向量优先决定维度；没有时才采用 repo 索引。
+        expected_dim = next((
+            int(vectors[index].shape[0])
+            for index in cache_lookup_indices
+            if (
+                vectors[index] is not None
+                and vectors[index].ndim == 1
+                and vectors[index].shape[0] > 0
+                and np.all(np.isfinite(vectors[index]))
+            )
+        ), None)
+        if expected_dim is None:
+            dimension_counts: dict[int, int] = {}
+            dimension_order: list[int] = []
+            for index in inline_indices:
+                vector = vectors[index]
+                if (
+                    vector is None or vector.ndim != 1 or vector.shape[0] <= 0
+                    or not np.all(np.isfinite(vector))
+                ):
+                    continue
+                dimension = int(vector.shape[0])
+                if dimension not in dimension_counts:
+                    dimension_order.append(dimension)
+                    dimension_counts[dimension] = 0
+                dimension_counts[dimension] += 1
+            if dimension_counts:
+                expected_dim = max(
+                    dimension_order, key=lambda dim: dimension_counts[dim],
+                )
+        if expected_dim is None:
+            return [], np.empty((0, 0), dtype=float)
+        present_indices: list[int] = []
+        normalized_vectors: list[np.ndarray] = []
+        for entry_index, vector in enumerate(vectors):
+            if (
+                vector is None
+                or vector.ndim != 1
+                or vector.shape[0] != expected_dim
+                or not np.all(np.isfinite(vector))
+            ):
+                continue
+            present_indices.append(entry_index)
+            normalized_vectors.append(_normalize(vector))
+        corpus_matrix = np.vstack(normalized_vectors)
         return present_indices, corpus_matrix
 
     def entry(self, name: str, *, force_refresh: bool = False) -> dict | None:
@@ -1106,7 +1204,8 @@ class SkillHub:
     def _ux_avg_for_entry(self, entry: dict, days: int = 30) -> float | None:
         """按已解析 entry 读取近期均分，并用短 TTL 避免搜索热路径重复扫文件。"""
         sha = str(entry["content_sha"])
-        cache_key = (str(entry["skill_id"]), int(days))
+        ux_side = entry.get("ux_side")
+        cache_key = (str(entry["skill_id"]), int(days), ux_side)
         now = time.monotonic()
         with self._ux_avg_cache_lock:
             cached = self._ux_avg_cache.get(cache_key)
@@ -1127,6 +1226,7 @@ class SkillHub:
                 rows = recent_rows
             scores = [r.get("score") for r in rows
                       if r.get("commit_sha") == sha
+                      and (ux_side is None or r.get("side") == ux_side)
                       and isinstance(r.get("score"), (int, float))]
             value = sum(scores) / len(scores) if scores else None
             self._ux_avg_cache[cache_key] = (

--- a/src/xskill/skill/repo.py
+++ b/src/xskill/skill/repo.py
@@ -229,6 +229,7 @@ def rebuild_skill_index(
         "embeddings": embeddings,
         "atom_feats": atom_feats,
         "atom_feat_present": atom_present,
+        "model": str(getattr(embed_client, "model", "") or ""),
         "schema_version": 2,
         "method": "api",
     }

--- a/src/xskill/team/server/api.py
+++ b/src/xskill/team/server/api.py
@@ -28,15 +28,25 @@ import time
 from typing import Callable
 import zipfile
 
+from dulwich.errors import NotGitRepository, ObjectMissing
 from fastapi import APIRouter, File, Form, Header, HTTPException, Request, UploadFile
 from fastapi.responses import FileResponse, JSONResponse, Response
 from starlette.concurrency import run_in_threadpool
 
 from xskill import __version__ as XSKILL_VERSION
+from xskill.canary import main_sha, staging_sha
 from xskill.config import get_team_server_whl_dir
 from xskill.team.server.client_registry import ClientRegistry
-from xskill.team.shared.git_bundle import fetch_branch_from_bundle, make_repo_bundle
-from xskill.team.server.skill_manifest import build_manifest
+from xskill.team.shared.git_bundle import (
+    fetch_branch_from_bundle, make_repo_archive, make_repo_bundle,
+)
+from xskill.team.server.skill_manifest import (
+    _resolve_slot,
+    build_manifest,
+    get_recommend_engine,
+    manifest_catalog_snapshot,
+    repo_search_id,
+)
 from xskill.team.shared.protocol import (
     PushEditResponse, RegisterRequest, RegisterResponse,
     UploadRejection, UploadRequest, UploadResponse,
@@ -50,6 +60,10 @@ router = APIRouter(prefix="/api/v1/team")
 _SKILL_ARCHIVE_MAX_FILES = 2048
 _SKILL_ARCHIVE_MAX_FILE_BYTES = 50 * 1024 * 1024
 _SKILL_ARCHIVE_MAX_TOTAL_BYTES = 100 * 1024 * 1024
+_REPO_SEARCH_GRANT_TTL_SECONDS = 300.0
+_REPO_SEARCH_GRANT_CAPACITY = 4096
+_REPO_SEARCH_GRANTS: dict[tuple[str, str], tuple[float, str, str, str]] = {}
+_REPO_SEARCH_GRANTS_LOCK = threading.Lock()
 
 
 class _Ctx:
@@ -253,6 +267,8 @@ def init_team_context(
     _ctx.configure_watch_dir = configure_watch_dir
     _ctx.skillhub = skillhub
     _ctx.profile_refresh_service = profile_refresh_service
+    with _REPO_SEARCH_GRANTS_LOCK:
+        _REPO_SEARCH_GRANTS.clear()
 
 
 def clear_team_context(*, profile_refresh_shutdown_timeout: float = 5.0) -> bool:
@@ -284,6 +300,8 @@ def clear_team_context(*, profile_refresh_shutdown_timeout: float = 5.0) -> bool
     _ctx.configure_watch_dir = None
     _ctx.skillhub = None
     _ctx.profile_refresh_service = None
+    with _REPO_SEARCH_GRANTS_LOCK:
+        _REPO_SEARCH_GRANTS.clear()
     return stopped
 
 
@@ -844,19 +862,83 @@ async def team_skill_bundle(
     x_xskill_token: str | None = Header(default=None),
     x_xskill_client: str | None = Header(default=None),
 ) -> Response:
-    _auth(x_xskill_token, x_xskill_client)
+    client_id = _auth(x_xskill_token, x_xskill_client)
     repo_dir = _ctx.skill_dir / name
-    if not (repo_dir / ".git").is_dir():
-        hub = _ctx.skillhub
-        if hub is None:
-            raise HTTPException(status_code=404, detail=f"skill not found: {name}")
-        hub_dir = hub.skill_path(name)
-        if hub_dir is None:
-            raise HTTPException(status_code=404, detail=f"skill not found: {name}")
-        archive = _make_skillhub_archive(hub_dir)
-        return Response(content=archive, media_type="application/zip")
-    bundle = make_repo_bundle(repo_dir)
-    return Response(content=bundle, media_type="application/octet-stream")
+    exact_repo = (repo_dir / ".git").is_dir()
+    if _is_repo_search_id(name):
+        download = await run_in_threadpool(
+            _repo_search_archive, name, client_id, exact_repo,
+        )
+        if download is not None:
+            archive, content_sha, side = download
+            return Response(
+                content=archive,
+                media_type="application/zip",
+                headers={
+                    "X-XSkill-Content-Sha": content_sha,
+                    "X-XSkill-Side": side,
+                },
+            )
+
+    if exact_repo:
+        bundle = make_repo_bundle(repo_dir)
+        return Response(content=bundle, media_type="application/octet-stream")
+
+    hub = _ctx.skillhub
+    hub_dir = hub.skill_path(name) if hub is not None else None
+    if hub_dir is None:
+        raise HTTPException(status_code=404, detail=f"skill not found: {name}")
+    archive = _make_skillhub_archive(hub_dir)
+    return Response(content=archive, media_type="application/zip")
+
+
+def _repo_search_archive(
+    search_id: str, client_id: str, exact_repo: bool,
+) -> tuple[bytes, str, str] | None:
+    """在线程内强制刷新 refs、校验 search grant，并导出固定 commit。"""
+    grant = _repo_search_grant(client_id, search_id)
+    if grant is None:
+        catalog = manifest_catalog_snapshot(_ctx.skill_dir, max_age_seconds=0)
+        skill = catalog.search_by_id.get(search_id)
+        if skill is None:
+            if exact_repo:
+                return None
+            raise HTTPException(status_code=404, detail=f"skill not found: {search_id}")
+        if exact_repo:
+            raise HTTPException(status_code=409, detail="ambiguous repo search id")
+        _total_slots, _ranked_slots, probability = live_manifest_tuning()
+        slot = _resolve_slot(
+            skill, client_id, probability, "ranked", refs=catalog.refs,
+        )
+        if slot is None:
+            raise HTTPException(status_code=404, detail=f"skill not found: {search_id}")
+        repo_name = skill.name
+        content_sha, side = _pin_repo_search_grant(
+            client_id, search_id, repo_name, slot.sha, slot.side,
+            catalog.refs[repo_name],
+        )
+    else:
+        repo_name, content_sha, side = grant
+    if exact_repo:
+        raise HTTPException(status_code=409, detail="ambiguous repo search id")
+    if repo_search_id(repo_name) != search_id:
+        raise HTTPException(status_code=409, detail="invalid search grant")
+    repo_dir = _ctx.skill_dir / repo_name
+    if content_sha not in (main_sha(repo_dir), staging_sha(repo_dir)):
+        raise HTTPException(
+            status_code=409, detail="skill version changed; search again",
+        )
+    try:
+        archive = make_repo_archive(repo_dir, content_sha)
+    except (KeyError, NotGitRepository, ObjectMissing, OSError, ValueError) as error:
+        logger.warning(
+            "repo search archive changed during download: %s (%s)",
+            repo_name, type(error).__name__,
+        )
+        raise HTTPException(
+            status_code=409, detail="skill version changed; search again",
+        ) from error
+    return archive, content_sha, side
 
 
 @router.get("/skill_hub/search")
@@ -866,43 +948,34 @@ async def team_skill_hub_search(
     x_xskill_token: str | None = Header(default=None),
     x_xskill_client: str | None = Header(default=None),
 ) -> dict:
-    """BM25 + 语义向量混合检索 skillhub；与推荐画像完全无关。"""
+    """BM25 + 语义 RRF 统一检索自产 main skill + SkillHub（无画像）。"""
     client_id = _auth(x_xskill_token, x_xskill_client)
     hub = _ctx.skillhub
-    if hub is None or not getattr(hub, "enabled", False):
-        raise HTTPException(status_code=503, detail="skillhub not enabled on server")
     if not query.strip():
         raise HTTPException(status_code=400, detail="empty query")
     bounded_limit = max(1, min(int(limit), 10))
     try:
-        # A hot result is a bounded in-memory lookup.  Keep that path on the event
-        # loop instead of creating 50 short-lived AnyIO worker jobs beside CPU-heavy
-        # /sync work; misses and expired snapshots still run entirely off-loop.
+        _total_slots, _ranked_slots, probability = live_manifest_tuning()
+        engine = get_recommend_engine()
+        if engine is None and (hub is None or not getattr(hub, "enabled", False)):
+            raise HTTPException(
+                status_code=503, detail="skillhub not enabled on server",
+            )
+        if engine is not None:
+            return await run_in_threadpool(
+                _search_and_format_team_skills,
+                engine, query, bounded_limit, client_id, probability,
+            )
+
         matches = hub.cached_search(query, bounded_limit)
         hot_cache_hit = matches is not None
         if hot_cache_hit:
-            # Fifty cache-hit handlers otherwise contain no suspension point and can
-            # monopolize one event-loop turn.  Yield around result assembly so health
-            # and dashboard requests keep their latency budget during a search burst.
             await asyncio.sleep(0)
         else:
             matches = await run_in_threadpool(hub.search, query, bounded_limit)
-        payload = {"results": [
-            {
-                "skill_id": match["skill_id"],
-                "display_name": match["display_name"],
-                "description": match["description"],
-                "content_sha": match["content_sha"],
-                "source_path": match["source_path"],
-                "source": _skillhub_result_source(match["source_path"]),
-                "ux_avg": match.get("ux_avg"),
-                "match": {
-                    "bm25_rank": match.get("bm25_rank"),
-                    "semantic_rank": match.get("semantic_rank"),
-                },
-            }
-            for match in matches
-        ]}
+        payload = _format_team_search_results(
+            matches, None, client_id, probability,
+        )
         if hot_cache_hit:
             await asyncio.sleep(0)
         return payload
@@ -942,6 +1015,126 @@ async def team_skill_hub_search(
             },
             headers={"X-Request-ID": request_id},
         )
+
+
+def _search_and_format_team_skills(
+    engine,
+    query: str,
+    limit: int,
+    client_id: str,
+    probability: float,
+) -> dict:
+    """冷路径：刷新 catalog、统一 hybrid search，并在线程内补齐灰度元数据。"""
+    catalog = manifest_catalog_snapshot(_ctx.skill_dir)
+    if (
+        not catalog.search_by_id
+        and not getattr(engine.skillhub, "enabled", False)
+    ):
+        raise HTTPException(status_code=503, detail="no searchable skill source")
+    matches = engine.search_team_skills(query, limit, catalog)
+    return _format_team_search_results(
+        matches, catalog, client_id, probability,
+    )
+
+
+def _format_team_search_results(
+    matches: list[dict], catalog, client_id: str, probability: float,
+) -> dict:
+    """把统一排名命中投影为既有 search/install 响应契约。"""
+    results: list[dict] = []
+    for hit in matches:
+        source = hit.get("source")
+        result = {
+            "skill_id": hit["skill_id"],
+            "display_name": hit["display_name"],
+            "description": hit["description"],
+            "content_sha": hit["content_sha"],
+            "source_path": hit["source_path"],
+            "source": (
+                "repo" if source == "repo"
+                else _skillhub_result_source(hit["source_path"])
+            ),
+            "ux_avg": hit.get("ux_avg"),
+            "match": {
+                "bm25_rank": hit.get("bm25_rank"),
+                "semantic_rank": hit.get("semantic_rank"),
+            },
+        }
+        if source == "repo":
+            search_id = repo_search_id(hit["repo_name"])
+            skill = catalog.search_by_id.get(search_id)
+            if skill is None:
+                continue
+            slot = _resolve_slot(
+                skill, client_id, probability, "ranked", refs=catalog.refs,
+            )
+            if slot is None:
+                continue
+            grant = _pin_repo_search_grant(
+                client_id, search_id, skill.name, slot.sha, slot.side,
+                catalog.refs[skill.name],
+            )
+            content_sha, side = grant
+            result.update({
+                "skill_id": search_id,
+                "content_sha": content_sha,
+                "side": side,
+                "staging_available": catalog.refs[skill.name][1] is not None,
+                "staging_assigned": side == "staging",
+            })
+        results.append(result)
+    return {"results": results}
+
+
+def _pin_repo_search_grant(
+    client_id: str,
+    search_id: str,
+    repo_name: str,
+    content_sha: str,
+    side: str,
+    current_refs: tuple[str, str | None],
+) -> tuple[str, str]:
+    """同一 client/skill 的有效租约不被并发搜索覆盖。"""
+    key = (client_id, search_id)
+    now = time.monotonic()
+    with _REPO_SEARCH_GRANTS_LOCK:
+        existing = _REPO_SEARCH_GRANTS.get(key)
+        if existing is not None and now < existing[0]:
+            if existing[2] in current_refs:
+                return existing[2], existing[3]
+        _REPO_SEARCH_GRANTS.pop(key, None)
+        _REPO_SEARCH_GRANTS[key] = (
+            now + _REPO_SEARCH_GRANT_TTL_SECONDS,
+            repo_name,
+            content_sha,
+            side,
+        )
+        while len(_REPO_SEARCH_GRANTS) > _REPO_SEARCH_GRANT_CAPACITY:
+            _REPO_SEARCH_GRANTS.pop(next(iter(_REPO_SEARCH_GRANTS)))
+        return content_sha, side
+
+
+def _repo_search_grant(
+    client_id: str, search_id: str,
+) -> tuple[str, str, str] | None:
+    key = (client_id, search_id)
+    with _REPO_SEARCH_GRANTS_LOCK:
+        grant = _REPO_SEARCH_GRANTS.get(key)
+        if grant is None:
+            return None
+        expires_at, repo_name, content_sha, side = grant
+        if time.monotonic() >= expires_at:
+            del _REPO_SEARCH_GRANTS[key]
+            return None
+        return repo_name, content_sha, side
+
+
+def _is_repo_search_id(name: str) -> bool:
+    return (
+        name.startswith("repo@")
+        and len(name) == 69
+        and all(char in "0123456789abcdef" for char in name[5:])
+    )
 
 
 def _skillhub_result_source(source_path: str) -> str:

--- a/src/xskill/team/server/skill_manifest.py
+++ b/src/xskill/team/server/skill_manifest.py
@@ -14,6 +14,7 @@ slot 结构 = 80 ranked + 20 recommended：
 """
 from __future__ import annotations
 
+import hashlib
 import logging
 import threading
 import time
@@ -34,12 +35,19 @@ _logger = logging.getLogger("xskill.team.manifest")
 _engine = None
 
 
+def repo_search_id(skill_name: str) -> str:
+    """自产 skill 在 search/install 协议中的稳定虚拟 ID。"""
+    digest = hashlib.sha256(skill_name.encode("utf-8")).hexdigest()
+    return f"repo@{digest}"
+
+
 @dataclass(frozen=True)
 class _CatalogSnapshot:
     """一次 skill 仓扫描的不可变结果。"""
 
     skills: tuple[Skill, ...]
     refs: dict[str, tuple[str, str | None]]
+    search_by_id: dict[str, Skill]
     built_at: float
 
 
@@ -144,8 +152,20 @@ class _ManifestCatalogCache:
             key=lambda skill: _rank_key(skill, main_ref=refs[skill.name][0]),
             reverse=True,
         )
+        repo_names = {skill.name for skill in skills}
+        search_by_id: dict[str, Skill] = {}
+        for skill in skills:
+            search_id = repo_search_id(skill.name)
+            if search_id in repo_names or search_id in search_by_id:
+                _logger.error(
+                    "repo search id collision; skill omitted from search: %s",
+                    skill.name,
+                )
+                continue
+            search_by_id[search_id] = skill
         return _CatalogSnapshot(
-            skills=tuple(skills), refs=refs, built_at=self.clock(),
+            skills=tuple(skills), refs=refs,
+            search_by_id=search_by_id, built_at=self.clock(),
         )
 
     def clear(self, skill_dir: Path | None = None) -> None:

--- a/src/xskill/team/shared/git_bundle.py
+++ b/src/xskill/team/shared/git_bundle.py
@@ -16,6 +16,8 @@ from __future__ import annotations
 
 import io
 from pathlib import Path
+import tarfile
+import zipfile
 
 from dulwich import porcelain
 from dulwich.bundle import create_bundle_from_repo, read_bundle, write_bundle
@@ -36,6 +38,29 @@ def make_repo_bundle(repo_dir: Path | str) -> bytes:
         buf = io.BytesIO()
         write_bundle(buf, bundle)
         return buf.getvalue()
+
+
+def make_repo_archive(repo_dir: Path | str, commit_sha: str) -> bytes:
+    """把指定 commit 打成与 SkillHub 分发契约一致的确定性 ZIP。"""
+    tar_buffer = io.BytesIO()
+    porcelain.archive(str(repo_dir), commit_sha, outstream=tar_buffer)
+    tar_buffer.seek(0)
+    zip_buffer = io.BytesIO()
+    with tarfile.open(fileobj=tar_buffer, mode="r:") as archive, zipfile.ZipFile(
+        zip_buffer, "w", compression=zipfile.ZIP_DEFLATED,
+    ) as output:
+        for member in sorted(archive.getmembers(), key=lambda item: item.name):
+            if not member.isfile():
+                continue
+            source = archive.extractfile(member)
+            if source is None:
+                continue
+            info = zipfile.ZipInfo(member.name, date_time=(1980, 1, 1, 0, 0, 0))
+            info.compress_type = zipfile.ZIP_DEFLATED
+            info.create_system = 3
+            info.external_attr = (member.mode & 0o777) << 16
+            output.writestr(info, source.read())
+    return zip_buffer.getvalue()
 
 
 def apply_repo_bundle(bundle_bytes: bytes, dest_dir: Path | str) -> None:

--- a/tests/test_skill_hub_search_upload.py
+++ b/tests/test_skill_hub_search_upload.py
@@ -36,6 +36,15 @@ class _FailingSearchHub:
         raise self.error
 
 
+class _CombinedSearchEngine:
+    def __init__(self, hub, ranked: list[dict]) -> None:
+        self.skillhub = hub
+        self.ranked = ranked
+
+    def search_team_skills(self, _query: str, limit: int, _catalog):
+        return self.ranked[:limit]
+
+
 def _write_hub_skill(hub_dir: Path, folder: str, name: str, description: str) -> Path:
     d = hub_dir / folder
     d.mkdir(parents=True)
@@ -140,6 +149,117 @@ def test_search_and_upload_503_when_skillhub_disabled(tmp_path):
                     files={"file": ("x.zip", b"zz", "application/zip")},
                     headers=hdr)
     assert r.status_code == 503
+
+
+def test_repo_search_works_when_skillhub_disabled(tmp_path, monkeypatch):
+    client = _make_team_client(tmp_path, skillhub=None)
+    repo_dir = tmp_path / "skill" / "repo-only"
+    (repo_dir / ".git").mkdir(parents=True)
+    skill = SimpleNamespace(
+        name="repo-only",
+        path=repo_dir,
+        frontmatter={"name": "repo-only"},
+        description="docker repo helper",
+        ux_avg=lambda **_kwargs: None,
+    )
+    search_id = server_api.repo_search_id(skill.name)
+    main_sha, staging_sha = "a" * 40, "b" * 40
+    catalog = SimpleNamespace(
+        skills=(skill,),
+        refs={skill.name: (main_sha, staging_sha)},
+        search_by_id={search_id: skill},
+    )
+    engine = _CombinedSearchEngine(
+        SimpleNamespace(enabled=False),
+        [{
+            "source": "repo",
+            "skill_id": "repo:repo-only",
+            "repo_name": skill.name,
+            "display_name": skill.name,
+            "description": skill.description,
+            "source_path": skill.name,
+            "content_sha": main_sha,
+            "ux_avg": None,
+            "bm25_rank": 1,
+            "semantic_rank": None,
+        }],
+    )
+    monkeypatch.setattr(server_api, "get_recommend_engine", lambda: engine)
+    monkeypatch.setattr(
+        server_api, "manifest_catalog_snapshot", lambda _path, **_kwargs: catalog,
+    )
+    monkeypatch.setattr(
+        server_api, "live_manifest_tuning", lambda: (100, 80, 1.0),
+    )
+    monkeypatch.setattr(
+        server_api, "main_sha", lambda path: catalog.refs[path.name][0],
+    )
+    monkeypatch.setattr(
+        server_api, "staging_sha", lambda path: catalog.refs[path.name][1],
+    )
+    monkeypatch.setattr("xskill.team.server.skill_manifest._engine", None)
+    _cid, headers = _register(client)
+
+    response = client.get(
+        "/api/v1/team/skill_hub/search",
+        params={"query": "docker"}, headers=headers,
+    )
+
+    assert response.status_code == 200
+    result = response.json()["results"][0]
+    assert result["skill_id"] == search_id
+    assert result["content_sha"] == staging_sha
+    assert result["match"] == {
+        "bm25_rank": 1, "semantic_rank": None,
+    }
+    monkeypatch.setattr(
+        server_api, "live_manifest_tuning", lambda: (100, 80, 0.0),
+    )
+    repeated = client.get(
+        "/api/v1/team/skill_hub/search",
+        params={"query": "docker"}, headers=headers,
+    )
+    assert repeated.json()["results"][0]["content_sha"] == staging_sha
+
+    archived = []
+    monkeypatch.setattr(
+        server_api, "make_repo_archive",
+        lambda path, sha: archived.append((path, sha)) or _fake_archive("repo"),
+    )
+    original_resolve_slot = server_api._resolve_slot
+    monkeypatch.setattr(
+        server_api, "_resolve_slot",
+        lambda *_args, **_kwargs: pytest.fail("bundle recomputed search side"),
+    )
+    bundle = client.get(
+        f"/api/v1/team/skill/{search_id}/bundle", headers=headers,
+    )
+    assert bundle.status_code == 200
+    assert archived == [(repo_dir, staging_sha)]
+    assert bundle.headers["X-XSkill-Content-Sha"] == staging_sha
+
+    monkeypatch.setattr(
+        server_api, "live_manifest_tuning", lambda: (100, 80, 1.0),
+    )
+    monkeypatch.setattr(server_api, "_resolve_slot", original_resolve_slot)
+    with server_api._REPO_SEARCH_GRANTS_LOCK:
+        server_api._REPO_SEARCH_GRANTS.clear()
+    recovered = client.get(
+        f"/api/v1/team/skill/{search_id}/bundle", headers=headers,
+    )
+    assert recovered.status_code == 200
+    assert archived == [(repo_dir, staging_sha), (repo_dir, staging_sha)]
+
+    catalog.refs[skill.name] = ("c" * 40, None)
+    changed = client.get(
+        f"/api/v1/team/skill/{search_id}/bundle", headers=headers,
+    )
+    assert changed.status_code == 409
+    refreshed = client.get(
+        "/api/v1/team/skill_hub/search",
+        params={"query": "docker"}, headers=headers,
+    )
+    assert refreshed.json()["results"][0]["content_sha"] == "c" * 40
 
 
 def test_search_unknown_error_returns_safe_correlated_response(tmp_path, caplog):

--- a/tests/test_skillhub.py
+++ b/tests/test_skillhub.py
@@ -23,7 +23,9 @@ from xskill.team.client.daemon import TeamClient
 from xskill.team.client.state import ClientState
 from xskill.team.server import api as server_api
 from xskill.team.server.client_registry import ClientRegistry
-from xskill.team.server.skill_manifest import build_manifest, set_recommend_engine
+from xskill.team.server.skill_manifest import (
+    build_manifest, manifest_catalog_snapshot, set_recommend_engine,
+)
 from xskill.team.shared.protocol import SkillSlot, SyncResponse
 
 
@@ -220,7 +222,7 @@ class TestEngineSkillhubPool:
         hub_dir = tmp_path / "hub"
         _write_hub_skill(hub_dir, "extfoo", "django migration helper")
         eng = self._engine(tmp_path, skillhub_enabled=True, hub_dir=hub_dir)
-        # 用与 extfoo description 同向的 query 向量检索
+        # 推荐画像侧原有向量池接口保持不变；team search 不再旁路它做纯语义检索。
         q = FakeEmbed(dim=4).encode("django migration helper")
         q = q / np.linalg.norm(q)
         results = eng.relevance_search(q, top_k=5)
@@ -243,6 +245,50 @@ class TestEngineSkillhubPool:
         results = eng.relevance_search(q, top_k=5)
         names = [n for n, _h in results]
         assert "extfoo" not in names
+
+    def test_repo_search_corpus_keeps_bm25_docs_and_exact_vectors(self, tmp_path):
+        skill_dir = tmp_path / "skills"
+        exact = _make_main_skill(skill_dir, "exact", "exact description")
+        _make_main_skill(skill_dir, "stale", "current description")
+        with open(skill_dir / ".skill_index.pkl", "wb") as index_file:
+            pickle.dump({
+                "skill_names": ["exact", "stale"],
+                "texts": ["exact description", "old description"],
+                "embeddings": np.eye(2, dtype=float),
+                "model": "",
+            }, index_file)
+        engine = SkillRecommendEngine(
+            config={"recommend": {"quality_ratio": 0.8}},
+            skill_dir=skill_dir,
+            traj_root=tmp_path / "traj",
+            embed_client=FakeEmbed(dim=2),
+            profile_db=tmp_path / "p.db",
+        )
+        catalog = manifest_catalog_snapshot(skill_dir)
+
+        corpus = engine.repo_search_corpus(catalog)
+
+        assert corpus is not None
+        by_name = {entry["repo_name"]: entry for entry in corpus}
+        assert set(by_name) == {"exact", "stale"}
+        assert np.array_equal(by_name["exact"]["vec"], np.array([1.0, 0.0]))
+        assert "vec" not in by_name["stale"]
+        assert by_name["exact"]["path"] == exact
+        assert engine.repo_search_corpus(catalog) is corpus
+        refreshed_catalog = type(catalog)(
+            catalog.skills, catalog.refs, catalog.search_by_id, catalog.built_at + 1,
+        )
+        assert engine.repo_search_corpus(refreshed_catalog) is corpus
+
+        with open(skill_dir / ".skill_index.pkl", "rb") as index_file:
+            mismatched = pickle.load(index_file)
+        mismatched["model"] = "another-model"
+        with open(skill_dir / ".skill_index.pkl", "wb") as index_file:
+            pickle.dump(mismatched, index_file)
+        engine.invalidate_cache()
+        refreshed = engine.repo_search_corpus(catalog)
+        assert refreshed is not corpus
+        assert all("vec" not in entry for entry in refreshed)
 
     def test_recommends_existing_skillhub_entries_and_skips_deleted_cache(
         self, tmp_path,

--- a/tests/test_skillhub_hybrid_search.py
+++ b/tests/test_skillhub_hybrid_search.py
@@ -20,7 +20,9 @@ from fastapi import FastAPI
 from fastapi.testclient import TestClient
 
 from xskill.recommend import skillhub as skillhub_module
-from xskill.recommend.skillhub import EMBED_CACHE_NAME, SkillHub, _tokenize
+from xskill.recommend.skillhub import (
+    EMBED_CACHE_NAME, SearchCorpus, SkillHub, _tokenize,
+)
 from xskill.team.server import api as server_api
 from xskill.team.server.client_registry import ClientRegistry, safe_dir_name
 from xskill.utils.embed_store import EmbedStore
@@ -69,6 +71,27 @@ def _prime_corpus_cache(hub: SkillHub) -> None:
     hub.embed_client.encode_calls.clear()
 
 
+def _repo_corpus(
+    tmp_path: Path, *, description: str, vec: list[float] | None = None,
+) -> SearchCorpus:
+    repo_dir = tmp_path / "repo-skill"
+    repo_dir.mkdir(exist_ok=True)
+    entry = {
+        "source": "repo",
+        "name": "repo:repo-skill",
+        "skill_id": "repo:repo-skill",
+        "repo_name": "repo-skill",
+        "display_name": "repo-skill",
+        "description": description,
+        "source_path": "repo-skill",
+        "content_sha": "a" * 40,
+        "path": repo_dir,
+    }
+    if vec is not None:
+        entry["vec"] = np.asarray(vec, dtype=float)
+    return (entry,)
+
+
 # ── 分词 ─────────────────────────────────────────────────────────
 
 def test_tokenize_mixed_chinese_english():
@@ -91,6 +114,98 @@ def test_bm25_orders_matches_and_name_outranks_description(tmp_path):
     assert names == ["alpha", "beta"]
     assert results[0]["bm25_rank"] == 1 and results[1]["bm25_rank"] == 2
     assert all(result["semantic_rank"] is None for result in results)
+
+
+def test_supplemental_repo_and_skillhub_share_global_bm25_rank(tmp_path):
+    hub_dir = tmp_path / "hub"
+    _write_hub_skill(hub_dir, "hub-alpha", "alpha", "shared")
+    hub = SkillHub(enabled=True, hub_dir=hub_dir, embed_client=None)
+    corpus = _repo_corpus(tmp_path, description="alpha shared")
+
+    results = hub.search("alpha", limit=5, supplemental=corpus)
+
+    assert [result["source"] for result in results] == ["skillhub", "repo"]
+    assert [result["bm25_rank"] for result in results] == [1, 2]
+    assert all(result["semantic_rank"] is None for result in results)
+
+
+def test_supplemental_repo_and_skillhub_share_semantic_and_rrf(tmp_path):
+    hub_dir = tmp_path / "hub"
+    _write_hub_skill(hub_dir, "hub-alpha", "alpha", "gamma one")
+    embed = ControlledEmbed({
+        "gamma one": [0.8, 0.6],
+        "alpha": [1.0, 0.0],
+    })
+    hub = SkillHub(enabled=True, hub_dir=hub_dir, embed_client=embed)
+    _prime_corpus_cache(hub)
+    corpus = _repo_corpus(
+        tmp_path, description="alpha two", vec=[0.0, 1.0],
+    )
+
+    results = hub.search("alpha", limit=5, supplemental=corpus)
+
+    by_source = {result["source"]: result for result in results}
+    assert by_source["skillhub"]["bm25_rank"] == 1
+    assert by_source["repo"]["bm25_rank"] == 2
+    assert by_source["skillhub"]["semantic_rank"] == 1
+    assert by_source["repo"]["semantic_rank"] == 2
+
+
+def test_disabled_skillhub_searches_repo_only_with_bm25(tmp_path):
+    hub = SkillHub(
+        enabled=False, hub_dir=tmp_path / "missing-hub", embed_client=None,
+    )
+    corpus = _repo_corpus(tmp_path, description="docker compose helper")
+
+    results = hub.search("docker", limit=5, supplemental=corpus)
+
+    assert len(results) == 1
+    assert results[0]["source"] == "repo"
+    assert results[0]["bm25_rank"] == 1
+    assert results[0]["semantic_rank"] is None
+
+
+def test_mismatched_repo_vector_keeps_bm25_and_skips_semantic(tmp_path):
+    hub_dir = tmp_path / "hub"
+    _write_hub_skill(hub_dir, "hub-alpha", "alpha", "alpha helper")
+    embed = ControlledEmbed({
+        "alpha helper": [1.0, 0.0],
+        "alpha": [1.0, 0.0],
+    })
+    hub = SkillHub(enabled=True, hub_dir=hub_dir, embed_client=embed)
+    _prime_corpus_cache(hub)
+    corpus = _repo_corpus(
+        tmp_path, description="alpha repo helper", vec=[1.0, 0.0, 0.0],
+    )
+
+    results = hub.search("alpha", limit=5, supplemental=corpus)
+
+    by_source = {result["source"]: result for result in results}
+    assert by_source["repo"]["bm25_rank"] is not None
+    assert by_source["repo"]["semantic_rank"] is None
+    assert by_source["skillhub"]["semantic_rank"] == 1
+    assert all("vec" not in result for result in results)
+
+
+def test_supplemental_cached_search_uses_corpus_identity(tmp_path, monkeypatch):
+    hub_dir = tmp_path / "hub"
+    _write_hub_skill(hub_dir, "hub-alpha", "alpha", "alpha helper")
+    hub = SkillHub(enabled=True, hub_dir=hub_dir, embed_client=None)
+    corpus = _repo_corpus(tmp_path, description="alpha repo helper")
+    expected = hub.search("alpha", limit=5, supplemental=corpus)
+
+    original_build = hub._build_search_index
+    monkeypatch.setattr(
+        hub, "_build_search_index",
+        lambda *_args: (_ for _ in ()).throw(
+            AssertionError("same supplemental corpus rebuilt index")
+        ),
+    )
+    assert hub.search("alpha", limit=5, supplemental=corpus) == expected
+
+    monkeypatch.setattr(hub, "_build_search_index", original_build)
+    equal_but_new = tuple(dict(entry) for entry in corpus)
+    assert hub.search("alpha", limit=5, supplemental=equal_but_new) == expected
 
 
 # ── RRF 融合（构造双通道 rank） ─────────────────────────────────

--- a/tests/test_team_git_bundle.py
+++ b/tests/test_team_git_bundle.py
@@ -1,12 +1,15 @@
 from __future__ import annotations
 
-import subprocess
+import io
 from pathlib import Path
+import subprocess
+import zipfile
 
 import pytest
 
 from xskill.team.shared.git_bundle import (
-    make_repo_bundle, apply_repo_bundle, make_branch_bundle, fetch_branch_from_bundle,
+    make_repo_archive, make_repo_bundle, apply_repo_bundle,
+    make_branch_bundle, fetch_branch_from_bundle,
 )
 
 
@@ -55,6 +58,14 @@ def test_apply_bundle_updates_existing_repo(tmp_path):
     new_main = _git(["rev-parse", "main"], src)
     apply_repo_bundle(make_repo_bundle(src), dest)
     assert _git(["rev-parse", "main"], dest) == new_main
+
+
+def test_repo_archive_exports_selected_commit_as_zip(tmp_path):
+    repo = _seed_repo(tmp_path / "central" / "fix-foo")
+    staging_sha = _git(["rev-parse", "staging"], repo)
+    payload = make_repo_archive(repo, staging_sha)
+    with zipfile.ZipFile(io.BytesIO(payload)) as archive:
+        assert archive.read("SKILL.md") == b"v2"
 
 
 def test_push_branch_roundtrip(tmp_path):


### PR DESCRIPTION
## Summary

- extend the existing SkillHub BM25 + semantic + RRF search with generated repository skills as supplemental documents in the same corpus
- compute global BM25 document frequencies/ranks and global semantic ranks before one shared RRF ordering, so `repo` and `skillhub` results are peers
- keep baby-only skills out by sourcing repository candidates from the existing distributable manifest catalog
- reuse the existing server-side `_resolve_slot` logic for main/staging assignment and return `side`, `staging_available`, and `staging_assigned`
- keep a stable logical search ID for repository skills; the server pins the selected commit briefly and exports that commit as the ZIP contract already consumed by `SearchSlots`
- preserve the exact-name Git bundle path used by normal sync, and keep `src/xskill/cli.py`, `team/client/search_slots.py`, and `team/client/daemon.py` unchanged

## Why this shape

The old team endpoint searched only SkillHub. The revised implementation reuses `SkillHub.search()` itself instead of adding a second ranking algorithm: generated skills are projected into the same search index, and missing/stale/incompatible vectors degrade only that document to BM25.

The source-format difference is contained at the server boundary. Search-selected repository commits are normalized to ZIP for the existing installer; normal repository synchronization remains Git-bundle based.

## Safety and caching

- repository vectors are used only when the cached description and embedding model match the current index
- unchanged manifest refreshes reuse the same supplemental corpus and hybrid-search caches
- search/install leases pin the selected SHA/side, survive cache eviction through the existing slot resolver, and revalidate current Git refs before archive creation
- archive/catalog work stays off the event loop

## Validation

- `341 passed` across team, search, SkillHub, repository-index, and client-output regression tests
- `ruff check` passed for all changed production modules and focused tests
- `git diff --check` passed and changed modules compile on Python 3.11
- three independent read-only subagent reviews found no remaining blocker/high-severity issue

Fixes #137
