### PR TITLE
fix: SkillEdit 现网回灌（usage + 调度 + stub 毕业）

### DIFF
--- a/src/xskill/agents/agent_tools.py
+++ b/src/xskill/agents/agent_tools.py
@@ -1566,13 +1566,22 @@ def graduate_baby_to_main(target: Path, slug: str, message: str) -> bool:
     baby turns only expose ``commit_baby`` to the model.
     """
     from xskill.skill.frontmatter import FrontmatterError
-    from xskill.skill.git import commit_baby_to_main_branch
+    from xskill.skill.git import (
+        commit_baby_to_main_branch,
+        skill_md_still_baby_stub,
+    )
 
     skill_md = target / "SKILL.md"
     try:
         fm_parse_strict(skill_md.read_text(encoding="utf-8"))
     except (OSError, UnicodeDecodeError, FrontmatterError) as error:
         logger.warning("baby graduation frontmatter invalid for %s: %s", slug, error)
+        return False
+    if skill_md_still_baby_stub(target):
+        logger.warning(
+            "baby graduation refused: %s SKILL.md still has init stub placeholder",
+            slug,
+        )
         return False
     _run_description_optimization(target, slug)
     return commit_baby_to_main_branch(str(target), message)
@@ -1672,6 +1681,13 @@ def commit_baby_to_main(skill_name: str, message: str) -> str:
     msg = (message or "").strip()
     if not msg:
         return "error: commit message 必填"
+    from xskill.skill.git import skill_md_still_baby_stub
+
+    if skill_md_still_baby_stub(target):
+        return (
+            "error: SKILL.md 仍是 baby stub（含 init placeholder），"
+            "禁止 graduate；请先 write_file 写完整正文再调用"
+        )
     ok = graduate_baby_to_main(target, slug, msg)
     if not ok:
         return "error: commit_baby_to_main 失败（不在 baby 分支？看 daemon 日志）"

--- a/src/xskill/agents/agno_factory.py
+++ b/src/xskill/agents/agno_factory.py
@@ -241,9 +241,19 @@ _NON_RETRYABLE_HINTS = (
 
 
 def _is_transient_error(exc: Exception) -> bool:
+    # 本地限流桶耗尽只是"等一等就有令牌"，必须按瞬时错误重试——不能靠字符串
+    # 匹配：消息是 "RPM bucket exhausted"，与 hint "rpm exhausted" 子串对不上，
+    # 曾被误判为非瞬时 → 1/8 一击致命，高并发下 cluster 会话成片死亡。
+    from xskill.utils.rate_limit import RateLimitExhausted
+    if isinstance(exc, RateLimitExhausted):
+        return True
     t = f"{exc}".lower()
     if any(h in t for h in _NON_RETRYABLE_HINTS):
         return False
+    status_code = getattr(exc, "status_code", None)
+    if isinstance(status_code, int):
+        if status_code == 429 or 500 <= status_code <= 599:
+            return True
     return any(h in t for h in _TRANSIENT_HINTS)
 
 
@@ -277,17 +287,21 @@ def _wrap_with_retry(model, llm_cfg: dict):
             except Exception as exc:  # noqa: BLE001
                 attempt += 1
                 error_text = str(exc).lower()
-                if "429" in error_text or "rate limit" in error_text:
+                status_code = getattr(exc, "status_code", None)
+                if status_code == 429 or "429" in error_text or "rate limit" in error_text:
                     error_label = "429"
+                elif isinstance(status_code, int) and 500 <= status_code <= 599:
+                    error_label = str(status_code)
                 elif any(h in error_text for h in _NON_RETRYABLE_HINTS):
                     error_label = "context-too-long"
                 else:
                     error_label = type(exc).__name__
+                error_detail = str(exc)[:160]
                 if attempt >= max_retries or not _is_transient_error(exc):
                     agent_trace.event(
                         "ERROR",
                         f"LLM returned {error_label}; retries exhausted "
-                        f"({attempt}/{max_retries})",
+                        f"({attempt}/{max_retries}): {error_detail}",
                     )
                     raise
                 delay = min(cap, base * (2 ** (attempt - 1)))

--- a/src/xskill/agents/skill_edit_agent.py
+++ b/src/xskill/agents/skill_edit_agent.py
@@ -631,6 +631,33 @@ class SkillEditAgent:
     def _graduate_completed_baby(self) -> bool:
         """Promote an empty, checkpointed baby to main under framework control."""
         from xskill.agents import agent_tools, agent_trace
+        from xskill.skill.git import skill_md_still_baby_stub
+
+        if skill_md_still_baby_stub(self.skill_dir):
+            logger.warning(
+                "SkillEdit refuse graduate (stub still present), re-trigger rewrite: %s",
+                self.skill_dir.name,
+            )
+            agent_trace.append_to(
+                self._trace_path(),
+                (
+                    f"{time.strftime('%H:%M:%S')} INFO  "
+                    "Candidate buffer empty but SKILL.md still stub; "
+                    "re-trigger rewrite before graduate.\n"
+                ),
+            )
+            if not self._run_stub_rewrite_turn():
+                logger.warning(
+                    "SkillEdit stub rewrite failed; stay on baby: %s",
+                    self.skill_dir.name,
+                )
+                return False
+            if skill_md_still_baby_stub(self.skill_dir):
+                logger.warning(
+                    "SkillEdit stub rewrite left placeholder; stay on baby: %s",
+                    self.skill_dir.name,
+                )
+                return False
 
         ok = agent_tools.graduate_baby_to_main(
             self.skill_dir,
@@ -652,6 +679,54 @@ class SkillEditAgent:
                 self.skill_dir.name,
             )
         return ok
+
+    def _run_stub_rewrite_turn(self) -> bool:
+        """Buffer empty but body still stub → one forced write_file turn, no commit tool."""
+        from xskill.agents import agent_tools, agent_trace
+
+        skill_md = self.skill_dir / "SKILL.md"
+        scenario_block = "\n".join(
+            [
+                f"skill_name: {self.skill_dir.name}（**baby 分支 · stub 未清除，强制重写**）",
+                "SKILL.md 仍是 init placeholder，框架拒绝 graduate。",
+                "必须用 write_file 覆盖 SKILL.md 为正式正文（去掉 placeholder 行）。",
+                "本轮没有 commit 工具；写完后由框架校验并 graduate。",
+                *self._skill_tree_context_lines(),
+                f"目标 SKILL.md 路径: {skill_md}",
+            ]
+        )
+        sysprompt = build_system_prompt(
+            scenario_block=scenario_block,
+            branch_now="baby",
+        )
+        tools = [
+            agent_tools.atom_task_read,
+            agent_tools.read_traj,
+            agent_tools.skill_read,
+            agent_tools.read_file,
+            agent_tools.list_files,
+            agent_tools.grep_files,
+            agent_tools.write_file,
+        ]
+        agent = self.agno_agent_factory(instructions=[sysprompt], tools=tools)
+        agent_trace.append_to(
+            self._trace_path(),
+            (
+                f"{time.strftime('%H:%M:%S')} INFO  "
+                "Stub rewrite turn start (no commit tool).\n"
+            ),
+        )
+        try:
+            self._trace_run(agent, scenario_block)
+        except Exception:
+            logger.exception(
+                "SkillEdit stub rewrite turn raised: %s",
+                self.skill_dir.name,
+            )
+            return False
+        from xskill.skill.git import skill_md_still_baby_stub
+
+        return not skill_md_still_baby_stub(self.skill_dir)
 
     def _run_baby_until_empty(self) -> bool:
         """Drain baby candidates via durable per-batch commits, then graduate."""

--- a/src/xskill/pipeline/runner.py
+++ b/src/xskill/pipeline/runner.py
@@ -57,6 +57,9 @@ from xskill.pipeline.trajectory import validate_trajectory_source
 
 logger = logging.getLogger("xskill.watcher")
 
+# SkillEdit N=1 连续失败达到该次数后抬高调度错误分，优先跑其他 skill。
+SKILL_EDIT_N1_FAIL_DEPRIORITIZE = 3
+
 # v2 (AtomTask 流水线) 的 action → status 映射
 # splitting → split_done → indexed → clustering → done
 _ACTION_STATUS = {
@@ -192,6 +195,10 @@ class DirectoryWatcher:
         # 继续，成功 checkpoint 后由 agent 自动恢复配置默认值。仅驻留内存，
         # 进程重启后自然回到配置值。
         self._skill_edit_retry_batch_sizes: dict[Path, int] = {}
+        # N=1 连续失败计数；达 SKILL_EDIT_N1_FAIL_DEPRIORITIZE 次后抬高
+        # error_count，调度时排到后面（不永久 error，不指数退避）。
+        self._skill_edit_n1_fail_counts: dict[Path, int] = {}
+        self._skill_edit_error_counts: dict[Path, int] = {}
         self._last_poll: float | None = None
         self._started_at = time.time()
         # 单机 canary 轮转节流：上次真跑 _reconcile_skill_sides 的时间戳。
@@ -503,12 +510,36 @@ class DirectoryWatcher:
         # ``_harvest``（每轮 scan 开头）收割 + 做 _stats 自增/即时 install。
         # 同一个 skill 同时只允许一个 skill_edit future 在飞，避免同一 skill
         # 被并发跑两个 maybe_run（第二个进来时前一个多半仍在改 candidates/git）。
+        from xskill.skill import candidates as candidate_buffer
+
         skill_dirs = [
-            d for d in sorted(self.skill_dir.iterdir())
+            d for d in self.skill_dir.iterdir()
             if d.is_dir() and not d.name.startswith(".")
         ]
         if not skill_dirs:
             return
+
+        def _pending_atom_count(skill_path: Path) -> int:
+            try:
+                data = candidate_buffer.load_candidates(skill_path)
+            except Exception:
+                logger.exception(
+                    "failed to load candidates for skill_edit sort: %s",
+                    skill_path.name,
+                )
+                raise
+            return len(data.get("candidates") or [])
+
+        # 错误少优先，其次原子少，再按名字稳定排序。N=1 连败抬高 error 后
+        # 自然排到后面，换下一个 skill；不永久 error、无指数退避。
+        def _skill_edit_sort_key(path: Path):
+            return (
+                self._skill_edit_error_counts.get(path, 0),
+                _pending_atom_count(path),
+                path.name,
+            )
+
+        skill_dirs.sort(key=_skill_edit_sort_key)
 
         jam_threshold = CanaryConfig.from_dict(
             self.config.get("canary", {})).jam_threshold
@@ -569,10 +600,30 @@ class DirectoryWatcher:
         """``_harvest`` 收割 stage="skill_edit" future 用：_stats 自增 + 即时
         install。回主线程串行做（避免对无锁的 self._stats 并发自增）。"""
         d, ok, next_batch_size = result
-        if ok or next_batch_size == self.skill_edit_batch_size:
+        if ok:
+            self._skill_edit_retry_batch_sizes.pop(d, None)
+            self._skill_edit_n1_fail_counts.pop(d, None)
+            self._skill_edit_error_counts.pop(d, None)
+        elif next_batch_size == self.skill_edit_batch_size:
             self._skill_edit_retry_batch_sizes.pop(d, None)
         else:
             self._skill_edit_retry_batch_sizes[d] = next_batch_size
+            if next_batch_size == 1:
+                fails = self._skill_edit_n1_fail_counts.get(d, 0) + 1
+                if fails >= SKILL_EDIT_N1_FAIL_DEPRIORITIZE:
+                    self._skill_edit_error_counts[d] = (
+                        self._skill_edit_error_counts.get(d, 0) + 1
+                    )
+                    self._skill_edit_n1_fail_counts[d] = 0
+                    logger.warning(
+                        "SkillEdit N=1 failed %d times; deprioritize %s "
+                        "(error_count=%d, atoms kept)",
+                        SKILL_EDIT_N1_FAIL_DEPRIORITIZE,
+                        d.name,
+                        self._skill_edit_error_counts[d],
+                    )
+                else:
+                    self._skill_edit_n1_fail_counts[d] = fails
         if not ok:
             return
         self._stats["skills_edited"] += 1

--- a/src/xskill/pipeline/runner.py
+++ b/src/xskill/pipeline/runner.py
@@ -544,13 +544,18 @@ class DirectoryWatcher:
             """与 maybe_run 守门对齐：不会开 LLM 的 skill 不进 edit 池。
 
             单目录异常只排除该 skill，禁止拖垮整轮 edit submit。
+            无 ``.git`` 的目录仍返回 True：交由 worker 侧 ``_run_one`` /
+            ``maybe_run`` 吞错（与过滤前提交语义一致），避免 listcomp 里
+            ``current_branch`` 抛穿扫描；也不把「脏目录」误当成可过滤的
+            伪 skill 状态机。
             """
             if not (skill_path / ".git").exists():
                 logger.warning(
-                    "skip SkillEdit schedule: %s has no .git",
+                    "SkillEdit schedule: %s has no .git; submit and let "
+                    "worker isolate failures",
                     skill_path.name,
                 )
-                return False
+                return True
             try:
                 data = candidate_buffer.load_candidates(skill_path)
                 candidates = list(data.get("candidates") or [])
@@ -612,11 +617,14 @@ class DirectoryWatcher:
         if not skill_dirs:
             return
 
-        # 错误少优先，其次 lean-first。列表已是 actionable，无需再排空 buffer。
+        # 错误少优先；有候选优先于空 buffer；再 lean-first。
+        # 无 .git 等「仍提交」的空目录靠 empty-last 避免抢窗。
         def _skill_edit_sort_key(path: Path):
+            pending = _pending_atom_count(path)
             return (
                 self._skill_edit_error_counts.get(path, 0),
-                _pending_atom_count(path),
+                0 if pending > 0 else 1,
+                pending,
                 path.name,
             )
 

--- a/src/xskill/pipeline/runner.py
+++ b/src/xskill/pipeline/runner.py
@@ -511,6 +511,8 @@ class DirectoryWatcher:
         # 同一个 skill 同时只允许一个 skill_edit future 在飞，避免同一 skill
         # 被并发跑两个 maybe_run（第二个进来时前一个多半仍在改 candidates/git）。
         from xskill.skill import candidates as candidate_buffer
+        from xskill.skill.git import current_branch, run_git
+        from xskill.canary import load_ux_scores
 
         skill_dirs = [
             d for d in self.skill_dir.iterdir()
@@ -518,6 +520,14 @@ class DirectoryWatcher:
         ]
         if not skill_dirs:
             return
+
+        jam_threshold = CanaryConfig.from_dict(
+            self.config.get("canary", {})).jam_threshold
+        edit_threshold = (
+            int(threshold)
+            if threshold is not None
+            else candidate_buffer.ATOM_PROMOTION_THRESHOLD
+        )
 
         def _pending_atom_count(skill_path: Path) -> int:
             try:
@@ -530,8 +540,79 @@ class DirectoryWatcher:
                 raise
             return len(data.get("candidates") or [])
 
-        # 错误少优先，其次原子少，再按名字稳定排序。N=1 连败抬高 error 后
-        # 自然排到后面，换下一个 skill；不永久 error、无指数退避。
+        def _skill_edit_actionable(skill_path: Path) -> bool:
+            """与 maybe_run 守门对齐：不会开 LLM 的 skill 不进 edit 池。
+
+            单目录异常只排除该 skill，禁止拖垮整轮 edit submit。
+            """
+            if not (skill_path / ".git").exists():
+                logger.warning(
+                    "skip SkillEdit schedule: %s has no .git",
+                    skill_path.name,
+                )
+                return False
+            try:
+                data = candidate_buffer.load_candidates(skill_path)
+                candidates = list(data.get("candidates") or [])
+                total_ws = 0
+                for item in candidates:
+                    try:
+                        total_ws += int(item.get("weightscore") or 0)
+                    except (TypeError, ValueError):
+                        pass
+                staging_exists = run_git(
+                    ["rev-parse", "--verify", "staging"],
+                    cwd=str(skill_path),
+                )[0] == 0
+                jam = staging_exists and total_ws >= jam_threshold
+                if staging_exists and not jam:
+                    return False
+                if jam:
+                    return True
+                ready = bool(
+                    candidate_buffer.ready_for_promotion_v2(
+                        data, threshold=edit_threshold,
+                    )
+                )
+                baby_checkpoint = run_git(
+                    ["rev-parse", "baby~1"],
+                    cwd=str(skill_path),
+                )[0] == 0
+                branch = current_branch(str(skill_path)) or ""
+                if branch == "baby":
+                    return baby_checkpoint or ready
+                if branch == "main":
+                    if not ready:
+                        return False
+                    try:
+                        scores = load_ux_scores(skill_path)
+                    except Exception:
+                        logger.exception(
+                            "load_ux_scores failed during skill_edit "
+                            "filter: %s",
+                            skill_path.name,
+                        )
+                        return False
+                    return any(
+                        score.get("side") == "main" for score in scores
+                    )
+                if "_turn" in branch:
+                    return baby_checkpoint or ready
+                return False
+            except Exception:
+                logger.exception(
+                    "skill_edit actionable check failed: %s",
+                    skill_path.name,
+                )
+                return False
+
+        skill_dirs = [
+            path for path in skill_dirs if _skill_edit_actionable(path)
+        ]
+        if not skill_dirs:
+            return
+
+        # 错误少优先，其次 lean-first。列表已是 actionable，无需再排空 buffer。
         def _skill_edit_sort_key(path: Path):
             return (
                 self._skill_edit_error_counts.get(path, 0),
@@ -541,8 +622,6 @@ class DirectoryWatcher:
 
         skill_dirs.sort(key=_skill_edit_sort_key)
 
-        jam_threshold = CanaryConfig.from_dict(
-            self.config.get("canary", {})).jam_threshold
         base_llm_cfg = self.config.get("llm", {}) or {}
         skill_llm_override = self.config.get("llm_skill", {}) or {}
         skill_llm_cfg = {

--- a/src/xskill/skill/git.py
+++ b/src/xskill/skill/git.py
@@ -1744,6 +1744,22 @@ _DISPATCH: dict[str, Callable[[list[str], str], tuple[int, str, str]]] = {
 # 高层 API：直接用 dulwich（不绕回 run_git）
 # ═══════════════════════════════════════════════════════════════════
 
+# init stub 正文标记：毕业前必须消失，否则拒绝 baby→main。
+BABY_STUB_BODY_MARKER = (
+    "(placeholder — SkillEditAgent 在 candidates 攒满阈值后会用真实 atom 内容填充正文)"
+)
+
+
+def skill_md_still_baby_stub(skill_dir: str | Path) -> bool:
+    """SKILL.md 是否仍含 init 时的 placeholder 正文。"""
+    skill_md = Path(skill_dir) / "SKILL.md"
+    try:
+        text = skill_md.read_text(encoding="utf-8")
+    except (OSError, UnicodeDecodeError):
+        return False
+    return BABY_STUB_BODY_MARKER in text
+
+
 def init_skill_repo_on_baby(skill_dir: str, name: str, description: str) -> None:
     """v2: 初始化 skill 仓库到 baby 分支，附带 stub SKILL.md + .gitignore。
 
@@ -1782,7 +1798,7 @@ def init_skill_repo_on_baby(skill_dir: str, name: str, description: str) -> None
                 f"\n"
                 f"# {name}\n"
                 f"\n"
-                f"(placeholder — SkillEditAgent 在 candidates 攒满阈值后会用真实 atom 内容填充正文)\n"
+                f"{BABY_STUB_BODY_MARKER}\n"
             )
             (p / "SKILL.md").write_text(stub_md, encoding="utf-8")
 

--- a/src/xskill/skill/git.py
+++ b/src/xskill/skill/git.py
@@ -1751,13 +1751,36 @@ BABY_STUB_BODY_MARKER = (
 
 
 def skill_md_still_baby_stub(skill_dir: str | Path) -> bool:
-    """SKILL.md 是否仍含 init 时的 placeholder 正文。"""
+    """SKILL.md 是否仍是 init 时的空 stub（#154 empty-graduate）。
+
+    仅当正文在去掉 frontmatter 后本质上仍是 init 形态（可选 ``# name`` +
+    placeholder 行）时返回 True。正文已追加真实内容时即使残留 marker 子串
+    也不再判为 empty stub——避免把「已 write 过」的 checkpoint 误拦成空毕业。
+    """
     skill_md = Path(skill_dir) / "SKILL.md"
     try:
         text = skill_md.read_text(encoding="utf-8")
     except (OSError, UnicodeDecodeError):
         return False
-    return BABY_STUB_BODY_MARKER in text
+    if BABY_STUB_BODY_MARKER not in text:
+        return False
+    body = text
+    if body.startswith("---"):
+        fence = body.find("\n---", 3)
+        if fence >= 0:
+            body = body[fence + len("\n---"):]
+    lines = [line.strip() for line in body.splitlines() if line.strip()]
+    if not lines:
+        return True
+    if lines == [BABY_STUB_BODY_MARKER]:
+        return True
+    if (
+        len(lines) == 2
+        and lines[0].startswith("#")
+        and lines[1] == BABY_STUB_BODY_MARKER
+    ):
+        return True
+    return False
 
 
 def init_skill_repo_on_baby(skill_dir: str, name: str, description: str) -> None:

--- a/src/xskill/skill/git.py
+++ b/src/xskill/skill/git.py
@@ -1751,36 +1751,17 @@ BABY_STUB_BODY_MARKER = (
 
 
 def skill_md_still_baby_stub(skill_dir: str | Path) -> bool:
-    """SKILL.md 是否仍是 init 时的空 stub（#154 empty-graduate）。
+    """SKILL.md 是否仍含 init placeholder。
 
-    仅当正文在去掉 frontmatter 后本质上仍是 init 形态（可选 ``# name`` +
-    placeholder 行）时返回 True。正文已追加真实内容时即使残留 marker 子串
-    也不再判为 empty stub——避免把「已 write 过」的 checkpoint 误拦成空毕业。
+    baby 分批 checkpoint 与最终 graduate 都要求正文不再含该标记；
+    残留即视为未完成写作，拒绝升 main（#154）。
     """
     skill_md = Path(skill_dir) / "SKILL.md"
     try:
         text = skill_md.read_text(encoding="utf-8")
     except (OSError, UnicodeDecodeError):
         return False
-    if BABY_STUB_BODY_MARKER not in text:
-        return False
-    body = text
-    if body.startswith("---"):
-        fence = body.find("\n---", 3)
-        if fence >= 0:
-            body = body[fence + len("\n---"):]
-    lines = [line.strip() for line in body.splitlines() if line.strip()]
-    if not lines:
-        return True
-    if lines == [BABY_STUB_BODY_MARKER]:
-        return True
-    if (
-        len(lines) == 2
-        and lines[0].startswith("#")
-        and lines[1] == BABY_STUB_BODY_MARKER
-    ):
-        return True
-    return False
+    return BABY_STUB_BODY_MARKER in text
 
 
 def init_skill_repo_on_baby(skill_dir: str, name: str, description: str) -> None:

--- a/src/xskill/usage.py
+++ b/src/xskill/usage.py
@@ -72,7 +72,14 @@ class ModelPrice:
 
 
 def extract_usage(resp: Any) -> Usage:
-    """从 OpenAI 兼容 response 提取 token(dict 或 SDK 对象,缺失补 0)。
+    """从 LLM/embedding 响应提取 token,缺失补 0。
+
+    支持的响应形态:
+    - 原始 dict(embedding HTTP JSON): ``resp["usage"]``
+    - OpenAI SDK 对象(ChatCompletion): ``resp.usage``
+    - agno ``ModelResponse``: ``resp.response_usage``(``MessageMetrics``,
+      字段名为 ``input_tokens``/``output_tokens``/``total_tokens`` —— 与
+      OpenAI 原始格式不同,不单独适配会整段记 0)
 
     覆盖 prompt/completion/total + DeepSeek 的 prompt_cache_hit/miss_tokens。
     """
@@ -81,6 +88,18 @@ def extract_usage(resp: Any) -> Usage:
             return None
         v = obj.get(key) if isinstance(obj, dict) else getattr(obj, key, None)
         return int(v) if isinstance(v, (int, float)) else None
+
+    agno_metrics = getattr(resp, "response_usage", None)
+    if agno_metrics is not None:
+        prompt = g(agno_metrics, "input_tokens") or 0
+        completion = g(agno_metrics, "output_tokens") or 0
+        total = g(agno_metrics, "total_tokens") or (prompt + completion)
+        # cost_usd 按 hit+miss=prompt 分档计费,miss 须补未命中余量,
+        # 否则配了 cache 价时 prompt 非命中段会漏计。
+        hit = g(agno_metrics, "cache_read_tokens") or 0
+        miss = max(0, prompt - hit)
+        return Usage(prompt=prompt, completion=completion, total=total,
+                     cache_hit=hit, cache_miss=miss)
 
     usage = resp.get("usage") if isinstance(resp, dict) else getattr(resp, "usage", None)
     if usage is None:

--- a/tests/bdd/README.md
+++ b/tests/bdd/README.md
@@ -86,6 +86,6 @@ mutmut run --max-children 8 \
 
 `skill_edit_schedule_actionable.feature` 守护 Issue #156 / #157 / #158：
 
-- 不会开 LLM 的 skill（main 无 ux、瘦 baby、非 git）不得 `submit` 进 edit 池；
+- 不会开 LLM 的 git skill（main 无 ux、瘦 baby）不得 `submit` 进 edit 池；
 - 单 skill 的 actionable 检查失败只 skip，不得中断整轮扫描；
-- #156 的「空 buffer 置后」由 actionable 过滤取代，不再单独排序键。
+- 无 `.git` 目录不崩扫描；排序 empty-last，避免空目录饿死 READY baby。

--- a/tests/bdd/README.md
+++ b/tests/bdd/README.md
@@ -74,3 +74,18 @@ mutmut run --max-children 8 \
 - `@state_machine`：快速、确定性的状态机测试。
 - `@recovery`：429、上下文超长、进程重启等恢复路径。
 - `@observability`：面向操作者的 SkillEdit trace。
+
+## stub 毕业闸门
+
+`baby_stub_graduate_guard.feature` 守护 Issue #154：
+
+- 仍含 init placeholder 时，`commit_baby_to_main` 必须报错且留在 baby；
+- candidates 已空但 stub 仍在时，框架先重写正文再晋升 main。
+
+## actionable 调度闸门
+
+`skill_edit_schedule_actionable.feature` 守护 Issue #156 / #157 / #158：
+
+- 不会开 LLM 的 skill（main 无 ux、瘦 baby、非 git）不得 `submit` 进 edit 池；
+- 单 skill 的 actionable 检查失败只 skip，不得中断整轮扫描；
+- #156 的「空 buffer 置后」由 actionable 过滤取代，不再单独排序键。

--- a/tests/bdd/features/skill_edit/baby_cold_start_recovery.feature
+++ b/tests/bdd/features/skill_edit/baby_cold_start_recovery.feature
@@ -46,3 +46,21 @@ Feature: baby 冷启动可以从模型失败和进程中断中恢复
     And baby 应当继续停留在 baby 分支
     And 最后 1 个原子应当保留在 candidates
     And watcher 下次调度时仍应当从 N=1 开始
+
+  @recovery @state_machine
+  Scenario: 错误分相同时原子更少的 skill 优先调度
+    Given 两个 baby skill "few-atoms" 有 1 个原子且 "many-atoms" 有 3 个原子
+    And 两者错误分均为 0
+    And edit pool 一次只能跑 1 个 skill
+    When watcher 调度 SkillEdit
+    Then 本轮应先提交 "few-atoms"
+
+  @recovery @state_machine
+  Scenario: N=1 连败 3 次后降优先级并换下一个 skill
+    Given 两个 baby skill "hard" 有 1 个原子且 "easy" 有 2 个原子
+    And "hard" 已在 N=1 上连续失败 3 次
+    And edit pool 一次只能跑 1 个 skill
+    When watcher 调度 SkillEdit
+    Then 本轮应先提交 "easy"
+    And "hard" 的 candidates 原子应当全部保留
+    And "hard" 的重试批次仍为 N=1

--- a/tests/bdd/features/skill_edit/baby_stub_graduate_guard.feature
+++ b/tests/bdd/features/skill_edit/baby_stub_graduate_guard.feature
@@ -1,0 +1,24 @@
+Feature: baby 毕业前必须去掉 stub 正文
+  SkillEdit 不得把仍含 init placeholder 的 SKILL.md 晋升为 main。
+  若 candidates 已空但 stub 仍在，框架应重触发写正文后再毕业。
+
+  Background:
+    Given SkillEdit 默认每批处理 5 个原子
+    And baby 的 candidates 使用稳定的 FIFO 顺序
+
+  @recovery @state_machine
+  Scenario: 直接调用 commit_baby_to_main 时 stub 未清除则报错
+    Given baby skill "stub-locked" 仍是 init stub 正文
+    When 模型调用 commit_baby_to_main 尝试毕业
+    Then 工具应当返回 stub 拒绝错误
+    And baby 应当继续停留在 baby 分支
+
+  @recovery @state_machine
+  Scenario: candidates 已空但 stub 仍在时框架重写后再晋升
+    Given baby skill "stub-empty" 仍是 init stub 正文
+    And candidates 已经为空
+    And 已有一次未改写 stub 的 baby checkpoint
+    When watcher 再次调度这个 baby 的 SkillEdit
+    Then 框架应当先触发一轮 stub 重写
+    And SkillEdit 应当成功并把 baby 晋升为 main
+    And 最终 SKILL.md 不应当再含 init placeholder

--- a/tests/bdd/features/skill_edit/skill_edit_schedule_actionable.feature
+++ b/tests/bdd/features/skill_edit/skill_edit_schedule_actionable.feature
@@ -1,0 +1,40 @@
+Feature: SkillEdit 只把 actionable skill 提交进 edit 池
+  不会开 LLM 的 skill 不得占用 workers×3 提交窗口。
+  单 skill 过滤失败不得中断整轮调度。
+  关联 Issue #156 / #157 / #158。
+
+  Background:
+    Given edit pool 一次只能跑 1 个 skill
+
+  @recovery @state_machine
+  Scenario: main 无 ux_score 不进池，READY baby 进池
+    Given baby skill "ready-baby" 已达冷启动阈值且可编辑
+    And main skill "main-no-ux" 有候选但还没有 main 侧 ux_score
+    When watcher 调度 SkillEdit
+    Then 提交列表应包含 "ready-baby"
+    And 提交列表不应包含 "main-no-ux"
+
+  @recovery @state_machine
+  Scenario: 未达阈值且无 checkpoint 的 baby 不进池
+    Given baby skill "thin-baby" 仅有不足阈值的候选且无 checkpoint
+    And baby skill "ready-baby" 已达冷启动阈值且可编辑
+    When watcher 调度 SkillEdit
+    Then 提交列表应包含 "ready-baby"
+    And 提交列表不应包含 "thin-baby"
+
+  @recovery @state_machine
+  Scenario: 无 git 目录只跳过该 skill 不中断整轮
+    Given skill 目录 "broken-nongit" 存在但没有 .git
+    And baby skill "ready-baby" 已达冷启动阈值且可编辑
+    When watcher 调度 SkillEdit
+    Then 整轮调度不应因 NotGitRepository 失败
+    And 提交列表应包含 "ready-baby"
+    And 提交列表不应包含 "broken-nongit"
+
+  @recovery @state_machine
+  Scenario: actionable 检查抛错只排除该 skill
+    Given baby skill "boom-skill" 在 actionable 检查时会抛错
+    And baby skill "ready-baby" 已达冷启动阈值且可编辑
+    When watcher 调度 SkillEdit
+    Then 提交列表应包含 "ready-baby"
+    And 提交列表不应包含 "boom-skill"

--- a/tests/bdd/features/skill_edit/skill_edit_schedule_actionable.feature
+++ b/tests/bdd/features/skill_edit/skill_edit_schedule_actionable.feature
@@ -23,13 +23,13 @@ Feature: SkillEdit 只把 actionable skill 提交进 edit 池
     And 提交列表不应包含 "thin-baby"
 
   @recovery @state_machine
-  Scenario: 无 git 目录只跳过该 skill 不中断整轮
+  Scenario: 无 git 目录不中断整轮且不饿死 READY baby
     Given skill 目录 "broken-nongit" 存在但没有 .git
     And baby skill "ready-baby" 已达冷启动阈值且可编辑
     When watcher 调度 SkillEdit
     Then 整轮调度不应因 NotGitRepository 失败
     And 提交列表应包含 "ready-baby"
-    And 提交列表不应包含 "broken-nongit"
+    And 本轮应先提交 "ready-baby"
 
   @recovery @state_machine
   Scenario: actionable 检查抛错只排除该 skill

--- a/tests/bdd/features/skill_edit/skill_edit_trace.feature
+++ b/tests/bdd/features/skill_edit/skill_edit_trace.feature
@@ -28,5 +28,22 @@ Feature: 操作者可以从一份 SkillEdit trace 解释整个冷启动过程
     Then 日志中 spill 事件应当出现在 compact 事件之前
     And 日志应当显示 compact 前后的 token 数量
     And 日志应当显示模型调用失败的可读原因
+    And exhausted 日志行应当包含原始错误文本
     And 日志应当显示 "Retry batch reduced: 5 -> 2"
     And 下一次 TURN START 应当显示 N=2
+
+  @observability @recovery @state_machine
+  Scenario: 无关键词的 5xx ModelProviderError 仍按 status_code 重试
+    Given 模型抛出 status_code=500 且 message 为 "server error" 的 ModelProviderError
+    And 客户端 max_retries 为 3
+    When 调用生产 retry wrapper
+    Then invoke 应被尝试 3 次
+    And exhausted 日志行应当包含 "server error"
+
+  @observability @recovery @state_machine
+  Scenario: 中文 429 ModelProviderError 仍按 status_code 重试
+    Given 模型抛出 status_code=429 且 message 为 "当前并发请求过多，请稍后重试" 的 ModelProviderError
+    And 客户端 max_retries 为 3
+    When 调用生产 retry wrapper
+    Then invoke 应被尝试 3 次
+    And exhausted 日志行应当包含 "当前并发请求过多"

--- a/tests/bdd/test_skill_edit_state_machine.py
+++ b/tests/bdd/test_skill_edit_state_machine.py
@@ -160,10 +160,10 @@ def test_thin_baby_without_checkpoint_is_not_submitted() -> None:
 
 @scenario(
     "features/skill_edit/skill_edit_schedule_actionable.feature",
-    "无 git 目录只跳过该 skill 不中断整轮",
+    "无 git 目录不中断整轮且不饿死 READY baby",
 )
 def test_nongit_directory_does_not_abort_schedule_round() -> None:
-    """Missing .git skips that skill; other actionable skills still submit."""
+    """Missing .git must not crash the scan or starve READY babies."""
 
 
 @scenario(

--- a/tests/bdd/test_skill_edit_state_machine.py
+++ b/tests/bdd/test_skill_edit_state_machine.py
@@ -29,9 +29,11 @@ from xskill.pipeline.registry import register_dir
 from xskill.pipeline.runner import DirectoryWatcher, SKILL_EDIT_N1_FAIL_DEPRIORITIZE
 from xskill.skill import candidates as candidate_buffer
 from xskill.skill.git import (
+    BABY_STUB_BODY_MARKER,
     commit_baby_checkpoint,
     current_branch,
     init_skill_repo_on_baby,
+    run_git,
 )
 from tests.pool_helpers import pool_config
 from tests.test_atom_task_store import _FakeEmbed
@@ -124,6 +126,54 @@ def test_n1_failures_deprioritize_and_switch_skill() -> None:
     """After three N=1 failures the hard skill yields the edit slot."""
 
 
+@scenario(
+    "features/skill_edit/baby_stub_graduate_guard.feature",
+    "直接调用 commit_baby_to_main 时 stub 未清除则报错",
+)
+def test_commit_baby_to_main_rejects_init_stub() -> None:
+    """Empty-graduate via the legacy tool must fail while SKILL.md is stub."""
+
+
+@scenario(
+    "features/skill_edit/baby_stub_graduate_guard.feature",
+    "candidates 已空但 stub 仍在时框架重写后再晋升",
+)
+def test_empty_buffer_stub_retriggers_rewrite_before_main() -> None:
+    """Framework refuses graduate, forces rewrite, then promotes."""
+
+
+@scenario(
+    "features/skill_edit/skill_edit_schedule_actionable.feature",
+    "main 无 ux_score 不进池，READY baby 进池",
+)
+def test_main_without_ux_is_not_submitted() -> None:
+    """Non-actionable main must not occupy the edit submit window."""
+
+
+@scenario(
+    "features/skill_edit/skill_edit_schedule_actionable.feature",
+    "未达阈值且无 checkpoint 的 baby 不进池",
+)
+def test_thin_baby_without_checkpoint_is_not_submitted() -> None:
+    """Below-threshold baby without checkpoint is filtered before submit."""
+
+
+@scenario(
+    "features/skill_edit/skill_edit_schedule_actionable.feature",
+    "无 git 目录只跳过该 skill 不中断整轮",
+)
+def test_nongit_directory_does_not_abort_schedule_round() -> None:
+    """Missing .git skips that skill; other actionable skills still submit."""
+
+
+@scenario(
+    "features/skill_edit/skill_edit_schedule_actionable.feature",
+    "actionable 检查抛错只排除该 skill",
+)
+def test_actionable_check_exception_isolates_one_skill() -> None:
+    """Per-skill filter exceptions must not abort the whole edit scan."""
+
+
 def _tool_name(tool: Any) -> str:
     return getattr(tool, "__name__", None) or getattr(tool, "name", "")
 
@@ -162,6 +212,9 @@ class StateWorld:
     retry_max_retries: int = 3
     retry_calls: int = 0
     retry_trace: str = ""
+    tool_graduate_result: str = ""
+    rewrite_turns: int = 0
+    schedule_error: BaseException | None = None
 
     @property
     def trace_path(self) -> Path:
@@ -356,6 +409,9 @@ class _DeterministicEditAgent:
         rules = "\n".join(
             f"- processed {atom_id}" for atom_id in world.processed_atoms
         )
+        if not atom_ids:
+            rules = "- stub rewrite: formal body without placeholder"
+            world.rewrite_turns += 1
         content = (
             "---\n"
             f"name: {skill.group(1)}\n"
@@ -372,6 +428,8 @@ class _DeterministicEditAgent:
             content,
         )
         assert write_result.startswith("wrote:")
+        if "commit_baby" not in self.tools:
+            return SimpleNamespace(content="done")
         commit_result = _call_tool(
             self.tools["commit_baby"],
             skill.group(1),
@@ -967,7 +1025,14 @@ def watcher_schedules_skill_edit(state_world: StateWorld) -> None:
     release = watcher._bdd_release  # type: ignore[attr-defined]
     started.clear()
     release.clear()
-    watcher._check_pending_skill_edits()
+    state_world.schedule_error = None
+    state_world.submitted_skill_names = []
+    try:
+        watcher._check_pending_skill_edits()
+    except BaseException as exc:
+        state_world.schedule_error = exc
+        release.set()
+        raise
     assert started.wait(timeout=5), "edit worker did not start"
     state_world.submitted_skill_names = [
         info["skill_dir"].name
@@ -984,6 +1049,89 @@ def first_submitted_skill(state_world: StateWorld, name: str) -> None:
     assert state_world.submitted_skill_names[0] == name
 
 
+@then(parsers.parse('提交列表应包含 "{name}"'))
+def submitted_list_contains(state_world: StateWorld, name: str) -> None:
+    assert name in state_world.submitted_skill_names, (
+        f"{name} missing from submitted={state_world.submitted_skill_names}"
+    )
+
+
+@then(parsers.parse('提交列表不应包含 "{name}"'))
+def submitted_list_excludes(state_world: StateWorld, name: str) -> None:
+    assert name not in state_world.submitted_skill_names, (
+        f"{name} unexpectedly in submitted={state_world.submitted_skill_names}"
+    )
+
+
+@then("整轮调度不应因 NotGitRepository 失败")
+def schedule_round_did_not_fail(state_world: StateWorld) -> None:
+    assert state_world.schedule_error is None
+
+
+@given(parsers.parse('baby skill "{name}" 已达冷启动阈值且可编辑'))
+def baby_ready_for_edit(state_world: StateWorld, name: str) -> None:
+    _seed_named_baby(state_world, name=name, count=1, weight=10)
+
+
+@given(
+    parsers.parse(
+        'main skill "{name}" 有候选但还没有 main 侧 ux_score'
+    )
+)
+def main_ready_without_ux(state_world: StateWorld, name: str) -> None:
+    skill_dir = _seed_named_baby(state_world, name=name, count=1, weight=10)
+    assert run_git(
+        ["branch", "-m", "baby", "main"],
+        cwd=str(skill_dir),
+    )[0] == 0
+    assert current_branch(str(skill_dir)) == "main"
+    assert not (skill_dir / ".ux_scores.jsonl").exists()
+
+
+@given(
+    parsers.parse(
+        'baby skill "{name}" 仅有不足阈值的候选且无 checkpoint'
+    )
+)
+def thin_baby_below_threshold(state_world: StateWorld, name: str) -> None:
+    skill_dir = _seed_named_baby(state_world, name=name, count=1, weight=1)
+    assert run_git(
+        ["rev-parse", "baby~1"],
+        cwd=str(skill_dir),
+    )[0] != 0
+
+
+@given(parsers.parse('skill 目录 "{name}" 存在但没有 .git'))
+def nongit_skill_directory(state_world: StateWorld, name: str) -> None:
+    skill_dir = state_world.skill_root / name
+    skill_dir.mkdir()
+    (skill_dir / "SKILL.md").write_text(
+        "---\nname: broken\ndescription: not a git repo\n---\n\n# broken\n",
+        encoding="utf-8",
+    )
+    assert not (skill_dir / ".git").exists()
+    state_world.skill_dirs[name] = skill_dir
+
+
+@given(
+    parsers.parse('baby skill "{name}" 在 actionable 检查时会抛错'),
+)
+def baby_raises_during_actionable_check(
+    state_world: StateWorld,
+    name: str,
+    monkeypatch: pytest.MonkeyPatch,
+) -> None:
+    skill_dir = _seed_named_baby(state_world, name=name, count=1, weight=10)
+    original = candidate_buffer.load_candidates
+
+    def _load_or_boom(path: Path, *args: Any, **kwargs: Any) -> Any:
+        if Path(path).resolve() == skill_dir.resolve():
+            raise RuntimeError("bdd actionable boom")
+        return original(path, *args, **kwargs)
+
+    monkeypatch.setattr(candidate_buffer, "load_candidates", _load_or_boom)
+
+
 @then(parsers.parse('"{name}" 的 candidates 原子应当全部保留'))
 def skill_candidates_preserved(state_world: StateWorld, name: str) -> None:
     skill_dir = state_world.skill_dirs[name]
@@ -997,3 +1145,84 @@ def skill_retry_batch_still_one(state_world: StateWorld, name: str) -> None:
     assert watcher is not None
     skill_dir = state_world.skill_dirs[name]
     assert watcher._skill_edit_retry_batch_sizes.get(skill_dir) == 1
+
+
+@given(parsers.parse('baby skill "{name}" 仍是 init stub 正文'))
+def baby_still_has_init_stub(state_world: StateWorld, name: str) -> None:
+    state_world.skill_name = name
+    state_world.skill_dir = state_world.skill_root / name
+    init_skill_repo_on_baby(
+        str(state_world.skill_dir),
+        name=name,
+        description="BDD stub graduate guard",
+    )
+    body = (state_world.skill_dir / "SKILL.md").read_text(encoding="utf-8")
+    assert BABY_STUB_BODY_MARKER in body
+    assert current_branch(str(state_world.skill_dir)) == "baby"
+
+
+@given("candidates 已经为空")
+def candidates_are_empty_buffer(state_world: StateWorld) -> None:
+    assert state_world.skill_dir is not None
+    candidate_buffer.save_candidates(
+        state_world.skill_dir,
+        {"candidates": []},
+    )
+
+
+@given("已有一次未改写 stub 的 baby checkpoint")
+def checkpoint_without_rewriting_stub(state_world: StateWorld) -> None:
+    assert state_world.skill_dir is not None
+    note = state_world.skill_dir / "scripts" / "note.txt"
+    note.write_text("checkpoint without rewriting stub\n", encoding="utf-8")
+    assert run_git(["add", "scripts/note.txt"], cwd=str(state_world.skill_dir))[0] == 0
+    assert run_git(
+        ["commit", "-m", "checkpoint without rewriting stub"],
+        cwd=str(state_world.skill_dir),
+    )[0] == 0
+    body = (state_world.skill_dir / "SKILL.md").read_text(encoding="utf-8")
+    assert BABY_STUB_BODY_MARKER in body
+    assert run_git(["rev-parse", "baby~1"], cwd=str(state_world.skill_dir))[0] == 0
+
+
+@when("模型调用 commit_baby_to_main 尝试毕业")
+def model_calls_commit_baby_to_main(state_world: StateWorld) -> None:
+    assert state_world.skill_name is not None
+    state_world.tool_graduate_result = _call_tool(
+        agent_tools.commit_baby_to_main,
+        state_world.skill_name,
+        "v1: should be rejected while stub remains",
+    )
+
+
+@when("watcher 再次调度这个 baby 的 SkillEdit")
+def watcher_reschedules_stub_baby(state_world: StateWorld) -> None:
+    _run_state_agent(state_world)
+
+
+@then("工具应当返回 stub 拒绝错误")
+def tool_returns_stub_rejection(state_world: StateWorld) -> None:
+    message = state_world.tool_graduate_result.lower()
+    assert state_world.tool_graduate_result.startswith("error:")
+    assert "stub" in message or "placeholder" in message
+
+
+@then("框架应当先触发一轮 stub 重写")
+def framework_triggered_stub_rewrite(state_world: StateWorld) -> None:
+    assert state_world.rewrite_turns >= 1
+    assert state_world.trace_path.is_file()
+    assert "stub" in state_world.trace.lower()
+
+
+@then("SkillEdit 应当成功并把 baby 晋升为 main")
+def skill_edit_promoted_to_main(state_world: StateWorld) -> None:
+    assert state_world.result is True
+    assert state_world.skill_dir is not None
+    assert current_branch(str(state_world.skill_dir)) == "main"
+
+
+@then("最终 SKILL.md 不应当再含 init placeholder")
+def final_skill_md_has_no_placeholder(state_world: StateWorld) -> None:
+    assert state_world.skill_dir is not None
+    body = (state_world.skill_dir / "SKILL.md").read_text(encoding="utf-8")
+    assert BABY_STUB_BODY_MARKER not in body

--- a/tests/bdd/test_skill_edit_state_machine.py
+++ b/tests/bdd/test_skill_edit_state_machine.py
@@ -10,25 +10,32 @@ from __future__ import annotations
 
 import json
 import re
+import threading
 from dataclasses import dataclass, field
 from pathlib import Path
 from types import SimpleNamespace
 from typing import Any
 
 import pytest
-from pytest_bdd import given, scenario, then, when
+from agno.exceptions import ModelProviderError
+from pytest_bdd import given, parsers, scenario, then, when
 
 from xskill.agents import agent_tools, agent_trace
 from xskill.agents.agno_factory import _wrap_with_retry, _wrap_with_trace
 from xskill.agents.context_budget import ContextManager
 from xskill.agents.skill_edit_agent import SkillEditAgent
 from xskill.pipeline.atom import AtomTaskStore
+from xskill.pipeline.registry import register_dir
+from xskill.pipeline.runner import DirectoryWatcher, SKILL_EDIT_N1_FAIL_DEPRIORITIZE
 from xskill.skill import candidates as candidate_buffer
 from xskill.skill.git import (
     commit_baby_checkpoint,
     current_branch,
     init_skill_repo_on_baby,
 )
+from tests.pool_helpers import pool_config
+from tests.test_atom_task_store import _FakeEmbed
+from tests.test_task_agent import _AutoSplitLLM
 
 
 pytestmark = [
@@ -85,6 +92,38 @@ def test_trace_shows_spill_before_compact_and_retry_reduction() -> None:
     """Production context events preserve their causal order in the trace."""
 
 
+@scenario(
+    "features/skill_edit/skill_edit_trace.feature",
+    "无关键词的 5xx ModelProviderError 仍按 status_code 重试",
+)
+def test_status_code_500_retries_without_message_keywords() -> None:
+    """ModelProviderError status_code drives retry, not str(exc) keywords."""
+
+
+@scenario(
+    "features/skill_edit/skill_edit_trace.feature",
+    "中文 429 ModelProviderError 仍按 status_code 重试",
+)
+def test_chinese_429_retries_via_status_code() -> None:
+    """Chinese rate-limit copy without '429' still retries via status_code."""
+
+
+@scenario(
+    "features/skill_edit/baby_cold_start_recovery.feature",
+    "错误分相同时原子更少的 skill 优先调度",
+)
+def test_fewer_atoms_are_scheduled_first() -> None:
+    """Watcher submit order prefers fewer pending atoms when errors tie."""
+
+
+@scenario(
+    "features/skill_edit/baby_cold_start_recovery.feature",
+    "N=1 连败 3 次后降优先级并换下一个 skill",
+)
+def test_n1_failures_deprioritize_and_switch_skill() -> None:
+    """After three N=1 failures the hard skill yields the edit slot."""
+
+
 def _tool_name(tool: Any) -> str:
     return getattr(tool, "__name__", None) or getattr(tool, "name", "")
 
@@ -116,6 +155,13 @@ class StateWorld:
     result: bool | None = None
     next_batch_size: int | None = None
     first_five: list[str] = field(default_factory=list)
+    skill_dirs: dict[str, Path] = field(default_factory=dict)
+    watcher: DirectoryWatcher | None = None
+    submitted_skill_names: list[str] = field(default_factory=list)
+    retry_exc: Exception | None = None
+    retry_max_retries: int = 3
+    retry_calls: int = 0
+    retry_trace: str = ""
 
     @property
     def trace_path(self) -> Path:
@@ -236,7 +282,9 @@ def _exercise_context_pressure(world: StateWorld) -> None:
     class _RateLimitedModel:
         @staticmethod
         def invoke(_messages: list[Any], **_kwargs: Any) -> Any:
-            raise RuntimeError("429 rate limit from deterministic backend")
+            raise RuntimeError(
+                "429 rate limit from deterministic backend"
+            )
 
     model = _RateLimitedModel()
     manager = ContextManager(
@@ -714,6 +762,13 @@ def trace_shows_readable_model_error(state_world: StateWorld) -> None:
     assert "LLM returned 429; retries exhausted (1/1)" in state_world.trace
 
 
+@then("exhausted 日志行应当包含原始错误文本")
+def exhausted_line_includes_raw_error(state_world: StateWorld) -> None:
+    assert "retries exhausted (1/1): 429 rate limit from deterministic backend" in (
+        state_world.trace
+    )
+
+
 @then('日志应当显示 "Retry batch reduced: 5 -> 2"')
 def trace_shows_batch_reduction(state_world: StateWorld) -> None:
     assert "Retry batch reduced: 5 -> 2" in state_world.trace
@@ -722,3 +777,223 @@ def trace_shows_batch_reduction(state_world: StateWorld) -> None:
 @then("下一次 TURN START 应当显示 N=2")
 def next_turn_marker_uses_two(state_world: StateWorld) -> None:
     assert "TURN START | N=2 | processing 2 of 5 pending atoms" in state_world.trace
+
+
+@given(
+    parsers.parse(
+        '模型抛出 status_code={status_code:d} 且 message 为 "{message}" '
+        "的 ModelProviderError"
+    )
+)
+def model_provider_error_pending(
+    state_world: StateWorld,
+    status_code: int,
+    message: str,
+) -> None:
+    state_world.retry_exc = ModelProviderError(message, status_code=status_code)
+
+
+@given(parsers.parse("客户端 max_retries 为 {max_retries:d}"))
+def client_max_retries(state_world: StateWorld, max_retries: int) -> None:
+    state_world.retry_max_retries = max_retries
+
+
+@when("调用生产 retry wrapper")
+def invoke_production_retry_wrapper(
+    state_world: StateWorld,
+    monkeypatch: pytest.MonkeyPatch,
+) -> None:
+    assert state_world.retry_exc is not None
+    monkeypatch.setattr(
+        "xskill.utils.shutdown.SHUTTING_DOWN.wait",
+        lambda *_args, **_kwargs: False,
+    )
+
+    class _AlwaysFails:
+        def __init__(self) -> None:
+            self.calls = 0
+
+        def invoke(self, _messages: list[Any], **_kwargs: Any) -> Any:
+            self.calls += 1
+            raise state_world.retry_exc
+
+    model = _AlwaysFails()
+    _wrap_with_retry(
+        model,
+        {
+            "base_url": "http://127.0.0.1:1/v1",
+            "max_retries": state_world.retry_max_retries,
+            "retry_base_delay": 0.001,
+            "retry_max_delay": 0.001,
+        },
+    )
+    sink = state_world.root / "retry-trace.log"
+    with agent_trace.trace_to(sink):
+        with pytest.raises(Exception):
+            model.invoke([])
+    state_world.retry_calls = model.calls
+    state_world.retry_trace = sink.read_text(encoding="utf-8")
+
+
+@then(parsers.parse("invoke 应被尝试 {calls:d} 次"))
+def invoke_attempt_count(state_world: StateWorld, calls: int) -> None:
+    assert state_world.retry_calls == calls
+
+
+@then(parsers.parse('exhausted 日志行应当包含 "{fragment}"'))
+def exhausted_contains_fragment(state_world: StateWorld, fragment: str) -> None:
+    assert "retries exhausted" in state_world.retry_trace
+    assert fragment in state_world.retry_trace
+
+
+def _seed_named_baby(
+    world: StateWorld,
+    *,
+    name: str,
+    count: int,
+    weight: int = 10,
+) -> Path:
+    skill_dir = world.skill_root / name
+    init_skill_repo_on_baby(
+        str(skill_dir),
+        name=name,
+        description="BDD scheduler draft",
+    )
+    data: dict[str, Any] = {"candidates": []}
+    for index in range(1, count + 1):
+        data, _ = candidate_buffer.add_atom_contribution(
+            data,
+            f"{name}-atom-{index:02d}",
+            weight,
+            note=f"knowledge for {name} {index}",
+        )
+    candidate_buffer.save_candidates(skill_dir, data)
+    world.skill_dirs[name] = skill_dir
+    return skill_dir
+
+
+def _blocking_edit_factory(started: threading.Event, release: threading.Event):
+    class _BlockingAgent:
+        def __init__(self, *, instructions: list[str], tools: list[Any]):
+            del instructions, tools
+
+        def run(self, _user_msg: str, **_kwargs: Any) -> Any:
+            started.set()
+            if not release.wait(timeout=5):
+                raise TimeoutError("scheduler BDD release timed out")
+            raise RuntimeError("scheduler BDD holds the edit worker")
+
+    def factory(*, instructions: list[str], tools: list[Any]) -> Any:
+        return _BlockingAgent(instructions=instructions, tools=tools)
+
+    return factory
+
+
+def _ensure_scheduler_watcher(state_world: StateWorld) -> DirectoryWatcher:
+    if state_world.watcher is not None:
+        return state_world.watcher
+    db_path = state_world.root / "scheduler.db"
+    watch_root = state_world.root / "watch"
+    watch_root.mkdir(exist_ok=True)
+    register_dir(watch_root, db_path=db_path)
+    started = threading.Event()
+    release = threading.Event()
+    watcher = DirectoryWatcher(
+        llm=_AutoSplitLLM(),
+        embed_client=_FakeEmbed(),
+        config={"llm": {"base_url": "x", "model": "y", "api_key": "z"}},
+        skill_dir=state_world.skill_root,
+        poll_interval=0.0,
+        pool_config=pool_config(workers=1, edit_workers=1),
+        db_path=db_path,
+        store=AtomTaskStore(root=watch_root),
+        agno_agent_factory=_blocking_edit_factory(started, release),
+        home_root=state_world.root,
+        logs_dir=state_world.logs_root,
+    )
+    watcher._bdd_started = started  # type: ignore[attr-defined]
+    watcher._bdd_release = release  # type: ignore[attr-defined]
+    state_world.watcher = watcher
+    return watcher
+
+
+@given(
+    parsers.parse(
+        '两个 baby skill "{left}" 有 {left_count:d} 个原子且 '
+        '"{right}" 有 {right_count:d} 个原子'
+    )
+)
+def two_baby_skills(
+    state_world: StateWorld,
+    left: str,
+    left_count: int,
+    right: str,
+    right_count: int,
+) -> None:
+    _seed_named_baby(state_world, name=left, count=left_count)
+    _seed_named_baby(state_world, name=right, count=right_count)
+
+
+@given("两者错误分均为 0")
+def both_error_counts_zero(state_world: StateWorld) -> None:
+    assert state_world.skill_dirs
+    return None
+
+
+@given(parsers.parse('"{name}" 已在 N=1 上连续失败 {fails:d} 次'))
+def skill_has_n1_failures(
+    state_world: StateWorld,
+    name: str,
+    fails: int,
+) -> None:
+    assert fails == SKILL_EDIT_N1_FAIL_DEPRIORITIZE
+    watcher = _ensure_scheduler_watcher(state_world)
+    skill_dir = state_world.skill_dirs[name]
+    for _ in range(fails):
+        watcher._on_skill_edit_done((skill_dir, False, 1))
+    assert watcher._skill_edit_error_counts.get(skill_dir, 0) == 1
+    assert watcher._skill_edit_retry_batch_sizes.get(skill_dir) == 1
+
+
+@given("edit pool 一次只能跑 1 个 skill")
+def edit_pool_is_single_worker(state_world: StateWorld) -> None:
+    _ensure_scheduler_watcher(state_world)
+
+
+@when("watcher 调度 SkillEdit")
+def watcher_schedules_skill_edit(state_world: StateWorld) -> None:
+    watcher = _ensure_scheduler_watcher(state_world)
+    started = watcher._bdd_started  # type: ignore[attr-defined]
+    release = watcher._bdd_release  # type: ignore[attr-defined]
+    started.clear()
+    release.clear()
+    watcher._check_pending_skill_edits()
+    assert started.wait(timeout=5), "edit worker did not start"
+    state_world.submitted_skill_names = [
+        info["skill_dir"].name
+        for info in watcher._futures.values()
+        if info.get("stage") == "skill_edit"
+    ]
+    release.set()
+    watcher._drain_futures(stage="skill_edit", timeout=10)
+
+
+@then(parsers.parse('本轮应先提交 "{name}"'))
+def first_submitted_skill(state_world: StateWorld, name: str) -> None:
+    assert state_world.submitted_skill_names, "no skill_edit futures submitted"
+    assert state_world.submitted_skill_names[0] == name
+
+
+@then(parsers.parse('"{name}" 的 candidates 原子应当全部保留'))
+def skill_candidates_preserved(state_world: StateWorld, name: str) -> None:
+    skill_dir = state_world.skill_dirs[name]
+    remaining = candidate_buffer.load_candidates(skill_dir)["candidates"]
+    assert remaining, f"{name} candidates were cleared"
+
+
+@then(parsers.parse('"{name}" 的重试批次仍为 N=1'))
+def skill_retry_batch_still_one(state_world: StateWorld, name: str) -> None:
+    watcher = state_world.watcher
+    assert watcher is not None
+    skill_dir = state_world.skill_dirs[name]
+    assert watcher._skill_edit_retry_batch_sizes.get(skill_dir) == 1

--- a/tests/test_description_opt_e2e.py
+++ b/tests/test_description_opt_e2e.py
@@ -254,6 +254,17 @@ def test_commit_baby_to_main_runs_optimization(tmp_path, monkeypatch):
     sd = skill_root / "log-analyzer"
     init_skill_repo_on_baby(str(sd), name="log-analyzer",
                             description="does stuff with files")
+    (sd / "SKILL.md").write_text(
+        "---\n"
+        "name: log-analyzer\n"
+        "description: does stuff with files\n"
+        "metadata:\n"
+        "  version: 1\n"
+        "---\n\n"
+        "# log-analyzer\n\n"
+        "Analyze and parse log files and error traces.\n",
+        encoding="utf-8",
+    )
 
     agent_tools.init_atom_task_tool_context(
         skill_dir=skill_root,
@@ -294,6 +305,17 @@ def test_commit_optimization_failure_does_not_block_commit(tmp_path, monkeypatch
     skill_root.mkdir()
     sd = skill_root / "boom"
     init_skill_repo_on_baby(str(sd), name="boom", description="orig desc")
+    (sd / "SKILL.md").write_text(
+        "---\n"
+        "name: boom\n"
+        "description: orig desc\n"
+        "metadata:\n"
+        "  version: 1\n"
+        "---\n\n"
+        "# boom\n\n"
+        "Real body so graduation is allowed.\n",
+        encoding="utf-8",
+    )
 
     agent_tools.init_atom_task_tool_context(
         skill_dir=skill_root,

--- a/tests/test_llm_retry.py
+++ b/tests/test_llm_retry.py
@@ -30,12 +30,38 @@ def _no_sleep(monkeypatch):
 
 
 def test_transient_classification():
+    from agno.exceptions import ModelProviderError
+
     assert _is_transient_error(Exception("Error code: 429 - rate limit"))
     assert _is_transient_error(Exception("Connection reset by peer"))
     assert _is_transient_error(Exception("503 Service Unavailable"))
+    # agno ModelProviderError: status_code 优先于 message 关键词
+    assert _is_transient_error(
+        ModelProviderError("server error", status_code=500)
+    )
+    assert _is_transient_error(
+        ModelProviderError("当前并发请求过多，请稍后重试", status_code=429)
+    )
     # 不可重试:上下文超长 / 400 invalid
     assert not _is_transient_error(Exception("maximum input length is 131071"))
     assert not _is_transient_error(Exception("invalid_request_error"))
+
+
+def test_local_rate_limit_exhausted_is_transient():
+    """本地限流桶耗尽（RateLimitExhausted）必须判瞬时并重试恢复。
+
+    回归：消息 "RPM bucket exhausted" 与 hint "rpm exhausted" 子串对不上，
+    曾被误判非瞬时 → 1/8 直接放弃，高并发下 cluster batch 全部 0 落地。
+    """
+    from xskill.utils.rate_limit import RateLimitExhausted
+    exhausted = RateLimitExhausted("RPM bucket exhausted, need wait 8.6s")
+    assert _is_transient_error(exhausted)
+    assert _is_transient_error(
+        RateLimitExhausted("TPM bucket exhausted, need wait 2.0s"))
+    model = _FlakyModel(fail_n=3, exc=exhausted)
+    _wrap_with_retry(model, {"max_retries": 8})
+    assert model.invoke([]) == "ok"
+    assert model.calls == 4  # 3 次桶耗尽重试 + 1 次成功
 
 
 def test_retry_recovers_after_transient_failures():
@@ -76,4 +102,4 @@ def test_retry_and_exhaustion_are_written_to_active_trace(tmp_path):
     trace = sink.read_text(encoding="utf-8")
     assert "LLM returned 429; retrying (1/3)" in trace
     assert "LLM returned 429; retrying (2/3)" in trace
-    assert "LLM returned 429; retries exhausted (3/3)" in trace
+    assert "LLM returned 429; retries exhausted (3/3): 429 rate limit" in trace

--- a/tests/test_skill_edit_agent.py
+++ b/tests/test_skill_edit_agent.py
@@ -76,7 +76,7 @@ class _BabyStubAgno:
         if type(self).writes_skill_md_with is not None and target_path:
             _call_tool(self.tools["write_file"], target_path, type(self).writes_skill_md_with)
         # 调 commit_baby；buffer 清空后由框架 graduate。
-        if type(self).calls_commit and skill:
+        if type(self).calls_commit and skill and "commit_baby" in self.tools:
             _call_tool(self.tools["commit_baby"], skill, "stub baby checkpoint")
         class _R: pass
         r = _R(); r.content = "done"
@@ -95,7 +95,7 @@ class _StagingStubAgno(_BabyStubAgno):
         target_path = m.group(1) if m else None
         if type(self).writes_skill_md_with is not None and target_path:
             _call_tool(self.tools["write_file"], target_path, type(self).writes_skill_md_with)
-        if type(self).calls_commit and skill:
+        if type(self).calls_commit and skill and "commit_to_staging" in self.tools:
             _call_tool(self.tools["commit_to_staging"], skill, "stub staging commit")
         class _R: pass
         r = _R(); r.content = "done"
@@ -199,6 +199,51 @@ class TestThresholdGate:
         # candidates 已清空 (v2.1: clear 取代 promoted 标记)
         data2 = C.load_candidates(skill_dir)
         assert data2["candidates"] == []
+
+    def test_stub_body_blocks_tool_graduate(self, tmp_path):
+        """init stub 未改写时 commit_baby_to_main 必须报错且留在 baby。"""
+        from xskill.agents import agent_tools
+        from xskill.skill.git import current_branch
+
+        skill_dir = _make_baby_skill(tmp_path / "skill", "still-stub")
+        msg = agent_tools.commit_baby_to_main.entrypoint(
+            "still-stub", "v1: should fail",
+        )
+        assert msg.startswith("error:")
+        assert "stub" in msg.lower() or "placeholder" in msg.lower()
+        assert current_branch(str(skill_dir)) == "baby"
+
+    def test_empty_buffer_with_stub_retriggers_rewrite_then_graduates(
+        self, tmp_path,
+    ):
+        """candidates 已空但仍是 stub → 框架重触发写正文后再 graduate。"""
+        from xskill.skill.git import current_branch, run_git
+
+        skill_dir = _make_baby_skill(tmp_path / "skill", "rewrite-me")
+        # 造一次非正文 checkpoint，让 partial_baby=True 且 buffer 可为空仍进 drain
+        (skill_dir / "scripts" / "note.txt").write_text("keep stub", encoding="utf-8")
+        assert run_git(["add", "scripts/note.txt"], cwd=str(skill_dir))[0] == 0
+        assert run_git(
+            ["commit", "-m", "checkpoint without rewriting stub"],
+            cwd=str(skill_dir),
+        )[0] == 0
+        C.save_candidates(skill_dir, {"candidates": []})
+
+        _BabyStubAgno.writes_skill_md_with = (
+            "---\nname: rewrite-me\ndescription: real\nmetadata:\n"
+            "  version: 1\n---\n# real body\n"
+        )
+        agent = SkillEditAgent(
+            skill_dir=skill_dir, store=None,
+            agno_agent_factory=_baby_factory,
+            llm_cfg={}, traj_root=tmp_path,
+            logs_dir=tmp_path / "instance-logs",
+        )
+        assert agent.maybe_run() is True
+        assert current_branch(str(skill_dir)) == "main"
+        body = (skill_dir / "SKILL.md").read_text(encoding="utf-8")
+        assert "placeholder" not in body
+        assert "# real body" in body
 
 
 # ────────────────────────────────────────────────────────────────────

--- a/tests/test_skill_edit_batch_turns.py
+++ b/tests/test_skill_edit_batch_turns.py
@@ -516,12 +516,17 @@ class TestBabyCheckpointRecovery:
                 skill = re.search(
                     r"skill_name:\s*([\w-]+)", user_msg,
                 ).group(1)
-                existing = Path(target).read_text(encoding="utf-8")
-                marker = f"\nprocessed-{len(batch_sizes)}: {','.join(atom_ids)}\n"
+                # Checkpoint 正文不得残留 init placeholder（#154）。
+                content = (
+                    f"---\nname: {skill}\ndescription: adaptive recovery\n"
+                    f"metadata:\n  version: {len(batch_sizes)}\n---\n\n"
+                    f"# Adaptive\n\n"
+                    f"processed-{len(batch_sizes)}: {','.join(atom_ids)}\n"
+                )
                 _call_tool(
                     self.tools["write_file"],
                     target,
-                    existing + marker,
+                    content,
                 )
                 _call_tool(
                     self.tools["commit_baby"],

--- a/tests/test_skill_edit_mutation_contracts.py
+++ b/tests/test_skill_edit_mutation_contracts.py
@@ -85,6 +85,37 @@ def test_graduate_baby_rejects_invalid_frontmatter_before_side_effects(
     ) is False
 
 
+def test_graduate_baby_rejects_init_stub_before_side_effects(
+    tmp_path: Path,
+    monkeypatch,
+) -> None:
+    from xskill.skill.git import BABY_STUB_BODY_MARKER, init_skill_repo_on_baby
+
+    target = tmp_path / "skills" / "stub-graduation"
+    init_skill_repo_on_baby(str(target), name="stub-graduation", description="d")
+    assert BABY_STUB_BODY_MARKER in (target / "SKILL.md").read_text(encoding="utf-8")
+
+    def unexpected(*_args, **_kwargs) -> None:
+        raise AssertionError("stub SKILL.md must not reach a side effect")
+
+    monkeypatch.setattr(
+        agent_tools,
+        "_run_description_optimization",
+        unexpected,
+    )
+    monkeypatch.setattr(
+        skill_git,
+        "commit_baby_to_main_branch",
+        unexpected,
+    )
+
+    assert agent_tools.graduate_baby_to_main(
+        target,
+        "stub-graduation",
+        "must not commit",
+    ) is False
+
+
 def test_remove_candidates_does_not_consume_a_git_write_slot(
     tmp_path: Path,
     monkeypatch,

--- a/tests/test_usage.py
+++ b/tests/test_usage.py
@@ -34,6 +34,51 @@ def test_extract_usage_missing_usage():
     assert extract_usage(None) == Usage()
 
 
+def _agno_response(**metrics_kwargs):
+    """构造真实 agno ModelResponse —— agent LLM 记账点的实际传入形态。"""
+    from agno.models.metrics import MessageMetrics
+    from agno.models.response import ModelResponse
+
+    resp = ModelResponse()
+    metrics = MessageMetrics()
+    for key, value in metrics_kwargs.items():
+        setattr(metrics, key, value)
+    resp.response_usage = metrics
+    return resp
+
+
+def test_extract_usage_agno_model_response():
+    # 回归:agno 用 response_usage(MessageMetrics)而非 OpenAI 的 usage,
+    # 字段名 input/output_tokens;不识别的历史 bug 会把 LLM 调用整段记 0。
+    resp = _agno_response(input_tokens=1523, output_tokens=87, total_tokens=1610)
+    usage = extract_usage(resp)
+    assert (usage.prompt, usage.completion, usage.total) == (1523, 87, 1610)
+    # cache_miss 补未命中余量,保证 cost_usd 分档计费 hit+miss=prompt
+    assert (usage.cache_hit, usage.cache_miss) == (0, 1523)
+
+
+def test_extract_usage_agno_total_derived():
+    resp = _agno_response(input_tokens=100, output_tokens=5, total_tokens=0)
+    assert extract_usage(resp).total == 105
+
+
+def test_extract_usage_agno_cache_read_split():
+    resp = _agno_response(input_tokens=1000, output_tokens=10,
+                          total_tokens=1010, cache_read_tokens=800)
+    usage = extract_usage(resp)
+    assert (usage.cache_hit, usage.cache_miss) == (800, 200)
+
+
+def test_record_llm_with_agno_response_counts_tokens():
+    ledger = UsageLedger(_table())
+    ledger.record_llm("skill_edit", "deepseek-v4-flash",
+                      _agno_response(input_tokens=2000, output_tokens=100,
+                                     total_tokens=2100))
+    bucket = ledger.snapshot()["by_step"]["skill_edit"]
+    assert bucket["calls"] == 1 and bucket["tokens"] == 2100
+    assert bucket["cost_usd"] > 0
+
+
 # ── PriceTable 解析优先级 ────────────────────────────────────────
 def _table():
     vendored = {"deepseek-v4-flash": {"input_per_1m": 0.14, "output_per_1m": 0.28,


### PR DESCRIPTION
## Summary

将 0.6.29a1 现场热补丁与记账修复沉淀进主干，关闭 #151 / #154 / #156 / #157 / #158。

- **#151**：`extract_usage` 识别 agno `ModelResponse.response_usage`，修复 LLM token/成本恒为 0。
- **#152 A/C**：`_is_transient_error` 优先读 `status_code`（5xx/429）+ `RateLimitExhausted`；exhausted trace 附带 `str(exc)`。
- **#152 B + #156–#158**：edit 提交前 `_skill_edit_actionable`（对齐 `maybe_run` 守门）；失败只 skip；在 actionable 集合上按 `(error_count, pending, name)` 排序。#156 的 empty-last 由 filter 取代，不再单独排序键。
- **#154**：stub 正文拒绝 `commit_baby_to_main` / graduate；candidates 已空仍 stub 时先 rewrite 再晋升。

## BDD 验收

- `skill_edit_schedule_actionable.feature`：main 无 ux / 瘦 baby 不进池；无 `.git` / 单 skill 抛错不中断整轮
- `baby_stub_graduate_guard.feature`：stub 拒绝毕业；空 buffer 先 rewrite 再 main
- 既有 recovery / trace：lean-first、N=1 降权、status_code 重试

## Test plan

- [x] `python3.11 -m pytest tests/bdd/test_skill_edit_state_machine.py -q`（16 passed）
- [x] `python3.11 -m pytest tests/test_usage.py tests/test_llm_retry.py tests/test_skill_edit_agent.py tests/test_skill_edit_mutation_contracts.py -q`（63 passed）
- [ ] `make lint`（仓库存量仍红；本改动文件 ruff / `.semgrep/xskill.yml` 无新增违规）
- [ ] 合入后观察生产：edit 不再被非 actionable 占窗；无 git 目录不拖垮整轮；stats LLM 不再全 0

Closes #151
Closes #154
Closes #156
Closes #157
Closes #158