### PR TITLE
fix(dashboard): 流水线日志滚动改为贴底跟随（#178）

### DIFF
--- a/src/xskill/dashboard/static/app.js
+++ b/src/xskill/dashboard/static/app.js
@@ -1026,6 +1026,13 @@ function pmSelectedSeat() {
   return (pool.seats || [])[pmSelected.seat] || null;
 }
 
+// 日志区是否贴底：仅贴底时跟随新行，用户上滚后不被轮询抢走位置
+function pmLogNearBottom(el, pad) {
+  if (!el) return true;
+  pad = pad == null ? 48 : pad;
+  return el.scrollHeight - el.scrollTop - el.clientHeight <= pad;
+}
+
 function pmRenderDrawer() {
   const dr = document.getElementById('pm-drawer');
   const seat = pmSelectedSeat();
@@ -1041,10 +1048,12 @@ function pmRenderDrawer() {
   const task = seat.task || {};
   const age = pmAgeText(pmSeatAge(seat));
   const def = PM_POOLS.find(p => p.key === pmSelected.pool);
-  // 抽屉随 live 轮询重渲染：同一任务的日志内容要保住，否则每 3s 闪回「加载中」
+  // 抽屉随 live 轮询重渲染：同一任务的日志内容与滚动位置要保住，否则每 3s 闪回/跳底
   const hasStream = task.kind === 'skill' || task.kind === 'traj';
-  const existingLog = (hasStream && pmLogKey && document.getElementById('pm-log'))
-    ? document.getElementById('pm-log').innerHTML : '';
+  const existingEl = (hasStream && pmLogKey) ? document.getElementById('pm-log') : null;
+  const existingLog = existingEl ? existingEl.innerHTML : '';
+  const stickBottom = pmLogNearBottom(existingEl);
+  const savedScroll = existingEl ? existingEl.scrollTop : 0;
   const logPane = `<div class="pm-log" id="pm-log">${existingLog || '<div class="dim">日志加载中…</div>'}</div>`;
   let head = '', logHtml = '';
   if (task.kind === 'skill') {
@@ -1068,6 +1077,10 @@ function pmRenderDrawer() {
   dr.className = 'pm-drawer ring-1 ring-slate-200';
   dr.innerHTML = `<div class="flex items-start justify-between gap-2"><div class="min-w-0">${head}</div>
     <button type="button" class="pm-btn ghost shrink-0" data-pm-close>关闭</button></div>${logHtml}`;
+  const newLog = document.getElementById('pm-log');
+  if (newLog && existingLog) {
+    newLog.scrollTop = stickBottom ? newLog.scrollHeight : savedScroll;
+  }
   if (task.kind === 'skill' || task.kind === 'traj') pmStartLog(task.kind, task.kind === 'skill' ? task.skill_name : task.traj_id);
   else pmStopLog();
 }
@@ -1087,20 +1100,21 @@ async function pmPollLog() {
     const log = document.getElementById('pm-log');
     if (!log) return;
     if (!r.exists) { log.innerHTML = `<div class="dim">${esc(r.message || '该任务暂无日志文件')}</div>`; return; }
+    const stickBottom = pmLogNearBottom(log);
     log.innerHTML = (r.lines || []).map(l => {
       const cls = pmLogClassify(l);
       return cls ? `<div class="${cls}">${esc(l)}</div>` : `<div>${esc(l)}</div>`;
     }).join('') || '<div class="dim">（日志为空）</div>';
     if (r.truncated) log.insertAdjacentHTML('afterbegin', '<div class="dim">…（仅显示日志尾部）</div>');
-    log.scrollTop = log.scrollHeight;
+    if (stickBottom) log.scrollTop = log.scrollHeight;
   } catch (e) {
     const log = document.getElementById('pm-log');
     if (log) log.innerHTML = `<div class="err">日志读取失败：${esc(e.message)}</div>`;
   }
 }
 function pmStartLog(kind, name) {
-  const key = kind + ':' + name;
-  if (pmLogKey === key) return;
+  // pmLogKey 是 {kind,name}，不可与字符串 key 做 ===（否则每次抽屉重渲染都会重启轮询并强制贴底）
+  if (pmLogKey && pmLogKey.kind === kind && pmLogKey.name === name) return;
   pmStopLog();
   pmLogKey = { kind, name };
   pmPollLog();

--- a/tests/test_dashboard_frontend_smoke.py
+++ b/tests/test_dashboard_frontend_smoke.py
@@ -155,3 +155,45 @@ def test_appjs_routes_skillhub_detail_by_source():
     assert "dashboard/skillhub/" in js
     assert "/ux?days=" in js
     assert "/ux/atoms?days=" in js
+
+
+def test_pipeline_log_scroll_is_sticky_not_forced():
+    """#178: 流水线日志仅在贴底时跟随；pmStartLog 用 kind/name 比较，避免抽屉重渲染重启轮询。"""
+    js = (STATIC / "app.js").read_text(encoding="utf-8")
+    assert "function pmLogNearBottom(" in js
+    assert "if (stickBottom) log.scrollTop = log.scrollHeight" in js
+    # 禁止无条件贴底（旧逻辑）
+    assert re.search(
+        r"if \(r\.truncated\).*?\n\s*log\.scrollTop = log\.scrollHeight",
+        js,
+        re.S,
+    ) is None
+    assert "pmLogKey.kind === kind && pmLogKey.name === name" in js
+    # 抽屉重渲染后恢复滚动
+    assert "stickBottom ? newLog.scrollHeight : savedScroll" in js
+
+
+def test_pm_log_near_bottom_behavior():
+    """pmLogNearBottom：贴底/上滚两种姿态。"""
+    script = f"""
+const fs = require('node:fs');
+const vm = require('node:vm');
+const source = fs.readFileSync({json.dumps(str(STATIC / "app.js"))}, 'utf8');
+const start = source.indexOf('function pmLogNearBottom(');
+const end = source.indexOf('function pmRenderDrawer(');
+if (start < 0 || end < 0) throw new Error('pmLogNearBottom marker missing');
+const context = vm.createContext({{}});
+vm.runInContext(source.slice(start, end) + '\\nthis.pmLogNearBottom = pmLogNearBottom;', context);
+const near = context.pmLogNearBottom;
+const bottom = {{ scrollHeight: 1000, scrollTop: 920, clientHeight: 80 }};
+const mid = {{ scrollHeight: 1000, scrollTop: 200, clientHeight: 80 }};
+process.stdout.write(JSON.stringify([near(null), near(bottom), near(mid)]));
+"""
+    result = subprocess.run(
+        ["node", "-e", script],
+        check=True,
+        capture_output=True,
+        text=True,
+        encoding="utf-8",
+    )
+    assert json.loads(result.stdout) == [True, True, False]


### PR DESCRIPTION
## Summary
- Fixes #178：流水线任务日志不再无条件锁死在底部；用户上滚后保持当前位置，贴底时继续跟随新日志
- 抽屉随 live 重渲染时保留滚动位置；修正 `pmStartLog` 用 `kind`/`name` 去重（原先对象与字符串 `===` 恒为 false，导致每轮重启轮询）

## Test plan
- [x] `python3.11 -m pytest tests/test_dashboard_frontend_smoke.py -q`（含新增 sticky-scroll 断言与 `pmLogNearBottom` 行为用例）
- [ ] 打开 Dashboard → 流水线 → 点选有日志的任务：保持贴底时跟随；上滚后轮询不再抢滚动条；过几轮 live 刷新后位置仍稳定


Made with [Cursor](https://cursor.com)