### PR TITLE
fix(reindex): 默认 scope=search，避免 atom 全表扫卡死

### DIFF
--- a/docs/northbound-api.md
+++ b/docs/northbound-api.md
@@ -135,7 +135,7 @@ standalone 与 team server 均可用（无需 team token）。
 | GET | `/api/v1/trajectories/list` | 轨迹列表 |
 | GET | `/api/v1/registry/dirs` | 已注册 watch dir 列表 |
 | POST | `/api/v1/registry/dirs` | 注册 watch dir |
-| POST | `/api/v1/reindex` | 重建 skill 向量索引（★ 本 PR：传 `atom_store_roots` 算 `atom_feats`，重建后失效引擎缓存） |
+| POST | `/api/v1/reindex` | 重建 skill 向量索引。Query `scope=search`（**默认**）：只写 description→`.skill_index.pkl` embeddings，不扫 atom；`scope=full`：另算 `atom_feats`（扫全部 client atom，代价高）。重建后失效引擎缓存。非法 scope → 400。 |
 
 ---
 

--- a/src/xskill/api/app.py
+++ b/src/xskill/api/app.py
@@ -26,7 +26,7 @@ from pathlib import Path
 from typing import Optional
 
 from dulwich.errors import NotGitRepository
-from fastapi import APIRouter, FastAPI, HTTPException, Request
+from fastapi import APIRouter, FastAPI, HTTPException, Query, Request
 from fastapi.responses import FileResponse
 from pydantic import BaseModel, Field
 
@@ -814,17 +814,27 @@ async def api_init(req: InitRequest):
 
 
 @router.post("/reindex", response_model=MessageResponse)
-def api_reindex():
+def api_reindex(
+    scope: str = Query(
+        default="search",
+        description=(
+            "search=仅 description→embeddings（默认，检索止血，不扫 atom）；"
+            "full=description+atom_feats（扫全部 client atom，代价高）"
+        ),
+    ),
+):
     """Rebuild the skill vector index.
 
-    同步 def：全量重建 = 大量同步 embed 调用，可能持续分钟级；放事件循环上
-    会让服务整段假死，见 api_search_trajectories 的说明。
+    同步 def：embed 调用可能持续较久；放事件循环上会让服务假死，见
+    api_search_trajectories 的说明。默认 ``scope=search`` 只重建检索用
+    description 向量；``scope=full`` 才扫 atom 算 atom_feats。
     """
     try:
         embedding_client = create_embed_client(_config)
+        atom_roots = _team_atom_roots() if scope == "full" else None
         rebuild_skill_index(
             skill_dir=_skill_dir, embed_client=embedding_client,
-            atom_store_roots=_team_atom_roots(),
+            atom_store_roots=atom_roots, scope=scope,
         )
         # 失效推荐引擎的 skill 索引 / skillhub 缓存，否则引擎仍服务旧 embedding
         try:
@@ -834,7 +844,11 @@ def api_reindex():
                 eng.invalidate_cache()
         except Exception:  # pylint: disable=broad-exception-caught
             logger.debug("engine cache invalidation skipped", exc_info=True)
-        return MessageResponse(message="Skill index rebuilt", ok=True)
+        return MessageResponse(
+            message=f"Skill index rebuilt (scope={scope})", ok=True,
+        )
+    except ValueError as exc:
+        raise HTTPException(status_code=400, detail=str(exc)) from exc
     except Exception as e:
         logger.exception("reindex failed")
         raise HTTPException(status_code=500, detail=str(e)) from e

--- a/src/xskill/skill/repo.py
+++ b/src/xskill/skill/repo.py
@@ -11,6 +11,7 @@ skill/repo.py — SkillRepo 集合 + 集合级 git 操作
 from __future__ import annotations
 
 import logging
+import operator
 import pickle
 import shutil
 from pathlib import Path
@@ -76,18 +77,25 @@ class SkillRepo:
         return sum(1 for _ in self)
 
     # ─── 索引 ──────────────────────────────────────────────────
-    def rebuild_index(self, *, atom_store_roots: list[Path] | None = None) -> None:
+    def rebuild_index(
+        self,
+        *,
+        atom_store_roots: list[Path] | None = None,
+        scope: str = "search",
+    ) -> None:
         """重建 .skill_index.pkl（向量检索用）。
 
-        ``atom_store_roots``：可选的 AtomTaskStore 根目录列表，用于计算每个 skill 的
-        ``atom_feat``；为 None 时 ``atom_feats`` 全部 absent（standalone 场景）。
+        ``scope``：``search``（默认）只写 description embeddings；``full`` 另算
+        ``atom_feats``（需 ``atom_store_roots``，会扫全部 atom，代价高）。
+        ``atom_store_roots``：仅 ``scope=full`` 时使用；为 None 时 ``atom_feats``
+        全部 absent。
         """
         from xskill.config import get_config
         from xskill.utils.llm import create_embed_client
         embed_client = create_embed_client(get_config())
         rebuild_skill_index(
             skill_dir=self.root, embed_client=embed_client,
-            atom_store_roots=atom_store_roots,
+            atom_store_roots=atom_store_roots, scope=scope,
         )
 
     # ─── 清空（rebuild --force 用）──────────────────────────────
@@ -163,20 +171,30 @@ def rebuild_skill_index(
     embed_client,
     atom_store_roots: list[Path] | None = None,
     last_n_atoms: int = 5,
+    scope: str = "search",
 ) -> None:
     """Rebuild ``<skill_dir>/.skill_index.pkl`` for skill semantic search.
 
     主特征 ``embeddings`` = **description-only** 向量（L2 归一）——不融合 tags/summary。
-    辅助 ``atom_feats`` = 每个 skill 最近 ``last_n_atoms`` 个被路由 atom 摘要均值向量
-    （独立存 ``atom_feats`` 字段，不并入 ``embeddings``）；无 atom 的 skill 该行为零向量、
-    ``atom_feat_present`` 标 False。``atom_store_roots`` 给定时才算 atom_feat，否则全部
-    不存在（present=False）。
+
+    ``scope``：
+    - ``search``（默认）：只写 description embeddings；``atom_feats`` 全零、
+      ``atom_feat_present`` 全 False；**不扫描** atom store。用于检索止血。
+    - ``full``：另算 ``atom_feats`` = 每个 skill 最近 ``last_n_atoms`` 个被路由
+      atom 摘要均值（独立字段，不并入 ``embeddings``）。会扫全部
+      ``atom_store_roots`` 下 atom（代价高，O(atoms) 一次扫描 + summary embed）。
+      无 ``atom_store_roots`` 或某 skill 无 atom 时该行零向量、present=False。
+
+    非法 ``scope`` 抛 ``ValueError``，不做静默兜底。
     """
     skill_root = Path(skill_dir)
     if embed_client is None:
         raise RuntimeError("rebuild_skill_index: embed_client is required")
-
-    from xskill.recommend.skill_feature import last_n_atom_summaries
+    if scope not in ("search", "full"):
+        raise ValueError(
+            f"rebuild_skill_index: invalid scope {scope!r}; "
+            "expected 'search' or 'full'"
+        )
 
     entries = []
     for skill_path in sorted(skill_root.iterdir()):
@@ -204,23 +222,77 @@ def rebuild_skill_index(
     norms[norms == 0] = 1
     embeddings = embeddings / norms
 
-    # 辅助属性 atom_feat：每个 skill 最近 N atom 摘要均值（独立，不并入 embeddings）
+    # 辅助属性 atom_feat：仅 scope=full；search 路径明确跳过 atom 扫描
     dim = embeddings.shape[1]
     atom_feats = numpy.zeros((len(skill_names), dim), dtype=float)
     atom_present = [False] * len(skill_names)
-    for i, name in enumerate(skill_names):
-        summaries = last_n_atom_summaries(
-            name, atom_store_roots, n=last_n_atoms,
-        )
-        if not summaries:
-            continue
-        vecs = numpy.asarray(embed_store.encode_cached(summaries), dtype=float)
-        mean = vecs.mean(axis=0)
-        n = float(numpy.linalg.norm(mean))
-        atom_feats[i] = mean / n if n > 0 else mean
-        atom_present[i] = True
 
-    # 本轮已覆盖全部 description + summary，压掉已删除/改写条目的陈旧向量。
+    if scope == "full" and atom_store_roots:
+        # 一次扫完全部 atom，按 skill 聚最近 N 条，再对去重 summary 组批 embed
+        # ——避免旧实现「每 skill 重复全表扫」的 O(skills×atoms)。
+        from xskill.pipeline.atom import AtomTaskStore
+
+        skill_name_set = set(skill_names)
+        collected_by_skill: dict[str, list[tuple[float, str]]] = {
+            name: [] for name in skill_names
+        }
+        for root in atom_store_roots:
+            store = AtomTaskStore(root=Path(root))
+            for atom in store.all_atoms():
+                if not atom.summary:
+                    continue
+                used_skills = atom.used_skills or []
+                atom_path = (
+                    Path(root) / atom.traj_id / "tasks" / f"{atom.atom_id}.json"
+                )
+                try:
+                    mtime = atom_path.stat().st_mtime
+                except OSError:
+                    mtime = 0.0
+                for used_name in used_skills:
+                    if used_name in skill_name_set:
+                        collected_by_skill[used_name].append(
+                            (mtime, atom.summary),
+                        )
+
+        summary_lists: list[list[str]] = []
+        unique_summaries: list[str] = []
+        seen_summaries: set[str] = set()
+        for name in skill_names:
+            rows = collected_by_skill[name]
+            rows.sort(key=operator.itemgetter(0), reverse=True)
+            summaries = [text for _mtime, text in rows[:last_n_atoms]]
+            summary_lists.append(summaries)
+            for text in summaries:
+                if text not in seen_summaries:
+                    seen_summaries.add(text)
+                    unique_summaries.append(text)
+
+        summary_vectors: dict[str, numpy.ndarray] = {}
+        if unique_summaries:
+            vectors = numpy.asarray(
+                embed_store.encode_cached(unique_summaries), dtype=float,
+            )
+            for text, vector in zip(unique_summaries, vectors):
+                summary_vectors[text] = vector
+
+        for index, summaries in enumerate(summary_lists):
+            if not summaries:
+                continue
+            vecs = numpy.asarray(
+                [summary_vectors[text] for text in summaries], dtype=float,
+            )
+            mean = vecs.mean(axis=0)
+            norm = float(numpy.linalg.norm(mean))
+            atom_feats[index] = mean / norm if norm > 0 else mean
+            atom_present[index] = True
+    elif scope == "full":
+        logger.info(
+            "rebuild_skill_index scope=full but atom_store_roots is empty; "
+            "atom_feats left absent"
+        )
+
+    # 本轮已覆盖全部 description（+ full 时的 summary），压掉陈旧向量。
     embed_store.flush_pruned()
 
     index_data = {
@@ -238,7 +310,10 @@ def rebuild_skill_index(
     with open(index_path, "wb") as index_file:
         pickle.dump(index_data, index_file)
 
-    logger.info("skill index rebuilt: %d entries -> %s", len(skill_names), index_path)
+    logger.info(
+        "skill index rebuilt (scope=%s): %d entries -> %s",
+        scope, len(skill_names), index_path,
+    )
 
 
 def search_skill_index(*, skill_dir: Path, query: str, embed_client, top_k: int = 5) -> list[dict]:

--- a/tests/test_skill_feature.py
+++ b/tests/test_skill_feature.py
@@ -206,7 +206,8 @@ class TestRebuildIndex:
 
         fake = FakeEmbed()
         rebuild_skill_index(skill_dir=skill_dir, embed_client=fake,
-                            atom_store_roots=[atom_root], last_n_atoms=5)
+                            atom_store_roots=[atom_root], last_n_atoms=5,
+                            scope="full")
 
         with open(skill_dir / ".skill_index.pkl", "rb") as f:
             idx = pickle.load(f)
@@ -230,7 +231,32 @@ class TestRebuildIndex:
         d = skill_dir / "foo"; d.mkdir(parents=True)
         (d / "SKILL.md").write_text(_make_skill_md("foo", "desc"), encoding="utf-8")
         rebuild_skill_index(skill_dir=skill_dir, embed_client=FakeEmbed(),
-                            atom_store_roots=None)
+                            atom_store_roots=None, scope="full")
         with open(skill_dir / ".skill_index.pkl", "rb") as f:
             idx = pickle.load(f)
         assert idx["atom_feat_present"] == [False]
+
+
+    def test_default_scope_is_search_skips_atom_feats(self, tmp_path):
+        """默认 scope=search：即便给了 atom_store_roots 也不算 atom_feats。"""
+        skill_dir = tmp_path / "skills"
+        d = skill_dir / "foo"
+        d.mkdir(parents=True)
+        (d / "SKILL.md").write_text(_make_skill_md("foo", "desc"), encoding="utf-8")
+        atom_root = tmp_path / "atoms"
+        tasks = atom_root / "traj_001" / "tasks"
+        tasks.mkdir(parents=True)
+        import json
+        (tasks / "atom_traj_001_0001.json").write_text(json.dumps({
+            "atom_id": "atom_traj_001_0001", "traj_id": "traj_001",
+            "offset_start": 1, "offset_end": 2, "intent": "i",
+            "summary": "foo summary", "used_skills": ["foo"],
+        }), encoding="utf-8")
+        rebuild_skill_index(
+            skill_dir=skill_dir, embed_client=FakeEmbed(),
+            atom_store_roots=[atom_root],
+        )
+        with open(skill_dir / ".skill_index.pkl", "rb") as f:
+            idx = pickle.load(f)
+        assert idx["atom_feat_present"] == [False]
+        assert np.allclose(idx["atom_feats"][0], 0.0)

--- a/tests/test_skill_repo.py
+++ b/tests/test_skill_repo.py
@@ -49,6 +49,47 @@ def test_rebuild_skill_index_requires_embed_client(tmp_path):
         rebuild_skill_index(skill_dir=tmp_path, embed_client=None)
 
 
+def test_rebuild_skill_index_rejects_invalid_scope(tmp_path):
+    """非法 scope 直接抛错，不做静默兜底。"""
+    _make_skill(tmp_path)
+    with pytest.raises(ValueError, match="invalid scope"):
+        rebuild_skill_index(
+            skill_dir=tmp_path, embed_client=_StubEmbed(), scope="everything",
+        )
+
+
+def test_rebuild_skill_index_default_scope_is_search(tmp_path, monkeypatch):
+    """默认 scope=search：不进入 atom 扫描路径。"""
+    _make_skill(tmp_path)
+
+    def _boom(*_args, **_kwargs):
+        raise AssertionError("AtomTaskStore must not be constructed for scope=search")
+
+    monkeypatch.setattr("xskill.pipeline.atom.AtomTaskStore", _boom)
+    rebuild_skill_index(
+        skill_dir=tmp_path,
+        embed_client=_StubEmbed(),
+        atom_store_roots=[tmp_path / "atoms"],
+    )
+    assert (tmp_path / ".skill_index.pkl").is_file()
+
+
+def test_rebuild_skill_index_search_scope_skips_atom_scan(tmp_path, monkeypatch):
+    """显式 scope=search 同样不构造 AtomTaskStore。"""
+    _make_skill(tmp_path)
+
+    def _boom(*_args, **_kwargs):
+        raise AssertionError("AtomTaskStore must not be constructed for scope=search")
+
+    monkeypatch.setattr("xskill.pipeline.atom.AtomTaskStore", _boom)
+    rebuild_skill_index(
+        skill_dir=tmp_path,
+        embed_client=_StubEmbed(),
+        atom_store_roots=[tmp_path / "atoms"],
+        scope="search",
+    )
+
+
 def test_skill_repo_rebuild_index_no_typeerror_regression(tmp_path, monkeypatch):
     """SkillRepo.rebuild_index() 从 config 创建 embed client 后显式传入 repo 函数。"""
     _make_skill(tmp_path)


### PR DESCRIPTION
## Summary
- `POST /api/v1/reindex` 与 `rebuild_skill_index` 增加 `scope` 入参：默认 `search` 只重建 description→`.skill_index.pkl` embeddings，**不扫 atom**，用于现网检索止血。
- `scope=full` 保留 atom_feats；改为一次扫完全部 atom + 去重 summary 组批 embed，避免旧实现 O(skills×atoms) 重复全表扫。
- 非法 scope 抛 `ValueError` / HTTP 400；北向 API 文档补一行。

Closes #159

## Test plan
- [x] `python3.11 -m pytest tests/test_skill_repo.py tests/test_skill_feature.py`（19 passed）
- [x] 覆盖：默认 scope=search、显式 search 不构造 `AtomTaskStore`、非法 scope 抛错、full 仍算 atom_feats
- [x] 改动文件 ruff 通过；本改动无新增 semgrep lambda/private-import 违规（存量基线仍在）
- [ ] 现网：`POST /api/v1/reindex`（默认）后 `xskill search` 能命中 `source=repo` 自产 main


Made with [Cursor](https://cursor.com)