### PR TITLE
feat(dashboard): skills 投影表 + 写出口 UPSERT / skills catalog projection table (#162)

### DIFF
--- a/src/xskill/agents/agent_tools.py
+++ b/src/xskill/agents/agent_tools.py
@@ -1807,6 +1807,8 @@ def absorb_user_edit_to_main(skill_name: str, message: str) -> str:
             shutil.rmtree(canary_md, ignore_errors=True)
         result += " (deleted in-flight staging)"
 
+    from xskill.skill.catalog_store import upsert_native_skill
+    upsert_native_skill(target)
     return result
 
 
@@ -1860,6 +1862,8 @@ def rename_skill(old_name: str, new_name: str) -> str:
     run_git(["add", "-A"], cwd=str(new_path))
     run_git(["commit", "-m", f"rename: {old_slug} → {new_slug}"], cwd=str(new_path))
     logger.info(f"renamed baby skill: {old_slug} → {new_slug}")
+    from xskill.skill.catalog_store import rename_native_skill
+    rename_native_skill(old_slug, new_path)
     return f"renamed: {old_slug} → {new_slug}"
 
 

--- a/src/xskill/agents/agent_tools.py
+++ b/src/xskill/agents/agent_tools.py
@@ -82,6 +82,8 @@ class AgentToolContext:
     skill_edit_skill_name: str | None = None
     skill_edit_batch_ids: tuple[str, ...] = ()
     grep_fallback_warned: bool = False
+    # 实例 registry.db；skills_catalog 写出口从此取库，禁止隐式摸全局库。
+    registry_db_path: Path | None = None
 
     def __post_init__(self) -> None:
         object.__setattr__(
@@ -89,6 +91,12 @@ class AgentToolContext:
             "config",
             _freeze_config(self.config or {}),
         )
+        if self.registry_db_path is not None:
+            object.__setattr__(
+                self,
+                "registry_db_path",
+                Path(self.registry_db_path),
+            )
 
 
 _EMPTY_AGENT_TOOL_CONTEXT = AgentToolContext()
@@ -114,6 +122,7 @@ def create_agent_tool_context(
     cluster_result_recorder=None,
     skill_edit_skill_name=None,
     skill_edit_batch_ids=(),
+    registry_db_path=None,
 ) -> AgentToolContext:
     """Create an immutable context without changing the current task."""
     return AgentToolContext(
@@ -141,6 +150,9 @@ def create_agent_tool_context(
         ),
         skill_edit_batch_ids=tuple(
             str(atom_id) for atom_id in (skill_edit_batch_ids or ())
+        ),
+        registry_db_path=(
+            Path(registry_db_path) if registry_db_path is not None else None
         ),
     )
 
@@ -250,6 +262,7 @@ class AgentToolConfig:
             "skill_edit_skill_name": current.skill_edit_skill_name,
             "skill_edit_batch_ids": current.skill_edit_batch_ids,
             "grep_fallback_warned": current.grep_fallback_warned,
+            "registry_db_path": current.registry_db_path,
         }
 
     def restore(self, snapshot: dict) -> None:
@@ -266,6 +279,7 @@ class AgentToolConfig:
             cluster_result_recorder=snapshot.get("cluster_result_recorder"),
             skill_edit_skill_name=snapshot.get("skill_edit_skill_name"),
             skill_edit_batch_ids=snapshot.get("skill_edit_batch_ids") or (),
+            registry_db_path=snapshot.get("registry_db_path"),
         ))
         if not snapshot.get("configured", True):
             current = _AGENT_TOOL_CONTEXT.get()
@@ -1807,8 +1821,8 @@ def absorb_user_edit_to_main(skill_name: str, message: str) -> str:
             shutil.rmtree(canary_md, ignore_errors=True)
         result += " (deleted in-flight staging)"
 
-    from xskill.skill.catalog_store import upsert_native_skill
-    upsert_native_skill(target)
+    from xskill.skill.catalog_store import notify_native_upsert
+    notify_native_upsert(target)
     return result
 
 
@@ -1862,8 +1876,8 @@ def rename_skill(old_name: str, new_name: str) -> str:
     run_git(["add", "-A"], cwd=str(new_path))
     run_git(["commit", "-m", f"rename: {old_slug} → {new_slug}"], cwd=str(new_path))
     logger.info(f"renamed baby skill: {old_slug} → {new_slug}")
-    from xskill.skill.catalog_store import rename_native_skill
-    rename_native_skill(old_slug, new_path)
+    from xskill.skill.catalog_store import notify_native_rename
+    notify_native_rename(old_slug, new_path)
     return f"renamed: {old_slug} → {new_slug}"
 
 

--- a/src/xskill/canary.py
+++ b/src/xskill/canary.py
@@ -284,6 +284,8 @@ def merge_staging_to_main(skill_dir: Path) -> bool:
     if canary_copy.is_dir():
         shutil.rmtree(canary_copy)
     logger.info(f"{skill_dir.name}: staging merged to main and deleted")
+    from xskill.skill.catalog_store import upsert_native_skill
+    upsert_native_skill(skill_dir)
     return True
 
 
@@ -331,6 +333,8 @@ def discard_staging(skill_dir: Path) -> bool:
     if canary_copy.is_dir():
         shutil.rmtree(canary_copy)
     logger.info(f"{skill_dir.name}: staging discarded")
+    from xskill.skill.catalog_store import upsert_native_skill
+    upsert_native_skill(skill_dir)
     return True
 
 

--- a/src/xskill/canary.py
+++ b/src/xskill/canary.py
@@ -284,8 +284,8 @@ def merge_staging_to_main(skill_dir: Path) -> bool:
     if canary_copy.is_dir():
         shutil.rmtree(canary_copy)
     logger.info(f"{skill_dir.name}: staging merged to main and deleted")
-    from xskill.skill.catalog_store import upsert_native_skill
-    upsert_native_skill(skill_dir)
+    from xskill.skill.catalog_store import notify_native_upsert
+    notify_native_upsert(skill_dir)
     return True
 
 
@@ -333,8 +333,8 @@ def discard_staging(skill_dir: Path) -> bool:
     if canary_copy.is_dir():
         shutil.rmtree(canary_copy)
     logger.info(f"{skill_dir.name}: staging discarded")
-    from xskill.skill.catalog_store import upsert_native_skill
-    upsert_native_skill(skill_dir)
+    from xskill.skill.catalog_store import notify_native_upsert
+    notify_native_upsert(skill_dir)
     return True
 
 

--- a/src/xskill/cli.py
+++ b/src/xskill/cli.py
@@ -1372,10 +1372,12 @@ def cmd_rebuild(args, _xskill) -> int:
             return 2
 
     if args.force:
-        from xskill.config import get_skill_dir
+        from xskill.config import get_registry_db_path, get_skill_dir
         from xskill.pipeline.registry import clear_rebuild_derived_state
         from xskill.skill.repo import SkillRepo
-        skill_count = SkillRepo(get_skill_dir()).wipe_all_skills()
+        skill_count = SkillRepo(get_skill_dir()).wipe_all_skills(
+            db_path=get_registry_db_path(),
+        )
         print(f"--force: 清空 skill 仓（删 {skill_count} 个 skill）")
         deleted_counts = clear_rebuild_derived_state()
         print(

--- a/src/xskill/dashboard/console.py
+++ b/src/xskill/dashboard/console.py
@@ -605,8 +605,8 @@ def build_console_router(db_path: Optional[Path] = None) -> APIRouter:
     def admin_skills(_=Depends(require_admin)):
         """技能生命周期表：状态徽章 + 近 30 日使用数。
 
-        状态取 ``skills_catalog`` 的短时缓存清单（其 ``state`` 已由同一次扫描读出
-        staging/main/baby 分支），不再逐个 skill 现读一次 git ref——十万级技能库
+        状态取 ``skills_catalog`` 投影表（其 ``state`` 已由 backfill/写出口写出
+        staging/main/baby），不再逐个 skill 现读一次 git ref——十万级技能库
         下那是每请求十万次文件读。清单口径比 SkillRepo 宽（它列所有非隐藏目录），
         故这里补上 SkillRepo 的两条筛选：``references`` 与无 SKILL.md 的目录不是
         skill，保持响应与旧实现逐条一致。

--- a/src/xskill/dashboard/console.py
+++ b/src/xskill/dashboard/console.py
@@ -624,7 +624,7 @@ def build_console_router(db_path: Optional[Path] = None) -> APIRouter:
                 usage30[rec.get("skill") or ""] = \
                     usage30.get(rec.get("skill") or "", 0) + 1
         out = []
-        for entry in skills_catalog(skill_dir):
+        for entry in skills_catalog(skill_dir, db_path=db_path):
             name = entry["name"]
             if name == "references" or not (skill_dir / name / "SKILL.md").is_file():
                 continue
@@ -675,7 +675,7 @@ def build_console_router(db_path: Optional[Path] = None) -> APIRouter:
         from xskill.skill.git import skill_repo_lock
         from xskill.skill.skill import delete_skill
         with skill_repo_lock(skill_dir / name):
-            ok = delete_skill(skill_dir, name)
+            ok = delete_skill(skill_dir, name, db_path=db_path)
         if not ok:
             raise HTTPException(status_code=500, detail="delete commit failed")
         purge_skill_records(skill_name=name, db_path=db_path)

--- a/src/xskill/dashboard/metrics.py
+++ b/src/xskill/dashboard/metrics.py
@@ -381,86 +381,14 @@ def _skills_catalog_cache_key(skill_dir: Path, skillhub) -> tuple:
 def _build_skills_catalog_uncached(skill_dir: Path, skillhub=None) -> list[dict]:
     """列出 skill 库里的所有 skill —— 纯分析式(读目录 + SKILL.md + .candidates.yml)。
 
-    该函数只执行一次磁盘扫描；:func:`skills_catalog` 负责缓存和合并并发调用。
-
-    不依赖任何埋点事件,永远有内容(只要库里有 skill 目录)。每条含:
-    name / state(baby|main|staging) / description / version / use_count / candidates,
-    并统一带 ``source``：自产 git 技能为 ``"native"``。
-
-    ``skillhub``（可选，向后兼容——不传即旧行为）：三方 skill 来源，可传 SkillHub
-    对象或其条目列表。合入的三方条目 ``source="skillhub"`` / ``state="skillhub"``
-    （无 git 分支）,额外带 ``hub``（skillhub 目录下相对路径/子目录名）与 ``skill_id``
-    （``name@path_hash``）,``use_count`` 有则带否则 0。
+    供投影表 backfill / 调试扫盘；dashboard 列表热路径请走投影表
+    (:func:`skills_catalog` / :func:`skills_catalog_page`)。
     """
-    from xskill.skill.frontmatter import parse as fm_parse
-    skill_dir = Path(skill_dir)
-    out: list[dict] = []
-    if skill_dir.is_dir():
-        skill_dirs = [
-            path for path in sorted(skill_dir.iterdir())
-            if path.is_dir() and not path.name.startswith(".")
-        ]
-        snapshot_rows = _rows_from_manifest_snapshot(skill_dir, skill_dirs)
-        if snapshot_rows is not None:
-            out = snapshot_rows
-        else:
-            for d in skill_dirs:
-                branches = _branches(d)
-                if "staging" in branches:
-                    state = "staging"
-                elif "main" in branches:
-                    state = "main"
-                elif "baby" in branches:
-                    state = "baby"
-                else:
-                    state = "unknown"
-                desc, version = "", 0
-                smd = d / "SKILL.md"
-                if smd.is_file():
-                    try:
-                        fm, _ = fm_parse(smd.read_text(encoding="utf-8"))
-                        desc = (fm.get("description") or "").strip().replace("\n", " ")
-                        meta = fm.get("metadata", {}) or {}
-                        version = meta.get("version", 0)
-                    except Exception:  # pylint: disable=broad-exception-caught
-                        logger.warning("failed to read skill metadata: %s",
-                                       smd, exc_info=True)
-                n_cand = 0
-                cand = d / ".candidates.yml"
-                if cand.is_file():
-                    try:
-                        import yaml
-                        data = yaml.safe_load(cand.read_text(encoding="utf-8")) or {}
-                        n_cand = len(data.get("candidates", []) or [])
-                    except Exception:  # pylint: disable=broad-exception-caught
-                        logger.warning("failed to read candidate buffer: %s",
-                                       cand, exc_info=True)
-                out.append({
-                    "name": d.name, "state": state, "source": "native",
-                    "description": desc[:300], "version": version,
-                    "candidates": n_cand,
-                })
-    # main/staging（已正式产出）排前,其次 baby,再按名字
-    # （禁 lambda：装饰-排序-还原；下标项保证元组比较永不落到不可比的 dict 上）
-    order = {"main": 0, "staging": 0, "baby": 1, "unknown": 2}
-    out = [row for _rank, _name, _index, row in sorted(
-        (order.get(row["state"], 3), row["name"], index, row)
-        for index, row in enumerate(out))]
-    # 三方（skillhub）技能追加在自产之后：独立目录、无 git 分支 → state="skillhub"。
-    hub_rows: list[dict] = []
-    for e in _skillhub_entries(skillhub):
-        desc = str(e.get("description") or "").strip().replace("\n", " ")
-        hub_rows.append({
-            "name": e.get("display_name") or e.get("name") or "",
-            "state": "skillhub", "source": "skillhub",
-            "hub": e.get("source_path") or "",
-            "skill_id": e.get("skill_id") or e.get("name") or "",
-            "description": desc[:300], "version": 0,
-            "candidates": 0, "use_count": e.get("use_count", 0) or 0,
-        })
-    hub_rows.sort(key=operator.itemgetter("hub", "name"))
-    out.extend(hub_rows)
-    return out
+    from xskill.skill.catalog_store import catalog_api_row, scan_skills_catalog
+    return [
+        catalog_api_row(row)
+        for row in scan_skills_catalog(skill_dir, skillhub=skillhub)
+    ]
 
 
 def _rows_from_manifest_snapshot(
@@ -526,42 +454,31 @@ def _skills_catalog_bundle(skill_dir: Path, skillhub) -> "_CatalogBundle":
 
 
 def skills_catalog(skill_dir: Path, skillhub=None) -> list[dict]:
-    """返回短时缓存的技能清单全量，每次都给调用方独立的可修改副本。
+    """返回技能清单全量（查 ``skills_catalog`` 投影表）。
 
-    分页读取请走 :func:`skills_catalog_page`——它只深拷贝请求的那一页并 O(1)
-    取聚合计数；本函数保留全量深拷贝语义，服务于需要整份清单的既有调用方。
+    分页请走 :func:`skills_catalog_page`。磁盘仍是真相源；表由写出口 UPSERT，
+    冷启动对该 root 做一次性 backfill。返回独立可修改副本。
     """
-    return copy.deepcopy(_skills_catalog_bundle(skill_dir, skillhub).rows)
+    from xskill.skill.catalog_store import list_skills_catalog
+    return list_skills_catalog(skill_dir, skillhub=skillhub)
 
 
 def skills_catalog_page(skill_dir: Path, skillhub=None, *,
                         limit: int = 0, offset: int = 0,
                         name: str = "") -> dict:
-    """分页读取技能清单：``total`` / ``by_state`` 从缓存 bundle O(1) 取，只深拷贝
-    请求的那一页（审计 L9——避免每请求深拷贝全部 N 条并重算计数）。
+    """分页读取技能清单（查投影表，不扫盘）。
 
-    - ``name`` 非空：定向查该名字的条目（可能多于一条，语义同旧实现的全量筛选），
-      只遍历不深拷贝全部 N。
-    - ``limit`` > 0：返回 ``rows[offset:offset+limit]`` 这一页。
-    - 否则：返回 ``rows[offset:]``（``limit=0`` 向后兼容旧行为）。
+    - ``name`` 非空：精确匹配该名字。
+    - ``limit`` > 0：返回 ``[offset:offset+limit]``。
+    - 否则：返回 ``[offset:]``（``limit=0`` 向后兼容）。
 
-    响应形状与旧 ``/skills`` 端点严格一致：
-    ``{total, by_state, offset, limit, skills}``；``skills`` 为当前页的独立可修改副本。
+    响应形状：``{total, by_state, offset, limit, skills}``。
     """
-    bundle = _skills_catalog_bundle(skill_dir, skillhub)
-    if name:
-        page = [entry for entry in bundle.rows if entry["name"] == name]
-    elif limit > 0:
-        page = bundle.rows[offset:offset + limit]
-    else:
-        page = bundle.rows[offset:]
-    return {
-        "total": bundle.total,
-        "by_state": dict(bundle.by_state),
-        "offset": offset,
-        "limit": limit,
-        "skills": copy.deepcopy(page),
-    }
+    from xskill.skill.catalog_store import page_skills_catalog
+    return page_skills_catalog(
+        skill_dir, skillhub=skillhub,
+        limit=limit, offset=offset, name=name,
+    )
 
 
 class DashboardMetrics:

--- a/src/xskill/dashboard/metrics.py
+++ b/src/xskill/dashboard/metrics.py
@@ -453,19 +453,19 @@ def _skills_catalog_bundle(skill_dir: Path, skillhub) -> "_CatalogBundle":
         _skills_catalog_cache_key(skill_dir, skillhub), build_bundle)
 
 
-def skills_catalog(skill_dir: Path, skillhub=None) -> list[dict]:
+def skills_catalog(skill_dir: Path, skillhub=None, *, db_path=None) -> list[dict]:
     """返回技能清单全量（查 ``skills_catalog`` 投影表）。
 
     分页请走 :func:`skills_catalog_page`。磁盘仍是真相源；表由写出口 UPSERT，
     冷启动对该 root 做一次性 backfill。返回独立可修改副本。
     """
     from xskill.skill.catalog_store import list_skills_catalog
-    return list_skills_catalog(skill_dir, skillhub=skillhub)
+    return list_skills_catalog(skill_dir, skillhub=skillhub, db_path=db_path)
 
 
 def skills_catalog_page(skill_dir: Path, skillhub=None, *,
                         limit: int = 0, offset: int = 0,
-                        name: str = "") -> dict:
+                        name: str = "", db_path=None) -> dict:
     """分页读取技能清单（查投影表，不扫盘）。
 
     - ``name`` 非空：精确匹配该名字。
@@ -477,7 +477,7 @@ def skills_catalog_page(skill_dir: Path, skillhub=None, *,
     from xskill.skill.catalog_store import page_skills_catalog
     return page_skills_catalog(
         skill_dir, skillhub=skillhub,
-        limit=limit, offset=offset, name=name,
+        limit=limit, offset=offset, name=name, db_path=db_path,
     )
 
 

--- a/src/xskill/dashboard/router.py
+++ b/src/xskill/dashboard/router.py
@@ -152,8 +152,8 @@ def build_dashboard_router(db_path: Optional[Path] = None, *,
         **分页**(海量 skill,如 1 万条,别让前端一次性拉全量炸锅):``limit``>0 时只返回
         ``skills[offset:offset+limit]`` 这一页;``limit``=0(默认)返回全部,向后兼容。
         ``total`` / ``by_state`` 始终按**全量**统计(概览计数准确),``skills`` 只含当前页。
-        目录扫描结果按内容指纹缓存,翻页命中缓存不重扫；``total`` / ``by_state`` 在
-        构建清单时算一次随缓存复用(O(1) 取),每请求只深拷贝当前页(审计 L9)。
+        列表读 ``skills_catalog`` 投影表（写出口 UPSERT；冷启动对该 root 一次性
+        backfill），翻页不再扫盘。
         """
         page = skills_catalog_page(
             skill_dir, skillhub=_build_skillhub(),

--- a/src/xskill/dashboard/router.py
+++ b/src/xskill/dashboard/router.py
@@ -157,7 +157,7 @@ def build_dashboard_router(db_path: Optional[Path] = None, *,
         """
         page = skills_catalog_page(
             skill_dir, skillhub=_build_skillhub(),
-            limit=limit, offset=offset, name=name)
+            limit=limit, offset=offset, name=name, db_path=db_path)
         if expose_sensitive:
             return page
         for index, row in enumerate(page["skills"]):

--- a/src/xskill/pipeline/registry.py
+++ b/src/xskill/pipeline/registry.py
@@ -219,6 +219,40 @@ CREATE TABLE IF NOT EXISTS skill_lifecycle (
     ts         TEXT DEFAULT (datetime('now'))
 );
 
+-- skills 列表投影表：磁盘为真相源；写出口 UPSERT；dashboard 分页查表。
+-- catalog_key=native:{name} | skillhub:{skill_id}；root_key=自产 skill 根目录。
+CREATE TABLE IF NOT EXISTS skills_catalog (
+    catalog_key       TEXT PRIMARY KEY,
+    root_key          TEXT NOT NULL DEFAULT '',
+    name              TEXT NOT NULL,
+    repo_name         TEXT NOT NULL DEFAULT '',
+    source            TEXT NOT NULL CHECK(source IN ('native','skillhub')),
+    state             TEXT NOT NULL,
+    description       TEXT NOT NULL DEFAULT '',
+    version           INTEGER NOT NULL DEFAULT 0,
+    candidates_count  INTEGER NOT NULL DEFAULT 0,
+    main_sha          TEXT NOT NULL DEFAULT '',
+    staging_sha       TEXT NOT NULL DEFAULT '',
+    distributable     INTEGER NOT NULL DEFAULT 0,
+    search_id         TEXT NOT NULL DEFAULT '',
+    hub               TEXT NOT NULL DEFAULT '',
+    skill_id          TEXT NOT NULL DEFAULT '',
+    use_count         INTEGER NOT NULL DEFAULT 0,
+    updated_at        TEXT DEFAULT (datetime('now'))
+);
+CREATE INDEX IF NOT EXISTS idx_skills_catalog_root
+    ON skills_catalog(root_key);
+CREATE INDEX IF NOT EXISTS idx_skills_catalog_root_name
+    ON skills_catalog(root_key, name);
+CREATE INDEX IF NOT EXISTS idx_skills_catalog_root_state
+    ON skills_catalog(root_key, state);
+
+CREATE TABLE IF NOT EXISTS skills_catalog_meta (
+    root_key      TEXT PRIMARY KEY,
+    backfilled_at TEXT NOT NULL,
+    skillhub_key  TEXT NOT NULL DEFAULT ''
+);
+
 -- P3-3.1 events:四类既有事实源的消费者(D7),通知+世界消息共用。
 -- kind: feedback(他人触发+ux打分) / push_edit(修改分支) / canary(裁决) / pin。
 -- targets 单独成表:一条事件可通知多个贡献者;世界消息 feed 直接读 events。

--- a/src/xskill/pipeline/runner.py
+++ b/src/xskill/pipeline/runner.py
@@ -488,6 +488,7 @@ class DirectoryWatcher:
             default_traj_root=traj_root,
             spill_root=self.spill_root,
             usage_ledger=self.usage_ledger,
+            registry_db_path=self.db_path,
         )
         # ── 跨技能并行写正文，且不阻塞扫描循环 ──
         # 每个 skill 文件夹是独立 git 仓（skill/git.py 各自 git init），仓锁
@@ -772,6 +773,7 @@ class DirectoryWatcher:
             default_traj_root=self.skill_dir,
             spill_root=self.spill_root,
             usage_ledger=self.usage_ledger,
+            registry_db_path=self.db_path,
         )
         for d in sorted(self.skill_dir.iterdir()):
             if not d.is_dir() or d.name.startswith("."):
@@ -2094,6 +2096,7 @@ class DirectoryWatcher:
             default_traj_root=dir_path,
             spill_root=self.spill_root,
             usage_ledger=self.usage_ledger,
+            registry_db_path=self.db_path,
         )
         try:
             with agent_tools.use_agent_tool_context(tool_context):
@@ -2611,6 +2614,7 @@ def process_atom_task(*, atom_id: str, config: dict, skill_dir: Path,
         usage_ledger=usage_ledger,
         cluster_write_queue=cluster_write_queue,
         cluster_result_recorder=recorder,
+        registry_db_path=db_path,
     )
     with agent_tools.use_agent_tool_context(tool_context):
         return _process_atom_task_bound(
@@ -2744,6 +2748,7 @@ def process_atom_batch(*, atom_ids: list[str], config: dict, skill_dir: Path,
         usage_ledger=usage_ledger,
         cluster_write_queue=cluster_write_queue,
         cluster_result_recorder=recorder,
+        registry_db_path=db_path,
     )
     with agent_tools.use_agent_tool_context(tool_context):
         return _process_atom_batch_bound(

--- a/src/xskill/skill/candidates.py
+++ b/src/xskill/skill/candidates.py
@@ -129,8 +129,11 @@ def _atomic_save_candidates_unlocked(skill_dir: Path, data: dict) -> None:
     finally:
         if temporary_path is not None:
             temporary_path.unlink(missing_ok=True)
-    from xskill.skill.catalog_store import upsert_native_skill
-    upsert_native_skill(skill_dir)
+    from xskill.skill.catalog_store import notify_native_candidates_count
+    notify_native_candidates_count(
+        skill_dir,
+        len(data.get("candidates", []) or []),
+    )
 
 
 def save_candidates(skill_dir: Path, data: dict) -> None:

--- a/src/xskill/skill/candidates.py
+++ b/src/xskill/skill/candidates.py
@@ -129,6 +129,8 @@ def _atomic_save_candidates_unlocked(skill_dir: Path, data: dict) -> None:
     finally:
         if temporary_path is not None:
             temporary_path.unlink(missing_ok=True)
+    from xskill.skill.catalog_store import upsert_native_skill
+    upsert_native_skill(skill_dir)
 
 
 def save_candidates(skill_dir: Path, data: dict) -> None:

--- a/src/xskill/skill/catalog_store.py
+++ b/src/xskill/skill/catalog_store.py
@@ -1,0 +1,551 @@
+"""skills_catalog 投影表：磁盘为真相源，表供列表/分页查询。
+
+写路径在确认的出口 UPSERT/DELETE；读路径只查表。空表（或该 root 尚未
+backfill）时一次性扫盘灌表——这是初始化，不是每请求静默回退扫盘。
+"""
+from __future__ import annotations
+
+import logging
+import operator
+import threading
+from pathlib import Path
+from typing import Optional
+
+from xskill.pipeline.registry import pooled_connection
+
+logger = logging.getLogger(__name__)
+
+_SOURCE_NATIVE = "native"
+_SOURCE_SKILLHUB = "skillhub"
+
+_STATE_ORDER_SQL = """
+CASE state
+  WHEN 'main' THEN 0
+  WHEN 'staging' THEN 0
+  WHEN 'baby' THEN 1
+  WHEN 'unknown' THEN 2
+  WHEN 'skillhub' THEN 3
+  ELSE 4
+END
+"""
+
+_BACKFILL_LOCKS_GUARD = threading.Lock()
+_BACKFILL_FLIGHTS: dict[tuple[str, str], "_BackfillFlight"] = {}
+
+
+class _BackfillFlight:
+    def __init__(self) -> None:
+        self.done = threading.Event()
+        self.error: BaseException | None = None
+
+
+def _root_key(skill_dir: Path | str) -> str:
+    path = Path(skill_dir).expanduser()
+    try:
+        return str(path.resolve(strict=False))
+    except (OSError, RuntimeError):
+        return str(path.absolute())
+
+
+def catalog_root_key(skill_dir: Path | str) -> str:
+    """自产 skill 根目录的投影表 root_key（绝对路径字符串）。"""
+    return _root_key(skill_dir)
+
+
+def _native_catalog_key(name: str) -> str:
+    return f"native:{name}"
+
+
+def _skillhub_catalog_key(skill_id: str) -> str:
+    return f"skillhub:{skill_id}"
+
+
+def _branch_names(skill_path: Path) -> set[str]:
+    git = skill_path / ".git"
+    names: set[str] = set()
+    heads = git / "refs" / "heads"
+    if heads.is_dir():
+        for path in heads.iterdir():
+            if path.is_file():
+                names.add(path.name)
+    packed = git / "packed-refs"
+    if packed.is_file():
+        try:
+            for line in packed.read_text(encoding="utf-8").splitlines():
+                line = line.strip()
+                if " refs/heads/" in line:
+                    names.add(line.split("refs/heads/", 1)[1])
+        except OSError:
+            logger.warning("failed to read packed-refs: %s", packed, exc_info=True)
+    return names
+
+
+def _ref_sha(skill_path: Path, branch: str) -> str:
+    loose = skill_path / ".git" / "refs" / "heads" / branch
+    if loose.is_file():
+        try:
+            return loose.read_text(encoding="utf-8").strip()
+        except OSError:
+            logger.warning("failed to read ref %s", loose, exc_info=True)
+            return ""
+    packed = skill_path / ".git" / "packed-refs"
+    if not packed.is_file():
+        return ""
+    needle = f" refs/heads/{branch}"
+    try:
+        for line in packed.read_text(encoding="utf-8").splitlines():
+            line = line.strip()
+            if line.endswith(needle) and not line.startswith("#"):
+                return line.split(" ", 1)[0]
+    except OSError:
+        logger.warning("failed to read packed-refs for sha: %s", packed, exc_info=True)
+    return ""
+
+
+def _read_native_row(skill_path: Path) -> dict:
+    """从单个 skill 目录读出投影行（API 字段 + 表扩展字段）。"""
+    from xskill.skill.frontmatter import parse as fm_parse
+
+    skill_path = Path(skill_path)
+    branches = _branch_names(skill_path)
+    if "staging" in branches:
+        state = "staging"
+    elif "main" in branches:
+        state = "main"
+    elif "baby" in branches:
+        state = "baby"
+    else:
+        state = "unknown"
+    description, version = "", 0
+    skill_md = skill_path / "SKILL.md"
+    if skill_md.is_file():
+        try:
+            frontmatter, _ = fm_parse(skill_md.read_text(encoding="utf-8"))
+            description = (
+                (frontmatter.get("description") or "").strip().replace("\n", " ")
+            )
+            metadata = frontmatter.get("metadata", {}) or {}
+            version = metadata.get("version", 0)
+        except Exception:  # pylint: disable=broad-exception-caught
+            logger.warning("failed to read skill metadata: %s", skill_md, exc_info=True)
+    candidates_count = 0
+    candidates_path = skill_path / ".candidates.yml"
+    if candidates_path.is_file():
+        try:
+            import yaml
+            data = yaml.safe_load(candidates_path.read_text(encoding="utf-8")) or {}
+            candidates_count = len(data.get("candidates", []) or [])
+        except Exception:  # pylint: disable=broad-exception-caught
+            logger.warning(
+                "failed to read candidate buffer: %s", candidates_path, exc_info=True,
+            )
+    main_sha = _ref_sha(skill_path, "main")
+    staging_sha = _ref_sha(skill_path, "staging")
+    distributable = 1 if state in ("main", "staging") and skill_md.is_file() else 0
+    return {
+        "catalog_key": _native_catalog_key(skill_path.name),
+        "name": skill_path.name,
+        "repo_name": skill_path.name,
+        "source": _SOURCE_NATIVE,
+        "state": state,
+        "description": description[:300],
+        "version": version,
+        "candidates": candidates_count,
+        "candidates_count": candidates_count,
+        "main_sha": main_sha,
+        "staging_sha": staging_sha,
+        "distributable": distributable,
+        "search_id": skill_path.name,
+        "hub": "",
+        "skill_id": "",
+        "use_count": 0,
+        "root_key": _root_key(skill_path.parent),
+    }
+
+
+def _skillhub_entries(skillhub) -> list[dict]:
+    """归一 skillhub 入参：None / list / SkillHub 对象 → 条目列表。"""
+    if skillhub is None:
+        return []
+    if isinstance(skillhub, list):
+        return list(skillhub)
+    return list(skillhub._entries(  # pylint: disable=protected-access
+        include_vec=False, require_description=True))
+
+
+def _skillhub_fingerprint(skillhub) -> str:
+    if skillhub is None:
+        return "none"
+    if isinstance(skillhub, list):
+        rows = []
+        for entry in skillhub:
+            rows.append(tuple(
+                repr(entry.get(field)) for field in (
+                    "display_name", "name", "source_path", "skill_id",
+                    "description", "use_count",
+                )
+            ))
+        return "entries:" + repr(tuple(sorted(rows)))
+    hub_dir = getattr(skillhub, "dir", None)
+    if hub_dir is not None:
+        return "skillhub:" + _root_key(hub_dir) + f":{bool(getattr(skillhub, 'enabled', True))}"
+    return f"object:{type(skillhub).__module__}.{type(skillhub).__qualname__}:{id(skillhub)}"
+
+
+def _skillhub_rows(skillhub) -> list[dict]:
+    rows: list[dict] = []
+    for entry in _skillhub_entries(skillhub):
+        description = str(entry.get("description") or "").strip().replace("\n", " ")
+        skill_id = entry.get("skill_id") or entry.get("name") or ""
+        name = entry.get("display_name") or entry.get("name") or ""
+        hub = entry.get("source_path") or ""
+        use_count = entry.get("use_count", 0) or 0
+        rows.append({
+            "catalog_key": _skillhub_catalog_key(str(skill_id)),
+            "name": name,
+            "repo_name": name,
+            "source": _SOURCE_SKILLHUB,
+            "state": "skillhub",
+            "description": description[:300],
+            "version": 0,
+            "candidates": 0,
+            "candidates_count": 0,
+            "main_sha": "",
+            "staging_sha": "",
+            "distributable": 0,
+            "search_id": str(skill_id),
+            "hub": hub,
+            "skill_id": str(skill_id),
+            "use_count": use_count,
+            "root_key": "",
+        })
+    rows.sort(key=operator.itemgetter("hub", "name"))
+    return rows
+
+
+def scan_skills_catalog(skill_dir: Path, skillhub=None) -> list[dict]:
+    """扫盘得到完整清单行（backfill / 调试用）；排序与旧 dashboard 一致。"""
+    skill_dir = Path(skill_dir)
+    out: list[dict] = []
+    root = _root_key(skill_dir)
+    if skill_dir.is_dir():
+        for path in sorted(skill_dir.iterdir()):
+            if not path.is_dir() or path.name.startswith("."):
+                continue
+            row = _read_native_row(path)
+            row["root_key"] = root
+            out.append(row)
+    order = {"main": 0, "staging": 0, "baby": 1, "unknown": 2}
+    out = [row for _rank, _name, _index, row in sorted(
+        (order.get(row["state"], 3), row["name"], index, row)
+        for index, row in enumerate(out))]
+    hub_rows = _skillhub_rows(skillhub)
+    for row in hub_rows:
+        row["root_key"] = root
+    out.extend(hub_rows)
+    return out
+
+
+def catalog_api_row(stored: dict) -> dict:
+    """表行 / 扫盘行 → dashboard API 行形状。"""
+    row = {
+        "name": stored["name"],
+        "state": stored["state"],
+        "source": stored["source"],
+        "description": stored["description"],
+        "version": stored["version"],
+        "candidates": stored.get("candidates", stored.get("candidates_count", 0)),
+    }
+    if stored["source"] == _SOURCE_SKILLHUB:
+        row["hub"] = stored.get("hub") or ""
+        row["skill_id"] = stored.get("skill_id") or stored.get("search_id") or ""
+        row["use_count"] = stored.get("use_count", 0) or 0
+    return row
+
+
+def _upsert_row(conn, row: dict) -> None:
+    conn.execute(
+        """
+        INSERT INTO skills_catalog(
+            catalog_key, root_key, name, repo_name, source, state,
+            description, version, candidates_count, main_sha, staging_sha,
+            distributable, search_id, hub, skill_id, use_count, updated_at
+        ) VALUES (?,?,?,?,?,?,?,?,?,?,?,?,?,?,?,?,datetime('now'))
+        ON CONFLICT(catalog_key) DO UPDATE SET
+            root_key=excluded.root_key,
+            name=excluded.name,
+            repo_name=excluded.repo_name,
+            source=excluded.source,
+            state=excluded.state,
+            description=excluded.description,
+            version=excluded.version,
+            candidates_count=excluded.candidates_count,
+            main_sha=excluded.main_sha,
+            staging_sha=excluded.staging_sha,
+            distributable=excluded.distributable,
+            search_id=excluded.search_id,
+            hub=excluded.hub,
+            skill_id=excluded.skill_id,
+            use_count=excluded.use_count,
+            updated_at=datetime('now')
+        """,
+        (
+            row["catalog_key"],
+            row["root_key"],
+            row["name"],
+            row["repo_name"],
+            row["source"],
+            row["state"],
+            row["description"],
+            int(row["version"] or 0),
+            int(row["candidates_count"]),
+            row["main_sha"],
+            row["staging_sha"],
+            int(row["distributable"]),
+            row["search_id"],
+            row.get("hub") or "",
+            row.get("skill_id") or "",
+            int(row.get("use_count") or 0),
+        ),
+    )
+
+
+def upsert_native_skill(skill_path: Path | str, *, db_path: Optional[Path] = None) -> None:
+    """写出口：按磁盘现状 UPSERT 一条自产 skill。"""
+    path = Path(skill_path)
+    if not path.is_dir():
+        raise FileNotFoundError(f"skill path not found for catalog upsert: {path}")
+    row = _read_native_row(path)
+    with pooled_connection(db_path) as conn:
+        _upsert_row(conn, row)
+        conn.commit()
+
+
+def delete_native_skill(name: str, *, db_path: Optional[Path] = None) -> None:
+    with pooled_connection(db_path) as conn:
+        conn.execute(
+            "DELETE FROM skills_catalog WHERE catalog_key=?",
+            (_native_catalog_key(name),),
+        )
+        conn.commit()
+
+
+def delete_all_native(*, root_key: str = "", db_path: Optional[Path] = None) -> int:
+    """wipe_all_skills：删该 root 下全部 native 行；root_key 空则删所有 native。"""
+    with pooled_connection(db_path) as conn:
+        if root_key:
+            cursor = conn.execute(
+                "DELETE FROM skills_catalog WHERE source=? AND root_key=?",
+                (_SOURCE_NATIVE, root_key),
+            )
+        else:
+            cursor = conn.execute(
+                "DELETE FROM skills_catalog WHERE source=?",
+                (_SOURCE_NATIVE,),
+            )
+        conn.commit()
+        return int(cursor.rowcount or 0)
+
+
+def rename_native_skill(
+    old_name: str,
+    new_skill_path: Path | str,
+    *,
+    db_path: Optional[Path] = None,
+) -> None:
+    delete_native_skill(old_name, db_path=db_path)
+    upsert_native_skill(new_skill_path, db_path=db_path)
+
+
+def _meta_ready(conn, root_key: str, skillhub_key: str) -> bool:
+    row = conn.execute(
+        "SELECT skillhub_key FROM skills_catalog_meta WHERE root_key=?",
+        (root_key,),
+    ).fetchone()
+    if row is None:
+        return False
+    return row["skillhub_key"] == skillhub_key
+
+
+def backfill_skills_catalog(
+    skill_dir: Path | str,
+    skillhub=None,
+    *,
+    db_path: Optional[Path] = None,
+) -> int:
+    """全量用磁盘扫描替换该 root 的投影行，并标记 meta 已就绪。"""
+    skill_dir = Path(skill_dir)
+    root = _root_key(skill_dir)
+    skillhub_key = _skillhub_fingerprint(skillhub)
+    rows = scan_skills_catalog(skill_dir, skillhub=skillhub)
+    with pooled_connection(db_path) as conn:
+        conn.execute(
+            "DELETE FROM skills_catalog WHERE root_key=?",
+            (root,),
+        )
+        for row in rows:
+            row["root_key"] = root
+            _upsert_row(conn, row)
+        conn.execute(
+            """
+            INSERT INTO skills_catalog_meta(root_key, backfilled_at, skillhub_key)
+            VALUES (?, datetime('now'), ?)
+            ON CONFLICT(root_key) DO UPDATE SET
+                backfilled_at=datetime('now'),
+                skillhub_key=excluded.skillhub_key
+            """,
+            (root, skillhub_key),
+        )
+        conn.commit()
+    logger.info(
+        "skills_catalog backfill: root=%s rows=%d", root, len(rows),
+    )
+    return len(rows)
+
+
+def ensure_skills_catalog(
+    skill_dir: Path | str,
+    skillhub=None,
+    *,
+    db_path: Optional[Path] = None,
+) -> None:
+    """该 root 尚未 backfill（或 skillhub 身份变了）时做一次灌表。
+
+    并发请求单飞：一次成功灌表，失败时等待方共享同一异常（不再各自重扫）。
+    """
+    skill_dir = Path(skill_dir)
+    root = _root_key(skill_dir)
+    skillhub_key = _skillhub_fingerprint(skillhub)
+    with pooled_connection(db_path) as conn:
+        if _meta_ready(conn, root, skillhub_key):
+            return
+    flight_key = (root, skillhub_key)
+    owner = False
+    with _BACKFILL_LOCKS_GUARD:
+        with pooled_connection(db_path) as conn:
+            if _meta_ready(conn, root, skillhub_key):
+                return
+        flight = _BACKFILL_FLIGHTS.get(flight_key)
+        if flight is None:
+            flight = _BackfillFlight()
+            _BACKFILL_FLIGHTS[flight_key] = flight
+            owner = True
+    if not owner:
+        flight.done.wait()
+        if flight.error is not None:
+            raise flight.error
+        return
+    try:
+        backfill_skills_catalog(skill_dir, skillhub=skillhub, db_path=db_path)
+    except BaseException as error:
+        flight.error = error
+        raise
+    finally:
+        with _BACKFILL_LOCKS_GUARD:
+            if _BACKFILL_FLIGHTS.get(flight_key) is flight:
+                _BACKFILL_FLIGHTS.pop(flight_key, None)
+        flight.done.set()
+
+
+def list_skills_catalog(
+    skill_dir: Path | str,
+    skillhub=None,
+    *,
+    db_path: Optional[Path] = None,
+) -> list[dict]:
+    """读投影表全量（API 行形状）。"""
+    ensure_skills_catalog(skill_dir, skillhub=skillhub, db_path=db_path)
+    root = _root_key(skill_dir)
+    with pooled_connection(db_path) as conn:
+        rows = conn.execute(
+            f"""
+            SELECT name, state, source, description, version, candidates_count,
+                   hub, skill_id, search_id, use_count
+            FROM skills_catalog
+            WHERE root_key=?
+            ORDER BY {_STATE_ORDER_SQL},
+                     CASE WHEN source='skillhub' THEN hub ELSE '' END,
+                     name
+            """,
+            (root,),
+        ).fetchall()
+    out: list[dict] = []
+    for row in rows:
+        stored = dict(row)
+        stored["candidates"] = stored.pop("candidates_count")
+        if not stored.get("skill_id"):
+            stored["skill_id"] = stored.get("search_id") or ""
+        out.append(catalog_api_row(stored))
+    return out
+
+
+def page_skills_catalog(
+    skill_dir: Path | str,
+    skillhub=None,
+    *,
+    limit: int = 0,
+    offset: int = 0,
+    name: str = "",
+    db_path: Optional[Path] = None,
+) -> dict:
+    """分页读投影表；形状与旧 skills_catalog_page 一致。"""
+    ensure_skills_catalog(skill_dir, skillhub=skillhub, db_path=db_path)
+    root = _root_key(skill_dir)
+    with pooled_connection(db_path) as conn:
+        total = conn.execute(
+            "SELECT COUNT(*) AS n FROM skills_catalog WHERE root_key=?",
+            (root,),
+        ).fetchone()["n"]
+        by_state_rows = conn.execute(
+            """
+            SELECT state, COUNT(*) AS n FROM skills_catalog
+            WHERE root_key=? GROUP BY state
+            """,
+            (root,),
+        ).fetchall()
+        by_state = {row["state"]: row["n"] for row in by_state_rows}
+        if name:
+            selected = conn.execute(
+                f"""
+                SELECT name, state, source, description, version, candidates_count,
+                       hub, skill_id, search_id, use_count
+                FROM skills_catalog
+                WHERE root_key=? AND name=?
+                ORDER BY {_STATE_ORDER_SQL},
+                         CASE WHEN source='skillhub' THEN hub ELSE '' END,
+                         name
+                """,
+                (root, name),
+            ).fetchall()
+        else:
+            query = f"""
+                SELECT name, state, source, description, version, candidates_count,
+                       hub, skill_id, search_id, use_count
+                FROM skills_catalog
+                WHERE root_key=?
+                ORDER BY {_STATE_ORDER_SQL},
+                         CASE WHEN source='skillhub' THEN hub ELSE '' END,
+                         name
+            """
+            params: list = [root]
+            if limit > 0:
+                query += " LIMIT ? OFFSET ?"
+                params.extend([limit, offset])
+            elif offset > 0:
+                query += " LIMIT -1 OFFSET ?"
+                params.append(offset)
+            selected = conn.execute(query, params).fetchall()
+    skills: list[dict] = []
+    for row in selected:
+        stored = dict(row)
+        stored["candidates"] = stored.pop("candidates_count")
+        if not stored.get("skill_id"):
+            stored["skill_id"] = stored.get("search_id") or ""
+        skills.append(catalog_api_row(stored))
+    return {
+        "total": int(total),
+        "by_state": by_state,
+        "offset": offset,
+        "limit": limit,
+        "skills": skills,
+    }

--- a/src/xskill/skill/catalog_store.py
+++ b/src/xskill/skill/catalog_store.py
@@ -102,8 +102,15 @@ def _ref_sha(skill_path: Path, branch: str) -> str:
     return ""
 
 
-def _read_native_row(skill_path: Path) -> dict:
-    """从单个 skill 目录读出投影行（API 字段 + 表扩展字段）。"""
+def _read_native_row(
+    skill_path: Path,
+    *,
+    candidates_count: int | None = None,
+) -> dict:
+    """从单个 skill 目录读出投影行（API 字段 + 表扩展字段）。
+
+    ``candidates_count`` 非空时跳过读 ``.candidates.yml``（写出口已有 data）。
+    """
     from xskill.skill.frontmatter import parse as fm_parse
 
     skill_path = Path(skill_path)
@@ -128,17 +135,18 @@ def _read_native_row(skill_path: Path) -> dict:
             version = metadata.get("version", 0)
         except Exception:  # pylint: disable=broad-exception-caught
             logger.warning("failed to read skill metadata: %s", skill_md, exc_info=True)
-    candidates_count = 0
-    candidates_path = skill_path / ".candidates.yml"
-    if candidates_path.is_file():
-        try:
-            import yaml
-            data = yaml.safe_load(candidates_path.read_text(encoding="utf-8")) or {}
-            candidates_count = len(data.get("candidates", []) or [])
-        except Exception:  # pylint: disable=broad-exception-caught
-            logger.warning(
-                "failed to read candidate buffer: %s", candidates_path, exc_info=True,
-            )
+    if candidates_count is None:
+        candidates_count = 0
+        candidates_path = skill_path / ".candidates.yml"
+        if candidates_path.is_file():
+            try:
+                import yaml
+                data = yaml.safe_load(candidates_path.read_text(encoding="utf-8")) or {}
+                candidates_count = len(data.get("candidates", []) or [])
+            except Exception:  # pylint: disable=broad-exception-caught
+                logger.warning(
+                    "failed to read candidate buffer: %s", candidates_path, exc_info=True,
+                )
     main_sha = _ref_sha(skill_path, "main")
     staging_sha = _ref_sha(skill_path, "staging")
     distributable = 1 if state in ("main", "staging") and skill_md.is_file() else 0
@@ -151,7 +159,7 @@ def _read_native_row(skill_path: Path) -> dict:
         "description": description[:300],
         "version": version,
         "candidates": candidates_count,
-        "candidates_count": candidates_count,
+        "candidates_count": int(candidates_count),
         "main_sha": main_sha,
         "staging_sha": staging_sha,
         "distributable": distributable,
@@ -310,19 +318,50 @@ def _upsert_row(conn, row: dict) -> None:
     )
 
 
-def upsert_native_skill(skill_path: Path | str, *, db_path: Optional[Path] = None) -> None:
-    """写出口：按磁盘现状 UPSERT 一条自产 skill。"""
+_BACKFILL_WAIT_TIMEOUT_SECONDS = 120.0
+
+
+def resolve_catalog_db_path(explicit: Path | str | None = None) -> Path | None:
+    """解析投影表所用 registry 库路径。
+
+    写出口禁止 ``pooled_connection(None)`` 隐式摸全局库：必须显式传入，或从
+    当前 ``AgentToolContext.registry_db_path`` 读取。两者皆无则返回 ``None``
+    （调用方应跳过投影写入）。
+    """
+    if explicit is not None:
+        return Path(explicit)
+    try:
+        from xskill.agents.agent_tools import current_agent_tool_context
+        context = current_agent_tool_context()
+    except Exception:  # pylint: disable=broad-exception-caught
+        return None
+    if context.configured and context.registry_db_path is not None:
+        return Path(context.registry_db_path)
+    return None
+
+
+def upsert_native_skill(
+    skill_path: Path | str,
+    *,
+    db_path: Path,
+    candidates_count: int | None = None,
+) -> None:
+    """按磁盘现状 UPSERT 一条自产 skill。``db_path`` 必填，禁止隐式全局库。"""
+    if db_path is None:
+        raise TypeError("skills_catalog upsert requires explicit db_path")
     path = Path(skill_path)
     if not path.is_dir():
         raise FileNotFoundError(f"skill path not found for catalog upsert: {path}")
-    row = _read_native_row(path)
-    with pooled_connection(db_path) as conn:
+    row = _read_native_row(path, candidates_count=candidates_count)
+    with pooled_connection(Path(db_path)) as conn:
         _upsert_row(conn, row)
         conn.commit()
 
 
-def delete_native_skill(name: str, *, db_path: Optional[Path] = None) -> None:
-    with pooled_connection(db_path) as conn:
+def delete_native_skill(name: str, *, db_path: Path) -> None:
+    if db_path is None:
+        raise TypeError("skills_catalog delete requires explicit db_path")
+    with pooled_connection(Path(db_path)) as conn:
         conn.execute(
             "DELETE FROM skills_catalog WHERE catalog_key=?",
             (_native_catalog_key(name),),
@@ -330,9 +369,11 @@ def delete_native_skill(name: str, *, db_path: Optional[Path] = None) -> None:
         conn.commit()
 
 
-def delete_all_native(*, root_key: str = "", db_path: Optional[Path] = None) -> int:
+def delete_all_native(*, root_key: str = "", db_path: Path) -> int:
     """wipe_all_skills：删该 root 下全部 native 行；root_key 空则删所有 native。"""
-    with pooled_connection(db_path) as conn:
+    if db_path is None:
+        raise TypeError("skills_catalog wipe requires explicit db_path")
+    with pooled_connection(Path(db_path)) as conn:
         if root_key:
             cursor = conn.execute(
                 "DELETE FROM skills_catalog WHERE source=? AND root_key=?",
@@ -351,10 +392,145 @@ def rename_native_skill(
     old_name: str,
     new_skill_path: Path | str,
     *,
-    db_path: Optional[Path] = None,
+    db_path: Path,
 ) -> None:
-    delete_native_skill(old_name, db_path=db_path)
-    upsert_native_skill(new_skill_path, db_path=db_path)
+    """同一连接内 DELETE 旧行 + UPSERT 新行，避免中间态丢行。"""
+    if db_path is None:
+        raise TypeError("skills_catalog rename requires explicit db_path")
+    path = Path(new_skill_path)
+    if not path.is_dir():
+        raise FileNotFoundError(f"skill path not found for catalog rename: {path}")
+    row = _read_native_row(path)
+    with pooled_connection(Path(db_path)) as conn:
+        conn.execute(
+            "DELETE FROM skills_catalog WHERE catalog_key=?",
+            (_native_catalog_key(old_name),),
+        )
+        _upsert_row(conn, row)
+        conn.commit()
+
+
+def update_native_candidates_count(
+    skill_path: Path | str,
+    candidates_count: int,
+    *,
+    db_path: Path,
+) -> None:
+    """热路径：只改 ``candidates_count``，不重读 SKILL.md / yaml / refs。"""
+    if db_path is None:
+        raise TypeError("skills_catalog candidates update requires explicit db_path")
+    name = Path(skill_path).name
+    with pooled_connection(Path(db_path)) as conn:
+        conn.execute(
+            """
+            UPDATE skills_catalog
+            SET candidates_count=?, updated_at=datetime('now')
+            WHERE catalog_key=?
+            """,
+            (int(candidates_count), _native_catalog_key(name)),
+        )
+        conn.commit()
+
+
+def notify_native_upsert(
+    skill_path: Path | str,
+    *,
+    db_path: Path | str | None = None,
+    candidates_count: int | None = None,
+) -> None:
+    """写出口钩子：投影失败只记日志，绝不砸穿磁盘真相写路径。"""
+    try:
+        resolved = resolve_catalog_db_path(db_path)
+        if resolved is None:
+            logger.debug(
+                "skills_catalog skip upsert (no registry_db_path): %s", skill_path,
+            )
+            return
+        upsert_native_skill(
+            skill_path, db_path=resolved, candidates_count=candidates_count,
+        )
+    except Exception:  # pylint: disable=broad-exception-caught
+        logger.exception("skills_catalog upsert failed: %s", skill_path)
+
+
+def notify_native_candidates_count(
+    skill_path: Path | str,
+    candidates_count: int,
+    *,
+    db_path: Path | str | None = None,
+) -> None:
+    """candidates 落盘钩子：只用内存 count 更新投影列。"""
+    try:
+        resolved = resolve_catalog_db_path(db_path)
+        if resolved is None:
+            logger.debug(
+                "skills_catalog skip candidates_count (no registry_db_path): %s",
+                skill_path,
+            )
+            return
+        update_native_candidates_count(
+            skill_path, candidates_count, db_path=resolved,
+        )
+    except Exception:  # pylint: disable=broad-exception-caught
+        logger.exception(
+            "skills_catalog candidates_count update failed: %s", skill_path,
+        )
+
+
+def notify_native_delete(
+    name: str,
+    *,
+    db_path: Path | str | None = None,
+) -> None:
+    try:
+        resolved = resolve_catalog_db_path(db_path)
+        if resolved is None:
+            logger.debug(
+                "skills_catalog skip delete (no registry_db_path): %s", name,
+            )
+            return
+        delete_native_skill(name, db_path=resolved)
+    except Exception:  # pylint: disable=broad-exception-caught
+        logger.exception("skills_catalog delete failed: %s", name)
+
+
+def notify_native_rename(
+    old_name: str,
+    new_skill_path: Path | str,
+    *,
+    db_path: Path | str | None = None,
+) -> None:
+    try:
+        resolved = resolve_catalog_db_path(db_path)
+        if resolved is None:
+            logger.debug(
+                "skills_catalog skip rename (no registry_db_path): %s → %s",
+                old_name, new_skill_path,
+            )
+            return
+        rename_native_skill(old_name, new_skill_path, db_path=resolved)
+    except Exception:  # pylint: disable=broad-exception-caught
+        logger.exception(
+            "skills_catalog rename failed: %s → %s", old_name, new_skill_path,
+        )
+
+
+def notify_native_wipe(
+    *,
+    root_key: str = "",
+    db_path: Path | str | None = None,
+) -> None:
+    try:
+        resolved = resolve_catalog_db_path(db_path)
+        if resolved is None:
+            logger.debug(
+                "skills_catalog skip wipe (no registry_db_path): root_key=%s",
+                root_key,
+            )
+            return
+        delete_all_native(root_key=root_key, db_path=resolved)
+    except Exception:  # pylint: disable=broad-exception-caught
+        logger.exception("skills_catalog wipe failed: root_key=%s", root_key)
 
 
 def _meta_ready(conn, root_key: str, skillhub_key: str) -> bool:
@@ -431,7 +607,11 @@ def ensure_skills_catalog(
             _BACKFILL_FLIGHTS[flight_key] = flight
             owner = True
     if not owner:
-        flight.done.wait()
+        if not flight.done.wait(timeout=_BACKFILL_WAIT_TIMEOUT_SECONDS):
+            raise TimeoutError(
+                f"skills_catalog backfill wait timed out after "
+                f"{_BACKFILL_WAIT_TIMEOUT_SECONDS}s: root={root}"
+            )
         if flight.error is not None:
             raise flight.error
         return

--- a/src/xskill/skill/git.py
+++ b/src/xskill/skill/git.py
@@ -1812,6 +1812,8 @@ def init_skill_repo_on_baby(skill_dir: str, name: str, description: str) -> None
         finally:
             repo.close()
     logger.info(f"🌱 init skill on baby branch: {skill_dir}")
+    from xskill.skill.catalog_store import upsert_native_skill
+    upsert_native_skill(skill_dir)
 
 
 def commit_baby_to_main_branch(skill_dir: str, message: str) -> bool:
@@ -1842,6 +1844,8 @@ def commit_baby_to_main_branch(skill_dir: str, message: str) -> bool:
             del repo.refs[baby_ref]
             repo.refs.set_symbolic_ref(b"HEAD", main_ref)
     logger.info(f"🎓 baby → main graduated: {Path(skill_dir).name}: {message}")
+    from xskill.skill.catalog_store import upsert_native_skill
+    upsert_native_skill(skill_dir)
     return True
 
 
@@ -1873,6 +1877,8 @@ def commit_baby_checkpoint(skill_dir: str, message: str) -> str | None:
         full_sha[:7],
         message,
     )
+    from xskill.skill.catalog_store import upsert_native_skill
+    upsert_native_skill(skill_dir)
     return full_sha
 
 
@@ -1933,6 +1939,8 @@ def commit_to_staging_branch(skill_dir: str, message: str) -> bool:
             except Exception as e:
                 logger.warning("reset back to main failed: %s", e)
     logger.info(f"🚦 staging candidate committed: {Path(skill_dir).name}: {message}")
+    from xskill.skill.catalog_store import upsert_native_skill
+    upsert_native_skill(skill_dir)
     return True
 
 
@@ -1960,6 +1968,8 @@ def commit_update_main_branch(skill_dir: str, message: str) -> bool:
                     return False
                 raise RuntimeError(f"commit_update_main_branch commit 失败: {err}")
     logger.info("♻️ main direct update commit: %s: %s", Path(skill_dir).name, message)
+    from xskill.skill.catalog_store import upsert_native_skill
+    upsert_native_skill(skill_dir)
     return True
 
 

--- a/src/xskill/skill/git.py
+++ b/src/xskill/skill/git.py
@@ -1812,8 +1812,8 @@ def init_skill_repo_on_baby(skill_dir: str, name: str, description: str) -> None
         finally:
             repo.close()
     logger.info(f"🌱 init skill on baby branch: {skill_dir}")
-    from xskill.skill.catalog_store import upsert_native_skill
-    upsert_native_skill(skill_dir)
+    from xskill.skill.catalog_store import notify_native_upsert
+    notify_native_upsert(skill_dir)
 
 
 def commit_baby_to_main_branch(skill_dir: str, message: str) -> bool:
@@ -1844,8 +1844,8 @@ def commit_baby_to_main_branch(skill_dir: str, message: str) -> bool:
             del repo.refs[baby_ref]
             repo.refs.set_symbolic_ref(b"HEAD", main_ref)
     logger.info(f"🎓 baby → main graduated: {Path(skill_dir).name}: {message}")
-    from xskill.skill.catalog_store import upsert_native_skill
-    upsert_native_skill(skill_dir)
+    from xskill.skill.catalog_store import notify_native_upsert
+    notify_native_upsert(skill_dir)
     return True
 
 
@@ -1877,8 +1877,8 @@ def commit_baby_checkpoint(skill_dir: str, message: str) -> str | None:
         full_sha[:7],
         message,
     )
-    from xskill.skill.catalog_store import upsert_native_skill
-    upsert_native_skill(skill_dir)
+    from xskill.skill.catalog_store import notify_native_upsert
+    notify_native_upsert(skill_dir)
     return full_sha
 
 
@@ -1939,8 +1939,8 @@ def commit_to_staging_branch(skill_dir: str, message: str) -> bool:
             except Exception as e:
                 logger.warning("reset back to main failed: %s", e)
     logger.info(f"🚦 staging candidate committed: {Path(skill_dir).name}: {message}")
-    from xskill.skill.catalog_store import upsert_native_skill
-    upsert_native_skill(skill_dir)
+    from xskill.skill.catalog_store import notify_native_upsert
+    notify_native_upsert(skill_dir)
     return True
 
 
@@ -1968,8 +1968,8 @@ def commit_update_main_branch(skill_dir: str, message: str) -> bool:
                     return False
                 raise RuntimeError(f"commit_update_main_branch commit 失败: {err}")
     logger.info("♻️ main direct update commit: %s: %s", Path(skill_dir).name, message)
-    from xskill.skill.catalog_store import upsert_native_skill
-    upsert_native_skill(skill_dir)
+    from xskill.skill.catalog_store import notify_native_upsert
+    notify_native_upsert(skill_dir)
     return True
 
 

--- a/src/xskill/skill/repo.py
+++ b/src/xskill/skill/repo.py
@@ -91,7 +91,7 @@ class SkillRepo:
         )
 
     # ─── 清空（rebuild --force 用）──────────────────────────────
-    def wipe_all_skills(self) -> int:
+    def wipe_all_skills(self, *, db_path: Path | None = None) -> int:
         """删除仓里所有 skill 子目录（含各自 ``.git`` 子仓），返回删除个数。
 
         ``xskill rebuild --force`` 用：换强模型从零重建前先清空旧 skill。
@@ -118,8 +118,10 @@ class SkillRepo:
             idx.unlink()
         logger.info("wipe_all_skills: removed %d skill(s) under %s", n, self.root)
         if n:
-            from xskill.skill.catalog_store import catalog_root_key, delete_all_native
-            delete_all_native(root_key=catalog_root_key(self.root))
+            from xskill.skill.catalog_store import catalog_root_key, notify_native_wipe
+            notify_native_wipe(
+                root_key=catalog_root_key(self.root), db_path=db_path,
+            )
         return n
 
     def __repr__(self) -> str:

--- a/src/xskill/skill/repo.py
+++ b/src/xskill/skill/repo.py
@@ -117,6 +117,9 @@ class SkillRepo:
         if idx.is_file():
             idx.unlink()
         logger.info("wipe_all_skills: removed %d skill(s) under %s", n, self.root)
+        if n:
+            from xskill.skill.catalog_store import catalog_root_key, delete_all_native
+            delete_all_native(root_key=catalog_root_key(self.root))
         return n
 
     def __repr__(self) -> str:

--- a/src/xskill/skill/skill.py
+++ b/src/xskill/skill/skill.py
@@ -570,6 +570,8 @@ def delete_skill(skill_dir: Path, name: str) -> bool:
     committed = commit_changes(str(skill_dir), f"delete skill: {name}")
     if committed:
         logger.info(f"deleted: {name}")
+        from xskill.skill.catalog_store import delete_native_skill
+        delete_native_skill(name)
     return committed
 
 

--- a/src/xskill/skill/skill.py
+++ b/src/xskill/skill/skill.py
@@ -559,7 +559,7 @@ def _set_frozen(skill_dir: Path, name: str, frozen: bool) -> bool:
     return True
 
 
-def delete_skill(skill_dir: Path, name: str) -> bool:
+def delete_skill(skill_dir: Path, name: str, *, db_path: Path | None = None) -> bool:
     """Delete a skill directory and commit."""
     skill_path = skill_dir / name
     if not skill_path.is_dir():
@@ -570,8 +570,8 @@ def delete_skill(skill_dir: Path, name: str) -> bool:
     committed = commit_changes(str(skill_dir), f"delete skill: {name}")
     if committed:
         logger.info(f"deleted: {name}")
-        from xskill.skill.catalog_store import delete_native_skill
-        delete_native_skill(name)
+        from xskill.skill.catalog_store import notify_native_delete
+        notify_native_delete(name, db_path=db_path)
     return committed
 
 

--- a/tests/test_dashboard_console_p2.py
+++ b/tests/test_dashboard_console_p2.py
@@ -638,6 +638,10 @@ def test_admin_skills_uses_cached_catalog_and_keeps_skillrepo_scope(
         "xskill.config.get_registry_db_path",
         lambda: db,
     )
+    monkeypatch.setattr(
+        "xskill.pipeline.registry.get_registry_db_path",
+        lambda: db,
+    )
     # beta 起灰度 → canary；gamma 下线 → retired；alpha 近 30 日有使用
     _git(["checkout", "-q", "-b", "staging"], skills / "beta")
     R.retire_skill(skill_name="gamma", set_by="boss", db_path=db)

--- a/tests/test_dashboard_console_p2.py
+++ b/tests/test_dashboard_console_p2.py
@@ -629,11 +629,15 @@ def test_users_matrix_reads_prefs_in_one_query(console_env, monkeypatch):
 
 def test_admin_skills_uses_cached_catalog_and_keeps_skillrepo_scope(
         console_env, monkeypatch):
-    """技能生命周期表：状态取共享清单缓存(不再逐 skill 现读 git ref)，
+    """技能生命周期表：状态取投影表（冷启动一次 backfill），
     但列出的 skill 集合仍与 SkillRepo 完全一致。"""
-    import xskill.dashboard.metrics as dashboard_metrics
+    import xskill.skill.catalog_store as catalog_store
     db = console_env["db"]
     skills = console_env["skills"]
+    monkeypatch.setattr(
+        "xskill.config.get_registry_db_path",
+        lambda: db,
+    )
     # beta 起灰度 → canary；gamma 下线 → retired；alpha 近 30 日有使用
     _git(["checkout", "-q", "-b", "staging"], skills / "beta")
     R.retire_skill(skill_name="gamma", set_by="boss", db_path=db)
@@ -651,20 +655,19 @@ def test_admin_skills_uses_cached_catalog_and_keeps_skillrepo_scope(
     _clear_console_caches()
 
     scans: list[int] = []
-    real_build = dashboard_metrics._build_skills_catalog_uncached
+    real_scan = catalog_store.scan_skills_catalog
 
-    def counting_build(*args, **kwargs):
+    def counting_scan(*args, **kwargs):
         scans.append(1)
-        return real_build(*args, **kwargs)
+        return real_scan(*args, **kwargs)
 
-    monkeypatch.setattr(
-        dashboard_metrics, "_build_skills_catalog_uncached", counting_build)
+    monkeypatch.setattr(catalog_store, "scan_skills_catalog", counting_scan)
 
     boss = console_env["boss"]
     first = boss.get("/api/v1/dashboard/admin/skills").json()
     second = boss.get("/api/v1/dashboard/admin/skills").json()
 
-    assert len(scans) == 1                    # 两次请求共用一次清单扫描
+    assert len(scans) == 1                    # 两次请求共用一次 backfill 扫盘
     assert first == second
     assert first["skills"] == [
         {"name": "alpha", "state": "active", "usage_30d": 2},

--- a/tests/test_dashboard_metrics.py
+++ b/tests/test_dashboard_metrics.py
@@ -34,6 +34,10 @@ def _isolate_skills_catalog_registry(tmp_path, monkeypatch):
         "xskill.config.get_registry_db_path",
         lambda: registry,
     )
+    monkeypatch.setattr(
+        "xskill.pipeline.registry.get_registry_db_path",
+        lambda: registry,
+    )
 
 
 def _seed_team(db):
@@ -463,7 +467,7 @@ def test_skills_catalog_upsert_picks_up_disk_mutations(tmp_path):
     assert (still_stale["state"], still_stale["description"], still_stale["candidates"]) == (
         "main", "version one", 0)
 
-    catalog_store.upsert_native_skill(skill)
+    catalog_store.upsert_native_skill(skill, db_path=tmp_path / "_skills_catalog_registry.db")
     refreshed = skills_catalog(root)[0]
     assert (refreshed["state"], refreshed["description"], refreshed["version"],
             refreshed["candidates"]) == ("staging", "version two", 2, 2)

--- a/tests/test_dashboard_metrics.py
+++ b/tests/test_dashboard_metrics.py
@@ -8,6 +8,7 @@ from concurrent.futures import ThreadPoolExecutor
 import pytest
 
 import xskill.dashboard.metrics as dashboard_metrics
+import xskill.skill.catalog_store as catalog_store
 from xskill.pipeline.registry import (
     TrajectoryStatus,
     get_connection,
@@ -23,6 +24,16 @@ SUCCESSFULLY_SPLIT_STATUSES = (
     TrajectoryStatus.CLUSTERING,
     TrajectoryStatus.DONE,
 )
+
+
+@pytest.fixture(autouse=True)
+def _isolate_skills_catalog_registry(tmp_path, monkeypatch):
+    """技能清单投影表写入隔离 registry，避免污染本机 DB / 串测。"""
+    registry = tmp_path / "_skills_catalog_registry.db"
+    monkeypatch.setattr(
+        "xskill.config.get_registry_db_path",
+        lambda: registry,
+    )
 
 
 def _seed_team(db):
@@ -407,7 +418,7 @@ def test_skills_catalog_concurrent_calls_for_300_skills_scan_once(
     for i in range(300):
         _write_catalog_skill(root, f"skill-{i:03d}", f"description {i}")
 
-    original = dashboard_metrics._build_skills_catalog_uncached
+    original = catalog_store.scan_skills_catalog
     calls = 0
     calls_lock = threading.Lock()
 
@@ -417,7 +428,7 @@ def test_skills_catalog_concurrent_calls_for_300_skills_scan_once(
             calls += 1
         return original(*args, **kwargs)
 
-    monkeypatch.setattr(dashboard_metrics, "_build_skills_catalog_uncached", counted)
+    monkeypatch.setattr(catalog_store, "scan_skills_catalog", counted)
     barrier = threading.Barrier(32)
 
     def load():
@@ -430,18 +441,15 @@ def test_skills_catalog_concurrent_calls_for_300_skills_scan_once(
     assert all(len(rows) == 300 for rows in results)
 
 
-def test_skills_catalog_cache_ttl_reloads_refs_content_and_candidates(
-        tmp_path, monkeypatch):
+def test_skills_catalog_upsert_picks_up_disk_mutations(tmp_path):
+    """投影表：仅改盘不 UPSERT 时列表保持旧值；写出口 UPSERT 后立即可见。"""
     root = tmp_path / "skills"
     root.mkdir()
     skill = _write_catalog_skill(root, "alpha", "version one", branch="main")
-    # 清单缓存与它内部复用的 sync 仓快照(_rows_from_manifest_snapshot 的
-    # max_age_seconds)同用这个 TTL,两处都要缩短才能观察到过期重扫。
-    monkeypatch.setattr(dashboard_metrics, "_SKILLS_CATALOG_TTL_SECONDS", 0.02)
-    monkeypatch.setattr(
-        dashboard_metrics._skills_catalog_cache, "ttl_seconds", 0.02)
 
     first = skills_catalog(root)[0]
+    assert first["description"] == "version one"
+
     (skill / ".git" / "refs" / "heads" / "staging").write_text("sha2\n", encoding="utf-8")
     (skill / "SKILL.md").write_text(
         "---\nname: alpha\ndescription: version two\n"
@@ -451,14 +459,14 @@ def test_skills_catalog_cache_ttl_reloads_refs_content_and_candidates(
     (skill / ".candidates.yml").write_text(
         "candidates:\n  - summary: one\n  - summary: two\n", encoding="utf-8")
 
-    still_cached = skills_catalog(root)[0]
-    assert (still_cached["state"], still_cached["description"], still_cached["candidates"]) == (
+    still_stale = skills_catalog(root)[0]
+    assert (still_stale["state"], still_stale["description"], still_stale["candidates"]) == (
         "main", "version one", 0)
-    time.sleep(0.04)
+
+    catalog_store.upsert_native_skill(skill)
     refreshed = skills_catalog(root)[0]
     assert (refreshed["state"], refreshed["description"], refreshed["version"],
             refreshed["candidates"]) == ("staging", "version two", 2, 2)
-    assert first == still_cached
 
 
 def test_skills_catalog_cache_isolates_roots_and_skillhub_inputs(tmp_path):
@@ -479,7 +487,7 @@ def test_skills_catalog_cache_isolates_roots_and_skillhub_inputs(tmp_path):
         ("same", "root b"), ("hub-b", "B")]
 
 
-def test_skills_catalog_equivalent_skillhub_instances_share_cache(
+def test_skills_catalog_equivalent_skillhub_instances_share_backfill(
         tmp_path, monkeypatch):
     from xskill.recommend.skillhub import SkillHub
 
@@ -488,7 +496,7 @@ def test_skills_catalog_equivalent_skillhub_instances_share_cache(
     _write_catalog_skill(hub_root, "vendor", "third party")
     first_hub = SkillHub(enabled=True, hub_dir=hub_root, embed_client=None)
     second_hub = SkillHub(enabled=True, hub_dir=hub_root, embed_client=object())
-    original = dashboard_metrics._build_skills_catalog_uncached
+    original = catalog_store.scan_skills_catalog
     calls = 0
 
     def counted(*args, **kwargs):
@@ -496,14 +504,13 @@ def test_skills_catalog_equivalent_skillhub_instances_share_cache(
         calls += 1
         return original(*args, **kwargs)
 
-    monkeypatch.setattr(
-        dashboard_metrics, "_build_skills_catalog_uncached", counted)
+    monkeypatch.setattr(catalog_store, "scan_skills_catalog", counted)
     assert skills_catalog(root, skillhub=first_hub) == skills_catalog(
         root, skillhub=second_hub)
     assert calls == 1
 
 
-def test_skills_catalog_failed_build_does_not_poison_cache(tmp_path):
+def test_skills_catalog_failed_backfill_does_not_poison_meta(tmp_path):
     from xskill.recommend.skillhub import SkillHub
 
     root = tmp_path / "skills"; root.mkdir()
@@ -518,16 +525,16 @@ def test_skills_catalog_failed_build_does_not_poison_cache(tmp_path):
         ("vendor", "skillhub")]
 
 
-def test_skills_catalog_concurrent_failure_is_shared_and_cleans_flight(
+def test_skills_catalog_concurrent_failure_is_shared(
         tmp_path, monkeypatch):
     root = tmp_path / "skills"; root.mkdir()
-    original = dashboard_metrics._build_skills_catalog_uncached
+    original = catalog_store.scan_skills_catalog
     entered = threading.Event()
     release = threading.Event()
     calls = 0
     calls_lock = threading.Lock()
 
-    def failing(*args, **kwargs):
+    def failing(*_args, **_kwargs):
         nonlocal calls
         with calls_lock:
             calls += 1
@@ -535,8 +542,7 @@ def test_skills_catalog_concurrent_failure_is_shared_and_cleans_flight(
         assert release.wait(timeout=5)
         raise FileNotFoundError("catalog unavailable")
 
-    monkeypatch.setattr(
-        dashboard_metrics, "_build_skills_catalog_uncached", failing)
+    monkeypatch.setattr(catalog_store, "scan_skills_catalog", failing)
 
     def load_error():
         try:
@@ -554,29 +560,17 @@ def test_skills_catalog_concurrent_failure_is_shared_and_cleans_flight(
 
     assert calls == 1
     assert all(isinstance(error, FileNotFoundError) for error in errors)
-    assert len({id(error) for error in errors}) == len(errors)
-    key = dashboard_metrics._skills_catalog_cache_key(root, None)
-    assert dashboard_metrics._skills_catalog_cache.in_flight_count == 0
-    assert key not in dashboard_metrics._skills_catalog_cache
 
-    monkeypatch.setattr(
-        dashboard_metrics, "_build_skills_catalog_uncached", original)
+    monkeypatch.setattr(catalog_store, "scan_skills_catalog", original)
     assert skills_catalog(root) == []
 
 
-def test_skills_catalog_cache_has_bounded_number_of_keys(tmp_path, monkeypatch):
-    monkeypatch.setattr(
-        dashboard_metrics._skills_catalog_cache, "max_entries", 2)
-    dashboard_metrics._skills_catalog_cache.clear()
-
+def test_skills_catalog_isolates_multiple_roots(tmp_path):
     for index in range(3):
         root = tmp_path / f"skills-{index}"
         root.mkdir()
         _write_catalog_skill(root, f"skill-{index}", f"description {index}")
         assert len(skills_catalog(root)) == 1
-
-    assert len(dashboard_metrics._skills_catalog_cache) == 2
-    assert dashboard_metrics._skills_catalog_cache.in_flight_count == 0
 
 
 def test_skills_catalog_returns_independent_copies(tmp_path):
@@ -592,73 +586,90 @@ def test_skills_catalog_returns_independent_copies(tmp_path):
     assert second[0]["description"] == "original"
 
 
-def test_skills_catalog_page_counts_from_cache_and_deepcopies_only_page(
-        tmp_path, monkeypatch):
-    """L9：分页只深拷贝当前页，total/by_state 从缓存 bundle 取；改页不污染缓存。"""
+def _fake_scan_rows(root, count):
+    root_key = catalog_store.catalog_root_key(root)
+    rows = []
+    for index in range(count):
+        state = "main" if index % 2 else "staging"
+        name = f"s{index:04d}"
+        rows.append({
+            "catalog_key": f"native:{name}",
+            "root_key": root_key,
+            "name": name,
+            "repo_name": name,
+            "source": "native",
+            "state": state,
+            "description": "",
+            "version": 1,
+            "candidates": 0,
+            "candidates_count": 0,
+            "main_sha": "",
+            "staging_sha": "",
+            "distributable": 1,
+            "search_id": name,
+            "hub": "",
+            "skill_id": "",
+            "use_count": 0,
+        })
+    return rows
+
+
+def test_skills_catalog_page_counts_and_page_isolation(tmp_path, monkeypatch):
+    """分页：total/by_state 按全量；改返回页不污染下一请求。"""
     root = tmp_path / "skills"
-    rows = [
-        {"name": f"s{index}",
-         "state": "main" if index % 2 else "staging",
-         "source": "native", "description": "", "version": 1, "candidates": 0}
-        for index in range(300)
-    ]
+    root.mkdir()
+    rows = _fake_scan_rows(root, 300)
+
     def build_rows(*_args, **_kwargs):
         return [dict(entry) for entry in rows]
 
-    monkeypatch.setattr(
-        dashboard_metrics, "_build_skills_catalog_uncached", build_rows)
+    monkeypatch.setattr(catalog_store, "scan_skills_catalog", build_rows)
 
     page = skills_catalog_page(root, limit=10, offset=20)
     assert page["total"] == 300
     assert page["by_state"] == {"staging": 150, "main": 150}
     assert [entry["name"] for entry in page["skills"]] == [
-        f"s{index}" for index in range(20, 30)]
+        f"s{index:04d}" for index in range(20, 30)]
     assert page["offset"] == 20 and page["limit"] == 10
 
-    # 改写返回页不得污染缓存里的行（只深拷贝当前页的保证）。
     page["skills"][0]["description"] = "caller mutation"
     fresh = skills_catalog_page(root, limit=10, offset=20)
     assert fresh["skills"][0]["description"] == ""
-    # 返回的 by_state 是独立副本，改它也不动缓存。
     page["by_state"]["main"] = -1
     assert skills_catalog_page(root, limit=1)["by_state"]["main"] == 150
 
 
-def test_skills_catalog_page_builds_once_across_requests(tmp_path, monkeypatch):
-    """L9：多次翻页 / 计数只触发一次磁盘扫描（缓存 bundle 复用）。"""
+def test_skills_catalog_page_backfills_once_across_requests(tmp_path, monkeypatch):
+    """多次翻页只触发一次扫盘 backfill。"""
     root = tmp_path / "skills"
+    root.mkdir()
     calls = 0
 
     def counted(*_args, **_kwargs):
         nonlocal calls
         calls += 1
-        return [{"name": f"s{index}", "state": "main", "source": "native",
-                 "description": "", "version": 1, "candidates": 0}
-                for index in range(50)]
+        return _fake_scan_rows(root, 50)
 
-    monkeypatch.setattr(
-        dashboard_metrics, "_build_skills_catalog_uncached", counted)
+    monkeypatch.setattr(catalog_store, "scan_skills_catalog", counted)
     skills_catalog_page(root, limit=10, offset=0)
     skills_catalog_page(root, limit=10, offset=10)
-    skills_catalog_page(root, name="s7")
+    skills_catalog_page(root, name="s0007")
     assert calls == 1
 
 
 def test_skills_catalog_page_name_filter_returns_matches(tmp_path, monkeypatch):
-    """L9：name 定向查返回匹配条目，total/by_state 仍按全量。"""
+    """name 定向查返回匹配条目，total/by_state 仍按全量。"""
     root = tmp_path / "skills"
+    root.mkdir()
 
     def build_thousand(*_args, **_kwargs):
-        return [{"name": f"s{index}", "state": "main", "source": "native",
-                 "description": "", "version": 1, "candidates": 0}
-                for index in range(1000)]
+        return _fake_scan_rows(root, 1000)
 
-    monkeypatch.setattr(
-        dashboard_metrics, "_build_skills_catalog_uncached", build_thousand)
-    page = skills_catalog_page(root, name="s512")
-    assert [entry["name"] for entry in page["skills"]] == ["s512"]
+    monkeypatch.setattr(catalog_store, "scan_skills_catalog", build_thousand)
+    page = skills_catalog_page(root, name="s0512")
+    assert [entry["name"] for entry in page["skills"]] == ["s0512"]
     assert page["total"] == 1000
-    assert page["by_state"] == {"main": 1000}
+    assert page["by_state"] == {"main": 500, "staging": 500}
 
 
 def test_users_lists_team_clients(tmp_path):

--- a/tests/test_dashboard_skills_pagination.py
+++ b/tests/test_dashboard_skills_pagination.py
@@ -1,7 +1,6 @@
 """海量 skill 分页:/skills 支持 limit/offset 分页 + name 定向查,total/by_state 按全量。
 
-分页 / 计数 / 深拷贝隔离都走真实的 :func:`skills_catalog_page` + 缓存 bundle
-（审计 L9），测试只在最底层磁盘扫描处注入假清单，让真实读路径全程被覆盖。
+分页走投影表 :func:`skills_catalog_page`；测试在扫盘 backfill 入口注入假清单。
 """
 from __future__ import annotations
 
@@ -10,39 +9,54 @@ from unittest.mock import Mock
 from fastapi import FastAPI
 from fastapi.testclient import TestClient
 
-from xskill.dashboard import metrics as metrics_mod
+import xskill.skill.catalog_store as catalog_store
 from xskill.dashboard import router as router_mod
 from xskill.dashboard.mount import mount_dashboard
 from xskill.dashboard.router import build_dashboard_router
 from xskill.pipeline.registry import get_connection
 
 
-def _fake_catalog(n):
-    return [
-        {
-            "name": f"s{i}",
-            "state": "main" if i % 2 else "staging",
-            "version": "1",
-            "candidates": 0,
+def _fake_catalog_rows(skill_dir, n):
+    root_key = catalog_store.catalog_root_key(skill_dir)
+    rows = []
+    for index in range(n):
+        name = f"s{index:04d}"
+        rows.append({
+            "catalog_key": f"native:{name}",
+            "root_key": root_key,
+            "name": name,
+            "repo_name": name,
             "source": "native",
+            "state": "main" if index % 2 else "staging",
             "description": "",
-        }
-        for i in range(n)
-    ]
+            "version": 1,
+            "candidates": 0,
+            "candidates_count": 0,
+            "main_sha": "",
+            "staging_sha": "",
+            "distributable": 1,
+            "search_id": name,
+            "hub": "",
+            "skill_id": "",
+            "use_count": 0,
+        })
+    return rows
 
 
 def _client(tmp_path, monkeypatch, n):
     db = tmp_path / "r.db"
     get_connection(db).close()
+    monkeypatch.setattr(
+        "xskill.config.get_registry_db_path",
+        lambda: tmp_path / "_skills_catalog_registry.db",
+    )
     app = FastAPI()
     mount_dashboard(app, {"dashboard": {"enabled": True, "public": True}}, db_path=db)
 
-    # 注入到最底层磁盘扫描：真实的缓存 bundle + 分页 + 计数 + 单页深拷贝全程被覆盖。
-    # 每个用例用独立 tmp_path/skill 作缓存键，天然隔离不串缓存。
-    def fake_build(*_args, **_kwargs):
-        return _fake_catalog(n)
+    def fake_scan(skill_dir, skillhub=None):  # noqa: ARG001
+        return _fake_catalog_rows(skill_dir, n)
 
-    monkeypatch.setattr(metrics_mod, "_build_skills_catalog_uncached", fake_build)
+    monkeypatch.setattr(catalog_store, "scan_skills_catalog", fake_scan)
     return TestClient(app)
 
 
@@ -57,7 +71,7 @@ def test_limit_offset_returns_one_page(tmp_path, monkeypatch):
         "/api/v1/dashboard/skills?limit=100&offset=100").json()
     assert body["total"] == 250  # total 仍按全量
     assert len(body["skills"]) == 100
-    assert body["skills"][0]["name"] == "s100"
+    assert body["skills"][0]["name"] == "s0100"
     assert body["offset"] == 100 and body["limit"] == 100
 
 
@@ -77,10 +91,15 @@ def test_name_filter_returns_single_skill(tmp_path, monkeypatch):
 
 def test_standalone_projects_10000_skills_for_all_page_and_name(
         tmp_path, monkeypatch):
-    def fake_build(*_args, **_kwargs):
-        return _fake_catalog(10000)
+    monkeypatch.setattr(
+        "xskill.config.get_registry_db_path",
+        lambda: tmp_path / "_skills_catalog_registry.db",
+    )
 
-    monkeypatch.setattr(metrics_mod, "_build_skills_catalog_uncached", fake_build)
+    def fake_scan(skill_dir, skillhub=None):  # noqa: ARG001
+        return _fake_catalog_rows(skill_dir, 10000)
+
+    monkeypatch.setattr(catalog_store, "scan_skills_catalog", fake_scan)
     monkeypatch.setattr(
         router_mod,
         "_build_skillhub",
@@ -117,13 +136,23 @@ def test_standalone_projects_10000_skills_for_all_page_and_name(
         "name": "s4242",
         "state": "staging",
         "source": "native",
-        "version": "1",
+        "version": 1,
         "candidates": 0,
     }]
 
 
 def test_standalone_projection_reuses_catalog_page_list(tmp_path, monkeypatch):
-    source_rows = _fake_catalog(10000)
+    source_rows = [
+        {
+            "name": f"s{i}",
+            "state": "main" if i % 2 else "staging",
+            "version": "1",
+            "candidates": 0,
+            "source": "native",
+            "description": "",
+        }
+        for i in range(10000)
+    ]
     original_list = source_rows
     original_first_row = source_rows[0]
     page = {
@@ -154,10 +183,8 @@ def test_standalone_projection_reuses_catalog_page_list(tmp_path, monkeypatch):
         for route in router.routes
         if route.path == "/api/v1/dashboard/skills"
     )
-
-    projected_page = skills_endpoint()
-
-    assert projected_page is page
-    assert projected_page["skills"] is original_list
-    assert projected_page["skills"][0] is not original_first_row
-    assert len(projected_page["skills"]) == 10000
+    body = skills_endpoint()
+    assert body is page
+    assert body["skills"] is original_list
+    assert body["skills"][0] is not original_first_row
+    assert len(body["skills"]) == 10000

--- a/tests/test_dashboard_skills_pagination.py
+++ b/tests/test_dashboard_skills_pagination.py
@@ -50,6 +50,10 @@ def _client(tmp_path, monkeypatch, n):
         "xskill.config.get_registry_db_path",
         lambda: tmp_path / "_skills_catalog_registry.db",
     )
+    monkeypatch.setattr(
+        "xskill.pipeline.registry.get_registry_db_path",
+        lambda: tmp_path / "_skills_catalog_registry.db",
+    )
     app = FastAPI()
     mount_dashboard(app, {"dashboard": {"enabled": True, "public": True}}, db_path=db)
 
@@ -93,6 +97,10 @@ def test_standalone_projects_10000_skills_for_all_page_and_name(
         tmp_path, monkeypatch):
     monkeypatch.setattr(
         "xskill.config.get_registry_db_path",
+        lambda: tmp_path / "_skills_catalog_registry.db",
+    )
+    monkeypatch.setattr(
+        "xskill.pipeline.registry.get_registry_db_path",
         lambda: tmp_path / "_skills_catalog_registry.db",
     )
 

--- a/tests/test_skills_catalog_store.py
+++ b/tests/test_skills_catalog_store.py
@@ -14,42 +14,56 @@ def _isolate_registry(tmp_path, monkeypatch):
         "xskill.config.get_registry_db_path",
         lambda: registry,
     )
+    monkeypatch.setattr(
+        "xskill.pipeline.registry.get_registry_db_path",
+        lambda: registry,
+    )
 
 
 def test_init_and_graduate_upsert_native_row(tmp_path):
+    from xskill.agents import agent_tools
     root = tmp_path / "skills"
     root.mkdir()
-    init_skill_repo_on_baby(
-        str(root / "demo"), name="demo", description="baby desc",
+    registry = tmp_path / "registry.db"
+    context = agent_tools.create_agent_tool_context(
+        skill_dir=root,
+        atom_skill_dir=root,
+        registry_db_path=registry,
     )
-    page = catalog_store.page_skills_catalog(root, limit=10)
-    assert page["total"] == 1
-    assert page["skills"][0]["state"] == "baby"
-    assert "baby desc" in page["skills"][0]["description"]
+    with agent_tools.use_agent_tool_context(context):
+        init_skill_repo_on_baby(
+            str(root / "demo"), name="demo", description="baby desc",
+        )
+        page = catalog_store.page_skills_catalog(root, limit=10, db_path=registry)
+        assert page["total"] == 1
+        assert page["skills"][0]["state"] == "baby"
+        assert "baby desc" in page["skills"][0]["description"]
 
-    assert commit_baby_to_main_branch(str(root / "demo"), "graduate")
-    page = catalog_store.page_skills_catalog(root, limit=10)
-    assert page["skills"][0]["state"] == "main"
+        assert commit_baby_to_main_branch(str(root / "demo"), "graduate")
+        page = catalog_store.page_skills_catalog(root, limit=10, db_path=registry)
+        assert page["skills"][0]["state"] == "main"
 
 
 def test_delete_native_removes_row(tmp_path):
     root = tmp_path / "skills"
     root.mkdir()
+    registry = tmp_path / "registry.db"
     init_skill_repo_on_baby(
         str(root / "gone"), name="gone", description="x",
     )
-    catalog_store.ensure_skills_catalog(root)
-    catalog_store.delete_native_skill("gone")
-    assert catalog_store.list_skills_catalog(root) == []
+    catalog_store.ensure_skills_catalog(root, db_path=registry)
+    catalog_store.delete_native_skill("gone", db_path=registry)
+    assert catalog_store.list_skills_catalog(root, db_path=registry) == []
 
 
 def test_backfill_replaces_stale_native_and_hub(tmp_path):
     root = tmp_path / "skills"
     root.mkdir()
+    registry = tmp_path / "registry.db"
     init_skill_repo_on_baby(
         str(root / "keep"), name="keep", description="keep me",
     )
-    catalog_store.ensure_skills_catalog(root)
+    catalog_store.ensure_skills_catalog(root, db_path=registry)
     hub = [{
         "display_name": "hub-skill",
         "source_path": "team/x",
@@ -57,8 +71,71 @@ def test_backfill_replaces_stale_native_and_hub(tmp_path):
         "description": "from hub",
         "use_count": 2,
     }]
-    count = catalog_store.backfill_skills_catalog(root, skillhub=hub)
+    count = catalog_store.backfill_skills_catalog(
+        root, skillhub=hub, db_path=registry,
+    )
     assert count == 2
-    rows = catalog_store.list_skills_catalog(root, skillhub=hub)
+    rows = catalog_store.list_skills_catalog(
+        root, skillhub=hub, db_path=registry,
+    )
     assert [row["name"] for row in rows] == ["keep", "hub-skill"]
     assert rows[1]["use_count"] == 2
+
+
+def test_candidates_notify_uses_count_not_reread(tmp_path, monkeypatch):
+    registry = tmp_path / "registry.db"
+    root = tmp_path / "skills"
+    skill = root / "demo"
+    skill.mkdir(parents=True)
+    (skill / ".git" / "refs" / "heads").mkdir(parents=True)
+    (skill / ".git" / "refs" / "heads" / "baby").write_text("sha\n", encoding="utf-8")
+    (skill / "SKILL.md").write_text(
+        "---\nname: demo\ndescription: d\nmetadata:\n  version: 0\n---\n",
+        encoding="utf-8",
+    )
+    catalog_store.ensure_skills_catalog(root, db_path=registry)
+    catalog_store.notify_native_candidates_count(skill, 3, db_path=registry)
+    page = catalog_store.page_skills_catalog(root, db_path=registry)
+    assert page["skills"][0]["candidates"] == 3
+
+
+def test_notify_upsert_without_db_path_skips_global(tmp_path, monkeypatch):
+    """无 registry_db_path 时 hook 不得创建全局库。"""
+    global_db = tmp_path / "global" / "registry.db"
+    monkeypatch.setattr(
+        "xskill.config.get_registry_db_path",
+        lambda: global_db,
+    )
+    monkeypatch.setattr(
+        "xskill.pipeline.registry.get_registry_db_path",
+        lambda: global_db,
+    )
+    root = tmp_path / "skills"
+    root.mkdir()
+    skill = root / "solo"
+    skill.mkdir()
+    (skill / "SKILL.md").write_text(
+        "---\nname: solo\ndescription: d\n---\n", encoding="utf-8",
+    )
+    catalog_store.notify_native_upsert(skill)
+    assert not global_db.exists()
+
+def test_rename_is_single_transaction(tmp_path):
+    registry = tmp_path / "registry.db"
+    root = tmp_path / "skills"
+    old_path = root / "old"
+    new_path = root / "new"
+    old_path.mkdir(parents=True)
+    (old_path / ".git" / "refs" / "heads").mkdir(parents=True)
+    (old_path / ".git" / "refs" / "heads" / "baby").write_text("a\n", encoding="utf-8")
+    (old_path / "SKILL.md").write_text(
+        "---\nname: old\ndescription: d\n---\n", encoding="utf-8",
+    )
+    catalog_store.upsert_native_skill(old_path, db_path=registry)
+    old_path.rename(new_path)
+    (new_path / "SKILL.md").write_text(
+        "---\nname: new\ndescription: d\n---\n", encoding="utf-8",
+    )
+    catalog_store.rename_native_skill("old", new_path, db_path=registry)
+    rows = catalog_store.list_skills_catalog(root, db_path=registry)
+    assert [row["name"] for row in rows] == ["new"]

--- a/tests/test_skills_catalog_store.py
+++ b/tests/test_skills_catalog_store.py
@@ -1,0 +1,64 @@
+"""skills_catalog 投影表：UPSERT / DELETE / backfill / page。"""
+from __future__ import annotations
+
+import pytest
+
+from xskill.skill import catalog_store
+from xskill.skill.git import commit_baby_to_main_branch, init_skill_repo_on_baby
+
+
+@pytest.fixture(autouse=True)
+def _isolate_registry(tmp_path, monkeypatch):
+    registry = tmp_path / "registry.db"
+    monkeypatch.setattr(
+        "xskill.config.get_registry_db_path",
+        lambda: registry,
+    )
+
+
+def test_init_and_graduate_upsert_native_row(tmp_path):
+    root = tmp_path / "skills"
+    root.mkdir()
+    init_skill_repo_on_baby(
+        str(root / "demo"), name="demo", description="baby desc",
+    )
+    page = catalog_store.page_skills_catalog(root, limit=10)
+    assert page["total"] == 1
+    assert page["skills"][0]["state"] == "baby"
+    assert "baby desc" in page["skills"][0]["description"]
+
+    assert commit_baby_to_main_branch(str(root / "demo"), "graduate")
+    page = catalog_store.page_skills_catalog(root, limit=10)
+    assert page["skills"][0]["state"] == "main"
+
+
+def test_delete_native_removes_row(tmp_path):
+    root = tmp_path / "skills"
+    root.mkdir()
+    init_skill_repo_on_baby(
+        str(root / "gone"), name="gone", description="x",
+    )
+    catalog_store.ensure_skills_catalog(root)
+    catalog_store.delete_native_skill("gone")
+    assert catalog_store.list_skills_catalog(root) == []
+
+
+def test_backfill_replaces_stale_native_and_hub(tmp_path):
+    root = tmp_path / "skills"
+    root.mkdir()
+    init_skill_repo_on_baby(
+        str(root / "keep"), name="keep", description="keep me",
+    )
+    catalog_store.ensure_skills_catalog(root)
+    hub = [{
+        "display_name": "hub-skill",
+        "source_path": "team/x",
+        "skill_id": "hub-skill@1",
+        "description": "from hub",
+        "use_count": 2,
+    }]
+    count = catalog_store.backfill_skills_catalog(root, skillhub=hub)
+    assert count == 2
+    rows = catalog_store.list_skills_catalog(root, skillhub=hub)
+    assert [row["name"] for row in rows] == ["keep", "hub-skill"]
+    assert rows[1]["use_count"] == 2


### PR DESCRIPTION
## Summary
- Closes #162：在 `registry.db` 增加 `skills_catalog` 投影表（磁盘仍为真相源）
- 已确认写出口（init/graduate/staging/canary/candidates/delete/wipe/rename/absorb）实时 UPSERT/DELETE
- Dashboard `/api/v1/dashboard/skills`（及 `skills_catalog`）查表分页；冷启动对该 root 一次性 backfill（并发单飞）
- **Out of scope**：UX score / `.ux_scores.jsonl` 迁移

## Test plan
- [x] `pytest tests/test_skills_catalog_store.py tests/test_dashboard_skills_pagination.py tests/test_dashboard_metrics.py` + console admin skills cache test
- [ ] 本地/预发：大量 skill 下翻页应接近 O(1) SQL，不再每次扫盘
- [ ] 新建 baby → graduate → staging → merge：列表状态即时更新
- [ ] 删除 / wipe / rename 后列表一致


Made with [Cursor](https://cursor.com)