### PR TITLE
修复 SkillEdit：按批次提交 baby 并支持冷启动断点续跑

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -55,6 +55,25 @@ jobs:
         # Excludes tests under tests/e2e/ (covered by smoke-e2e job in P4).
         run: pytest tests/ --ignore=tests/e2e -q
 
+  skill-edit-bdd:
+    name: skill-edit BDD (aimock)
+    runs-on: ubuntu-latest
+    steps:
+      - uses: actions/checkout@v4
+      - uses: actions/setup-python@v5
+        with:
+          python-version: "3.11"
+          cache: pip
+      - uses: actions/setup-node@v4
+        with:
+          node-version: "20"
+      - name: Install xskill test dependencies
+        run: pip install -e .[dev]
+      - name: Run all SkillEdit behavior scenarios
+        env:
+          XSKILL_AIMOCK_E2E: "1"
+        run: pytest tests/bdd -v --timeout=120
+
   smoke-e2e:
     name: smoke-e2e (${{ matrix.os }}, ${{ matrix.agent }})
     needs: ut-it

--- a/.gitignore
+++ b/.gitignore
@@ -35,6 +35,7 @@ build/
 .eggs/
 *.so
 .pytest_cache/
+mutants/
 
 # setuptools-scm generated version file
 src/xskill/_version.py

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -52,7 +52,19 @@ dependencies = [
 ]
 
 [project.optional-dependencies]
-dev = ["pytest>=7", "pytest-timeout>=2", "pytest-asyncio>=0.21", "requests>=2"]
+dev = [
+    "pytest>=7",
+    "pytest-timeout>=2",
+    "pytest-asyncio>=0.21",
+    "pytest-bdd>=8,<9",
+    "requests>=2",
+    # HTTP LLM contract tests only.  The Python fixture downloads the pinned
+    # @copilotkit/aimock npm artifact and manages its local Node.js process.
+    "aimock-pytest==0.5.0; python_version >= '3.10'",
+    # Mutation testing is a developer/CI concern and never enters the wheel's
+    # runtime dependency set.
+    "mutmut>=3.6,<4; python_version >= '3.10'",
+]
 
 [project.urls]
 Homepage = "https://github.com/SkillNerds/xskill"
@@ -89,6 +101,39 @@ markers = [
     # ``pytest -m live_agent`` 触发。
     "live_agent: real codex/opencode process + mock LLM end-to-end (slow, optional)",
     "stress: slow real-process load and smoke tests (excluded by default)",
+    "bdd: executable product behavior specifications",
+    "http_llm: real OpenAI-compatible HTTP boundary backed by local aimock",
+    "state_machine: deterministic SkillEdit state-machine coverage for mutation testing",
+    "primary: primary user success journey",
+    "golden_path: end-to-end happy-path behavior",
+    "recovery: retry and restart recovery behavior",
+    "contract: external protocol contract behavior",
+    "observability: operator-facing trace behavior",
 ]
 addopts = "--ignore=tests/live --ignore=tests/stress"
 asyncio_mode = "strict"
+
+[tool.mutmut]
+# Keep mutation testing focused on the Issue #146 durable boundaries:
+# framework-owned candidate consumption and baby graduation.  The local HTTP
+# contract is intentionally excluded: mutation workers should not start a
+# Node process or depend on fixture timing.
+source_paths = ["src/xskill"]
+only_mutate = [
+    "src/xskill/skill/candidates.py",
+    "src/xskill/agents/agent_tools.py",
+]
+# Logging prose and spelling-equivalent encoding names are not observable
+# product behavior; mutating them creates equivalent mutants.
+do_not_mutate_patterns = [
+    "logger\\.",
+    "encoding=\"utf-8\"",
+]
+pytest_add_cli_args = ["-q", "--override-ini=addopts="]
+pytest_add_cli_args_test_selection = [
+    "tests/bdd/test_skill_edit_state_machine.py",
+    "tests/test_skill_edit_batch_turns.py::TestRemoveCandidates",
+    "tests/test_skill_edit_mutation_contracts.py",
+]
+timeout_multiplier = 5.0
+timeout_constant = 1.0

--- a/src/xskill/agents/agent_tools.py
+++ b/src/xskill/agents/agent_tools.py
@@ -79,6 +79,8 @@ class AgentToolContext:
     usage_ledger: Any = None
     cluster_write_queue: Any = None
     cluster_result_recorder: Any = None
+    skill_edit_skill_name: str | None = None
+    skill_edit_batch_ids: tuple[str, ...] = ()
     grep_fallback_warned: bool = False
 
     def __post_init__(self) -> None:
@@ -110,6 +112,8 @@ def create_agent_tool_context(
     usage_ledger=None,
     cluster_write_queue=None,
     cluster_result_recorder=None,
+    skill_edit_skill_name=None,
+    skill_edit_batch_ids=(),
 ) -> AgentToolContext:
     """Create an immutable context without changing the current task."""
     return AgentToolContext(
@@ -130,6 +134,14 @@ def create_agent_tool_context(
         usage_ledger=usage_ledger,
         cluster_write_queue=cluster_write_queue,
         cluster_result_recorder=cluster_result_recorder,
+        skill_edit_skill_name=(
+            str(skill_edit_skill_name)
+            if skill_edit_skill_name is not None
+            else None
+        ),
+        skill_edit_batch_ids=tuple(
+            str(atom_id) for atom_id in (skill_edit_batch_ids or ())
+        ),
     )
 
 
@@ -162,6 +174,26 @@ def use_agent_tool_context(
         yield context
     finally:
         reset_agent_tool_context(token)
+
+
+@contextlib.contextmanager
+def use_skill_edit_batch(
+    skill_name: str,
+    batch_ids,
+) -> Iterator[AgentToolContext]:
+    """Bind immutable checkpoint authority for one baby SkillEdit turn.
+
+    The model never supplies candidate IDs to ``commit_baby``.  It can only
+    consume the exact ordered IDs that the framework put into this context.
+    """
+    current = current_agent_tool_context()
+    bound = replace(
+        current,
+        skill_edit_skill_name=_slugify(skill_name),
+        skill_edit_batch_ids=tuple(str(atom_id) for atom_id in batch_ids),
+    )
+    with use_agent_tool_context(bound):
+        yield bound
 
 
 class AgentToolConfig:
@@ -215,6 +247,8 @@ class AgentToolConfig:
             "usage_ledger": current.usage_ledger,
             "cluster_write_queue": current.cluster_write_queue,
             "cluster_result_recorder": current.cluster_result_recorder,
+            "skill_edit_skill_name": current.skill_edit_skill_name,
+            "skill_edit_batch_ids": current.skill_edit_batch_ids,
             "grep_fallback_warned": current.grep_fallback_warned,
         }
 
@@ -230,6 +264,8 @@ class AgentToolConfig:
             usage_ledger=snapshot.get("usage_ledger"),
             cluster_write_queue=snapshot.get("cluster_write_queue"),
             cluster_result_recorder=snapshot.get("cluster_result_recorder"),
+            skill_edit_skill_name=snapshot.get("skill_edit_skill_name"),
+            skill_edit_batch_ids=snapshot.get("skill_edit_batch_ids") or (),
         ))
         if not snapshot.get("configured", True):
             current = _AGENT_TOOL_CONTEXT.get()
@@ -1521,6 +1557,93 @@ def _run_description_optimization(target: Path, slug: str) -> None:
         )
 
 
+def graduate_baby_to_main(target: Path, slug: str, message: str) -> bool:
+    """Framework-controlled final baby graduation.
+
+    Description optimization runs once here, after every candidate checkpoint
+    has been consumed.  The legacy ``commit_baby_to_main`` tool delegates to
+    this function and remains available for compatibility, but checkpointed
+    baby turns only expose ``commit_baby`` to the model.
+    """
+    from xskill.skill.frontmatter import FrontmatterError
+    from xskill.skill.git import commit_baby_to_main_branch
+
+    skill_md = target / "SKILL.md"
+    try:
+        fm_parse_strict(skill_md.read_text(encoding="utf-8"))
+    except (OSError, UnicodeDecodeError, FrontmatterError) as error:
+        logger.warning("baby graduation frontmatter invalid for %s: %s", slug, error)
+        return False
+    _run_description_optimization(target, slug)
+    return commit_baby_to_main_branch(str(target), message)
+
+
+@tool(name="commit_baby")
+def commit_baby(skill_name: str, message: str) -> str:
+    """Commit the current framework-bound atom batch on ``baby``.
+
+    Candidate IDs are deliberately not arguments: the framework binds the
+    exact ordered batch in ``AgentToolContext`` before this turn.  A successful
+    call creates one non-empty commit, then removes only those bound IDs while
+    holding the same repository lock.  It never renames the branch and never
+    runs description optimization.
+    """
+    from xskill.agents import agent_trace
+    from xskill.skill import candidates as candidate_buffer
+    from xskill.skill.frontmatter import FrontmatterError
+    from xskill.skill.git import (
+        commit_baby_checkpoint,
+        current_branch,
+        skill_repo_lock,
+    )
+
+    context = current_agent_tool_context()
+    skill_root = context.atom_skill_dir
+    if skill_root is None:
+        return "error: atom task tool context not initialized"
+    slug = _slugify(skill_name)
+    if not context.skill_edit_skill_name or not context.skill_edit_batch_ids:
+        return "error: no framework-bound SkillEdit batch"
+    if slug != context.skill_edit_skill_name:
+        return (
+            "error: commit_baby can only commit the framework-bound skill "
+            f"{context.skill_edit_skill_name}"
+        )
+    target = skill_root / slug
+    if not target.is_dir() or not (target / ".git").is_dir():
+        return f"error: skill {slug} not found or has no git repository"
+    msg = (message or "").strip()
+    if not msg:
+        return "error: commit message 必填"
+
+    skill_md = target / "SKILL.md"
+    try:
+        fm_parse_strict(skill_md.read_text(encoding="utf-8"))
+    except (OSError, UnicodeDecodeError, FrontmatterError) as error:
+        return f"error: invalid SKILL.md frontmatter: {error}"
+
+    batch_ids = tuple(context.skill_edit_batch_ids)
+    with skill_repo_lock(target):
+        if current_branch(str(target)) != "baby":
+            return "error: commit_baby only works on the baby branch"
+        commit_sha = commit_baby_checkpoint(str(target), msg)
+        if commit_sha is None:
+            return "error: commit_baby requires a real non-empty change"
+        consumed, remaining = candidate_buffer.remove_candidates(
+            target,
+            set(batch_ids),
+        )
+
+    lines = [
+        f"Created baby checkpoint {commit_sha[:7]}.",
+        "Consumed atoms:",
+        *[f"  {atom_id}" for atom_id in consumed],
+        f"{remaining} atoms remain.",
+    ]
+    agent_trace.event("INFO", "\n".join(lines), include_timestamp=False)
+    return "\n".join(lines)
+
+
 @tool(name="commit_baby_to_main")
 def commit_baby_to_main(skill_name: str, message: str) -> str:
     """SkillEditAgent 首次为某 skill 出版本时调用。
@@ -1537,7 +1660,6 @@ def commit_baby_to_main(skill_name: str, message: str) -> str:
         成功："graduated baby → main: <skill_name>"
         失败："error: ..."
     """
-    from xskill.skill.git import commit_baby_to_main_branch
     skill_dir = agent_tool_config.atom_skill_dir
     if skill_dir is None:
         return "error: atom task tool context not initialized"
@@ -1550,10 +1672,7 @@ def commit_baby_to_main(skill_name: str, message: str) -> str:
     msg = (message or "").strip()
     if not msg:
         return "error: commit message 必填"
-    # commit 前先跑 description 触发优化（best desc 写回 frontmatter），优化产物
-    # 随 add . 一起进 commit。失败只 log，不阻断 commit。
-    _run_description_optimization(target, slug)
-    ok = commit_baby_to_main_branch(str(target), msg)
+    ok = graduate_baby_to_main(target, slug, msg)
     if not ok:
         return "error: commit_baby_to_main 失败（不在 baby 分支？看 daemon 日志）"
     return f"graduated baby → main: {slug}"

--- a/src/xskill/agents/agent_trace.py
+++ b/src/xskill/agents/agent_trace.py
@@ -11,7 +11,7 @@ look 了哪、submit 了什么"排查。这里给每次 ``agent.run()`` 开一�
 路径由调用方通过当前 XSkill 实例的 ``logs_dir`` 显式决定：
   task_agents/<traj_id>.log
   task_cluster_agents/<traj_id>/<atom_id>.log
-  skill_edit_agents/skills/<skill>_<ts>.log
+  skill_edit_agents/skills/<skill>.log  (all SkillEdit turns append here)
 
 线程模型：watcher 每条 agent 跑在线程池各自线程，``threading.local`` 让各线程的
 sink 互不串（同一次 run 内的多轮 invoke 都在同一线程 → 同一文件）。
@@ -19,8 +19,10 @@ sink 互不串（同一次 run 内的多轮 invoke 都在同一线程 → 同一
 from __future__ import annotations
 
 import hashlib
+import json
 import logging
 import threading
+import time
 from collections import OrderedDict
 from pathlib import Path
 from typing import Any
@@ -59,16 +61,32 @@ def _warn_io_failure(exc: OSError, sink: Path) -> None:
     )
 
 
-def set_sink(path) -> None:
-    """设当前线程的 trace sink；每次 run 开头清空同名文件（覆盖上一次）。"""
+def set_sink(
+    path,
+    *,
+    append: bool = False,
+    spill_token_limit: int | None = None,
+    compact_token_limit: int | None = None,
+) -> None:
+    """Set the current trace sink.
+
+    Ordinary agents keep the historical truncate-on-run behaviour.  SkillEdit
+    opts into ``append=True`` so every turn for one skill lands in one file.
+    """
     if path is None:
         _STATE.sink = None
         _STATE.round = 0
+        _STATE.spill_token_limit = None
+        _STATE.compact_token_limit = None
+        _STATE.seen_tool_results = set()
         return
     p = Path(path)
     try:
         p.parent.mkdir(parents=True, exist_ok=True)
-        p.write_text("", encoding="utf-8")
+        if append:
+            p.touch(exist_ok=True)
+        else:
+            p.write_text("", encoding="utf-8")
     except OSError as exc:
         _warn_io_failure(exc, p)
         _STATE.sink = None
@@ -76,11 +94,17 @@ def set_sink(path) -> None:
         return
     _STATE.sink = p
     _STATE.round = 0
+    _STATE.spill_token_limit = spill_token_limit
+    _STATE.compact_token_limit = compact_token_limit
+    _STATE.seen_tool_results = set()
 
 
 def clear_sink() -> None:
     _STATE.sink = None
     _STATE.round = 0
+    _STATE.spill_token_limit = None
+    _STATE.compact_token_limit = None
+    _STATE.seen_tool_results = set()
 
 
 class trace_to:
@@ -89,15 +113,42 @@ class trace_to:
     path 为 None → 在该作用域显式禁用 trace，退出后恢复外层 sink。
     """
 
-    def __init__(self, path):
+    def __init__(
+        self,
+        path,
+        *,
+        append: bool = False,
+        spill_token_limit: int | None = None,
+        compact_token_limit: int | None = None,
+    ):
         self.path = path
+        self.append = append
+        self.spill_token_limit = spill_token_limit
+        self.compact_token_limit = compact_token_limit
         self._previous_sink: Path | None = None
         self._previous_round = 0
+        self._previous_spill_token_limit: int | None = None
+        self._previous_compact_token_limit: int | None = None
+        self._previous_seen_tool_results: set[str] = set()
 
     def __enter__(self) -> "trace_to":
         self._previous_sink = _sink()
         self._previous_round = getattr(_STATE, "round", 0)
-        set_sink(self.path)
+        self._previous_spill_token_limit = getattr(
+            _STATE, "spill_token_limit", None,
+        )
+        self._previous_compact_token_limit = getattr(
+            _STATE, "compact_token_limit", None,
+        )
+        self._previous_seen_tool_results = getattr(
+            _STATE, "seen_tool_results", set(),
+        )
+        set_sink(
+            self.path,
+            append=self.append,
+            spill_token_limit=self.spill_token_limit,
+            compact_token_limit=self.compact_token_limit,
+        )
         return self
 
     def __exit__(self, *exc) -> bool:
@@ -105,6 +156,9 @@ class trace_to:
         # truncate an outer trace file when nested scopes unwind.
         _STATE.sink = self._previous_sink
         _STATE.round = self._previous_round
+        _STATE.spill_token_limit = self._previous_spill_token_limit
+        _STATE.compact_token_limit = self._previous_compact_token_limit
+        _STATE.seen_tool_results = self._previous_seen_tool_results
         return False
 
 
@@ -137,32 +191,189 @@ def _extract(resp: Any):
                 or (fn.get("name") if isinstance(fn, dict) else "?"))
         args = (getattr(fn, "arguments", None)
                 or (fn.get("arguments") if isinstance(fn, dict) else ""))
-        tcs.append((name, str(args)[:400]))
+        tcs.append((name, args))
     return rc, ct, tcs
 
 
-def record(messages, resp) -> None:
-    """工厂 invoke 包装层每轮调一次：把这轮 reasoning/content/tool_calls append 进 sink。
-
-    没设 sink（普通调用）→ 直接返回，零开销。预期的文件系统错误会限频告警后
-    继续主流程；未知程序错误会向上传播。
-    """
+def _append(text: str) -> None:
     sink = _sink()
     if sink is None:
+        return
+    try:
+        with open(sink, "a", encoding="utf-8") as trace_file:
+            trace_file.write(text)
+    except OSError as exc:
+        _warn_io_failure(exc, sink)
+
+
+def append_to(path: Path | str | None, text: str) -> None:
+    """Append framework-owned turn markers outside an active model call."""
+    if path is None:
+        return
+    sink = Path(path)
+    try:
+        sink.parent.mkdir(parents=True, exist_ok=True)
+        with sink.open("a", encoding="utf-8") as trace_file:
+            trace_file.write(text)
+    except OSError as exc:
+        _warn_io_failure(exc, sink)
+
+
+def event(
+    level: str,
+    message: str,
+    *,
+    include_timestamp: bool = True,
+) -> None:
+    """Write a readable retry/context/checkpoint event to the active sink."""
+    if _sink() is None:
+        return
+    prefix = (
+        f"{time.strftime('%H:%M:%S')} {level.upper():<5} "
+        if include_timestamp else ""
+    )
+    lines = str(message).splitlines() or [""]
+    rendered = [prefix + lines[0]]
+    rendered.extend(" " * len(prefix) + line for line in lines[1:])
+    _append("\n".join(rendered) + "\n")
+
+
+def _format_tokens(value: int | None) -> str:
+    if value is None:
+        return "off"
+    if value >= 1000:
+        rounded = value / 1000
+        return f"{rounded:.1f}k".replace(".0k", "k")
+    return str(value)
+
+
+def _message_value(message: Any, name: str, default=None):
+    if isinstance(message, dict):
+        return message.get(name, default)
+    return getattr(message, name, default)
+
+
+def _tool_result_lines(messages) -> list[str]:
+    seen = getattr(_STATE, "seen_tool_results", set())
+    out: list[str] = []
+    for message in messages or []:
+        if _message_value(message, "role") != "tool":
+            continue
+        content = str(_message_value(message, "content", "") or "")
+        tool_name = str(
+            _message_value(message, "tool_name")
+            or _message_value(message, "name")
+            or "tool"
+        )
+        tool_call_id = str(_message_value(message, "tool_call_id", "") or "")
+        fingerprint = hashlib.sha256(
+            f"{tool_call_id}\0{tool_name}\0{content}".encode(
+                "utf-8", errors="replace",
+            )
+        ).hexdigest()
+        if fingerprint in seen:
+            continue
+        seen.add(fingerprint)
+        if tool_name == "commit_baby":
+            # commit_baby writes its authoritative multi-line result directly.
+            continue
+        out.append(f"TOOL RESULT  {tool_name}")
+        stripped = content.strip()
+        try:
+            structured = json.loads(stripped) if stripped else None
+        except (json.JSONDecodeError, TypeError):
+            structured = None
+        if structured is not None:
+            summary = f"Returned structured result ({len(content):,} chars)."
+        elif not stripped:
+            summary = "Returned no text."
+        elif len(stripped) <= 160 and "\n" not in stripped:
+            summary = stripped
+        else:
+            summary = f"Returned {len(content):,} chars."
+        out.append(f"             {summary}")
+    _STATE.seen_tool_results = seen
+    return out
+
+
+def _format_argument_value(value: Any) -> str:
+    if isinstance(value, str):
+        flattened = " ".join(value.split())
+        if len(flattened) > 100:
+            return f"<{len(value):,} chars>"
+        return flattened
+    if isinstance(value, (int, float, bool)) or value is None:
+        return str(value)
+    if isinstance(value, (list, tuple)):
+        if len(value) <= 4 and all(
+            isinstance(item, (str, int, float, bool)) for item in value
+        ):
+            return "[" + ", ".join(_format_argument_value(item) for item in value) + "]"
+        return f"<{len(value)} items>"
+    if isinstance(value, dict):
+        return f"<{len(value)} fields>"
+    return f"<{type(value).__name__}>"
+
+
+def _format_tool_call(name: str, arguments: Any) -> str:
+    parsed = arguments
+    if isinstance(arguments, str):
+        try:
+            parsed = json.loads(arguments)
+        except (json.JSONDecodeError, TypeError):
+            parsed = arguments
+    if isinstance(parsed, dict):
+        values = list(parsed.items())
+        if len(values) == 1:
+            rendered = _format_argument_value(values[0][1])
+        else:
+            rendered = ", ".join(
+                f"{key}={_format_argument_value(value)}"
+                for key, value in values
+            )
+    else:
+        rendered = _format_argument_value(parsed)
+    return f"TOOL  {name}({rendered})"
+
+
+def begin_round(messages) -> None:
+    """Start one outer model.invoke round before retries/context management."""
+    if _sink() is None:
         return
     n = getattr(_STATE, "round", 0) + 1
     _STATE.round = n
     chars = sum(_content_len(m) for m in (messages or []))
-    out = [f"\n=== round {n} | {len(messages or [])} msgs | ~{chars // 4} tokens ==="]
+    spill = _format_tokens(getattr(_STATE, "spill_token_limit", None))
+    compact = _format_tokens(getattr(_STATE, "compact_token_limit", None))
+    out = [
+        "",
+        (
+            f"---- ROUND {n} | tokens={_format_tokens(chars // 4)} "
+            f"| spill@{spill} | compact@{compact} ----"
+        ),
+        "",
+        *_tool_result_lines(messages),
+    ]
+    _append("\n".join(out).rstrip() + "\n")
+
+
+def record_response(resp) -> None:
+    """Append reasoning, answer, and human-readable tool calls for one round."""
+    if _sink() is None:
+        return
+    out: list[str] = []
     rc, ct, tcs = _extract(resp)
     if rc and str(rc).strip():
-        out.append("💭 think:\n" + str(rc).strip())
+        out.extend(["THINK", str(rc).strip(), ""])
     if ct and str(ct).strip():
-        out.append("💬 say: " + str(ct).strip())
+        out.extend(["SAY", str(ct).strip(), ""])
     for name, args in tcs:
-        out.append(f"🔧 {name}({args})")
-    try:
-        with open(sink, "a", encoding="utf-8") as f:
-            f.write("\n".join(out) + "\n")
-    except OSError as exc:
-        _warn_io_failure(exc, sink)
+        out.extend([_format_tool_call(name, args), ""])
+    if out:
+        _append("\n".join(out).rstrip() + "\n")
+
+
+def record(messages, resp) -> None:
+    """Backward-compatible one-shot record used by tests and direct callers."""
+    begin_round(messages)
+    record_response(resp)

--- a/src/xskill/agents/agno_factory.py
+++ b/src/xskill/agents/agno_factory.py
@@ -268,15 +268,34 @@ def _wrap_with_retry(model, llm_cfg: dict):
     base_url = llm_cfg.get("base_url", "")
 
     def retrying_invoke(messages, **kwargs):
+        from xskill.agents import agent_trace
+
         attempt = 0
         while True:
             try:
                 return original_invoke(messages, **kwargs)
             except Exception as exc:  # noqa: BLE001
                 attempt += 1
+                error_text = str(exc).lower()
+                if "429" in error_text or "rate limit" in error_text:
+                    error_label = "429"
+                elif any(h in error_text for h in _NON_RETRYABLE_HINTS):
+                    error_label = "context-too-long"
+                else:
+                    error_label = type(exc).__name__
                 if attempt >= max_retries or not _is_transient_error(exc):
+                    agent_trace.event(
+                        "ERROR",
+                        f"LLM returned {error_label}; retries exhausted "
+                        f"({attempt}/{max_retries})",
+                    )
                     raise
                 delay = min(cap, base * (2 ** (attempt - 1)))
+                agent_trace.event(
+                    "WARN",
+                    f"LLM returned {error_label}; retrying "
+                    f"({attempt}/{max_retries})",
+                )
                 import logging
                 logging.getLogger("xskill.agno_factory").warning(
                     "LLM 瞬时错误,第 %d/%d 次重试(%.0fs 后): %s",
@@ -304,8 +323,9 @@ def _wrap_with_trace(model):
     original_invoke = model.invoke
 
     def traced_invoke(messages, **kwargs):
+        agent_trace.begin_round(messages)
         resp = original_invoke(messages, **kwargs)
-        agent_trace.record(messages, resp)
+        agent_trace.record_response(resp)
         return resp
 
     model.invoke = traced_invoke

--- a/src/xskill/agents/context_budget.py
+++ b/src/xskill/agents/context_budget.py
@@ -11,8 +11,9 @@
    ``look`` 工具结果替换成短标记；把 SkillEdit 的读文件类工具结果 spill 到
    当前 XSkill 实例的隔离目录，message 里只保留摘要 + ``spill_path``。
    从最旧的开始剪,剪到回落 85% 以下为止。
-3. **可选 compact**：如果本轮剪裁后仍超过 ``compact_token_limit``，调用同一个
-   model 做一次工作记忆摘要，然后保留 system、首轮 user、摘要和最近完整消息块。
+3. **可选 compact**：先把可 spill 的结果尽量降到 85% 边界；仍超出
+   ``max(compact_token_limit, spill 边界)`` 才调用同一个 model 做一次工作
+   记忆摘要，然后保留 system、首轮 user、摘要和最近完整消息块。
 4. **最底层兜底（唯一）**：抓住后端抛的"上下文超长"报错 → 再剪一轮历史 →
    **重发一次**。就这一条,不做解析上限学分母、不做多触发统一。
 5. **真实已用 token**：每次请求拿到 ``usage.prompt_tokens`` 写进 thread-local,
@@ -473,8 +474,13 @@ class ContextManager:
             if spill_root is not None
             else None
         )
+        # Compact is always a fallback after the proactive spill boundary.
+        # A legacy config below spill@ can no longer make summarization fire
+        # first or on every moderately large round.
         self.compact_token_limit = (
-            int(compact_token_limit) if compact_token_limit is not None else None
+            max(int(compact_token_limit), self.trigger)
+            if compact_token_limit is not None
+            else None
         )
         self.compact_keep_recent_messages = int(compact_keep_recent_messages)
         self.compact_fn = compact_fn
@@ -487,6 +493,8 @@ class ContextManager:
     def wrap(self, original_invoke):
         """返回包好上下文自管理的 invoke。"""
         def managed_invoke(messages, **kwargs):
+            from xskill.agents import agent_trace
+
             set_max_context(self.max_context)
             # 1) 主动剪裁：到 85% 就剪旧工具结果（纯截断/spill,不调模型）。
             est = _estimate_history_tokens(messages)
@@ -496,11 +504,25 @@ class ContextManager:
                     messages, self.trigger, spill_root=self.spill_root,
                 )
                 if trimmed:
+                    after_spill = _estimate_history_tokens(messages)
                     logger.info("上下文到 %d/%d token,主动剪裁 %d 条旧工具结果",
                                 est, self.max_context, trimmed)
+                    agent_trace.event(
+                        "CONTEXT",
+                        f"Spilled {trimmed} old tool result(s): "
+                        f"{est:,} -> {after_spill:,} tokens.",
+                        include_timestamp=False,
+                    )
+                else:
+                    agent_trace.event(
+                        "CONTEXT",
+                        "No more eligible tool results could be spilled.",
+                        include_timestamp=False,
+                    )
+            after_spill = _estimate_history_tokens(messages)
             if (
                 self.compact_token_limit is not None
-                and _estimate_history_tokens(messages) > self.compact_token_limit
+                and after_spill > self.compact_token_limit
             ):
                 compact_fn = self.compact_fn or _model_compact_fn(original_invoke)
                 try:
@@ -512,11 +534,32 @@ class ContextManager:
                 except Exception as exc:  # noqa: BLE001
                     compacted = False
                     logger.warning("上下文 compact 失败,继续使用剪裁后的历史：%s", exc)
+                    agent_trace.event(
+                        "CONTEXT",
+                        "Compact failed; continuing with spilled history.",
+                        include_timestamp=False,
+                    )
                 if compacted:
+                    after_compact = _estimate_history_tokens(messages)
                     logger.info(
                         "上下文仍超过 compact_token_limit=%d,已压缩历史到 %d 条消息",
                         self.compact_token_limit, len(messages or []),
                     )
+                    agent_trace.event(
+                        "CONTEXT",
+                        f"Compacted context: {after_spill:,} -> "
+                        f"{after_compact:,} tokens.",
+                        include_timestamp=False,
+                    )
+            elif (
+                self.compact_token_limit is not None
+                and est >= self.trigger
+            ):
+                agent_trace.event(
+                    "CONTEXT",
+                    "Compact was not needed.",
+                    include_timestamp=False,
+                )
             try:
                 resp = original_invoke(messages, **kwargs)
             except Exception as exc:  # noqa: BLE001 — 唯一底层兜底
@@ -524,9 +567,18 @@ class ContextManager:
                     raise
                 # 2) 超长兜底（唯一）：再狠剪一轮 → 重发一次。
                 logger.warning("后端报上下文超长,剪裁历史后重发一次：%s", exc)
+                before_retry_spill = _estimate_history_tokens(messages)
                 _trim_old_look_results(messages, self.max_context // 2,
                                        force_all=True,
                                        spill_root=self.spill_root)
+                after_retry_spill = _estimate_history_tokens(messages)
+                agent_trace.event(
+                    "CONTEXT",
+                    "Backend reported context too long; forced spill before "
+                    f"one retry: {before_retry_spill:,} -> "
+                    f"{after_retry_spill:,} tokens.",
+                    include_timestamp=False,
+                )
                 resp = original_invoke(messages, **kwargs)
             # 3) 记后端真实 prompt_tokens（context_budget 工具读这个）。
             self._record_prompt_tokens(resp)

--- a/src/xskill/agents/skill_edit_agent.py
+++ b/src/xskill/agents/skill_edit_agent.py
@@ -1,5 +1,5 @@
-"""SkillEditAgent —— SKILL.md 自主整理 + git commit（baby→main 或 staging）
-========================================================================
+"""SkillEditAgent —— SKILL.md 自主整理 + 可恢复 checkpoint
+===========================================================
 
 何时触发（``maybe_run`` 守门）：
   1. 该 skill 没有 staging 分支（灰度中不再触发新 SkillEdit）
@@ -9,30 +9,20 @@
      避免冷启动后 main 无人用就连开 staging 卡死灰度链路
   4. 调用方（watcher._check_pending_skill_edits）保证不在冷启动期触发
 
-agent 写完 SKILL.md / scripts / references 后**必须**调以下两个 commit
-工具之一（依当前分支状态）：
-  - baby 分支：调 ``commit_baby_to_main(skill_name, message)`` 完成首版
-  - main 分支：调 ``commit_to_staging(skill_name, message)`` 产出灰度候选
+baby 冷启动按配置 N（默认 5）以 candidates YAML 插入顺序逐批处理。每批使用
+全新 agent 上下文，写完后必须调用 ``commit_baby``：在 baby 上创建真实非空
+commit，并在同一仓锁内消费框架绑定的 atom_id。失败按 N/2（最小 1）重试；
+任一批成功后下一批恢复配置 N。buffer 清空后框架统一跑一次 description
+optimization，并把 baby 晋升 main。这样第 199/200 批崩溃也只重试未提交批次。
 
-落盘成功（SKILL.md mtime 推进 + 非空 + 分支真推进）→ 从 buffer 摘除本次
-快照到的 atom_id + 立即 install_to_claude_code 让 CC 立刻看到新版本。
-
-多轮渐进式消化（buffer 超过 ``SKILL_EDIT_BATCH_SIZE`` 条候选时）：
-一次 ``maybe_run`` 对 buffer 做一次快照,按 ``(weightscore 降序, atom_id 升序)``
-切成多批,每批一轮**全新上下文**的 ``agent.run()``（不带前一轮的对话历史，
-与 TaskAgent 弃窗单趟同一设计哲学，见 ``context_budget.py``）。除最后一轮外
-每轮结束后由**宿主 Python 代码**（不是 agent）把改动 commit 到一个新建的
-``<branch>_turn<N>`` 分支承接进度；中间轮的 agent 完全不会拿到任何终态
-commit 工具——分支推进对它不可见也不可调用，是结构性保证而非约定。最后一轮
-开跑前宿主代码把 HEAD 切回原分支（工作区不动），agent 此时才拿到终态 commit
-工具，一次 commit 落地全部批次的累计改动。成功后清理所有遗留 turn 分支；
-若发现残留 turn 分支（上次崩溃/失败），不续传，直接重置重来（详见
-``SkillEditAgent._recover_crashed_turns``）。
+main→staging 与 jam 路径保留旧 ``*_turnN`` 渐进分支语义，避免扩大 Issue #146
+的行为面。
 """
 from __future__ import annotations
 
 import logging
-from dataclasses import dataclass
+import time
+from dataclasses import dataclass, field
 from pathlib import Path
 from typing import Any, Callable
 
@@ -214,8 +204,9 @@ metadata:
 
 ## 当前在 {branch_now} 分支，按场景调对应工具：
 
-- **如果在 baby 分支**：调 ``commit_baby_to_main(skill_name, message)``
-  这是该 skill 第一次出版本，graduate 到 main 分支。
+- **如果在 baby 分支**：调 ``commit_baby(skill_name, message)``
+  checkpoint 当前批次。它保持 baby 分支并消费系统绑定的 atom_id；当
+  candidates 全部清空后，框架会自动 graduate 到 main。
 - **如果在 main 分支**（已有 main，本次是更新）：调
   ``commit_to_staging(skill_name, message)`` 把更新作为灰度候选放进 staging。
   staging 会被灰度系统 vs main 对比，胜出才升级。
@@ -233,7 +224,7 @@ commit message 写明本次基于哪些 atom_id 整理，例如：
 - grep_files(pattern, path="", glob="", max_results=100) — 全文检索（ripgrep），
   返回「文件:行号:内容」；先检索定位、再 read_file 精读，别逐个翻文件
 - write_file(path, content) — 写任意文件到 skill_dir 下
-- commit_baby_to_main(skill_name, message) — 仅 baby 分支可用
+- commit_baby(skill_name, message) — 仅 baby 分支可用；checkpoint 当前批次
 - commit_to_staging(skill_name, message) — 仅 main 分支可用
 
 # 隐私守护
@@ -340,11 +331,27 @@ class SkillEditAgent:
     traj_root: Path
     threshold: int = C.ATOM_PROMOTION_THRESHOLD
     jam_threshold: int = 50
+    batch_size: int = 5
+    retry_batch_size: int | None = None
     logs_dir: Path | None = None
+    next_batch_size: int = field(init=False)
 
     def __post_init__(self) -> None:
         self.skill_dir = Path(self.skill_dir)
         self.traj_root = Path(self.traj_root)
+        if isinstance(self.batch_size, bool) or int(self.batch_size) <= 0:
+            raise ValueError("SkillEditAgent batch_size must be a positive integer")
+        self.batch_size = int(self.batch_size)
+        if self.retry_batch_size is not None:
+            if (
+                isinstance(self.retry_batch_size, bool)
+                or int(self.retry_batch_size) <= 0
+            ):
+                raise ValueError(
+                    "SkillEditAgent retry_batch_size must be a positive integer"
+                )
+            self.retry_batch_size = int(self.retry_batch_size)
+        self.next_batch_size = self.retry_batch_size or self.batch_size
         if self.logs_dir is not None:
             self.logs_dir = Path(self.logs_dir)
 
@@ -382,9 +389,8 @@ class SkillEditAgent:
              - .ux_scores.jsonl 必须至少有 1 条 side=main → 证明 main 真有人用
              - 否则保留 candidates 等用户用过 main 再触发
 
-        全过 → 跑 agent（可能多轮渐进式） → 验证 SKILL.md mtime 推进 + 非空 +
-        分支真推进 → 从 buffer 摘除本次快照的 atom_id。
-        agent 没落盘 SKILL.md，或分支没真推进 → 保留 candidates 等下轮重试。
+        baby 全过 → 按 N 逐批 checkpoint + 消费，清空后框架晋升 main。
+        main/jam 全过 → 保留旧渐进分支链，终态成功后摘除入口快照 atom_id。
         """
         from xskill.skill.git import current_branch, run_git
 
@@ -405,13 +411,25 @@ class SkillEditAgent:
             return False
 
         if not staging_exists:
-            # 守门 2: 阈值
-            ready = C.ready_for_promotion_v2(data, threshold=self.threshold)
-            if not ready:
-                return False
-            # 守门 3: 若场景是 "create staging"（即在 main 上）→ 额外要求 main 真有人用过
             cur = current_branch(str(self.skill_dir))
+            if cur == "baby":
+                partial_baby = self._baby_has_checkpoint()
+                # 首次启动仍要求累计达到 promotion threshold；一旦已有 baby
+                # checkpoint，就必须无视剩余权重继续 drain，避免最后几个低分
+                # atom 永远无法完成毕业。candidate 已空则补完 crash window 中
+                # “remove 成功、rename 前进程退出”的最终晋升。
+                if not partial_baby:
+                    if not C.ready_for_promotion_v2(
+                        data, threshold=self.threshold,
+                    ):
+                        return False
+                return self._run_baby_until_empty()
             if cur == "main":
+                # 守门 2: main 的新一轮更新仍要求累计达到阈值。
+                ready = C.ready_for_promotion_v2(data, threshold=self.threshold)
+                if not ready:
+                    return False
+                # 守门 3: create staging 前要求 main 真有人用过。
                 if not self._main_has_ux_score():
                     logger.info(
                         "skip SkillEdit: %s main 还没真实 ux_score，"
@@ -419,7 +437,7 @@ class SkillEditAgent:
                         self.skill_dir.name,
                     )
                     return False
-            elif cur != "baby":
+            else:
                 logger.warning(
                     "skip SkillEdit: %s 在异常分支 %r (期望 baby 或 main)",
                     self.skill_dir.name, cur,
@@ -522,6 +540,264 @@ class SkillEditAgent:
                     len(snapshot_atom_ids), self.skill_dir.name)
         return True
 
+    def _baby_has_checkpoint(self) -> bool:
+        """Return whether baby has at least one commit after its init commit."""
+        from xskill.skill.git import run_git
+
+        return run_git(
+            ["rev-parse", "baby~1"],
+            cwd=str(self.skill_dir),
+        )[0] == 0
+
+    def _trace_path(self) -> Path | None:
+        if self.logs_dir is None:
+            return None
+        return (
+            self.logs_dir
+            / "agents"
+            / "skill_edit_agents"
+            / "skills"
+            / f"{self.skill_dir.name}.log"
+        )
+
+    def _trace_limits(self) -> tuple[int, int | None]:
+        from xskill.agents.context_budget import (
+            DEFAULT_MAX_CONTEXT,
+            TRIM_TRIGGER_RATIO,
+        )
+
+        max_context = int(
+            (self.llm_cfg or {}).get("max_context") or DEFAULT_MAX_CONTEXT
+        )
+        spill_limit = int(max_context * TRIM_TRIGGER_RATIO)
+        compact_raw = (self.llm_cfg or {}).get("compact_token_limit")
+        compact_limit = (
+            max(int(compact_raw), spill_limit)
+            if compact_raw not in (None, "")
+            else None
+        )
+        return spill_limit, compact_limit
+
+    def _append_turn_start(self, n: int, processing: int, pending: int) -> None:
+        from xskill.agents import agent_trace
+
+        agent_trace.append_to(
+            self._trace_path(),
+            (
+                "\n================ TURN START "
+                f"| N={n} | processing {processing} of {pending} "
+                "pending atoms ================\n\n"
+            ),
+        )
+
+    def _append_turn_end(
+        self,
+        status: str,
+        *,
+        consumed: int,
+        remaining: int,
+        next_n: int,
+    ) -> None:
+        from xskill.agents import agent_trace
+
+        agent_trace.append_to(
+            self._trace_path(),
+            (
+                f"\nTURN END | {status} | consumed={consumed} "
+                f"| {remaining} remaining | next N={next_n}\n\n"
+            ),
+        )
+
+    def _reset_baby_worktree(self) -> None:
+        """Discard uncheckpointed tracked/untracked edits, preserving ignored buffers."""
+        from xskill.skill.git import run_git
+
+        reset_code, _, reset_error = run_git(
+            ["reset", "--hard", "HEAD"],
+            cwd=str(self.skill_dir),
+        )
+        clean_code, _, clean_error = run_git(
+            ["clean", "-fd"],
+            cwd=str(self.skill_dir),
+        )
+        if reset_code != 0 or clean_code != 0:
+            logger.warning(
+                "SkillEdit baby worktree cleanup incomplete for %s: reset=%s clean=%s",
+                self.skill_dir.name,
+                reset_error,
+                clean_error,
+            )
+
+    def _graduate_completed_baby(self) -> bool:
+        """Promote an empty, checkpointed baby to main under framework control."""
+        from xskill.agents import agent_tools, agent_trace
+
+        ok = agent_tools.graduate_baby_to_main(
+            self.skill_dir,
+            self.skill_dir.name,
+            "graduate baby after all candidate checkpoints",
+        )
+        if ok:
+            self.next_batch_size = self.batch_size
+            agent_trace.append_to(
+                self._trace_path(),
+                (
+                    f"{time.strftime('%H:%M:%S')} INFO  "
+                    "Candidate buffer empty; promoted baby -> main.\n"
+                ),
+            )
+        else:
+            logger.warning(
+                "SkillEdit baby checkpoints complete but graduation failed: %s",
+                self.skill_dir.name,
+            )
+        return ok
+
+    def _run_baby_until_empty(self) -> bool:
+        """Drain baby candidates via durable per-batch commits, then graduate."""
+        current_n = self.retry_batch_size or self.batch_size
+        current_n = max(1, min(int(current_n), self.batch_size))
+        self.next_batch_size = current_n
+
+        while True:
+            data = C.load_candidates(self.skill_dir)
+            candidates = list(data.get("candidates", []) or [])
+            if not candidates:
+                return self._graduate_completed_baby()
+
+            pending = len(candidates)
+            batch = self._take_baby_batch(candidates, current_n)
+            batch_ids = [
+                str(candidate["atom_id"])
+                for candidate in batch
+                if candidate.get("atom_id")
+            ]
+            if not batch_ids:
+                logger.warning(
+                    "SkillEdit baby candidate batch has no atom_id: %s",
+                    self.skill_dir.name,
+                )
+                return False
+
+            self._append_turn_start(current_n, len(batch_ids), pending)
+            committed, remaining = self._run_baby_batch(
+                batch,
+                batch_ids=batch_ids,
+                n=current_n,
+            )
+            if committed:
+                self.next_batch_size = self.batch_size
+                self._append_turn_end(
+                    "COMMITTED",
+                    consumed=len(batch_ids),
+                    remaining=remaining,
+                    next_n=self.batch_size,
+                )
+                current_n = self.batch_size
+                continue
+
+            next_n = max(1, current_n // 2)
+            self.next_batch_size = next_n
+            from xskill.agents import agent_trace
+            agent_trace.append_to(
+                self._trace_path(),
+                (
+                    f"{time.strftime('%H:%M:%S')} INFO  "
+                    f"Retry batch reduced: {current_n} -> {next_n}\n"
+                ),
+            )
+            self._append_turn_end(
+                "FAILED",
+                consumed=0,
+                remaining=remaining,
+                next_n=next_n,
+            )
+            if current_n == 1:
+                return False
+            current_n = next_n
+
+    @staticmethod
+    def _take_baby_batch(candidates: list[dict], n: int) -> list[dict]:
+        """Take at most N candidates in stable YAML insertion (FIFO) order."""
+        return candidates[:min(max(1, int(n)), len(candidates))]
+
+    def _run_baby_batch(
+        self,
+        batch: list[dict],
+        *,
+        batch_ids: list[str],
+        n: int,
+    ) -> tuple[bool, int]:
+        """Run one baby turn and verify the durable checkpoint, not run() return."""
+        from xskill.agents import agent_tools
+        from xskill.skill.git import run_git
+
+        before_code, before_out, _ = run_git(
+            ["rev-parse", "HEAD"],
+            cwd=str(self.skill_dir),
+        )
+        before_sha = before_out.strip() if before_code == 0 else ""
+        run_error: Exception | None = None
+        try:
+            with agent_tools.use_skill_edit_batch(
+                self.skill_dir.name,
+                batch_ids,
+            ):
+                self._run_normal_round(
+                    batch,
+                    current_branch_name="baby",
+                    turn_idx=1,
+                    num_batches=1,
+                    is_last=True,
+                )
+        except Exception as error:  # noqa: BLE001
+            run_error = error
+            logger.warning(
+                "SkillEdit baby turn failed for %s (N=%d): %s",
+                self.skill_dir.name,
+                n,
+                error,
+            )
+
+        after_code, after_out, _ = run_git(
+            ["rev-parse", "HEAD"],
+            cwd=str(self.skill_dir),
+        )
+        after_sha = after_out.strip() if after_code == 0 else ""
+        try:
+            remaining_candidates = list(
+                C.load_candidates(self.skill_dir).get("candidates", []) or []
+            )
+        except Exception:
+            logger.exception(
+                "failed to reload candidates after baby turn: %s",
+                self.skill_dir.name,
+            )
+            remaining_candidates = []
+            remaining_ids = set(batch_ids)
+        else:
+            remaining_ids = {
+                str(candidate.get("atom_id"))
+                for candidate in remaining_candidates
+                if candidate.get("atom_id")
+            }
+        checkpointed = bool(
+            before_sha
+            and after_sha
+            and before_sha != after_sha
+            and not (set(batch_ids) & remaining_ids)
+        )
+        self._reset_baby_worktree()
+        if checkpointed:
+            if run_error is not None:
+                logger.info(
+                    "SkillEdit baby turn raised after durable checkpoint; "
+                    "treating as success: %s",
+                    self.skill_dir.name,
+                )
+            return True, len(remaining_candidates)
+        return False, len(remaining_candidates)
+
     def _main_has_ux_score(self) -> bool:
         """检查该 skill 的 .ux_scores.jsonl 是否有至少 1 条 side=main 记录。
 
@@ -607,20 +883,17 @@ class SkillEditAgent:
             )
         return ["", note]
 
-    def _trace_run(self, agent: Any, user_msg: str, *, log_suffix: str) -> None:
-        """跑一轮 agent.run() 并把逐轮 CoT/工具调用记到
-        logs/agents/skill_edit_agents/skills/<skill><suffix>_<ts>.log。"""
-        import time as _time
+    def _trace_run(self, agent: Any, user_msg: str) -> None:
+        """Append one agent.run() to the skill's single human-readable trace."""
         from xskill.agents.agent_trace import trace_to
 
-        _ts = _time.strftime("%Y%m%d-%H%M%S")
-        sink = (
-            self.logs_dir / "agents" / "skill_edit_agents" / "skills"
-            / f"{self.skill_dir.name}{log_suffix}_{_ts}.log"
-            if self.logs_dir is not None
-            else None
-        )
-        with trace_to(sink):
+        spill_limit, compact_limit = self._trace_limits()
+        with trace_to(
+            self._trace_path(),
+            append=True,
+            spill_token_limit=spill_limit,
+            compact_token_limit=compact_limit,
+        ):
             agent.run(user_msg)
 
     # ───────────────────────────────────────────────────────────────
@@ -741,8 +1014,7 @@ class SkillEditAgent:
             tools.append(agent_tools.commit_update_main)
 
         agent = self.agno_agent_factory(instructions=[sysprompt], tools=tools)
-        suffix = "_jam" if num_batches <= 1 else f"_jam_turn{turn_idx}"
-        self._trace_run(agent, scenario_block, log_suffix=suffix)
+        self._trace_run(agent, scenario_block)
 
     def _run_normal_round(
         self, batch: list[dict], *, current_branch_name: str,
@@ -758,16 +1030,12 @@ class SkillEditAgent:
                 "skill_name: " + self.skill_dir.name + "（**baby 分支**——首次出版本）"
             )
             scenario_lines.extend(self._round_info_lines(turn_idx, num_batches))
-            if is_last:
-                scenario_lines.append(
-                    "写完 SKILL.md 后调 ``commit_baby_to_main(skill_name, message)`` "
-                    "graduate 到 main 分支。"
-                )
-            else:
-                scenario_lines.append(
-                    "本轮没有提供任何 commit 工具——分支推进由系统在全部批次渐进式"
-                    "消化完成后自动处理，你只需要把本轮候选编辑进 SKILL.md。"
-                )
+            scenario_lines.append(
+                "本轮只处理下面这批候选。写完后必须调 "
+                "``commit_baby(skill_name, message)``：它会 checkpoint 当前改动"
+                "并消费系统绑定的 atom_id，但保持在 baby；buffer 清空后由框架"
+                "自动 graduate 到 main。"
+            )
         else:
             scenario_lines.append(
                 "skill_name: " + self.skill_dir.name + "（**main 分支** —— 更新现有 skill）"
@@ -828,10 +1096,9 @@ class SkillEditAgent:
         ]
         if is_last:
             if current_branch_name == "baby":
-                tools.append(agent_tools.commit_baby_to_main)
+                tools.append(agent_tools.commit_baby)
             else:
                 tools.append(agent_tools.commit_to_staging)
 
         agent = self.agno_agent_factory(instructions=[sysprompt], tools=tools)
-        suffix = "" if num_batches <= 1 else f"_turn{turn_idx}"
-        self._trace_run(agent, user_msg, log_suffix=suffix)
+        self._trace_run(agent, user_msg)

--- a/src/xskill/config.py
+++ b/src/xskill/config.py
@@ -31,7 +31,7 @@ _overrides: dict = {}
 DEFAULT_AGENT_WORKER_POOLS = {
     "split": {"workers": 24, "llm_weight": 6},
     "cluster": {"workers": 8, "batch_size": 8, "llm_weight": 3},
-    "edit": {"workers": 4, "llm_weight": 1},
+    "edit": {"workers": 4, "batch_size": 5, "llm_weight": 1},
     "embed": {"workers": 4},
 }
 DEFAULT_LLM_RATE_LIMIT = {
@@ -83,7 +83,9 @@ llm:
   # compact_token_limit: 120000  # optional; after trimming/spilling old tool
                          # results, if the estimated history is still above this
                          # limit, ask the same chat model to summarize old
-                         # SkillEditAgent memory. Leave commented to disable.
+                         # SkillEditAgent memory. The effective limit is never
+                         # below spill@ (85% of max_context), so spill always
+                         # runs first. Leave commented to disable.
   # compact_keep_recent_messages: 6 # optional; recent complete message blocks
                          # kept verbatim after compact. Default 6.
   # temperature: 0.0     # optional; default 0 (deterministic)
@@ -208,6 +210,7 @@ agent_worker:
       llm_weight: 3
     edit:
       workers: 4
+      batch_size: 5
       llm_weight: 1
     embed:
       workers: 4
@@ -367,6 +370,10 @@ def normalize_runtime_config(config_data: dict) -> dict:
     normalized_pools["cluster"]["batch_size"] = _positive_int(
         cluster_batch_size,
         "agent_worker.pools.cluster.batch_size",
+    )
+    normalized_pools["edit"]["batch_size"] = _positive_int(
+        normalized_pools["edit"].get("batch_size"),
+        "agent_worker.pools.edit.batch_size",
     )
     worker = dict(worker)
     worker["pools"] = normalized_pools

--- a/src/xskill/pipeline/runner.py
+++ b/src/xskill/pipeline/runner.py
@@ -158,11 +158,14 @@ class DirectoryWatcher:
         default_pools = {
             "split": {"workers": 24, "llm_weight": 6},
             "cluster": {"workers": 8, "batch_size": 8, "llm_weight": 3},
-            "edit": {"workers": 4, "llm_weight": 1},
+            "edit": {"workers": 4, "batch_size": 5, "llm_weight": 1},
             "embed": {"workers": 4},
         }
         self.pool_config = pool_config or default_pools
         self.cluster_batch_size = int(self.pool_config["cluster"]["batch_size"])
+        self.skill_edit_batch_size = int(
+            self.pool_config["edit"].get("batch_size", 5)
+        )
         self.interests = interests_config(self.config)
         self.interest_fingerprint = interests_fingerprint(self.interests)
 
@@ -185,6 +188,10 @@ class DirectoryWatcher:
         self.pending_atoms: deque[str] = deque()
         self.claimed_atoms: set[str] = set()
         self.cluster_futures: set[Future] = set()
+        # SkillEdit baby 消化失败到 N=1 时释放 worker；下一轮 watcher 从 1
+        # 继续，成功 checkpoint 后由 agent 自动恢复配置默认值。仅驻留内存，
+        # 进程重启后自然回到配置值。
+        self._skill_edit_retry_batch_sizes: dict[Path, int] = {}
         self._last_poll: float | None = None
         self._started_at = time.time()
         # 单机 canary 轮转节流：上次真跑 _reconcile_skill_sides 的时间戳。
@@ -505,6 +512,16 @@ class DirectoryWatcher:
 
         jam_threshold = CanaryConfig.from_dict(
             self.config.get("canary", {})).jam_threshold
+        base_llm_cfg = self.config.get("llm", {}) or {}
+        skill_llm_override = self.config.get("llm_skill", {}) or {}
+        skill_llm_cfg = {
+            **base_llm_cfg,
+            **{
+                key: value
+                for key, value in skill_llm_override.items()
+                if value not in (None, "")
+            },
+        }
 
         def _run_one(d):
             """在 pool 工作线程里跑单个 skill 的 maybe_run；返回 (d, promoted)。
@@ -513,17 +530,28 @@ class DirectoryWatcher:
                 editor = SkillEditAgent(
                     skill_dir=d, store=store,
                     agno_agent_factory=factory,
-                    llm_cfg=self.config.get("llm", {}),
+                    llm_cfg=skill_llm_cfg,
                     traj_root=traj_root,
                     logs_dir=self.logs_dir,
                     jam_threshold=jam_threshold,
+                    batch_size=self.skill_edit_batch_size,
+                    retry_batch_size=self._skill_edit_retry_batch_sizes.get(d),
                     **({} if threshold is None else {"threshold": threshold}),
                 )
                 try:
-                    return d, bool(editor.maybe_run())
+                    promoted = bool(editor.maybe_run())
+                    return d, promoted, getattr(
+                        editor,
+                        "next_batch_size",
+                        self.skill_edit_batch_size,
+                    )
                 except Exception:
                     logger.exception("SkillEditAgent failed: %s", d.name)
-                    return d, False
+                    return d, False, getattr(
+                        editor,
+                        "next_batch_size",
+                        self.skill_edit_batch_size,
+                    )
 
         skill_edit_in_flight = {
             info.get("skill_dir") for info in self._futures.values()
@@ -540,7 +568,11 @@ class DirectoryWatcher:
     def _on_skill_edit_done(self, result) -> None:
         """``_harvest`` 收割 stage="skill_edit" future 用：_stats 自增 + 即时
         install。回主线程串行做（避免对无锁的 self._stats 并发自增）。"""
-        d, ok = result
+        d, ok, next_batch_size = result
+        if ok or next_batch_size == self.skill_edit_batch_size:
+            self._skill_edit_retry_batch_sizes.pop(d, None)
+        else:
+            self._skill_edit_retry_batch_sizes[d] = next_batch_size
         if not ok:
             return
         self._stats["skills_edited"] += 1

--- a/src/xskill/skill/candidates.py
+++ b/src/xskill/skill/candidates.py
@@ -43,11 +43,9 @@ FUZZY_PREFIX = 60
 # 单 atom 给 10 分立即触发——cluster agent 的提示词鼓励"非常确信时打高分"。
 ATOM_PROMOTION_THRESHOLD = 10
 
-# SkillEditAgent 单轮最多消化的候选数。buffer 攒满阈值时可能已经堆到几十上百
-# 条（xskill rebuild --force 重放全部历史 / 团队突然活跃），一次性塞进单个
-# agent.run() 会话会让证据读取/compact 无限拉长，且整条流水线扫描循环会被
-# 这一个技能的整理过程卡死。超过这个数就切成多批，每批一轮独立的 agent 会话，
-# 轮与轮之间用 git turn 分支承接进度（见 skill_edit_agent.py）。
+# main→staging / jam 旧渐进链的单轮候选数。baby 冷启动不再使用这个常量：
+# 它从 ``agent_worker.pools.edit.batch_size`` 读取 N（默认 5），每 N 个候选
+# 直接 checkpoint 到 baby 并立即消费。
 SKILL_EDIT_BATCH_SIZE = 20
 
 
@@ -351,25 +349,34 @@ def clear_candidates(skill_dir: Path) -> None:
         )
 
 
-def remove_candidates(skill_dir: Path, atom_ids: set[str]) -> None:
+def remove_candidates(
+    skill_dir: Path,
+    atom_ids: set[str],
+) -> tuple[list[str], int]:
     """按 atom_id 集合从 buffer 中摘除条目,其余原样保留。
 
-    SkillEditAgent 多轮渐进式消化用：只摘除本次 maybe_run 开始时快照到的
-    atom_id,消化期间 cluster 并发 add 进来的新候选不受影响,留给下一次
-    maybe_run 处理。取代 ``clear_candidates`` 的整文件清空——那样会把消化
-    期间新增的候选一并静默丢掉。
+    返回 ``(实际摘除的 atom_id（按文件顺序）, 剩余条数)``。返回值供
+    ``commit_baby`` 把本轮真实消费证据写入 SkillEdit trace；旧调用方可以
+    继续忽略返回值。
     """
     with skill_repo_lock(skill_dir, use_git_write_limit=False):
         data = _load_candidates_unlocked(skill_dir)
+        candidates = data.get("candidates", []) or []
+        consumed = [
+            str(candidate.get("atom_id"))
+            for candidate in candidates
+            if candidate.get("atom_id") in atom_ids
+        ]
         remaining = [
             candidate
-            for candidate in data.get("candidates", []) or []
+            for candidate in candidates
             if candidate.get("atom_id") not in atom_ids
         ]
         _atomic_save_candidates_unlocked(
             skill_dir,
             {**data, "candidates": remaining},
         )
+        return consumed, len(remaining)
 
 
 def move_atom_contribution(

--- a/src/xskill/skill/candidates.py
+++ b/src/xskill/skill/candidates.py
@@ -361,7 +361,7 @@ def remove_candidates(
     """
     with skill_repo_lock(skill_dir, use_git_write_limit=False):
         data = _load_candidates_unlocked(skill_dir)
-        candidates = data.get("candidates", []) or []
+        candidates = data.get("candidates") or []
         consumed = [
             str(candidate.get("atom_id"))
             for candidate in candidates

--- a/src/xskill/skill/git.py
+++ b/src/xskill/skill/git.py
@@ -1845,6 +1845,37 @@ def commit_baby_to_main_branch(skill_dir: str, message: str) -> bool:
     return True
 
 
+def commit_baby_checkpoint(skill_dir: str, message: str) -> str | None:
+    """Commit one non-empty SkillEdit batch on ``baby`` without renaming it.
+
+    Returns the full commit SHA on success.  ``None`` means the branch was not
+    baby, the worktree had no real change, or the commit failed.  Candidate
+    removal intentionally lives in the caller so it can share one outer
+    ``skill_repo_lock`` transaction with this Git mutation.
+    """
+    with skill_repo_lock(skill_dir):
+        with _open_repo(skill_dir) as repo:
+            cur = _current_branch_name(repo)
+            if cur != "baby":
+                logger.warning(
+                    "commit_baby_checkpoint 拒绝：当前不在 baby (在 %s)", cur,
+                )
+                return None
+            _stage_all(repo, Path(skill_dir))
+            sha, err = _do_commit(repo, message)
+            if sha is None:
+                logger.warning("baby checkpoint commit 失败: %s", err)
+                return None
+    full_sha = sha.decode("ascii", errors="strict")
+    logger.info(
+        "🌱 baby checkpoint: %s %s: %s",
+        Path(skill_dir).name,
+        full_sha[:7],
+        message,
+    )
+    return full_sha
+
+
 def commit_to_staging_branch(skill_dir: str, message: str) -> bool:
     """SkillEditAgent 调用：从 main 切 staging 分支并提交灰度候选。
 

--- a/tests/bdd/README.md
+++ b/tests/bdd/README.md
@@ -1,0 +1,50 @@
+# SkillEdit BDD specifications
+
+本目录先保存可由产品、开发和测试共同审阅的 Gherkin 规格。
+当前阶段只定义行为，不绑定 pytest step definitions，也不引入测试依赖。
+
+## 主用户成功路径
+
+主成功路径是：
+
+`baby_cold_start_golden_path.feature`
+中的 `用户等待系统把新知识整理成可用的 main skill`。
+
+它从 watcher 调度已经达到冷启动条件的 baby 开始，经过真实的
+OpenAI-compatible HTTP 模型边界、两次分批编辑和 checkpoint，最终得到：
+
+- 所有原子按 FIFO 顺序且只被消费一次；
+- 每批改动都有可恢复的 baby commit；
+- `candidates.yaml` 被消费为空；
+- baby 由框架晋升为 main；
+- main 中包含所有批次贡献的知识。
+
+## 测试层次
+
+这些规格后续分成两种执行层：
+
+1. `@http_llm` 场景使用真实 Agno/OpenAI 客户端，模型地址指向本地
+   `ai-mocks`，验证请求、tool call、工具执行和后续模型轮次的完整 HTTP 边界。
+2. `@state_machine` 场景使用进程内的确定性模型脚本，快速验证批次缩减、
+   checkpoint 判定和重启恢复，供日常 pytest 与 mutation testing 重复执行。
+
+Mutation testing 不会为每个 mutant 启动 JVM 或容器。它复用快速的
+`@state_machine` 测试杀死状态机 mutant；`@http_llm` 负责证明真实协议集成没有
+被测试替身掩盖。
+
+## 依赖边界
+
+BDD、mutation testing 和 `ai-mocks` 都只属于测试环境：
+
+- 不加入 `[project].dependencies`；
+- 不会被 `pip install xskill` 安装；
+- `pytest-bdd` 与 `mutmut` 后续放入测试专用依赖组；
+- `ai-mocks` 由测试 fixture 或 CI sidecar 启动，不进入 xskill wheel。
+
+## 标签
+
+- `@primary`：主用户成功路径。
+- `@http_llm`：经过本地 OpenAI-compatible HTTP 后端。
+- `@state_machine`：快速、确定性的状态机测试。
+- `@recovery`：429、上下文超长、进程重启等恢复路径。
+- `@observability`：面向操作者的 SkillEdit trace。

--- a/tests/bdd/README.md
+++ b/tests/bdd/README.md
@@ -1,7 +1,8 @@
 # SkillEdit BDD specifications
 
-本目录先保存可由产品、开发和测试共同审阅的 Gherkin 规格。
-当前阶段只定义行为，不绑定 pytest step definitions，也不引入测试依赖。
+本目录保存可由产品、开发和测试共同审阅的 Gherkin 规格，以及 11 个场景的
+pytest-bdd step definitions。HTTP 场景由本地 `aimock` 驱动，测试不会访问真实
+模型服务。
 
 ## 主用户成功路径
 
@@ -21,25 +22,50 @@ OpenAI-compatible HTTP 模型边界、两次分批编辑和 checkpoint，最终�
 
 ## 测试层次
 
-这些规格后续分成两种执行层：
+这些规格分成两种执行层：
 
 1. `@http_llm` 场景使用真实 Agno/OpenAI 客户端，模型地址指向本地
-   `ai-mocks`，验证请求、tool call、工具执行和后续模型轮次的完整 HTTP 边界。
+   `aimock`，验证请求、tool call、工具执行和后续模型轮次的完整 HTTP 边界。
 2. `@state_machine` 场景使用进程内的确定性模型脚本，快速验证批次缩减、
    checkpoint 判定和重启恢复，供日常 pytest 与 mutation testing 重复执行。
 
-Mutation testing 不会为每个 mutant 启动 JVM 或容器。它复用快速的
+Mutation testing 不会为每个 mutant 启动 Node.js sidecar。它复用快速的
 `@state_machine` 测试杀死状态机 mutant；`@http_llm` 负责证明真实协议集成没有
 被测试替身掩盖。
 
 ## 依赖边界
 
-BDD、mutation testing 和 `ai-mocks` 都只属于测试环境：
+BDD、mutation testing 和 `aimock` 都只属于测试环境：
 
 - 不加入 `[project].dependencies`；
 - 不会被 `pip install xskill` 安装；
-- `pytest-bdd` 与 `mutmut` 后续放入测试专用依赖组；
-- `ai-mocks` 由测试 fixture 或 CI sidecar 启动，不进入 xskill wheel。
+- `pytest-bdd`、`mutmut` 和 `aimock-pytest` 位于 `dev` extra；
+- `aimock-pytest` 自动下载固定版本的 `@copilotkit/aimock`，在随机本地端口
+  启停 Node.js 子进程，不进入 xskill wheel；
+- `aimock` 要求 Node.js 20.15+，仅 `@http_llm` 测试需要。
+
+## 执行
+
+主成功路径默认显式 opt-in，避免普通单测矩阵在每个 Python/OS 组合都启动
+HTTP sidecar：
+
+```bash
+XSKILL_AIMOCK_E2E=1 pytest tests/bdd/test_skill_edit_golden_path.py -v
+```
+
+CI 中有独立的 `skill-edit-bdd` job 执行该命令。普通 `pytest` 仍运行快速的
+状态机单测；mutmut 也只选择这些进程内测试。
+
+聚焦执行 candidate 消费与 baby 晋升两个耐久边界的 mutation testing：
+
+```bash
+mutmut run --max-children 8 \
+  '*remove_candidates__mutmut_*' \
+  '*graduate_baby_to_main__mutmut_*'
+```
+
+`mutants/` 是本地生成目录，已加入 `.gitignore`。mutmut 配置只选择进程内 BDD
+和 candidate 精确消费测试，不会启动 aimock。
 
 ## 标签
 

--- a/tests/bdd/features/skill_edit/baby_cold_start_golden_path.feature
+++ b/tests/bdd/features/skill_edit/baby_cold_start_golden_path.feature
@@ -1,0 +1,42 @@
+Feature: 用户在冷启动后获得完整可用的 main skill
+  新采集的原子知识先进入 baby 的 candidates 队列。
+  用户不需要手工合并分支，也不需要在任务失败后重新提交已经处理的原子。
+  系统应当持续编辑 baby，并在所有原子都形成可恢复提交后将它晋升为 main。
+
+  Background:
+    Given xskill 使用隔离的测试目录
+    And SkillEdit 每批最多处理 5 个原子
+    And SkillEdit 模型指向本地 OpenAI-compatible 测试后端
+
+  @primary @golden_path @http_llm
+  Scenario: 用户等待系统把新知识整理成可用的 main skill
+    Given cluster 已经创建名为 "incident-recovery" 的 baby skill
+    And baby 的 candidates 按以下顺序保存
+      | atom_id | knowledge                                      |
+      | atom-01 | 检查服务进程是否存在                           |
+      | atom-02 | 检查监听端口是否存在                           |
+      | atom-03 | 检查反向代理的 upstream 配置                   |
+      | atom-04 | 对比进程端口和 upstream 端口                   |
+      | atom-05 | 恢复服务后先执行本地健康检查                   |
+      | atom-06 | 最后从代理入口验证请求                         |
+      | atom-07 | 把恢复结果和失败原因写入操作记录               |
+    And candidates 的总权重已经达到 baby 冷启动阈值
+    And 测试模型会根据每批原子更新 SKILL.md 并调用 commit_baby
+    When watcher 调度这个 baby 的 SkillEdit 工作
+    Then 模型应当收到 2 个互相独立的编辑 turn
+    And 第 1 个 turn 应当只包含 "atom-01,atom-02,atom-03,atom-04,atom-05"
+    And 第 2 个 turn 应当只包含 "atom-06,atom-07"
+    And 每个 turn 都应当在 baby 上产生一个非空 checkpoint commit
+    And 每次 commit 只应当删除当前 turn 绑定的 atom_id
+    And candidates 最终应当为空
+    And 框架应当把 baby 晋升为 main
+    And main 的 SKILL.md 应当包含 7 个原子贡献的恢复流程
+
+  @state_machine
+  Scenario: 新原子在编辑过程中到达时不会破坏当前批次边界
+    Given baby 当前有 5 个已经绑定到本 turn 的原子
+    And cluster 在模型编辑期间追加了 1 个新原子
+    When 模型提交当前 baby checkpoint
+    Then 当前 commit 只应当消费原先绑定的 5 个原子
+    And 新原子应当留给下一个 turn
+    And 下一个 turn 成功后 baby 才能晋升为 main

--- a/tests/bdd/features/skill_edit/baby_cold_start_golden_path.feature
+++ b/tests/bdd/features/skill_edit/baby_cold_start_golden_path.feature
@@ -6,10 +6,10 @@ Feature: 用户在冷启动后获得完整可用的 main skill
   Background:
     Given xskill 使用隔离的测试目录
     And SkillEdit 每批最多处理 5 个原子
-    And SkillEdit 模型指向本地 OpenAI-compatible 测试后端
 
   @primary @golden_path @http_llm
   Scenario: 用户等待系统把新知识整理成可用的 main skill
+    Given SkillEdit 模型指向本地 OpenAI-compatible 测试后端
     Given cluster 已经创建名为 "incident-recovery" 的 baby skill
     And baby 的 candidates 按以下顺序保存
       | atom_id | knowledge                                      |

--- a/tests/bdd/features/skill_edit/baby_cold_start_recovery.feature
+++ b/tests/bdd/features/skill_edit/baby_cold_start_recovery.feature
@@ -1,0 +1,48 @@
+Feature: baby 冷启动可以从模型失败和进程中断中恢复
+  已经形成 checkpoint 的工作不应重放。
+  尚未形成 checkpoint 的工作不应丢失。
+
+  Background:
+    Given SkillEdit 默认每批处理 5 个原子
+    And baby 的 candidates 使用稳定的 FIFO 顺序
+
+  @recovery @state_machine
+  Scenario: 连续失败时缩小当前批次，成功后恢复默认批次
+    Given baby 中按顺序存在 5 个原子
+    And N=5 的第一次尝试因 429 失败
+    And N=2 的第二次尝试因上下文超长失败
+    When N=1 的第三次尝试成功提交 checkpoint
+    Then 三次尝试处理的 atom_id 都应当从 FIFO 队首开始
+    And 前两次失败不应当消费任何原子
+    And 第三次只应当消费 1 个原子
+    And 剩余 4 个原子的下一次成功尝试应当使用默认 N=5
+
+  @recovery @http_llm
+  Scenario: commit 完成后的模型 429 不会导致原子被再次处理
+    Given 模型已经调用 commit_baby 并成功提交当前批次
+    And commit_baby 已经从 candidates 删除当前批次 atom_id
+    And ai-mocks 在模型的结束响应阶段返回 HTTP 429
+    When SkillEditAgent 检查 baby HEAD 和剩余 candidates
+    Then 当前 turn 应当被判定为成功
+    And 当前批次不应当再次发送给模型
+    And 下一个 turn 应当从第一个未消费 atom_id 开始
+
+  @recovery @state_machine
+  Scenario: 进程在多个 checkpoint 之间重启
+    Given baby 最初有 6 个原子
+    And 第一个进程已经提交并消费前 5 个原子
+    And 第一个进程在晋升 main 之前退出
+    When watcher 在新进程中再次调度这个 baby
+    Then 新进程只应当把最后 1 个原子发送给模型
+    And 已提交的前 5 个原子不应当重放
+    And 最后 1 个原子成功后 baby 应当晋升为 main
+
+  @recovery @state_machine
+  Scenario: N=1 仍失败时把工作留给下一次 watcher 调度
+    Given baby 中只剩 1 个原子
+    And 当前重试批次已经降为 N=1
+    When 模型仍然因为上下文超长而失败
+    Then SkillEdit 工作应当结束并释放 worker
+    And baby 应当继续停留在 baby 分支
+    And 最后 1 个原子应当保留在 candidates
+    And watcher 下次调度时仍应当从 N=1 开始

--- a/tests/bdd/features/skill_edit/baby_cold_start_recovery.feature
+++ b/tests/bdd/features/skill_edit/baby_cold_start_recovery.feature
@@ -21,7 +21,7 @@ Feature: baby 冷启动可以从模型失败和进程中断中恢复
   Scenario: commit 完成后的模型 429 不会导致原子被再次处理
     Given 模型已经调用 commit_baby 并成功提交当前批次
     And commit_baby 已经从 candidates 删除当前批次 atom_id
-    And ai-mocks 在模型的结束响应阶段返回 HTTP 429
+    And aimock 在模型的结束响应阶段返回 HTTP 429
     When SkillEditAgent 检查 baby HEAD 和剩余 candidates
     Then 当前 turn 应当被判定为成功
     And 当前批次不应当再次发送给模型

--- a/tests/bdd/features/skill_edit/skill_edit_llm_backend.feature
+++ b/tests/bdd/features/skill_edit/skill_edit_llm_backend.feature
@@ -1,0 +1,43 @@
+Feature: SkillEdit 通过可控的本地模型后端执行真实工具调用
+  BDD 不应把 SkillEditAgent 替换成一个直接修改文件的假对象。
+  至少主成功路径必须经过生产使用的 Agno/OpenAI 客户端和 HTTP 协议，
+  同时不能访问公网或依赖真实模型账号。
+
+  Background:
+    Given ai-mocks 在随机本地端口启动 OpenAI-compatible 服务
+    And xskill 的 llm.base_url 指向该服务
+    And xskill 使用无权限的测试 API key
+
+  @http_llm @contract
+  Scenario: 模型通过 OpenAI tool calls 完成一次 baby checkpoint
+    Given 一个 SkillEdit turn 绑定了 5 个 atom_id
+    And ai-mocks 为这个 turn 准备了以下响应
+      | response | behavior                                      |
+      | first    | 调用 write_file 更新目标 SKILL.md             |
+      | second   | 收到 write_file 结果后调用 commit_baby         |
+      | third    | 收到 commit_baby 结果后结束模型 turn           |
+    When SkillEdit 使用生产 Agno factory 执行这个 turn
+    Then ai-mocks 应当收到真实的 POST /v1/chat/completions 请求
+    And 第一次请求应当声明 write_file 和 commit_baby 工具
+    And 第二次请求应当包含 write_file 的 tool result
+    And 第三次请求应当包含 commit_baby 的 tool result
+    And atom_id 不应当由模型作为 commit_baby 参数提供
+    And commit_baby 应当从框架绑定的批次取得 atom_id
+
+  @http_llm @contract
+  Scenario: 测试运行期间没有请求离开本机
+    Given 主成功路径已经执行完成
+    When 检查测试后端的 request journal
+    Then 所有模型请求都应当发送到 ai-mocks
+    And 请求不应当包含生产 API key
+    And 测试不应当访问任何公共模型 endpoint
+
+  @http_llm @recovery
+  Scenario: 模型后端持续返回 429 时当前批次不会被误提交
+    Given 当前 turn 的 N 为 5
+    And ai-mocks 对模型请求返回 HTTP 429 和 Retry-After
+    And 模型客户端已经耗尽该 turn 内部的有限重试
+    When SkillEditAgent 收到模型调用失败
+    Then baby 的 HEAD 不应当前进
+    And 当前 5 个 atom_id 不应当从 candidates 删除
+    And 下一次尝试的 N 应当变为 2

--- a/tests/bdd/features/skill_edit/skill_edit_llm_backend.feature
+++ b/tests/bdd/features/skill_edit/skill_edit_llm_backend.feature
@@ -4,20 +4,20 @@ Feature: SkillEdit 通过可控的本地模型后端执行真实工具调用
   同时不能访问公网或依赖真实模型账号。
 
   Background:
-    Given ai-mocks 在随机本地端口启动 OpenAI-compatible 服务
+    Given aimock 在随机本地端口启动 OpenAI-compatible 服务
     And xskill 的 llm.base_url 指向该服务
     And xskill 使用无权限的测试 API key
 
   @http_llm @contract
   Scenario: 模型通过 OpenAI tool calls 完成一次 baby checkpoint
     Given 一个 SkillEdit turn 绑定了 5 个 atom_id
-    And ai-mocks 为这个 turn 准备了以下响应
+    And aimock 为这个 turn 准备了以下响应
       | response | behavior                                      |
       | first    | 调用 write_file 更新目标 SKILL.md             |
       | second   | 收到 write_file 结果后调用 commit_baby         |
       | third    | 收到 commit_baby 结果后结束模型 turn           |
     When SkillEdit 使用生产 Agno factory 执行这个 turn
-    Then ai-mocks 应当收到真实的 POST /v1/chat/completions 请求
+    Then aimock 应当收到真实的 POST /v1/chat/completions 请求
     And 第一次请求应当声明 write_file 和 commit_baby 工具
     And 第二次请求应当包含 write_file 的 tool result
     And 第三次请求应当包含 commit_baby 的 tool result
@@ -28,16 +28,17 @@ Feature: SkillEdit 通过可控的本地模型后端执行真实工具调用
   Scenario: 测试运行期间没有请求离开本机
     Given 主成功路径已经执行完成
     When 检查测试后端的 request journal
-    Then 所有模型请求都应当发送到 ai-mocks
+    Then 所有模型请求都应当发送到 aimock
     And 请求不应当包含生产 API key
     And 测试不应当访问任何公共模型 endpoint
 
   @http_llm @recovery
   Scenario: 模型后端持续返回 429 时当前批次不会被误提交
     Given 当前 turn 的 N 为 5
-    And ai-mocks 对模型请求返回 HTTP 429 和 Retry-After
+    And aimock 对模型请求返回 HTTP 429 和 Retry-After
     And 模型客户端已经耗尽该 turn 内部的有限重试
     When SkillEditAgent 收到模型调用失败
     Then baby 的 HEAD 不应当前进
     And 当前 5 个 atom_id 不应当从 candidates 删除
-    And 下一次尝试的 N 应当变为 2
+    And 本次调度应当依次尝试 N=5、N=2、N=1
+    And watcher 下次调度时应当继续使用 N=1

--- a/tests/bdd/features/skill_edit/skill_edit_trace.feature
+++ b/tests/bdd/features/skill_edit/skill_edit_trace.feature
@@ -1,0 +1,32 @@
+Feature: 操作者可以从一份 SkillEdit trace 解释整个冷启动过程
+  当模型失败、spill 或 compact 发生时，操作者不应依赖原始 JSON 猜测状态。
+  同一个 skill 的所有 turn 应当追加到同一个可读日志文件。
+
+  Background:
+    Given SkillEdit 已为目标 skill 创建唯一的追加日志
+    And 日志不记录原始 tool call JSON
+
+  @observability @state_machine
+  Scenario: 成功的多批次冷启动可以从日志完整复盘
+    Given baby 中存在 7 个原子
+    And 默认批次大小 N=5
+    When 两个 turn 分别成功提交 5 个和 2 个原子
+    Then 日志应当包含两个显著的 TURN START 分隔
+    And 每个 TURN START 应当显示当次 N 和待处理数量
+    And 每个 round 应当显示当前 token、spill 上限和 compact 上限
+    And 工具摘要应当显示 commit_baby 消费的 atom_id
+    And 每个 turn 应当显示已消费数量、剩余数量和下一次 N
+    And 日志不应当包含原始 JSON 对象
+
+  @observability @recovery @state_machine
+  Scenario: 失败缩批和上下文处理顺序可以从日志确认
+    Given 当前 turn 从 N=5 开始
+    And 模型第一次调用触发上下文压力
+    And spill 后仍然超过 compact 上限
+    And 本次模型调用最终因 429 失败
+    When SkillEdit 把当前工作缩小到 N=2 后重试
+    Then 日志中 spill 事件应当出现在 compact 事件之前
+    And 日志应当显示 compact 前后的 token 数量
+    And 日志应当显示模型调用失败的可读原因
+    And 日志应当显示 "Retry batch reduced: 5 -> 2"
+    And 下一次 TURN START 应当显示 N=2

--- a/tests/bdd/test_skill_edit_golden_path.py
+++ b/tests/bdd/test_skill_edit_golden_path.py
@@ -1,0 +1,890 @@
+"""Executable BDD for the Issue #146 primary user journey.
+
+This test deliberately keeps the production boundary intact:
+
+DirectoryWatcher -> SkillEditAgent -> Agno/OpenAI client -> HTTP -> aimock
+                 -> tool call -> xskill tool implementation -> git/candidates
+
+Only the remote model is replaced.  The agent, tool schemas, tool execution,
+candidate consumption, git checkpoints, and framework-controlled graduation
+are production code.
+"""
+
+from __future__ import annotations
+
+import os
+import re
+from dataclasses import dataclass, field
+from pathlib import Path
+from typing import Any
+
+import pytest
+from pytest_bdd import given, scenario, then, when
+
+from xskill.agents import agent_tools
+from tests.pool_helpers import pool_config
+from xskill.agents.agno_factory import make_default_factory
+from xskill.agents.skill_edit_agent import SkillEditAgent
+from xskill.pipeline.atom import AtomTaskStore
+from xskill.pipeline.registry import register_dir
+from xskill.pipeline.runner import DirectoryWatcher
+from xskill.skill import candidates as candidate_buffer
+from xskill.skill.git import current_branch, init_skill_repo_on_baby, run_git
+
+
+RUN_AIMOCK_E2E = os.environ.get("XSKILL_AIMOCK_E2E") == "1"
+
+pytestmark = [
+    pytest.mark.bdd,
+    pytest.mark.http_llm,
+    pytest.mark.skipif(
+        not RUN_AIMOCK_E2E,
+        reason="set XSKILL_AIMOCK_E2E=1 to run the local aimock HTTP contract",
+    ),
+]
+
+
+@scenario(
+    "features/skill_edit/baby_cold_start_golden_path.feature",
+    "用户等待系统把新知识整理成可用的 main skill",
+)
+def test_user_receives_complete_main_skill() -> None:
+    """The Gherkin scenario is implemented by the steps below."""
+
+
+@scenario(
+    "features/skill_edit/skill_edit_llm_backend.feature",
+    "模型通过 OpenAI tool calls 完成一次 baby checkpoint",
+)
+def test_aimock_executes_one_real_checkpoint() -> None:
+    """Production Agno performs the complete three-request tool loop."""
+
+
+@scenario(
+    "features/skill_edit/skill_edit_llm_backend.feature",
+    "测试运行期间没有请求离开本机",
+)
+def test_model_requests_remain_local() -> None:
+    """The request journal proves that the contract stays on loopback."""
+
+
+@scenario(
+    "features/skill_edit/skill_edit_llm_backend.feature",
+    "模型后端持续返回 429 时当前批次不会被误提交",
+)
+def test_persistent_429_preserves_the_batch() -> None:
+    """A real HTTP 429 drives the production adaptive batch state machine."""
+
+
+@scenario(
+    "features/skill_edit/baby_cold_start_recovery.feature",
+    "commit 完成后的模型 429 不会导致原子被再次处理",
+)
+def test_post_commit_429_does_not_replay_atoms() -> None:
+    """The durable checkpoint wins over a failed final model response."""
+
+
+@dataclass
+class SkillEditWorld:
+    root: Path
+    aimock: Any
+    skill_root: Path
+    watch_root: Path
+    db_path: Path
+    logs_root: Path
+    batch_size: int = 5
+    api_key: str = "sk-aimock-xskill-test"
+    skill_name: str | None = None
+    skill_dir: Path | None = None
+    candidate_rows: list[dict[str, str]] = field(default_factory=list)
+    watcher: DirectoryWatcher | None = None
+    journal: list[dict[str, Any]] = field(default_factory=list)
+    result: bool | None = None
+    head_before: str = ""
+    attempts: list[int] = field(default_factory=list)
+
+    @property
+    def model_requests(self) -> list[dict[str, Any]]:
+        return [
+            entry
+            for entry in self.journal
+            if entry.get("method") == "POST"
+            and entry.get("path") == "/v1/chat/completions"
+        ]
+
+    @property
+    def initial_turn_requests(self) -> list[dict[str, Any]]:
+        requests = []
+        for entry in self.model_requests:
+            messages = (entry.get("body") or {}).get("messages") or []
+            if not any(message.get("role") == "tool" for message in messages):
+                requests.append(entry)
+        return requests
+
+    def stop_watcher(self) -> None:
+        if self.watcher is not None:
+            self.watcher.stop()
+            self.watcher = None
+
+
+@pytest.fixture
+def skill_edit_world(
+    tmp_path: Path,
+    request: pytest.FixtureRequest,
+) -> SkillEditWorld:
+    if not RUN_AIMOCK_E2E:
+        pytest.skip("set XSKILL_AIMOCK_E2E=1 to start the aimock backend")
+    aimock = request.getfixturevalue("aimock")
+    skill_root = tmp_path / "skills"
+    watch_root = tmp_path / "watch"
+    skill_root.mkdir()
+    watch_root.mkdir()
+    world = SkillEditWorld(
+        root=tmp_path,
+        aimock=aimock,
+        skill_root=skill_root,
+        watch_root=watch_root,
+        db_path=tmp_path / "registry.db",
+        logs_root=tmp_path / "logs",
+    )
+    yield world
+    world.stop_watcher()
+
+
+def _skill_document(
+    skill_name: str,
+    rows: list[dict[str, str]],
+    *,
+    version: int,
+) -> str:
+    rules = "\n".join(
+        f"{index}. {row['knowledge']}"
+        for index, row in enumerate(rows, start=1)
+    )
+    return (
+        "---\n"
+        f"name: {skill_name}\n"
+        "description: 系统化恢复反向代理后端服务并验证结果。"
+        "适用于进程、端口和 upstream 不一致的故障定位。\n"
+        "metadata:\n"
+        f"  version: {version}\n"
+        "---\n\n"
+        f"# {skill_name}\n\n"
+        "## 恢复流程\n\n"
+        f"{rules}\n"
+    )
+
+
+def _register_turn(
+    world: SkillEditWorld,
+    *,
+    turn: int,
+    rows: list[dict[str, str]],
+) -> None:
+    assert world.skill_name is not None
+    assert world.skill_dir is not None
+    target = world.skill_dir / "SKILL.md"
+
+    # aimock deliberately owns/generated tool-call IDs.  Match follow-ups by
+    # the observable tool result instead of coupling this contract to an ID
+    # that the mock backend is allowed to rewrite.
+    world.aimock.add_fixture(
+        match={
+            "userMessage": rows[0]["atom_id"],
+            "hasToolResult": True,
+            "toolResultContains": "Created baby checkpoint",
+        },
+        response={"content": f"turn {turn} checkpoint complete"},
+    )
+    world.aimock.add_fixture(
+        match={
+            "userMessage": rows[0]["atom_id"],
+            "hasToolResult": True,
+            "toolResultContains": "wrote:",
+        },
+        response={
+            "toolCalls": [
+                {
+                    "name": "commit_baby",
+                    "arguments": {
+                        "skill_name": world.skill_name,
+                        "message": f"BDD checkpoint turn {turn}",
+                    },
+                }
+            ]
+        },
+    )
+    world.aimock.add_fixture(
+        match={
+            "userMessage": rows[0]["atom_id"],
+            "hasToolResult": False,
+        },
+        response={
+            "toolCalls": [
+                {
+                    "name": "write_file",
+                    "arguments": {
+                        "path": str(target),
+                        "content": _skill_document(
+                            world.skill_name,
+                            world.candidate_rows[: turn * world.batch_size],
+                            version=turn,
+                        ),
+                    },
+                }
+            ]
+        },
+    )
+
+
+def _create_baby_with_candidates(
+    world: SkillEditWorld,
+    *,
+    name: str,
+    count: int,
+    weight: int,
+) -> None:
+    world.skill_name = name
+    world.skill_dir = world.skill_root / name
+    init_skill_repo_on_baby(
+        str(world.skill_dir),
+        name=name,
+        description="BDD aimock contract draft",
+    )
+    world.candidate_rows = [
+        {
+            "atom_id": f"atom-{index:02d}",
+            "knowledge": f"可复用恢复规则 {index}",
+        }
+        for index in range(1, count + 1)
+    ]
+    data: dict[str, Any] = {"candidates": []}
+    for row in world.candidate_rows:
+        data, _ = candidate_buffer.add_atom_contribution(
+            data,
+            row["atom_id"],
+            weight,
+            note=row["knowledge"],
+        )
+    candidate_buffer.save_candidates(world.skill_dir, data)
+    world.head_before = run_git(
+        ["rev-parse", "HEAD"],
+        cwd=str(world.skill_dir),
+    )[1].strip()
+
+
+def _run_direct_agent(world: SkillEditWorld, *, retry_batch_size: int | None = None) -> None:
+    assert world.skill_dir is not None
+    config = {
+        "llm": {
+            "base_url": f"{world.aimock.base_url}/v1",
+            "model": "aimock-skill-edit",
+            "api_key": world.api_key,
+            "request_timeout": 10,
+            "connect_timeout": 2,
+            "client_max_retries": 0,
+            "max_retries": 1,
+            "retry_base_delay": 0.01,
+            "retry_max_delay": 0.01,
+            "max_context": 128_000,
+        },
+        "skill_opt": {"enabled": False},
+    }
+    default_factory = make_default_factory(
+        config,
+        spill_root=world.root / "spill",
+    )
+
+    def factory(*, instructions: list[str], tools: list[Any]) -> Any:
+        return default_factory(
+            instructions=instructions,
+            tools=tools,
+            retries=0,
+        )
+
+    saved_context = agent_tools.agent_tool_config.snapshot()
+    store = AtomTaskStore(root=world.watch_root)
+    agent_tools.init_atom_task_tool_context(
+        skill_dir=world.skill_root,
+        atom_store=store,
+        default_traj_root=world.watch_root,
+    )
+    agent_tools.init_skill_authoring_tool_context(
+        world.skill_root,
+        world.skill_root,
+        config,
+        spill_root=world.root / "spill",
+    )
+    try:
+        agent = SkillEditAgent(
+            skill_dir=world.skill_dir,
+            store=store,
+            agno_agent_factory=factory,
+            llm_cfg=config["llm"],
+            traj_root=world.watch_root,
+            batch_size=world.batch_size,
+            retry_batch_size=retry_batch_size,
+            logs_dir=world.logs_root,
+        )
+        world.result = agent.maybe_run()
+    finally:
+        world.journal = world.aimock.get_journal()
+        agent_tools.agent_tool_config.restore(saved_context)
+    # Derive batch sizes after the journal has been captured.
+    world.attempts = [
+        len(set(re.findall(r"atom-\d{2}", _joined_message_content(entry))))
+        for entry in world.initial_turn_requests
+    ]
+
+
+@given("xskill 使用隔离的测试目录")
+def isolated_xskill_directory(skill_edit_world: SkillEditWorld) -> None:
+    assert skill_edit_world.root.is_dir()
+    assert skill_edit_world.skill_root.parent == skill_edit_world.root
+
+
+@given("SkillEdit 每批最多处理 5 个原子")
+def edit_batch_size_is_five(skill_edit_world: SkillEditWorld) -> None:
+    skill_edit_world.batch_size = 5
+
+
+@given("SkillEdit 默认每批处理 5 个原子")
+def default_edit_batch_size_is_five(skill_edit_world: SkillEditWorld) -> None:
+    skill_edit_world.batch_size = 5
+
+
+@given("baby 的 candidates 使用稳定的 FIFO 顺序")
+def candidates_use_fifo_order() -> None:
+    return None
+
+
+@given("SkillEdit 模型指向本地 OpenAI-compatible 测试后端")
+def local_openai_backend(skill_edit_world: SkillEditWorld) -> None:
+    assert skill_edit_world.aimock.base_url.startswith("http://127.0.0.1:")
+
+
+@given('cluster 已经创建名为 "incident-recovery" 的 baby skill')
+def existing_baby_skill(skill_edit_world: SkillEditWorld) -> None:
+    skill_edit_world.skill_name = "incident-recovery"
+    skill_edit_world.skill_dir = skill_edit_world.skill_root / skill_edit_world.skill_name
+    init_skill_repo_on_baby(
+        str(skill_edit_world.skill_dir),
+        name=skill_edit_world.skill_name,
+        description="incident recovery draft",
+    )
+    assert current_branch(str(skill_edit_world.skill_dir)) == "baby"
+
+
+@given("baby 的 candidates 按以下顺序保存")
+def ordered_candidates(
+    skill_edit_world: SkillEditWorld,
+    datatable: list[list[str]],
+) -> None:
+    assert skill_edit_world.skill_dir is not None
+    headers = datatable[0]
+    rows = [dict(zip(headers, values, strict=True)) for values in datatable[1:]]
+    skill_edit_world.candidate_rows = rows
+
+    data: dict[str, Any] = {"candidates": []}
+    for row in rows:
+        data, _ = candidate_buffer.add_atom_contribution(
+            data,
+            row["atom_id"],
+            2,
+            note=row["knowledge"],
+        )
+    candidate_buffer.save_candidates(skill_edit_world.skill_dir, data)
+
+
+@given("candidates 的总权重已经达到 baby 冷启动阈值")
+def candidates_reach_threshold(skill_edit_world: SkillEditWorld) -> None:
+    assert skill_edit_world.skill_dir is not None
+    data = candidate_buffer.load_candidates(skill_edit_world.skill_dir)
+    assert sum(item["weightscore"] for item in data["candidates"]) >= 10
+
+
+@given("测试模型会根据每批原子更新 SKILL.md 并调用 commit_baby")
+def scripted_model_updates_and_commits(skill_edit_world: SkillEditWorld) -> None:
+    rows = skill_edit_world.candidate_rows
+    assert [row["atom_id"] for row in rows] == [
+        f"atom-{index:02d}" for index in range(1, 8)
+    ]
+    _register_turn(
+        skill_edit_world,
+        turn=1,
+        rows=rows[: skill_edit_world.batch_size],
+    )
+    _register_turn(
+        skill_edit_world,
+        turn=2,
+        rows=rows[skill_edit_world.batch_size :],
+    )
+
+
+@given("aimock 在随机本地端口启动 OpenAI-compatible 服务")
+def aimock_runs_on_random_loopback_port(skill_edit_world: SkillEditWorld) -> None:
+    assert re.fullmatch(r"http://127\.0\.0\.1:\d+", skill_edit_world.aimock.base_url)
+
+
+@given("xskill 的 llm.base_url 指向该服务")
+def llm_points_to_aimock(skill_edit_world: SkillEditWorld) -> None:
+    assert skill_edit_world.aimock.base_url.startswith("http://127.0.0.1:")
+
+
+@given("xskill 使用无权限的测试 API key")
+def harmless_api_key(skill_edit_world: SkillEditWorld) -> None:
+    assert skill_edit_world.api_key == "sk-aimock-xskill-test"
+
+
+@given("一个 SkillEdit turn 绑定了 5 个 atom_id")
+def five_atoms_are_bound(skill_edit_world: SkillEditWorld) -> None:
+    _create_baby_with_candidates(
+        skill_edit_world,
+        name="aimock-contract",
+        count=5,
+        weight=2,
+    )
+
+
+@given("aimock 为这个 turn 准备了以下响应")
+def aimock_prepares_tool_loop(
+    skill_edit_world: SkillEditWorld,
+    datatable: list[list[str]],
+) -> None:
+    assert [row[0] for row in datatable[1:]] == ["first", "second", "third"]
+    _register_turn(
+        skill_edit_world,
+        turn=1,
+        rows=skill_edit_world.candidate_rows,
+    )
+
+
+@given("主成功路径已经执行完成")
+def completed_success_path(skill_edit_world: SkillEditWorld) -> None:
+    five_atoms_are_bound(skill_edit_world)
+    _register_turn(
+        skill_edit_world,
+        turn=1,
+        rows=skill_edit_world.candidate_rows,
+    )
+    _run_direct_agent(skill_edit_world)
+    assert skill_edit_world.result is True
+
+
+@given("当前 turn 的 N 为 5")
+def current_turn_n_is_five(skill_edit_world: SkillEditWorld) -> None:
+    skill_edit_world.batch_size = 5
+    _create_baby_with_candidates(
+        skill_edit_world,
+        name="aimock-rate-limit",
+        count=5,
+        weight=2,
+    )
+
+
+@given("aimock 对模型请求返回 HTTP 429 和 Retry-After")
+def aimock_always_rate_limits(skill_edit_world: SkillEditWorld) -> None:
+    skill_edit_world.aimock.add_fixture(
+        match={"userMessage": "atom-01", "hasToolResult": False},
+        response={
+            "error": {
+                "message": "Rate limited by BDD fixture",
+                "type": "rate_limit_error",
+                "code": "rate_limit_exceeded",
+            },
+            "status": 429,
+        },
+    )
+
+
+@given("模型客户端已经耗尽该 turn 内部的有限重试")
+def client_retry_is_bounded() -> None:
+    # _run_direct_agent configures max_retries=1 and OpenAI max_retries=0.
+    return None
+
+
+@given("模型已经调用 commit_baby 并成功提交当前批次")
+def model_will_commit_before_error(skill_edit_world: SkillEditWorld) -> None:
+    _create_baby_with_candidates(
+        skill_edit_world,
+        name="aimock-post-commit-429",
+        count=3,
+        weight=4,
+    )
+
+
+@given("commit_baby 已经从 candidates 删除当前批次 atom_id")
+def commit_consumes_bound_atoms() -> None:
+    # This is asserted from the real commit_baby result after execution.
+    return None
+
+
+@given("aimock 在模型的结束响应阶段返回 HTTP 429")
+def final_model_response_is_429(skill_edit_world: SkillEditWorld) -> None:
+    rows = skill_edit_world.candidate_rows
+    assert skill_edit_world.skill_name is not None
+    assert skill_edit_world.skill_dir is not None
+    target = skill_edit_world.skill_dir / "SKILL.md"
+    skill_edit_world.aimock.add_fixture(
+        match={
+            "userMessage": rows[0]["atom_id"],
+            "hasToolResult": True,
+            "toolResultContains": "Created baby checkpoint",
+        },
+        response={
+            "error": {
+                "message": "Rate limited after durable checkpoint",
+                "type": "rate_limit_error",
+            },
+            "status": 429,
+        },
+    )
+    skill_edit_world.aimock.add_fixture(
+        match={
+            "userMessage": rows[0]["atom_id"],
+            "hasToolResult": True,
+            "toolResultContains": "wrote:",
+        },
+        response={
+            "toolCalls": [
+                {
+                    "name": "commit_baby",
+                    "arguments": {
+                        "skill_name": skill_edit_world.skill_name,
+                        "message": "BDD durable before final 429",
+                    },
+                }
+            ]
+        },
+    )
+    skill_edit_world.aimock.add_fixture(
+        match={
+            "userMessage": rows[0]["atom_id"],
+            "hasToolResult": False,
+        },
+        response={
+            "toolCalls": [
+                {
+                    "name": "write_file",
+                    "arguments": {
+                        "path": str(target),
+                        "content": _skill_document(
+                            skill_edit_world.skill_name,
+                            rows,
+                            version=1,
+                        ),
+                    },
+                }
+            ]
+        },
+    )
+
+
+@when("watcher 调度这个 baby 的 SkillEdit 工作")
+def watcher_schedules_skill_edit(skill_edit_world: SkillEditWorld) -> None:
+    config = {
+        "llm": {
+            "base_url": f"{skill_edit_world.aimock.base_url}/v1",
+            "model": "aimock-skill-edit",
+            "api_key": skill_edit_world.api_key,
+            "request_timeout": 10,
+            "connect_timeout": 2,
+            "client_max_retries": 0,
+            "max_retries": 1,
+            "retry_base_delay": 0.01,
+            "retry_max_delay": 0.01,
+            "max_context": 128_000,
+        },
+        "skill_opt": {"enabled": False},
+    }
+    store = AtomTaskStore(root=skill_edit_world.watch_root)
+    register_dir(skill_edit_world.watch_root, db_path=skill_edit_world.db_path)
+    default_factory = make_default_factory(
+        config,
+        spill_root=skill_edit_world.root / "spill",
+    )
+
+    def factory(*, instructions: list[str], tools: list[Any]) -> Any:
+        # Fixture mismatches should fail this contract immediately; retry and
+        # backoff behavior has separate state-machine/429 scenarios.
+        return default_factory(
+            instructions=instructions,
+            tools=tools,
+            retries=0,
+        )
+
+    watcher = DirectoryWatcher(
+        config=config,
+        skill_dir=skill_edit_world.skill_root,
+        poll_interval=0,
+        pool_config=pool_config(
+            workers=1,
+            edit_workers=1,
+            edit_batch_size=skill_edit_world.batch_size,
+        ),
+        db_path=skill_edit_world.db_path,
+        store=store,
+        agno_agent_factory=factory,
+        home_root=skill_edit_world.root / "home",
+        xskill_home=skill_edit_world.root / "xskill",
+        logs_dir=skill_edit_world.logs_root,
+        server_mode=True,
+    )
+    skill_edit_world.watcher = watcher
+    watcher._check_pending_skill_edits()
+    watcher._drain_futures(stage="skill_edit", timeout=90)
+    skill_edit_world.journal = skill_edit_world.aimock.get_journal()
+    if watcher.stats["skills_edited"] != 1:
+        evidence = []
+        for entry in skill_edit_world.model_requests:
+            messages = (entry.get("body") or {}).get("messages") or []
+            content = "\n".join(
+                str(message.get("content") or "") for message in messages
+            )
+            evidence.append(
+                {
+                    "roles": [message.get("role") for message in messages],
+                    "atom_ids": sorted(set(re.findall(r"atom-\d{2}", content))),
+                    "tool_results": [
+                        str(message.get("content") or "").splitlines()[0][:100]
+                        for message in messages
+                        if message.get("role") == "tool"
+                    ],
+                    "status": (entry.get("response") or {}).get("status"),
+                }
+            )
+        pytest.fail(
+            "watcher did not complete SkillEdit; compact aimock evidence: "
+            f"{evidence!r}"
+        )
+
+
+@when("SkillEdit 使用生产 Agno factory 执行这个 turn")
+def production_factory_executes_turn(skill_edit_world: SkillEditWorld) -> None:
+    _run_direct_agent(skill_edit_world)
+
+
+@when("检查测试后端的 request journal")
+def inspect_request_journal(skill_edit_world: SkillEditWorld) -> None:
+    assert skill_edit_world.journal
+
+
+@when("SkillEditAgent 收到模型调用失败")
+def agent_receives_backend_failure(skill_edit_world: SkillEditWorld) -> None:
+    _run_direct_agent(skill_edit_world)
+
+
+@when("SkillEditAgent 检查 baby HEAD 和剩余 candidates")
+def agent_checks_durable_state(skill_edit_world: SkillEditWorld) -> None:
+    _run_direct_agent(skill_edit_world)
+
+
+@then("模型应当收到 2 个互相独立的编辑 turn")
+def two_independent_turns(skill_edit_world: SkillEditWorld) -> None:
+    initial_requests = skill_edit_world.initial_turn_requests
+    assert len(initial_requests) == 2
+    assert len(skill_edit_world.model_requests) == 6
+
+
+def _joined_message_content(entry: dict[str, Any]) -> str:
+    messages = (entry.get("body") or {}).get("messages") or []
+    return "\n".join(str(message.get("content") or "") for message in messages)
+
+
+@then('第 1 个 turn 应当只包含 "atom-01,atom-02,atom-03,atom-04,atom-05"')
+def first_turn_contains_first_batch_only(skill_edit_world: SkillEditWorld) -> None:
+    content = _joined_message_content(skill_edit_world.initial_turn_requests[0])
+    for atom_id in [f"atom-{index:02d}" for index in range(1, 6)]:
+        assert atom_id in content
+    assert "atom-06" not in content
+    assert "atom-07" not in content
+
+
+@then('第 2 个 turn 应当只包含 "atom-06,atom-07"')
+def second_turn_contains_second_batch_only(skill_edit_world: SkillEditWorld) -> None:
+    content = _joined_message_content(skill_edit_world.initial_turn_requests[1])
+    assert "atom-06" in content
+    assert "atom-07" in content
+    for atom_id in [f"atom-{index:02d}" for index in range(1, 6)]:
+        assert atom_id not in content
+
+
+@then("每个 turn 都应当在 baby 上产生一个非空 checkpoint commit")
+def every_turn_creates_checkpoint(skill_edit_world: SkillEditWorld) -> None:
+    assert skill_edit_world.skill_dir is not None
+    code, output, error = run_git(
+        ["log", "--oneline", "-20"],
+        cwd=str(skill_edit_world.skill_dir),
+    )
+    assert code == 0, error
+    assert "BDD checkpoint turn 1" in output
+    assert "BDD checkpoint turn 2" in output
+
+
+def _tool_results(world: SkillEditWorld, marker: str) -> list[str]:
+    results = []
+    for entry in world.model_requests:
+        messages = (entry.get("body") or {}).get("messages") or []
+        for message in messages:
+            if message.get("role") == "tool" and marker in str(message.get("content")):
+                results.append(str(message["content"]))
+    return results
+
+
+@then("每次 commit 只应当删除当前 turn 绑定的 atom_id")
+def commits_consume_only_bound_atoms(skill_edit_world: SkillEditWorld) -> None:
+    results = _tool_results(skill_edit_world, "Consumed atoms:")
+    # Each result remains in later history, so keep the first occurrence for
+    # each checkpoint rather than asserting a raw count.
+    unique_results = list(dict.fromkeys(results))
+    assert len(unique_results) == 2
+    for atom_id in [f"atom-{index:02d}" for index in range(1, 6)]:
+        assert atom_id in unique_results[0]
+        assert atom_id not in unique_results[1]
+    assert "atom-06" not in unique_results[0]
+    assert "atom-07" not in unique_results[0]
+    assert "atom-06" in unique_results[1]
+    assert "atom-07" in unique_results[1]
+
+
+@then("candidates 最终应当为空")
+def candidates_are_empty(skill_edit_world: SkillEditWorld) -> None:
+    assert skill_edit_world.skill_dir is not None
+    assert candidate_buffer.load_candidates(skill_edit_world.skill_dir)["candidates"] == []
+
+
+@then("框架应当把 baby 晋升为 main")
+def framework_promotes_main(skill_edit_world: SkillEditWorld) -> None:
+    assert skill_edit_world.skill_dir is not None
+    assert current_branch(str(skill_edit_world.skill_dir)) == "main"
+
+
+@then("main 的 SKILL.md 应当包含 7 个原子贡献的恢复流程")
+def final_skill_contains_all_knowledge(skill_edit_world: SkillEditWorld) -> None:
+    assert skill_edit_world.skill_dir is not None
+    body = (skill_edit_world.skill_dir / "SKILL.md").read_text(encoding="utf-8")
+    for row in skill_edit_world.candidate_rows:
+        assert row["knowledge"] in body
+
+
+@then("aimock 应当收到真实的 POST /v1/chat/completions 请求")
+def aimock_received_chat_completions(skill_edit_world: SkillEditWorld) -> None:
+    assert len(skill_edit_world.model_requests) == 3
+
+
+@then("第一次请求应当声明 write_file 和 commit_baby 工具")
+def first_request_declares_tools(skill_edit_world: SkillEditWorld) -> None:
+    tools = (skill_edit_world.model_requests[0].get("body") or {}).get("tools") or []
+    names = {
+        (tool.get("function") or {}).get("name")
+        for tool in tools
+    }
+    assert {"write_file", "commit_baby"} <= names
+
+
+@then("第二次请求应当包含 write_file 的 tool result")
+def second_request_contains_write_result(skill_edit_world: SkillEditWorld) -> None:
+    assert "wrote:" in _joined_message_content(skill_edit_world.model_requests[1])
+
+
+@then("第三次请求应当包含 commit_baby 的 tool result")
+def third_request_contains_commit_result(skill_edit_world: SkillEditWorld) -> None:
+    assert "Created baby checkpoint" in _joined_message_content(
+        skill_edit_world.model_requests[2]
+    )
+
+
+@then("atom_id 不应当由模型作为 commit_baby 参数提供")
+def commit_schema_excludes_atom_ids(skill_edit_world: SkillEditWorld) -> None:
+    tools = (skill_edit_world.model_requests[0].get("body") or {}).get("tools") or []
+    commit = next(
+        tool["function"] for tool in tools
+        if tool["function"]["name"] == "commit_baby"
+    )
+    properties = (commit.get("parameters") or {}).get("properties") or {}
+    assert "atom_id" not in properties
+    assert "atom_ids" not in properties
+
+
+@then("commit_baby 应当从框架绑定的批次取得 atom_id")
+def commit_uses_framework_bound_ids(skill_edit_world: SkillEditWorld) -> None:
+    results = list(dict.fromkeys(_tool_results(skill_edit_world, "Consumed atoms:")))
+    assert len(results) == 1
+    for row in skill_edit_world.candidate_rows:
+        assert row["atom_id"] in results[0]
+
+
+@then("所有模型请求都应当发送到 aimock")
+def all_requests_hit_aimock(skill_edit_world: SkillEditWorld) -> None:
+    assert skill_edit_world.model_requests
+    assert all(entry["path"] == "/v1/chat/completions" for entry in skill_edit_world.model_requests)
+
+
+@then("请求不应当包含生产 API key")
+def no_production_key_is_sent(skill_edit_world: SkillEditWorld) -> None:
+    for entry in skill_edit_world.model_requests:
+        authorization = (entry.get("headers") or {}).get("authorization", "")
+        assert authorization == "[REDACTED]"
+        assert skill_edit_world.api_key not in str(entry.get("headers") or {})
+
+
+@then("测试不应当访问任何公共模型 endpoint")
+def no_public_model_endpoint(skill_edit_world: SkillEditWorld) -> None:
+    assert skill_edit_world.aimock.base_url.startswith("http://127.0.0.1:")
+
+
+@then("baby 的 HEAD 不应当前进")
+def baby_head_does_not_advance(skill_edit_world: SkillEditWorld) -> None:
+    assert skill_edit_world.skill_dir is not None
+    head_after = run_git(
+        ["rev-parse", "HEAD"],
+        cwd=str(skill_edit_world.skill_dir),
+    )[1].strip()
+    assert head_after == skill_edit_world.head_before
+
+
+@then("当前 5 个 atom_id 不应当从 candidates 删除")
+def rate_limited_atoms_remain(skill_edit_world: SkillEditWorld) -> None:
+    assert skill_edit_world.skill_dir is not None
+    remaining = candidate_buffer.load_candidates(
+        skill_edit_world.skill_dir
+    )["candidates"]
+    assert [item["atom_id"] for item in remaining] == [
+        row["atom_id"] for row in skill_edit_world.candidate_rows
+    ]
+
+
+@then("本次调度应当依次尝试 N=5、N=2、N=1")
+def adaptive_attempt_sizes_are_observed(skill_edit_world: SkillEditWorld) -> None:
+    assert skill_edit_world.attempts == [5, 2, 1]
+
+
+@then("watcher 下次调度时应当继续使用 N=1")
+def retry_size_stays_at_one(skill_edit_world: SkillEditWorld) -> None:
+    # The failed direct agent exposes the value the watcher persists.
+    trace = (
+        skill_edit_world.logs_root
+        / "agents"
+        / "skill_edit_agents"
+        / "skills"
+        / f"{skill_edit_world.skill_name}.log"
+    ).read_text(encoding="utf-8")
+    assert "TURN END | FAILED | consumed=0 | 5 remaining | next N=1" in trace
+
+
+@then("当前 turn 应当被判定为成功")
+def post_commit_turn_is_success(skill_edit_world: SkillEditWorld) -> None:
+    assert skill_edit_world.result is True
+
+
+@then("当前批次不应当再次发送给模型")
+def committed_batch_is_not_replayed(skill_edit_world: SkillEditWorld) -> None:
+    assert skill_edit_world.attempts == [3]
+
+
+@then("下一个 turn 应当从第一个未消费 atom_id 开始")
+def next_turn_starts_after_committed_batch(skill_edit_world: SkillEditWorld) -> None:
+    assert skill_edit_world.skill_dir is not None
+    assert candidate_buffer.load_candidates(
+        skill_edit_world.skill_dir
+    )["candidates"] == []

--- a/tests/bdd/test_skill_edit_state_machine.py
+++ b/tests/bdd/test_skill_edit_state_machine.py
@@ -1,0 +1,724 @@
+"""Executable BDD for SkillEdit recovery, concurrency, and readable traces.
+
+These scenarios keep the production state machine, candidate store, agent
+tools, Git operations, context manager, and trace renderer.  A deterministic
+in-process agent replaces the remote model because these tests are intended
+to run quickly under both ordinary pytest and mutation testing.
+"""
+
+from __future__ import annotations
+
+import json
+import re
+from dataclasses import dataclass, field
+from pathlib import Path
+from types import SimpleNamespace
+from typing import Any
+
+import pytest
+from pytest_bdd import given, scenario, then, when
+
+from xskill.agents import agent_tools, agent_trace
+from xskill.agents.agno_factory import _wrap_with_retry, _wrap_with_trace
+from xskill.agents.context_budget import ContextManager
+from xskill.agents.skill_edit_agent import SkillEditAgent
+from xskill.pipeline.atom import AtomTaskStore
+from xskill.skill import candidates as candidate_buffer
+from xskill.skill.git import (
+    commit_baby_checkpoint,
+    current_branch,
+    init_skill_repo_on_baby,
+)
+
+
+pytestmark = [
+    pytest.mark.bdd,
+    pytest.mark.state_machine,
+]
+
+
+@scenario(
+    "features/skill_edit/baby_cold_start_golden_path.feature",
+    "新原子在编辑过程中到达时不会破坏当前批次边界",
+)
+def test_new_atom_respects_the_current_batch_boundary() -> None:
+    """A concurrent append is picked up only after the bound checkpoint."""
+
+
+@scenario(
+    "features/skill_edit/baby_cold_start_recovery.feature",
+    "连续失败时缩小当前批次，成功后恢复默认批次",
+)
+def test_failures_reduce_the_batch_until_success() -> None:
+    """The batch sequence is 5 -> 2 -> 1 -> default 5."""
+
+
+@scenario(
+    "features/skill_edit/baby_cold_start_recovery.feature",
+    "进程在多个 checkpoint 之间重启",
+)
+def test_restart_continues_after_the_last_checkpoint() -> None:
+    """Only candidates not represented by a checkpoint are replayed."""
+
+
+@scenario(
+    "features/skill_edit/baby_cold_start_recovery.feature",
+    "N=1 仍失败时把工作留给下一次 watcher 调度",
+)
+def test_n1_failure_preserves_work_for_the_watcher() -> None:
+    """The worker returns while the final candidate remains durable."""
+
+
+@scenario(
+    "features/skill_edit/skill_edit_trace.feature",
+    "成功的多批次冷启动可以从日志完整复盘",
+)
+def test_successful_cold_start_has_one_readable_trace() -> None:
+    """Every model round and framework checkpoint lands in one log."""
+
+
+@scenario(
+    "features/skill_edit/skill_edit_trace.feature",
+    "失败缩批和上下文处理顺序可以从日志确认",
+)
+def test_trace_shows_spill_before_compact_and_retry_reduction() -> None:
+    """Production context events preserve their causal order in the trace."""
+
+
+def _tool_name(tool: Any) -> str:
+    return getattr(tool, "__name__", None) or getattr(tool, "name", "")
+
+
+def _call_tool(tool: Any, *args: Any) -> str:
+    entrypoint = tool if callable(tool) else getattr(tool, "entrypoint")
+    return str(entrypoint(*args))
+
+
+@dataclass
+class StateWorld:
+    root: Path
+    skill_root: Path
+    store: AtomTaskStore
+    logs_root: Path
+    skill_name: str | None = None
+    skill_dir: Path | None = None
+    batch_size: int = 5
+    retry_batch_size: int | None = None
+    mode: str = "success"
+    inject_new_atom: bool = False
+    injected: bool = False
+    fail_messages: list[str] = field(default_factory=list)
+    attempts: list[list[str]] = field(default_factory=list)
+    candidate_counts_before: list[int] = field(default_factory=list)
+    remaining_after_commit: list[list[str]] = field(default_factory=list)
+    processed_atoms: list[str] = field(default_factory=list)
+    commit_results: list[str] = field(default_factory=list)
+    result: bool | None = None
+    next_batch_size: int | None = None
+    first_five: list[str] = field(default_factory=list)
+
+    @property
+    def trace_path(self) -> Path:
+        assert self.skill_name is not None
+        return (
+            self.logs_root
+            / "agents"
+            / "skill_edit_agents"
+            / "skills"
+            / f"{self.skill_name}.log"
+        )
+
+    @property
+    def trace(self) -> str:
+        return self.trace_path.read_text(encoding="utf-8")
+
+
+@pytest.fixture
+def state_world(tmp_path: Path) -> StateWorld:
+    skill_root = tmp_path / "skills"
+    store_root = tmp_path / "store"
+    skill_root.mkdir()
+    store_root.mkdir()
+    store = AtomTaskStore(root=store_root)
+    world = StateWorld(
+        root=tmp_path,
+        skill_root=skill_root,
+        store=store,
+        logs_root=tmp_path / "logs",
+    )
+    saved_context = agent_tools.agent_tool_config.snapshot()
+    agent_tools.init_atom_task_tool_context(
+        skill_dir=skill_root,
+        atom_store=store,
+        default_traj_root=store_root,
+    )
+    agent_tools.init_skill_authoring_tool_context(
+        skill_root,
+        skill_root,
+        {"skill_opt": {"enabled": False}},
+        spill_root=tmp_path / "spill",
+    )
+    yield world
+    agent_tools.agent_tool_config.restore(saved_context)
+
+
+def _seed_baby(
+    world: StateWorld,
+    *,
+    name: str,
+    count: int,
+    weight: int,
+) -> list[str]:
+    world.skill_name = name
+    world.skill_dir = world.skill_root / name
+    init_skill_repo_on_baby(
+        str(world.skill_dir),
+        name=name,
+        description="BDD state-machine draft",
+    )
+    data: dict[str, Any] = {"candidates": []}
+    atom_ids = [f"atom-{index:02d}" for index in range(1, count + 1)]
+    for atom_id in atom_ids:
+        data, _ = candidate_buffer.add_atom_contribution(
+            data,
+            atom_id,
+            weight,
+            note=f"knowledge for {atom_id}",
+        )
+    candidate_buffer.save_candidates(world.skill_dir, data)
+    return atom_ids
+
+
+def _fake_trace_response(atom_ids: list[str]) -> Any:
+    calls = (
+        (
+            "write_file",
+            json.dumps(
+                {"path": "SKILL.md", "content": "x" * 240},
+                separators=(",", ":"),
+            ),
+        ),
+        (
+            "commit_baby",
+            json.dumps(
+                {"skill_name": "bdd-skill", "message": ",".join(atom_ids)},
+                separators=(",", ":"),
+            ),
+        ),
+    )
+    message = SimpleNamespace(
+        reasoning_content=f"整理当前批次：{','.join(atom_ids)}",
+        content="",
+        tool_calls=[
+            SimpleNamespace(
+                function=SimpleNamespace(name=name, arguments=arguments),
+            )
+            for name, arguments in calls
+        ],
+    )
+    return SimpleNamespace(choices=[SimpleNamespace(message=message)])
+
+
+def _exercise_context_pressure(world: StateWorld) -> None:
+    """Run the real spill -> compact -> bounded 429 wrappers in the trace sink."""
+    messages = [
+        SimpleNamespace(role="system", content="s" * 3600),
+        SimpleNamespace(role="user", content="u" * 400),
+        SimpleNamespace(
+            role="tool",
+            tool_name="read_file",
+            name="read_file",
+            tool_call_id="call-read",
+            content="evidence " * 500,
+        ),
+    ]
+
+    class _RateLimitedModel:
+        @staticmethod
+        def invoke(_messages: list[Any], **_kwargs: Any) -> Any:
+            raise RuntimeError("429 rate limit from deterministic backend")
+
+    model = _RateLimitedModel()
+    manager = ContextManager(
+        1000,
+        spill_root=world.root / "spill",
+        compact_token_limit=900,
+        compact_keep_recent_messages=1,
+        compact_fn=lambda _prompt: "保留候选、证据摘要和待完成提交。",
+    )
+    model.invoke = manager.wrap(model.invoke)
+    model = _wrap_with_retry(
+        model,
+        {
+            "base_url": "http://127.0.0.1:1/v1",
+            "max_retries": 1,
+            "retry_base_delay": 0.001,
+            "retry_max_delay": 0.001,
+        },
+    )
+    model = _wrap_with_trace(model)
+    model.invoke(messages)
+
+
+class _DeterministicEditAgent:
+    def __init__(
+        self,
+        *,
+        instructions: list[str],
+        tools: list[Any],
+        world: StateWorld,
+    ):
+        del instructions
+        self.tools = {_tool_name(tool): tool for tool in tools}
+        self.world = world
+
+    def run(self, user_msg: str, **_kwargs: Any) -> Any:
+        world = self.world
+        assert world.skill_dir is not None
+        target = re.search(r"目标 SKILL\.md 路径:\s*(\S+)", user_msg)
+        skill = re.search(r"skill_name:\s*([\w-]+)", user_msg)
+        assert target is not None and skill is not None
+        atom_ids = re.findall(r"atom_id=(\S+)\s+weightscore=", user_msg)
+        world.attempts.append(atom_ids)
+        candidates = candidate_buffer.load_candidates(world.skill_dir)["candidates"]
+        world.candidate_counts_before.append(len(candidates))
+
+        if world.inject_new_atom and not world.injected:
+            data = candidate_buffer.load_candidates(world.skill_dir)
+            data, _ = candidate_buffer.add_atom_contribution(
+                data,
+                "atom-06",
+                10,
+                note="arrived while the first turn was running",
+            )
+            candidate_buffer.save_candidates(world.skill_dir, data)
+            world.injected = True
+
+        if world.mode == "context_pressure" and len(world.attempts) == 1:
+            _exercise_context_pressure(world)
+
+        if world.fail_messages:
+            raise RuntimeError(world.fail_messages.pop(0))
+
+        agent_trace.record(
+            [SimpleNamespace(role="user", content=user_msg)],
+            _fake_trace_response(atom_ids),
+        )
+        world.processed_atoms.extend(atom_ids)
+        rules = "\n".join(
+            f"- processed {atom_id}" for atom_id in world.processed_atoms
+        )
+        content = (
+            "---\n"
+            f"name: {skill.group(1)}\n"
+            "description: BDD 可恢复 checkpoint 状态机。\n"
+            "metadata:\n"
+            f"  version: {len(world.commit_results) + 1}\n"
+            "---\n\n"
+            "# State machine\n\n"
+            f"{rules}\n"
+        )
+        write_result = _call_tool(
+            self.tools["write_file"],
+            target.group(1),
+            content,
+        )
+        assert write_result.startswith("wrote:")
+        commit_result = _call_tool(
+            self.tools["commit_baby"],
+            skill.group(1),
+            f"BDD checkpoint {len(world.commit_results) + 1}",
+        )
+        world.commit_results.append(commit_result)
+        remaining = candidate_buffer.load_candidates(
+            world.skill_dir
+        )["candidates"]
+        world.remaining_after_commit.append(
+            [item["atom_id"] for item in remaining]
+        )
+        return SimpleNamespace(content="done")
+
+
+def _run_state_agent(world: StateWorld) -> None:
+    assert world.skill_dir is not None
+
+    def factory(*, instructions: list[str], tools: list[Any]) -> Any:
+        return _DeterministicEditAgent(
+            instructions=instructions,
+            tools=tools,
+            world=world,
+        )
+
+    llm_cfg = {
+        "max_context": 1000 if world.mode == "context_pressure" else 128_000,
+        "compact_token_limit": 900 if world.mode == "context_pressure" else 112_000,
+    }
+    agent = SkillEditAgent(
+        skill_dir=world.skill_dir,
+        store=world.store,
+        agno_agent_factory=factory,
+        llm_cfg=llm_cfg,
+        traj_root=world.root / "store",
+        batch_size=world.batch_size,
+        retry_batch_size=world.retry_batch_size,
+        logs_dir=world.logs_root,
+    )
+    world.result = agent.maybe_run()
+    world.next_batch_size = agent.next_batch_size
+
+
+@given("xskill 使用隔离的测试目录")
+def isolated_directory(state_world: StateWorld) -> None:
+    assert state_world.skill_root.parent == state_world.root
+
+
+@given("SkillEdit 每批最多处理 5 个原子")
+@given("SkillEdit 默认每批处理 5 个原子")
+def batch_size_is_five(state_world: StateWorld) -> None:
+    state_world.batch_size = 5
+
+
+@given("baby 的 candidates 使用稳定的 FIFO 顺序")
+def fifo_candidates() -> None:
+    return None
+
+
+@given("baby 当前有 5 个已经绑定到本 turn 的原子")
+def five_bound_atoms(state_world: StateWorld) -> None:
+    state_world.first_five = _seed_baby(
+        state_world,
+        name="concurrent-append",
+        count=5,
+        weight=2,
+    )
+
+
+@given("cluster 在模型编辑期间追加了 1 个新原子")
+def append_during_edit(state_world: StateWorld) -> None:
+    state_world.inject_new_atom = True
+
+
+@when("模型提交当前 baby checkpoint")
+def submit_concurrent_checkpoint(state_world: StateWorld) -> None:
+    _run_state_agent(state_world)
+
+
+@then("当前 commit 只应当消费原先绑定的 5 个原子")
+def first_commit_consumes_only_bound_atoms(state_world: StateWorld) -> None:
+    first_result = state_world.commit_results[0]
+    assert all(atom_id in first_result for atom_id in state_world.first_five)
+    assert "atom-06" not in first_result
+
+
+@then("新原子应当留给下一个 turn")
+def new_atom_is_left_for_next_turn(state_world: StateWorld) -> None:
+    assert state_world.remaining_after_commit[0] == ["atom-06"]
+    assert state_world.attempts[1] == ["atom-06"]
+
+
+@then("下一个 turn 成功后 baby 才能晋升为 main")
+def promotion_waits_for_next_turn(state_world: StateWorld) -> None:
+    assert len(state_world.commit_results) == 2
+    assert state_world.result is True
+    assert state_world.skill_dir is not None
+    assert current_branch(str(state_world.skill_dir)) == "main"
+
+
+@given("baby 中按顺序存在 5 个原子")
+def five_fifo_atoms(state_world: StateWorld) -> None:
+    state_world.first_five = _seed_baby(
+        state_world,
+        name="adaptive-retry",
+        count=5,
+        weight=2,
+    )
+
+
+@given("N=5 的第一次尝试因 429 失败")
+def first_attempt_is_rate_limited(state_world: StateWorld) -> None:
+    state_world.fail_messages.append("429 rate limit")
+
+
+@given("N=2 的第二次尝试因上下文超长失败")
+def second_attempt_is_too_long(state_world: StateWorld) -> None:
+    state_world.fail_messages.append("maximum context length exceeded")
+
+
+@when("N=1 的第三次尝试成功提交 checkpoint")
+def third_attempt_commits(state_world: StateWorld) -> None:
+    _run_state_agent(state_world)
+
+
+@then("三次尝试处理的 atom_id 都应当从 FIFO 队首开始")
+def retries_start_at_fifo_head(state_world: StateWorld) -> None:
+    assert state_world.attempts[:3] == [
+        state_world.first_five,
+        state_world.first_five[:2],
+        state_world.first_five[:1],
+    ]
+
+
+@then("前两次失败不应当消费任何原子")
+def failures_do_not_consume(state_world: StateWorld) -> None:
+    assert state_world.candidate_counts_before[:3] == [5, 5, 5]
+
+
+@then("第三次只应当消费 1 个原子")
+def third_attempt_consumes_one(state_world: StateWorld) -> None:
+    assert state_world.remaining_after_commit[0] == state_world.first_five[1:]
+
+
+@then("剩余 4 个原子的下一次成功尝试应当使用默认 N=5")
+def success_restores_default_batch(state_world: StateWorld) -> None:
+    assert state_world.attempts[3] == state_world.first_five[1:]
+    assert state_world.next_batch_size == 5
+    assert state_world.result is True
+
+
+@given("baby 最初有 6 个原子")
+def six_initial_atoms(state_world: StateWorld) -> None:
+    state_world.first_five = _seed_baby(
+        state_world,
+        name="restart-recovery",
+        count=6,
+        weight=2,
+    )[:5]
+
+
+@given("第一个进程已经提交并消费前 5 个原子")
+def first_process_checkpointed_five(state_world: StateWorld) -> None:
+    assert state_world.skill_dir is not None
+    skill_md = state_world.skill_dir / "SKILL.md"
+    skill_md.write_text(
+        "---\n"
+        "name: restart-recovery\n"
+        "description: first process checkpoint\n"
+        "metadata:\n"
+        "  version: 1\n"
+        "---\n\n"
+        "# Restart recovery\n\n"
+        "first five were checkpointed\n",
+        encoding="utf-8",
+    )
+    assert commit_baby_checkpoint(
+        str(state_world.skill_dir),
+        "first process durable checkpoint",
+    )
+    consumed, remaining = candidate_buffer.remove_candidates(
+        state_world.skill_dir,
+        set(state_world.first_five),
+    )
+    assert consumed == state_world.first_five
+    assert remaining == 1
+
+
+@given("第一个进程在晋升 main 之前退出")
+def first_process_exits(state_world: StateWorld) -> None:
+    assert state_world.skill_dir is not None
+    assert current_branch(str(state_world.skill_dir)) == "baby"
+
+
+@when("watcher 在新进程中再次调度这个 baby")
+def restarted_watcher_runs(state_world: StateWorld) -> None:
+    _run_state_agent(state_world)
+
+
+@then("新进程只应当把最后 1 个原子发送给模型")
+def only_last_atom_is_sent(state_world: StateWorld) -> None:
+    assert state_world.attempts == [["atom-06"]]
+
+
+@then("已提交的前 5 个原子不应当重放")
+def first_five_are_not_replayed(state_world: StateWorld) -> None:
+    assert not set(state_world.first_five) & set(state_world.attempts[0])
+
+
+@then("最后 1 个原子成功后 baby 应当晋升为 main")
+def last_atom_allows_promotion(state_world: StateWorld) -> None:
+    assert state_world.result is True
+    assert state_world.skill_dir is not None
+    assert current_branch(str(state_world.skill_dir)) == "main"
+
+
+@given("baby 中只剩 1 个原子")
+def one_atom_remains(state_world: StateWorld) -> None:
+    _seed_baby(
+        state_world,
+        name="n1-failure",
+        count=1,
+        weight=10,
+    )
+
+
+@given("当前重试批次已经降为 N=1")
+def retry_batch_is_one(state_world: StateWorld) -> None:
+    state_world.retry_batch_size = 1
+
+
+@when("模型仍然因为上下文超长而失败")
+def n1_still_fails(state_world: StateWorld) -> None:
+    state_world.fail_messages.append("maximum context length exceeded")
+    _run_state_agent(state_world)
+
+
+@then("SkillEdit 工作应当结束并释放 worker")
+def worker_returns(state_world: StateWorld) -> None:
+    assert state_world.result is False
+    assert len(state_world.attempts) == 1
+
+
+@then("baby 应当继续停留在 baby 分支")
+def skill_stays_on_baby(state_world: StateWorld) -> None:
+    assert state_world.skill_dir is not None
+    assert current_branch(str(state_world.skill_dir)) == "baby"
+
+
+@then("最后 1 个原子应当保留在 candidates")
+def final_atom_is_preserved(state_world: StateWorld) -> None:
+    assert state_world.skill_dir is not None
+    remaining = candidate_buffer.load_candidates(
+        state_world.skill_dir
+    )["candidates"]
+    assert [item["atom_id"] for item in remaining] == ["atom-01"]
+
+
+@then("watcher 下次调度时仍应当从 N=1 开始")
+def watcher_remembers_n1(state_world: StateWorld) -> None:
+    assert state_world.next_batch_size == 1
+
+
+@given("SkillEdit 已为目标 skill 创建唯一的追加日志")
+def unique_append_log(state_world: StateWorld) -> None:
+    state_world.logs_root.mkdir()
+
+
+@given("日志不记录原始 tool call JSON")
+def trace_is_human_readable_contract() -> None:
+    return None
+
+
+@given("baby 中存在 7 个原子")
+def seven_atoms_for_trace(state_world: StateWorld) -> None:
+    _seed_baby(
+        state_world,
+        name="trace-success",
+        count=7,
+        weight=2,
+    )
+
+
+@given("默认批次大小 N=5")
+def trace_default_batch_is_five(state_world: StateWorld) -> None:
+    state_world.batch_size = 5
+
+
+@when("两个 turn 分别成功提交 5 个和 2 个原子")
+def two_trace_turns_commit(state_world: StateWorld) -> None:
+    _run_state_agent(state_world)
+    assert [len(batch) for batch in state_world.attempts] == [5, 2]
+
+
+@then("日志应当包含两个显著的 TURN START 分隔")
+def trace_has_two_turn_markers(state_world: StateWorld) -> None:
+    assert state_world.trace.count("================ TURN START") == 2
+
+
+@then("每个 TURN START 应当显示当次 N 和待处理数量")
+def trace_turn_markers_show_batch_state(state_world: StateWorld) -> None:
+    assert "TURN START | N=5 | processing 5 of 7 pending atoms" in state_world.trace
+    assert "TURN START | N=5 | processing 2 of 2 pending atoms" in state_world.trace
+
+
+@then("每个 round 应当显示当前 token、spill 上限和 compact 上限")
+def trace_rounds_show_context_limits(state_world: StateWorld) -> None:
+    rounds = [
+        line for line in state_world.trace.splitlines()
+        if line.startswith("---- ROUND")
+    ]
+    assert len(rounds) == 2
+    assert all(
+        "tokens=" in line and "spill@" in line and "compact@" in line
+        for line in rounds
+    )
+
+
+@then("工具摘要应当显示 commit_baby 消费的 atom_id")
+def trace_shows_consumed_atom_ids(state_world: StateWorld) -> None:
+    assert "Consumed atoms:" in state_world.trace
+    for atom_id in [f"atom-{index:02d}" for index in range(1, 8)]:
+        assert atom_id in state_world.trace
+
+
+@then("每个 turn 应当显示已消费数量、剩余数量和下一次 N")
+def trace_shows_turn_outcomes(state_world: StateWorld) -> None:
+    assert "TURN END | COMMITTED | consumed=5 | 2 remaining | next N=5" in state_world.trace
+    assert "TURN END | COMMITTED | consumed=2 | 0 remaining | next N=5" in state_world.trace
+
+
+@then("日志不应当包含原始 JSON 对象")
+def trace_has_no_raw_json(state_world: StateWorld) -> None:
+    assert '{"' not in state_world.trace
+    assert '"skill_name":' not in state_world.trace
+
+
+@given("当前 turn 从 N=5 开始")
+def pressure_turn_starts_at_five(state_world: StateWorld) -> None:
+    _seed_baby(
+        state_world,
+        name="trace-pressure",
+        count=5,
+        weight=2,
+    )
+    state_world.batch_size = 5
+
+
+@given("模型第一次调用触发上下文压力")
+def first_call_has_context_pressure(state_world: StateWorld) -> None:
+    state_world.mode = "context_pressure"
+
+
+@given("spill 后仍然超过 compact 上限")
+def spill_is_not_enough() -> None:
+    return None
+
+
+@given("本次模型调用最终因 429 失败")
+def pressure_call_is_rate_limited() -> None:
+    # _exercise_context_pressure uses the production retry wrapper and raises
+    # a bounded 429 after spill and compact have both been recorded.
+    return None
+
+
+@when("SkillEdit 把当前工作缩小到 N=2 后重试")
+def retry_with_two(state_world: StateWorld) -> None:
+    _run_state_agent(state_world)
+    assert [len(batch) for batch in state_world.attempts[:2]] == [5, 2]
+
+
+@then("日志中 spill 事件应当出现在 compact 事件之前")
+def spill_precedes_compact(state_world: StateWorld) -> None:
+    trace = state_world.trace
+    assert trace.index("Spilled 1 old tool result") < trace.index("Compacted context")
+
+
+@then("日志应当显示 compact 前后的 token 数量")
+def compact_shows_token_delta(state_world: StateWorld) -> None:
+    assert re.search(
+        r"Compacted context: [\d,]+ -> [\d,]+ tokens\.",
+        state_world.trace,
+    )
+
+
+@then("日志应当显示模型调用失败的可读原因")
+def trace_shows_readable_model_error(state_world: StateWorld) -> None:
+    assert "LLM returned 429; retries exhausted (1/1)" in state_world.trace
+
+
+@then('日志应当显示 "Retry batch reduced: 5 -> 2"')
+def trace_shows_batch_reduction(state_world: StateWorld) -> None:
+    assert "Retry batch reduced: 5 -> 2" in state_world.trace
+
+
+@then("下一次 TURN START 应当显示 N=2")
+def next_turn_marker_uses_two(state_world: StateWorld) -> None:
+    assert "TURN START | N=2 | processing 2 of 5 pending atoms" in state_world.trace

--- a/tests/pool_helpers.py
+++ b/tests/pool_helpers.py
@@ -7,6 +7,7 @@ def pool_config(
     workers: int = 2,
     *,
     batch_size: int = 8,
+    edit_batch_size: int = 5,
     split_workers: int | None = None,
     cluster_workers: int | None = None,
     edit_workers: int | None = None,
@@ -19,6 +20,10 @@ def pool_config(
             "batch_size": batch_size,
             "llm_weight": 3,
         },
-        "edit": {"workers": edit_workers or workers, "llm_weight": 1},
+        "edit": {
+            "workers": edit_workers or workers,
+            "batch_size": edit_batch_size,
+            "llm_weight": 1,
+        },
         "embed": {"workers": embed_workers or workers},
     }

--- a/tests/test_agent_trace.py
+++ b/tests/test_agent_trace.py
@@ -35,7 +35,7 @@ def test_record_writes_round_with_cot_and_tools(tmp_path):
                                     tools=(("submit_atom", '{"start_line":1}'),)))
     assert sink.is_file()
     txt = sink.read_text(encoding="utf-8")
-    assert "round 1" in txt and "round 2" in txt
+    assert "ROUND 1" in txt and "ROUND 2" in txt
     assert "第一步看上下文" in txt and "提交原子" in txt
     assert "look(" in txt and "submit_atom(" in txt
     assert "tokens" in txt  # 每轮带 token 估算
@@ -83,11 +83,11 @@ def test_nested_trace_restores_outer_sink_and_round(tmp_path):
     assert "outer-before" in outer_text
     assert "outer-after" in outer_text
     assert "inner" not in outer_text
-    assert "round 1" in outer_text
-    assert "round 2" in outer_text
+    assert "ROUND 1" in outer_text
+    assert "ROUND 2" in outer_text
     assert "inner" in inner_text
-    assert "round 1" in inner_text
-    assert "round 2" not in inner_text
+    assert "ROUND 1" in inner_text
+    assert "ROUND 2" not in inner_text
 
 
 def test_nested_none_temporarily_disables_outer_trace(tmp_path):
@@ -103,7 +103,7 @@ def test_nested_none_temporarily_disables_outer_trace(tmp_path):
     assert "outer-before" in text
     assert "suppressed" not in text
     assert "outer-after" in text
-    assert "round 2" in text
+    assert "ROUND 2" in text
 
 
 def test_trace_disk_errors_warn_once_without_path_or_error_text(
@@ -149,7 +149,7 @@ def test_wrap_with_trace_records_each_invoke(tmp_path):
         m.invoke(_msgs())
         m.invoke(_msgs())
     txt = sink.read_text(encoding="utf-8")
-    assert txt.count("wrapped-round") == 2 and "round 2" in txt
+    assert txt.count("wrapped-round") == 2 and "ROUND 2" in txt
 
 
 def test_wrap_with_trace_does_not_swallow_unexpected_trace_bug(tmp_path):
@@ -183,3 +183,33 @@ def test_dict_tool_call_shape(tmp_path):
     with trace_to(sink):
         record(_msgs(), resp)
     assert "grep(" in sink.read_text(encoding="utf-8")
+
+
+def test_tool_arguments_are_human_readable_without_raw_json(tmp_path):
+    sink = tmp_path / "readable.log"
+    with trace_to(
+        sink,
+        spill_token_limit=96000,
+        compact_token_limit=112000,
+    ):
+        record(
+            _msgs(),
+            _fake_resp(
+                reasoning="inspect and commit",
+                tools=(
+                    ("skill_read", '{"skill_name":"context-management"}'),
+                    (
+                        "write_file",
+                        '{"path":"SKILL.md","content":"'
+                        + ("x" * 300)
+                        + '"}',
+                    ),
+                ),
+            ),
+        )
+
+    trace = sink.read_text(encoding="utf-8")
+    assert "spill@96k | compact@112k" in trace
+    assert "TOOL  skill_read(context-management)" in trace
+    assert "TOOL  write_file(path=SKILL.md, content=<300 chars>)" in trace
+    assert '{"skill_name"' not in trace

--- a/tests/test_agent_worker_runtime.py
+++ b/tests/test_agent_worker_runtime.py
@@ -193,7 +193,7 @@ def test_v0627_config_gets_runtime_defaults_without_mutating_user_input():
     assert effective["agent_worker"]["pools"] == {
         "split": {"workers": 24, "llm_weight": 6},
         "cluster": {"workers": 8, "batch_size": 5, "llm_weight": 3},
-        "edit": {"workers": 4, "llm_weight": 1},
+        "edit": {"workers": 4, "batch_size": 5, "llm_weight": 1},
         "embed": {"workers": 4},
     }
     assert effective["llm"]["rate_limit"] == {
@@ -229,7 +229,7 @@ def test_explicit_new_values_win_and_missing_pool_fields_get_defaults():
     assert pools["cluster"] == {
         "workers": 3, "batch_size": 2, "llm_weight": 3,
     }
-    assert pools["edit"] == {"workers": 4, "llm_weight": 1}
+    assert pools["edit"] == {"workers": 4, "batch_size": 5, "llm_weight": 1}
     assert pools["embed"] == {"workers": 4}
     assert effective["llm"]["rate_limit"]["request_burst"] == 3
     assert effective["llm"]["rate_limit"]["max_inflight"] == 11
@@ -246,6 +246,19 @@ def test_missing_new_sections_use_release_defaults():
     }
     assert effective["embedding"]["rate_limit"] == {"max_inflight": 4}
     assert effective["agent_worker"]["pools"]["cluster"]["batch_size"] == 8
+    assert effective["agent_worker"]["pools"]["edit"]["batch_size"] == 5
+
+
+def test_edit_batch_size_must_be_a_positive_integer():
+    config = _legacy_config()
+    config["agent_worker"] = {
+        "pools": {"edit": {"batch_size": 0}},
+    }
+    with pytest.raises(
+        ValueError,
+        match=r"agent_worker\.pools\.edit\.batch_size",
+    ):
+        normalize_runtime_config(config)
 
 
 def test_load_config_accepts_old_yaml_without_rewriting_it(tmp_path):

--- a/tests/test_agno_factory_probe_smoke.py
+++ b/tests/test_agno_factory_probe_smoke.py
@@ -139,7 +139,10 @@ def test_context_management_reads_compact_config_and_calls_compactor(tmp_path):
     )
     assistant_message = Message(role="assistant", content=None)
     messages = [
-        Message(role="system", content="SkillEditAgent system prompt"),
+        Message(
+            role="system",
+            content="SkillEditAgent system prompt\n" + ("S" * 4000),
+        ),
         Message(role="user", content="turn0 scenario"),
         Message(role="assistant", content="old reasoning"),
         Message(role="tool", content="OLD_ATOM_RESULT\n" + ("x" * 8000),

--- a/tests/test_llm_retry.py
+++ b/tests/test_llm_retry.py
@@ -25,6 +25,8 @@ class _FlakyModel:
 def _no_sleep(monkeypatch):
     # 别真睡——把退避 sleep 打掉,测试秒过
     monkeypatch.setattr("time.sleep", lambda *_a, **_k: None)
+    from xskill.utils.shutdown import SHUTTING_DOWN
+    monkeypatch.setattr(SHUTTING_DOWN, "wait", lambda *_args: False)
 
 
 def test_transient_classification():
@@ -59,3 +61,19 @@ def test_non_transient_raises_immediately_no_retry():
     with pytest.raises(Exception):
         m.invoke([])
     assert m.calls == 1  # 只试一次
+
+
+def test_retry_and_exhaustion_are_written_to_active_trace(tmp_path):
+    from xskill.agents.agent_trace import trace_to
+
+    model = _FlakyModel(fail_n=999, exc=Exception("429 rate limit"))
+    _wrap_with_retry(model, {"max_retries": 3})
+    sink = tmp_path / "skill.log"
+    with trace_to(sink):
+        with pytest.raises(Exception):
+            model.invoke([])
+
+    trace = sink.read_text(encoding="utf-8")
+    assert "LLM returned 429; retrying (1/3)" in trace
+    assert "LLM returned 429; retrying (2/3)" in trace
+    assert "LLM returned 429; retries exhausted (3/3)" in trace

--- a/tests/test_skill_edit_agent.py
+++ b/tests/test_skill_edit_agent.py
@@ -51,7 +51,7 @@ def _add_ux_score(skill_dir: Path, side: str = "main"):
 
 
 class _BabyStubAgno:
-    """模拟 SkillEditAgent 在 baby 分支：写 SKILL.md + 调 commit_baby_to_main。"""
+    """模拟 baby turn：写 SKILL.md + 调 commit_baby checkpoint。"""
     invoked: bool = False
     user_msg: str = ""
     writes_skill_md_with: str | None = None
@@ -75,9 +75,9 @@ class _BabyStubAgno:
         # 写 SKILL.md
         if type(self).writes_skill_md_with is not None and target_path:
             _call_tool(self.tools["write_file"], target_path, type(self).writes_skill_md_with)
-        # 调 commit_baby_to_main
+        # 调 commit_baby；buffer 清空后由框架 graduate。
         if type(self).calls_commit and skill:
-            _call_tool(self.tools["commit_baby_to_main"], skill, "stub baby commit")
+            _call_tool(self.tools["commit_baby"], skill, "stub baby checkpoint")
         class _R: pass
         r = _R(); r.content = "done"
         return r
@@ -189,12 +189,10 @@ class TestThresholdGate:
             logs_dir=tmp_path / "instance-logs",
         )
         assert agent.maybe_run() is True
-        assert list(
-            (
-                tmp_path / "instance-logs" / "agents"
-                / "skill_edit_agents" / "skills"
-            ).glob("my-skill_*.log")
-        )
+        assert (
+            tmp_path / "instance-logs" / "agents"
+            / "skill_edit_agents" / "skills" / "my-skill.log"
+        ).is_file()
         # baby → main graduate 完成
         from xskill.skill.git import current_branch
         assert current_branch(str(skill_dir)) == "main"
@@ -478,7 +476,7 @@ class TestWritingDisciplineInPrompt:
         """管线契约部分（场景块占位/commit 工具/隐私守护/frontmatter/工具清单）保留不动。"""
         assert "{scenario_block}" in SYSTEM_PROMPT_TEMPLATE
         assert "{branch_now}" in SYSTEM_PROMPT_TEMPLATE
-        assert "commit_baby_to_main" in SYSTEM_PROMPT_TEMPLATE
+        assert "commit_baby" in SYSTEM_PROMPT_TEMPLATE
         assert "commit_to_staging" in SYSTEM_PROMPT_TEMPLATE
         assert "隐私守护" in SYSTEM_PROMPT_TEMPLATE
         assert "AtomTaskRead" in SYSTEM_PROMPT_TEMPLATE

--- a/tests/test_skill_edit_batch_turns.py
+++ b/tests/test_skill_edit_batch_turns.py
@@ -1,35 +1,9 @@
-"""SkillEditAgent 多轮渐进式消化（batch + turn 分支）验收单测
-================================================================
+"""Issue #146：baby checkpoint + legacy main/jam turn-chain 回归。
 
-背景：``.candidates.yml`` buffer 攒满阈值时曾经把全部候选一次性塞进单个
-``agent.run()``——``xskill rebuild --force`` 重放历史 / 团队突然活跃时 buffer
-可能攒到几十上百条，单次会话被拖到小时级,且落盘判定弱（agent 半途收笔也会
-被当成"成功"整批清空 buffer,未消化的候选静默丢失）。
-
-止血设计（用户拍板，见 PR 描述）：
-  1. ``maybe_run`` 对 buffer 做一次快照,按 ``(weightscore 降序, atom_id 升序)``
-     切成 ``SKILL_EDIT_BATCH_SIZE`` 条一批,每批一轮全新上下文的 agent.run()。
-  2. 除最后一轮外,每轮结束由宿主 Python 代码（不是 agent）commit 到
-     ``<branch>_turn<N>`` 分支承接进度；中间轮的 agent 完全拿不到任何终态
-     commit 工具——分支推进对它不可见也不可调用（结构性保证）。
-  3. 最后一轮开跑前宿主代码把 HEAD 切回原分支（工作区不动），agent 此时才
-     拿到终态 commit 工具，一次 commit 落地全部批次的累计改动。
-  4. 成功后清理所有 turn 分支；用快照的 atom_id 集合从 buffer 摘除（而非
-     清空整个文件）——消化期间新增的候选留给下一次 maybe_run。
-  5. 崩溃恢复：发现残留 ``*_turn*`` 分支就重置（不续传），buffer 未清过，
-     重新完整跑一遍不丢候选。
-
-本文件验收：
-  - 100+ 候选、真实 batch=20：多轮链条产出的 SKILL.md 融合全部批次内容，
-    turn 分支跑完后清理干净。
-  - 核心安全性质：中间轮不会推进 main / 不会创建 staging，只有最后一轮才推进。
-  - 四个终态落地场景（baby 毕业 / main 开 staging / jam 强砍合并——jam 内部
-    调用的 ``commit_update_main_branch`` 就是"main 直接更新"这第四种落地
-    方式，本仓库现状里它只在 jam 路径可达，因此用同一个 jam 多轮用例覆盖）
-    都各有一个多轮用例，共享同一套渐进式循环骨架。
-  - 崩溃恢复：残留 turn 分支被重置，重新完整跑一遍，候选不丢不重复消化。
-  - 快照语义：消化期间新增的候选本次不处理，运行结束后仍在 buffer 里。
-  - ``remove_candidates`` 只摘除快照里的 atom_id，其余原样保留。
+baby 每 N 个 FIFO candidates 形成一个真实 commit 并立即消费，失败按 N/2
+降压，成功恢复默认 N，buffer 空后框架晋升 main。main→staging 与 jam 则保留
+旧 ``*_turnN`` 链。本文件同时覆盖大 buffer、崩溃恢复、并发新增、精确消费、
+post-commit 异常不重放，以及旧 main/jam 语义不回归。
 """
 from __future__ import annotations
 
@@ -145,7 +119,7 @@ class _ProgressiveStub:
             "baby_sha": _rev("baby"),
             "main_sha": _rev("main"),
             "staging_exists": staging_ok,
-            "has_commit_baby": "commit_baby_to_main" in self.tools,
+            "has_commit_baby": "commit_baby" in self.tools,
             "has_commit_staging": "commit_to_staging" in self.tools,
             "has_commit_update_main": "commit_update_main" in self.tools,
         })
@@ -162,8 +136,8 @@ class _ProgressiveStub:
         )
         _call_tool(self.tools["write_file"], target, content)
 
-        if "commit_baby_to_main" in self.tools:
-            _call_tool(self.tools["commit_baby_to_main"], skill, "progressive graduate")
+        if "commit_baby" in self.tools:
+            _call_tool(self.tools["commit_baby"], skill, "baby batch checkpoint")
         elif "commit_to_staging" in self.tools:
             _call_tool(self.tools["commit_to_staging"], skill, "progressive staging")
         elif "commit_update_main" in self.tools:
@@ -187,10 +161,9 @@ def _make_progressive_factory(observed: list):
 # ═══════════════════════════════════════════════════════════════════
 
 class TestLargeBufferRealBatchSize:
-    def test_100_plus_candidates_batch_20_merges_all_and_cleans_turn_branches(
+    def test_100_candidates_default_batch_5_creates_20_checkpoints(
         self, tmp_path,
     ):
-        assert C.SKILL_EDIT_BATCH_SIZE == 20, "本用例故意验证真实默认 batch size"
         skill_dir = _make_baby_skill(tmp_path / "skill", "huge-skill")
         atom_ids = _seed_candidates(skill_dir, 100)
 
@@ -202,20 +175,21 @@ class TestLargeBufferRealBatchSize:
         )
         assert agent.maybe_run() is True
 
-        # 5 轮（100/20）
-        assert len(observed) == 5, f"expected 5 turns, got {len(observed)}"
+        # 20 轮（100/5），每轮都是真实 baby checkpoint。
+        assert len(observed) == 20, f"expected 20 turns, got {len(observed)}"
+        assert all(item["has_commit_baby"] for item in observed)
 
         # 毕业到 main
         assert current_branch(str(skill_dir)) == "main"
 
-        # 正文融合了全部 5 批的标记行，且每批 20 个 atom_id，并集 = 全部 100 个
+        # 正文融合全部 20 批，每批 5 个 atom_id。
         body = (skill_dir / "SKILL.md").read_text(encoding="utf-8")
         marker_lines = [ln for ln in body.splitlines() if ln.startswith("- round atoms:")]
-        assert len(marker_lines) == 5
+        assert len(marker_lines) == 20
         seen_atoms: set[str] = set()
         for ln in marker_lines:
             ids = ln.split(":", 1)[1].strip().split(",")
-            assert len(ids) == 20
+            assert len(ids) == 5
             seen_atoms.update(ids)
         assert seen_atoms == set(atom_ids)
 
@@ -242,7 +216,7 @@ def small_batch(monkeypatch):
 
 
 class TestFourTerminalScenariosMultiTurn:
-    def test_baby_graduate_multi_turn_only_final_round_advances(
+    def test_baby_checkpoints_every_turn_then_framework_graduates(
         self, tmp_path, small_batch,
     ):
         skill_dir = _make_baby_skill(tmp_path / "skill", "baby-multi")
@@ -253,17 +227,15 @@ class TestFourTerminalScenariosMultiTurn:
         agent = SkillEditAgent(
             skill_dir=skill_dir, store=None,
             agno_agent_factory=_make_progressive_factory(observed),
-            llm_cfg={}, traj_root=tmp_path,
+            llm_cfg={}, traj_root=tmp_path, batch_size=small_batch,
         )
         assert agent.maybe_run() is True
         assert len(observed) == 3
 
-        # 安全性质：只有最后一轮拿到 commit_baby_to_main；baby ref 在此之前
-        # 全程原地不动（turn 分支不影响 baby 自己的 tip）。
-        for round_info in observed[:-1]:
-            assert round_info["has_commit_baby"] is False
-            assert round_info["baby_sha"] == baby_sha_before
-        assert observed[-1]["has_commit_baby"] is True
+        # 每一轮都拿到 commit_baby；下一轮启动时 baby tip 已经前进。
+        assert all(round_info["has_commit_baby"] for round_info in observed)
+        assert observed[0]["baby_sha"] == baby_sha_before
+        assert len({round_info["baby_sha"] for round_info in observed}) == 3
 
         assert current_branch(str(skill_dir)) == "main"
         assert list_turn_branches(str(skill_dir)) == []
@@ -280,7 +252,7 @@ class TestFourTerminalScenariosMultiTurn:
         agent = SkillEditAgent(
             skill_dir=skill_dir, store=None,
             agno_agent_factory=_make_progressive_factory(observed),
-            llm_cfg={}, traj_root=tmp_path,
+            llm_cfg={}, traj_root=tmp_path, batch_size=small_batch,
         )
         assert agent.maybe_run() is True
         assert len(observed) == 3
@@ -363,7 +335,7 @@ class TestCrashRecovery:
         agent = SkillEditAgent(
             skill_dir=skill_dir, store=None,
             agno_agent_factory=_make_progressive_factory(observed),
-            llm_cfg={}, traj_root=tmp_path,
+            llm_cfg={}, traj_root=tmp_path, batch_size=small_batch,
         )
         assert agent.maybe_run() is True
 
@@ -423,20 +395,28 @@ class TestSnapshotSemantics:
             """写正文 + commit 之前,模拟 cluster 并发往 buffer 里加了条新候选。"""
             def __init__(self, *, instructions, tools):
                 self.tools = {_tool_name(t): t for t in tools}
+                self.injected = False
 
             def run(self, user_msg, **_kw):
                 target = re.search(r"目标 SKILL\.md 路径:\s*(\S+)", user_msg).group(1)
                 skill = re.search(r"skill_name:\s*([\w-]+)", user_msg).group(1)
+                atom_ids = re.findall(r"atom_id=(\S+)\s+weightscore=", user_msg)
 
-                data = C.load_candidates(skill_dir)
-                data, _ = C.add_atom_contribution(data, "atom_injected_concurrently", 5)
-                C.save_candidates(skill_dir, data)
+                if not getattr(_InjectingStub, "injected_once", False):
+                    data = C.load_candidates(skill_dir)
+                    data, _ = C.add_atom_contribution(
+                        data, "atom_injected_concurrently", 5,
+                    )
+                    C.save_candidates(skill_dir, data)
+                    _InjectingStub.injected_once = True
 
                 _call_tool(
                     self.tools["write_file"], target,
-                    f"---\nname: {skill}\ndescription: v1\nmetadata:\n  version: 1\n---\n# body\n",
+                    f"---\nname: {skill}\ndescription: checkpoint\n"
+                    "metadata:\n  version: 1\n---\n# body\n"
+                    f"processed: {','.join(atom_ids)}\n",
                 )
-                _call_tool(self.tools["commit_baby_to_main"], skill, "v1")
+                _call_tool(self.tools["commit_baby"], skill, "v1 checkpoint")
                 class _R:
                     pass
                 r = _R(); r.content = "done"
@@ -450,10 +430,9 @@ class TestSnapshotSemantics:
         assert agent.maybe_run() is True
 
         remaining = C.load_candidates(skill_dir)["candidates"]
-        remaining_ids = {c["atom_id"] for c in remaining}
-        # 快照里的 3 个已消化摘除；并发期间加进来的第 4 个还在,留给下次 maybe_run
-        assert remaining_ids == {"atom_injected_concurrently"}
-        assert not (remaining_ids & set(snapshot_ids))
+        # baby 会持续 drain 到当前 buffer 为空，并发新增 atom 在下一批被消费。
+        assert remaining == []
+        assert set(snapshot_ids)
 
 
 # ═══════════════════════════════════════════════════════════════════
@@ -486,3 +465,201 @@ class TestRemoveCandidates:
 
         remaining = C.load_candidates(skill_dir)["candidates"]
         assert [c["atom_id"] for c in remaining] == ["only-one"]
+
+
+class TestBabyCheckpointRecovery:
+    def test_1000_fifo_candidates_form_200_default_batches(self, tmp_path):
+        agent = SkillEditAgent(
+            skill_dir=tmp_path,
+            store=None,
+            agno_agent_factory=lambda **_kwargs: None,
+            llm_cfg={},
+            traj_root=tmp_path,
+        )
+        pending = [
+            {"atom_id": f"atom_{index:04d}", "weightscore": 1}
+            for index in range(1000)
+        ]
+        batches: list[list[str]] = []
+        while pending:
+            batch = agent._take_baby_batch(pending, agent.batch_size)
+            batches.append([candidate["atom_id"] for candidate in batch])
+            pending = pending[len(batch):]
+
+        assert agent.batch_size == 5
+        assert len(batches) == 200
+        assert batches[0] == [f"atom_{index:04d}" for index in range(5)]
+        assert batches[-1] == [f"atom_{index:04d}" for index in range(995, 1000)]
+
+    def test_failures_reduce_5_to_2_to_1_then_success_resets_to_5(
+        self, tmp_path,
+    ):
+        skill_dir = _make_baby_skill(tmp_path / "skill", "adaptive-baby")
+        _seed_candidates(skill_dir, 5, ws=2)
+        batch_sizes: list[int] = []
+
+        class _AdaptiveStub:
+            def __init__(self, *, instructions, tools):
+                del instructions
+                self.tools = {_tool_name(tool): tool for tool in tools}
+
+            def run(self, user_msg, **_kwargs):
+                atom_ids = re.findall(
+                    r"atom_id=(\S+)\s+weightscore=", user_msg,
+                )
+                batch_sizes.append(len(atom_ids))
+                if len(batch_sizes) <= 2:
+                    raise RuntimeError("429 rate limit")
+                target = re.search(
+                    r"目标 SKILL\.md 路径:\s*(\S+)", user_msg,
+                ).group(1)
+                skill = re.search(
+                    r"skill_name:\s*([\w-]+)", user_msg,
+                ).group(1)
+                existing = Path(target).read_text(encoding="utf-8")
+                marker = f"\nprocessed-{len(batch_sizes)}: {','.join(atom_ids)}\n"
+                _call_tool(
+                    self.tools["write_file"],
+                    target,
+                    existing + marker,
+                )
+                _call_tool(
+                    self.tools["commit_baby"],
+                    skill,
+                    f"checkpoint {len(batch_sizes)}",
+                )
+                return type("_R", (), {"content": "done"})()
+
+        logs_dir = tmp_path / "logs"
+        agent = SkillEditAgent(
+            skill_dir=skill_dir,
+            store=None,
+            agno_agent_factory=lambda **kwargs: _AdaptiveStub(**kwargs),
+            llm_cfg={"max_context": 128000, "compact_token_limit": 112000},
+            traj_root=tmp_path,
+            logs_dir=logs_dir,
+        )
+
+        assert agent.maybe_run() is True
+        assert batch_sizes == [5, 2, 1, 4]
+        assert agent.next_batch_size == 5
+        assert current_branch(str(skill_dir)) == "main"
+        trace = (
+            logs_dir / "agents" / "skill_edit_agents"
+            / "skills" / "adaptive-baby.log"
+        ).read_text(encoding="utf-8")
+        assert "Retry batch reduced: 5 -> 2" in trace
+        assert "Retry batch reduced: 2 -> 1" in trace
+        assert "TURN START | N=1 | processing 1 of 5" in trace
+        assert "TURN START | N=5 | processing 4 of 4" in trace
+        assert "TURN END | COMMITTED | consumed=4 | 0 remaining | next N=5" in trace
+        assert "{" not in trace
+
+    def test_exception_after_commit_is_not_replayed(self, tmp_path):
+        skill_dir = _make_baby_skill(tmp_path / "skill", "post-commit-error")
+        atom_ids = _seed_candidates(skill_dir, 3, ws=4)
+        calls = 0
+
+        class _CommitThenThrow:
+            def __init__(self, *, instructions, tools):
+                del instructions
+                self.tools = {_tool_name(tool): tool for tool in tools}
+
+            def run(self, user_msg, **_kwargs):
+                nonlocal calls
+                calls += 1
+                target = re.search(
+                    r"目标 SKILL\.md 路径:\s*(\S+)", user_msg,
+                ).group(1)
+                skill = re.search(
+                    r"skill_name:\s*([\w-]+)", user_msg,
+                ).group(1)
+                _call_tool(
+                    self.tools["write_file"],
+                    target,
+                    f"---\nname: {skill}\ndescription: durable checkpoint\n"
+                    "metadata:\n  version: 1\n---\n# body\n",
+                )
+                _call_tool(
+                    self.tools["commit_baby"],
+                    skill,
+                    "durable before final response",
+                )
+                raise RuntimeError("429 on post-tool model response")
+
+        agent = SkillEditAgent(
+            skill_dir=skill_dir,
+            store=None,
+            agno_agent_factory=lambda **kwargs: _CommitThenThrow(**kwargs),
+            llm_cfg={},
+            traj_root=tmp_path,
+        )
+
+        assert agent.maybe_run() is True
+        assert calls == 1
+        assert current_branch(str(skill_dir)) == "main"
+        assert C.load_candidates(skill_dir)["candidates"] == []
+        body = (skill_dir / "SKILL.md").read_text(encoding="utf-8")
+        assert "durable checkpoint" in body
+        assert atom_ids
+
+    def test_partial_baby_bypasses_threshold_after_restart(self, tmp_path):
+        from xskill.skill.git import commit_baby_checkpoint
+
+        skill_dir = _make_baby_skill(tmp_path / "skill", "partial-baby")
+        atom_ids = _seed_candidates(skill_dir, 6, ws=2)
+        skill_md = skill_dir / "SKILL.md"
+        skill_md.write_text(
+            "---\nname: partial-baby\ndescription: first checkpoint\n"
+            "metadata:\n  version: 1\n---\n# body\nfirst five\n",
+            encoding="utf-8",
+        )
+        assert commit_baby_checkpoint(
+            str(skill_dir), "simulate checkpoint before restart",
+        )
+        consumed, remaining = C.remove_candidates(
+            skill_dir, set(atom_ids[:5]),
+        )
+        assert consumed == atom_ids[:5]
+        assert remaining == 1
+
+        observed: list = []
+        agent = SkillEditAgent(
+            skill_dir=skill_dir,
+            store=None,
+            agno_agent_factory=_make_progressive_factory(observed),
+            llm_cfg={},
+            traj_root=tmp_path,
+        )
+        assert agent.maybe_run() is True
+        assert [item["atom_ids"] for item in observed] == [[atom_ids[-1]]]
+        assert current_branch(str(skill_dir)) == "main"
+
+    def test_n1_failure_releases_turn_and_preserves_retry_size(self, tmp_path):
+        skill_dir = _make_baby_skill(tmp_path / "skill", "n1-failure")
+        _seed_candidates(skill_dir, 1, ws=10)
+        calls = 0
+
+        class _AlwaysFails:
+            def __init__(self, **_kwargs):
+                pass
+
+            def run(self, _user_msg, **_kwargs):
+                nonlocal calls
+                calls += 1
+                raise RuntimeError("maximum context length exceeded")
+
+        agent = SkillEditAgent(
+            skill_dir=skill_dir,
+            store=None,
+            agno_agent_factory=lambda **kwargs: _AlwaysFails(**kwargs),
+            llm_cfg={},
+            traj_root=tmp_path,
+            retry_batch_size=1,
+        )
+
+        assert agent.maybe_run() is False
+        assert calls == 1
+        assert agent.next_batch_size == 1
+        assert current_branch(str(skill_dir)) == "baby"
+        assert len(C.load_candidates(skill_dir)["candidates"]) == 1

--- a/tests/test_skill_edit_mutation_contracts.py
+++ b/tests/test_skill_edit_mutation_contracts.py
@@ -1,0 +1,126 @@
+"""Focused contracts used by mutmut for SkillEdit's durable boundaries."""
+
+from __future__ import annotations
+
+from contextlib import contextmanager
+from pathlib import Path
+from typing import Iterator
+
+from xskill.agents import agent_tools
+from xskill.skill import candidates as candidate_buffer
+from xskill.skill import git as skill_git
+
+
+def test_graduate_baby_forwards_exact_optimizer_and_git_arguments(
+    tmp_path: Path,
+    monkeypatch,
+) -> None:
+    target = tmp_path / "skills" / "graduation-contract"
+    target.mkdir(parents=True)
+    (target / "SKILL.md").write_text(
+        "---\n"
+        "name: graduation-contract\n"
+        "description: valid mutation contract\n"
+        "---\n\n"
+        "# Graduation contract\n",
+        encoding="utf-8",
+    )
+    calls: list[tuple[object, ...]] = []
+
+    def optimize(actual_target: Path, actual_slug: str) -> None:
+        calls.append(("optimize", actual_target, actual_slug))
+
+    def graduate(actual_target: str, actual_message: str) -> bool:
+        calls.append(("git", actual_target, actual_message))
+        return True
+
+    monkeypatch.setattr(
+        agent_tools,
+        "_run_description_optimization",
+        optimize,
+    )
+    monkeypatch.setattr(
+        skill_git,
+        "commit_baby_to_main_branch",
+        graduate,
+    )
+
+    assert agent_tools.graduate_baby_to_main(
+        target,
+        "graduation-contract",
+        "all candidate checkpoints complete",
+    ) is True
+    assert calls == [
+        ("optimize", target, "graduation-contract"),
+        ("git", str(target), "all candidate checkpoints complete"),
+    ]
+
+
+def test_graduate_baby_rejects_invalid_frontmatter_before_side_effects(
+    tmp_path: Path,
+    monkeypatch,
+) -> None:
+    target = tmp_path / "skills" / "invalid-graduation"
+    target.mkdir(parents=True)
+    (target / "SKILL.md").write_text("not frontmatter", encoding="utf-8")
+
+    def unexpected(*_args, **_kwargs) -> None:
+        raise AssertionError("invalid SKILL.md must not reach a side effect")
+
+    monkeypatch.setattr(
+        agent_tools,
+        "_run_description_optimization",
+        unexpected,
+    )
+    monkeypatch.setattr(
+        skill_git,
+        "commit_baby_to_main_branch",
+        unexpected,
+    )
+
+    assert agent_tools.graduate_baby_to_main(
+        target,
+        "invalid-graduation",
+        "must not commit",
+    ) is False
+
+
+def test_remove_candidates_does_not_consume_a_git_write_slot(
+    tmp_path: Path,
+    monkeypatch,
+) -> None:
+    skill_dir = tmp_path / "skills" / "candidate-lock-contract"
+    skill_dir.mkdir(parents=True)
+    data: dict = {"candidates": []}
+    for atom_id in ("atom-01", "atom-02"):
+        data, _ = candidate_buffer.add_atom_contribution(
+            data,
+            atom_id,
+            5,
+        )
+    candidate_buffer.save_candidates(skill_dir, data)
+    lock_calls: list[tuple[Path, bool]] = []
+
+    @contextmanager
+    def recording_lock(
+        actual_skill_dir: Path,
+        *,
+        use_git_write_limit: bool = True,
+    ) -> Iterator[None]:
+        lock_calls.append((actual_skill_dir, use_git_write_limit))
+        yield
+
+    monkeypatch.setattr(
+        candidate_buffer,
+        "skill_repo_lock",
+        recording_lock,
+    )
+
+    consumed, remaining = candidate_buffer.remove_candidates(
+        skill_dir,
+        {"atom-01"},
+    )
+
+    assert consumed == ["atom-01"]
+    assert remaining == 1
+    assert lock_calls == [(skill_dir, False)]

--- a/tests/test_skilledit_parallel.py
+++ b/tests/test_skilledit_parallel.py
@@ -89,11 +89,11 @@ def _make_barrier_agno(expected_workers, barrier):
                     f"---\nname: {skill_slug}\ndescription: real body for {skill_slug}\n"
                     f"metadata:\n  version: 1\n---\n# {skill_slug}\nbody-of-{skill_slug}\n",
                 )
-            if "baby" in user_message and "commit_baby_to_main" in self.tools:
+            if "baby" in user_message and "commit_baby" in self.tools:
                 _call_tool(
-                    self.tools["commit_baby_to_main"],
+                    self.tools["commit_baby"],
                     skill_slug,
-                    f"graduate {skill_slug}",
+                    f"checkpoint {skill_slug}",
                 )
             class _Response:
                 pass
@@ -176,6 +176,26 @@ def test_runner_passes_jam_threshold(monkeypatch, tmp_path):
     assert captured.get("jam_threshold") == 33, (
         f"jam_threshold was not wired from config; captured={captured!r}"
     )
+
+
+def test_runner_remembers_n1_retry_until_a_checkpoint_succeeds(tmp_path):
+    skill_root = tmp_path / "skill"
+    skill_root.mkdir()
+    watcher = _make_watcher(
+        tmp_path,
+        skill_root,
+        _make_barrier_agno(1, threading.Barrier(1)),
+        edit_workers=1,
+    )
+    skill_dir = skill_root / "retry-target"
+
+    watcher._on_skill_edit_done((skill_dir, False, 1))
+    assert watcher._skill_edit_retry_batch_sizes[skill_dir] == 1
+
+    watcher._on_skill_edit_done(
+        (skill_dir, False, watcher.skill_edit_batch_size)
+    )
+    assert skill_dir not in watcher._skill_edit_retry_batch_sizes
 
 
 class TestSkillEditParallel:

--- a/tests/test_task_agent.py
+++ b/tests/test_task_agent.py
@@ -936,7 +936,7 @@ class TestContextManager:
             return "COMPACTED: keep atom evidence and pending edits"
 
         messages = [
-            _Msg("system", "SkillEditAgent system prompt"),
+            _Msg("system", "SkillEditAgent system prompt\n" + ("S" * 4000)),
             _Msg("user", "turn0 scenario with target skill"),
             _Msg("assistant", "I will inspect atoms"),
             _Msg("tool", "OLD_ATOM_RESULT\n" + ("x" * 8000), "atom_task_read"),
@@ -965,7 +965,7 @@ class TestContextManager:
         assert [m.role for m in compacted] == [
             "system", "user", "assistant", "assistant", "user",
         ]
-        assert compacted[0].content == "SkillEditAgent system prompt"
+        assert compacted[0].content.startswith("SkillEditAgent system prompt")
         assert compacted[1].content == "turn0 scenario with target skill"
         assert "COMPACTED" in compacted[2].content
         assert compacted[-2].content == "recent reasoning"
@@ -983,7 +983,7 @@ class TestContextManager:
                 self.tool_call_id = tool_call_id
 
         messages = [
-            _Msg("system", "SkillEditAgent system prompt"),
+            _Msg("system", "SkillEditAgent system prompt\n" + ("S" * 4000)),
             _Msg("user", "turn0 scenario"),
             _Msg("assistant", "old reasoning"),
             _Msg("tool", "OLD_ATOM_RESULT\n" + ("x" * 8000), "atom_task_read"),
@@ -1011,6 +1011,33 @@ class TestContextManager:
         ]
         assert all(m.content != "RECENT_TOOL_WITHOUT_ASSISTANT" for m in compacted)
         assert compacted[-1].content == "continue after tool"
+
+    def test_configured_compact_below_spill_does_not_compact_eagerly(self, tmp_path):
+        """低于 spill@ 的旧配置不能让 compact 抢在可回收 tool result 前触发。"""
+        from xskill.agents.context_budget import ContextManager
+
+        class _Msg:
+            def __init__(self, role, content, tool_name=None):
+                self.role = role
+                self.content = content
+                self.tool_name = tool_name
+
+        messages = [
+            _Msg("system", "short system"),
+            _Msg("user", "scenario"),
+            _Msg("tool", "x" * 8000, "atom_task_read"),
+        ]
+        compact_calls: list[str] = []
+        ContextManager(
+            max_context=1000,
+            spill_root=tmp_path / "spill",
+            compact_token_limit=20,
+            compact_fn=lambda prompt: compact_calls.append(prompt) or "summary",
+        ).wrap(lambda _messages, **_kwargs: {"usage": {"prompt_tokens": 100}})(
+            messages
+        )
+
+        assert compact_calls == []
 
     def test_overlong_error_triggers_retrim_and_resend(self):
         from xskill.agents.context_budget import ContextManager, _TRIM_MARK

--- a/tests/test_watcher_atom.py
+++ b/tests/test_watcher_atom.py
@@ -80,8 +80,8 @@ class _StubAgno:
                 )
             # 根据当前分支决定调哪个 commit
             if "baby" in user_msg:
-                if "commit_baby_to_main" in self.tools:
-                    _call_tool(self.tools["commit_baby_to_main"], "auto-skill", "stub baby")
+                if "commit_baby" in self.tools:
+                    _call_tool(self.tools["commit_baby"], "auto-skill", "stub baby")
             elif "main" in user_msg:
                 if "commit_to_staging" in self.tools:
                     _call_tool(self.tools["commit_to_staging"], "auto-skill", "stub staging")
@@ -412,8 +412,8 @@ class TestIndependentSkillEditScan:
                         m.group(1),
                         "---\nname: my-skill\ndescription: stub\nmetadata:\n  version: 1\n---\n# body\n",
                     )
-                if "commit_baby_to_main" in self.tools:
-                    _call_tool(self.tools["commit_baby_to_main"], "my-skill", "stub commit")
+                if "commit_baby" in self.tools:
+                    _call_tool(self.tools["commit_baby"], "my-skill", "stub commit")
                 class _R: pass
                 r = _R(); r.content = ""; return r
 


### PR DESCRIPTION
关联并关闭 #146

## 修改内容

- 将 baby 冷启动阶段原有的 `*_turnN` 分支链替换为：直接在现有 baby 分支上按 FIFO 顺序分批提交 checkpoint。
- 新增 `agent_worker.pools.edit.batch_size` 配置，默认值为 `5`。
- 新增 `commit_baby`：一次只提交当前绑定的原子批次，并在同一个仓库锁内精确消费该批次对应的 candidate ID。
- 批次失败后自适应缩小规模：`N → floor(N/2) → 1`；某批成功提交后，下一批恢复为配置的 N。
- `candidates.yaml` 清空后，由框架负责将 baby 晋升为 main；保留旧的 `commit_baby_to_main` 工具以兼容现有调用。
- 每个 skill 使用一个持续追加的可读日志，记录 turn/round 分隔、N、token 阈值、思考与工具摘要、已消费 ID、重试时 N 的变化、spill 和 compact 事件。
- 上下文处理调整为优先 spill；compact 不会在有效 spill 边界之前触发。
- main → staging 与 jam 原有的 turn 分支流程保持不变。

## 修改原因

原流程在较长的冷启动过程中，只有最终合并和晋升后才形成稳定结果。如果临近结束时失败，前面已经完成的大量 edit turn 可能无法复用。

新流程让每个小批次都立即形成可恢复的提交，并同步从 FIFO 队列中删除该批次对应的原子。进程或任务重启后，可以从剩余 candidates 继续处理，不再从头重建整条分支链。

## 关键行为

- 新 checkpoint 流程只作用于 baby 冷启动消化阶段。
- 如果 LLM 在 commit 完成后才抛出异常，只要 HEAD 已前进且绑定的 candidate ID 已消失，框架会判定该批成功，避免重复消费。
- 当 N 已降至 1 仍失败时，释放 worker；watcher 后续仍以 N=1 重试。进程重启后则恢复配置默认值。
- 已经处理过一部分的 baby，即使剩余原子权重低于最初的冷启动阈值，也可以继续恢复执行。
- candidates 的消费顺序保持 YAML 原始顺序。

## 验证结果

- SkillEdit、日志、重试、worker、watcher、并发隔离和 description optimization 等针对性测试：`117 passed`。
- 排除既有 E2E 目录和不兼容 canary E2E 后的回归测试：`1934 passed`。
- `git diff --check` 通过。
- Python 编译检查通过。
- 新增覆盖：1000 个 candidates 的 FIFO 消费（默认形成 200 批）、真实 checkpoint commit、精确 ID 消费、`5→2→1` 缩批与成功后恢复、commit 后异常恢复、重启续跑、可读日志以及 spill 优先 compact。

## 当前 CI 说明

GitHub Actions 中仅 `ut+it (windows-latest, py3.12)` 失败：`test_registry_concurrent_usage_writes_do_not_reassign_wal` 使用 30 个线程并发执行 600 次 SQLite usage 写入时出现 `sqlite3.OperationalError: database is locked`。Windows Python 3.9/3.10/3.11 及 Linux/macOS Python 3.12 均通过；本 MR 未修改 registry/SQLite 热路径，当前证据指向 Windows Python 3.12 下该并发压力测试的时序抖动。

另外，本地完整测试中的既有 canary E2E 因 mock cluster responder 不接受 `add_tasks_to_skill` schema、未产生 UX 样本而超时；该路径同样未进入本次 baby checkpoint 实现。
