### PR TITLE
fix: refine SkillHub downloads and unblock shared-link user edits

### DIFF
--- a/README.en.md
+++ b/README.en.md
@@ -140,11 +140,14 @@ On **macOS / Linux**, native persistence (launchd / systemd --user) is still on 
 #### Search / share skills on demand (skillhub)
 
 ```bash
-xskill search docker compose   # BM25 + semantic search of the server skillhub; hits are installed locally
+xskill search docker compose   # return compact metadata and skill IDs only
+xskill search docker --download  # legacy 10-slot LRU download and auto-install
+xskill download <skill-id>     # interactively select target harnesses
+xskill download <skill-id> --agent claude-code --agent codex -y
 xskill upload ./my-skill       # package & upload a skill folder (with SKILL.md); instantly searchable by the team
 ```
 
-`search` combines BM25 keyword and semantic-vector ranking, independently of the recommendation profile. If the embedding service is unavailable it automatically falls back to BM25, and it prints each hit's name, description, source, score, and absolute local path. Pulled skills live in `~/.xskill/search_skills/` with a rolling cap of **10 slots** (least-recently-hit evicted). `upload` lands under `skillhub/user_skill_hub/<your-username>/` on the server. Semantic search for local trajectories/skills has been removed from the CLI (no more `xskill search traj|skill <query>`); use the dashboard or the API (`POST /api/v1/skills/search`) instead.
+`search` combines BM25 keyword and semantic-vector ranking, independently of the recommendation profile. If embeddings are unavailable it falls back to BM25. By default it returns compact metadata, ranks, and IDs without changing the local machine. `search --download` preserves the original `~/.xskill/search_skills/` **10-slot** rolling LRU behavior. `download` persistently downloads one ID: humans can interactively select harnesses, while agents and scripts should repeat `--agent` and add `-y`; `-y` alone selects all detected harnesses. `upload` lands under `skillhub/user_skill_hub/<your-username>/` on the server. Semantic search for local trajectories/skills has been removed from the CLI (no more `xskill search traj|skill <query>`); use the dashboard or the API (`POST /api/v1/skills/search`) instead.
 
 * * *
 

--- a/README.md
+++ b/README.md
@@ -150,15 +150,19 @@ xskill connect <服务器地址:端口> --token <TOKEN>   # 首次握手(macOS/L
 
 #### 按需搜索 / 分享技能(skillhub)
 
-除了 server 按画像推送的技能,client 还可以主动搜 server 的 skillhub 并把命中的技能拉到本地:
+除了 server 按画像推送的技能,client 还可以主动搜索或下载 server skillhub 中的技能:
 
 ```bash
-xskill search docker compose        # BM25+语义混合检索 skillhub,命中的直接拉到本地并安装
+xskill search docker compose        # 只返回精简元信息和 skill ID
+xskill search docker --download     # 兼容旧行为:命中写入 10 槽 LRU 并自动安装
+xskill download <skill-id>          # 交互多选安装 harness
+xskill download <skill-id> --agent claude-code --agent codex -y
 xskill upload ./my-skill            # 打包上传一个 skill 目录(含 SKILL.md),全队立即可搜到
 ```
 
-- `search` 使用 BM25 关键词+语义向量混合检索 skillhub 目录(含团队成员上传的技能),与推荐画像无关;语义服务不可用时自动退化为 BM25，并输出名字、描述、来源、评分和本机绝对路径。
-- 搜下来的技能落在 `~/.xskill/search_skills/`,本地最多保留 **10 个槽位**,按最近命中滚动淘汰,不受 sync 清理影响。
+- `search` 使用 BM25 关键词+语义向量混合检索 skillhub 目录(含团队成员上传的技能),与推荐画像无关;语义服务不可用时自动退化为 BM25。默认只输出精简元信息、排名和 ID,不修改本机。
+- `search --download` 保留原有逻辑:技能落在 `~/.xskill/search_skills/`,本地最多保留 **10 个槽位**,按最近命中滚动淘汰,不受 sync 清理影响。
+- `download` 按 ID 持久下载;人类可交互多选 harness,agent/脚本应重复传 `--agent` 并加 `-y`。仅加 `-y` 时自动选择已检测到的 harness。
 - `upload` 会先校验 `SKILL.md` frontmatter,server 端落到 `skillhub/user_skill_hub/<你的用户名>/` 下。
 - 本机语义搜索已从 CLI 移除(不再有 `xskill search traj|skill <query>`);如需按语义检索本机轨迹/技能,请用 dashboard 或 API(`POST /api/v1/skills/search`)。
 

--- a/README.zh-CN.md
+++ b/README.zh-CN.md
@@ -101,11 +101,14 @@ macOS / Linux 的原生常驻（launchd / systemd --user）仍在路上，当前
 ### 按需搜索 / 分享技能（skillhub）
 
 ```bash
-xskill search docker compose        # BM25+语义混合检索 server skillhub，命中的拉到本地安装
+xskill search docker compose        # 只返回精简元信息和 skill ID
+xskill search docker --download     # 命中写入 10 槽 LRU 并自动安装
+xskill download <skill-id>          # 交互多选安装 harness
+xskill download <skill-id> --agent claude-code --agent codex -y
 xskill upload ./my-skill            # 打包上传一个 skill 目录(含 SKILL.md),全队立即可搜到
 ```
 
-`search` 使用 BM25 关键词+语义向量混合检索、与推荐画像无关；语义服务不可用时自动退化为 BM25，并输出名字、描述、来源、评分和本机绝对路径。本地最多保留 **10 个槽位**滚动淘汰。`upload` 在 server 端落到 `skillhub/user_skill_hub/<你的用户名>/` 下。本机轨迹/技能的语义搜索已从 CLI 移除（不再有 `xskill search traj|skill <query>`），改用 dashboard 或 API（`POST /api/v1/skills/search`）。
+`search` 使用 BM25 关键词+语义向量混合检索、与推荐画像无关；语义服务不可用时自动退化为 BM25。默认只输出精简元信息、排名和 ID，不修改本机；`search --download` 保留原来的 **10 个槽位**滚动淘汰逻辑。`download` 按 ID 持久下载，人类可交互多选 harness，agent/脚本应重复传 `--agent` 并加 `-y`。`upload` 在 server 端落到 `skillhub/user_skill_hub/<你的用户名>/` 下。本机轨迹/技能的语义搜索已从 CLI 移除（不再有 `xskill search traj|skill <query>`），改用 dashboard 或 API（`POST /api/v1/skills/search`）。
 
 ## 架构图
 

--- a/src/xskill/agents/user_edit_absorb_agent.py
+++ b/src/xskill/agents/user_edit_absorb_agent.py
@@ -432,8 +432,16 @@ def _dest_edit_status(
     exclude: frozenset[str],
 ) -> _DestEditAssessment:
     try:
-        if not dest_dir.is_dir():
+        root_stat = dest_dir.lstat()
+        # Link/junction 安装与 source 共享同一份文件，不需要 copy
+        # reverse-sync。返回 NO_EDIT 让调用方继续走 git status；仍不跟随
+        # 链接扫描，真实 copy 内部出现链接时继续 fail-closed。
+        if stat.S_ISLNK(root_stat.st_mode) or _is_reparse_point(root_stat):
             return _DestEditAssessment(_DestEditStatus.NO_EDIT)
+        if not stat.S_ISDIR(root_stat.st_mode):
+            return _DestEditAssessment(_DestEditStatus.FAILED)
+    except FileNotFoundError:
+        return _DestEditAssessment(_DestEditStatus.NO_EDIT)
     except OSError:
         return _DestEditAssessment(_DestEditStatus.FAILED)
     metadata_ok, installed_at = _read_install_meta_ts(dest_dir)

--- a/src/xskill/cli.py
+++ b/src/xskill/cli.py
@@ -6,6 +6,7 @@ cli.py — xskill 紧凑 CLI
     xskill serve [--host] [--port]
     xskill registry add|remove|list <path>
     xskill search <关键词...> [--top-k]
+    xskill download <skill-id>
 
 所有筛选/格式化交给 shell（grep/awk）。状态/配置全在 ~/.xskill/。
 """
@@ -705,8 +706,10 @@ def _write_search_output(text: str, *, to_stderr: bool = False) -> None:
         stream.write("\n")
 
 
-def _render_search_results(installed: list[dict], query: str) -> None:
-    """以实际安装结果渲染人读搜索输出，不重新探测本机生态。"""
+def _render_search_results(
+    results: list[dict], query: str, *, heading: str = "搜索",
+) -> None:
+    """渲染搜索元信息或显式下载结果，不重新探测本机生态。"""
     harness_names = {
         "claude_code": "Claude Code",
         "codex": "Codex",
@@ -718,15 +721,18 @@ def _render_search_results(installed: list[dict], query: str) -> None:
         "trae": "Trae",
     }
     output_lines = [
-        f"搜索：{query}",
-        f"找到 {len(installed)} 个 skill",
+        f"{heading}：{query}",
+        f"找到 {len(results)} 个 skill",
         "=" * 64,
     ]
     successful_installations = 0
-    for index, row in enumerate(installed, start=1):
+    for index, row in enumerate(results, start=1):
         if index > 1:
             output_lines.append("-" * 64)
-        output_lines.append(f"[{index}/{len(installed)}] {row['name']}")
+        display_name = row.get("display_name") or row.get("name")
+        output_lines.append(
+            f"[{index}/{len(results)}] {display_name or row['skill_id']}"
+        )
         output_lines.append(f"ID：{row['skill_id']}")
 
         description = " ".join(str(row.get("description") or "").split())
@@ -763,6 +769,13 @@ def _render_search_results(installed: list[dict], query: str) -> None:
         installation_records = row.get("installations")
         if not isinstance(installation_records, list):
             installation_records = []
+        local_path = row.get("path")
+        if local_path:
+            output_lines.append(f"本地：{local_path}")
+        elif not installation_records:
+            output_lines.append(
+                f"下载：xskill download {row['skill_id']}"
+            )
         successful_groups: dict[tuple[str, str], list[str]] = {}
         failed_records: list[dict] = []
         for record in installation_records:
@@ -800,10 +813,15 @@ def _render_search_results(installed: list[dict], query: str) -> None:
                 f"    原因：{error_text or '安装器未提供错误信息'}"
             )
     output_lines.append("=" * 64)
-    output_lines.append(
-        f"完成：{len(installed)} 个 skill，"
-        f"{successful_installations} 条 harness 安装记录"
-    )
+    if any(row.get("path") for row in results):
+        output_lines.append(
+            f"完成：{len(results)} 个 skill，"
+            f"{successful_installations} 条 harness 安装记录"
+        )
+    else:
+        output_lines.append(
+            "搜索仅返回元信息；使用上方 download 命令显式下载。"
+        )
     _write_search_output("\n".join(output_lines))
 
 
@@ -856,18 +874,14 @@ def _safe_search_http_error(response) -> dict:
 
 
 def cmd_search_hub(args, http=None, headers=None) -> int:
-    """`xskill search <query>` —— 搜 server skillhub，命中的拉到本地滚动槽位。
+    """`xskill search <query>` —— 只搜元信息，不下载或修改本机安装。
 
-    结果由 BM25 关键词与语义向量混合检索 skillhub 目录（含 user_skill_hub 上传件），
-    与推荐画像无关；语义服务不可用时自动退化为 BM25。每个命中 skill 下载解包到
-    ``~/.xskill/search_skills/<skill_id>/``、
-    打 ``.xskill_search.json`` 标记、装进本机生态；本地最多保留 10 个槽位，
-    按最近命中滚动淘汰。``http``/``headers`` 参数仅测试注入用。
+    结果由 BM25 关键词与语义向量混合检索自产 skill 与 SkillHub；语义服务
+    不可用时退化为 BM25。下载由 ``xskill download <skill-id>`` 显式执行。
+    ``http``/``headers`` 参数仅测试注入用。
     """
     import json as _json
     import httpx
-    from xskill.config import XSKILL_HOME
-    from xskill.team.client.search_slots import SearchSlots
 
     if http is None:
         http, headers = _team_client_http_and_headers()
@@ -908,31 +922,6 @@ def cmd_search_hub(args, http=None, headers=None) -> int:
         if not results:
             _write_search_output("skillhub 无匹配 skill")
             return 0
-        slots = SearchSlots(xskill_home=XSKILL_HOME)
-        installed = []
-        for result in results:
-            bundle = http.get(f"/api/v1/team/skill/{result['skill_id']}/bundle",
-                              headers=headers)
-            if bundle.status_code != 200:
-                _write_search_output(
-                    f"warning: 拉取 {result['skill_id']} 失败 "
-                    f"HTTP {bundle.status_code}",
-                    to_stderr=True,
-                )
-                continue
-            slot_result = slots.install(
-                result, bundle.content, query=query, return_details=True,
-            )
-            local_path = slot_result["cache_path"]
-            # 原样透传 server 返回的所有字段，再补本机安装信息
-            installed_entry = dict(result)
-            installed_entry["name"] = result["display_name"]
-            installed_entry["path"] = str(local_path)
-            installed_entry["cache_path"] = str(local_path)
-            installed_entry["installations"] = [
-                dict(record) for record in slot_result["installations"]
-            ]
-            installed.append(installed_entry)
     except (httpx.HTTPError, OSError) as network_error:
         _write_search_output(
             f"error: 无法连接 team server（{type(network_error).__name__}），"
@@ -942,10 +931,85 @@ def cmd_search_hub(args, http=None, headers=None) -> int:
         return 1
     if args.json:
         _write_search_output(_json.dumps(
-            installed, ensure_ascii=True, indent=2,
+            results, ensure_ascii=True, indent=2,
         ))
         return 0
-    _render_search_results(installed, query)
+    _render_search_results(results, query)
+    return 0
+
+
+def cmd_download(args, http=None, headers=None) -> int:
+    """`xskill download <skill-id>` —— 显式下载并持久安装一个搜索结果。"""
+    import json as _json
+    import zipfile
+    import httpx
+    from xskill.config import XSKILL_HOME
+    from xskill.team.client.search_slots import DownloadedSkills
+
+    if http is None:
+        http, headers = _team_client_http_and_headers()
+        if http is None:
+            return 1
+    skill_id = str(args.skill_id).strip()
+    if (
+        not skill_id or skill_id in {".", ".."}
+        or "/" in skill_id or "\\" in skill_id or "\x00" in skill_id
+    ):
+        _write_search_output("error: 非法 skill ID", to_stderr=True)
+        return 2
+    try:
+        metadata_response = http.get(
+            f"/api/v1/team/skill_hub/entry/{skill_id}",
+            headers=headers,
+        )
+        if metadata_response.status_code != 200:
+            _write_search_output(
+                f"error: 找不到可下载的 skill（HTTP "
+                f"{metadata_response.status_code}）",
+                to_stderr=True,
+            )
+            return 1
+        result = metadata_response.json().get("result")
+        if not isinstance(result, dict):
+            _write_search_output(
+                "error: server 返回了无效的 skill 元信息",
+                to_stderr=True,
+            )
+            return 1
+        bundle = http.get(
+            f"/api/v1/team/skill/{skill_id}/bundle",
+            headers=headers,
+        )
+        if bundle.status_code != 200:
+            _write_search_output(
+                f"error: 下载 skill 失败（HTTP {bundle.status_code}）",
+                to_stderr=True,
+            )
+            return 1
+        manager = DownloadedSkills(xskill_home=XSKILL_HOME)
+        installed = manager.install(
+            result, bundle.content, return_details=True,
+        )
+        output = dict(result)
+        output["name"] = result.get("display_name") or skill_id
+        output["path"] = str(installed["path"])
+        output["installations"] = [
+            dict(record) for record in installed["installations"]
+        ]
+    except (
+        httpx.HTTPError, OSError, RuntimeError, ValueError, zipfile.BadZipFile,
+    ) as download_error:
+        _write_search_output(
+            f"error: 下载失败（{type(download_error).__name__}）",
+            to_stderr=True,
+        )
+        return 1
+    if args.json:
+        _write_search_output(_json.dumps(
+            output, ensure_ascii=True, indent=2,
+        ))
+    else:
+        _render_search_results([output], skill_id, heading="下载")
     return 0
 
 
@@ -1172,7 +1236,7 @@ def build_parser() -> argparse.ArgumentParser:
 
     p_search = sub.add_parser(
         "search",
-        help="搜 team server 的 skillhub 并把命中 skill 拉到本地槽位",
+        help="搜索 team server 的 skill 元信息（不下载）",
     )
     p_search.add_argument(
         "terms", nargs="+", metavar="QUERY",
@@ -1181,6 +1245,14 @@ def build_parser() -> argparse.ArgumentParser:
     p_search.add_argument("--top-k", "-k", type=int, default=5,
                           help="返回条数（skillhub 搜索最多 10）")
     p_search.add_argument("--json", action="store_true", help="机读 JSON 输出")
+
+    p_download = sub.add_parser(
+        "download", help="按 search 返回的 skill ID 显式下载并持久安装",
+    )
+    p_download.add_argument("skill_id", help="xskill search 返回的 skill ID")
+    p_download.add_argument(
+        "--json", action="store_true", help="机读 JSON 输出",
+    )
 
     p_upload = sub.add_parser(
         "upload", help="打包一个 skill 文件夹上传到 team server 的 user skillhub",
@@ -1376,9 +1448,11 @@ def main() -> int:
     if args.command == "dashboard":
         return cmd_dashboard(args)
 
-    # skillhub 搜索/上传是瘦客户端侧（走 team server），不碰 config.yaml。
+    # skillhub 搜索/下载/上传是瘦客户端侧（走 team server），不碰 config.yaml。
     if args.command == "search":
         return cmd_search_hub(args)
+    if args.command == "download":
+        return cmd_download(args)
     if args.command == "upload":
         return cmd_upload(args)
 

--- a/src/xskill/cli.py
+++ b/src/xskill/cli.py
@@ -706,10 +706,97 @@ def _write_search_output(text: str, *, to_stderr: bool = False) -> None:
         stream.write("\n")
 
 
+_DOWNLOAD_AGENT_OPTIONS = (
+    ("claude_code", "claude-code", "Claude Code"),
+    ("codex", "codex", "Codex"),
+    ("nga3", "nga3", "CodeAgent3 / NGA3"),
+    ("opencode", "opencode", "OpenCode"),
+    ("ngagent", "ngagent", "NGAgent"),
+    ("openclaw", "openclaw", "OpenClaw"),
+    ("cursor", "cursor", "Cursor"),
+    ("trae", "trae", "Trae"),
+)
+_DOWNLOAD_AGENT_ALIASES = {
+    "claude-code": "claude_code",
+    "claude_code": "claude_code",
+    "cc": "claude_code",
+    "codex": "codex",
+    "nga3": "nga3",
+    "codeagent3": "nga3",
+    "code-agent3": "nga3",
+    "opencode": "opencode",
+    "open-code": "opencode",
+    "ngagent": "ngagent",
+    "ng-agent": "ngagent",
+    "openclaw": "openclaw",
+    "open-claw": "openclaw",
+    "cursor": "cursor",
+    "trae": "trae",
+}
+_DOWNLOAD_AGENT_CHOICES = tuple(_DOWNLOAD_AGENT_ALIASES)
+_DOWNLOAD_AGENT_LABELS = {
+    ecosystem: label
+    for ecosystem, _cli_name, label in _DOWNLOAD_AGENT_OPTIONS
+}
+
+
+def _source_label(row: dict) -> str:
+    source = str(row.get("source") or "")
+    source_path = str(row.get("source_path") or "")
+    path_parts = source_path.replace("\\", "/").split("/")
+    if source == "repo":
+        return "XSkill 自蒸馏生成"
+    if source.startswith("上传者:"):
+        return f"{source}（用户上传）"
+    if len(path_parts) >= 2 and path_parts[0] == "user_skill_hub":
+        return f"用户上传（{path_parts[1]}）"
+    return "SkillHub"
+
+
+def _match_summary(row: dict) -> str:
+    match = row.get("match")
+    match_parts: list[str] = []
+    if isinstance(match, dict) and match.get("bm25_rank") is not None:
+        match_parts.append(f"关键词排名 #{match['bm25_rank']}")
+    if isinstance(match, dict) and match.get("semantic_rank") is not None:
+        match_parts.append(f"语义排名 #{match['semantic_rank']}")
+    if row.get("ux_avg") is not None:
+        match_parts.append(f"ux {row['ux_avg']}")
+    return "    ".join(match_parts)
+
+
+def _render_search_metadata_results(results: list[dict], query: str) -> None:
+    """精简渲染只读搜索结果，绝不展示本机路径或 harness 安装信息。"""
+    output_lines = [
+        f"搜索：{query}",
+        f"找到 {len(results)} 个 skill",
+        "=" * 64,
+    ]
+    for index, row in enumerate(results, start=1):
+        if index > 1:
+            output_lines.append("-" * 64)
+        display_name = row.get("display_name") or row.get("name")
+        output_lines.append(
+            f"[{index}/{len(results)}] {display_name or row['skill_id']}"
+        )
+        output_lines.append(f"ID：{row['skill_id']}")
+        description = " ".join(str(row.get("description") or "").split())
+        if len(description) > 180:
+            description = f"{description[:177].rstrip()}..."
+        output_lines.append(f"描述：{description or '（无描述）'}")
+        output_lines.append(f"来源：{_source_label(row)}")
+        match_summary = _match_summary(row)
+        if match_summary:
+            output_lines.append(f"匹配：{match_summary}")
+        output_lines.append(f"下载：xskill download {row['skill_id']}")
+    output_lines.append("=" * 64)
+    _write_search_output("\n".join(output_lines))
+
+
 def _render_search_results(
     results: list[dict], query: str, *, heading: str = "搜索",
 ) -> None:
-    """渲染搜索元信息或显式下载结果，不重新探测本机生态。"""
+    """渲染已经下载/安装的结果，不重新探测本机生态。"""
     harness_names = {
         "claude_code": "Claude Code",
         "codex": "Codex",
@@ -740,31 +827,14 @@ def _render_search_results(
             description = f"{description[:177].rstrip()}..."
         output_lines.append(f"描述：{description or '（无描述）'}")
 
-        source = str(row.get("source") or "")
         source_path = str(row.get("source_path") or "")
-        path_parts = source_path.replace("\\", "/").split("/")
-        if source == "repo":
-            source_label = "XSkill 自蒸馏生成"
-        elif source.startswith("上传者:"):
-            source_label = f"{source}（用户上传）"
-        elif len(path_parts) >= 2 and path_parts[0] == "user_skill_hub":
-            source_label = f"用户上传（{path_parts[1]}）"
-        else:
-            source_label = "SkillHub"
-        output_lines.append(f"来源: {source_label}")
+        output_lines.append(f"来源: {_source_label(row)}")
         if source_path:
             output_lines.append(f"  {source_path}")
 
-        match = row.get("match")
-        match_parts: list[str] = []
-        if isinstance(match, dict) and match.get("bm25_rank") is not None:
-            match_parts.append(f"关键词排名 #{match['bm25_rank']}")
-        if isinstance(match, dict) and match.get("semantic_rank") is not None:
-            match_parts.append(f"语义排名 #{match['semantic_rank']}")
-        if row.get("ux_avg") is not None:
-            match_parts.append(f"ux {row['ux_avg']}")
-        if match_parts:
-            output_lines.append(f"匹配：{'    '.join(match_parts)}")
+        match_summary = _match_summary(row)
+        if match_summary:
+            output_lines.append(f"匹配：{match_summary}")
 
         installation_records = row.get("installations")
         if not isinstance(installation_records, list):
@@ -772,10 +842,6 @@ def _render_search_results(
         local_path = row.get("path")
         if local_path:
             output_lines.append(f"本地：{local_path}")
-        elif not installation_records:
-            output_lines.append(
-                f"下载：xskill download {row['skill_id']}"
-            )
         successful_groups: dict[tuple[str, str], list[str]] = {}
         failed_records: list[dict] = []
         for record in installation_records:
@@ -813,15 +879,10 @@ def _render_search_results(
                 f"    原因：{error_text or '安装器未提供错误信息'}"
             )
     output_lines.append("=" * 64)
-    if any(row.get("path") for row in results):
-        output_lines.append(
-            f"完成：{len(results)} 个 skill，"
-            f"{successful_installations} 条 harness 安装记录"
-        )
-    else:
-        output_lines.append(
-            "搜索仅返回元信息；使用上方 download 命令显式下载。"
-        )
+    output_lines.append(
+        f"完成：{len(results)} 个 skill，"
+        f"{successful_installations} 条 harness 安装记录"
+    )
     _write_search_output("\n".join(output_lines))
 
 
@@ -873,11 +934,129 @@ def _safe_search_http_error(response) -> dict:
     return safe_error
 
 
+def _normalize_download_agents(raw_agents: list[str]) -> list[str]:
+    normalized: list[str] = []
+    for raw_agent in raw_agents:
+        canonical = _DOWNLOAD_AGENT_ALIASES.get(
+            str(raw_agent).strip().lower(),
+        )
+        if canonical is None:
+            raise ValueError(f"unsupported agent: {raw_agent}")
+        if canonical not in normalized:
+            normalized.append(canonical)
+    return normalized
+
+
+def _detected_download_agents() -> list[str]:
+    from pathlib import Path
+    from xskill.ecosystems import detect_known_ecosystems
+
+    detected = {
+        str(record.get("ecosystem") or "")
+        for record in detect_known_ecosystems(home_root=Path.home())
+        if isinstance(record, dict)
+    }
+    return [
+        ecosystem for ecosystem, _cli_name, _label
+        in _DOWNLOAD_AGENT_OPTIONS
+        if ecosystem in detected
+    ]
+
+
+def _stdin_is_interactive() -> bool:
+    return bool(getattr(sys.stdin, "isatty", lambda: False)())
+
+
+def _prompt_download_agents(candidates: list[str]) -> list[str] | None:
+    """用无依赖的编号多选询问 harness；None 表示用户取消。"""
+    lines = ["选择要安装到的 harness（可多选）："]
+    for index, ecosystem in enumerate(candidates, start=1):
+        lines.append(
+            f"  {index}. {_DOWNLOAD_AGENT_LABELS[ecosystem]}"
+        )
+    lines.append("输入编号（逗号/空格分隔）；直接回车全选；q 取消。")
+    _write_search_output("\n".join(lines), to_stderr=True)
+    while True:
+        sys.stderr.write("> ")
+        sys.stderr.flush()
+        raw_selection = sys.stdin.readline()
+        if raw_selection == "":
+            return None
+        selection = raw_selection.strip().lower()
+        if selection in {"q", "quit", "cancel"}:
+            return None
+        if not selection:
+            return list(candidates)
+        tokens = [
+            token for token in re.split(r"[\s,]+", selection) if token
+        ]
+        try:
+            indexes = [int(token) for token in tokens]
+        except ValueError:
+            indexes = []
+        if (
+            indexes and all(1 <= index <= len(candidates) for index in indexes)
+        ):
+            return list(dict.fromkeys(
+                candidates[index - 1] for index in indexes
+            ))
+        _write_search_output(
+            f"请输入 1-{len(candidates)} 的编号，或 q 取消。",
+            to_stderr=True,
+        )
+
+
+def _select_download_agents(args) -> tuple[list[str] | None, int]:
+    """解析 download 的自动/交互选择；返回 (agents, rc)。"""
+    try:
+        explicit_agents = _normalize_download_agents(
+            list(getattr(args, "agent", None) or [])
+        )
+    except ValueError as agent_error:
+        _write_search_output(
+            f"error: {agent_error}", to_stderr=True,
+        )
+        return None, 2
+
+    if bool(getattr(args, "yes", False)):
+        selected = explicit_agents or _detected_download_agents()
+        if not selected:
+            _write_search_output(
+                "warning: 未检测到可安装的 harness；skill 将仅持久下载，"
+                "也可用 --agent <name> -y 显式安装。",
+                to_stderr=True,
+            )
+        return selected, 0
+
+    if not _stdin_is_interactive():
+        _write_search_output(
+            "error: 当前不是交互终端；请使用可重复的 "
+            "--agent <name> 并加 -y，或仅加 -y 自动选择已检测 harness。",
+            to_stderr=True,
+        )
+        return None, 2
+    candidates = explicit_agents or _detected_download_agents()
+    if not candidates:
+        _write_search_output(
+            "warning: 未检测到可安装的 harness；skill 将仅持久下载，"
+            "也可用 --agent <name> -y 显式安装。",
+            to_stderr=True,
+        )
+        return [], 0
+    selected = _prompt_download_agents(candidates)
+    if selected is None:
+        _write_search_output("已取消下载。", to_stderr=True)
+        return None, 0
+    return selected, 0
+
+
 def cmd_search_hub(args, http=None, headers=None) -> int:
-    """`xskill search <query>` —— 只搜元信息，不下载或修改本机安装。
+    """`xskill search <query>` —— 默认只搜元信息。
 
     结果由 BM25 关键词与语义向量混合检索自产 skill 与 SkillHub；语义服务
     不可用时退化为 BM25。下载由 ``xskill download <skill-id>`` 显式执行。
+    ``--download`` 兼容旧 search：把全部命中放进 10 槽 LRU 并自动安装到
+    已检测 harness。
     ``http``/``headers`` 参数仅测试注入用。
     """
     import json as _json
@@ -920,8 +1099,45 @@ def cmd_search_hub(args, http=None, headers=None) -> int:
             return 1
         results = resp.json().get("results", [])
         if not results:
-            _write_search_output("skillhub 无匹配 skill")
+            if args.json:
+                _write_search_output("[]")
+            else:
+                _write_search_output("skillhub 无匹配 skill")
             return 0
+        if getattr(args, "download", False):
+            from xskill.config import XSKILL_HOME
+            from xskill.team.client.search_slots import SearchSlots
+
+            slots = SearchSlots(xskill_home=XSKILL_HOME)
+            installed = []
+            for result in results:
+                bundle = http.get(
+                    f"/api/v1/team/skill/{result['skill_id']}/bundle",
+                    headers=headers,
+                )
+                if bundle.status_code != 200:
+                    _write_search_output(
+                        f"warning: 拉取 {result['skill_id']} 失败 "
+                        f"HTTP {bundle.status_code}",
+                        to_stderr=True,
+                    )
+                    continue
+                slot_result = slots.install(
+                    result, bundle.content, query=query,
+                    return_details=True,
+                )
+                local_path = slot_result["cache_path"]
+                installed_entry = dict(result)
+                installed_entry["name"] = (
+                    result.get("display_name") or result["skill_id"]
+                )
+                installed_entry["path"] = str(local_path)
+                installed_entry["cache_path"] = str(local_path)
+                installed_entry["installations"] = [
+                    dict(record)
+                    for record in slot_result["installations"]
+                ]
+                installed.append(installed_entry)
     except (httpx.HTTPError, OSError) as network_error:
         _write_search_output(
             f"error: 无法连接 team server（{type(network_error).__name__}），"
@@ -929,12 +1145,18 @@ def cmd_search_hub(args, http=None, headers=None) -> int:
             to_stderr=True,
         )
         return 1
+    output_results = (
+        installed if getattr(args, "download", False) else results
+    )
     if args.json:
         _write_search_output(_json.dumps(
-            results, ensure_ascii=True, indent=2,
+            output_results, ensure_ascii=True, indent=2,
         ))
         return 0
-    _render_search_results(results, query)
+    if getattr(args, "download", False):
+        _render_search_results(output_results, query)
+    else:
+        _render_search_metadata_results(output_results, query)
     return 0
 
 
@@ -946,10 +1168,6 @@ def cmd_download(args, http=None, headers=None) -> int:
     from xskill.config import XSKILL_HOME
     from xskill.team.client.search_slots import DownloadedSkills
 
-    if http is None:
-        http, headers = _team_client_http_and_headers()
-        if http is None:
-            return 1
     skill_id = str(args.skill_id).strip()
     if (
         not skill_id or skill_id in {".", ".."}
@@ -957,6 +1175,13 @@ def cmd_download(args, http=None, headers=None) -> int:
     ):
         _write_search_output("error: 非法 skill ID", to_stderr=True)
         return 2
+    if http is None:
+        http, headers = _team_client_http_and_headers()
+        if http is None:
+            return 1
+    selected_agents, selection_rc = _select_download_agents(args)
+    if selected_agents is None:
+        return selection_rc
     try:
         metadata_response = http.get(
             f"/api/v1/team/skill_hub/entry/{skill_id}",
@@ -988,7 +1213,8 @@ def cmd_download(args, http=None, headers=None) -> int:
             return 1
         manager = DownloadedSkills(xskill_home=XSKILL_HOME)
         installed = manager.install(
-            result, bundle.content, return_details=True,
+            result, bundle.content, ecosystems=selected_agents,
+            return_details=True,
         )
         output = dict(result)
         output["name"] = result.get("display_name") or skill_id
@@ -1244,12 +1470,25 @@ def build_parser() -> argparse.ArgumentParser:
     )
     p_search.add_argument("--top-k", "-k", type=int, default=5,
                           help="返回条数（skillhub 搜索最多 10）")
+    p_search.add_argument(
+        "--download", action="store_true",
+        help="兼容旧 search：下载命中到 10 槽 LRU 并安装到已检测 harness",
+    )
     p_search.add_argument("--json", action="store_true", help="机读 JSON 输出")
 
     p_download = sub.add_parser(
         "download", help="按 search 返回的 skill ID 显式下载并持久安装",
     )
     p_download.add_argument("skill_id", help="xskill search 返回的 skill ID")
+    p_download.add_argument(
+        "--agent", action="append", choices=_DOWNLOAD_AGENT_CHOICES,
+        default=[], metavar="AGENT",
+        help="安装目标，可重复（如 claude-code、codex、cursor）",
+    )
+    p_download.add_argument(
+        "-y", "--yes", action="store_true",
+        help="不询问；未指定 --agent 时自动选择已检测 harness",
+    )
     p_download.add_argument(
         "--json", action="store_true", help="机读 JSON 输出",
     )

--- a/src/xskill/data/skill/xskill/SKILL.md
+++ b/src/xskill/data/skill/xskill/SKILL.md
@@ -87,7 +87,9 @@ black-window, copy-mode, and can't-connect issues in detail.
 
 ```bash
 xskill search <query...>       # search team skills; returns metadata only
-xskill download <skill-id>     # explicitly download and persist one search result
+xskill search <query...> --download  # legacy 10-slot LRU download + auto-install
+xskill download <skill-id>     # persist one result; interactively select harnesses
+xskill download <skill-id> --agent claude-code --agent codex -y  # for agents/scripts
 xskill search auth retry -k 3  # top-3 results (max 10)
 xskill upload ./my-skill       # package a SKILL.md folder and share to the team
 xskill dashboard               # print a passwordless link into the server dashboard

--- a/src/xskill/data/skill/xskill/SKILL.md
+++ b/src/xskill/data/skill/xskill/SKILL.md
@@ -86,7 +86,8 @@ black-window, copy-mode, and can't-connect issues in detail.
 ## Searching & sharing team skills
 
 ```bash
-xskill search <query...>       # search the team skillhub, pull hits into local slots
+xskill search <query...>       # search team skills; returns metadata only
+xskill download <skill-id>     # explicitly download and persist one search result
 xskill search auth retry -k 3  # top-3 results (max 10)
 xskill upload ./my-skill       # package a SKILL.md folder and share to the team
 xskill dashboard               # print a passwordless link into the server dashboard

--- a/src/xskill/ecosystems/installation.py
+++ b/src/xskill/ecosystems/installation.py
@@ -968,7 +968,11 @@ def copy_install_is_current(src_dir: Path, dest: Path) -> bool:
         dest, src_dir, metadata=metadata,
     ):
         return False
-    for marker_name in (".xskill_search.json", ".xskill_skillhub.json"):
+    for marker_name in (
+        ".xskill_download.json",
+        ".xskill_search.json",
+        ".xskill_skillhub.json",
+    ):
         source_marker = src_dir / marker_name
         dest_marker = dest / marker_name
         if not (source_marker.is_file() and dest_marker.is_file()):

--- a/src/xskill/team/client/daemon.py
+++ b/src/xskill/team/client/daemon.py
@@ -5,7 +5,8 @@ working copy 并对齐 side、把本地手改推成 user-staging/<client_id> 分
 零 LLM、零 git 写 main、零灰度判定。
 
 _tick 一轮：
-  collect_and_upload → sync → reconcile_skill_sides → push_user_edits → cleanup
+  collect_and_upload → sync → reconcile_skill_sides →
+  reconcile_downloaded_skills → push_user_edits → cleanup
 """
 from __future__ import annotations
 
@@ -227,6 +228,105 @@ class TeamClient:
     def _install_to_ecosystems(self, repo_dir: Path) -> None:
         install_skill_to_ecosystems(repo_dir, home_root=self.home_root)
 
+    def reconcile_downloaded_skills(self) -> int:
+        """刷新显式下载项；持久下载不占 search LRU，随服务端版本继续更新。"""
+        from xskill.team.client.search_slots import (
+            DownloadedSkills,
+            _valid_slot_id,
+        )
+
+        manager = DownloadedSkills(
+            xskill_home=self.skill_dir.parent,
+            home_root=self.home_root,
+        )
+        updated = 0
+        for entry in manager.entries():
+            skill_id = entry.get("skill_id")
+            if not isinstance(skill_id, str) or not _valid_slot_id(skill_id):
+                logger.warning(
+                    "ignored invalid downloaded skill id error_type="
+                    "DOWNLOAD_LEDGER_ID_INVALID",
+                )
+                continue
+            skill_hash = hashlib.sha256(
+                skill_id.encode("utf-8"),
+            ).hexdigest()[:12]
+            try:
+                metadata_response = self.http.get(
+                    f"/api/v1/team/skill_hub/entry/{skill_id}",
+                    headers=self._hdr(),
+                )
+            except Exception:  # pylint: disable=broad-exception-caught
+                logger.warning(
+                    "download refresh metadata failed skill_id_hash=%s "
+                    "error_type=DOWNLOAD_REFRESH_REQUEST_FAILED",
+                    skill_hash,
+                )
+                continue
+            if metadata_response.status_code != 200:
+                logger.warning(
+                    "download refresh metadata failed skill_id_hash=%s "
+                    "http_status=%s",
+                    skill_hash, metadata_response.status_code,
+                )
+                continue
+            try:
+                metadata_payload = metadata_response.json()
+            except (TypeError, ValueError):
+                metadata_payload = {}
+            result = (
+                metadata_payload.get("result")
+                if isinstance(metadata_payload, dict) else None
+            )
+            if not isinstance(result, dict):
+                logger.warning(
+                    "download refresh metadata invalid skill_id_hash=%s",
+                    skill_hash,
+                )
+                continue
+            local_skill = manager.skills_dir / skill_id / "SKILL.md"
+            if (
+                entry.get("sha") == result.get("content_sha")
+                and local_skill.is_file()
+            ):
+                continue
+            try:
+                bundle = self.http.get(
+                    f"/api/v1/team/skill/{skill_id}/bundle",
+                    headers=self._hdr(),
+                )
+            except Exception:  # pylint: disable=broad-exception-caught
+                logger.warning(
+                    "download refresh bundle failed skill_id_hash=%s "
+                    "error_type=DOWNLOAD_REFRESH_REQUEST_FAILED",
+                    skill_hash,
+                )
+                continue
+            if bundle.status_code != 200:
+                logger.warning(
+                    "download refresh bundle failed skill_id_hash=%s "
+                    "http_status=%s",
+                    skill_hash, bundle.status_code,
+                )
+                continue
+            try:
+                manager.install(result, bundle.content)
+            except (
+                OSError, RuntimeError, ValueError, zipfile.BadZipFile,
+            ):
+                logger.warning(
+                    "download refresh install failed skill_id_hash=%s "
+                    "error_type=DOWNLOAD_REFRESH_INSTALL_FAILED",
+                    skill_hash,
+                )
+                continue
+            updated += 1
+            logger.info(
+                "refreshed downloaded skill skill_id_hash=%s",
+                skill_hash,
+            )
+        return updated
+
     # ── ④ push 用户手改 ──────────────────────────────────────────
     def push_user_edits(self) -> int:
         """检测本地 working copy 的未吸收手改，推成 user-staging/<client_id>。
@@ -420,6 +520,7 @@ class TeamClient:
             self.collect_and_upload()
             manifest = self.sync()
             self.reconcile_skill_sides(manifest)
+            self.reconcile_downloaded_skills()
             self.push_user_edits()
             self.cleanup(manifest)
         except Exception as tick_error:
@@ -866,7 +967,11 @@ def _matching_source_version_marker(
     dest: Path, source_dir: Path,
 ) -> bool:
     """只用于新鲜度验证，不参与 copy 删除所有权判定。"""
-    for marker_name in (".xskill_search.json", ".xskill_skillhub.json"):
+    for marker_name in (
+        ".xskill_download.json",
+        ".xskill_search.json",
+        ".xskill_skillhub.json",
+    ):
         source_marker = source_dir / marker_name
         dest_marker = dest / marker_name
         if not source_marker.is_file() or not dest_marker.is_file():

--- a/src/xskill/team/client/daemon.py
+++ b/src/xskill/team/client/daemon.py
@@ -309,8 +309,17 @@ class TeamClient:
                     skill_hash, bundle.status_code,
                 )
                 continue
+            stored_agents = entry.get("agents")
+            refresh_agents = (
+                [str(agent) for agent in stored_agents]
+                if isinstance(stored_agents, list)
+                and all(isinstance(agent, str) for agent in stored_agents)
+                else None
+            )
             try:
-                manager.install(result, bundle.content)
+                manager.install(
+                    result, bundle.content, ecosystems=refresh_agents,
+                )
             except (
                 OSError, RuntimeError, ValueError, zipfile.BadZipFile,
             ):
@@ -751,14 +760,19 @@ def _copy_target_matches_source(dest: Path, source_dir: Path) -> bool:
     )
 
 
-def install_skill_to_ecosystems(repo_dir: Path, *, home_root: Path) -> list[dict]:
-    """把一个已就位的 skill 目录装到本机所有检测到的生态。
+def install_skill_to_ecosystems(
+    repo_dir: Path, *, home_root: Path,
+    ecosystems: list[str] | tuple[str, ...] | None = None,
+) -> list[dict]:
+    """把一个已就位的 skill 目录装到指定或本机已检测到的生态。
 
     working tree 已是最终内容，一律用 side='main' 语义（= 链接 / 拷贝整个
     目录）。openclaw 走 copy 不是 symlink（openclaw 拒收 escape-root 的
     symlink，详见 docs/ecosystem/openclaw-install-fix.md）；其他生态保持
-    symlink-first 三阶 fallback。返回每个已检测生态的本次安装结果；共享目标
-    的生态各保留一条记录，不能按 target 覆盖 harness 归属。
+    symlink-first 三阶 fallback。``ecosystems=None`` 保持旧行为，安装到所有
+    已检测生态；显式列表则不依赖探测，按安装器固定顺序精确安装。返回每个生态
+    的本次安装结果；共享目标的生态各保留一条记录，不能按 target 覆盖 harness
+    归属。
     """
     from xskill.ecosystems import (
         detect_known_ecosystems, install_to_claude_code,
@@ -783,9 +797,25 @@ def install_skill_to_ecosystems(repo_dir: Path, *, home_root: Path) -> list[dict
         "cursor": install_to_cursor,
         "trae": install_to_trae,
     }
+    if ecosystems is None:
+        ecosystem_names = [
+            str(det.get("ecosystem") or "")
+            for det in detect_known_ecosystems(home_root=home_root)
+        ]
+    else:
+        requested = set(ecosystems)
+        unknown = sorted(requested.difference(installer))
+        if unknown:
+            raise ValueError(
+                f"unsupported ecosystem(s): {', '.join(unknown)}"
+            )
+        # 固定顺序很重要：OpenClaw 必须在 Codex/OpenCode 之后，把共享目标
+        # 收敛为 copy，不能让 --agent 参数顺序改变最终安装形态。
+        ecosystem_names = [
+            ecosystem for ecosystem in installer if ecosystem in requested
+        ]
     installation_records: list[dict] = []
-    for det in detect_known_ecosystems(home_root=home_root):
-        ecosystem = det["ecosystem"]
+    for ecosystem in ecosystem_names:
         install_function = installer.get(ecosystem)
         if install_function is None:
             continue

--- a/src/xskill/team/client/search_slots.py
+++ b/src/xskill/team/client/search_slots.py
@@ -1,10 +1,14 @@
-"""search_slots.py — `xskill search` 拉取的 skillhub skill 的本地滚动槽位。
+"""search_slots.py — 搜索下载 skill 的本地安装与持久化管理。
 
 search 命中的 skill 落 ``~/.xskill/search_skills/<skill_id>/``，与 sync 管理的
 ``~/.xskill/skill/`` 分开——daemon 的 cleanup 按 manifest 清理那边，不碰这里。
 台账 ``~/.xskill/search_slots.json`` 按最近命中排序，超过容量淘汰最旧的
 （同时摘掉仍由该槽位拥有的生态安装）。每个槽位目录里有 ``.xskill_search.json``
 标记（sha / 查询词 / 时间），与 sync 的 ``.xskill_skillhub.json`` 区分来源。
+
+``DownloadedSkills`` 是 ``xskill download`` 的显式、持久化安装区：
+``~/.xskill/downloaded_skills/<skill_id>/``。它不参与 search slot 的 LRU，
+重复下载只更新同一条台账和安装内容。
 """
 from __future__ import annotations
 
@@ -19,11 +23,13 @@ from xskill.team.client.daemon import (
     install_skill_to_ecosystems,
     uninstall_skill_from_ecosystems,
 )
+from xskill.skill.git import skill_repo_lock
 
 logger = logging.getLogger("xskill.team.client")
 
 SEARCH_SLOT_CAPACITY = 10
 SEARCH_MARKER_NAME = ".xskill_search.json"
+DOWNLOAD_MARKER_NAME = ".xskill_download.json"
 
 
 def _valid_slot_id(skill_id: str) -> bool:
@@ -111,6 +117,99 @@ class SearchSlots:
         if return_details:
             return {
                 "cache_path": resolved_path,
+                "installations": tuple(
+                    dict(record) for record in installations
+                ),
+            }
+        return resolved_path
+
+
+class DownloadedSkills:
+    """显式下载的持久 skill：独立台账管理，不因后续搜索而淘汰。"""
+
+    def __init__(
+        self, *, xskill_home: Path, home_root: Path | None = None,
+    ) -> None:
+        self.skills_dir = Path(xskill_home) / "downloaded_skills"
+        self.ledger_path = Path(xskill_home) / "downloads.json"
+        self.home_root = Path(home_root) if home_root else Path.home()
+
+    def _entries_unlocked(self) -> list[dict]:
+        try:
+            loaded = json.loads(self.ledger_path.read_text(encoding="utf-8"))
+        except (OSError, ValueError):
+            return []
+        return (
+            [entry for entry in loaded if isinstance(entry, dict)]
+            if isinstance(loaded, list) else []
+        )
+
+    def entries(self) -> list[dict]:
+        with skill_repo_lock(
+            self.skills_dir, use_git_write_limit=False,
+        ):
+            return self._entries_unlocked()
+
+    def install(
+        self, result: dict, archive_bytes: bytes,
+        *, return_details: bool = False,
+    ) -> Path | dict:
+        """落盘并安装一个显式下载项；同 ID 原地更新，其余下载项全部保留。"""
+        skill_id = result.get("skill_id")
+        if not isinstance(skill_id, str) or not _valid_slot_id(skill_id):
+            raise ValueError(f"invalid download skill_id: {skill_id!r}")
+        content_sha = result.get("content_sha")
+        if not isinstance(content_sha, str) or not content_sha:
+            raise ValueError("download metadata missing content_sha")
+
+        with skill_repo_lock(
+            self.skills_dir, use_git_write_limit=False,
+        ):
+            dest_dir = self.skills_dir / skill_id
+            downloaded_at = datetime.now(timezone.utc).isoformat(
+                timespec="seconds",
+            )
+            apply_skillhub_archive(
+                archive_bytes,
+                dest_dir,
+                expected_sha=content_sha,
+                display_name=result.get("display_name"),
+                source_path=result.get("source_path"),
+                marker_name=DOWNLOAD_MARKER_NAME,
+                extra_meta={"downloaded_at": downloaded_at},
+            )
+            installations = install_skill_to_ecosystems(
+                dest_dir, home_root=self.home_root,
+            )
+            entries = [
+                entry for entry in self._entries_unlocked()
+                if entry.get("skill_id") != skill_id
+            ]
+            entries.append({
+                "skill_id": skill_id,
+                "display_name": result.get("display_name"),
+                "description": result.get("description"),
+                "source": result.get("source"),
+                "source_path": result.get("source_path"),
+                "sha": content_sha,
+                "downloaded_at": downloaded_at,
+                "installations": [
+                    dict(record) for record in installations
+                ],
+            })
+            self.ledger_path.parent.mkdir(parents=True, exist_ok=True)
+            temporary_ledger = self.ledger_path.with_name(
+                f".{self.ledger_path.name}.tmp",
+            )
+            temporary_ledger.write_text(
+                json.dumps(entries, ensure_ascii=False, indent=2),
+                encoding="utf-8",
+            )
+            temporary_ledger.replace(self.ledger_path)
+        resolved_path = dest_dir.resolve()
+        if return_details:
+            return {
+                "path": resolved_path,
                 "installations": tuple(
                     dict(record) for record in installations
                 ),

--- a/src/xskill/team/client/search_slots.py
+++ b/src/xskill/team/client/search_slots.py
@@ -152,9 +152,15 @@ class DownloadedSkills:
 
     def install(
         self, result: dict, archive_bytes: bytes,
-        *, return_details: bool = False,
+        *, ecosystems: list[str] | tuple[str, ...] | None = None,
+        return_details: bool = False,
     ) -> Path | dict:
-        """落盘并安装一个显式下载项；同 ID 原地更新，其余下载项全部保留。"""
+        """落盘并安装一个显式下载项；同 ID 原地更新，其余下载项全部保留。
+
+        显式 ``ecosystems`` 会写入台账，供 daemon 后续内容刷新继续复用。重复
+        下载同一 ID 时取新旧选择的并集，避免把仍在使用的旧 harness 变成不再
+        更新的孤儿安装；不传则兼容旧调用，继续安装到所有已检测生态。
+        """
         skill_id = result.get("skill_id")
         if not isinstance(skill_id, str) or not _valid_slot_id(skill_id):
             raise ValueError(f"invalid download skill_id: {skill_id!r}")
@@ -165,6 +171,30 @@ class DownloadedSkills:
         with skill_repo_lock(
             self.skills_dir, use_git_write_limit=False,
         ):
+            existing_entries = self._entries_unlocked()
+            existing_entry = next(
+                (
+                    entry for entry in existing_entries
+                    if entry.get("skill_id") == skill_id
+                ),
+                None,
+            )
+            selected_ecosystems = ecosystems
+            if ecosystems is not None:
+                stored_agents = (
+                    existing_entry.get("agents")
+                    if isinstance(existing_entry, dict) else None
+                )
+                previous_agents = (
+                    [
+                        agent for agent in stored_agents
+                        if isinstance(agent, str)
+                    ]
+                    if isinstance(stored_agents, list) else []
+                )
+                selected_ecosystems = list(dict.fromkeys(
+                    [*previous_agents, *ecosystems]
+                ))
             dest_dir = self.skills_dir / skill_id
             downloaded_at = datetime.now(timezone.utc).isoformat(
                 timespec="seconds",
@@ -180,11 +210,17 @@ class DownloadedSkills:
             )
             installations = install_skill_to_ecosystems(
                 dest_dir, home_root=self.home_root,
+                ecosystems=selected_ecosystems,
             )
             entries = [
-                entry for entry in self._entries_unlocked()
+                entry for entry in existing_entries
                 if entry.get("skill_id") != skill_id
             ]
+            installed_agents = list(dict.fromkeys(
+                str(record.get("ecosystem"))
+                for record in installations
+                if isinstance(record, dict) and record.get("ecosystem")
+            ))
             entries.append({
                 "skill_id": skill_id,
                 "display_name": result.get("display_name"),
@@ -193,6 +229,11 @@ class DownloadedSkills:
                 "source_path": result.get("source_path"),
                 "sha": content_sha,
                 "downloaded_at": downloaded_at,
+                "agents": (
+                    list(selected_ecosystems)
+                    if selected_ecosystems is not None
+                    else installed_agents
+                ),
                 "installations": [
                     dict(record) for record in installations
                 ],

--- a/src/xskill/team/server/api.py
+++ b/src/xskill/team/server/api.py
@@ -885,11 +885,18 @@ async def team_skill_bundle(
         return Response(content=bundle, media_type="application/octet-stream")
 
     hub = _ctx.skillhub
-    hub_dir = hub.skill_path(name) if hub is not None else None
-    if hub_dir is None:
+    hub_entry = hub.entry(name) if hub is not None else None
+    if hub_entry is None:
+        raise HTTPException(status_code=404, detail=f"skill not found: {name}")
+    hub_dir = Path(hub_entry["path"])
+    if not hub_dir.is_dir() or not (hub_dir / "SKILL.md").is_file():
         raise HTTPException(status_code=404, detail=f"skill not found: {name}")
     archive = _make_skillhub_archive(hub_dir)
-    return Response(content=archive, media_type="application/zip")
+    return Response(
+        content=archive,
+        media_type="application/zip",
+        headers={"X-XSkill-Content-Sha": hub_entry["content_sha"]},
+    )
 
 
 def _repo_search_archive(
@@ -939,6 +946,68 @@ def _repo_search_archive(
             status_code=409, detail="skill version changed; search again",
         ) from error
     return archive, content_sha, side
+
+
+@router.get("/skill_hub/entry/{skill_id}")
+async def team_skill_hub_entry(
+    skill_id: str,
+    x_xskill_token: str | None = Header(default=None),
+    x_xskill_client: str | None = Header(default=None),
+) -> dict:
+    """按 search 返回的稳定 ID 读取当前下载元信息，不传输 skill 内容。"""
+    client_id = _auth(x_xskill_token, x_xskill_client)
+    return await run_in_threadpool(
+        _team_skill_entry, skill_id, client_id,
+    )
+
+
+def _team_skill_entry(skill_id: str, client_id: str) -> dict:
+    _total_slots, _ranked_slots, probability = live_manifest_tuning()
+    if _is_repo_search_id(skill_id):
+        catalog = manifest_catalog_snapshot(
+            _ctx.skill_dir, max_age_seconds=0,
+        )
+        skill = catalog.search_by_id.get(skill_id)
+        if skill is None:
+            raise HTTPException(
+                status_code=404, detail=f"skill not found: {skill_id}",
+            )
+        hit = {
+            "source": "repo",
+            "skill_id": skill_id,
+            "repo_name": skill.name,
+            "display_name": str(
+                skill.frontmatter.get("name") or skill.name
+            ),
+            "description": skill.description,
+            "source_path": skill.name,
+            "content_sha": catalog.refs[skill.name][0],
+            "ux_avg": None,
+            "bm25_rank": None,
+            "semantic_rank": None,
+        }
+        results = _format_team_search_results(
+            [hit], catalog, client_id, probability,
+        )["results"]
+    else:
+        hub = _ctx.skillhub
+        entry = hub.entry(skill_id) if hub is not None else None
+        if entry is None:
+            raise HTTPException(
+                status_code=404, detail=f"skill not found: {skill_id}",
+            )
+        hit = dict(entry)
+        hit["bm25_rank"] = None
+        hit["semantic_rank"] = None
+        hit["ux_avg"] = hub.ux_avg(skill_id)
+        results = _format_team_search_results(
+            [hit], None, client_id, probability,
+        )["results"]
+    if not results:
+        raise HTTPException(
+            status_code=404, detail=f"skill not found: {skill_id}",
+        )
+    return {"result": results[0]}
 
 
 @router.get("/skill_hub/search")

--- a/tests/test_install_fallback_revsync.py
+++ b/tests/test_install_fallback_revsync.py
@@ -410,6 +410,58 @@ def test_reverse_sync_rejects_symlink_without_touching_source(tmp_path):
 
 
 @pytest.mark.skipif(
+    sys.platform == "win32",
+    reason="Windows CI 不保证普通用户可创建 symlink",
+)
+def test_reverse_sync_root_symlink_is_no_edit(tmp_path):
+    """link 安装与 source 同体，不应进入 copy reverse-sync 或报 FAILED。"""
+    from xskill.agents.user_edit_absorb_agent import (
+        ReverseSyncStatus,
+        reverse_sync_copy_dest,
+    )
+
+    src = _build_real_skill_repo(tmp_path)
+    dest = tmp_path / "out" / "demo-skill"
+    dest.parent.mkdir(parents=True)
+    dest.symlink_to(src, target_is_directory=True)
+    (dest / "SKILL.md").write_text("USER EDIT\n", encoding="utf-8")
+
+    status = reverse_sync_copy_dest(dest, src, quiet_seconds=0)
+
+    assert status == ReverseSyncStatus.NO_EDIT
+    assert (src / "SKILL.md").read_text(encoding="utf-8") == "USER EDIT\n"
+
+
+def test_reverse_sync_root_windows_junction_is_no_edit(
+    tmp_path, monkeypatch,
+):
+    """Windows junction/reparse root 与 symlink 一样不属于 copy 反向同步。"""
+    from xskill.agents import user_edit_absorb_agent as user_absorb
+
+    src = _build_real_skill_repo(tmp_path)
+    dest = tmp_path / "out" / "demo-skill"
+    dest.mkdir(parents=True)
+    (dest / "SKILL.md").write_text("SHARED EDIT\n", encoding="utf-8")
+    dest_stat = dest.lstat()
+    original_is_reparse = user_absorb._is_reparse_point
+
+    def mark_dest_as_reparse(file_stat):
+        return (
+            file_stat.st_dev == dest_stat.st_dev
+            and file_stat.st_ino == dest_stat.st_ino
+        ) or original_is_reparse(file_stat)
+
+    monkeypatch.setattr(
+        user_absorb, "_is_reparse_point", mark_dest_as_reparse,
+    )
+
+    assert user_absorb.reverse_sync_copy_dest(
+        dest, src, quiet_seconds=0,
+    ) == user_absorb.ReverseSyncStatus.NO_EDIT
+    assert (src / "SKILL.md").read_text(encoding="utf-8") != "SHARED EDIT\n"
+
+
+@pytest.mark.skipif(
     os.open not in os.supports_dir_fd,
     reason="openat/dir_fd unavailable",
 )

--- a/tests/test_search_cli_output.py
+++ b/tests/test_search_cli_output.py
@@ -1,4 +1,4 @@
-"""`xskill search` 客户端安装结果与人读输出测试。"""
+"""`xskill search` 元信息与 `xskill download` 安装输出测试。"""
 from __future__ import annotations
 
 import io
@@ -12,7 +12,7 @@ from types import SimpleNamespace
 import pytest
 
 from xskill import cli
-from xskill.team.client.search_slots import SearchSlots
+from xskill.team.client.search_slots import DownloadedSkills, SearchSlots
 
 
 class _Response:
@@ -36,6 +36,13 @@ class _SearchHttp:
     def get(self, path: str, **_kwargs) -> _Response:
         if "search" in path:
             return _Response(200, json_data={"results": self.results})
+        if "/entry/" in path:
+            skill_id = path.rsplit("/", 1)[-1]
+            result = next(
+                result for result in self.results
+                if result["skill_id"] == skill_id
+            )
+            return _Response(200, json_data={"result": result})
         skill_id = path.split("/")[-2]
         name = next(
             result["display_name"]
@@ -67,8 +74,8 @@ def _result(name: str, *, source: str = "skillhub",
 
 def _install_home(monkeypatch, tmp_path: Path, home: Path) -> None:
     monkeypatch.setattr(
-        "xskill.team.client.search_slots.SearchSlots",
-        lambda **_kwargs: SearchSlots(
+        "xskill.team.client.search_slots.DownloadedSkills",
+        lambda **_kwargs: DownloadedSkills(
             xskill_home=tmp_path / "xskill-home", home_root=home,
         ),
     )
@@ -91,13 +98,17 @@ def test_only_detected_ngagent_and_nga3_are_printed(
         ),
     ]
 
-    return_code = cli.cmd_search_hub(
-        SimpleNamespace(terms=["openqa"], top_k=5, json=False),
-        http=_SearchHttp(results), headers={},
-    )
+    search_http = _SearchHttp(results)
+    return_codes = [
+        cli.cmd_download(
+            SimpleNamespace(skill_id=result["skill_id"], json=False),
+            http=search_http, headers={},
+        )
+        for result in results
+    ]
 
     output = capsys.readouterr().out
-    assert return_code == 0
+    assert return_codes == [0, 0]
     assert "CodeAgent3 / NGA3" in output
     assert "NGAgent" in output
     assert str(home / ".cac" / "skills" / "repo-skill@abcdef") in output
@@ -113,7 +124,7 @@ def test_only_detected_ngagent_and_nga3_are_printed(
     assert "XSkill 自蒸馏生成" in output
     assert "上传者:alice（用户上传）" in output
     assert "描述中有 连续的 空白" in output
-    assert "\n" + "-" * 64 + "\n" in output
+    assert output.count("完成：1 个 skill") == 2
 
 
 def test_shared_target_keeps_each_harness_record(tmp_path):
@@ -165,8 +176,8 @@ def test_detected_install_failure_is_visible(
     )
     result = _result("partial")
 
-    return_code = cli.cmd_search_hub(
-        SimpleNamespace(terms=["partial"], top_k=5, json=False),
+    return_code = cli.cmd_download(
+        SimpleNamespace(skill_id=result["skill_id"], json=False),
         http=_SearchHttp([result]), headers={},
     )
 
@@ -178,7 +189,7 @@ def test_detected_install_failure_is_visible(
     assert "[成功] CodeAgent3 / NGA3" in output
 
 
-def test_json_keeps_path_and_adds_cache_path_and_installations(
+def test_search_json_is_metadata_only(
     tmp_path, monkeypatch, capsys,
 ):
     home = tmp_path / "home"
@@ -192,8 +203,9 @@ def test_json_keeps_path_and_adds_cache_path_and_installations(
 
     rows = json.loads(capsys.readouterr().out)
     assert return_code == 0
-    assert rows[0]["path"] == rows[0]["cache_path"]
-    assert rows[0]["installations"] == []
+    assert "path" not in rows[0]
+    assert "cache_path" not in rows[0]
+    assert "installations" not in rows[0]
     assert rows[0]["match"] == result["match"]
     assert rows[0]["source"] == result["source"]
 
@@ -256,14 +268,14 @@ def test_install_exception_secret_never_enters_output_or_ledger(
     caplog.set_level("WARNING", logger="xskill.team.client")
     result = _result("safe-error")
 
-    return_code = cli.cmd_search_hub(
-        SimpleNamespace(terms=["safe"], top_k=5, json=False),
+    return_code = cli.cmd_download(
+        SimpleNamespace(skill_id=result["skill_id"], json=False),
         http=_SearchHttp([result]), headers={},
     )
 
     output = capsys.readouterr().out
     ledger_text = (
-        tmp_path / "xskill-home" / "search_slots.json"
+        tmp_path / "xskill-home" / "downloads.json"
     ).read_text(encoding="utf-8")
     assert return_code == 0
     assert "Authorization" not in output
@@ -1885,7 +1897,7 @@ def test_cp936_json_output_with_emoji_is_valid(
 
     payload = json.loads(output_bytes.getvalue().decode("cp936"))
     assert return_code == 0
-    assert payload[0]["name"] == "json-\N{GRINNING FACE}"
+    assert payload[0]["display_name"] == "json-\N{GRINNING FACE}"
     assert payload[0]["description"] == "emoji \N{ROCKET}"
     assert payload[0]["source_path"] == (
         "user_skill_hub/\N{CAT FACE}/json-skill"

--- a/tests/test_search_cli_output.py
+++ b/tests/test_search_cli_output.py
@@ -32,8 +32,10 @@ class _Response:
 class _SearchHttp:
     def __init__(self, results: list[dict]):
         self.results = results
+        self.calls: list[str] = []
 
     def get(self, path: str, **_kwargs) -> _Response:
+        self.calls.append(path)
         if "search" in path:
             return _Response(200, json_data={"results": self.results})
         if "/entry/" in path:
@@ -81,6 +83,305 @@ def _install_home(monkeypatch, tmp_path: Path, home: Path) -> None:
     )
 
 
+def test_search_download_and_download_agent_flags_parse():
+    parser = cli.build_parser()
+
+    plain = parser.parse_args(["search", "docker"])
+    legacy = parser.parse_args(["search", "docker", "--download"])
+    download = parser.parse_args([
+        "download", "skill@sha",
+        "--agent", "claude-code", "--agent", "codex", "-y",
+    ])
+
+    assert plain.download is False
+    assert legacy.download is True
+    assert download.agent == ["claude-code", "codex"]
+    assert download.yes is True
+    with pytest.raises(SystemExit) as invalid_agent:
+        parser.parse_args([
+            "download", "skill@sha", "--agent", "mystery", "-y",
+        ])
+    assert invalid_agent.value.code == 2
+
+
+def test_search_plain_output_is_compact_and_read_only(capsys):
+    result = _result("compact")
+    result["path"] = "/private/cache/compact"
+    result["installations"] = [{
+        "ecosystem": "codex",
+        "target": "/private/harness/compact",
+        "status": "installed",
+    }]
+    search_http = _SearchHttp([result])
+
+    return_code = cli.cmd_search_hub(
+        SimpleNamespace(
+            terms=["compact"], top_k=5, json=False, download=False,
+        ),
+        http=search_http, headers={},
+    )
+
+    output = capsys.readouterr().out
+    assert return_code == 0
+    assert search_http.calls == ["/api/v1/team/skill_hub/search"]
+    assert "[1/1] compact" in output
+    assert "ID：compact@abcdef" in output
+    assert "关键词排名 #1" in output
+    assert "语义排名 #2" in output
+    assert "xskill download compact@abcdef" in output
+    assert "/private/cache" not in output
+    assert "/private/harness" not in output
+    assert "Codex" not in output
+    assert "已安装到" not in output
+
+
+def test_search_download_uses_legacy_search_slots(
+    tmp_path, monkeypatch, capsys,
+):
+    result = _result("legacy")
+    search_http = _SearchHttp([result])
+    captured: dict = {}
+
+    class _Slots:
+        def __init__(self, **kwargs):
+            captured["init"] = kwargs
+
+        def install(self, metadata, archive, **kwargs):
+            captured["metadata"] = metadata
+            captured["archive"] = archive
+            captured["install"] = kwargs
+            return {
+                "cache_path": tmp_path / "search_skills" / metadata["skill_id"],
+                "installations": (),
+            }
+
+    monkeypatch.setattr(
+        "xskill.team.client.search_slots.SearchSlots", _Slots,
+    )
+    monkeypatch.setattr("xskill.config.XSKILL_HOME", tmp_path / "xhome")
+
+    return_code = cli.cmd_search_hub(
+        SimpleNamespace(
+            terms=["legacy"], top_k=5, json=True, download=True,
+        ),
+        http=search_http, headers={},
+    )
+
+    row = json.loads(capsys.readouterr().out)[0]
+    assert return_code == 0
+    assert search_http.calls == [
+        "/api/v1/team/skill_hub/search",
+        f"/api/v1/team/skill/{result['skill_id']}/bundle",
+    ]
+    assert captured["install"] == {
+        "query": "legacy", "return_details": True,
+    }
+    assert row["cache_path"].endswith(result["skill_id"])
+    assert "path" in row and row["installations"] == []
+
+
+def test_download_repeated_agents_with_yes_is_noninteractive(
+    tmp_path, monkeypatch, capsys,
+):
+    result = _result("selected")
+    search_http = _SearchHttp([result])
+    captured: dict = {}
+
+    class _Downloads:
+        def __init__(self, **kwargs):
+            captured["init"] = kwargs
+
+        def install(self, metadata, archive, **kwargs):
+            captured["metadata"] = metadata
+            captured["archive"] = archive
+            captured["install"] = kwargs
+            return {
+                "path": tmp_path / metadata["skill_id"],
+                "installations": (),
+            }
+
+    monkeypatch.setattr(
+        "xskill.team.client.search_slots.DownloadedSkills", _Downloads,
+    )
+    monkeypatch.setattr(
+        cli, "_detected_download_agents",
+        lambda: pytest.fail("explicit --agent must not run detection"),
+    )
+    monkeypatch.setattr(
+        cli, "_prompt_download_agents",
+        lambda *_args: pytest.fail("-y must not prompt"),
+    )
+
+    return_code = cli.cmd_download(
+        SimpleNamespace(
+            skill_id=result["skill_id"], json=True,
+            agent=["claude-code", "codex", "claude_code"], yes=True,
+        ),
+        http=search_http, headers={},
+    )
+
+    output = json.loads(capsys.readouterr().out)
+    assert return_code == 0
+    assert captured["install"]["ecosystems"] == ["claude_code", "codex"]
+    assert captured["install"]["return_details"] is True
+    assert output["path"].endswith(result["skill_id"])
+
+
+def test_download_yes_without_agents_selects_detected(
+    tmp_path, monkeypatch, capsys,
+):
+    result = _result("auto-selected")
+    captured: dict = {}
+
+    class _Downloads:
+        def __init__(self, **_kwargs):
+            pass
+
+        def install(self, metadata, _archive, **kwargs):
+            captured.update(kwargs)
+            return {
+                "path": tmp_path / metadata["skill_id"],
+                "installations": (),
+            }
+
+    monkeypatch.setattr(
+        "xskill.team.client.search_slots.DownloadedSkills", _Downloads,
+    )
+    monkeypatch.setattr(
+        cli, "_detected_download_agents", lambda: ["nga3", "cursor"],
+    )
+
+    return_code = cli.cmd_download(
+        SimpleNamespace(
+            skill_id=result["skill_id"], json=True, agent=[], yes=True,
+        ),
+        http=_SearchHttp([result]), headers={},
+    )
+
+    assert return_code == 0
+    assert captured["ecosystems"] == ["nga3", "cursor"]
+    json.loads(capsys.readouterr().out)
+
+
+def test_download_yes_without_detected_agents_still_persists(
+    tmp_path, monkeypatch, capsys,
+):
+    result = _result("download-only")
+    captured: dict = {}
+
+    class _Downloads:
+        def __init__(self, **_kwargs):
+            pass
+
+        def install(self, metadata, _archive, **kwargs):
+            captured.update(kwargs)
+            return {
+                "path": tmp_path / metadata["skill_id"],
+                "installations": (),
+            }
+
+    monkeypatch.setattr(
+        "xskill.team.client.search_slots.DownloadedSkills", _Downloads,
+    )
+    monkeypatch.setattr(cli, "_detected_download_agents", lambda: [])
+
+    return_code = cli.cmd_download(
+        SimpleNamespace(
+            skill_id=result["skill_id"], json=True, agent=[], yes=True,
+        ),
+        http=_SearchHttp([result]), headers={},
+    )
+
+    captured_output = capsys.readouterr()
+    assert return_code == 0
+    assert captured["ecosystems"] == []
+    assert "仅持久下载" in captured_output.err
+    json.loads(captured_output.out)
+
+
+def test_download_interactive_multiselects_detected_agents(
+    tmp_path, monkeypatch, capsys,
+):
+    result = _result("interactive")
+    captured: dict = {}
+
+    class _Downloads:
+        def __init__(self, **_kwargs):
+            pass
+
+        def install(self, metadata, _archive, **kwargs):
+            captured.update(kwargs)
+            return {
+                "path": tmp_path / metadata["skill_id"],
+                "installations": (),
+            }
+
+    monkeypatch.setattr(
+        "xskill.team.client.search_slots.DownloadedSkills", _Downloads,
+    )
+    monkeypatch.setattr(cli, "_stdin_is_interactive", lambda: True)
+    monkeypatch.setattr(
+        cli, "_detected_download_agents",
+        lambda: ["claude_code", "codex", "cursor"],
+    )
+    monkeypatch.setattr(sys, "stdin", io.StringIO("1,3\n"))
+
+    return_code = cli.cmd_download(
+        SimpleNamespace(
+            skill_id=result["skill_id"], json=True, agent=[], yes=False,
+        ),
+        http=_SearchHttp([result]), headers={},
+    )
+
+    captured_output = capsys.readouterr()
+    assert return_code == 0
+    assert captured["ecosystems"] == ["claude_code", "cursor"]
+    assert "Claude Code" in captured_output.err
+    assert "Cursor" in captured_output.err
+    json.loads(captured_output.out)
+
+
+def test_download_without_yes_rejects_non_tty_before_network(
+    monkeypatch, capsys,
+):
+    result = _result("non-tty")
+    search_http = _SearchHttp([result])
+    monkeypatch.setattr(cli, "_stdin_is_interactive", lambda: False)
+
+    return_code = cli.cmd_download(
+        SimpleNamespace(
+            skill_id=result["skill_id"], json=False,
+            agent=["codex"], yes=False,
+        ),
+        http=search_http, headers={},
+    )
+
+    assert return_code == 2
+    assert search_http.calls == []
+    assert "--agent" in capsys.readouterr().err
+
+
+def test_download_cancel_stops_before_network(monkeypatch, capsys):
+    result = _result("cancel")
+    search_http = _SearchHttp([result])
+    monkeypatch.setattr(cli, "_stdin_is_interactive", lambda: True)
+    monkeypatch.setattr(
+        cli, "_detected_download_agents", lambda: ["codex", "cursor"],
+    )
+    monkeypatch.setattr(sys, "stdin", io.StringIO("q\n"))
+
+    return_code = cli.cmd_download(
+        SimpleNamespace(
+            skill_id=result["skill_id"], json=False, agent=[], yes=False,
+        ),
+        http=search_http, headers={},
+    )
+
+    assert return_code == 0
+    assert search_http.calls == []
+    assert "已取消" in capsys.readouterr().err
+
+
 def test_only_detected_ngagent_and_nga3_are_printed(
     tmp_path, monkeypatch, capsys,
 ):
@@ -101,7 +402,10 @@ def test_only_detected_ngagent_and_nga3_are_printed(
     search_http = _SearchHttp(results)
     return_codes = [
         cli.cmd_download(
-            SimpleNamespace(skill_id=result["skill_id"], json=False),
+            SimpleNamespace(
+                skill_id=result["skill_id"], json=False,
+                agent=["nga3", "ngagent"], yes=True,
+            ),
             http=search_http, headers={},
         )
         for result in results
@@ -158,6 +462,44 @@ def test_shared_target_keeps_each_harness_record(tmp_path):
     assert all(record["mode"] == "copy" for record in shared_records)
 
 
+def test_explicit_ecosystems_bypass_detection_and_use_fixed_order(
+    tmp_path, monkeypatch,
+):
+    from xskill.team.client.daemon import install_skill_to_ecosystems
+
+    repo_dir = tmp_path / "explicit"
+    repo_dir.mkdir()
+    (repo_dir / "SKILL.md").write_text(
+        "---\nname: explicit\ndescription: test\n---\nbody\n",
+        encoding="utf-8",
+    )
+    calls: list[str] = []
+    monkeypatch.setattr(
+        "xskill.ecosystems.detect_known_ecosystems",
+        lambda **_kwargs: pytest.fail(
+            "explicit ecosystems must bypass detection"
+        ),
+    )
+    monkeypatch.setattr(
+        "xskill.ecosystems.install_to_codex",
+        lambda *_args, **_kwargs: calls.append("codex"),
+    )
+    monkeypatch.setattr(
+        "xskill.ecosystems.install_to_openclaw",
+        lambda *_args, **_kwargs: calls.append("openclaw"),
+    )
+
+    records = install_skill_to_ecosystems(
+        repo_dir, home_root=tmp_path / "home",
+        ecosystems=["openclaw", "codex"],
+    )
+
+    assert calls == ["codex", "openclaw"]
+    assert [record["ecosystem"] for record in records] == [
+        "codex", "openclaw",
+    ]
+
+
 def test_detected_install_failure_is_visible(
     tmp_path, monkeypatch, capsys,
 ):
@@ -177,7 +519,10 @@ def test_detected_install_failure_is_visible(
     result = _result("partial")
 
     return_code = cli.cmd_download(
-        SimpleNamespace(skill_id=result["skill_id"], json=False),
+        SimpleNamespace(
+            skill_id=result["skill_id"], json=False,
+            agent=["nga3", "ngagent"], yes=True,
+        ),
         http=_SearchHttp([result]), headers={},
     )
 
@@ -269,7 +614,10 @@ def test_install_exception_secret_never_enters_output_or_ledger(
     result = _result("safe-error")
 
     return_code = cli.cmd_download(
-        SimpleNamespace(skill_id=result["skill_id"], json=False),
+        SimpleNamespace(
+            skill_id=result["skill_id"], json=False,
+            agent=["ngagent"], yes=True,
+        ),
         http=_SearchHttp([result]), headers={},
     )
 

--- a/tests/test_skill_hub_search_upload.py
+++ b/tests/test_skill_hub_search_upload.py
@@ -750,6 +750,39 @@ def test_downloaded_skills_are_persistent_without_lru(tmp_path, monkeypatch):
     )
 
 
+def test_downloaded_skills_persist_and_merge_selected_agents(
+    tmp_path, monkeypatch,
+):
+    selected: list[list[str] | None] = []
+
+    def record_install(*_args, **kwargs):
+        ecosystems = kwargs.get("ecosystems")
+        selected.append(
+            list(ecosystems) if ecosystems is not None else None
+        )
+        return []
+
+    monkeypatch.setattr(
+        "xskill.team.client.search_slots.install_skill_to_ecosystems",
+        record_install,
+    )
+    downloads = DownloadedSkills(
+        xskill_home=tmp_path / "xhome",
+        home_root=tmp_path / "home",
+    )
+    result = _fake_result("selected")
+
+    downloads.install(
+        result, _fake_archive("selected"), ecosystems=["codex"],
+    )
+    downloads.install(
+        result, _fake_archive("selected"), ecosystems=["cursor", "codex"],
+    )
+
+    assert selected == [["codex"], ["codex", "cursor"]]
+    assert downloads.entries()[0]["agents"] == ["codex", "cursor"]
+
+
 # ── client: CLI 端到端（TestClient 注入） ───────────────────────
 
 def test_cmd_search_hub_returns_metadata_without_download(
@@ -782,7 +815,10 @@ def test_cmd_download_persists_and_installs(hub_env, tmp_path,
         lambda *_args, **_kwargs: [],
     )
 
-    args = SimpleNamespace(skill_id=searched["skill_id"], json=True)
+    args = SimpleNamespace(
+        skill_id=searched["skill_id"], json=True,
+        agent=["codex"], yes=True,
+    )
     assert cli.cmd_download(args, http=hub_env.client, headers=hdr) == 0
 
     row = json.loads(capsys.readouterr().out)
@@ -895,7 +931,7 @@ def test_cmd_search_hub_renders_source_and_ux_defensively(tmp_path, monkeypatch,
     assert cli.cmd_search_hub(args, http=_FakeHttp(), headers={}) == 0
     out = capsys.readouterr().out
     assert "ux 4.2" in out
-    assert "来源: 上传者:alice" in out
+    assert "来源：上传者:alice" in out
     # 缺 source/ux_avg 的命中正常渲染，其名字行不带 ux/来源 后缀，不报错
     bare_line = next(line for line in out.splitlines() if "bare-meta" in line)
     assert "ux" not in bare_line and "来源" not in bare_line

--- a/tests/test_skill_hub_search_upload.py
+++ b/tests/test_skill_hub_search_upload.py
@@ -16,7 +16,7 @@ from fastapi.testclient import TestClient
 from xskill import cli
 from xskill.ecosystems._fallback import _install_meta_path, install_dir
 from xskill.recommend.skillhub import SkillHub
-from xskill.team.client.search_slots import SearchSlots
+from xskill.team.client.search_slots import DownloadedSkills, SearchSlots
 from xskill.team.server import api as server_api
 from xskill.team.server.client_registry import ClientRegistry, safe_dir_name
 
@@ -117,6 +117,26 @@ def test_search_matches_by_keyword_without_profile(hub_env):
     top = results[0]
     assert top["description"].startswith("Manage docker")
     assert top["skill_id"] and top["content_sha"] and top["source_path"]
+
+
+def test_entry_returns_download_metadata_without_bundle(hub_env):
+    _cid, hdr = _register(hub_env.client)
+    searched = hub_env.client.get(
+        "/api/v1/team/skill_hub/search",
+        params={"query": "docker"}, headers=hdr,
+    ).json()["results"][0]
+
+    response = hub_env.client.get(
+        f"/api/v1/team/skill_hub/entry/{searched['skill_id']}",
+        headers=hdr,
+    )
+
+    assert response.status_code == 200
+    assert response.json()["result"]["skill_id"] == searched["skill_id"]
+    assert (
+        response.json()["result"]["content_sha"]
+        == searched["content_sha"]
+    )
 
 
 def test_search_name_hit_outranks_description_hit(hub_env):
@@ -703,25 +723,74 @@ def test_search_slots_default_capacity_is_ten(tmp_path):
     assert slots.capacity == 10
 
 
+def test_downloaded_skills_are_persistent_without_lru(tmp_path, monkeypatch):
+    monkeypatch.setattr(
+        "xskill.team.client.search_slots.install_skill_to_ecosystems",
+        lambda *_args, **_kwargs: [],
+    )
+    downloads = DownloadedSkills(
+        xskill_home=tmp_path / "xhome",
+        home_root=tmp_path / "home",
+    )
+    for index in range(12):
+        result = {
+            "skill_id": f"skill-{index}",
+            "display_name": f"skill-{index}",
+            "description": "d",
+            "content_sha": f"sha-{index}",
+            "source": "skillhub",
+            "source_path": f"skills/skill-{index}",
+        }
+        downloads.install(result, _fake_archive(f"skill-{index}"))
+
+    assert len(downloads.entries()) == 12
+    assert all(
+        (downloads.skills_dir / f"skill-{index}" / "SKILL.md").is_file()
+        for index in range(12)
+    )
+
+
 # ── client: CLI 端到端（TestClient 注入） ───────────────────────
 
-def test_cmd_search_hub_installs_and_prints_paths(hub_env, tmp_path,
-                                                  monkeypatch, capsys):
+def test_cmd_search_hub_returns_metadata_without_download(
+    hub_env, tmp_path, monkeypatch, capsys,
+):
     _cid, hdr = _register(hub_env.client)
     xhome = tmp_path / "cli-xhome"
-    monkeypatch.setattr(
-        "xskill.team.client.search_slots.SearchSlots",
-        lambda **kw: SearchSlots(xskill_home=xhome,
-                                 home_root=tmp_path / "cli-home"))
+    monkeypatch.setattr("xskill.config.XSKILL_HOME", xhome)
     args = SimpleNamespace(terms=["docker"], top_k=5, json=True)
     assert cli.cmd_search_hub(args, http=hub_env.client, headers=hdr) == 0
     rows = json.loads(capsys.readouterr().out)
     assert len(rows) == 1
-    assert rows[0]["name"] == "docker-helper"
-    installed = Path(rows[0]["path"])
+    assert rows[0]["display_name"] == "docker-helper"
+    assert "path" not in rows[0]
+    assert not (xhome / "search_skills").exists()
+    assert not (xhome / "downloaded_skills").exists()
+
+
+def test_cmd_download_persists_and_installs(hub_env, tmp_path,
+                                            monkeypatch, capsys):
+    _cid, hdr = _register(hub_env.client)
+    searched = hub_env.client.get(
+        "/api/v1/team/skill_hub/search",
+        params={"query": "docker"}, headers=hdr,
+    ).json()["results"][0]
+    xhome = tmp_path / "cli-xhome"
+    monkeypatch.setattr("xskill.config.XSKILL_HOME", xhome)
+    monkeypatch.setattr(
+        "xskill.team.client.search_slots.install_skill_to_ecosystems",
+        lambda *_args, **_kwargs: [],
+    )
+
+    args = SimpleNamespace(skill_id=searched["skill_id"], json=True)
+    assert cli.cmd_download(args, http=hub_env.client, headers=hdr) == 0
+
+    row = json.loads(capsys.readouterr().out)
+    installed = Path(row["path"])
     assert (installed / "SKILL.md").is_file()
-    assert installed.is_absolute()
-    assert (installed / ".xskill_search.json").is_file()
+    assert (installed / ".xskill_download.json").is_file()
+    assert installed.parent == (xhome / "downloaded_skills").resolve()
+    assert len(json.loads((xhome / "downloads.json").read_text())) == 1
 
 
 def test_cmd_search_hub_no_match_returns_zero(hub_env, capsys):
@@ -854,4 +923,5 @@ def test_cmd_search_hub_json_passes_through_all_fields(tmp_path, monkeypatch,
     row = json.loads(capsys.readouterr().out)[0]
     assert row["source"] == "skillhub"
     assert row["match"] == {"field": "description"}
-    assert row["name"] == "json-skill" and row["path"]
+    assert row["display_name"] == "json-skill"
+    assert "name" not in row and "path" not in row

--- a/tests/test_team_client.py
+++ b/tests/test_team_client.py
@@ -177,7 +177,7 @@ def test_reconcile_downloaded_skills_refreshes_changed_version(
     local = skills_dir / "download@abcdef"
     local.mkdir(parents=True)
     (local / "SKILL.md").write_text("old\n", encoding="utf-8")
-    installed: list[tuple[dict, bytes]] = []
+    installed: list[tuple[dict, bytes, list[str] | None]] = []
 
     class _Manager:
         def __init__(self, **_kwargs):
@@ -185,11 +185,15 @@ def test_reconcile_downloaded_skills_refreshes_changed_version(
 
         @staticmethod
         def entries():
-            return [{"skill_id": "download@abcdef", "sha": "old-sha"}]
+            return [{
+                "skill_id": "download@abcdef",
+                "sha": "old-sha",
+                "agents": ["codex", "cursor"],
+            }]
 
         @staticmethod
-        def install(result, content):
-            installed.append((result, content))
+        def install(result, content, *, ecosystems=None):
+            installed.append((result, content, ecosystems))
 
     class _Http:
         @staticmethod
@@ -213,7 +217,7 @@ def test_reconcile_downloaded_skills_refreshes_changed_version(
     assert installed == [({
         "skill_id": "download@abcdef",
         "content_sha": "new-sha",
-    }, b"archive")]
+    }, b"archive", ["codex", "cursor"])]
 
 
 def test_cleanup_removes_skill_not_in_manifest(server_app, tmp_path):

--- a/tests/test_team_client.py
+++ b/tests/test_team_client.py
@@ -1,7 +1,9 @@
 from __future__ import annotations
 
 import subprocess
+import sys
 from pathlib import Path
+from types import SimpleNamespace
 
 import pytest
 from fastapi import FastAPI
@@ -138,6 +140,80 @@ def test_push_user_edits_stops_after_reverse_sync_failure(
     monkeypatch.setattr(daemon, "run_git", fail_if_git_status_runs)
 
     assert tc.push_user_edits() == 0
+
+
+@pytest.mark.skipif(
+    sys.platform == "win32",
+    reason="Windows CI 不保证普通用户可创建 symlink",
+)
+def test_push_user_edits_continues_for_shared_symlink(
+    server_app, tmp_path,
+):
+    """Codex/OpenCode shared link 无需反向 copy，仍须继续 Git 回传。"""
+    tc = _client(server_app, tmp_path)
+    manifest = tc.sync()
+    tc.reconcile_skill_sides(manifest)
+    repo = (
+        tmp_path / "client_home" / ".xskill" / "skill" / "fix-foo"
+    )
+    shared = (
+        tmp_path / "client_home" / ".agents" / "skills" / "fix-foo"
+    )
+    shared.parent.mkdir(parents=True)
+    shared.symlink_to(repo, target_is_directory=True)
+    (shared / "SKILL.md").write_text(
+        "---\nname: fix-foo\ndescription: changed\n---\n# fix\n",
+        encoding="utf-8",
+    )
+
+    assert tc.push_user_edits() == 1
+
+
+def test_reconcile_downloaded_skills_refreshes_changed_version(
+    server_app, tmp_path, monkeypatch,
+):
+    tc = _client(server_app, tmp_path)
+    skills_dir = tmp_path / "downloads"
+    local = skills_dir / "download@abcdef"
+    local.mkdir(parents=True)
+    (local / "SKILL.md").write_text("old\n", encoding="utf-8")
+    installed: list[tuple[dict, bytes]] = []
+
+    class _Manager:
+        def __init__(self, **_kwargs):
+            self.skills_dir = skills_dir
+
+        @staticmethod
+        def entries():
+            return [{"skill_id": "download@abcdef", "sha": "old-sha"}]
+
+        @staticmethod
+        def install(result, content):
+            installed.append((result, content))
+
+    class _Http:
+        @staticmethod
+        def get(path, **_kwargs):
+            if "/entry/" in path:
+                return SimpleNamespace(
+                    status_code=200,
+                    json=lambda: {"result": {
+                        "skill_id": "download@abcdef",
+                        "content_sha": "new-sha",
+                    }},
+                )
+            return SimpleNamespace(status_code=200, content=b"archive")
+
+    monkeypatch.setattr(
+        "xskill.team.client.search_slots.DownloadedSkills", _Manager,
+    )
+    tc.http = _Http()
+
+    assert tc.reconcile_downloaded_skills() == 1
+    assert installed == [({
+        "skill_id": "download@abcdef",
+        "content_sha": "new-sha",
+    }, b"archive")]
 
 
 def test_cleanup_removes_skill_not_in_manifest(server_app, tmp_path):


### PR DESCRIPTION
## Summary

- make `xskill search` a compact, metadata-only lookup that keeps IDs and ranking without exposing local harness paths
- add `xskill search --download` as the compatibility path for the original 10-slot LRU download/install behavior
- make `xskill download <skill-id>` persistent with interactive multi-select, repeatable `--agent`, and non-interactive `-y` support
- preserve selected harnesses in the download ledger so daemon refreshes do not expand installation scope; explicit targets bypass detector false negatives and shared targets retain fixed safe ordering
- treat root symlink/junction installs as shared state that does not need copy reverse-sync, while preserving fail-closed checks inside real copies

Closes #143
Closes #144

## Validation

- `220 passed` in the focused CLI, SkillHub, team-client, install and reverse-sync regression suite
- `1950 passed` in the full local test suite
- Ruff passed for the touched implementation and focused test files
- GitHub CI workflow succeeded across the 30-job Windows/macOS/Linux, Python 3.9-3.12, smoke, connect-lifecycle, and live-agent matrix; the secret-gated real-LLM job skipped as designed
- CodeQL Python and JavaScript/TypeScript analyses passed