### PR TITLE
test(skill-edit): 跑通 aimock BDD 与 mutation testing

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -55,6 +55,25 @@ jobs:
         # Excludes tests under tests/e2e/ (covered by smoke-e2e job in P4).
         run: pytest tests/ --ignore=tests/e2e -q
 
+  skill-edit-bdd:
+    name: skill-edit BDD (aimock)
+    runs-on: ubuntu-latest
+    steps:
+      - uses: actions/checkout@v4
+      - uses: actions/setup-python@v5
+        with:
+          python-version: "3.11"
+          cache: pip
+      - uses: actions/setup-node@v4
+        with:
+          node-version: "20"
+      - name: Install xskill test dependencies
+        run: pip install -e .[dev]
+      - name: Run all SkillEdit behavior scenarios
+        env:
+          XSKILL_AIMOCK_E2E: "1"
+        run: pytest tests/bdd -v --timeout=120
+
   smoke-e2e:
     name: smoke-e2e (${{ matrix.os }}, ${{ matrix.agent }})
     needs: ut-it

--- a/.gitignore
+++ b/.gitignore
@@ -35,6 +35,7 @@ build/
 .eggs/
 *.so
 .pytest_cache/
+mutants/
 
 # setuptools-scm generated version file
 src/xskill/_version.py

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -52,7 +52,19 @@ dependencies = [
 ]
 
 [project.optional-dependencies]
-dev = ["pytest>=7", "pytest-timeout>=2", "pytest-asyncio>=0.21", "requests>=2"]
+dev = [
+    "pytest>=7",
+    "pytest-timeout>=2",
+    "pytest-asyncio>=0.21",
+    "pytest-bdd>=8,<9",
+    "requests>=2",
+    # HTTP LLM contract tests only.  The Python fixture downloads the pinned
+    # @copilotkit/aimock npm artifact and manages its local Node.js process.
+    "aimock-pytest==0.5.0; python_version >= '3.10'",
+    # Mutation testing is a developer/CI concern and never enters the wheel's
+    # runtime dependency set.
+    "mutmut>=3.6,<4; python_version >= '3.10'",
+]
 
 [project.urls]
 Homepage = "https://github.com/SkillNerds/xskill"
@@ -89,6 +101,39 @@ markers = [
     # ``pytest -m live_agent`` 触发。
     "live_agent: real codex/opencode process + mock LLM end-to-end (slow, optional)",
     "stress: slow real-process load and smoke tests (excluded by default)",
+    "bdd: executable product behavior specifications",
+    "http_llm: real OpenAI-compatible HTTP boundary backed by local aimock",
+    "state_machine: deterministic SkillEdit state-machine coverage for mutation testing",
+    "primary: primary user success journey",
+    "golden_path: end-to-end happy-path behavior",
+    "recovery: retry and restart recovery behavior",
+    "contract: external protocol contract behavior",
+    "observability: operator-facing trace behavior",
 ]
 addopts = "--ignore=tests/live --ignore=tests/stress"
 asyncio_mode = "strict"
+
+[tool.mutmut]
+# Keep mutation testing focused on the Issue #146 durable boundaries:
+# framework-owned candidate consumption and baby graduation.  The local HTTP
+# contract is intentionally excluded: mutation workers should not start a
+# Node process or depend on fixture timing.
+source_paths = ["src/xskill"]
+only_mutate = [
+    "src/xskill/skill/candidates.py",
+    "src/xskill/agents/agent_tools.py",
+]
+# Logging prose and spelling-equivalent encoding names are not observable
+# product behavior; mutating them creates equivalent mutants.
+do_not_mutate_patterns = [
+    "logger\\.",
+    "encoding=\"utf-8\"",
+]
+pytest_add_cli_args = ["-q", "--override-ini=addopts="]
+pytest_add_cli_args_test_selection = [
+    "tests/bdd/test_skill_edit_state_machine.py",
+    "tests/test_skill_edit_batch_turns.py::TestRemoveCandidates",
+    "tests/test_skill_edit_mutation_contracts.py",
+]
+timeout_multiplier = 5.0
+timeout_constant = 1.0

--- a/src/xskill/skill/candidates.py
+++ b/src/xskill/skill/candidates.py
@@ -361,7 +361,7 @@ def remove_candidates(
     """
     with skill_repo_lock(skill_dir, use_git_write_limit=False):
         data = _load_candidates_unlocked(skill_dir)
-        candidates = data.get("candidates", []) or []
+        candidates = data.get("candidates") or []
         consumed = [
             str(candidate.get("atom_id"))
             for candidate in candidates

--- a/tests/bdd/README.md
+++ b/tests/bdd/README.md
@@ -1,7 +1,8 @@
 # SkillEdit BDD specifications
 
-本目录先保存可由产品、开发和测试共同审阅的 Gherkin 规格。
-当前阶段只定义行为，不绑定 pytest step definitions，也不引入测试依赖。
+本目录保存可由产品、开发和测试共同审阅的 Gherkin 规格，以及 11 个场景的
+pytest-bdd step definitions。HTTP 场景由本地 `aimock` 驱动，测试不会访问真实
+模型服务。
 
 ## 主用户成功路径
 
@@ -21,25 +22,50 @@ OpenAI-compatible HTTP 模型边界、两次分批编辑和 checkpoint，最终�
 
 ## 测试层次
 
-这些规格后续分成两种执行层：
+这些规格分成两种执行层：
 
 1. `@http_llm` 场景使用真实 Agno/OpenAI 客户端，模型地址指向本地
-   `ai-mocks`，验证请求、tool call、工具执行和后续模型轮次的完整 HTTP 边界。
+   `aimock`，验证请求、tool call、工具执行和后续模型轮次的完整 HTTP 边界。
 2. `@state_machine` 场景使用进程内的确定性模型脚本，快速验证批次缩减、
    checkpoint 判定和重启恢复，供日常 pytest 与 mutation testing 重复执行。
 
-Mutation testing 不会为每个 mutant 启动 JVM 或容器。它复用快速的
+Mutation testing 不会为每个 mutant 启动 Node.js sidecar。它复用快速的
 `@state_machine` 测试杀死状态机 mutant；`@http_llm` 负责证明真实协议集成没有
 被测试替身掩盖。
 
 ## 依赖边界
 
-BDD、mutation testing 和 `ai-mocks` 都只属于测试环境：
+BDD、mutation testing 和 `aimock` 都只属于测试环境：
 
 - 不加入 `[project].dependencies`；
 - 不会被 `pip install xskill` 安装；
-- `pytest-bdd` 与 `mutmut` 后续放入测试专用依赖组；
-- `ai-mocks` 由测试 fixture 或 CI sidecar 启动，不进入 xskill wheel。
+- `pytest-bdd`、`mutmut` 和 `aimock-pytest` 位于 `dev` extra；
+- `aimock-pytest` 自动下载固定版本的 `@copilotkit/aimock`，在随机本地端口
+  启停 Node.js 子进程，不进入 xskill wheel；
+- `aimock` 要求 Node.js 20.15+，仅 `@http_llm` 测试需要。
+
+## 执行
+
+主成功路径默认显式 opt-in，避免普通单测矩阵在每个 Python/OS 组合都启动
+HTTP sidecar：
+
+```bash
+XSKILL_AIMOCK_E2E=1 pytest tests/bdd/test_skill_edit_golden_path.py -v
+```
+
+CI 中有独立的 `skill-edit-bdd` job 执行该命令。普通 `pytest` 仍运行快速的
+状态机单测；mutmut 也只选择这些进程内测试。
+
+聚焦执行 candidate 消费与 baby 晋升两个耐久边界的 mutation testing：
+
+```bash
+mutmut run --max-children 8 \
+  '*remove_candidates__mutmut_*' \
+  '*graduate_baby_to_main__mutmut_*'
+```
+
+`mutants/` 是本地生成目录，已加入 `.gitignore`。mutmut 配置只选择进程内 BDD
+和 candidate 精确消费测试，不会启动 aimock。
 
 ## 标签
 

--- a/tests/bdd/features/skill_edit/baby_cold_start_golden_path.feature
+++ b/tests/bdd/features/skill_edit/baby_cold_start_golden_path.feature
@@ -6,10 +6,10 @@ Feature: 用户在冷启动后获得完整可用的 main skill
   Background:
     Given xskill 使用隔离的测试目录
     And SkillEdit 每批最多处理 5 个原子
-    And SkillEdit 模型指向本地 OpenAI-compatible 测试后端
 
   @primary @golden_path @http_llm
   Scenario: 用户等待系统把新知识整理成可用的 main skill
+    Given SkillEdit 模型指向本地 OpenAI-compatible 测试后端
     Given cluster 已经创建名为 "incident-recovery" 的 baby skill
     And baby 的 candidates 按以下顺序保存
       | atom_id | knowledge                                      |

--- a/tests/bdd/features/skill_edit/baby_cold_start_recovery.feature
+++ b/tests/bdd/features/skill_edit/baby_cold_start_recovery.feature
@@ -21,7 +21,7 @@ Feature: baby 冷启动可以从模型失败和进程中断中恢复
   Scenario: commit 完成后的模型 429 不会导致原子被再次处理
     Given 模型已经调用 commit_baby 并成功提交当前批次
     And commit_baby 已经从 candidates 删除当前批次 atom_id
-    And ai-mocks 在模型的结束响应阶段返回 HTTP 429
+    And aimock 在模型的结束响应阶段返回 HTTP 429
     When SkillEditAgent 检查 baby HEAD 和剩余 candidates
     Then 当前 turn 应当被判定为成功
     And 当前批次不应当再次发送给模型

--- a/tests/bdd/features/skill_edit/skill_edit_llm_backend.feature
+++ b/tests/bdd/features/skill_edit/skill_edit_llm_backend.feature
@@ -4,20 +4,20 @@ Feature: SkillEdit 通过可控的本地模型后端执行真实工具调用
   同时不能访问公网或依赖真实模型账号。
 
   Background:
-    Given ai-mocks 在随机本地端口启动 OpenAI-compatible 服务
+    Given aimock 在随机本地端口启动 OpenAI-compatible 服务
     And xskill 的 llm.base_url 指向该服务
     And xskill 使用无权限的测试 API key
 
   @http_llm @contract
   Scenario: 模型通过 OpenAI tool calls 完成一次 baby checkpoint
     Given 一个 SkillEdit turn 绑定了 5 个 atom_id
-    And ai-mocks 为这个 turn 准备了以下响应
+    And aimock 为这个 turn 准备了以下响应
       | response | behavior                                      |
       | first    | 调用 write_file 更新目标 SKILL.md             |
       | second   | 收到 write_file 结果后调用 commit_baby         |
       | third    | 收到 commit_baby 结果后结束模型 turn           |
     When SkillEdit 使用生产 Agno factory 执行这个 turn
-    Then ai-mocks 应当收到真实的 POST /v1/chat/completions 请求
+    Then aimock 应当收到真实的 POST /v1/chat/completions 请求
     And 第一次请求应当声明 write_file 和 commit_baby 工具
     And 第二次请求应当包含 write_file 的 tool result
     And 第三次请求应当包含 commit_baby 的 tool result
@@ -28,16 +28,17 @@ Feature: SkillEdit 通过可控的本地模型后端执行真实工具调用
   Scenario: 测试运行期间没有请求离开本机
     Given 主成功路径已经执行完成
     When 检查测试后端的 request journal
-    Then 所有模型请求都应当发送到 ai-mocks
+    Then 所有模型请求都应当发送到 aimock
     And 请求不应当包含生产 API key
     And 测试不应当访问任何公共模型 endpoint
 
   @http_llm @recovery
   Scenario: 模型后端持续返回 429 时当前批次不会被误提交
     Given 当前 turn 的 N 为 5
-    And ai-mocks 对模型请求返回 HTTP 429 和 Retry-After
+    And aimock 对模型请求返回 HTTP 429 和 Retry-After
     And 模型客户端已经耗尽该 turn 内部的有限重试
     When SkillEditAgent 收到模型调用失败
     Then baby 的 HEAD 不应当前进
     And 当前 5 个 atom_id 不应当从 candidates 删除
-    And 下一次尝试的 N 应当变为 2
+    And 本次调度应当依次尝试 N=5、N=2、N=1
+    And watcher 下次调度时应当继续使用 N=1

--- a/tests/bdd/test_skill_edit_golden_path.py
+++ b/tests/bdd/test_skill_edit_golden_path.py
@@ -1,0 +1,890 @@
+"""Executable BDD for the Issue #146 primary user journey.
+
+This test deliberately keeps the production boundary intact:
+
+DirectoryWatcher -> SkillEditAgent -> Agno/OpenAI client -> HTTP -> aimock
+                 -> tool call -> xskill tool implementation -> git/candidates
+
+Only the remote model is replaced.  The agent, tool schemas, tool execution,
+candidate consumption, git checkpoints, and framework-controlled graduation
+are production code.
+"""
+
+from __future__ import annotations
+
+import os
+import re
+from dataclasses import dataclass, field
+from pathlib import Path
+from typing import Any
+
+import pytest
+from pytest_bdd import given, scenario, then, when
+
+from xskill.agents import agent_tools
+from tests.pool_helpers import pool_config
+from xskill.agents.agno_factory import make_default_factory
+from xskill.agents.skill_edit_agent import SkillEditAgent
+from xskill.pipeline.atom import AtomTaskStore
+from xskill.pipeline.registry import register_dir
+from xskill.pipeline.runner import DirectoryWatcher
+from xskill.skill import candidates as candidate_buffer
+from xskill.skill.git import current_branch, init_skill_repo_on_baby, run_git
+
+
+RUN_AIMOCK_E2E = os.environ.get("XSKILL_AIMOCK_E2E") == "1"
+
+pytestmark = [
+    pytest.mark.bdd,
+    pytest.mark.http_llm,
+    pytest.mark.skipif(
+        not RUN_AIMOCK_E2E,
+        reason="set XSKILL_AIMOCK_E2E=1 to run the local aimock HTTP contract",
+    ),
+]
+
+
+@scenario(
+    "features/skill_edit/baby_cold_start_golden_path.feature",
+    "用户等待系统把新知识整理成可用的 main skill",
+)
+def test_user_receives_complete_main_skill() -> None:
+    """The Gherkin scenario is implemented by the steps below."""
+
+
+@scenario(
+    "features/skill_edit/skill_edit_llm_backend.feature",
+    "模型通过 OpenAI tool calls 完成一次 baby checkpoint",
+)
+def test_aimock_executes_one_real_checkpoint() -> None:
+    """Production Agno performs the complete three-request tool loop."""
+
+
+@scenario(
+    "features/skill_edit/skill_edit_llm_backend.feature",
+    "测试运行期间没有请求离开本机",
+)
+def test_model_requests_remain_local() -> None:
+    """The request journal proves that the contract stays on loopback."""
+
+
+@scenario(
+    "features/skill_edit/skill_edit_llm_backend.feature",
+    "模型后端持续返回 429 时当前批次不会被误提交",
+)
+def test_persistent_429_preserves_the_batch() -> None:
+    """A real HTTP 429 drives the production adaptive batch state machine."""
+
+
+@scenario(
+    "features/skill_edit/baby_cold_start_recovery.feature",
+    "commit 完成后的模型 429 不会导致原子被再次处理",
+)
+def test_post_commit_429_does_not_replay_atoms() -> None:
+    """The durable checkpoint wins over a failed final model response."""
+
+
+@dataclass
+class SkillEditWorld:
+    root: Path
+    aimock: Any
+    skill_root: Path
+    watch_root: Path
+    db_path: Path
+    logs_root: Path
+    batch_size: int = 5
+    api_key: str = "sk-aimock-xskill-test"
+    skill_name: str | None = None
+    skill_dir: Path | None = None
+    candidate_rows: list[dict[str, str]] = field(default_factory=list)
+    watcher: DirectoryWatcher | None = None
+    journal: list[dict[str, Any]] = field(default_factory=list)
+    result: bool | None = None
+    head_before: str = ""
+    attempts: list[int] = field(default_factory=list)
+
+    @property
+    def model_requests(self) -> list[dict[str, Any]]:
+        return [
+            entry
+            for entry in self.journal
+            if entry.get("method") == "POST"
+            and entry.get("path") == "/v1/chat/completions"
+        ]
+
+    @property
+    def initial_turn_requests(self) -> list[dict[str, Any]]:
+        requests = []
+        for entry in self.model_requests:
+            messages = (entry.get("body") or {}).get("messages") or []
+            if not any(message.get("role") == "tool" for message in messages):
+                requests.append(entry)
+        return requests
+
+    def stop_watcher(self) -> None:
+        if self.watcher is not None:
+            self.watcher.stop()
+            self.watcher = None
+
+
+@pytest.fixture
+def skill_edit_world(
+    tmp_path: Path,
+    request: pytest.FixtureRequest,
+) -> SkillEditWorld:
+    if not RUN_AIMOCK_E2E:
+        pytest.skip("set XSKILL_AIMOCK_E2E=1 to start the aimock backend")
+    aimock = request.getfixturevalue("aimock")
+    skill_root = tmp_path / "skills"
+    watch_root = tmp_path / "watch"
+    skill_root.mkdir()
+    watch_root.mkdir()
+    world = SkillEditWorld(
+        root=tmp_path,
+        aimock=aimock,
+        skill_root=skill_root,
+        watch_root=watch_root,
+        db_path=tmp_path / "registry.db",
+        logs_root=tmp_path / "logs",
+    )
+    yield world
+    world.stop_watcher()
+
+
+def _skill_document(
+    skill_name: str,
+    rows: list[dict[str, str]],
+    *,
+    version: int,
+) -> str:
+    rules = "\n".join(
+        f"{index}. {row['knowledge']}"
+        for index, row in enumerate(rows, start=1)
+    )
+    return (
+        "---\n"
+        f"name: {skill_name}\n"
+        "description: 系统化恢复反向代理后端服务并验证结果。"
+        "适用于进程、端口和 upstream 不一致的故障定位。\n"
+        "metadata:\n"
+        f"  version: {version}\n"
+        "---\n\n"
+        f"# {skill_name}\n\n"
+        "## 恢复流程\n\n"
+        f"{rules}\n"
+    )
+
+
+def _register_turn(
+    world: SkillEditWorld,
+    *,
+    turn: int,
+    rows: list[dict[str, str]],
+) -> None:
+    assert world.skill_name is not None
+    assert world.skill_dir is not None
+    target = world.skill_dir / "SKILL.md"
+
+    # aimock deliberately owns/generated tool-call IDs.  Match follow-ups by
+    # the observable tool result instead of coupling this contract to an ID
+    # that the mock backend is allowed to rewrite.
+    world.aimock.add_fixture(
+        match={
+            "userMessage": rows[0]["atom_id"],
+            "hasToolResult": True,
+            "toolResultContains": "Created baby checkpoint",
+        },
+        response={"content": f"turn {turn} checkpoint complete"},
+    )
+    world.aimock.add_fixture(
+        match={
+            "userMessage": rows[0]["atom_id"],
+            "hasToolResult": True,
+            "toolResultContains": "wrote:",
+        },
+        response={
+            "toolCalls": [
+                {
+                    "name": "commit_baby",
+                    "arguments": {
+                        "skill_name": world.skill_name,
+                        "message": f"BDD checkpoint turn {turn}",
+                    },
+                }
+            ]
+        },
+    )
+    world.aimock.add_fixture(
+        match={
+            "userMessage": rows[0]["atom_id"],
+            "hasToolResult": False,
+        },
+        response={
+            "toolCalls": [
+                {
+                    "name": "write_file",
+                    "arguments": {
+                        "path": str(target),
+                        "content": _skill_document(
+                            world.skill_name,
+                            world.candidate_rows[: turn * world.batch_size],
+                            version=turn,
+                        ),
+                    },
+                }
+            ]
+        },
+    )
+
+
+def _create_baby_with_candidates(
+    world: SkillEditWorld,
+    *,
+    name: str,
+    count: int,
+    weight: int,
+) -> None:
+    world.skill_name = name
+    world.skill_dir = world.skill_root / name
+    init_skill_repo_on_baby(
+        str(world.skill_dir),
+        name=name,
+        description="BDD aimock contract draft",
+    )
+    world.candidate_rows = [
+        {
+            "atom_id": f"atom-{index:02d}",
+            "knowledge": f"可复用恢复规则 {index}",
+        }
+        for index in range(1, count + 1)
+    ]
+    data: dict[str, Any] = {"candidates": []}
+    for row in world.candidate_rows:
+        data, _ = candidate_buffer.add_atom_contribution(
+            data,
+            row["atom_id"],
+            weight,
+            note=row["knowledge"],
+        )
+    candidate_buffer.save_candidates(world.skill_dir, data)
+    world.head_before = run_git(
+        ["rev-parse", "HEAD"],
+        cwd=str(world.skill_dir),
+    )[1].strip()
+
+
+def _run_direct_agent(world: SkillEditWorld, *, retry_batch_size: int | None = None) -> None:
+    assert world.skill_dir is not None
+    config = {
+        "llm": {
+            "base_url": f"{world.aimock.base_url}/v1",
+            "model": "aimock-skill-edit",
+            "api_key": world.api_key,
+            "request_timeout": 10,
+            "connect_timeout": 2,
+            "client_max_retries": 0,
+            "max_retries": 1,
+            "retry_base_delay": 0.01,
+            "retry_max_delay": 0.01,
+            "max_context": 128_000,
+        },
+        "skill_opt": {"enabled": False},
+    }
+    default_factory = make_default_factory(
+        config,
+        spill_root=world.root / "spill",
+    )
+
+    def factory(*, instructions: list[str], tools: list[Any]) -> Any:
+        return default_factory(
+            instructions=instructions,
+            tools=tools,
+            retries=0,
+        )
+
+    saved_context = agent_tools.agent_tool_config.snapshot()
+    store = AtomTaskStore(root=world.watch_root)
+    agent_tools.init_atom_task_tool_context(
+        skill_dir=world.skill_root,
+        atom_store=store,
+        default_traj_root=world.watch_root,
+    )
+    agent_tools.init_skill_authoring_tool_context(
+        world.skill_root,
+        world.skill_root,
+        config,
+        spill_root=world.root / "spill",
+    )
+    try:
+        agent = SkillEditAgent(
+            skill_dir=world.skill_dir,
+            store=store,
+            agno_agent_factory=factory,
+            llm_cfg=config["llm"],
+            traj_root=world.watch_root,
+            batch_size=world.batch_size,
+            retry_batch_size=retry_batch_size,
+            logs_dir=world.logs_root,
+        )
+        world.result = agent.maybe_run()
+    finally:
+        world.journal = world.aimock.get_journal()
+        agent_tools.agent_tool_config.restore(saved_context)
+    # Derive batch sizes after the journal has been captured.
+    world.attempts = [
+        len(set(re.findall(r"atom-\d{2}", _joined_message_content(entry))))
+        for entry in world.initial_turn_requests
+    ]
+
+
+@given("xskill 使用隔离的测试目录")
+def isolated_xskill_directory(skill_edit_world: SkillEditWorld) -> None:
+    assert skill_edit_world.root.is_dir()
+    assert skill_edit_world.skill_root.parent == skill_edit_world.root
+
+
+@given("SkillEdit 每批最多处理 5 个原子")
+def edit_batch_size_is_five(skill_edit_world: SkillEditWorld) -> None:
+    skill_edit_world.batch_size = 5
+
+
+@given("SkillEdit 默认每批处理 5 个原子")
+def default_edit_batch_size_is_five(skill_edit_world: SkillEditWorld) -> None:
+    skill_edit_world.batch_size = 5
+
+
+@given("baby 的 candidates 使用稳定的 FIFO 顺序")
+def candidates_use_fifo_order() -> None:
+    return None
+
+
+@given("SkillEdit 模型指向本地 OpenAI-compatible 测试后端")
+def local_openai_backend(skill_edit_world: SkillEditWorld) -> None:
+    assert skill_edit_world.aimock.base_url.startswith("http://127.0.0.1:")
+
+
+@given('cluster 已经创建名为 "incident-recovery" 的 baby skill')
+def existing_baby_skill(skill_edit_world: SkillEditWorld) -> None:
+    skill_edit_world.skill_name = "incident-recovery"
+    skill_edit_world.skill_dir = skill_edit_world.skill_root / skill_edit_world.skill_name
+    init_skill_repo_on_baby(
+        str(skill_edit_world.skill_dir),
+        name=skill_edit_world.skill_name,
+        description="incident recovery draft",
+    )
+    assert current_branch(str(skill_edit_world.skill_dir)) == "baby"
+
+
+@given("baby 的 candidates 按以下顺序保存")
+def ordered_candidates(
+    skill_edit_world: SkillEditWorld,
+    datatable: list[list[str]],
+) -> None:
+    assert skill_edit_world.skill_dir is not None
+    headers = datatable[0]
+    rows = [dict(zip(headers, values, strict=True)) for values in datatable[1:]]
+    skill_edit_world.candidate_rows = rows
+
+    data: dict[str, Any] = {"candidates": []}
+    for row in rows:
+        data, _ = candidate_buffer.add_atom_contribution(
+            data,
+            row["atom_id"],
+            2,
+            note=row["knowledge"],
+        )
+    candidate_buffer.save_candidates(skill_edit_world.skill_dir, data)
+
+
+@given("candidates 的总权重已经达到 baby 冷启动阈值")
+def candidates_reach_threshold(skill_edit_world: SkillEditWorld) -> None:
+    assert skill_edit_world.skill_dir is not None
+    data = candidate_buffer.load_candidates(skill_edit_world.skill_dir)
+    assert sum(item["weightscore"] for item in data["candidates"]) >= 10
+
+
+@given("测试模型会根据每批原子更新 SKILL.md 并调用 commit_baby")
+def scripted_model_updates_and_commits(skill_edit_world: SkillEditWorld) -> None:
+    rows = skill_edit_world.candidate_rows
+    assert [row["atom_id"] for row in rows] == [
+        f"atom-{index:02d}" for index in range(1, 8)
+    ]
+    _register_turn(
+        skill_edit_world,
+        turn=1,
+        rows=rows[: skill_edit_world.batch_size],
+    )
+    _register_turn(
+        skill_edit_world,
+        turn=2,
+        rows=rows[skill_edit_world.batch_size :],
+    )
+
+
+@given("aimock 在随机本地端口启动 OpenAI-compatible 服务")
+def aimock_runs_on_random_loopback_port(skill_edit_world: SkillEditWorld) -> None:
+    assert re.fullmatch(r"http://127\.0\.0\.1:\d+", skill_edit_world.aimock.base_url)
+
+
+@given("xskill 的 llm.base_url 指向该服务")
+def llm_points_to_aimock(skill_edit_world: SkillEditWorld) -> None:
+    assert skill_edit_world.aimock.base_url.startswith("http://127.0.0.1:")
+
+
+@given("xskill 使用无权限的测试 API key")
+def harmless_api_key(skill_edit_world: SkillEditWorld) -> None:
+    assert skill_edit_world.api_key == "sk-aimock-xskill-test"
+
+
+@given("一个 SkillEdit turn 绑定了 5 个 atom_id")
+def five_atoms_are_bound(skill_edit_world: SkillEditWorld) -> None:
+    _create_baby_with_candidates(
+        skill_edit_world,
+        name="aimock-contract",
+        count=5,
+        weight=2,
+    )
+
+
+@given("aimock 为这个 turn 准备了以下响应")
+def aimock_prepares_tool_loop(
+    skill_edit_world: SkillEditWorld,
+    datatable: list[list[str]],
+) -> None:
+    assert [row[0] for row in datatable[1:]] == ["first", "second", "third"]
+    _register_turn(
+        skill_edit_world,
+        turn=1,
+        rows=skill_edit_world.candidate_rows,
+    )
+
+
+@given("主成功路径已经执行完成")
+def completed_success_path(skill_edit_world: SkillEditWorld) -> None:
+    five_atoms_are_bound(skill_edit_world)
+    _register_turn(
+        skill_edit_world,
+        turn=1,
+        rows=skill_edit_world.candidate_rows,
+    )
+    _run_direct_agent(skill_edit_world)
+    assert skill_edit_world.result is True
+
+
+@given("当前 turn 的 N 为 5")
+def current_turn_n_is_five(skill_edit_world: SkillEditWorld) -> None:
+    skill_edit_world.batch_size = 5
+    _create_baby_with_candidates(
+        skill_edit_world,
+        name="aimock-rate-limit",
+        count=5,
+        weight=2,
+    )
+
+
+@given("aimock 对模型请求返回 HTTP 429 和 Retry-After")
+def aimock_always_rate_limits(skill_edit_world: SkillEditWorld) -> None:
+    skill_edit_world.aimock.add_fixture(
+        match={"userMessage": "atom-01", "hasToolResult": False},
+        response={
+            "error": {
+                "message": "Rate limited by BDD fixture",
+                "type": "rate_limit_error",
+                "code": "rate_limit_exceeded",
+            },
+            "status": 429,
+        },
+    )
+
+
+@given("模型客户端已经耗尽该 turn 内部的有限重试")
+def client_retry_is_bounded() -> None:
+    # _run_direct_agent configures max_retries=1 and OpenAI max_retries=0.
+    return None
+
+
+@given("模型已经调用 commit_baby 并成功提交当前批次")
+def model_will_commit_before_error(skill_edit_world: SkillEditWorld) -> None:
+    _create_baby_with_candidates(
+        skill_edit_world,
+        name="aimock-post-commit-429",
+        count=3,
+        weight=4,
+    )
+
+
+@given("commit_baby 已经从 candidates 删除当前批次 atom_id")
+def commit_consumes_bound_atoms() -> None:
+    # This is asserted from the real commit_baby result after execution.
+    return None
+
+
+@given("aimock 在模型的结束响应阶段返回 HTTP 429")
+def final_model_response_is_429(skill_edit_world: SkillEditWorld) -> None:
+    rows = skill_edit_world.candidate_rows
+    assert skill_edit_world.skill_name is not None
+    assert skill_edit_world.skill_dir is not None
+    target = skill_edit_world.skill_dir / "SKILL.md"
+    skill_edit_world.aimock.add_fixture(
+        match={
+            "userMessage": rows[0]["atom_id"],
+            "hasToolResult": True,
+            "toolResultContains": "Created baby checkpoint",
+        },
+        response={
+            "error": {
+                "message": "Rate limited after durable checkpoint",
+                "type": "rate_limit_error",
+            },
+            "status": 429,
+        },
+    )
+    skill_edit_world.aimock.add_fixture(
+        match={
+            "userMessage": rows[0]["atom_id"],
+            "hasToolResult": True,
+            "toolResultContains": "wrote:",
+        },
+        response={
+            "toolCalls": [
+                {
+                    "name": "commit_baby",
+                    "arguments": {
+                        "skill_name": skill_edit_world.skill_name,
+                        "message": "BDD durable before final 429",
+                    },
+                }
+            ]
+        },
+    )
+    skill_edit_world.aimock.add_fixture(
+        match={
+            "userMessage": rows[0]["atom_id"],
+            "hasToolResult": False,
+        },
+        response={
+            "toolCalls": [
+                {
+                    "name": "write_file",
+                    "arguments": {
+                        "path": str(target),
+                        "content": _skill_document(
+                            skill_edit_world.skill_name,
+                            rows,
+                            version=1,
+                        ),
+                    },
+                }
+            ]
+        },
+    )
+
+
+@when("watcher 调度这个 baby 的 SkillEdit 工作")
+def watcher_schedules_skill_edit(skill_edit_world: SkillEditWorld) -> None:
+    config = {
+        "llm": {
+            "base_url": f"{skill_edit_world.aimock.base_url}/v1",
+            "model": "aimock-skill-edit",
+            "api_key": skill_edit_world.api_key,
+            "request_timeout": 10,
+            "connect_timeout": 2,
+            "client_max_retries": 0,
+            "max_retries": 1,
+            "retry_base_delay": 0.01,
+            "retry_max_delay": 0.01,
+            "max_context": 128_000,
+        },
+        "skill_opt": {"enabled": False},
+    }
+    store = AtomTaskStore(root=skill_edit_world.watch_root)
+    register_dir(skill_edit_world.watch_root, db_path=skill_edit_world.db_path)
+    default_factory = make_default_factory(
+        config,
+        spill_root=skill_edit_world.root / "spill",
+    )
+
+    def factory(*, instructions: list[str], tools: list[Any]) -> Any:
+        # Fixture mismatches should fail this contract immediately; retry and
+        # backoff behavior has separate state-machine/429 scenarios.
+        return default_factory(
+            instructions=instructions,
+            tools=tools,
+            retries=0,
+        )
+
+    watcher = DirectoryWatcher(
+        config=config,
+        skill_dir=skill_edit_world.skill_root,
+        poll_interval=0,
+        pool_config=pool_config(
+            workers=1,
+            edit_workers=1,
+            edit_batch_size=skill_edit_world.batch_size,
+        ),
+        db_path=skill_edit_world.db_path,
+        store=store,
+        agno_agent_factory=factory,
+        home_root=skill_edit_world.root / "home",
+        xskill_home=skill_edit_world.root / "xskill",
+        logs_dir=skill_edit_world.logs_root,
+        server_mode=True,
+    )
+    skill_edit_world.watcher = watcher
+    watcher._check_pending_skill_edits()
+    watcher._drain_futures(stage="skill_edit", timeout=90)
+    skill_edit_world.journal = skill_edit_world.aimock.get_journal()
+    if watcher.stats["skills_edited"] != 1:
+        evidence = []
+        for entry in skill_edit_world.model_requests:
+            messages = (entry.get("body") or {}).get("messages") or []
+            content = "\n".join(
+                str(message.get("content") or "") for message in messages
+            )
+            evidence.append(
+                {
+                    "roles": [message.get("role") for message in messages],
+                    "atom_ids": sorted(set(re.findall(r"atom-\d{2}", content))),
+                    "tool_results": [
+                        str(message.get("content") or "").splitlines()[0][:100]
+                        for message in messages
+                        if message.get("role") == "tool"
+                    ],
+                    "status": (entry.get("response") or {}).get("status"),
+                }
+            )
+        pytest.fail(
+            "watcher did not complete SkillEdit; compact aimock evidence: "
+            f"{evidence!r}"
+        )
+
+
+@when("SkillEdit 使用生产 Agno factory 执行这个 turn")
+def production_factory_executes_turn(skill_edit_world: SkillEditWorld) -> None:
+    _run_direct_agent(skill_edit_world)
+
+
+@when("检查测试后端的 request journal")
+def inspect_request_journal(skill_edit_world: SkillEditWorld) -> None:
+    assert skill_edit_world.journal
+
+
+@when("SkillEditAgent 收到模型调用失败")
+def agent_receives_backend_failure(skill_edit_world: SkillEditWorld) -> None:
+    _run_direct_agent(skill_edit_world)
+
+
+@when("SkillEditAgent 检查 baby HEAD 和剩余 candidates")
+def agent_checks_durable_state(skill_edit_world: SkillEditWorld) -> None:
+    _run_direct_agent(skill_edit_world)
+
+
+@then("模型应当收到 2 个互相独立的编辑 turn")
+def two_independent_turns(skill_edit_world: SkillEditWorld) -> None:
+    initial_requests = skill_edit_world.initial_turn_requests
+    assert len(initial_requests) == 2
+    assert len(skill_edit_world.model_requests) == 6
+
+
+def _joined_message_content(entry: dict[str, Any]) -> str:
+    messages = (entry.get("body") or {}).get("messages") or []
+    return "\n".join(str(message.get("content") or "") for message in messages)
+
+
+@then('第 1 个 turn 应当只包含 "atom-01,atom-02,atom-03,atom-04,atom-05"')
+def first_turn_contains_first_batch_only(skill_edit_world: SkillEditWorld) -> None:
+    content = _joined_message_content(skill_edit_world.initial_turn_requests[0])
+    for atom_id in [f"atom-{index:02d}" for index in range(1, 6)]:
+        assert atom_id in content
+    assert "atom-06" not in content
+    assert "atom-07" not in content
+
+
+@then('第 2 个 turn 应当只包含 "atom-06,atom-07"')
+def second_turn_contains_second_batch_only(skill_edit_world: SkillEditWorld) -> None:
+    content = _joined_message_content(skill_edit_world.initial_turn_requests[1])
+    assert "atom-06" in content
+    assert "atom-07" in content
+    for atom_id in [f"atom-{index:02d}" for index in range(1, 6)]:
+        assert atom_id not in content
+
+
+@then("每个 turn 都应当在 baby 上产生一个非空 checkpoint commit")
+def every_turn_creates_checkpoint(skill_edit_world: SkillEditWorld) -> None:
+    assert skill_edit_world.skill_dir is not None
+    code, output, error = run_git(
+        ["log", "--oneline", "-20"],
+        cwd=str(skill_edit_world.skill_dir),
+    )
+    assert code == 0, error
+    assert "BDD checkpoint turn 1" in output
+    assert "BDD checkpoint turn 2" in output
+
+
+def _tool_results(world: SkillEditWorld, marker: str) -> list[str]:
+    results = []
+    for entry in world.model_requests:
+        messages = (entry.get("body") or {}).get("messages") or []
+        for message in messages:
+            if message.get("role") == "tool" and marker in str(message.get("content")):
+                results.append(str(message["content"]))
+    return results
+
+
+@then("每次 commit 只应当删除当前 turn 绑定的 atom_id")
+def commits_consume_only_bound_atoms(skill_edit_world: SkillEditWorld) -> None:
+    results = _tool_results(skill_edit_world, "Consumed atoms:")
+    # Each result remains in later history, so keep the first occurrence for
+    # each checkpoint rather than asserting a raw count.
+    unique_results = list(dict.fromkeys(results))
+    assert len(unique_results) == 2
+    for atom_id in [f"atom-{index:02d}" for index in range(1, 6)]:
+        assert atom_id in unique_results[0]
+        assert atom_id not in unique_results[1]
+    assert "atom-06" not in unique_results[0]
+    assert "atom-07" not in unique_results[0]
+    assert "atom-06" in unique_results[1]
+    assert "atom-07" in unique_results[1]
+
+
+@then("candidates 最终应当为空")
+def candidates_are_empty(skill_edit_world: SkillEditWorld) -> None:
+    assert skill_edit_world.skill_dir is not None
+    assert candidate_buffer.load_candidates(skill_edit_world.skill_dir)["candidates"] == []
+
+
+@then("框架应当把 baby 晋升为 main")
+def framework_promotes_main(skill_edit_world: SkillEditWorld) -> None:
+    assert skill_edit_world.skill_dir is not None
+    assert current_branch(str(skill_edit_world.skill_dir)) == "main"
+
+
+@then("main 的 SKILL.md 应当包含 7 个原子贡献的恢复流程")
+def final_skill_contains_all_knowledge(skill_edit_world: SkillEditWorld) -> None:
+    assert skill_edit_world.skill_dir is not None
+    body = (skill_edit_world.skill_dir / "SKILL.md").read_text(encoding="utf-8")
+    for row in skill_edit_world.candidate_rows:
+        assert row["knowledge"] in body
+
+
+@then("aimock 应当收到真实的 POST /v1/chat/completions 请求")
+def aimock_received_chat_completions(skill_edit_world: SkillEditWorld) -> None:
+    assert len(skill_edit_world.model_requests) == 3
+
+
+@then("第一次请求应当声明 write_file 和 commit_baby 工具")
+def first_request_declares_tools(skill_edit_world: SkillEditWorld) -> None:
+    tools = (skill_edit_world.model_requests[0].get("body") or {}).get("tools") or []
+    names = {
+        (tool.get("function") or {}).get("name")
+        for tool in tools
+    }
+    assert {"write_file", "commit_baby"} <= names
+
+
+@then("第二次请求应当包含 write_file 的 tool result")
+def second_request_contains_write_result(skill_edit_world: SkillEditWorld) -> None:
+    assert "wrote:" in _joined_message_content(skill_edit_world.model_requests[1])
+
+
+@then("第三次请求应当包含 commit_baby 的 tool result")
+def third_request_contains_commit_result(skill_edit_world: SkillEditWorld) -> None:
+    assert "Created baby checkpoint" in _joined_message_content(
+        skill_edit_world.model_requests[2]
+    )
+
+
+@then("atom_id 不应当由模型作为 commit_baby 参数提供")
+def commit_schema_excludes_atom_ids(skill_edit_world: SkillEditWorld) -> None:
+    tools = (skill_edit_world.model_requests[0].get("body") or {}).get("tools") or []
+    commit = next(
+        tool["function"] for tool in tools
+        if tool["function"]["name"] == "commit_baby"
+    )
+    properties = (commit.get("parameters") or {}).get("properties") or {}
+    assert "atom_id" not in properties
+    assert "atom_ids" not in properties
+
+
+@then("commit_baby 应当从框架绑定的批次取得 atom_id")
+def commit_uses_framework_bound_ids(skill_edit_world: SkillEditWorld) -> None:
+    results = list(dict.fromkeys(_tool_results(skill_edit_world, "Consumed atoms:")))
+    assert len(results) == 1
+    for row in skill_edit_world.candidate_rows:
+        assert row["atom_id"] in results[0]
+
+
+@then("所有模型请求都应当发送到 aimock")
+def all_requests_hit_aimock(skill_edit_world: SkillEditWorld) -> None:
+    assert skill_edit_world.model_requests
+    assert all(entry["path"] == "/v1/chat/completions" for entry in skill_edit_world.model_requests)
+
+
+@then("请求不应当包含生产 API key")
+def no_production_key_is_sent(skill_edit_world: SkillEditWorld) -> None:
+    for entry in skill_edit_world.model_requests:
+        authorization = (entry.get("headers") or {}).get("authorization", "")
+        assert authorization == "[REDACTED]"
+        assert skill_edit_world.api_key not in str(entry.get("headers") or {})
+
+
+@then("测试不应当访问任何公共模型 endpoint")
+def no_public_model_endpoint(skill_edit_world: SkillEditWorld) -> None:
+    assert skill_edit_world.aimock.base_url.startswith("http://127.0.0.1:")
+
+
+@then("baby 的 HEAD 不应当前进")
+def baby_head_does_not_advance(skill_edit_world: SkillEditWorld) -> None:
+    assert skill_edit_world.skill_dir is not None
+    head_after = run_git(
+        ["rev-parse", "HEAD"],
+        cwd=str(skill_edit_world.skill_dir),
+    )[1].strip()
+    assert head_after == skill_edit_world.head_before
+
+
+@then("当前 5 个 atom_id 不应当从 candidates 删除")
+def rate_limited_atoms_remain(skill_edit_world: SkillEditWorld) -> None:
+    assert skill_edit_world.skill_dir is not None
+    remaining = candidate_buffer.load_candidates(
+        skill_edit_world.skill_dir
+    )["candidates"]
+    assert [item["atom_id"] for item in remaining] == [
+        row["atom_id"] for row in skill_edit_world.candidate_rows
+    ]
+
+
+@then("本次调度应当依次尝试 N=5、N=2、N=1")
+def adaptive_attempt_sizes_are_observed(skill_edit_world: SkillEditWorld) -> None:
+    assert skill_edit_world.attempts == [5, 2, 1]
+
+
+@then("watcher 下次调度时应当继续使用 N=1")
+def retry_size_stays_at_one(skill_edit_world: SkillEditWorld) -> None:
+    # The failed direct agent exposes the value the watcher persists.
+    trace = (
+        skill_edit_world.logs_root
+        / "agents"
+        / "skill_edit_agents"
+        / "skills"
+        / f"{skill_edit_world.skill_name}.log"
+    ).read_text(encoding="utf-8")
+    assert "TURN END | FAILED | consumed=0 | 5 remaining | next N=1" in trace
+
+
+@then("当前 turn 应当被判定为成功")
+def post_commit_turn_is_success(skill_edit_world: SkillEditWorld) -> None:
+    assert skill_edit_world.result is True
+
+
+@then("当前批次不应当再次发送给模型")
+def committed_batch_is_not_replayed(skill_edit_world: SkillEditWorld) -> None:
+    assert skill_edit_world.attempts == [3]
+
+
+@then("下一个 turn 应当从第一个未消费 atom_id 开始")
+def next_turn_starts_after_committed_batch(skill_edit_world: SkillEditWorld) -> None:
+    assert skill_edit_world.skill_dir is not None
+    assert candidate_buffer.load_candidates(
+        skill_edit_world.skill_dir
+    )["candidates"] == []

--- a/tests/bdd/test_skill_edit_state_machine.py
+++ b/tests/bdd/test_skill_edit_state_machine.py
@@ -1,0 +1,724 @@
+"""Executable BDD for SkillEdit recovery, concurrency, and readable traces.
+
+These scenarios keep the production state machine, candidate store, agent
+tools, Git operations, context manager, and trace renderer.  A deterministic
+in-process agent replaces the remote model because these tests are intended
+to run quickly under both ordinary pytest and mutation testing.
+"""
+
+from __future__ import annotations
+
+import json
+import re
+from dataclasses import dataclass, field
+from pathlib import Path
+from types import SimpleNamespace
+from typing import Any
+
+import pytest
+from pytest_bdd import given, scenario, then, when
+
+from xskill.agents import agent_tools, agent_trace
+from xskill.agents.agno_factory import _wrap_with_retry, _wrap_with_trace
+from xskill.agents.context_budget import ContextManager
+from xskill.agents.skill_edit_agent import SkillEditAgent
+from xskill.pipeline.atom import AtomTaskStore
+from xskill.skill import candidates as candidate_buffer
+from xskill.skill.git import (
+    commit_baby_checkpoint,
+    current_branch,
+    init_skill_repo_on_baby,
+)
+
+
+pytestmark = [
+    pytest.mark.bdd,
+    pytest.mark.state_machine,
+]
+
+
+@scenario(
+    "features/skill_edit/baby_cold_start_golden_path.feature",
+    "新原子在编辑过程中到达时不会破坏当前批次边界",
+)
+def test_new_atom_respects_the_current_batch_boundary() -> None:
+    """A concurrent append is picked up only after the bound checkpoint."""
+
+
+@scenario(
+    "features/skill_edit/baby_cold_start_recovery.feature",
+    "连续失败时缩小当前批次，成功后恢复默认批次",
+)
+def test_failures_reduce_the_batch_until_success() -> None:
+    """The batch sequence is 5 -> 2 -> 1 -> default 5."""
+
+
+@scenario(
+    "features/skill_edit/baby_cold_start_recovery.feature",
+    "进程在多个 checkpoint 之间重启",
+)
+def test_restart_continues_after_the_last_checkpoint() -> None:
+    """Only candidates not represented by a checkpoint are replayed."""
+
+
+@scenario(
+    "features/skill_edit/baby_cold_start_recovery.feature",
+    "N=1 仍失败时把工作留给下一次 watcher 调度",
+)
+def test_n1_failure_preserves_work_for_the_watcher() -> None:
+    """The worker returns while the final candidate remains durable."""
+
+
+@scenario(
+    "features/skill_edit/skill_edit_trace.feature",
+    "成功的多批次冷启动可以从日志完整复盘",
+)
+def test_successful_cold_start_has_one_readable_trace() -> None:
+    """Every model round and framework checkpoint lands in one log."""
+
+
+@scenario(
+    "features/skill_edit/skill_edit_trace.feature",
+    "失败缩批和上下文处理顺序可以从日志确认",
+)
+def test_trace_shows_spill_before_compact_and_retry_reduction() -> None:
+    """Production context events preserve their causal order in the trace."""
+
+
+def _tool_name(tool: Any) -> str:
+    return getattr(tool, "__name__", None) or getattr(tool, "name", "")
+
+
+def _call_tool(tool: Any, *args: Any) -> str:
+    entrypoint = tool if callable(tool) else getattr(tool, "entrypoint")
+    return str(entrypoint(*args))
+
+
+@dataclass
+class StateWorld:
+    root: Path
+    skill_root: Path
+    store: AtomTaskStore
+    logs_root: Path
+    skill_name: str | None = None
+    skill_dir: Path | None = None
+    batch_size: int = 5
+    retry_batch_size: int | None = None
+    mode: str = "success"
+    inject_new_atom: bool = False
+    injected: bool = False
+    fail_messages: list[str] = field(default_factory=list)
+    attempts: list[list[str]] = field(default_factory=list)
+    candidate_counts_before: list[int] = field(default_factory=list)
+    remaining_after_commit: list[list[str]] = field(default_factory=list)
+    processed_atoms: list[str] = field(default_factory=list)
+    commit_results: list[str] = field(default_factory=list)
+    result: bool | None = None
+    next_batch_size: int | None = None
+    first_five: list[str] = field(default_factory=list)
+
+    @property
+    def trace_path(self) -> Path:
+        assert self.skill_name is not None
+        return (
+            self.logs_root
+            / "agents"
+            / "skill_edit_agents"
+            / "skills"
+            / f"{self.skill_name}.log"
+        )
+
+    @property
+    def trace(self) -> str:
+        return self.trace_path.read_text(encoding="utf-8")
+
+
+@pytest.fixture
+def state_world(tmp_path: Path) -> StateWorld:
+    skill_root = tmp_path / "skills"
+    store_root = tmp_path / "store"
+    skill_root.mkdir()
+    store_root.mkdir()
+    store = AtomTaskStore(root=store_root)
+    world = StateWorld(
+        root=tmp_path,
+        skill_root=skill_root,
+        store=store,
+        logs_root=tmp_path / "logs",
+    )
+    saved_context = agent_tools.agent_tool_config.snapshot()
+    agent_tools.init_atom_task_tool_context(
+        skill_dir=skill_root,
+        atom_store=store,
+        default_traj_root=store_root,
+    )
+    agent_tools.init_skill_authoring_tool_context(
+        skill_root,
+        skill_root,
+        {"skill_opt": {"enabled": False}},
+        spill_root=tmp_path / "spill",
+    )
+    yield world
+    agent_tools.agent_tool_config.restore(saved_context)
+
+
+def _seed_baby(
+    world: StateWorld,
+    *,
+    name: str,
+    count: int,
+    weight: int,
+) -> list[str]:
+    world.skill_name = name
+    world.skill_dir = world.skill_root / name
+    init_skill_repo_on_baby(
+        str(world.skill_dir),
+        name=name,
+        description="BDD state-machine draft",
+    )
+    data: dict[str, Any] = {"candidates": []}
+    atom_ids = [f"atom-{index:02d}" for index in range(1, count + 1)]
+    for atom_id in atom_ids:
+        data, _ = candidate_buffer.add_atom_contribution(
+            data,
+            atom_id,
+            weight,
+            note=f"knowledge for {atom_id}",
+        )
+    candidate_buffer.save_candidates(world.skill_dir, data)
+    return atom_ids
+
+
+def _fake_trace_response(atom_ids: list[str]) -> Any:
+    calls = (
+        (
+            "write_file",
+            json.dumps(
+                {"path": "SKILL.md", "content": "x" * 240},
+                separators=(",", ":"),
+            ),
+        ),
+        (
+            "commit_baby",
+            json.dumps(
+                {"skill_name": "bdd-skill", "message": ",".join(atom_ids)},
+                separators=(",", ":"),
+            ),
+        ),
+    )
+    message = SimpleNamespace(
+        reasoning_content=f"整理当前批次：{','.join(atom_ids)}",
+        content="",
+        tool_calls=[
+            SimpleNamespace(
+                function=SimpleNamespace(name=name, arguments=arguments),
+            )
+            for name, arguments in calls
+        ],
+    )
+    return SimpleNamespace(choices=[SimpleNamespace(message=message)])
+
+
+def _exercise_context_pressure(world: StateWorld) -> None:
+    """Run the real spill -> compact -> bounded 429 wrappers in the trace sink."""
+    messages = [
+        SimpleNamespace(role="system", content="s" * 3600),
+        SimpleNamespace(role="user", content="u" * 400),
+        SimpleNamespace(
+            role="tool",
+            tool_name="read_file",
+            name="read_file",
+            tool_call_id="call-read",
+            content="evidence " * 500,
+        ),
+    ]
+
+    class _RateLimitedModel:
+        @staticmethod
+        def invoke(_messages: list[Any], **_kwargs: Any) -> Any:
+            raise RuntimeError("429 rate limit from deterministic backend")
+
+    model = _RateLimitedModel()
+    manager = ContextManager(
+        1000,
+        spill_root=world.root / "spill",
+        compact_token_limit=900,
+        compact_keep_recent_messages=1,
+        compact_fn=lambda _prompt: "保留候选、证据摘要和待完成提交。",
+    )
+    model.invoke = manager.wrap(model.invoke)
+    model = _wrap_with_retry(
+        model,
+        {
+            "base_url": "http://127.0.0.1:1/v1",
+            "max_retries": 1,
+            "retry_base_delay": 0.001,
+            "retry_max_delay": 0.001,
+        },
+    )
+    model = _wrap_with_trace(model)
+    model.invoke(messages)
+
+
+class _DeterministicEditAgent:
+    def __init__(
+        self,
+        *,
+        instructions: list[str],
+        tools: list[Any],
+        world: StateWorld,
+    ):
+        del instructions
+        self.tools = {_tool_name(tool): tool for tool in tools}
+        self.world = world
+
+    def run(self, user_msg: str, **_kwargs: Any) -> Any:
+        world = self.world
+        assert world.skill_dir is not None
+        target = re.search(r"目标 SKILL\.md 路径:\s*(\S+)", user_msg)
+        skill = re.search(r"skill_name:\s*([\w-]+)", user_msg)
+        assert target is not None and skill is not None
+        atom_ids = re.findall(r"atom_id=(\S+)\s+weightscore=", user_msg)
+        world.attempts.append(atom_ids)
+        candidates = candidate_buffer.load_candidates(world.skill_dir)["candidates"]
+        world.candidate_counts_before.append(len(candidates))
+
+        if world.inject_new_atom and not world.injected:
+            data = candidate_buffer.load_candidates(world.skill_dir)
+            data, _ = candidate_buffer.add_atom_contribution(
+                data,
+                "atom-06",
+                10,
+                note="arrived while the first turn was running",
+            )
+            candidate_buffer.save_candidates(world.skill_dir, data)
+            world.injected = True
+
+        if world.mode == "context_pressure" and len(world.attempts) == 1:
+            _exercise_context_pressure(world)
+
+        if world.fail_messages:
+            raise RuntimeError(world.fail_messages.pop(0))
+
+        agent_trace.record(
+            [SimpleNamespace(role="user", content=user_msg)],
+            _fake_trace_response(atom_ids),
+        )
+        world.processed_atoms.extend(atom_ids)
+        rules = "\n".join(
+            f"- processed {atom_id}" for atom_id in world.processed_atoms
+        )
+        content = (
+            "---\n"
+            f"name: {skill.group(1)}\n"
+            "description: BDD 可恢复 checkpoint 状态机。\n"
+            "metadata:\n"
+            f"  version: {len(world.commit_results) + 1}\n"
+            "---\n\n"
+            "# State machine\n\n"
+            f"{rules}\n"
+        )
+        write_result = _call_tool(
+            self.tools["write_file"],
+            target.group(1),
+            content,
+        )
+        assert write_result.startswith("wrote:")
+        commit_result = _call_tool(
+            self.tools["commit_baby"],
+            skill.group(1),
+            f"BDD checkpoint {len(world.commit_results) + 1}",
+        )
+        world.commit_results.append(commit_result)
+        remaining = candidate_buffer.load_candidates(
+            world.skill_dir
+        )["candidates"]
+        world.remaining_after_commit.append(
+            [item["atom_id"] for item in remaining]
+        )
+        return SimpleNamespace(content="done")
+
+
+def _run_state_agent(world: StateWorld) -> None:
+    assert world.skill_dir is not None
+
+    def factory(*, instructions: list[str], tools: list[Any]) -> Any:
+        return _DeterministicEditAgent(
+            instructions=instructions,
+            tools=tools,
+            world=world,
+        )
+
+    llm_cfg = {
+        "max_context": 1000 if world.mode == "context_pressure" else 128_000,
+        "compact_token_limit": 900 if world.mode == "context_pressure" else 112_000,
+    }
+    agent = SkillEditAgent(
+        skill_dir=world.skill_dir,
+        store=world.store,
+        agno_agent_factory=factory,
+        llm_cfg=llm_cfg,
+        traj_root=world.root / "store",
+        batch_size=world.batch_size,
+        retry_batch_size=world.retry_batch_size,
+        logs_dir=world.logs_root,
+    )
+    world.result = agent.maybe_run()
+    world.next_batch_size = agent.next_batch_size
+
+
+@given("xskill 使用隔离的测试目录")
+def isolated_directory(state_world: StateWorld) -> None:
+    assert state_world.skill_root.parent == state_world.root
+
+
+@given("SkillEdit 每批最多处理 5 个原子")
+@given("SkillEdit 默认每批处理 5 个原子")
+def batch_size_is_five(state_world: StateWorld) -> None:
+    state_world.batch_size = 5
+
+
+@given("baby 的 candidates 使用稳定的 FIFO 顺序")
+def fifo_candidates() -> None:
+    return None
+
+
+@given("baby 当前有 5 个已经绑定到本 turn 的原子")
+def five_bound_atoms(state_world: StateWorld) -> None:
+    state_world.first_five = _seed_baby(
+        state_world,
+        name="concurrent-append",
+        count=5,
+        weight=2,
+    )
+
+
+@given("cluster 在模型编辑期间追加了 1 个新原子")
+def append_during_edit(state_world: StateWorld) -> None:
+    state_world.inject_new_atom = True
+
+
+@when("模型提交当前 baby checkpoint")
+def submit_concurrent_checkpoint(state_world: StateWorld) -> None:
+    _run_state_agent(state_world)
+
+
+@then("当前 commit 只应当消费原先绑定的 5 个原子")
+def first_commit_consumes_only_bound_atoms(state_world: StateWorld) -> None:
+    first_result = state_world.commit_results[0]
+    assert all(atom_id in first_result for atom_id in state_world.first_five)
+    assert "atom-06" not in first_result
+
+
+@then("新原子应当留给下一个 turn")
+def new_atom_is_left_for_next_turn(state_world: StateWorld) -> None:
+    assert state_world.remaining_after_commit[0] == ["atom-06"]
+    assert state_world.attempts[1] == ["atom-06"]
+
+
+@then("下一个 turn 成功后 baby 才能晋升为 main")
+def promotion_waits_for_next_turn(state_world: StateWorld) -> None:
+    assert len(state_world.commit_results) == 2
+    assert state_world.result is True
+    assert state_world.skill_dir is not None
+    assert current_branch(str(state_world.skill_dir)) == "main"
+
+
+@given("baby 中按顺序存在 5 个原子")
+def five_fifo_atoms(state_world: StateWorld) -> None:
+    state_world.first_five = _seed_baby(
+        state_world,
+        name="adaptive-retry",
+        count=5,
+        weight=2,
+    )
+
+
+@given("N=5 的第一次尝试因 429 失败")
+def first_attempt_is_rate_limited(state_world: StateWorld) -> None:
+    state_world.fail_messages.append("429 rate limit")
+
+
+@given("N=2 的第二次尝试因上下文超长失败")
+def second_attempt_is_too_long(state_world: StateWorld) -> None:
+    state_world.fail_messages.append("maximum context length exceeded")
+
+
+@when("N=1 的第三次尝试成功提交 checkpoint")
+def third_attempt_commits(state_world: StateWorld) -> None:
+    _run_state_agent(state_world)
+
+
+@then("三次尝试处理的 atom_id 都应当从 FIFO 队首开始")
+def retries_start_at_fifo_head(state_world: StateWorld) -> None:
+    assert state_world.attempts[:3] == [
+        state_world.first_five,
+        state_world.first_five[:2],
+        state_world.first_five[:1],
+    ]
+
+
+@then("前两次失败不应当消费任何原子")
+def failures_do_not_consume(state_world: StateWorld) -> None:
+    assert state_world.candidate_counts_before[:3] == [5, 5, 5]
+
+
+@then("第三次只应当消费 1 个原子")
+def third_attempt_consumes_one(state_world: StateWorld) -> None:
+    assert state_world.remaining_after_commit[0] == state_world.first_five[1:]
+
+
+@then("剩余 4 个原子的下一次成功尝试应当使用默认 N=5")
+def success_restores_default_batch(state_world: StateWorld) -> None:
+    assert state_world.attempts[3] == state_world.first_five[1:]
+    assert state_world.next_batch_size == 5
+    assert state_world.result is True
+
+
+@given("baby 最初有 6 个原子")
+def six_initial_atoms(state_world: StateWorld) -> None:
+    state_world.first_five = _seed_baby(
+        state_world,
+        name="restart-recovery",
+        count=6,
+        weight=2,
+    )[:5]
+
+
+@given("第一个进程已经提交并消费前 5 个原子")
+def first_process_checkpointed_five(state_world: StateWorld) -> None:
+    assert state_world.skill_dir is not None
+    skill_md = state_world.skill_dir / "SKILL.md"
+    skill_md.write_text(
+        "---\n"
+        "name: restart-recovery\n"
+        "description: first process checkpoint\n"
+        "metadata:\n"
+        "  version: 1\n"
+        "---\n\n"
+        "# Restart recovery\n\n"
+        "first five were checkpointed\n",
+        encoding="utf-8",
+    )
+    assert commit_baby_checkpoint(
+        str(state_world.skill_dir),
+        "first process durable checkpoint",
+    )
+    consumed, remaining = candidate_buffer.remove_candidates(
+        state_world.skill_dir,
+        set(state_world.first_five),
+    )
+    assert consumed == state_world.first_five
+    assert remaining == 1
+
+
+@given("第一个进程在晋升 main 之前退出")
+def first_process_exits(state_world: StateWorld) -> None:
+    assert state_world.skill_dir is not None
+    assert current_branch(str(state_world.skill_dir)) == "baby"
+
+
+@when("watcher 在新进程中再次调度这个 baby")
+def restarted_watcher_runs(state_world: StateWorld) -> None:
+    _run_state_agent(state_world)
+
+
+@then("新进程只应当把最后 1 个原子发送给模型")
+def only_last_atom_is_sent(state_world: StateWorld) -> None:
+    assert state_world.attempts == [["atom-06"]]
+
+
+@then("已提交的前 5 个原子不应当重放")
+def first_five_are_not_replayed(state_world: StateWorld) -> None:
+    assert not set(state_world.first_five) & set(state_world.attempts[0])
+
+
+@then("最后 1 个原子成功后 baby 应当晋升为 main")
+def last_atom_allows_promotion(state_world: StateWorld) -> None:
+    assert state_world.result is True
+    assert state_world.skill_dir is not None
+    assert current_branch(str(state_world.skill_dir)) == "main"
+
+
+@given("baby 中只剩 1 个原子")
+def one_atom_remains(state_world: StateWorld) -> None:
+    _seed_baby(
+        state_world,
+        name="n1-failure",
+        count=1,
+        weight=10,
+    )
+
+
+@given("当前重试批次已经降为 N=1")
+def retry_batch_is_one(state_world: StateWorld) -> None:
+    state_world.retry_batch_size = 1
+
+
+@when("模型仍然因为上下文超长而失败")
+def n1_still_fails(state_world: StateWorld) -> None:
+    state_world.fail_messages.append("maximum context length exceeded")
+    _run_state_agent(state_world)
+
+
+@then("SkillEdit 工作应当结束并释放 worker")
+def worker_returns(state_world: StateWorld) -> None:
+    assert state_world.result is False
+    assert len(state_world.attempts) == 1
+
+
+@then("baby 应当继续停留在 baby 分支")
+def skill_stays_on_baby(state_world: StateWorld) -> None:
+    assert state_world.skill_dir is not None
+    assert current_branch(str(state_world.skill_dir)) == "baby"
+
+
+@then("最后 1 个原子应当保留在 candidates")
+def final_atom_is_preserved(state_world: StateWorld) -> None:
+    assert state_world.skill_dir is not None
+    remaining = candidate_buffer.load_candidates(
+        state_world.skill_dir
+    )["candidates"]
+    assert [item["atom_id"] for item in remaining] == ["atom-01"]
+
+
+@then("watcher 下次调度时仍应当从 N=1 开始")
+def watcher_remembers_n1(state_world: StateWorld) -> None:
+    assert state_world.next_batch_size == 1
+
+
+@given("SkillEdit 已为目标 skill 创建唯一的追加日志")
+def unique_append_log(state_world: StateWorld) -> None:
+    state_world.logs_root.mkdir()
+
+
+@given("日志不记录原始 tool call JSON")
+def trace_is_human_readable_contract() -> None:
+    return None
+
+
+@given("baby 中存在 7 个原子")
+def seven_atoms_for_trace(state_world: StateWorld) -> None:
+    _seed_baby(
+        state_world,
+        name="trace-success",
+        count=7,
+        weight=2,
+    )
+
+
+@given("默认批次大小 N=5")
+def trace_default_batch_is_five(state_world: StateWorld) -> None:
+    state_world.batch_size = 5
+
+
+@when("两个 turn 分别成功提交 5 个和 2 个原子")
+def two_trace_turns_commit(state_world: StateWorld) -> None:
+    _run_state_agent(state_world)
+    assert [len(batch) for batch in state_world.attempts] == [5, 2]
+
+
+@then("日志应当包含两个显著的 TURN START 分隔")
+def trace_has_two_turn_markers(state_world: StateWorld) -> None:
+    assert state_world.trace.count("================ TURN START") == 2
+
+
+@then("每个 TURN START 应当显示当次 N 和待处理数量")
+def trace_turn_markers_show_batch_state(state_world: StateWorld) -> None:
+    assert "TURN START | N=5 | processing 5 of 7 pending atoms" in state_world.trace
+    assert "TURN START | N=5 | processing 2 of 2 pending atoms" in state_world.trace
+
+
+@then("每个 round 应当显示当前 token、spill 上限和 compact 上限")
+def trace_rounds_show_context_limits(state_world: StateWorld) -> None:
+    rounds = [
+        line for line in state_world.trace.splitlines()
+        if line.startswith("---- ROUND")
+    ]
+    assert len(rounds) == 2
+    assert all(
+        "tokens=" in line and "spill@" in line and "compact@" in line
+        for line in rounds
+    )
+
+
+@then("工具摘要应当显示 commit_baby 消费的 atom_id")
+def trace_shows_consumed_atom_ids(state_world: StateWorld) -> None:
+    assert "Consumed atoms:" in state_world.trace
+    for atom_id in [f"atom-{index:02d}" for index in range(1, 8)]:
+        assert atom_id in state_world.trace
+
+
+@then("每个 turn 应当显示已消费数量、剩余数量和下一次 N")
+def trace_shows_turn_outcomes(state_world: StateWorld) -> None:
+    assert "TURN END | COMMITTED | consumed=5 | 2 remaining | next N=5" in state_world.trace
+    assert "TURN END | COMMITTED | consumed=2 | 0 remaining | next N=5" in state_world.trace
+
+
+@then("日志不应当包含原始 JSON 对象")
+def trace_has_no_raw_json(state_world: StateWorld) -> None:
+    assert '{"' not in state_world.trace
+    assert '"skill_name":' not in state_world.trace
+
+
+@given("当前 turn 从 N=5 开始")
+def pressure_turn_starts_at_five(state_world: StateWorld) -> None:
+    _seed_baby(
+        state_world,
+        name="trace-pressure",
+        count=5,
+        weight=2,
+    )
+    state_world.batch_size = 5
+
+
+@given("模型第一次调用触发上下文压力")
+def first_call_has_context_pressure(state_world: StateWorld) -> None:
+    state_world.mode = "context_pressure"
+
+
+@given("spill 后仍然超过 compact 上限")
+def spill_is_not_enough() -> None:
+    return None
+
+
+@given("本次模型调用最终因 429 失败")
+def pressure_call_is_rate_limited() -> None:
+    # _exercise_context_pressure uses the production retry wrapper and raises
+    # a bounded 429 after spill and compact have both been recorded.
+    return None
+
+
+@when("SkillEdit 把当前工作缩小到 N=2 后重试")
+def retry_with_two(state_world: StateWorld) -> None:
+    _run_state_agent(state_world)
+    assert [len(batch) for batch in state_world.attempts[:2]] == [5, 2]
+
+
+@then("日志中 spill 事件应当出现在 compact 事件之前")
+def spill_precedes_compact(state_world: StateWorld) -> None:
+    trace = state_world.trace
+    assert trace.index("Spilled 1 old tool result") < trace.index("Compacted context")
+
+
+@then("日志应当显示 compact 前后的 token 数量")
+def compact_shows_token_delta(state_world: StateWorld) -> None:
+    assert re.search(
+        r"Compacted context: [\d,]+ -> [\d,]+ tokens\.",
+        state_world.trace,
+    )
+
+
+@then("日志应当显示模型调用失败的可读原因")
+def trace_shows_readable_model_error(state_world: StateWorld) -> None:
+    assert "LLM returned 429; retries exhausted (1/1)" in state_world.trace
+
+
+@then('日志应当显示 "Retry batch reduced: 5 -> 2"')
+def trace_shows_batch_reduction(state_world: StateWorld) -> None:
+    assert "Retry batch reduced: 5 -> 2" in state_world.trace
+
+
+@then("下一次 TURN START 应当显示 N=2")
+def next_turn_marker_uses_two(state_world: StateWorld) -> None:
+    assert "TURN START | N=2 | processing 2 of 5 pending atoms" in state_world.trace

--- a/tests/test_skill_edit_mutation_contracts.py
+++ b/tests/test_skill_edit_mutation_contracts.py
@@ -1,0 +1,126 @@
+"""Focused contracts used by mutmut for SkillEdit's durable boundaries."""
+
+from __future__ import annotations
+
+from contextlib import contextmanager
+from pathlib import Path
+from typing import Iterator
+
+from xskill.agents import agent_tools
+from xskill.skill import candidates as candidate_buffer
+from xskill.skill import git as skill_git
+
+
+def test_graduate_baby_forwards_exact_optimizer_and_git_arguments(
+    tmp_path: Path,
+    monkeypatch,
+) -> None:
+    target = tmp_path / "skills" / "graduation-contract"
+    target.mkdir(parents=True)
+    (target / "SKILL.md").write_text(
+        "---\n"
+        "name: graduation-contract\n"
+        "description: valid mutation contract\n"
+        "---\n\n"
+        "# Graduation contract\n",
+        encoding="utf-8",
+    )
+    calls: list[tuple[object, ...]] = []
+
+    def optimize(actual_target: Path, actual_slug: str) -> None:
+        calls.append(("optimize", actual_target, actual_slug))
+
+    def graduate(actual_target: str, actual_message: str) -> bool:
+        calls.append(("git", actual_target, actual_message))
+        return True
+
+    monkeypatch.setattr(
+        agent_tools,
+        "_run_description_optimization",
+        optimize,
+    )
+    monkeypatch.setattr(
+        skill_git,
+        "commit_baby_to_main_branch",
+        graduate,
+    )
+
+    assert agent_tools.graduate_baby_to_main(
+        target,
+        "graduation-contract",
+        "all candidate checkpoints complete",
+    ) is True
+    assert calls == [
+        ("optimize", target, "graduation-contract"),
+        ("git", str(target), "all candidate checkpoints complete"),
+    ]
+
+
+def test_graduate_baby_rejects_invalid_frontmatter_before_side_effects(
+    tmp_path: Path,
+    monkeypatch,
+) -> None:
+    target = tmp_path / "skills" / "invalid-graduation"
+    target.mkdir(parents=True)
+    (target / "SKILL.md").write_text("not frontmatter", encoding="utf-8")
+
+    def unexpected(*_args, **_kwargs) -> None:
+        raise AssertionError("invalid SKILL.md must not reach a side effect")
+
+    monkeypatch.setattr(
+        agent_tools,
+        "_run_description_optimization",
+        unexpected,
+    )
+    monkeypatch.setattr(
+        skill_git,
+        "commit_baby_to_main_branch",
+        unexpected,
+    )
+
+    assert agent_tools.graduate_baby_to_main(
+        target,
+        "invalid-graduation",
+        "must not commit",
+    ) is False
+
+
+def test_remove_candidates_does_not_consume_a_git_write_slot(
+    tmp_path: Path,
+    monkeypatch,
+) -> None:
+    skill_dir = tmp_path / "skills" / "candidate-lock-contract"
+    skill_dir.mkdir(parents=True)
+    data: dict = {"candidates": []}
+    for atom_id in ("atom-01", "atom-02"):
+        data, _ = candidate_buffer.add_atom_contribution(
+            data,
+            atom_id,
+            5,
+        )
+    candidate_buffer.save_candidates(skill_dir, data)
+    lock_calls: list[tuple[Path, bool]] = []
+
+    @contextmanager
+    def recording_lock(
+        actual_skill_dir: Path,
+        *,
+        use_git_write_limit: bool = True,
+    ) -> Iterator[None]:
+        lock_calls.append((actual_skill_dir, use_git_write_limit))
+        yield
+
+    monkeypatch.setattr(
+        candidate_buffer,
+        "skill_repo_lock",
+        recording_lock,
+    )
+
+    consumed, remaining = candidate_buffer.remove_candidates(
+        skill_dir,
+        {"atom-01"},
+    )
+
+    assert consumed == ["atom-01"]
+    assert remaining == 1
+    assert lock_calls == [(skill_dir, False)]


### PR DESCRIPTION
## 背景

这是基于 #147 的堆叠 MR，专门让测试后端、行为规格与 mutation testing 可以独立审阅。请先审阅 #147 的实现，再审阅本 MR 的测试层。

关联 #146。

## 本 MR 做了什么

- 将 11 个 Gherkin 场景全部接入 pytest-bdd，不再只有文字规格。
- 使用 CopilotKit aimock 启动本地 OpenAI-compatible HTTP 后端，贯通生产链路：watcher / SkillEditAgent → Agno/OpenAI → HTTP → tool calls → xskill 工具 → Git/candidates。
- 覆盖主用户成功路径、真实工具调用、请求不离开本机、持续 429、commit 后 429、缩批、重启、并发到达、spill/compact 与可读 trace。
- 将 pytest-bdd、aimock-pytest、mutmut 严格放在 dev extra，不进入用户运行时依赖。
- 配置 mutmut 聚焦 candidate 消费和 baby 晋升两个耐久边界，并补充独立 CI job。

## 本地验证

- `XSKILL_AIMOCK_E2E=1 pytest tests/bdd -q --timeout=120`：11 passed
- 全量非 e2e 测试：1946 passed, 6 skipped
- mutation testing：47/47 killed，0 survived，0 timeout
- 构建 wheel/sdist 成功；wheel runtime dependency leaks = 0
- `git diff --check` 通过

## 已知、但不属于本 MR 的 CI 信号

#147 的 Windows Python 3.9 和 3.11 各有一个失败，都是既有的 `test_registry_concurrent_usage_writes_do_not_reassign_wal`：30 线程执行 600 次 SQLite usage 写入时偶发 `sqlite3.OperationalError: database is locked`。Windows 3.10/3.12 与 Linux/macOS 通过；失败路径不经过 SkillEdit BDD 或 aimock。