### PR TITLE
feat(recommend): recommended 改为纯相关性轮询

### DIFF
--- a/docs/northbound-api.md
+++ b/docs/northbound-api.md
@@ -295,7 +295,7 @@ team:
     skill_slots: 100              # manifest 总槽位
     ranked_slots: 80              # 其中 ux 滑窗占；其余 = recommended(画像相关性)
 recommend:
-  quality_ratio: 0.8              # recommended 桶里质量位占比；其余=相关性
+  quality_ratio: 0.8              # 已废弃：引擎忽略；recommended 纯相关性轮询
   cluster_centers: 5              # 用户兴趣聚类中心上限
   last_n_atoms: 5                 # skill.atom_feat 取最近 N atom
   staging_need: 3                 # 可选；缺省=复用 canary.min_samples

--- a/src/xskill/config.py
+++ b/src/xskill/config.py
@@ -248,7 +248,7 @@ team:
 # ===== Skill recommend engine =====
 # 用户画像 + skill 特征 + 推荐引擎参数。仅 team server 端生效。
 recommend:
-  quality_ratio:   0.8   # 推荐位中按 ux 质量排序的占比；其余按向量相关性
+  quality_ratio:   0.8   # 已废弃：引擎忽略；recommended 纯相关性轮询，不足时 UX 回填
   cluster_centers: 5     # 用户兴趣聚类中心上限（≤5）；atom 少时自动降 k
   last_n_atoms:    5     # skill.atom_feat 取最近 N 个被路由 atom 摘要的均值
   # staging_need:   5    # 可选；缺省 None = 复用 canary.min_samples（推荐侧达量阈值，
@@ -640,6 +640,7 @@ def recommend_config(cfg: Optional[dict] = None) -> dict:
     返回 ``{quality_ratio, cluster_centers, last_n_atoms, staging_need}``。
     ``staging_need`` 缺省 None = 复用 ``canary.min_samples``（推荐侧达量阈值，
     比 total_samples 更适合小团队；引擎构造时解析）。
+    ``quality_ratio`` 仍校验/返回以兼容旧 yaml，推荐引擎已忽略。
     """
     section = (cfg or {}).get("recommend") or {}
     quality_ratio = section.get("quality_ratio", 0.8)

--- a/src/xskill/recommend/engine.py
+++ b/src/xskill/recommend/engine.py
@@ -4,7 +4,8 @@
 （``.skill_index.pkl``，仅 main+staging 可分发 skill，排除 baby）。
 
 - ``update_user_interest``：atom 触发 → 重扫用户 atom 摘要 → 重新聚类 → upsert 画像。
-- ``get_skill_for_client``：80% 质量（ux）+ 20% 相关性（向量 KNN），质量不足相关性回填。
+- ``get_skill_for_client``：recommended 纯相关性（按兴趣中心轮询，每中心每轮
+  取 1 个最高分未选 skill，多轮填满）；冷启动或相关性不足时 UX 序回填。
 - ``resolve_side``：staging 优先达量（未达量→staging；staging 达量 main 未达量→main；
   双侧达量→``pick_side`` 确定性分流），修复 pickside 饿死。记录双向推荐。
 - ``find_friend`` / ``find_tag_for_user`` / ``find_tag_for_skill``。
@@ -15,7 +16,6 @@ from dataclasses import dataclass
 import hashlib
 import json
 import logging
-import math
 from operator import attrgetter, itemgetter
 from pathlib import Path
 import threading
@@ -530,12 +530,13 @@ class SkillRecommendEngine:
         persist_recommendations: bool = True,
         candidate_pool_quality_ordered: bool = False,
     ) -> list["Skill"]:
-        """80% 质量 + 20% 相关性，质量不足相关性回填；记录推荐 + resolve side。
+        """recommended 纯相关性：按兴趣中心轮询（每中心每轮 1 个），多轮填满
+        ``skill_num``；冷启动或相关性不足时 UX 序回填；记录推荐 + resolve side。
 
         ``exclude_names``：从候选池排除的 skill 名（如已占 ranked 槽位的），供
         ``_pick_recommended`` 在 ranked 之外选 recommended 位用。
         ``candidate_pool_quality_ordered`` 表示调用方已按同一质量键排好候选，
-        可避免 manifest 热路径重复读取每个 skill 的评分文件。
+        可避免 manifest 热路径重复读取每个 skill 的评分文件（仅用于 UX 回填）。
         """
         source_pool = (
             list(candidate_pool)
@@ -546,8 +547,6 @@ class SkillRecommendEngine:
         if exclude_names:
             pool = [s for s in pool if s.name not in exclude_names]
 
-        quality_ratio = self.rcfg["quality_ratio"]
-        qn = min(math.ceil(skill_num * quality_ratio), len(pool))
         if candidate_pool_quality_ordered:
             quality_ordered = pool
         else:
@@ -565,49 +564,52 @@ class SkillRecommendEngine:
             decorated = [(quality_keys[skill.name], skill) for skill in pool]
             decorated.sort(key=itemgetter(0), reverse=True)
             quality_ordered = [skill for _key, skill in decorated]
-        quality = quality_ordered[:qn]
-        quality_names = {s.name for s in quality}
 
         relevance: list["Skill"] = []
+        picked: set[str] = set()
         ci = client_user.client_interest
         if ci is not None and ci.feature_tensor is not None:
             names, embs, is_hub = self._combined_relevance(source_pool)
             by_name = {s.name: s for s in pool}  # pool 已排除 exclude_names
-            picked = set(quality_names)
-            for center in ci.feature_tensor:
-                if len(quality) + len(relevance) >= skill_num:
-                    break
-                if embs.shape[0] == 0:
-                    break
-                sims = embs @ np.asarray(center, dtype=float)
-                order = np.argsort(-sims)
-                for i in order:
-                    nm = names[i]
-                    if exclude_names and nm in exclude_names:
-                        continue
-                    if nm in picked:
-                        continue
-                    if is_hub.get(nm):
-                        entry = self.skillhub.entry(nm)
-                        if entry is not None:
-                            relevance.append(entry)
-                            picked.add(nm)
-                            if len(quality) + len(relevance) >= skill_num:
-                                break
-                    elif nm in by_name:
-                        relevance.append(by_name[nm])
-                        picked.add(nm)
-                        if len(quality) + len(relevance) >= skill_num:
+            centers = list(ci.feature_tensor)
+            if len(centers) > 0 and embs.shape[0] > 0:
+                while len(relevance) < skill_num:
+                    progress = False
+                    for center in centers:
+                        if len(relevance) >= skill_num:
                             break
+                        sims = embs @ np.asarray(center, dtype=float)
+                        order = np.argsort(-sims)
+                        for i in order:
+                            nm = names[i]
+                            if exclude_names and nm in exclude_names:
+                                continue
+                            if nm in picked:
+                                continue
+                            if is_hub.get(nm):
+                                entry = self.skillhub.entry(nm)
+                                if entry is None:
+                                    continue
+                                relevance.append(entry)
+                            elif nm in by_name:
+                                relevance.append(by_name[nm])
+                            else:
+                                continue
+                            picked.add(nm)
+                            progress = True
+                            break  # 每中心每轮只取 1 个
+                    if not progress:
+                        break
 
-        chosen = quality + relevance
-        # 回填：质量池不足时从 pool（ux 序）补齐至 skill_num
+        chosen = relevance
+        # 回填：冷启动或相关性不足时从 pool（ux 序）补齐至 skill_num
         if len(chosen) < skill_num:
             for s in quality_ordered:
                 if len(chosen) >= skill_num:
                     break
-                if s not in chosen:
+                if s.name not in picked:
                     chosen.append(s)
+                    picked.add(s.name)
 
         chosen = chosen[:skill_num]
         # 记录推荐 + resolve side（双向）

--- a/tests/test_recommend_config.py
+++ b/tests/test_recommend_config.py
@@ -127,6 +127,7 @@ class TestRecommendConfig:
         assert "recommend:" in CONFIG_TEMPLATE
         assert "quality_ratio" in CONFIG_TEMPLATE
         assert "cluster_centers" in CONFIG_TEMPLATE
+        assert "per_center" not in CONFIG_TEMPLATE
 
 
 # ── skillhub_config ───────────────────────────────────────────────

--- a/tests/test_recommend_engine.py
+++ b/tests/test_recommend_engine.py
@@ -1,6 +1,6 @@
 """test_recommend_engine.py — §5 SkillRecommendEngine
 
-TDD: baby 排除、update_user_interest、80/20+回填、staging 优先达量、双向记录、
+TDD: baby 排除、update_user_interest、纯相关性轮询+回填、staging 优先达量、双向记录、
 find_friend、find_tag_*。
 """
 from __future__ import annotations
@@ -487,28 +487,27 @@ class TestGetSkill:
         _write_index(skill_dir, [f"s{i}" for i in range(5)], dim=5)
         return skill_dir, shas
 
-    def test_standard_80_20(self, tmp_path):
+    def test_pure_relevance_from_profile(self, tmp_path):
         skill_dir, shas = self._setup5(tmp_path)
-        # s0..s3 有 ux 分；s4 无
+        # s0..s3 有 ux 分；s4 无 — recommended 不再按 quality_ratio 占质量位
         for i in range(4):
             append_ux_score(skill_dir / f"s{i}", traj_id="t", skill_name=f"s{i}",
                             side="main", commit_sha=shas[f"s{i}"], score=5 + i, reasons="r")
         traj_root = tmp_path / "traj"
         eng = _engine(tmp_path, skill_dir, traj_root)
-        # 用户 feature_tensor = [one-hot(s4)] → 相关性应选 s4
+        # 用户 feature_tensor = [one-hot(s4)] → 相关性应优先 s4
         ci = ClientInterest("u1")
         ci._feature_tensor = np.array([[0.0, 0.0, 0.0, 0.0, 1.0]])  # s4 one-hot
         ci._mean_tensor = np.array([0.0, 0.0, 0.0, 0.0, 1.0])
         user = ClientUser("u1", client_interest=ci)
-        # 预置画像让 find 不报错
         eng.profile_store.upsert("u1", feature_tensor=ci._feature_tensor,
                                  mean_tensor=ci._mean_tensor, used_skills=[])
         skills = eng.get_skill_for_client(user, skill_num=5)
         names = [s.name for s in skills]
-        # 质量 4 个（s0..s3）+ 相关性 1 个（s4）
+        assert names[0] == "s4"  # 单中心对齐 s4，相关性首位
         assert set(names) == {"s0", "s1", "s2", "s3", "s4"}
 
-    def test_backfill_when_quality_small(self, tmp_path):
+    def test_backfill_when_cold_start(self, tmp_path):
         skill_dir, shas = self._setup5(tmp_path)
         # 只有 s0 有 ux 分
         append_ux_score(skill_dir / "s0", traj_id="t", skill_name="s0",
@@ -516,8 +515,48 @@ class TestGetSkill:
         eng = _engine(tmp_path, skill_dir, tmp_path / "traj")
         user = ClientUser("u1")  # 冷启动无画像
         skills = eng.get_skill_for_client(user, skill_num=5)
-        assert len(skills) == 5  # 质量 1 + 回填 4
-        assert "s0" in [s.name for s in skills]
+        assert len(skills) == 5  # 无画像 → 全 UX 回填
+        assert skills[0].name == "s0"  # ux 最高优先
+
+    def test_relevance_round_robin_per_center(self, tmp_path):
+        """多兴趣中心时每轮每中心取 1 个，轮询填满名额。"""
+        skill_dir = tmp_path / "skills"
+        names = [f"s{i}" for i in range(6)]
+        for i, name in enumerate(names):
+            _make_main_skill(skill_dir, name, desc=f"desc {i}")
+        _write_index(skill_dir, names, dim=6)
+        traj_root = tmp_path / "traj"
+        cfg = {
+            "recommend": {"staging_need": 3},
+            "canary": {"min_samples": 3, "total_samples": 3},
+            "skillhub": {"enabled": False},
+        }
+        eng = SkillRecommendEngine(
+            config=cfg,
+            skill_dir=skill_dir,
+            traj_root=traj_root,
+            embed_client=FakeEmbed(dim=6),
+            profile_db=tmp_path / "profile.db",
+        )
+        # 两个中心：分别对齐 s0 / s3
+        ci = ClientInterest("u1")
+        ci._feature_tensor = np.array([
+            [1.0, 0.0, 0.0, 0.0, 0.0, 0.0],
+            [0.0, 0.0, 0.0, 1.0, 0.0, 0.0],
+        ])
+        ci._mean_tensor = ci._feature_tensor.mean(axis=0)
+        user = ClientUser("u1", client_interest=ci)
+        eng.profile_store.upsert(
+            "u1", feature_tensor=ci._feature_tensor,
+            mean_tensor=ci._mean_tensor, used_skills=[],
+        )
+        skills = eng.get_skill_for_client(user, skill_num=4)
+        got = [s.name for s in skills]
+        # 第一轮：各中心 1 个 → s0, s3；第二轮再各 1 个 → s1, s4…
+        assert "s0" in got and "s3" in got
+        assert len(got) == 4
+        assert got[0] == "s0"
+        assert got[1] == "s3"
 
 
 # ── resolve_side staging 优先达量 ─────────────────────────────────

--- a/tests/test_skillhub.py
+++ b/tests/test_skillhub.py
@@ -231,12 +231,12 @@ class TestEngineSkillhubPool:
         assert any(n.startswith("extfoo@") for n in hub_names)  # 三方 skill 进了检索池
         assert "s0" in all_names
 
-    def test_skillhub_not_in_quality_bucket(self, tmp_path):
+    def test_skillhub_not_in_distributable_pool(self, tmp_path):
         hub_dir = tmp_path / "hub"
         _write_hub_skill(hub_dir, "extfoo", "django migration helper")
         eng = self._engine(tmp_path, skillhub_enabled=True, hub_dir=hub_dir)
         pool = eng._distributable_skills()
-        # 三方 skill 无 git/main → 不在可分发池 → 不进质量位
+        # 三方 skill 无 git/main → 不在可分发池
         assert all(s.name != "extfoo" for s in pool)
 
     def test_skillhub_disabled_not_in_pool(self, tmp_path):


### PR DESCRIPTION
## Summary

recommended 桶改为按兴趣中心轮询取相关性最高且未入选的 skill，不再在推荐桶里按 quality_ratio 混 UX 质量位。不足时再用 UX 回填。

## Changes

- `get_skill_for_client`：有画像时纯相关性轮询；冷启动或填不满时 UX 回填
- 配置里 `quality_ratio` 保留校验以兼容旧 yaml，引擎不再用它切质量位
- 去掉 `per_center` 配置
- 更新相关单测与 northbound 文档说明

## Test plan

- [x] Added/updated unit tests for the change
- [x] `pytest tests/test_recommend_config.py tests/test_recommend_engine.py tests/test_skillhub.py` passes
- [ ] `make test` passes
- [ ] Manually verified the affected user flow

## Linked issues

Related to #172
