### PR TITLE
fix(ci): rerun known flaky sqlite/TTL tests

### DIFF
--- a/pyproject.toml
+++ b/pyproject.toml
@@ -57,6 +57,9 @@ dev = [
     "pytest-timeout>=2",
     "pytest-asyncio>=0.21",
     "pytest-bdd>=8,<9",
+    # Known CI flakes (SQLite WAL lock / short TTL cache race) use
+    # ``@pytest.mark.flaky`` from this plugin; see marked tests below.
+    "pytest-rerunfailures>=14",
     "requests>=2",
     # HTTP LLM contract tests only.  The Python fixture downloads the pinned
     # @copilotkit/aimock npm artifact and manages its local Node.js process.
@@ -118,6 +121,9 @@ markers = [
     "compact: compact trigger behavior",
     "calibration: EMA calibration behavior",
     "unknown-family: unknown model family fallback behavior",
+    # Registered by pytest-rerunfailures; listed here so ``pytest --markers``
+    # documents the known CI flake retries.
+    "flaky: known intermittent CI failures; rerun via pytest-rerunfailures",
 ]
 addopts = "--ignore=tests/live --ignore=tests/stress"
 asyncio_mode = "strict"

--- a/tests/test_dashboard_metrics.py
+++ b/tests/test_dashboard_metrics.py
@@ -430,8 +430,10 @@ def test_skills_catalog_concurrent_calls_for_300_skills_scan_once(
     assert all(len(rows) == 300 for rows in results)
 
 
+@pytest.mark.flaky(reruns=3, reruns_delay=0.05)
 def test_skills_catalog_cache_ttl_reloads_refs_content_and_candidates(
         tmp_path, monkeypatch):
+    """清单缓存 TTL 命中/过期；CI 慢机上 0.02s TTL 易被文件写入拖过期。"""
     root = tmp_path / "skills"
     root.mkdir()
     skill = _write_catalog_skill(root, "alpha", "version one", branch="main")

--- a/tests/test_sqlite_hot_paths.py
+++ b/tests/test_sqlite_hot_paths.py
@@ -668,8 +668,13 @@ def test_registry_new_db_concurrent_open_assigns_wal_once(tmp_path, monkeypatch)
     assert len(_journal_mode_assignments(statements)) == 1
 
 
+@pytest.mark.flaky(reruns=3, reruns_delay=1, only_rerun=["database is locked"])
 def test_registry_concurrent_usage_writes_do_not_reassign_wal(tmp_path, monkeypatch):
-    """600 次 LLM usage 写入期间，热连接不重复赋值 WAL。"""
+    """600 次 LLM usage 写入期间，热连接不重复赋值 WAL。
+
+    Windows CI 偶发 ``sqlite3.OperationalError: database is locked``（WAL
+    并发平台 flake）；仅对该错误重跑，其它失败仍一次挂掉。
+    """
     from xskill.pipeline import registry
 
     db_path = tmp_path / "registry.db"


### PR DESCRIPTION
## Summary
- Add `pytest-rerunfailures` and mark two known CI flakes:
  - `test_registry_concurrent_usage_writes_do_not_reassign_wal` — rerun only on `database is locked`
  - `test_skills_catalog_cache_ttl_reloads_refs_content_and_candidates` — short TTL timing race on slow runners

## Test plan
- [x] Local: both marked tests pass under pytest with plugin loaded
- [ ] CI `ut+it` matrix green (esp. windows-latest)


Made with [Cursor](https://cursor.com)