### PR TITLE
feat(dashboard): 流水线监控页（三池席位/排队/日志抽屉）

### DIFF
--- a/src/xskill/agents/agent_tools.py
+++ b/src/xskill/agents/agent_tools.py
@@ -1566,13 +1566,22 @@ def graduate_baby_to_main(target: Path, slug: str, message: str) -> bool:
     baby turns only expose ``commit_baby`` to the model.
     """
     from xskill.skill.frontmatter import FrontmatterError
-    from xskill.skill.git import commit_baby_to_main_branch
+    from xskill.skill.git import (
+        commit_baby_to_main_branch,
+        skill_md_still_baby_stub,
+    )
 
     skill_md = target / "SKILL.md"
     try:
         fm_parse_strict(skill_md.read_text(encoding="utf-8"))
     except (OSError, UnicodeDecodeError, FrontmatterError) as error:
         logger.warning("baby graduation frontmatter invalid for %s: %s", slug, error)
+        return False
+    if skill_md_still_baby_stub(target):
+        logger.warning(
+            "baby graduation refused: %s SKILL.md still has init stub placeholder",
+            slug,
+        )
         return False
     _run_description_optimization(target, slug)
     return commit_baby_to_main_branch(str(target), message)
@@ -1672,6 +1681,13 @@ def commit_baby_to_main(skill_name: str, message: str) -> str:
     msg = (message or "").strip()
     if not msg:
         return "error: commit message 必填"
+    from xskill.skill.git import skill_md_still_baby_stub
+
+    if skill_md_still_baby_stub(target):
+        return (
+            "error: SKILL.md 仍是 baby stub（含 init placeholder），"
+            "禁止 graduate；请先 write_file 写完整正文再调用"
+        )
     ok = graduate_baby_to_main(target, slug, msg)
     if not ok:
         return "error: commit_baby_to_main 失败（不在 baby 分支？看 daemon 日志）"

--- a/src/xskill/agents/agno_factory.py
+++ b/src/xskill/agents/agno_factory.py
@@ -241,9 +241,19 @@ _NON_RETRYABLE_HINTS = (
 
 
 def _is_transient_error(exc: Exception) -> bool:
+    # 本地限流桶耗尽只是"等一等就有令牌"，必须按瞬时错误重试——不能靠字符串
+    # 匹配：消息是 "RPM bucket exhausted"，与 hint "rpm exhausted" 子串对不上，
+    # 曾被误判为非瞬时 → 1/8 一击致命，高并发下 cluster 会话成片死亡。
+    from xskill.utils.rate_limit import RateLimitExhausted
+    if isinstance(exc, RateLimitExhausted):
+        return True
     t = f"{exc}".lower()
     if any(h in t for h in _NON_RETRYABLE_HINTS):
         return False
+    status_code = getattr(exc, "status_code", None)
+    if isinstance(status_code, int):
+        if status_code == 429 or 500 <= status_code <= 599:
+            return True
     return any(h in t for h in _TRANSIENT_HINTS)
 
 
@@ -277,17 +287,21 @@ def _wrap_with_retry(model, llm_cfg: dict):
             except Exception as exc:  # noqa: BLE001
                 attempt += 1
                 error_text = str(exc).lower()
-                if "429" in error_text or "rate limit" in error_text:
+                status_code = getattr(exc, "status_code", None)
+                if status_code == 429 or "429" in error_text or "rate limit" in error_text:
                     error_label = "429"
+                elif isinstance(status_code, int) and 500 <= status_code <= 599:
+                    error_label = str(status_code)
                 elif any(h in error_text for h in _NON_RETRYABLE_HINTS):
                     error_label = "context-too-long"
                 else:
                     error_label = type(exc).__name__
+                error_detail = str(exc)[:160]
                 if attempt >= max_retries or not _is_transient_error(exc):
                     agent_trace.event(
                         "ERROR",
                         f"LLM returned {error_label}; retries exhausted "
-                        f"({attempt}/{max_retries})",
+                        f"({attempt}/{max_retries}): {error_detail}",
                     )
                     raise
                 delay = min(cap, base * (2 ** (attempt - 1)))

--- a/src/xskill/agents/skill_edit_agent.py
+++ b/src/xskill/agents/skill_edit_agent.py
@@ -631,6 +631,33 @@ class SkillEditAgent:
     def _graduate_completed_baby(self) -> bool:
         """Promote an empty, checkpointed baby to main under framework control."""
         from xskill.agents import agent_tools, agent_trace
+        from xskill.skill.git import skill_md_still_baby_stub
+
+        if skill_md_still_baby_stub(self.skill_dir):
+            logger.warning(
+                "SkillEdit refuse graduate (stub still present), re-trigger rewrite: %s",
+                self.skill_dir.name,
+            )
+            agent_trace.append_to(
+                self._trace_path(),
+                (
+                    f"{time.strftime('%H:%M:%S')} INFO  "
+                    "Candidate buffer empty but SKILL.md still stub; "
+                    "re-trigger rewrite before graduate.\n"
+                ),
+            )
+            if not self._run_stub_rewrite_turn():
+                logger.warning(
+                    "SkillEdit stub rewrite failed; stay on baby: %s",
+                    self.skill_dir.name,
+                )
+                return False
+            if skill_md_still_baby_stub(self.skill_dir):
+                logger.warning(
+                    "SkillEdit stub rewrite left placeholder; stay on baby: %s",
+                    self.skill_dir.name,
+                )
+                return False
 
         ok = agent_tools.graduate_baby_to_main(
             self.skill_dir,
@@ -652,6 +679,54 @@ class SkillEditAgent:
                 self.skill_dir.name,
             )
         return ok
+
+    def _run_stub_rewrite_turn(self) -> bool:
+        """Buffer empty but body still stub → one forced write_file turn, no commit tool."""
+        from xskill.agents import agent_tools, agent_trace
+
+        skill_md = self.skill_dir / "SKILL.md"
+        scenario_block = "\n".join(
+            [
+                f"skill_name: {self.skill_dir.name}（**baby 分支 · stub 未清除，强制重写**）",
+                "SKILL.md 仍是 init placeholder，框架拒绝 graduate。",
+                "必须用 write_file 覆盖 SKILL.md 为正式正文（去掉 placeholder 行）。",
+                "本轮没有 commit 工具；写完后由框架校验并 graduate。",
+                *self._skill_tree_context_lines(),
+                f"目标 SKILL.md 路径: {skill_md}",
+            ]
+        )
+        sysprompt = build_system_prompt(
+            scenario_block=scenario_block,
+            branch_now="baby",
+        )
+        tools = [
+            agent_tools.atom_task_read,
+            agent_tools.read_traj,
+            agent_tools.skill_read,
+            agent_tools.read_file,
+            agent_tools.list_files,
+            agent_tools.grep_files,
+            agent_tools.write_file,
+        ]
+        agent = self.agno_agent_factory(instructions=[sysprompt], tools=tools)
+        agent_trace.append_to(
+            self._trace_path(),
+            (
+                f"{time.strftime('%H:%M:%S')} INFO  "
+                "Stub rewrite turn start (no commit tool).\n"
+            ),
+        )
+        try:
+            self._trace_run(agent, scenario_block)
+        except Exception:
+            logger.exception(
+                "SkillEdit stub rewrite turn raised: %s",
+                self.skill_dir.name,
+            )
+            return False
+        from xskill.skill.git import skill_md_still_baby_stub
+
+        return not skill_md_still_baby_stub(self.skill_dir)
 
     def _run_baby_until_empty(self) -> bool:
         """Drain baby candidates via durable per-batch commits, then graduate."""

--- a/src/xskill/dashboard/pipeline_live.py
+++ b/src/xskill/dashboard/pipeline_live.py
@@ -1,0 +1,169 @@
+"""看板「流水线」页的实时监看数据：读 agent-worker 状态文件 + agent 日志尾巴。
+
+常驻 agent-worker 子进程每 ``status_interval`` 秒把
+``DirectoryWatcher.agent_worker_status`` 原子落盘到
+``<home>/agent_worker_status.json``（见 ``utils/status_file.py``）；本模块只做
+只读整形，不碰 watcher 进程内存，因此 serve 内置看板与独立只读实例都能用。
+
+原则（与概念稿一致）：**禁止 fallback 糊弄**——状态文件缺失 / 日志不存在
+一律显式空态，由前端如实展示，绝不编造数据。
+"""
+from __future__ import annotations
+
+import logging
+from pathlib import Path
+from typing import Optional
+
+from xskill.utils.status_file import AGENT_WORKER_STATUS_FILE, read_status_file
+
+logger = logging.getLogger(__name__)
+
+# 监看展示的三池（embed 不进概念稿：读库事实，不占席位色块）。
+MONITORED_POOLS = ("split", "cluster", "edit")
+
+# 日志尾巴默认/上限行数。
+DEFAULT_LOG_TAIL = 300
+MAX_LOG_TAIL = 2000
+# 读日志尾巴时最多回退的字节数（避免整文件载入内存）。
+_LOG_READBACK_BYTES = 512 * 1024
+
+_KIND_TO_LOG_SUBPATH = {
+    # SkillEditAgent._trace_path()
+    "skill": ("agents", "skill_edit_agents", "skills"),
+    # TaskAgent 拆分轨迹的逐轮 trace
+    "traj": ("agents", "task_agents"),
+}
+
+
+def status_root_for(db_path: Optional[Path]) -> Path:
+    """状态文件所在 home：与 ``_skill_dir_for`` 同一套旁推——registry.db /
+    状态文件 / skill 库同在 XSKILL_HOME 下；独立实例（显式 db_path）与
+    serve 内置（db_path=None 走 config 默认）都能解析。"""
+    if db_path is not None:
+        return Path(db_path).parent
+    from xskill.config import XSKILL_HOME
+    return XSKILL_HOME
+
+
+def pipeline_live(db_path: Optional[Path]) -> dict:
+    """整形 agent-worker 状态文件为「流水线」页响应。
+
+    状态文件缺失 / 内容为空 / watcher 已停 → ``running: False`` + 明示原因；
+    绝不返回半真半假的占位数据。
+    """
+    root = status_root_for(db_path)
+    payload = read_status_file(root / AGENT_WORKER_STATUS_FILE)
+    if payload is None:
+        return {
+            "running": False,
+            "message": "agent-worker 尚未启动（无状态文件）",
+        }
+    stats = payload.get("stats") or {}
+    if not stats:
+        return {
+            "running": False,
+            "ok": bool(payload.get("ok")),
+            "error": payload.get("error"),
+            "message": "agent-worker 未上报状态（状态文件为空）",
+        }
+
+    pool_config = stats.get("pool_config") or {}
+    raw_pools = stats.get("pools") or {}
+    pools: dict[str, dict] = {}
+    for name in MONITORED_POOLS:
+        status = raw_pools.get(name) or {}
+        cfg = pool_config.get(name) or {}
+        workers = int(status.get("workers") or cfg.get("workers") or 0)
+        seats = status.get("seats")
+        if not isinstance(seats, list) or len(seats) != workers:
+            # 老版本 worker 未上报席位簿记：显式空席，不伪造任务。
+            seats = [None] * workers
+        queue = status.get("queue")
+        if not isinstance(queue, list):
+            queue = []
+        pools[name] = {
+            "workers": workers,
+            "llm_weight": cfg.get("llm_weight"),
+            "batch_size": cfg.get("batch_size"),
+            "seats": seats,
+            "queue": queue,
+            "queued": int(status.get("queued") or 0),
+            "completed": int(status.get("completed") or 0),
+            "failed": int(status.get("failed") or 0),
+        }
+
+    watcher = stats.get("watcher") or {}
+    cluster = stats.get("cluster") or {}
+    return {
+        "running": bool(watcher.get("running")),
+        "ok": bool(payload.get("ok")),
+        "error": payload.get("error"),
+        "pid": stats.get("pid"),
+        "started_at": stats.get("started_at"),
+        "heartbeat_at": stats.get("heartbeat_at"),
+        "llm": stats.get("llm") or {},
+        "pending_atoms": int(cluster.get("pending_atoms") or 0),
+        "pools": pools,
+    }
+
+
+def _safe_log_name(name: str) -> str:
+    """日志文件名防路径穿越：只允许单段文件名。"""
+    if not name or name in (".", ".."):
+        raise ValueError("name 不能为空")
+    if "/" in name or "\\" in name or ".." in name:
+        raise ValueError(f"非法日志名: {name!r}")
+    return name
+
+
+def tail_task_log(
+    db_path: Optional[Path],
+    *,
+    kind: str,
+    name: str,
+    tail: int = DEFAULT_LOG_TAIL,
+) -> dict:
+    """读单个任务的 agent trace 尾巴。
+
+    ``kind`` 只认 ``skill`` / ``traj``；cluster 批没有独立日志文件（概念稿
+    的 Cluster 详情展示本批 atom id 列表，不走本端点）。文件不存在是正常
+    情况（任务刚起跑 / logs_dir 未配），返回显式空态而非 404 错误页。
+    """
+    if kind not in _KIND_TO_LOG_SUBPATH:
+        raise ValueError(f"kind 必须是 {sorted(_KIND_TO_LOG_SUBPATH)} 之一")
+    name = _safe_log_name(name)
+    tail = max(1, min(int(tail), MAX_LOG_TAIL))
+    root = status_root_for(db_path) / "logs"
+    path = root.joinpath(*_KIND_TO_LOG_SUBPATH[kind]) / f"{name}.log"
+    if not path.is_file():
+        return {
+            "kind": kind,
+            "name": name,
+            "exists": False,
+            "lines": [],
+            "message": "该任务暂无日志文件",
+        }
+    try:
+        with path.open("rb") as handle:
+            handle.seek(0, 2)
+            size = handle.tell()
+            handle.seek(max(0, size - _LOG_READBACK_BYTES))
+            raw = handle.read()
+    except OSError as exc:
+        logger.warning("读任务日志失败 %s: %s", path, exc)
+        return {
+            "kind": kind,
+            "name": name,
+            "exists": False,
+            "lines": [],
+            "message": f"日志读取失败: {exc}",
+        }
+    text = raw.decode("utf-8", errors="replace")
+    lines = text.splitlines()[-tail:]
+    return {
+        "kind": kind,
+        "name": name,
+        "exists": True,
+        "lines": lines,
+        "truncated": size > _LOG_READBACK_BYTES,
+    }

--- a/src/xskill/dashboard/router.py
+++ b/src/xskill/dashboard/router.py
@@ -214,6 +214,36 @@ def build_dashboard_router(db_path: Optional[Path] = None, *,
         from xskill.dashboard.explore import pipeline_progress
         return pipeline_progress(db_path, skill_dir)
 
+    @router.get("/api/v1/dashboard/pipeline/live")
+    def pipeline_live_ep() -> dict:
+        """三池实时监看：固定席位 + 排队预览（agent-worker 状态文件只读整形）。
+
+        公网只读实例剥掉任务级身份（skill/traj/atom 名），只留席位占用与
+        计时——与 ``dirs``/``tags`` 的白名单裁剪同一套；日志尾巴属内容级，
+        物理不注册（见下）。
+        """
+        from xskill.dashboard.pipeline_live import pipeline_live
+        live = pipeline_live(db_path)
+        if expose_sensitive or not live.get("running"):
+            return live
+        for pool in (live.get("pools") or {}).values():
+            pool["seats"] = [
+                ({"seat": seat.get("seat"), "started_at": seat.get("started_at")}
+                 if isinstance(seat, dict) else None)
+                for seat in pool.get("seats") or []
+            ]
+            pool["queue"] = []
+        return live
+
+    @sensitive_router.get("/api/v1/dashboard/pipeline/log")
+    def pipeline_log_ep(kind: str, name: str, tail: int = 300) -> dict:
+        """单任务 agent trace 日志尾巴（内容级，只挂内置看板）。"""
+        from xskill.dashboard.pipeline_live import tail_task_log
+        try:
+            return tail_task_log(db_path, kind=kind, name=name, tail=tail)
+        except ValueError as e:
+            raise HTTPException(status_code=400, detail=str(e)) from e
+
     # 文件名、文件正文和 diff 都属于 skill 内容；只挂到内置看板。
     @sensitive_router.get("/api/v1/dashboard/skill/{name}/tree")
     def skill_tree(name: str) -> dict:

--- a/src/xskill/dashboard/static/app.js
+++ b/src/xskill/dashboard/static/app.js
@@ -873,8 +873,289 @@ async function loadCanary() {
     '还没有灰度使用记录');
 }
 
+// ═════════════ 流水线 Monitor（三池固定席位实时事实板） ═════════════
+// 数据：pipeline/live（agent-worker 状态文件只读整形，~5s 粒度），3s 轮询；
+// 点选席位/任务后 pipeline/log 轮询日志尾巴。禁止 fallback：状态文件缺失、
+// 日志不存在、席位已腾空一律显式空态，绝不编造。
+const PM_POOLS = [
+  { key: 'split', title: 'Split', subtitle: '轨迹', weight: true, batch: false },
+  { key: 'cluster', title: 'Cluster', subtitle: 'atom 批', weight: true, batch: true },
+  { key: 'edit', title: 'SkillEditAgent', subtitle: 'A→B 转移', weight: true, batch: true },
+];
+const PM_XFER = {
+  baby_main: { from: 'baby', to: 'main', tip: '冷启动消化后 graduate' },
+  main_staging: { from: 'main', to: 'staging', tip: '产灰度候选' },
+  staging_main: { from: 'staging', to: 'main', tip: 'Jam 强砍回 main' },
+};
+const PM_POLL_MS = 3000, PM_LOG_MS = 2500;
+let pmState = null;      // 最近一次 live 响应
+let pmFetchAt = 0;       // 响应到达的本地时刻（席位龄期在两次轮询间本地走秒）
+let pmSelected = null;   // {pool, seat}：席位号才是稳定身份（任务完成只清该坑）
+let pmPollTimer = null, pmLogTimer = null, pmLogKey = null;
+
+function pmAgeText(sec) {
+  sec = Math.max(0, Math.round(sec));
+  if (sec < 60) return sec + 's';
+  if (sec < 3600) return (sec / 60).toFixed(1) + 'm';
+  return (sec / 3600).toFixed(1) + 'h';
+}
+// 席位色：浅=刚起，深=已久（约 0→120s 饱和）：#99f6e4 → #0f766e → #042f2e
+function pmSeatColor(ageSec) {
+  const t = Math.max(0, Math.min(1, ageSec / 120));
+  const stops = [[153, 246, 228], [15, 118, 110], [4, 47, 46]];
+  const [a, b, local] = t < 0.5
+    ? [stops[0], stops[1], t / 0.5]
+    : [stops[1], stops[2], (t - 0.5) / 0.5];
+  const rgb = a.map((v, i) => Math.round(v + (b[i] - v) * local));
+  return 'rgb(' + rgb.join(',') + ')';
+}
+function pmSeatAge(seat) {
+  if (!pmState || !seat || !seat.started_at) return 0;
+  return Math.max(0, (pmState.heartbeat_at || 0) - seat.started_at)
+    + (Date.now() - pmFetchAt) / 1000;
+}
+function pmOccupied(pool) { return (pool.seats || []).filter(Boolean); }
+
+function pmRenderBubbles() {
+  const d = pmState, el = document.getElementById('pm-bubbles');
+  if (!d) { el.innerHTML = ''; return; }
+  if (!d.pools) {  // running:false 的显式空态（无状态文件 / 空上报）
+    el.innerHTML = `<div class="pm-bubble bad ring-1 ring-slate-200"><span class="pm-dot"></span><span class="k">心跳</span><span class="v">已停</span></div>`
+      + `<div class="pm-bubble ring-1 ring-slate-200"><span class="k">${esc(d.message || 'agent-worker 未在运行')}</span></div>`;
+    return;
+  }
+  const llm = d.llm || {};
+  const quotaWait = (llm.rate_limit_waiting || 0) + (llm.retry_waiting || 0);
+  const failed = PM_POOLS.reduce((n, p) => n + ((d.pools[p.key] || {}).failed || 0), 0);
+  const hbAge = Math.max(0, Date.now() / 1000 - (d.heartbeat_at || 0));
+  let html = `<div class="pm-bubble ${d.running && d.ok !== false ? '' : 'bad'} ring-1 ring-slate-200">`
+    + `<span class="pm-dot"></span><span class="k">心跳</span>`
+    + `<span class="v">${d.running ? pmAgeText(hbAge) + '前' : '已停'}</span></div>`;
+  html += `<div class="pm-bubble ring-1 ring-slate-200"><span class="k">模型请求</span><span class="v">${llm.inflight || 0}</span></div>`;
+  if (quotaWait > 0) html += `<div class="pm-bubble warn ring-1 ring-slate-200"><span class="pm-dot"></span><span class="k">配额排队</span><span class="v">${quotaWait}</span></div>`;
+  html += `<div class="pm-bubble ring-1 ring-slate-200"><span class="k">未归类原子</span><span class="v">${d.pending_atoms || 0}</span></div>`;
+  if (failed > 0) html += `<div class="pm-bubble bad ring-1 ring-slate-200"><span class="pm-dot"></span><span class="k">异常</span><span class="v">${failed}</span></div>`;
+  for (const p of PM_POOLS) {
+    const pool = d.pools[p.key] || {};
+    html += `<div class="pm-bubble ring-1 ring-slate-200"><span class="k">${p.title}</span><span class="v">${pmOccupied(pool).length}/${pool.workers || 0}</span></div>`;
+  }
+  el.innerHTML = html;
+}
+
+function pmTaskCard(task, poolKey, selKey) {
+  const sel = selKey ? ' sel' : '';
+  // 排队预览不可点（无席位、无日志）：不发 data-pm-open、用默认光标
+  const queued = String(task._seat).startsWith('q');
+  const open = queued ? '' : ` data-pm-open="${poolKey}:${task._seat}"`;
+  const style = queued ? ' style="cursor:default"' : '';
+  if (task.kind === 'skill') {
+    const x = PM_XFER[task.xfer];
+    return `<div class="pm-card${sel}"${open}${style}>
+      <div class="nm font-mono">${esc(task.skill_name)}</div>
+      ${x ? `<div class="pm-xfer pm-xfer-${task.xfer}">${x.from} <span class="arrow">→</span> ${x.to}</div>` : ''}
+      <div class="inf">${task.candidates != null ? `cand <b>${esc(task.candidates)}</b> · ` : ''}${task.weightscore != null ? `ws <b>${esc(task.weightscore)}</b> · ` : ''}${task._age != null ? pmAgeText(task._age) : '排队中'}</div>
+    </div>`;
+  }
+  if (task.kind === 'atom_batch') {
+    const ids = task.atom_ids || [];
+    const preview = ids.slice(0, 4).map(a => `<code class="font-mono" style="font-size:10px;color:#0f766e">${esc(a)}</code>`).join(' ');
+    return `<div class="pm-card${sel}"${open}${style}>
+      <div class="nm">本批 ${ids.length} 个原子</div>
+      <div class="inf">${task._age != null ? pmAgeText(task._age) : '排队中'}</div>
+      <div class="mt-1 flex flex-wrap gap-1">${preview}${ids.length > 4 ? `<span class="inf">+${ids.length - 4}</span>` : ''}</div>
+    </div>`;
+  }
+  // traj（拆分代理没有任务名，只有轨迹 id）
+  return `<div class="pm-card${sel}"${open}${style}>
+    <div class="nm font-mono">${esc(task.traj_id || '?')}</div>
+    <div class="inf">${esc(task.watch_dir || '')}${task._age != null ? ' · ' + pmAgeText(task._age) : ' · 排队中'}</div>
+  </div>`;
+}
+
+function pmRenderStages() {
+  const wrap = document.getElementById('pm-stages');
+  const d = pmState;
+  if (!d || !d.pools) {
+    wrap.innerHTML = `<div class="pm-stage ring-1 ring-slate-200" style="align-items:center;justify-content:center;min-height:160px">
+      <span class="text-slate-400 text-xs">${esc((d && d.message) || 'agent-worker 未在运行')}</span></div>`;
+    return;
+  }
+  wrap.innerHTML = PM_POOLS.map(def => {
+    const pool = d.pools[def.key] || {};
+    const seats = pool.seats || [];
+    const queue = pool.queue || [];
+    const chips = [
+      `<span class="text-[10px] px-1.5 py-0.5 rounded bg-slate-100 text-slate-600" title="pools.${def.key}.workers（热更 P1 评审中，暂只读）">席位 ${pool.workers ?? '—'}</span>`,
+    ];
+    if (def.weight && pool.llm_weight != null) chips.push(`<span class="text-[10px] px-1.5 py-0.5 rounded bg-slate-100 text-slate-600" title="pools.${def.key}.llm_weight（暂只读）">配额比 ${esc(pool.llm_weight)}</span>`);
+    if (def.batch && pool.batch_size != null) chips.push(`<span class="text-[10px] px-1.5 py-0.5 rounded bg-slate-100 text-slate-600" title="pools.${def.key}.batch_size（暂只读）">批量 ${esc(pool.batch_size)}</span>`);
+    const seatHtml = seats.map((seat, i) => {
+      if (!seat) return `<button type="button" class="pm-seat" title="席位 ${i + 1} · 空闲"></button>`;
+      const task = { ...(seat.task || {}), _seat: i, _age: pmSeatAge(seat) };
+      const sel = pmSelected && pmSelected.pool === def.key && pmSelected.seat === i;
+      const color = pmSeatColor(task._age);
+      return `<button type="button" class="pm-seat busy${sel ? ' sel' : ''}" data-pm-open="${def.key}:${i}"
+        title="席位 ${i + 1} · 已跑 ${pmAgeText(task._age)}" style="background:${color};border-color:${color}"></button>`;
+    }).join('');
+    const activeCards = seats.map((seat, i) => seat && { ...(seat.task || {}), _seat: i, _age: pmSeatAge(seat) })
+      .filter(Boolean).map(t => pmTaskCard(t, def.key,
+        pmSelected && pmSelected.pool === def.key && pmSelected.seat === t._seat)).join('');
+    const queueCards = queue.map((t, i) => pmTaskCard({ ...t, _seat: 'q' + i, _age: null }, def.key, false)).join('');
+    const qlabel = def.key === 'cluster'
+      ? `未归类 ${d.pending_atoms || 0} · 排队 ${pool.queued || queue.length}`
+      : `排队 ${pool.queued || queue.length}`;
+    return `<section class="pm-stage ring-1 ring-slate-200">
+      <div class="flex items-baseline justify-between gap-1.5">
+        <div><div class="font-semibold text-[13px]">${def.title}</div>
+        <div class="text-[10.5px] text-slate-400">${def.subtitle}</div></div>
+        <div class="flex flex-wrap gap-1 justify-end">${chips.join('')}</div>
+      </div>
+      <div class="pm-seats">${seatHtml}</div>
+      <div class="text-[10.5px] text-slate-400 font-medium">进行中 ${pmOccupied(pool).length}</div>
+      <div class="pm-lane">${activeCards || '<div class="text-[11px] text-slate-400">—</div>'}</div>
+      <div class="text-[10.5px] text-slate-400 font-medium">${qlabel}</div>
+      <div class="pm-lane">${queueCards || '<div class="text-[11px] text-slate-400">—</div>'}</div>
+      <div class="pm-foot"><span>完成 ${pool.completed || 0}</span><span>失败 ${pool.failed || 0}</span></div>
+    </section>`;
+  }).join('');
+}
+
+function pmSelectedSeat() {
+  if (!pmSelected || !pmState || !pmState.pools) return null;
+  const pool = (pmState.pools[pmSelected.pool] || {});
+  return (pool.seats || [])[pmSelected.seat] || null;
+}
+
+function pmRenderDrawer() {
+  const dr = document.getElementById('pm-drawer');
+  const seat = pmSelectedSeat();
+  if (!pmSelected || !seat) {
+    pmStopLog();
+    dr.className = 'pm-drawer empty ring-1 ring-slate-200';
+    dr.innerHTML = pmSelected
+      ? '该席位任务已结束 <button type="button" class="pm-btn ghost" data-pm-close>关闭</button>'
+      : '点选进行中的任务看实时日志';
+    if (pmSelected) pmSelected = null;
+    return;
+  }
+  const task = seat.task || {};
+  const age = pmAgeText(pmSeatAge(seat));
+  const def = PM_POOLS.find(p => p.key === pmSelected.pool);
+  // 抽屉随 live 轮询重渲染：同一任务的日志内容要保住，否则每 3s 闪回「加载中」
+  const hasStream = task.kind === 'skill' || task.kind === 'traj';
+  const existingLog = (hasStream && pmLogKey && document.getElementById('pm-log'))
+    ? document.getElementById('pm-log').innerHTML : '';
+  const logPane = `<div class="pm-log" id="pm-log">${existingLog || '<div class="dim">日志加载中…</div>'}</div>`;
+  let head = '', logHtml = '';
+  if (task.kind === 'skill') {
+    const x = PM_XFER[task.xfer];
+    head = `<h2 class="font-mono text-sm font-semibold break-all">${esc(task.skill_name)}</h2>
+      <div class="text-[11px] text-slate-400 mt-0.5">${def.title} · 席位 ${pmSelected.seat + 1} · 已跑 ${age}</div>
+      ${x ? `<div class="flex items-center gap-2 flex-wrap mt-1"><span class="pm-xfer pm-xfer-${task.xfer}" style="margin-top:0">${x.from} <span class="arrow">→</span> ${x.to}</span><span class="text-xs text-slate-500">${x.tip}</span>
+      <span class="text-[11px] text-slate-400">${task.candidates != null ? `cand ${esc(task.candidates)} · ` : ''}${task.weightscore != null ? `ws ${esc(task.weightscore)}` : ''}</span></div>` : ''}`;
+    logHtml = logPane;
+  } else if (task.kind === 'traj') {
+    head = `<h2 class="font-mono text-sm font-semibold break-all">${esc(task.traj_id || '?')}</h2>
+      <div class="text-[11px] text-slate-400 mt-0.5">${def.title} · ${esc(task.watch_dir || '')} · 席位 ${pmSelected.seat + 1} · 已跑 ${age}</div>`;
+    logHtml = logPane;
+  } else {  // atom_batch：Cluster 批没有独立日志，展示本批原子名单（概念稿语义）
+    const ids = (task.atom_ids || []).map(a => `<code class="font-mono text-[11px] text-teal-700">${esc(a)}</code>`).join(' · ');
+    head = `<h2 class="text-sm font-semibold">本批 ${(task.atom_ids || []).length} 个原子</h2>
+      <div class="text-[11px] text-slate-400 mt-0.5">${def.title} · 席位 ${pmSelected.seat + 1} · 已跑 ${age}</div>
+      <div class="flex flex-wrap gap-1.5 mt-1">${ids || '<span class="text-[11px] text-slate-400">—</span>'}</div>`;
+    logHtml = '<div class="pm-log" style="min-height:60px"><div class="dim">Cluster 批没有独立日志文件（逐轮 trace 在 split/edit 任务上）</div></div>';
+  }
+  dr.className = 'pm-drawer ring-1 ring-slate-200';
+  dr.innerHTML = `<div class="flex items-start justify-between gap-2"><div class="min-w-0">${head}</div>
+    <button type="button" class="pm-btn ghost shrink-0" data-pm-close>关闭</button></div>${logHtml}`;
+  if (task.kind === 'skill' || task.kind === 'traj') pmStartLog(task.kind, task.kind === 'skill' ? task.skill_name : task.traj_id);
+  else pmStopLog();
+}
+
+function pmLogClassify(line) {
+  if (/ERROR|失败|超时|Traceback|溢出|停滞/.test(line)) return 'err';
+  if (/graduate|commit|split_done|clustered|完成|成功/.test(line)) return 'okl';
+  if (/→|Candidates|staging|Jam|baby|main|TURN|ROUND/.test(line)) return 'hl';
+  return '';
+}
+async function pmPollLog() {
+  if (!pmLogKey) return;
+  const { kind, name } = pmLogKey;
+  try {
+    const r = await j('api/v1/dashboard/pipeline/log?kind=' + encodeURIComponent(kind)
+      + '&name=' + encodeURIComponent(name) + '&tail=300');
+    const log = document.getElementById('pm-log');
+    if (!log) return;
+    if (!r.exists) { log.innerHTML = `<div class="dim">${esc(r.message || '该任务暂无日志文件')}</div>`; return; }
+    log.innerHTML = (r.lines || []).map(l => {
+      const cls = pmLogClassify(l);
+      return cls ? `<div class="${cls}">${esc(l)}</div>` : `<div>${esc(l)}</div>`;
+    }).join('') || '<div class="dim">（日志为空）</div>';
+    if (r.truncated) log.insertAdjacentHTML('afterbegin', '<div class="dim">…（仅显示日志尾部）</div>');
+    log.scrollTop = log.scrollHeight;
+  } catch (e) {
+    const log = document.getElementById('pm-log');
+    if (log) log.innerHTML = `<div class="err">日志读取失败：${esc(e.message)}</div>`;
+  }
+}
+function pmStartLog(kind, name) {
+  const key = kind + ':' + name;
+  if (pmLogKey === key) return;
+  pmStopLog();
+  pmLogKey = { kind, name };
+  pmPollLog();
+  pmLogTimer = setInterval(pmPollLog, PM_LOG_MS);
+}
+function pmStopLog() {
+  pmLogKey = null;
+  if (pmLogTimer) { clearInterval(pmLogTimer); pmLogTimer = null; }
+}
+
+async function pmFetchLive() {
+  try {
+    pmState = await j('api/v1/dashboard/pipeline/live');  // 不走 jc：每轮都要新数据
+    pmFetchAt = Date.now();
+  } catch (e) {
+    pmState = { running: false, message: '流水线状态读取失败：' + e.message };
+  }
+  pmRenderBubbles();
+  pmRenderStages();
+  pmRenderDrawer();
+}
+function pmSetActive(on) {
+  if (on) {
+    if (pmPollTimer) return;
+    pmFetchLive();
+    pmPollTimer = setInterval(pmFetchLive, PM_POLL_MS);
+  } else {
+    if (pmPollTimer) { clearInterval(pmPollTimer); pmPollTimer = null; }
+    pmStopLog();
+  }
+}
+// 席位/任务点选 + 抽屉关闭（事件委托，重渲染不丢）
+document.addEventListener('click', e => {
+  const open = e.target.closest('[data-pm-open]');
+  if (open) {
+    const [pool, seat] = open.dataset.pmOpen.split(':');
+    if (seat.startsWith('q')) return;   // 排队预览不可点（无日志/详情）
+    const key = { pool, seat: Number(seat) };
+    const same = pmSelected && pmSelected.pool === key.pool && pmSelected.seat === key.seat;
+    pmSelected = same ? null : key;
+    pmStopLog();
+    pmRenderStages();
+    pmRenderDrawer();
+    return;
+  }
+  if (e.target.closest('[data-pm-close]')) {
+    pmSelected = null;
+    pmStopLog();
+    pmRenderStages();
+    pmRenderDrawer();
+  }
+});
+
 // ── SPA-lite 路由（hash）─────────────────────────────────────────
-const NAMES = { overview: '总览', skills: '技能库', traj: '轨迹 & 原子', users: '用户 & 画像', canary: '灰度 Canary', my: '我的', admin: '管理', settings: '设置' };
+const NAMES = { overview: '总览', skills: '技能库', pipeline: '流水线', traj: '轨迹 & 原子', users: '用户 & 画像', canary: '灰度 Canary', my: '我的', admin: '管理', settings: '设置' };
 function showPage(pg) {
   if (!document.getElementById('pg-' + pg)) pg = 'overview';
   document.querySelectorAll('.sec-page').forEach(s => s.classList.remove('on'));
@@ -888,6 +1169,7 @@ function showPage(pg) {
   });
   document.getElementById('pgname').textContent = NAMES[pg] || '总览';
   window.scrollTo(0, 0);
+  pmSetActive(pg === 'pipeline');   // 只在流水线页轮询，离开即停
 }
 function route() {
   const h = decodeURIComponent(location.hash.replace(/^#/, ''));

--- a/src/xskill/dashboard/static/index.html
+++ b/src/xskill/dashboard/static/index.html
@@ -17,6 +17,42 @@
   .toast{animation:toast-in .18s ease-out}
   @keyframes toast-in{from{transform:translateY(8px);opacity:0}to{transform:none;opacity:1}}
   #scatter-tip{position:fixed;z-index:70;pointer-events:none;max-width:280px}
+  /* ══ 流水线 Monitor：固定席位色块 + 日志抽屉（tw.css 编译期没扫过的部件手写） ══ */
+  .pm-bubbles{display:flex;flex-wrap:wrap;gap:8px;align-items:center;margin-bottom:12px}
+  .pm-bubble{display:inline-flex;align-items:center;gap:6px;background:#fff;border-radius:999px;padding:5px 11px;font-size:12px}
+  .pm-bubble .k{color:#94a3b8;font-size:11px}
+  .pm-bubble .v{font-weight:700;font-variant-numeric:tabular-nums}
+  .pm-dot{width:7px;height:7px;border-radius:50%;background:#10b981}
+  .pm-bubble.warn .pm-dot{background:#f59e0b}
+  .pm-bubble.bad .pm-dot{background:#f43f5e}
+  .pm-stages{display:grid;grid-template-columns:1fr;gap:10px;align-items:stretch}
+  @media (min-width:1100px){.pm-stages{grid-template-columns:1fr 1fr 1.35fr}}
+  .pm-stage{background:#fff;border-radius:12px;padding:10px;min-height:340px;display:flex;flex-direction:column;gap:7px}
+  .pm-seats{display:grid;grid-template-columns:repeat(auto-fill,minmax(22px,1fr));gap:4px}
+  .pm-seat{aspect-ratio:1;border-radius:5px;border:1px solid #cbd5e1;background:#f8fafc;transition:background-color .4s ease,border-color .4s ease}
+  .pm-seat.busy{cursor:pointer}
+  .pm-seat.sel{outline:2px solid #0f172a;outline-offset:1px}
+  .pm-lane{display:flex;flex-direction:column;gap:5px;min-height:36px;max-height:280px;overflow:auto}
+  .pm-card{border:1px solid #e2e8f0;border-radius:8px;padding:7px 8px;background:#fff;cursor:pointer;font-size:11.5px}
+  .pm-card:hover{border-color:#99f6e4}
+  .pm-card.sel{border-color:#0d9488;background:#f0fdfa}
+  .pm-card .nm{font-weight:600;font-size:11.5px;white-space:nowrap;overflow:hidden;text-overflow:ellipsis}
+  .pm-card .inf{color:#64748b;font-size:10.5px;margin-top:2px}
+  .pm-xfer{margin-top:6px;display:inline-flex;align-items:center;gap:5px;border-radius:999px;padding:2px 8px;font-size:11px;font-weight:700}
+  .pm-xfer .arrow{opacity:.65}
+  .pm-xfer-baby_main{background:#e0f2fe;color:#0369a1}
+  .pm-xfer-main_staging{background:#ecfdf5;color:#047857}
+  .pm-xfer-staging_main{background:#fff7ed;color:#c2410c}
+  .pm-foot{margin-top:auto;padding-top:6px;border-top:1px dashed #e2e8f0;color:#94a3b8;font-size:10.5px;display:flex;justify-content:space-between}
+  .pm-drawer{margin-top:10px;background:#fff;border-radius:12px;padding:12px;display:flex;flex-direction:column;gap:8px}
+  .pm-drawer.empty{align-items:center;justify-content:center;color:#94a3b8;min-height:140px;text-align:center}
+  .pm-log{flex:1;background:#0f172a;color:#e2e8f0;border-radius:10px;padding:10px 12px;overflow:auto;min-height:240px;max-height:420px;font-family:ui-monospace,SFMono-Regular,Menlo,Consolas,monospace;font-size:11.5px;line-height:1.5;white-space:pre-wrap;word-break:break-all}
+  .pm-log .err{color:#fb7185}
+  .pm-log .okl{color:#34d399}
+  .pm-log .hl{color:#5eead4}
+  .pm-log .dim{color:#94a3b8}
+  .pm-btn{border:1px solid #e2e8f0;background:#fff;border-radius:7px;padding:4px 8px;cursor:pointer;font-size:11px;color:#334155}
+  .pm-btn.ghost{background:transparent}
 </style></head>
 <body class="bg-slate-100 text-slate-900 text-[13px] leading-normal">
 <div class="flex min-h-screen">
@@ -30,6 +66,7 @@
     <nav class="px-3 space-y-0.5 mt-1 text-[13px]" id="nav">
       <a href="#overview" data-pg="overview" class="nav-link flex items-center gap-2.5 px-3 py-2 rounded-lg text-slate-500 hover:bg-slate-50"><svg width="15" height="15" viewBox="0 0 16 16" fill="none" stroke="currentColor" stroke-width="1.5"><rect x="1.5" y="1.5" width="5.4" height="5.4" rx="1.5"/><rect x="9.1" y="1.5" width="5.4" height="5.4" rx="1.5"/><rect x="1.5" y="9.1" width="5.4" height="5.4" rx="1.5"/><rect x="9.1" y="9.1" width="5.4" height="5.4" rx="1.5"/></svg>总览</a>
       <a href="#skills" data-pg="skills" class="nav-link flex items-center gap-2.5 px-3 py-2 rounded-lg text-slate-500 hover:bg-slate-50"><svg width="15" height="15" viewBox="0 0 16 16" fill="none" stroke="currentColor" stroke-width="1.5"><path d="M8 1.5l5.5 3v7l-5.5 3-5.5-3v-7l5.5-3z"/><path d="M2.5 4.5L8 7.5l5.5-3M8 7.5v7"/></svg>技能库</a>
+      <a href="#pipeline" data-pg="pipeline" class="nav-link flex items-center gap-2.5 px-3 py-2 rounded-lg text-slate-500 hover:bg-slate-50"><svg width="15" height="15" viewBox="0 0 16 16" fill="none" stroke="currentColor" stroke-width="1.5"><rect x="1.5" y="6" width="3.2" height="4" rx="1"/><rect x="6.4" y="6" width="3.2" height="4" rx="1"/><rect x="11.3" y="6" width="3.2" height="4" rx="1"/><path d="M4.7 8h1.7M9.6 8h1.7"/></svg>流水线</a>
       <a href="#traj" data-pg="traj" class="nav-link flex items-center gap-2.5 px-3 py-2 rounded-lg text-slate-500 hover:bg-slate-50"><svg width="15" height="15" viewBox="0 0 16 16" fill="none" stroke="currentColor" stroke-width="1.5"><path d="M2 4h9M2 8h12M2 12h7"/><circle cx="13.5" cy="4" r="1.4" fill="currentColor" stroke="none"/></svg>轨迹 &amp; 原子</a>
       <a href="#users" data-pg="users" class="nav-link flex items-center gap-2.5 px-3 py-2 rounded-lg text-slate-500 hover:bg-slate-50"><svg width="15" height="15" viewBox="0 0 16 16" fill="none" stroke="currentColor" stroke-width="1.5"><circle cx="5.5" cy="5" r="2.4"/><circle cx="11.5" cy="6" r="1.9"/><path d="M1.5 13.5c0-2.4 1.8-4 4-4s4 1.6 4 4M10 13.5c0-1.9 1.3-3.2 3-3.2s3 1.3 3 3.2" transform="scale(0.92)"/></svg>用户 &amp; 画像</a>
       <a href="#canary" data-pg="canary" class="nav-link flex items-center gap-2.5 px-3 py-2 rounded-lg text-slate-500 hover:bg-slate-50"><svg width="15" height="15" viewBox="0 0 16 16" fill="none" stroke="currentColor" stroke-width="1.5"><path d="M6 1.5h4M7 1.5v4.2L3 12a2 2 0 001.8 3h6.4A2 2 0 0013 12L9 5.7V1.5"/><path d="M4.5 10.5h7"/></svg>灰度 Canary</a>
@@ -182,6 +219,13 @@
       </div>
 
       <div id="skill-detail" class="mt-4"></div>
+    </div>
+
+    <!-- ══ 流水线 Monitor ══ -->
+    <div class="sec-page" id="pg-pipeline">
+      <div id="pm-bubbles" class="pm-bubbles"></div>
+      <div id="pm-stages" class="pm-stages"></div>
+      <div id="pm-drawer" class="pm-drawer empty ring-1 ring-slate-200">点选进行中的任务看实时日志</div>
     </div>
 
     <!-- ══ 轨迹 & 原子 ══ -->

--- a/src/xskill/pipeline/runner.py
+++ b/src/xskill/pipeline/runner.py
@@ -31,6 +31,7 @@ import threading
 import time
 from collections import deque
 from concurrent.futures import Future
+from functools import partial
 from pathlib import Path
 
 from xskill.config import (
@@ -264,6 +265,12 @@ class DirectoryWatcher:
             "heartbeat_at": time.time(),
             "watcher": self.stats,
             "pools": {name: pool.status for name, pool in self._pools.items()},
+            # 看板「流水线」页配置 chip 的展示值（席位/配额比/批量）；
+            # 配置键不变，热更在 P1 另行评审。
+            "pool_config": {
+                name: dict(self.pool_config.get(name) or {})
+                for name in ("split", "cluster", "edit")
+            },
             "cluster": {
                 "pending_atoms": len(self.pending_atoms),
                 "claimed_atoms": len(self.claimed_atoms),
@@ -560,10 +567,55 @@ class DirectoryWatcher:
         for d in skill_dirs:
             if d in skill_edit_in_flight:
                 continue
-            fut = self._pools["edit"].submit(_run_one, d)
+            fut = self._pools["edit"].submit(
+                _run_one,
+                d,
+                task={"kind": "skill", "skill_name": d.name},
+                task_factory=partial(self._skill_edit_task_meta, d),
+            )
             if fut is None:
                 break
             self._futures[fut] = {"stage": "skill_edit", "skill_dir": d}
+
+    def _skill_edit_task_meta(self, d: Path) -> dict:
+        """流水线 Monitor 的 edit 席位元数据：A→B 转移 + buffer 事实。
+
+        作为 ``task_factory`` 在 pool 工作线程起跑时求值：git / candidates
+        都是当时的鲜活读数，且不花 watcher 扫描线程的时间。SkillEdit 只占
+        席位时一定在做三种转移之一：``baby_main``（冷启动消化后 graduate）、
+        ``main_staging``（产灰度候选）、``staging_main``（Jam 强砍回 main）。
+        读失败不拖垮真任务——退回 submit 时的静态元数据（仅 skill 名）。
+        """
+        from xskill.canary import CanaryConfig
+        from xskill.skill import candidates as candidate_buffer
+        from xskill.skill.git import current_branch, run_git
+
+        meta = {"kind": "skill", "skill_name": d.name}
+        data = candidate_buffer.load_candidates(d)
+        items = list(data.get("candidates") or [])
+        total_ws = 0
+        for item in items:
+            try:
+                total_ws += int(item.get("weightscore") or 0)
+            except (TypeError, ValueError):
+                pass
+        meta["candidates"] = len(items)
+        meta["weightscore"] = total_ws
+        staging_exists = run_git(
+            ["rev-parse", "--verify", "staging"], cwd=str(d),
+        )[0] == 0
+        jam_threshold = CanaryConfig.from_dict(
+            self.config.get("canary", {}),
+        ).jam_threshold
+        branch = current_branch(str(d)) or ""
+        meta["branch"] = branch
+        if staging_exists and total_ws >= jam_threshold:
+            meta["xfer"] = "staging_main"
+        elif branch == "main":
+            meta["xfer"] = "main_staging"
+        else:
+            meta["xfer"] = "baby_main"
+        return meta
 
     def _on_skill_edit_done(self, result) -> None:
         """``_harvest`` 收割 stage="skill_edit" future 用：_stats 自增 + 即时
@@ -1984,7 +2036,14 @@ class DirectoryWatcher:
                         )
                         continue
                     fut = self._pools["split"].submit(
-                        self._do_split, dir_path, fname,
+                        self._do_split,
+                        dir_path,
+                        fname,
+                        task={
+                            "kind": "traj",
+                            "traj_id": (dir_path / fname).stem,
+                            "watch_dir": dir_path.name,
+                        },
                     )
                     if fut is None:
                         break
@@ -2000,7 +2059,11 @@ class DirectoryWatcher:
                 i["stage"] == "embed" and i["wd_id"] == wd_id for i in self._futures.values()
             ):
                 fut = self._pools["embed"].submit(
-                    self._do_atom_index, dir_path, wd_id, split_done_files,
+                    self._do_atom_index,
+                    dir_path,
+                    wd_id,
+                    split_done_files,
+                    task={"kind": "embed", "count": len(split_done_files)},
                 )
                 if fut is not None:
                     self._futures[fut] = {
@@ -2169,7 +2232,9 @@ class DirectoryWatcher:
             batch_size = min(self.cluster_batch_size, len(self.pending_atoms))
             atom_ids = list(self.pending_atoms)[:batch_size]
             future = self._pools["cluster"].submit(
-                self._do_cluster_batch, atom_ids,
+                self._do_cluster_batch,
+                atom_ids,
+                task={"kind": "atom_batch", "atom_ids": list(atom_ids)},
             )
             if future is None:
                 return

--- a/src/xskill/pipeline/runner.py
+++ b/src/xskill/pipeline/runner.py
@@ -57,6 +57,9 @@ from xskill.pipeline.trajectory import validate_trajectory_source
 
 logger = logging.getLogger("xskill.watcher")
 
+# SkillEdit N=1 连续失败达到该次数后抬高调度错误分，优先跑其他 skill。
+SKILL_EDIT_N1_FAIL_DEPRIORITIZE = 3
+
 # v2 (AtomTask 流水线) 的 action → status 映射
 # splitting → split_done → indexed → clustering → done
 _ACTION_STATUS = {
@@ -192,6 +195,10 @@ class DirectoryWatcher:
         # 继续，成功 checkpoint 后由 agent 自动恢复配置默认值。仅驻留内存，
         # 进程重启后自然回到配置值。
         self._skill_edit_retry_batch_sizes: dict[Path, int] = {}
+        # N=1 连续失败计数；达 SKILL_EDIT_N1_FAIL_DEPRIORITIZE 次后抬高
+        # error_count，调度时排到后面（不永久 error，不指数退避）。
+        self._skill_edit_n1_fail_counts: dict[Path, int] = {}
+        self._skill_edit_error_counts: dict[Path, int] = {}
         self._last_poll: float | None = None
         self._started_at = time.time()
         # 单机 canary 轮转节流：上次真跑 _reconcile_skill_sides 的时间戳。
@@ -503,12 +510,36 @@ class DirectoryWatcher:
         # ``_harvest``（每轮 scan 开头）收割 + 做 _stats 自增/即时 install。
         # 同一个 skill 同时只允许一个 skill_edit future 在飞，避免同一 skill
         # 被并发跑两个 maybe_run（第二个进来时前一个多半仍在改 candidates/git）。
+        from xskill.skill import candidates as candidate_buffer
+
         skill_dirs = [
-            d for d in sorted(self.skill_dir.iterdir())
+            d for d in self.skill_dir.iterdir()
             if d.is_dir() and not d.name.startswith(".")
         ]
         if not skill_dirs:
             return
+
+        def _pending_atom_count(skill_path: Path) -> int:
+            try:
+                data = candidate_buffer.load_candidates(skill_path)
+            except Exception:
+                logger.exception(
+                    "failed to load candidates for skill_edit sort: %s",
+                    skill_path.name,
+                )
+                raise
+            return len(data.get("candidates") or [])
+
+        # 错误少优先，其次原子少，再按名字稳定排序。N=1 连败抬高 error 后
+        # 自然排到后面，换下一个 skill；不永久 error、无指数退避。
+        def _skill_edit_sort_key(path: Path):
+            return (
+                self._skill_edit_error_counts.get(path, 0),
+                _pending_atom_count(path),
+                path.name,
+            )
+
+        skill_dirs.sort(key=_skill_edit_sort_key)
 
         jam_threshold = CanaryConfig.from_dict(
             self.config.get("canary", {})).jam_threshold
@@ -569,10 +600,30 @@ class DirectoryWatcher:
         """``_harvest`` 收割 stage="skill_edit" future 用：_stats 自增 + 即时
         install。回主线程串行做（避免对无锁的 self._stats 并发自增）。"""
         d, ok, next_batch_size = result
-        if ok or next_batch_size == self.skill_edit_batch_size:
+        if ok:
+            self._skill_edit_retry_batch_sizes.pop(d, None)
+            self._skill_edit_n1_fail_counts.pop(d, None)
+            self._skill_edit_error_counts.pop(d, None)
+        elif next_batch_size == self.skill_edit_batch_size:
             self._skill_edit_retry_batch_sizes.pop(d, None)
         else:
             self._skill_edit_retry_batch_sizes[d] = next_batch_size
+            if next_batch_size == 1:
+                fails = self._skill_edit_n1_fail_counts.get(d, 0) + 1
+                if fails >= SKILL_EDIT_N1_FAIL_DEPRIORITIZE:
+                    self._skill_edit_error_counts[d] = (
+                        self._skill_edit_error_counts.get(d, 0) + 1
+                    )
+                    self._skill_edit_n1_fail_counts[d] = 0
+                    logger.warning(
+                        "SkillEdit N=1 failed %d times; deprioritize %s "
+                        "(error_count=%d, atoms kept)",
+                        SKILL_EDIT_N1_FAIL_DEPRIORITIZE,
+                        d.name,
+                        self._skill_edit_error_counts[d],
+                    )
+                else:
+                    self._skill_edit_n1_fail_counts[d] = fails
         if not ok:
             return
         self._stats["skills_edited"] += 1

--- a/src/xskill/pipeline/runner.py
+++ b/src/xskill/pipeline/runner.py
@@ -544,13 +544,18 @@ class DirectoryWatcher:
             """与 maybe_run 守门对齐：不会开 LLM 的 skill 不进 edit 池。
 
             单目录异常只排除该 skill，禁止拖垮整轮 edit submit。
+            无 ``.git`` 的目录仍返回 True：交由 worker 侧 ``_run_one`` /
+            ``maybe_run`` 吞错（与过滤前提交语义一致），避免 listcomp 里
+            ``current_branch`` 抛穿扫描；也不把「脏目录」误当成可过滤的
+            伪 skill 状态机。
             """
             if not (skill_path / ".git").exists():
                 logger.warning(
-                    "skip SkillEdit schedule: %s has no .git",
+                    "SkillEdit schedule: %s has no .git; submit and let "
+                    "worker isolate failures",
                     skill_path.name,
                 )
-                return False
+                return True
             try:
                 data = candidate_buffer.load_candidates(skill_path)
                 candidates = list(data.get("candidates") or [])
@@ -612,11 +617,14 @@ class DirectoryWatcher:
         if not skill_dirs:
             return
 
-        # 错误少优先，其次 lean-first。列表已是 actionable，无需再排空 buffer。
+        # 错误少优先；有候选优先于空 buffer；再 lean-first。
+        # 无 .git 等「仍提交」的空目录靠 empty-last 避免抢窗。
         def _skill_edit_sort_key(path: Path):
+            pending = _pending_atom_count(path)
             return (
                 self._skill_edit_error_counts.get(path, 0),
-                _pending_atom_count(path),
+                0 if pending > 0 else 1,
+                pending,
                 path.name,
             )
 

--- a/src/xskill/pipeline/runner.py
+++ b/src/xskill/pipeline/runner.py
@@ -511,6 +511,8 @@ class DirectoryWatcher:
         # 同一个 skill 同时只允许一个 skill_edit future 在飞，避免同一 skill
         # 被并发跑两个 maybe_run（第二个进来时前一个多半仍在改 candidates/git）。
         from xskill.skill import candidates as candidate_buffer
+        from xskill.skill.git import current_branch, run_git
+        from xskill.canary import load_ux_scores
 
         skill_dirs = [
             d for d in self.skill_dir.iterdir()
@@ -518,6 +520,14 @@ class DirectoryWatcher:
         ]
         if not skill_dirs:
             return
+
+        jam_threshold = CanaryConfig.from_dict(
+            self.config.get("canary", {})).jam_threshold
+        edit_threshold = (
+            int(threshold)
+            if threshold is not None
+            else candidate_buffer.ATOM_PROMOTION_THRESHOLD
+        )
 
         def _pending_atom_count(skill_path: Path) -> int:
             try:
@@ -530,8 +540,79 @@ class DirectoryWatcher:
                 raise
             return len(data.get("candidates") or [])
 
-        # 错误少优先，其次原子少，再按名字稳定排序。N=1 连败抬高 error 后
-        # 自然排到后面，换下一个 skill；不永久 error、无指数退避。
+        def _skill_edit_actionable(skill_path: Path) -> bool:
+            """与 maybe_run 守门对齐：不会开 LLM 的 skill 不进 edit 池。
+
+            单目录异常只排除该 skill，禁止拖垮整轮 edit submit。
+            """
+            if not (skill_path / ".git").exists():
+                logger.warning(
+                    "skip SkillEdit schedule: %s has no .git",
+                    skill_path.name,
+                )
+                return False
+            try:
+                data = candidate_buffer.load_candidates(skill_path)
+                candidates = list(data.get("candidates") or [])
+                total_ws = 0
+                for item in candidates:
+                    try:
+                        total_ws += int(item.get("weightscore") or 0)
+                    except (TypeError, ValueError):
+                        pass
+                staging_exists = run_git(
+                    ["rev-parse", "--verify", "staging"],
+                    cwd=str(skill_path),
+                )[0] == 0
+                jam = staging_exists and total_ws >= jam_threshold
+                if staging_exists and not jam:
+                    return False
+                if jam:
+                    return True
+                ready = bool(
+                    candidate_buffer.ready_for_promotion_v2(
+                        data, threshold=edit_threshold,
+                    )
+                )
+                baby_checkpoint = run_git(
+                    ["rev-parse", "baby~1"],
+                    cwd=str(skill_path),
+                )[0] == 0
+                branch = current_branch(str(skill_path)) or ""
+                if branch == "baby":
+                    return baby_checkpoint or ready
+                if branch == "main":
+                    if not ready:
+                        return False
+                    try:
+                        scores = load_ux_scores(skill_path)
+                    except Exception:
+                        logger.exception(
+                            "load_ux_scores failed during skill_edit "
+                            "filter: %s",
+                            skill_path.name,
+                        )
+                        return False
+                    return any(
+                        score.get("side") == "main" for score in scores
+                    )
+                if "_turn" in branch:
+                    return baby_checkpoint or ready
+                return False
+            except Exception:
+                logger.exception(
+                    "skill_edit actionable check failed: %s",
+                    skill_path.name,
+                )
+                return False
+
+        skill_dirs = [
+            path for path in skill_dirs if _skill_edit_actionable(path)
+        ]
+        if not skill_dirs:
+            return
+
+        # 错误少优先，其次 lean-first。列表已是 actionable，无需再排空 buffer。
         def _skill_edit_sort_key(path: Path):
             return (
                 self._skill_edit_error_counts.get(path, 0),
@@ -541,8 +622,6 @@ class DirectoryWatcher:
 
         skill_dirs.sort(key=_skill_edit_sort_key)
 
-        jam_threshold = CanaryConfig.from_dict(
-            self.config.get("canary", {})).jam_threshold
         base_llm_cfg = self.config.get("llm", {}) or {}
         skill_llm_override = self.config.get("llm_skill", {}) or {}
         skill_llm_cfg = {

--- a/src/xskill/pipeline/worker_runtime.py
+++ b/src/xskill/pipeline/worker_runtime.py
@@ -11,9 +11,14 @@ new skill repositories are changed in a deterministic order.
 from __future__ import annotations
 
 import threading
+import time
+from collections import deque
 from concurrent.futures import Future, ThreadPoolExecutor
 from dataclasses import dataclass
 from typing import Any, Callable
+
+# 排队任务预览上限：状态文件每 5s 落盘一次，队列只需够看，不许无限增长。
+_QUEUED_PREVIEW_LIMIT = 50
 
 
 def _install_worker_context() -> None:
@@ -35,6 +40,13 @@ class BoundedExecutor:
     reserves one slot before submission, giving this wrapper a hard total
     capacity of ``workers * 3``.  Rejected work is never submitted and the
     caller can leave its durable DB/file state untouched for the next scan.
+
+    Seat model for the pipeline monitor: running tasks occupy a **fixed**
+    seat (index into a list of length ``workers``).  Completion only clears
+    its own index — neighbours never shift.  New tasks take the lowest free
+    seat.  ``task`` / ``task_factory`` attach monitor metadata (skill name,
+    atom ids, transfer type, …) shown on the dashboard; both are optional
+    and seats track occupancy even without metadata.
     """
 
     def __init__(self, name: str, workers: int):
@@ -50,27 +62,74 @@ class BoundedExecutor:
         self._queued = 0
         self._completed = 0
         self._failed = 0
+        self._seats: list[dict | None] = [None] * workers
+        # (token, task) FIFO 预览；token 用于取消/起跑时精确移除。
+        self._queued_tasks: deque[tuple[int, dict]] = deque()
+        self._task_token = 0
         self._executor = ThreadPoolExecutor(
             max_workers=workers,
             thread_name_prefix=f"xskill-{name}",
             initializer=_install_worker_context,
         )
 
-    def submit(self, function: Callable[..., Any], /, *args, **kwargs) -> Future | None:
-        """Submit immediately or return ``None`` when this pool is full."""
+    def _take_seat(self) -> int:
+        """Return the lowest free seat index (caller holds ``self._lock``)."""
+        for index, entry in enumerate(self._seats):
+            if entry is None:
+                return index
+        # max_workers == len(seats)，跑到这里说明席位簿记与执行器脱节。
+        raise RuntimeError(f"{self.name}: no free seat for a running task")
+
+    def submit(
+        self,
+        function: Callable[..., Any],
+        /,
+        *args,
+        task: dict | None = None,
+        task_factory: Callable[[], dict] | None = None,
+        **kwargs,
+    ) -> Future | None:
+        """Submit immediately or return ``None`` when this pool is full.
+
+        ``task`` is cheap static monitor metadata (also used for the queued
+        preview).  ``task_factory`` is evaluated in the worker thread when
+        the run actually starts, so it may do fresh reads (git branch,
+        candidates file) without costing the watcher thread; its result
+        overrides ``task`` on the occupied seat.
+        """
         if not self._slots.acquire(blocking=False):
             return None
         state = _SubmissionState()
         state_lock = threading.Lock()
         with self._lock:
             self._queued += 1
+            self._task_token += 1
+            token = self._task_token
+            if task is not None:
+                self._queued_tasks.append((token, task))
+                while len(self._queued_tasks) > _QUEUED_PREVIEW_LIMIT:
+                    self._queued_tasks.popleft()
 
         def run():
+            meta = task
+            if task_factory is not None:
+                try:
+                    meta = task_factory()
+                except Exception:
+                    # 监看元数据失败绝不拖垮真任务；退到 submit 时的静态 task。
+                    meta = task
             with state_lock:
                 state.started = True
             with self._lock:
                 self._queued -= 1
                 self._running += 1
+                seat = self._take_seat()
+                self._seats[seat] = {
+                    "seat": seat,
+                    "task": meta or {},
+                    "started_at": time.time(),
+                }
+                self._drop_queued(token)
             try:
                 from xskill.utils.rate_limit import request_source
 
@@ -87,6 +146,7 @@ class BoundedExecutor:
             finally:
                 with self._lock:
                     self._running -= 1
+                    self._seats[seat] = None
                 self._slots.release()
 
         try:
@@ -94,6 +154,7 @@ class BoundedExecutor:
         except BaseException:
             with self._lock:
                 self._queued -= 1
+                self._drop_queued(token)
             self._slots.release()
             raise
 
@@ -106,10 +167,18 @@ class BoundedExecutor:
                 state.started = True
             with self._lock:
                 self._queued -= 1
+                self._drop_queued(token)
             self._slots.release()
 
         future.add_done_callback(release_cancelled)
         return future
+
+    def _drop_queued(self, token: int) -> None:
+        """Remove a queued-preview entry by token (caller holds ``self._lock``)."""
+        for item in self._queued_tasks:
+            if item[0] == token:
+                self._queued_tasks.remove(item)
+                return
 
     @property
     def available_capacity(self) -> int:
@@ -117,7 +186,10 @@ class BoundedExecutor:
             return self.total_capacity - self._running - self._queued
 
     @property
-    def status(self) -> dict[str, int | float]:
+    def status(self) -> dict[str, Any]:
+        """Counts plus the monitor view: fixed seats (``None`` = free) and a
+        FIFO preview of queued tasks.  Seats are copied so the status-file
+        writer never mutates live entries."""
         with self._lock:
             occupied = self._running + self._queued
             return {
@@ -129,6 +201,11 @@ class BoundedExecutor:
                 "completed": self._completed,
                 "failed": self._failed,
                 "occupancy": occupied / self.total_capacity,
+                "seats": [
+                    dict(entry) if entry is not None else None
+                    for entry in self._seats
+                ],
+                "queue": [dict(task) for _, task in self._queued_tasks],
             }
 
     def shutdown(self, *, wait: bool = False, cancel_futures: bool = True) -> None:

--- a/src/xskill/skill/git.py
+++ b/src/xskill/skill/git.py
@@ -1744,6 +1744,22 @@ _DISPATCH: dict[str, Callable[[list[str], str], tuple[int, str, str]]] = {
 # 高层 API：直接用 dulwich（不绕回 run_git）
 # ═══════════════════════════════════════════════════════════════════
 
+# init stub 正文标记：毕业前必须消失，否则拒绝 baby→main。
+BABY_STUB_BODY_MARKER = (
+    "(placeholder — SkillEditAgent 在 candidates 攒满阈值后会用真实 atom 内容填充正文)"
+)
+
+
+def skill_md_still_baby_stub(skill_dir: str | Path) -> bool:
+    """SKILL.md 是否仍含 init 时的 placeholder 正文。"""
+    skill_md = Path(skill_dir) / "SKILL.md"
+    try:
+        text = skill_md.read_text(encoding="utf-8")
+    except (OSError, UnicodeDecodeError):
+        return False
+    return BABY_STUB_BODY_MARKER in text
+
+
 def init_skill_repo_on_baby(skill_dir: str, name: str, description: str) -> None:
     """v2: 初始化 skill 仓库到 baby 分支，附带 stub SKILL.md + .gitignore。
 
@@ -1782,7 +1798,7 @@ def init_skill_repo_on_baby(skill_dir: str, name: str, description: str) -> None
                 f"\n"
                 f"# {name}\n"
                 f"\n"
-                f"(placeholder — SkillEditAgent 在 candidates 攒满阈值后会用真实 atom 内容填充正文)\n"
+                f"{BABY_STUB_BODY_MARKER}\n"
             )
             (p / "SKILL.md").write_text(stub_md, encoding="utf-8")
 

--- a/src/xskill/skill/git.py
+++ b/src/xskill/skill/git.py
@@ -1751,13 +1751,36 @@ BABY_STUB_BODY_MARKER = (
 
 
 def skill_md_still_baby_stub(skill_dir: str | Path) -> bool:
-    """SKILL.md 是否仍含 init 时的 placeholder 正文。"""
+    """SKILL.md 是否仍是 init 时的空 stub（#154 empty-graduate）。
+
+    仅当正文在去掉 frontmatter 后本质上仍是 init 形态（可选 ``# name`` +
+    placeholder 行）时返回 True。正文已追加真实内容时即使残留 marker 子串
+    也不再判为 empty stub——避免把「已 write 过」的 checkpoint 误拦成空毕业。
+    """
     skill_md = Path(skill_dir) / "SKILL.md"
     try:
         text = skill_md.read_text(encoding="utf-8")
     except (OSError, UnicodeDecodeError):
         return False
-    return BABY_STUB_BODY_MARKER in text
+    if BABY_STUB_BODY_MARKER not in text:
+        return False
+    body = text
+    if body.startswith("---"):
+        fence = body.find("\n---", 3)
+        if fence >= 0:
+            body = body[fence + len("\n---"):]
+    lines = [line.strip() for line in body.splitlines() if line.strip()]
+    if not lines:
+        return True
+    if lines == [BABY_STUB_BODY_MARKER]:
+        return True
+    if (
+        len(lines) == 2
+        and lines[0].startswith("#")
+        and lines[1] == BABY_STUB_BODY_MARKER
+    ):
+        return True
+    return False
 
 
 def init_skill_repo_on_baby(skill_dir: str, name: str, description: str) -> None:

--- a/src/xskill/skill/git.py
+++ b/src/xskill/skill/git.py
@@ -1751,36 +1751,17 @@ BABY_STUB_BODY_MARKER = (
 
 
 def skill_md_still_baby_stub(skill_dir: str | Path) -> bool:
-    """SKILL.md 是否仍是 init 时的空 stub（#154 empty-graduate）。
+    """SKILL.md 是否仍含 init placeholder。
 
-    仅当正文在去掉 frontmatter 后本质上仍是 init 形态（可选 ``# name`` +
-    placeholder 行）时返回 True。正文已追加真实内容时即使残留 marker 子串
-    也不再判为 empty stub——避免把「已 write 过」的 checkpoint 误拦成空毕业。
+    baby 分批 checkpoint 与最终 graduate 都要求正文不再含该标记；
+    残留即视为未完成写作，拒绝升 main（#154）。
     """
     skill_md = Path(skill_dir) / "SKILL.md"
     try:
         text = skill_md.read_text(encoding="utf-8")
     except (OSError, UnicodeDecodeError):
         return False
-    if BABY_STUB_BODY_MARKER not in text:
-        return False
-    body = text
-    if body.startswith("---"):
-        fence = body.find("\n---", 3)
-        if fence >= 0:
-            body = body[fence + len("\n---"):]
-    lines = [line.strip() for line in body.splitlines() if line.strip()]
-    if not lines:
-        return True
-    if lines == [BABY_STUB_BODY_MARKER]:
-        return True
-    if (
-        len(lines) == 2
-        and lines[0].startswith("#")
-        and lines[1] == BABY_STUB_BODY_MARKER
-    ):
-        return True
-    return False
+    return BABY_STUB_BODY_MARKER in text
 
 
 def init_skill_repo_on_baby(skill_dir: str, name: str, description: str) -> None:

--- a/src/xskill/usage.py
+++ b/src/xskill/usage.py
@@ -72,7 +72,14 @@ class ModelPrice:
 
 
 def extract_usage(resp: Any) -> Usage:
-    """从 OpenAI 兼容 response 提取 token(dict 或 SDK 对象,缺失补 0)。
+    """从 LLM/embedding 响应提取 token,缺失补 0。
+
+    支持的响应形态:
+    - 原始 dict(embedding HTTP JSON): ``resp["usage"]``
+    - OpenAI SDK 对象(ChatCompletion): ``resp.usage``
+    - agno ``ModelResponse``: ``resp.response_usage``(``MessageMetrics``,
+      字段名为 ``input_tokens``/``output_tokens``/``total_tokens`` —— 与
+      OpenAI 原始格式不同,不单独适配会整段记 0)
 
     覆盖 prompt/completion/total + DeepSeek 的 prompt_cache_hit/miss_tokens。
     """
@@ -81,6 +88,18 @@ def extract_usage(resp: Any) -> Usage:
             return None
         v = obj.get(key) if isinstance(obj, dict) else getattr(obj, key, None)
         return int(v) if isinstance(v, (int, float)) else None
+
+    agno_metrics = getattr(resp, "response_usage", None)
+    if agno_metrics is not None:
+        prompt = g(agno_metrics, "input_tokens") or 0
+        completion = g(agno_metrics, "output_tokens") or 0
+        total = g(agno_metrics, "total_tokens") or (prompt + completion)
+        # cost_usd 按 hit+miss=prompt 分档计费,miss 须补未命中余量,
+        # 否则配了 cache 价时 prompt 非命中段会漏计。
+        hit = g(agno_metrics, "cache_read_tokens") or 0
+        miss = max(0, prompt - hit)
+        return Usage(prompt=prompt, completion=completion, total=total,
+                     cache_hit=hit, cache_miss=miss)
 
     usage = resp.get("usage") if isinstance(resp, dict) else getattr(resp, "usage", None)
     if usage is None:

--- a/tests/bdd/README.md
+++ b/tests/bdd/README.md
@@ -86,6 +86,6 @@ mutmut run --max-children 8 \
 
 `skill_edit_schedule_actionable.feature` 守护 Issue #156 / #157 / #158：
 
-- 不会开 LLM 的 skill（main 无 ux、瘦 baby、非 git）不得 `submit` 进 edit 池；
+- 不会开 LLM 的 git skill（main 无 ux、瘦 baby）不得 `submit` 进 edit 池；
 - 单 skill 的 actionable 检查失败只 skip，不得中断整轮扫描；
-- #156 的「空 buffer 置后」由 actionable 过滤取代，不再单独排序键。
+- 无 `.git` 目录不崩扫描；排序 empty-last，避免空目录饿死 READY baby。

--- a/tests/bdd/README.md
+++ b/tests/bdd/README.md
@@ -74,3 +74,18 @@ mutmut run --max-children 8 \
 - `@state_machine`：快速、确定性的状态机测试。
 - `@recovery`：429、上下文超长、进程重启等恢复路径。
 - `@observability`：面向操作者的 SkillEdit trace。
+
+## stub 毕业闸门
+
+`baby_stub_graduate_guard.feature` 守护 Issue #154：
+
+- 仍含 init placeholder 时，`commit_baby_to_main` 必须报错且留在 baby；
+- candidates 已空但 stub 仍在时，框架先重写正文再晋升 main。
+
+## actionable 调度闸门
+
+`skill_edit_schedule_actionable.feature` 守护 Issue #156 / #157 / #158：
+
+- 不会开 LLM 的 skill（main 无 ux、瘦 baby、非 git）不得 `submit` 进 edit 池；
+- 单 skill 的 actionable 检查失败只 skip，不得中断整轮扫描；
+- #156 的「空 buffer 置后」由 actionable 过滤取代，不再单独排序键。

--- a/tests/bdd/features/skill_edit/baby_cold_start_recovery.feature
+++ b/tests/bdd/features/skill_edit/baby_cold_start_recovery.feature
@@ -46,3 +46,21 @@ Feature: baby 冷启动可以从模型失败和进程中断中恢复
     And baby 应当继续停留在 baby 分支
     And 最后 1 个原子应当保留在 candidates
     And watcher 下次调度时仍应当从 N=1 开始
+
+  @recovery @state_machine
+  Scenario: 错误分相同时原子更少的 skill 优先调度
+    Given 两个 baby skill "few-atoms" 有 1 个原子且 "many-atoms" 有 3 个原子
+    And 两者错误分均为 0
+    And edit pool 一次只能跑 1 个 skill
+    When watcher 调度 SkillEdit
+    Then 本轮应先提交 "few-atoms"
+
+  @recovery @state_machine
+  Scenario: N=1 连败 3 次后降优先级并换下一个 skill
+    Given 两个 baby skill "hard" 有 1 个原子且 "easy" 有 2 个原子
+    And "hard" 已在 N=1 上连续失败 3 次
+    And edit pool 一次只能跑 1 个 skill
+    When watcher 调度 SkillEdit
+    Then 本轮应先提交 "easy"
+    And "hard" 的 candidates 原子应当全部保留
+    And "hard" 的重试批次仍为 N=1

--- a/tests/bdd/features/skill_edit/baby_stub_graduate_guard.feature
+++ b/tests/bdd/features/skill_edit/baby_stub_graduate_guard.feature
@@ -1,0 +1,24 @@
+Feature: baby 毕业前必须去掉 stub 正文
+  SkillEdit 不得把仍含 init placeholder 的 SKILL.md 晋升为 main。
+  若 candidates 已空但 stub 仍在，框架应重触发写正文后再毕业。
+
+  Background:
+    Given SkillEdit 默认每批处理 5 个原子
+    And baby 的 candidates 使用稳定的 FIFO 顺序
+
+  @recovery @state_machine
+  Scenario: 直接调用 commit_baby_to_main 时 stub 未清除则报错
+    Given baby skill "stub-locked" 仍是 init stub 正文
+    When 模型调用 commit_baby_to_main 尝试毕业
+    Then 工具应当返回 stub 拒绝错误
+    And baby 应当继续停留在 baby 分支
+
+  @recovery @state_machine
+  Scenario: candidates 已空但 stub 仍在时框架重写后再晋升
+    Given baby skill "stub-empty" 仍是 init stub 正文
+    And candidates 已经为空
+    And 已有一次未改写 stub 的 baby checkpoint
+    When watcher 再次调度这个 baby 的 SkillEdit
+    Then 框架应当先触发一轮 stub 重写
+    And SkillEdit 应当成功并把 baby 晋升为 main
+    And 最终 SKILL.md 不应当再含 init placeholder

--- a/tests/bdd/features/skill_edit/skill_edit_schedule_actionable.feature
+++ b/tests/bdd/features/skill_edit/skill_edit_schedule_actionable.feature
@@ -1,0 +1,40 @@
+Feature: SkillEdit 只把 actionable skill 提交进 edit 池
+  不会开 LLM 的 skill 不得占用 workers×3 提交窗口。
+  单 skill 过滤失败不得中断整轮调度。
+  关联 Issue #156 / #157 / #158。
+
+  Background:
+    Given edit pool 一次只能跑 1 个 skill
+
+  @recovery @state_machine
+  Scenario: main 无 ux_score 不进池，READY baby 进池
+    Given baby skill "ready-baby" 已达冷启动阈值且可编辑
+    And main skill "main-no-ux" 有候选但还没有 main 侧 ux_score
+    When watcher 调度 SkillEdit
+    Then 提交列表应包含 "ready-baby"
+    And 提交列表不应包含 "main-no-ux"
+
+  @recovery @state_machine
+  Scenario: 未达阈值且无 checkpoint 的 baby 不进池
+    Given baby skill "thin-baby" 仅有不足阈值的候选且无 checkpoint
+    And baby skill "ready-baby" 已达冷启动阈值且可编辑
+    When watcher 调度 SkillEdit
+    Then 提交列表应包含 "ready-baby"
+    And 提交列表不应包含 "thin-baby"
+
+  @recovery @state_machine
+  Scenario: 无 git 目录只跳过该 skill 不中断整轮
+    Given skill 目录 "broken-nongit" 存在但没有 .git
+    And baby skill "ready-baby" 已达冷启动阈值且可编辑
+    When watcher 调度 SkillEdit
+    Then 整轮调度不应因 NotGitRepository 失败
+    And 提交列表应包含 "ready-baby"
+    And 提交列表不应包含 "broken-nongit"
+
+  @recovery @state_machine
+  Scenario: actionable 检查抛错只排除该 skill
+    Given baby skill "boom-skill" 在 actionable 检查时会抛错
+    And baby skill "ready-baby" 已达冷启动阈值且可编辑
+    When watcher 调度 SkillEdit
+    Then 提交列表应包含 "ready-baby"
+    And 提交列表不应包含 "boom-skill"

--- a/tests/bdd/features/skill_edit/skill_edit_schedule_actionable.feature
+++ b/tests/bdd/features/skill_edit/skill_edit_schedule_actionable.feature
@@ -23,13 +23,13 @@ Feature: SkillEdit 只把 actionable skill 提交进 edit 池
     And 提交列表不应包含 "thin-baby"
 
   @recovery @state_machine
-  Scenario: 无 git 目录只跳过该 skill 不中断整轮
+  Scenario: 无 git 目录不中断整轮且不饿死 READY baby
     Given skill 目录 "broken-nongit" 存在但没有 .git
     And baby skill "ready-baby" 已达冷启动阈值且可编辑
     When watcher 调度 SkillEdit
     Then 整轮调度不应因 NotGitRepository 失败
     And 提交列表应包含 "ready-baby"
-    And 提交列表不应包含 "broken-nongit"
+    And 本轮应先提交 "ready-baby"
 
   @recovery @state_machine
   Scenario: actionable 检查抛错只排除该 skill

--- a/tests/bdd/features/skill_edit/skill_edit_trace.feature
+++ b/tests/bdd/features/skill_edit/skill_edit_trace.feature
@@ -28,5 +28,22 @@ Feature: 操作者可以从一份 SkillEdit trace 解释整个冷启动过程
     Then 日志中 spill 事件应当出现在 compact 事件之前
     And 日志应当显示 compact 前后的 token 数量
     And 日志应当显示模型调用失败的可读原因
+    And exhausted 日志行应当包含原始错误文本
     And 日志应当显示 "Retry batch reduced: 5 -> 2"
     And 下一次 TURN START 应当显示 N=2
+
+  @observability @recovery @state_machine
+  Scenario: 无关键词的 5xx ModelProviderError 仍按 status_code 重试
+    Given 模型抛出 status_code=500 且 message 为 "server error" 的 ModelProviderError
+    And 客户端 max_retries 为 3
+    When 调用生产 retry wrapper
+    Then invoke 应被尝试 3 次
+    And exhausted 日志行应当包含 "server error"
+
+  @observability @recovery @state_machine
+  Scenario: 中文 429 ModelProviderError 仍按 status_code 重试
+    Given 模型抛出 status_code=429 且 message 为 "当前并发请求过多，请稍后重试" 的 ModelProviderError
+    And 客户端 max_retries 为 3
+    When 调用生产 retry wrapper
+    Then invoke 应被尝试 3 次
+    And exhausted 日志行应当包含 "当前并发请求过多"

--- a/tests/bdd/test_skill_edit_state_machine.py
+++ b/tests/bdd/test_skill_edit_state_machine.py
@@ -160,10 +160,10 @@ def test_thin_baby_without_checkpoint_is_not_submitted() -> None:
 
 @scenario(
     "features/skill_edit/skill_edit_schedule_actionable.feature",
-    "无 git 目录只跳过该 skill 不中断整轮",
+    "无 git 目录不中断整轮且不饿死 READY baby",
 )
 def test_nongit_directory_does_not_abort_schedule_round() -> None:
-    """Missing .git skips that skill; other actionable skills still submit."""
+    """Missing .git must not crash the scan or starve READY babies."""
 
 
 @scenario(

--- a/tests/bdd/test_skill_edit_state_machine.py
+++ b/tests/bdd/test_skill_edit_state_machine.py
@@ -29,9 +29,11 @@ from xskill.pipeline.registry import register_dir
 from xskill.pipeline.runner import DirectoryWatcher, SKILL_EDIT_N1_FAIL_DEPRIORITIZE
 from xskill.skill import candidates as candidate_buffer
 from xskill.skill.git import (
+    BABY_STUB_BODY_MARKER,
     commit_baby_checkpoint,
     current_branch,
     init_skill_repo_on_baby,
+    run_git,
 )
 from tests.pool_helpers import pool_config
 from tests.test_atom_task_store import _FakeEmbed
@@ -124,6 +126,54 @@ def test_n1_failures_deprioritize_and_switch_skill() -> None:
     """After three N=1 failures the hard skill yields the edit slot."""
 
 
+@scenario(
+    "features/skill_edit/baby_stub_graduate_guard.feature",
+    "直接调用 commit_baby_to_main 时 stub 未清除则报错",
+)
+def test_commit_baby_to_main_rejects_init_stub() -> None:
+    """Empty-graduate via the legacy tool must fail while SKILL.md is stub."""
+
+
+@scenario(
+    "features/skill_edit/baby_stub_graduate_guard.feature",
+    "candidates 已空但 stub 仍在时框架重写后再晋升",
+)
+def test_empty_buffer_stub_retriggers_rewrite_before_main() -> None:
+    """Framework refuses graduate, forces rewrite, then promotes."""
+
+
+@scenario(
+    "features/skill_edit/skill_edit_schedule_actionable.feature",
+    "main 无 ux_score 不进池，READY baby 进池",
+)
+def test_main_without_ux_is_not_submitted() -> None:
+    """Non-actionable main must not occupy the edit submit window."""
+
+
+@scenario(
+    "features/skill_edit/skill_edit_schedule_actionable.feature",
+    "未达阈值且无 checkpoint 的 baby 不进池",
+)
+def test_thin_baby_without_checkpoint_is_not_submitted() -> None:
+    """Below-threshold baby without checkpoint is filtered before submit."""
+
+
+@scenario(
+    "features/skill_edit/skill_edit_schedule_actionable.feature",
+    "无 git 目录只跳过该 skill 不中断整轮",
+)
+def test_nongit_directory_does_not_abort_schedule_round() -> None:
+    """Missing .git skips that skill; other actionable skills still submit."""
+
+
+@scenario(
+    "features/skill_edit/skill_edit_schedule_actionable.feature",
+    "actionable 检查抛错只排除该 skill",
+)
+def test_actionable_check_exception_isolates_one_skill() -> None:
+    """Per-skill filter exceptions must not abort the whole edit scan."""
+
+
 def _tool_name(tool: Any) -> str:
     return getattr(tool, "__name__", None) or getattr(tool, "name", "")
 
@@ -162,6 +212,9 @@ class StateWorld:
     retry_max_retries: int = 3
     retry_calls: int = 0
     retry_trace: str = ""
+    tool_graduate_result: str = ""
+    rewrite_turns: int = 0
+    schedule_error: BaseException | None = None
 
     @property
     def trace_path(self) -> Path:
@@ -356,6 +409,9 @@ class _DeterministicEditAgent:
         rules = "\n".join(
             f"- processed {atom_id}" for atom_id in world.processed_atoms
         )
+        if not atom_ids:
+            rules = "- stub rewrite: formal body without placeholder"
+            world.rewrite_turns += 1
         content = (
             "---\n"
             f"name: {skill.group(1)}\n"
@@ -372,6 +428,8 @@ class _DeterministicEditAgent:
             content,
         )
         assert write_result.startswith("wrote:")
+        if "commit_baby" not in self.tools:
+            return SimpleNamespace(content="done")
         commit_result = _call_tool(
             self.tools["commit_baby"],
             skill.group(1),
@@ -967,7 +1025,14 @@ def watcher_schedules_skill_edit(state_world: StateWorld) -> None:
     release = watcher._bdd_release  # type: ignore[attr-defined]
     started.clear()
     release.clear()
-    watcher._check_pending_skill_edits()
+    state_world.schedule_error = None
+    state_world.submitted_skill_names = []
+    try:
+        watcher._check_pending_skill_edits()
+    except BaseException as exc:
+        state_world.schedule_error = exc
+        release.set()
+        raise
     assert started.wait(timeout=5), "edit worker did not start"
     state_world.submitted_skill_names = [
         info["skill_dir"].name
@@ -984,6 +1049,89 @@ def first_submitted_skill(state_world: StateWorld, name: str) -> None:
     assert state_world.submitted_skill_names[0] == name
 
 
+@then(parsers.parse('提交列表应包含 "{name}"'))
+def submitted_list_contains(state_world: StateWorld, name: str) -> None:
+    assert name in state_world.submitted_skill_names, (
+        f"{name} missing from submitted={state_world.submitted_skill_names}"
+    )
+
+
+@then(parsers.parse('提交列表不应包含 "{name}"'))
+def submitted_list_excludes(state_world: StateWorld, name: str) -> None:
+    assert name not in state_world.submitted_skill_names, (
+        f"{name} unexpectedly in submitted={state_world.submitted_skill_names}"
+    )
+
+
+@then("整轮调度不应因 NotGitRepository 失败")
+def schedule_round_did_not_fail(state_world: StateWorld) -> None:
+    assert state_world.schedule_error is None
+
+
+@given(parsers.parse('baby skill "{name}" 已达冷启动阈值且可编辑'))
+def baby_ready_for_edit(state_world: StateWorld, name: str) -> None:
+    _seed_named_baby(state_world, name=name, count=1, weight=10)
+
+
+@given(
+    parsers.parse(
+        'main skill "{name}" 有候选但还没有 main 侧 ux_score'
+    )
+)
+def main_ready_without_ux(state_world: StateWorld, name: str) -> None:
+    skill_dir = _seed_named_baby(state_world, name=name, count=1, weight=10)
+    assert run_git(
+        ["branch", "-m", "baby", "main"],
+        cwd=str(skill_dir),
+    )[0] == 0
+    assert current_branch(str(skill_dir)) == "main"
+    assert not (skill_dir / ".ux_scores.jsonl").exists()
+
+
+@given(
+    parsers.parse(
+        'baby skill "{name}" 仅有不足阈值的候选且无 checkpoint'
+    )
+)
+def thin_baby_below_threshold(state_world: StateWorld, name: str) -> None:
+    skill_dir = _seed_named_baby(state_world, name=name, count=1, weight=1)
+    assert run_git(
+        ["rev-parse", "baby~1"],
+        cwd=str(skill_dir),
+    )[0] != 0
+
+
+@given(parsers.parse('skill 目录 "{name}" 存在但没有 .git'))
+def nongit_skill_directory(state_world: StateWorld, name: str) -> None:
+    skill_dir = state_world.skill_root / name
+    skill_dir.mkdir()
+    (skill_dir / "SKILL.md").write_text(
+        "---\nname: broken\ndescription: not a git repo\n---\n\n# broken\n",
+        encoding="utf-8",
+    )
+    assert not (skill_dir / ".git").exists()
+    state_world.skill_dirs[name] = skill_dir
+
+
+@given(
+    parsers.parse('baby skill "{name}" 在 actionable 检查时会抛错'),
+)
+def baby_raises_during_actionable_check(
+    state_world: StateWorld,
+    name: str,
+    monkeypatch: pytest.MonkeyPatch,
+) -> None:
+    skill_dir = _seed_named_baby(state_world, name=name, count=1, weight=10)
+    original = candidate_buffer.load_candidates
+
+    def _load_or_boom(path: Path, *args: Any, **kwargs: Any) -> Any:
+        if Path(path).resolve() == skill_dir.resolve():
+            raise RuntimeError("bdd actionable boom")
+        return original(path, *args, **kwargs)
+
+    monkeypatch.setattr(candidate_buffer, "load_candidates", _load_or_boom)
+
+
 @then(parsers.parse('"{name}" 的 candidates 原子应当全部保留'))
 def skill_candidates_preserved(state_world: StateWorld, name: str) -> None:
     skill_dir = state_world.skill_dirs[name]
@@ -997,3 +1145,84 @@ def skill_retry_batch_still_one(state_world: StateWorld, name: str) -> None:
     assert watcher is not None
     skill_dir = state_world.skill_dirs[name]
     assert watcher._skill_edit_retry_batch_sizes.get(skill_dir) == 1
+
+
+@given(parsers.parse('baby skill "{name}" 仍是 init stub 正文'))
+def baby_still_has_init_stub(state_world: StateWorld, name: str) -> None:
+    state_world.skill_name = name
+    state_world.skill_dir = state_world.skill_root / name
+    init_skill_repo_on_baby(
+        str(state_world.skill_dir),
+        name=name,
+        description="BDD stub graduate guard",
+    )
+    body = (state_world.skill_dir / "SKILL.md").read_text(encoding="utf-8")
+    assert BABY_STUB_BODY_MARKER in body
+    assert current_branch(str(state_world.skill_dir)) == "baby"
+
+
+@given("candidates 已经为空")
+def candidates_are_empty_buffer(state_world: StateWorld) -> None:
+    assert state_world.skill_dir is not None
+    candidate_buffer.save_candidates(
+        state_world.skill_dir,
+        {"candidates": []},
+    )
+
+
+@given("已有一次未改写 stub 的 baby checkpoint")
+def checkpoint_without_rewriting_stub(state_world: StateWorld) -> None:
+    assert state_world.skill_dir is not None
+    note = state_world.skill_dir / "scripts" / "note.txt"
+    note.write_text("checkpoint without rewriting stub\n", encoding="utf-8")
+    assert run_git(["add", "scripts/note.txt"], cwd=str(state_world.skill_dir))[0] == 0
+    assert run_git(
+        ["commit", "-m", "checkpoint without rewriting stub"],
+        cwd=str(state_world.skill_dir),
+    )[0] == 0
+    body = (state_world.skill_dir / "SKILL.md").read_text(encoding="utf-8")
+    assert BABY_STUB_BODY_MARKER in body
+    assert run_git(["rev-parse", "baby~1"], cwd=str(state_world.skill_dir))[0] == 0
+
+
+@when("模型调用 commit_baby_to_main 尝试毕业")
+def model_calls_commit_baby_to_main(state_world: StateWorld) -> None:
+    assert state_world.skill_name is not None
+    state_world.tool_graduate_result = _call_tool(
+        agent_tools.commit_baby_to_main,
+        state_world.skill_name,
+        "v1: should be rejected while stub remains",
+    )
+
+
+@when("watcher 再次调度这个 baby 的 SkillEdit")
+def watcher_reschedules_stub_baby(state_world: StateWorld) -> None:
+    _run_state_agent(state_world)
+
+
+@then("工具应当返回 stub 拒绝错误")
+def tool_returns_stub_rejection(state_world: StateWorld) -> None:
+    message = state_world.tool_graduate_result.lower()
+    assert state_world.tool_graduate_result.startswith("error:")
+    assert "stub" in message or "placeholder" in message
+
+
+@then("框架应当先触发一轮 stub 重写")
+def framework_triggered_stub_rewrite(state_world: StateWorld) -> None:
+    assert state_world.rewrite_turns >= 1
+    assert state_world.trace_path.is_file()
+    assert "stub" in state_world.trace.lower()
+
+
+@then("SkillEdit 应当成功并把 baby 晋升为 main")
+def skill_edit_promoted_to_main(state_world: StateWorld) -> None:
+    assert state_world.result is True
+    assert state_world.skill_dir is not None
+    assert current_branch(str(state_world.skill_dir)) == "main"
+
+
+@then("最终 SKILL.md 不应当再含 init placeholder")
+def final_skill_md_has_no_placeholder(state_world: StateWorld) -> None:
+    assert state_world.skill_dir is not None
+    body = (state_world.skill_dir / "SKILL.md").read_text(encoding="utf-8")
+    assert BABY_STUB_BODY_MARKER not in body

--- a/tests/bdd/test_skill_edit_state_machine.py
+++ b/tests/bdd/test_skill_edit_state_machine.py
@@ -10,25 +10,32 @@ from __future__ import annotations
 
 import json
 import re
+import threading
 from dataclasses import dataclass, field
 from pathlib import Path
 from types import SimpleNamespace
 from typing import Any
 
 import pytest
-from pytest_bdd import given, scenario, then, when
+from agno.exceptions import ModelProviderError
+from pytest_bdd import given, parsers, scenario, then, when
 
 from xskill.agents import agent_tools, agent_trace
 from xskill.agents.agno_factory import _wrap_with_retry, _wrap_with_trace
 from xskill.agents.context_budget import ContextManager
 from xskill.agents.skill_edit_agent import SkillEditAgent
 from xskill.pipeline.atom import AtomTaskStore
+from xskill.pipeline.registry import register_dir
+from xskill.pipeline.runner import DirectoryWatcher, SKILL_EDIT_N1_FAIL_DEPRIORITIZE
 from xskill.skill import candidates as candidate_buffer
 from xskill.skill.git import (
     commit_baby_checkpoint,
     current_branch,
     init_skill_repo_on_baby,
 )
+from tests.pool_helpers import pool_config
+from tests.test_atom_task_store import _FakeEmbed
+from tests.test_task_agent import _AutoSplitLLM
 
 
 pytestmark = [
@@ -85,6 +92,38 @@ def test_trace_shows_spill_before_compact_and_retry_reduction() -> None:
     """Production context events preserve their causal order in the trace."""
 
 
+@scenario(
+    "features/skill_edit/skill_edit_trace.feature",
+    "无关键词的 5xx ModelProviderError 仍按 status_code 重试",
+)
+def test_status_code_500_retries_without_message_keywords() -> None:
+    """ModelProviderError status_code drives retry, not str(exc) keywords."""
+
+
+@scenario(
+    "features/skill_edit/skill_edit_trace.feature",
+    "中文 429 ModelProviderError 仍按 status_code 重试",
+)
+def test_chinese_429_retries_via_status_code() -> None:
+    """Chinese rate-limit copy without '429' still retries via status_code."""
+
+
+@scenario(
+    "features/skill_edit/baby_cold_start_recovery.feature",
+    "错误分相同时原子更少的 skill 优先调度",
+)
+def test_fewer_atoms_are_scheduled_first() -> None:
+    """Watcher submit order prefers fewer pending atoms when errors tie."""
+
+
+@scenario(
+    "features/skill_edit/baby_cold_start_recovery.feature",
+    "N=1 连败 3 次后降优先级并换下一个 skill",
+)
+def test_n1_failures_deprioritize_and_switch_skill() -> None:
+    """After three N=1 failures the hard skill yields the edit slot."""
+
+
 def _tool_name(tool: Any) -> str:
     return getattr(tool, "__name__", None) or getattr(tool, "name", "")
 
@@ -116,6 +155,13 @@ class StateWorld:
     result: bool | None = None
     next_batch_size: int | None = None
     first_five: list[str] = field(default_factory=list)
+    skill_dirs: dict[str, Path] = field(default_factory=dict)
+    watcher: DirectoryWatcher | None = None
+    submitted_skill_names: list[str] = field(default_factory=list)
+    retry_exc: Exception | None = None
+    retry_max_retries: int = 3
+    retry_calls: int = 0
+    retry_trace: str = ""
 
     @property
     def trace_path(self) -> Path:
@@ -236,7 +282,9 @@ def _exercise_context_pressure(world: StateWorld) -> None:
     class _RateLimitedModel:
         @staticmethod
         def invoke(_messages: list[Any], **_kwargs: Any) -> Any:
-            raise RuntimeError("429 rate limit from deterministic backend")
+            raise RuntimeError(
+                "429 rate limit from deterministic backend"
+            )
 
     model = _RateLimitedModel()
     manager = ContextManager(
@@ -714,6 +762,13 @@ def trace_shows_readable_model_error(state_world: StateWorld) -> None:
     assert "LLM returned 429; retries exhausted (1/1)" in state_world.trace
 
 
+@then("exhausted 日志行应当包含原始错误文本")
+def exhausted_line_includes_raw_error(state_world: StateWorld) -> None:
+    assert "retries exhausted (1/1): 429 rate limit from deterministic backend" in (
+        state_world.trace
+    )
+
+
 @then('日志应当显示 "Retry batch reduced: 5 -> 2"')
 def trace_shows_batch_reduction(state_world: StateWorld) -> None:
     assert "Retry batch reduced: 5 -> 2" in state_world.trace
@@ -722,3 +777,223 @@ def trace_shows_batch_reduction(state_world: StateWorld) -> None:
 @then("下一次 TURN START 应当显示 N=2")
 def next_turn_marker_uses_two(state_world: StateWorld) -> None:
     assert "TURN START | N=2 | processing 2 of 5 pending atoms" in state_world.trace
+
+
+@given(
+    parsers.parse(
+        '模型抛出 status_code={status_code:d} 且 message 为 "{message}" '
+        "的 ModelProviderError"
+    )
+)
+def model_provider_error_pending(
+    state_world: StateWorld,
+    status_code: int,
+    message: str,
+) -> None:
+    state_world.retry_exc = ModelProviderError(message, status_code=status_code)
+
+
+@given(parsers.parse("客户端 max_retries 为 {max_retries:d}"))
+def client_max_retries(state_world: StateWorld, max_retries: int) -> None:
+    state_world.retry_max_retries = max_retries
+
+
+@when("调用生产 retry wrapper")
+def invoke_production_retry_wrapper(
+    state_world: StateWorld,
+    monkeypatch: pytest.MonkeyPatch,
+) -> None:
+    assert state_world.retry_exc is not None
+    monkeypatch.setattr(
+        "xskill.utils.shutdown.SHUTTING_DOWN.wait",
+        lambda *_args, **_kwargs: False,
+    )
+
+    class _AlwaysFails:
+        def __init__(self) -> None:
+            self.calls = 0
+
+        def invoke(self, _messages: list[Any], **_kwargs: Any) -> Any:
+            self.calls += 1
+            raise state_world.retry_exc
+
+    model = _AlwaysFails()
+    _wrap_with_retry(
+        model,
+        {
+            "base_url": "http://127.0.0.1:1/v1",
+            "max_retries": state_world.retry_max_retries,
+            "retry_base_delay": 0.001,
+            "retry_max_delay": 0.001,
+        },
+    )
+    sink = state_world.root / "retry-trace.log"
+    with agent_trace.trace_to(sink):
+        with pytest.raises(Exception):
+            model.invoke([])
+    state_world.retry_calls = model.calls
+    state_world.retry_trace = sink.read_text(encoding="utf-8")
+
+
+@then(parsers.parse("invoke 应被尝试 {calls:d} 次"))
+def invoke_attempt_count(state_world: StateWorld, calls: int) -> None:
+    assert state_world.retry_calls == calls
+
+
+@then(parsers.parse('exhausted 日志行应当包含 "{fragment}"'))
+def exhausted_contains_fragment(state_world: StateWorld, fragment: str) -> None:
+    assert "retries exhausted" in state_world.retry_trace
+    assert fragment in state_world.retry_trace
+
+
+def _seed_named_baby(
+    world: StateWorld,
+    *,
+    name: str,
+    count: int,
+    weight: int = 10,
+) -> Path:
+    skill_dir = world.skill_root / name
+    init_skill_repo_on_baby(
+        str(skill_dir),
+        name=name,
+        description="BDD scheduler draft",
+    )
+    data: dict[str, Any] = {"candidates": []}
+    for index in range(1, count + 1):
+        data, _ = candidate_buffer.add_atom_contribution(
+            data,
+            f"{name}-atom-{index:02d}",
+            weight,
+            note=f"knowledge for {name} {index}",
+        )
+    candidate_buffer.save_candidates(skill_dir, data)
+    world.skill_dirs[name] = skill_dir
+    return skill_dir
+
+
+def _blocking_edit_factory(started: threading.Event, release: threading.Event):
+    class _BlockingAgent:
+        def __init__(self, *, instructions: list[str], tools: list[Any]):
+            del instructions, tools
+
+        def run(self, _user_msg: str, **_kwargs: Any) -> Any:
+            started.set()
+            if not release.wait(timeout=5):
+                raise TimeoutError("scheduler BDD release timed out")
+            raise RuntimeError("scheduler BDD holds the edit worker")
+
+    def factory(*, instructions: list[str], tools: list[Any]) -> Any:
+        return _BlockingAgent(instructions=instructions, tools=tools)
+
+    return factory
+
+
+def _ensure_scheduler_watcher(state_world: StateWorld) -> DirectoryWatcher:
+    if state_world.watcher is not None:
+        return state_world.watcher
+    db_path = state_world.root / "scheduler.db"
+    watch_root = state_world.root / "watch"
+    watch_root.mkdir(exist_ok=True)
+    register_dir(watch_root, db_path=db_path)
+    started = threading.Event()
+    release = threading.Event()
+    watcher = DirectoryWatcher(
+        llm=_AutoSplitLLM(),
+        embed_client=_FakeEmbed(),
+        config={"llm": {"base_url": "x", "model": "y", "api_key": "z"}},
+        skill_dir=state_world.skill_root,
+        poll_interval=0.0,
+        pool_config=pool_config(workers=1, edit_workers=1),
+        db_path=db_path,
+        store=AtomTaskStore(root=watch_root),
+        agno_agent_factory=_blocking_edit_factory(started, release),
+        home_root=state_world.root,
+        logs_dir=state_world.logs_root,
+    )
+    watcher._bdd_started = started  # type: ignore[attr-defined]
+    watcher._bdd_release = release  # type: ignore[attr-defined]
+    state_world.watcher = watcher
+    return watcher
+
+
+@given(
+    parsers.parse(
+        '两个 baby skill "{left}" 有 {left_count:d} 个原子且 '
+        '"{right}" 有 {right_count:d} 个原子'
+    )
+)
+def two_baby_skills(
+    state_world: StateWorld,
+    left: str,
+    left_count: int,
+    right: str,
+    right_count: int,
+) -> None:
+    _seed_named_baby(state_world, name=left, count=left_count)
+    _seed_named_baby(state_world, name=right, count=right_count)
+
+
+@given("两者错误分均为 0")
+def both_error_counts_zero(state_world: StateWorld) -> None:
+    assert state_world.skill_dirs
+    return None
+
+
+@given(parsers.parse('"{name}" 已在 N=1 上连续失败 {fails:d} 次'))
+def skill_has_n1_failures(
+    state_world: StateWorld,
+    name: str,
+    fails: int,
+) -> None:
+    assert fails == SKILL_EDIT_N1_FAIL_DEPRIORITIZE
+    watcher = _ensure_scheduler_watcher(state_world)
+    skill_dir = state_world.skill_dirs[name]
+    for _ in range(fails):
+        watcher._on_skill_edit_done((skill_dir, False, 1))
+    assert watcher._skill_edit_error_counts.get(skill_dir, 0) == 1
+    assert watcher._skill_edit_retry_batch_sizes.get(skill_dir) == 1
+
+
+@given("edit pool 一次只能跑 1 个 skill")
+def edit_pool_is_single_worker(state_world: StateWorld) -> None:
+    _ensure_scheduler_watcher(state_world)
+
+
+@when("watcher 调度 SkillEdit")
+def watcher_schedules_skill_edit(state_world: StateWorld) -> None:
+    watcher = _ensure_scheduler_watcher(state_world)
+    started = watcher._bdd_started  # type: ignore[attr-defined]
+    release = watcher._bdd_release  # type: ignore[attr-defined]
+    started.clear()
+    release.clear()
+    watcher._check_pending_skill_edits()
+    assert started.wait(timeout=5), "edit worker did not start"
+    state_world.submitted_skill_names = [
+        info["skill_dir"].name
+        for info in watcher._futures.values()
+        if info.get("stage") == "skill_edit"
+    ]
+    release.set()
+    watcher._drain_futures(stage="skill_edit", timeout=10)
+
+
+@then(parsers.parse('本轮应先提交 "{name}"'))
+def first_submitted_skill(state_world: StateWorld, name: str) -> None:
+    assert state_world.submitted_skill_names, "no skill_edit futures submitted"
+    assert state_world.submitted_skill_names[0] == name
+
+
+@then(parsers.parse('"{name}" 的 candidates 原子应当全部保留'))
+def skill_candidates_preserved(state_world: StateWorld, name: str) -> None:
+    skill_dir = state_world.skill_dirs[name]
+    remaining = candidate_buffer.load_candidates(skill_dir)["candidates"]
+    assert remaining, f"{name} candidates were cleared"
+
+
+@then(parsers.parse('"{name}" 的重试批次仍为 N=1'))
+def skill_retry_batch_still_one(state_world: StateWorld, name: str) -> None:
+    watcher = state_world.watcher
+    assert watcher is not None
+    skill_dir = state_world.skill_dirs[name]
+    assert watcher._skill_edit_retry_batch_sizes.get(skill_dir) == 1

--- a/tests/test_agent_worker_runtime.py
+++ b/tests/test_agent_worker_runtime.py
@@ -86,6 +86,164 @@ def test_all_pool_thread_names_are_visible():
             pool.shutdown(wait=True)
 
 
+def _wait_for(predicate, timeout=2.0):
+    deadline = time.time() + timeout
+    while time.time() < deadline:
+        if predicate():
+            return True
+        time.sleep(0.02)
+    return False
+
+
+def test_seats_are_fixed_completion_clears_only_own_index():
+    """流水线 Monitor 席位模型：一席一位，完成只清该坑，邻居不左挤。"""
+    pool = BoundedExecutor("edit", 3)
+    gates = [threading.Event() for _ in range(3)]
+    try:
+        futures = [
+            pool.submit(gate.wait, 2, task={"kind": "skill", "n": index})
+            for index, gate in enumerate(gates)
+        ]
+        assert all(future is not None for future in futures)
+        assert _wait_for(lambda: all(pool.status["seats"]))
+        seats = pool.status["seats"]
+        assert [seat["seat"] for seat in seats] == [0, 1, 2]
+        assert [seat["task"]["n"] for seat in seats] == [0, 1, 2]
+        assert all(seat["started_at"] > 0 for seat in seats)
+
+        gates[1].set()  # 中间席位完成：只清下标 1，0/2 不动
+        assert futures[1].result(2) is True
+        assert _wait_for(lambda: pool.status["seats"][1] is None)
+        seats = pool.status["seats"]
+        assert [seat["task"]["n"] if seat else None for seat in seats] == [0, None, 2]
+
+        gates[0].set()
+        gates[2].set()
+        for future in (futures[0], futures[2]):
+            future.result(2)
+        assert pool.status["seats"] == [None, None, None]
+        assert pool.status["completed"] == 3
+    finally:
+        for gate in gates:
+            gate.set()
+        pool.shutdown(wait=True)
+
+
+def test_new_task_takes_lowest_free_seat_and_task_factory_overrides():
+    """新任务补最低空席；task_factory 在工作线程起跑时求值并覆盖静态 task。"""
+    pool = BoundedExecutor("edit", 2)
+    gate = threading.Event()
+    try:
+        hold = pool.submit(gate.wait, 2, task={"kind": "skill", "skill_name": "held"})
+        assert hold is not None
+        assert _wait_for(lambda: pool.status["seats"][0] is not None)
+
+        fresh = pool.submit(
+            lambda: "done",
+            task={"kind": "skill", "skill_name": "static"},
+            task_factory=lambda: {"kind": "skill", "skill_name": "fresh",
+                                  "xfer": "baby_main"},
+        )
+        assert fresh is not None
+        assert fresh.result(2) == "done"
+        # factory 结果曾落在席位 1（最低空席）；完成后席位清空
+        assert pool.status["seats"][1] is None
+        gate.set()
+        hold.result(2)
+    finally:
+        gate.set()
+        pool.shutdown(wait=True)
+
+
+def test_task_factory_failure_falls_back_to_static_task():
+    """监看元数据求值失败绝不拖垮真任务：席位退回 submit 时的静态 task。"""
+    pool = BoundedExecutor("edit", 1)
+    try:
+        future = pool.submit(
+            lambda: "ok",
+            task={"kind": "skill", "skill_name": "static"},
+            task_factory=lambda: (_ for _ in ()).throw(RuntimeError("git down")),
+        )
+        assert future is not None
+        assert future.result(2) == "ok"
+        assert pool.status["completed"] == 1
+        assert pool.status["failed"] == 0
+    finally:
+        pool.shutdown(wait=True)
+
+
+def test_queued_preview_fifo_and_drop_on_start():
+    """排队预览：FIFO 记录 task 元数据，起跑即移除，席位起跑后不再出现。"""
+    pool = BoundedExecutor("split", 1)
+    gate = threading.Event()
+    try:
+        running = pool.submit(gate.wait, 2, task={"kind": "traj", "traj_id": "t0"})
+        assert running is not None
+        assert _wait_for(lambda: pool.status["running"] == 1)
+        queued = [
+            pool.submit(gate.wait, 2, task={"kind": "traj", "traj_id": f"t{index}"})
+            for index in (1, 2)
+        ]
+        assert all(future is not None for future in queued)
+        assert pool.status["queue"] == [
+            {"kind": "traj", "traj_id": "t1"},
+            {"kind": "traj", "traj_id": "t2"},
+        ]
+        gate.set()
+        running.result(2)
+        for future in queued:
+            future.result(2)
+        assert pool.status["queue"] == []
+        assert pool.status["queued"] == 0
+    finally:
+        gate.set()
+        pool.shutdown(wait=True)
+
+
+def test_queued_preview_never_exceeds_cap_and_status_copies_are_independent():
+    """预览只够看不许无限增长；status 的 seats/queue 是拷贝，可安全落盘。"""
+    from xskill.pipeline.worker_runtime import _QUEUED_PREVIEW_LIMIT
+
+    # workers=26 → 排队容量 52 > 预览上限 50，才能把预览顶到 cap。
+    pool = BoundedExecutor("split", 26)
+    gate = threading.Event()
+    try:
+        futures = [
+            pool.submit(gate.wait, 2, task={"n": index})
+            for index in range(26 + 52)
+        ]
+        assert all(future is not None for future in futures)
+        assert _wait_for(lambda: pool.status["running"] == 26)
+        assert _wait_for(lambda: len(pool.status["queue"]) == _QUEUED_PREVIEW_LIMIT)
+        preview = pool.status["queue"]
+        assert len(preview) == _QUEUED_PREVIEW_LIMIT
+        assert len({task["n"] for task in preview}) == _QUEUED_PREVIEW_LIMIT
+        preview[0]["n"] = -1
+        assert pool.status["queue"][0]["n"] != -1
+    finally:
+        gate.set()
+        pool.shutdown(wait=True, cancel_futures=True)
+
+
+def test_submit_rejection_leaves_no_seat_or_queue_residue():
+    """容量满拒收返回 None：席位/排队预览/计数都不留残渣。"""
+    pool = BoundedExecutor("edit", 1)
+    gate = threading.Event()
+    try:
+        accepted = [pool.submit(gate.wait, 2, task={"n": i}) for i in range(3)]
+        assert all(future is not None for future in accepted)
+        assert _wait_for(lambda: pool.status["running"] == 1)
+        assert _wait_for(lambda: pool.status["queued"] == 2)
+        assert pool.submit(gate.wait, 2, task={"n": 99}) is None
+        status = pool.status
+        assert status["queued"] == 2
+        assert [task["n"] for task in status["queue"]] == [1, 2]
+        assert len([seat for seat in status["seats"] if seat]) == 1
+    finally:
+        gate.set()
+        pool.shutdown(wait=True, cancel_futures=True)
+
+
 def test_shared_request_limiter_caps_real_http_inflight():
     limiter = SharedRequestLimiter(
         max_inflight=2,

--- a/tests/test_dashboard_pipeline_live.py
+++ b/tests/test_dashboard_pipeline_live.py
@@ -1,0 +1,216 @@
+"""流水线 Monitor：pipeline_live 只读整形 + router 端点（含公网白名单裁剪）。
+
+原则：禁止 fallback 糊弄——状态文件缺失/老版 worker/日志不存在一律显式空态。
+"""
+from __future__ import annotations
+
+import json
+import time
+
+import pytest
+from fastapi import FastAPI
+from fastapi.testclient import TestClient
+
+from xskill.dashboard.pipeline_live import pipeline_live, tail_task_log
+from xskill.dashboard.router import build_dashboard_router
+from xskill.pipeline.registry import get_connection
+from xskill.utils.status_file import AGENT_WORKER_STATUS_FILE
+
+
+def _write_status(home, stats, *, ok=True, error=None):
+    payload = {"ok": ok, "error": error, "ended_at": time.time(), "stats": stats}
+    (home / AGENT_WORKER_STATUS_FILE).write_text(
+        json.dumps(payload, ensure_ascii=False), encoding="utf-8")
+
+
+def _full_stats():
+    now = time.time()
+    return {
+        "pid": 1234,
+        "started_at": now - 60,
+        "heartbeat_at": now,
+        "watcher": {"running": True, "polls": 9},
+        "llm": {"inflight": 2, "waiting": 0, "rate_limit_waiting": 1, "retry_waiting": 0},
+        "pool_config": {
+            "split": {"workers": 2, "llm_weight": 6},
+            "cluster": {"workers": 2, "batch_size": 8, "llm_weight": 3},
+            "edit": {"workers": 3, "batch_size": 5, "llm_weight": 1},
+        },
+        "pools": {
+            "split": {
+                "workers": 2, "queued": 1, "completed": 10, "failed": 0,
+                "seats": [
+                    {"seat": 0, "started_at": now - 5,
+                     "task": {"kind": "traj", "traj_id": "traj_a", "watch_dir": "cc"}},
+                    None,
+                ],
+                "queue": [{"kind": "traj", "traj_id": "traj_b", "watch_dir": "cc"}],
+            },
+            "cluster": {
+                "workers": 2, "queued": 0, "completed": 4, "failed": 1,
+                "seats": [
+                    {"seat": 0, "started_at": now - 8,
+                     "task": {"kind": "atom_batch", "atom_ids": ["atom_1", "atom_2"]}},
+                    None,
+                ],
+                "queue": [],
+            },
+            "edit": {
+                "workers": 3, "queued": 0, "completed": 7, "failed": 0,
+                "seats": [
+                    {"seat": 0, "started_at": now - 12,
+                     "task": {"kind": "skill", "skill_name": "alpha", "xfer": "baby_main",
+                              "candidates": 2, "weightscore": 15, "branch": "baby"}},
+                    None,
+                    None,
+                ],
+                "queue": [],
+            },
+            # embed 不进监看（读库事实，不占席位色块）
+            "embed": {"workers": 2, "queued": 0, "completed": 9, "failed": 0},
+        },
+        "cluster": {"pending_atoms": 6, "claimed_atoms": 2, "running_batches": 1},
+    }
+
+
+# ── pipeline_live 整形 ────────────────────────────────────────────
+
+def test_missing_status_file_is_explicit_not_running(tmp_path):
+    body = pipeline_live(tmp_path / "r.db")
+    assert body["running"] is False
+    assert "无状态文件" in body["message"]
+    assert "pools" not in body  # 绝不编造占位池
+
+
+def test_full_status_shapes_three_monitored_pools(tmp_path):
+    _write_status(tmp_path, _full_stats())
+    body = pipeline_live(tmp_path / "r.db")
+    assert body["running"] is True
+    assert body["pid"] == 1234
+    assert body["pending_atoms"] == 6
+    assert body["llm"]["inflight"] == 2
+    assert set(body["pools"]) == {"split", "cluster", "edit"}
+
+    split = body["pools"]["split"]
+    assert split["workers"] == 2
+    assert split["llm_weight"] == 6
+    assert split["batch_size"] is None  # split 无批量配置
+    assert len(split["seats"]) == 2
+    assert split["seats"][0]["task"]["traj_id"] == "traj_a"
+    assert split["seats"][1] is None  # 固定席位：空位不左挤
+    assert split["queue"][0]["traj_id"] == "traj_b"
+
+    cluster = body["pools"]["cluster"]
+    assert cluster["batch_size"] == 8
+    assert cluster["seats"][0]["task"]["atom_ids"] == ["atom_1", "atom_2"]
+
+    edit = body["pools"]["edit"]
+    assert edit["seats"][0]["task"]["xfer"] == "baby_main"
+    assert edit["failed"] == 0
+
+
+def test_legacy_worker_without_seat_bookkeeping_gets_explicit_empty_seats(tmp_path):
+    stats = _full_stats()
+    for pool in stats["pools"].values():
+        pool.pop("seats", None)
+        pool.pop("queue", None)
+    _write_status(tmp_path, stats)
+    body = pipeline_live(tmp_path / "r.db")
+    edit = body["pools"]["edit"]
+    assert edit["seats"] == [None, None, None]  # 显式空席，不伪造任务
+    assert edit["queue"] == []
+
+
+def test_empty_stats_means_worker_not_reporting(tmp_path):
+    _write_status(tmp_path, {}, ok=False, error="boom")
+    body = pipeline_live(tmp_path / "r.db")
+    assert body["running"] is False
+    assert body["ok"] is False
+    assert body["error"] == "boom"
+
+
+# ── tail_task_log ─────────────────────────────────────────────────
+
+def test_tail_log_missing_file_is_explicit_empty_state(tmp_path):
+    body = tail_task_log(tmp_path / "r.db", kind="skill", name="nope")
+    assert body["exists"] is False
+    assert body["lines"] == []
+    assert "暂无日志" in body["message"]
+
+
+def test_tail_log_reads_last_lines(tmp_path):
+    log_dir = tmp_path / "logs" / "agents" / "skill_edit_agents" / "skills"
+    log_dir.mkdir(parents=True)
+    (log_dir / "alpha.log").write_text(
+        "\n".join(f"line-{index}" for index in range(10)), encoding="utf-8")
+    body = tail_task_log(tmp_path / "r.db", kind="skill", name="alpha", tail=3)
+    assert body["exists"] is True
+    assert body["lines"] == ["line-7", "line-8", "line-9"]
+
+
+def test_tail_log_rejects_path_traversal_and_bad_kind(tmp_path):
+    with pytest.raises(ValueError):
+        tail_task_log(tmp_path / "r.db", kind="skill", name="../secret")
+    with pytest.raises(ValueError):
+        tail_task_log(tmp_path / "r.db", kind="skill", name="a/b")
+    with pytest.raises(ValueError):
+        tail_task_log(tmp_path / "r.db", kind="atom_batch", name="x")
+
+
+# ── router 端点 ───────────────────────────────────────────────────
+
+def _client(home, *, expose_sensitive=True):
+    db = home / "r.db"
+    conn = get_connection(db)
+    conn.close()
+    app = FastAPI()
+    app.include_router(build_dashboard_router(
+        db_path=db, expose_sensitive=expose_sensitive))
+    return TestClient(app)
+
+
+def test_live_endpoint_not_running_explicit_state(tmp_path):
+    r = _client(tmp_path).get("/api/v1/dashboard/pipeline/live")
+    assert r.status_code == 200
+    assert r.json()["running"] is False
+
+
+def test_live_endpoint_serves_full_monitor_shape(tmp_path):
+    _write_status(tmp_path, _full_stats())
+    body = _client(tmp_path).get("/api/v1/dashboard/pipeline/live").json()
+    assert body["running"] is True
+    assert body["pools"]["edit"]["seats"][0]["task"]["skill_name"] == "alpha"
+    assert body["pools"]["split"]["queue"][0]["traj_id"] == "traj_b"
+
+
+def test_live_endpoint_standalone_strips_task_identity(tmp_path):
+    """公网只读实例：席位只留占用/计时，任务身份（skill/traj/atom 名）剥掉。"""
+    _write_status(tmp_path, _full_stats())
+    body = _client(tmp_path, expose_sensitive=False).get(
+        "/api/v1/dashboard/pipeline/live").json()
+    assert body["running"] is True
+    seat = body["pools"]["edit"]["seats"][0]
+    assert seat is not None and "started_at" in seat
+    assert "task" not in seat
+    assert body["pools"]["split"]["queue"] == []
+    assert body["pools"]["split"]["queued"] == 1  # 计数仍在
+
+
+def test_log_endpoint_only_on_sensitive_router(tmp_path):
+    log_dir = tmp_path / "logs" / "agents" / "task_agents"
+    log_dir.mkdir(parents=True)
+    (log_dir / "traj_a.log").write_text("TURN 1\nTOOL read\n", encoding="utf-8")
+
+    r = _client(tmp_path).get("/api/v1/dashboard/pipeline/log",
+                              params={"kind": "traj", "name": "traj_a"})
+    assert r.status_code == 200
+    assert r.json()["lines"] == ["TURN 1", "TOOL read"]
+
+    r = _client(tmp_path).get("/api/v1/dashboard/pipeline/log",
+                              params={"kind": "bogus", "name": "x"})
+    assert r.status_code == 400
+
+    # 公网只读实例物理不注册（内容级端点 404）
+    r = _client(tmp_path, expose_sensitive=False).get(
+        "/api/v1/dashboard/pipeline/log", params={"kind": "traj", "name": "traj_a"})
+    assert r.status_code == 404

--- a/tests/test_dashboard_standalone.py
+++ b/tests/test_dashboard_standalone.py
@@ -26,6 +26,8 @@ _STANDALONE_ALLOWED_OPERATIONS = {
     ("get", "/api/v1/dashboard/skills"),
     ("get", "/api/v1/dashboard/skill/{name}/ux/daily"),
     ("get", "/api/v1/dashboard/pipeline"),
+    # 流水线实时监看：公网实例剥任务身份，只留席位占用/计时与聚合计数。
+    ("get", "/api/v1/dashboard/pipeline/live"),
     ("get", "/api/v1/dashboard/skill/{name}/ux"),
     ("get", "/api/v1/dashboard/skillhub/{name}/ux"),
     ("get", "/api/v1/dashboard/skill/{name}/trigger"),
@@ -34,6 +36,8 @@ _STANDALONE_ALLOWED_OPERATIONS = {
 _BUILTIN_ONLY_OPERATIONS = {
     # 用户、原始轨迹、原子、skill 内容及逐 case 数据。
     ("get", "/api/v1/dashboard/users"),
+    # 单任务 agent trace 日志尾巴（内容级）。
+    ("get", "/api/v1/dashboard/pipeline/log"),
     ("get", "/api/v1/dashboard/skill/{name}/detail"),
     ("get", "/api/v1/dashboard/skill/{name}/graph"),
     ("get", "/api/v1/dashboard/skill/{name}/lineage"),

--- a/tests/test_description_opt_e2e.py
+++ b/tests/test_description_opt_e2e.py
@@ -254,6 +254,17 @@ def test_commit_baby_to_main_runs_optimization(tmp_path, monkeypatch):
     sd = skill_root / "log-analyzer"
     init_skill_repo_on_baby(str(sd), name="log-analyzer",
                             description="does stuff with files")
+    (sd / "SKILL.md").write_text(
+        "---\n"
+        "name: log-analyzer\n"
+        "description: does stuff with files\n"
+        "metadata:\n"
+        "  version: 1\n"
+        "---\n\n"
+        "# log-analyzer\n\n"
+        "Analyze and parse log files and error traces.\n",
+        encoding="utf-8",
+    )
 
     agent_tools.init_atom_task_tool_context(
         skill_dir=skill_root,
@@ -294,6 +305,17 @@ def test_commit_optimization_failure_does_not_block_commit(tmp_path, monkeypatch
     skill_root.mkdir()
     sd = skill_root / "boom"
     init_skill_repo_on_baby(str(sd), name="boom", description="orig desc")
+    (sd / "SKILL.md").write_text(
+        "---\n"
+        "name: boom\n"
+        "description: orig desc\n"
+        "metadata:\n"
+        "  version: 1\n"
+        "---\n\n"
+        "# boom\n\n"
+        "Real body so graduation is allowed.\n",
+        encoding="utf-8",
+    )
 
     agent_tools.init_atom_task_tool_context(
         skill_dir=skill_root,

--- a/tests/test_llm_retry.py
+++ b/tests/test_llm_retry.py
@@ -30,12 +30,38 @@ def _no_sleep(monkeypatch):
 
 
 def test_transient_classification():
+    from agno.exceptions import ModelProviderError
+
     assert _is_transient_error(Exception("Error code: 429 - rate limit"))
     assert _is_transient_error(Exception("Connection reset by peer"))
     assert _is_transient_error(Exception("503 Service Unavailable"))
+    # agno ModelProviderError: status_code 优先于 message 关键词
+    assert _is_transient_error(
+        ModelProviderError("server error", status_code=500)
+    )
+    assert _is_transient_error(
+        ModelProviderError("当前并发请求过多，请稍后重试", status_code=429)
+    )
     # 不可重试:上下文超长 / 400 invalid
     assert not _is_transient_error(Exception("maximum input length is 131071"))
     assert not _is_transient_error(Exception("invalid_request_error"))
+
+
+def test_local_rate_limit_exhausted_is_transient():
+    """本地限流桶耗尽（RateLimitExhausted）必须判瞬时并重试恢复。
+
+    回归：消息 "RPM bucket exhausted" 与 hint "rpm exhausted" 子串对不上，
+    曾被误判非瞬时 → 1/8 直接放弃，高并发下 cluster batch 全部 0 落地。
+    """
+    from xskill.utils.rate_limit import RateLimitExhausted
+    exhausted = RateLimitExhausted("RPM bucket exhausted, need wait 8.6s")
+    assert _is_transient_error(exhausted)
+    assert _is_transient_error(
+        RateLimitExhausted("TPM bucket exhausted, need wait 2.0s"))
+    model = _FlakyModel(fail_n=3, exc=exhausted)
+    _wrap_with_retry(model, {"max_retries": 8})
+    assert model.invoke([]) == "ok"
+    assert model.calls == 4  # 3 次桶耗尽重试 + 1 次成功
 
 
 def test_retry_recovers_after_transient_failures():
@@ -76,4 +102,4 @@ def test_retry_and_exhaustion_are_written_to_active_trace(tmp_path):
     trace = sink.read_text(encoding="utf-8")
     assert "LLM returned 429; retrying (1/3)" in trace
     assert "LLM returned 429; retrying (2/3)" in trace
-    assert "LLM returned 429; retries exhausted (3/3)" in trace
+    assert "LLM returned 429; retries exhausted (3/3): 429 rate limit" in trace

--- a/tests/test_skill_edit_agent.py
+++ b/tests/test_skill_edit_agent.py
@@ -76,7 +76,7 @@ class _BabyStubAgno:
         if type(self).writes_skill_md_with is not None and target_path:
             _call_tool(self.tools["write_file"], target_path, type(self).writes_skill_md_with)
         # 调 commit_baby；buffer 清空后由框架 graduate。
-        if type(self).calls_commit and skill:
+        if type(self).calls_commit and skill and "commit_baby" in self.tools:
             _call_tool(self.tools["commit_baby"], skill, "stub baby checkpoint")
         class _R: pass
         r = _R(); r.content = "done"
@@ -95,7 +95,7 @@ class _StagingStubAgno(_BabyStubAgno):
         target_path = m.group(1) if m else None
         if type(self).writes_skill_md_with is not None and target_path:
             _call_tool(self.tools["write_file"], target_path, type(self).writes_skill_md_with)
-        if type(self).calls_commit and skill:
+        if type(self).calls_commit and skill and "commit_to_staging" in self.tools:
             _call_tool(self.tools["commit_to_staging"], skill, "stub staging commit")
         class _R: pass
         r = _R(); r.content = "done"
@@ -199,6 +199,51 @@ class TestThresholdGate:
         # candidates 已清空 (v2.1: clear 取代 promoted 标记)
         data2 = C.load_candidates(skill_dir)
         assert data2["candidates"] == []
+
+    def test_stub_body_blocks_tool_graduate(self, tmp_path):
+        """init stub 未改写时 commit_baby_to_main 必须报错且留在 baby。"""
+        from xskill.agents import agent_tools
+        from xskill.skill.git import current_branch
+
+        skill_dir = _make_baby_skill(tmp_path / "skill", "still-stub")
+        msg = agent_tools.commit_baby_to_main.entrypoint(
+            "still-stub", "v1: should fail",
+        )
+        assert msg.startswith("error:")
+        assert "stub" in msg.lower() or "placeholder" in msg.lower()
+        assert current_branch(str(skill_dir)) == "baby"
+
+    def test_empty_buffer_with_stub_retriggers_rewrite_then_graduates(
+        self, tmp_path,
+    ):
+        """candidates 已空但仍是 stub → 框架重触发写正文后再 graduate。"""
+        from xskill.skill.git import current_branch, run_git
+
+        skill_dir = _make_baby_skill(tmp_path / "skill", "rewrite-me")
+        # 造一次非正文 checkpoint，让 partial_baby=True 且 buffer 可为空仍进 drain
+        (skill_dir / "scripts" / "note.txt").write_text("keep stub", encoding="utf-8")
+        assert run_git(["add", "scripts/note.txt"], cwd=str(skill_dir))[0] == 0
+        assert run_git(
+            ["commit", "-m", "checkpoint without rewriting stub"],
+            cwd=str(skill_dir),
+        )[0] == 0
+        C.save_candidates(skill_dir, {"candidates": []})
+
+        _BabyStubAgno.writes_skill_md_with = (
+            "---\nname: rewrite-me\ndescription: real\nmetadata:\n"
+            "  version: 1\n---\n# real body\n"
+        )
+        agent = SkillEditAgent(
+            skill_dir=skill_dir, store=None,
+            agno_agent_factory=_baby_factory,
+            llm_cfg={}, traj_root=tmp_path,
+            logs_dir=tmp_path / "instance-logs",
+        )
+        assert agent.maybe_run() is True
+        assert current_branch(str(skill_dir)) == "main"
+        body = (skill_dir / "SKILL.md").read_text(encoding="utf-8")
+        assert "placeholder" not in body
+        assert "# real body" in body
 
 
 # ────────────────────────────────────────────────────────────────────

--- a/tests/test_skill_edit_batch_turns.py
+++ b/tests/test_skill_edit_batch_turns.py
@@ -516,12 +516,17 @@ class TestBabyCheckpointRecovery:
                 skill = re.search(
                     r"skill_name:\s*([\w-]+)", user_msg,
                 ).group(1)
-                existing = Path(target).read_text(encoding="utf-8")
-                marker = f"\nprocessed-{len(batch_sizes)}: {','.join(atom_ids)}\n"
+                # Checkpoint 正文不得残留 init placeholder（#154）。
+                content = (
+                    f"---\nname: {skill}\ndescription: adaptive recovery\n"
+                    f"metadata:\n  version: {len(batch_sizes)}\n---\n\n"
+                    f"# Adaptive\n\n"
+                    f"processed-{len(batch_sizes)}: {','.join(atom_ids)}\n"
+                )
                 _call_tool(
                     self.tools["write_file"],
                     target,
-                    existing + marker,
+                    content,
                 )
                 _call_tool(
                     self.tools["commit_baby"],

--- a/tests/test_skill_edit_mutation_contracts.py
+++ b/tests/test_skill_edit_mutation_contracts.py
@@ -85,6 +85,37 @@ def test_graduate_baby_rejects_invalid_frontmatter_before_side_effects(
     ) is False
 
 
+def test_graduate_baby_rejects_init_stub_before_side_effects(
+    tmp_path: Path,
+    monkeypatch,
+) -> None:
+    from xskill.skill.git import BABY_STUB_BODY_MARKER, init_skill_repo_on_baby
+
+    target = tmp_path / "skills" / "stub-graduation"
+    init_skill_repo_on_baby(str(target), name="stub-graduation", description="d")
+    assert BABY_STUB_BODY_MARKER in (target / "SKILL.md").read_text(encoding="utf-8")
+
+    def unexpected(*_args, **_kwargs) -> None:
+        raise AssertionError("stub SKILL.md must not reach a side effect")
+
+    monkeypatch.setattr(
+        agent_tools,
+        "_run_description_optimization",
+        unexpected,
+    )
+    monkeypatch.setattr(
+        skill_git,
+        "commit_baby_to_main_branch",
+        unexpected,
+    )
+
+    assert agent_tools.graduate_baby_to_main(
+        target,
+        "stub-graduation",
+        "must not commit",
+    ) is False
+
+
 def test_remove_candidates_does_not_consume_a_git_write_slot(
     tmp_path: Path,
     monkeypatch,

--- a/tests/test_usage.py
+++ b/tests/test_usage.py
@@ -34,6 +34,51 @@ def test_extract_usage_missing_usage():
     assert extract_usage(None) == Usage()
 
 
+def _agno_response(**metrics_kwargs):
+    """构造真实 agno ModelResponse —— agent LLM 记账点的实际传入形态。"""
+    from agno.models.metrics import MessageMetrics
+    from agno.models.response import ModelResponse
+
+    resp = ModelResponse()
+    metrics = MessageMetrics()
+    for key, value in metrics_kwargs.items():
+        setattr(metrics, key, value)
+    resp.response_usage = metrics
+    return resp
+
+
+def test_extract_usage_agno_model_response():
+    # 回归:agno 用 response_usage(MessageMetrics)而非 OpenAI 的 usage,
+    # 字段名 input/output_tokens;不识别的历史 bug 会把 LLM 调用整段记 0。
+    resp = _agno_response(input_tokens=1523, output_tokens=87, total_tokens=1610)
+    usage = extract_usage(resp)
+    assert (usage.prompt, usage.completion, usage.total) == (1523, 87, 1610)
+    # cache_miss 补未命中余量,保证 cost_usd 分档计费 hit+miss=prompt
+    assert (usage.cache_hit, usage.cache_miss) == (0, 1523)
+
+
+def test_extract_usage_agno_total_derived():
+    resp = _agno_response(input_tokens=100, output_tokens=5, total_tokens=0)
+    assert extract_usage(resp).total == 105
+
+
+def test_extract_usage_agno_cache_read_split():
+    resp = _agno_response(input_tokens=1000, output_tokens=10,
+                          total_tokens=1010, cache_read_tokens=800)
+    usage = extract_usage(resp)
+    assert (usage.cache_hit, usage.cache_miss) == (800, 200)
+
+
+def test_record_llm_with_agno_response_counts_tokens():
+    ledger = UsageLedger(_table())
+    ledger.record_llm("skill_edit", "deepseek-v4-flash",
+                      _agno_response(input_tokens=2000, output_tokens=100,
+                                     total_tokens=2100))
+    bucket = ledger.snapshot()["by_step"]["skill_edit"]
+    assert bucket["calls"] == 1 and bucket["tokens"] == 2100
+    assert bucket["cost_usd"] > 0
+
+
 # ── PriceTable 解析优先级 ────────────────────────────────────────
 def _table():
     vendored = {"deepseek-v4-flash": {"input_per_1m": 0.14, "output_per_1m": 0.28,


### PR DESCRIPTION
## Summary

- BoundedExecutor 固定席位簿记 + 排队预览：修复旧 `submit` 遮蔽新方法的 bug（席位模型此前是死代码）；补 6 个席位行为单测。
- runner 三池提交附带任务元数据：skill（xfer/candidates/ws）、traj、atom 批（atom_ids），`task_factory` 用 `partial` 起跑时求鲜活值。
- 新增只读整形层 `pipeline_live` + 端点 `GET /pipeline/live`、`GET /pipeline/log`（公开只读实例脱敏：去任务身份、队列清空留计数；log 仅内置）。
- 前端「流水线」页：顶栏气泡（心跳/模型请求/配额排队/未归类原子/异常/三池占用）+ 三池固定席位色块（色深=跑久）+ 点选抽屉实时日志流；缺数据显式空态，无 fallback。
- 本分支已合入 `fix/usage-llm-agno-response`（#152 的 5 个修复）；#152 先合则本 PR diff 自动缩减。

## Test plan

- [x] `pytest tests/test_agent_worker_runtime.py tests/test_dashboard_pipeline_live.py tests/test_dashboard_standalone.py -q`（15 新测试全绿）
- [x] 合并 #152 后 149 个相关测试全绿（runtime/runner/dashboard/usage/retry/skill_edit/BDD）
- [x] Playwright 页面冒烟：气泡/席位/抽屉/日志流/防闪回全过
- [x] 改动文件 semgrep/ruff 零新增 findings
- [ ] CI ut+it 全矩阵

Made with [Cursor](https://cursor.com)