### PR TITLE
feat(dashboard): 「我的」页 UX（#174）

### DIFF
--- a/src/xskill/dashboard/console.py
+++ b/src/xskill/dashboard/console.py
@@ -94,6 +94,70 @@ def _client_to_user(registry) -> dict[str, str]:
 # 推荐 × 触发（2.6 用户级精确口径）
 # ---------------------------------------------------------------------------
 
+def _norm_skill_source(raw: str | None) -> str:
+    """把 manifest/catalog 的 source 归一到 UI 三态: native / upload / skillhub。"""
+    if raw in ("skillhub", "upload"):
+        return raw
+    return "native"
+
+
+def _slot_source_fields(slot) -> dict:
+    raw = getattr(slot, "source", None) or "repo"
+    out = {
+        "source": _norm_skill_source(raw),
+        "source_path": getattr(slot, "source_path", None) or None,
+    }
+    return out
+
+
+def _skill_meta_for_names(names: list[str], *, db_path: Optional[Path],
+                          skill_dir: Path) -> dict[str, dict]:
+    """贡献关系图 skill 芯片用的轻量摘要。"""
+    from xskill.events import skill_main_producer
+    from xskill.dashboard.explore import skill_lineage
+
+    meta: dict[str, dict] = {}
+    for name in names:
+        if not name:
+            continue
+        entry: dict = {"source": "native", "source_path": None,
+                       "producer": None, "producer_trajs": None,
+                       "ux": None, "top": None, "recent": [], "trend": []}
+        # skillhub 目录启发式：skill_dir 下若有 .skillhub 元数据则标第三方
+        sub = Path(skill_dir) / name
+        if sub.is_dir():
+            # 尝试读 skillhub 路径标记
+            sp = None
+            for cand in (sub / "SOURCE_PATH", sub / ".source_path"):
+                if cand.is_file():
+                    sp = cand.read_text(encoding="utf-8").strip() or None
+                    break
+            if sp:
+                entry["source"] = "skillhub"
+                entry["source_path"] = sp
+        prod = skill_main_producer(name, db_path=db_path)
+        if prod and entry["source"] == "native":
+            entry["producer"] = prod["user"]
+            entry["producer_trajs"] = prod["traj_count"]
+        try:
+            lin = skill_lineage(Path(skill_dir), name, db_path=db_path)
+            entry["ux"] = lin.get("avg_ux")
+            by_user = lin.get("by_user") or []
+            if by_user:
+                top = by_user[0]
+                entry["top"] = {
+                    "user": top.get("user"),
+                    "count": (top.get("atoms") or top.get("count")
+                              or top.get("n") or top.get("triggers") or 0),
+                }
+                entry["recent"] = [{"user": u.get("user")}
+                                   for u in by_user[:3] if u.get("user")]
+        except Exception:  # noqa: BLE001 — 芯片摘要失败不挡主路径
+            pass
+        meta[name] = entry
+    return meta
+
+
 def reco_trigger_for_users(*, db_path: Optional[Path], skill_dir: Path,
                            registry) -> dict[str, list[dict]]:
     """全量算 user_key → [{skill, exposures, triggers, rate, last_trigger,
@@ -304,17 +368,34 @@ def build_console_router(db_path: Optional[Path] = None) -> APIRouter:
             retired=retired_skills(db_path=db_path),
         )
         slots = []
+        trigger_by_skill = {
+            r["skill"]: int(r.get("triggers") or 0)
+            for r in reco_trigger_for_users(
+                db_path=db_path, skill_dir=Path(ctx.skill_dir),
+                registry=ctx.client_registry).get(user, [])
+        }
+        from xskill.events import skill_main_producer
         for s in resp.slots:
             meta = prefs["pin_meta"].get(s.skill_name, {})
-            slots.append({
+            src = _slot_source_fields(s)
+            row = {
                 "skill_name": s.skill_name, "side": s.side, "sha": s.sha,
-                "bucket": s.bucket, "source": s.source,
+                "bucket": s.bucket,
+                "source": src["source"],
+                "source_path": src["source_path"],
+                "my_triggers": trigger_by_skill.get(s.skill_name, 0),
                 # pinned 细分:自己 pin / admin 代 pin / 全局 pin——前端置灰依据
                 "pin_scope": meta.get("scope", ""),
                 "pin_set_by": meta.get("set_by", ""),
                 "user_removable": (
                     s.bucket != "pinned" or meta.get("set_by") == user),
-            })
+            }
+            if src["source"] == "native":
+                prod = skill_main_producer(s.skill_name, db_path=db_path)
+                if prod:
+                    row["producer"] = prod["user"]
+                    row["producer_trajs"] = prod["traj_count"]
+            slots.append(row)
         blocked_rows = [r for r in prefs_for(user, db_path=db_path)
                         if r["pref"] == "blocked"]
         return {"user": user, "slots": slots,
@@ -419,6 +500,60 @@ def build_console_router(db_path: Optional[Path] = None) -> APIRouter:
                       "skills": len(my_skills)},
             "skills": my_skills,
             "usage": usage,
+        }
+
+    @router.get("/my/contributions/trajs")
+    def my_contribution_trajs(offset: int = 0, limit: int = 5,
+                              ident=Depends(require_user)):
+        """我的贡献去向：分页轨迹 + traj→atom→skill 去向（供关系图）。"""
+        ctx = _require_team_ctx()
+        from xskill.dashboard.explore import TrajExplorer
+        user = ident["user"]
+        limit = max(1, min(int(limit or 5), 20))
+        offset = max(0, int(offset or 0))
+        with pooled_connection(db_path) as conn:
+            total = conn.execute(
+                "SELECT COUNT(*) n FROM trajectories t"
+                " JOIN watch_dirs w ON t.watch_dir_id=w.id"
+                " WHERE t.user_key=? AND "
+                f"{dashboard_visible_trajectory_sql('t', 'w')}",
+                (user,),
+            ).fetchone()["n"]
+            rows = conn.execute(
+                "SELECT t.filename FROM trajectories t"
+                " JOIN watch_dirs w ON t.watch_dir_id=w.id"
+                " WHERE t.user_key=? AND "
+                f"{dashboard_visible_trajectory_sql('t', 'w')}"
+                " ORDER BY t.discovered_at DESC, t.filename DESC"
+                " LIMIT ? OFFSET ?",
+                (user, limit, offset),
+            ).fetchall()
+        explorer = TrajExplorer(db_path=db_path, skill_dir=Path(ctx.skill_dir))
+        trajs = []
+        skill_names: set[str] = set()
+        for r in rows:
+            fn = r["filename"] or ""
+            traj_id = fn[:-3] if fn.endswith(".md") else fn
+            try:
+                atoms_raw = explorer.traj_atoms(traj_id)
+            except KeyError:
+                atoms_raw = []
+            atoms = []
+            for a in atoms_raw:
+                dests = [
+                    {"skill": d.get("skill"), "weightscore": d.get("weightscore"),
+                     "state": d.get("state")}
+                    for d in (a.get("destinations") or []) if d.get("skill")
+                ]
+                for d in dests:
+                    skill_names.add(d["skill"])
+                atoms.append({"atom_id": a.get("atom_id"), "destinations": dests})
+            trajs.append({"traj_id": traj_id, "atoms": atoms})
+        skill_meta = _skill_meta_for_names(
+            sorted(skill_names), db_path=db_path, skill_dir=Path(ctx.skill_dir))
+        return {
+            "user": user, "total": total, "offset": offset, "limit": limit,
+            "trajs": trajs, "skill_meta": skill_meta,
         }
 
     @router.get("/my/reco-trigger")

--- a/src/xskill/dashboard/console.py
+++ b/src/xskill/dashboard/console.py
@@ -113,9 +113,10 @@ def _slot_source_fields(slot) -> dict:
 def _skill_meta_for_names(names: list[str], *, db_path: Optional[Path],
                           skill_dir: Path) -> dict[str, dict]:
     """贡献关系图 skill 芯片用的轻量摘要。"""
-    from xskill.events import skill_main_producer
+    from xskill.events import skill_main_producers
     from xskill.dashboard.explore import skill_lineage
 
+    producers = skill_main_producers(names, db_path=db_path)
     meta: dict[str, dict] = {}
     for name in names:
         if not name:
@@ -135,7 +136,7 @@ def _skill_meta_for_names(names: list[str], *, db_path: Optional[Path],
             if sp:
                 entry["source"] = "skillhub"
                 entry["source_path"] = sp
-        prod = skill_main_producer(name, db_path=db_path)
+        prod = producers.get(name)
         if prod and entry["source"] == "native":
             entry["producer"] = prod["user"]
             entry["producer_trajs"] = prod["traj_count"]
@@ -374,10 +375,17 @@ def build_console_router(db_path: Optional[Path] = None) -> APIRouter:
                 db_path=db_path, skill_dir=Path(ctx.skill_dir),
                 registry=ctx.client_registry).get(user, [])
         }
-        from xskill.events import skill_main_producer
+        from xskill.events import skill_main_producers
+        native_names = []
+        slot_srcs = []
         for s in resp.slots:
-            meta = prefs["pin_meta"].get(s.skill_name, {})
             src = _slot_source_fields(s)
+            slot_srcs.append(src)
+            if src["source"] == "native":
+                native_names.append(s.skill_name)
+        producers = skill_main_producers(native_names, db_path=db_path)
+        for s, src in zip(resp.slots, slot_srcs):
+            meta = prefs["pin_meta"].get(s.skill_name, {})
             row = {
                 "skill_name": s.skill_name, "side": s.side, "sha": s.sha,
                 "bucket": s.bucket,
@@ -391,7 +399,7 @@ def build_console_router(db_path: Optional[Path] = None) -> APIRouter:
                     s.bucket != "pinned" or meta.get("set_by") == user),
             }
             if src["source"] == "native":
-                prod = skill_main_producer(s.skill_name, db_path=db_path)
+                prod = producers.get(s.skill_name)
                 if prod:
                     row["producer"] = prod["user"]
                     row["producer_trajs"] = prod["traj_count"]

--- a/src/xskill/dashboard/static/app.js
+++ b/src/xskill/dashboard/static/app.js
@@ -400,6 +400,7 @@ function renderDiff(diff) {
 }
 
 let _curSkill = null;
+let _skillBackHash = null; // 从「我的」贡献图点入时回到 #my
 // 判定某 skill 属于自产(native)还是三方(skillhub)——从技能库列表载荷取
 // source 字段(列表由另一路渲染，本函数只读)。jc 已缓存该端点，无额外请求。
 // 拿不到 source / 请求失败 → 安全兜底按自产走，绝不因缺字段崩。
@@ -417,6 +418,9 @@ async function skillSource(name) {
 async function openSkill(name) {
   _curSkill = name;
   const box = document.getElementById('skill-detail');
+  const back = _skillBackHash === 'my'
+    ? `<a href="#my" class="text-teal-700 hover:underline">我的</a>`
+    : '技能库';
   box.innerHTML = `<div class="bg-white rounded-2xl ring-1 ring-slate-200 p-5 text-slate-400">加载 ${esc(name)} …</div>`;
   // 三方 skill 无 git / staging，走 skillhub 专用端点(自产 detail 对其 404)。
   if (await skillSource(name) === 'skillhub') { await renderSkillhubDetail(name, box); return; }
@@ -466,7 +470,7 @@ async function openSkill(name) {
 
   box.innerHTML = `
   <div class="bg-white rounded-2xl ring-1 ring-slate-200 p-5">
-    <div class="text-xs text-slate-400 mb-1.5">技能库 <span class="mx-1">/</span> <span class="text-slate-600">${esc(name)}</span></div>
+    <div class="text-xs text-slate-400 mb-1.5">${back} <span class="mx-1">/</span> <span class="text-slate-600">${esc(name)}</span></div>
     <div class="flex items-start justify-between gap-3 flex-wrap">
       <div>
         <h2 class="text-lg font-bold tracking-tight">${esc(name)}</h2>
@@ -1184,7 +1188,13 @@ function route() {
     openSkill(parts[1]).catch(console.error);
     return;
   }
-  showPage(parts[0] || 'overview');
+  // #174：普通用户默认进「我的」；admin 保持总览
+  let pg = parts[0] || '';
+  if (!pg || pg === 'overview') {
+    if (IDENT && IDENT.role !== 'admin') pg = 'my';
+    else pg = pg || 'overview';
+  }
+  showPage(pg);
 }
 window.addEventListener('hashchange', route);
 
@@ -1199,9 +1209,9 @@ document.addEventListener('click', async e => {
     return;
   }
   const row = e.target.closest('[data-skill-row]');
-  if (row) { location.hash = 'skill/' + encodeURIComponent(row.dataset.skillRow); return; }
+  if (row) { _skillBackHash = null; location.hash = 'skill/' + encodeURIComponent(row.dataset.skillRow); return; }
   const sj = e.target.closest('.skill-jump');
-  if (sj) { location.hash = 'skill/' + encodeURIComponent(sj.dataset.skill); return; }
+  if (sj) { _skillBackHash = null; location.hash = 'skill/' + encodeURIComponent(sj.dataset.skill); return; }
   const aj = e.target.closest('[data-atom-jump]');
   if (aj) { location.hash = 'traj/' + aj.dataset.atomJump; return; }
   const step = e.target.closest('.atom-step');
@@ -1312,6 +1322,11 @@ async function initIdent() {
   applyIdent();
   if (IDENT) { loadMy().catch(console.error); initEvents(); }
   if (IDENT && IDENT.role === 'admin') { loadAdmin().catch(console.error); loadSettings().catch(console.error); }
+  // 登录后若仍停在空/#overview，普通用户跳到「我的」
+  if (IDENT && IDENT.role !== 'admin') {
+    const h = (location.hash || '').replace(/^#/, '');
+    if (!h || h === 'overview') location.hash = '#my';
+  }
 }
 
 // 登录弹窗
@@ -1330,6 +1345,7 @@ document.getElementById('login-submit').addEventListener('click', async () => {
     loadMy().catch(console.error);
     initEvents();
     if (IDENT.role === 'admin') { loadAdmin().catch(console.error); loadSettings().catch(console.error); }
+    else location.hash = '#my';
   } catch (e) { err.textContent = e.message; }
 });
 document.getElementById('login-secret').addEventListener('keydown', e => { if (e.key === 'Enter') document.getElementById('login-submit').click(); });
@@ -1344,10 +1360,195 @@ const BUCKET_CHIP = {
   ranked: 'bg-teal-50 text-teal-700 ring-1 ring-teal-100',
   recommended: 'bg-sky-100 text-sky-700',
 };
+const TRAJ_PAGE = 5;
+const RT_PAGE = 10;
+const FEED_PAGE = 5;
+let _rtRows = [];
+let _rtPage = 0;
+let _rtOpen = false;
+let _contribOpen = true;
+let _trajPage = 0;
+let _contribTraj = null;
+let _contribPayload = null; // {total, trajs, skill_meta}
+let _feedPages = []; // cached pages of events
+let _feedPage = 0;
+let _feedBefore = null;
+let _feedExhausted = false;
+
 function bucketLabel(s) {
   if (s.bucket !== 'pinned') return s.bucket;
   return s.pin_scope === 'global' ? 'pinned·全局' : (s.user_removable ? 'pinned·自己' : 'pinned·admin');
 }
+function mySourceBadge(s, withDetail) {
+  const src = s.source || 'native';
+  let b = `<span class="src-badge src-native">自产</span>`;
+  if (src === 'skillhub') b = `<span class="src-badge src-hub">第三方</span>`;
+  else if (src === 'upload') b = `<span class="src-badge src-upload">上传</span>`;
+  if (src === 'native' && s.producer) {
+    b += ` <span class="text-[10px] text-slate-500">主要贡献人 <b class="font-medium text-slate-700">${esc(s.producer)}</b></span>`;
+    if (withDetail && s.producer_trajs != null) b += ` <span class="src-path">${s.producer_trajs} 条轨迹</span>`;
+  } else if (withDetail) {
+    if (s.source_path) b += ` <span class="src-path">${esc(s.source_path)}</span>`;
+  }
+  return b;
+}
+function sparkline(vals, w, h) {
+  vals = vals && vals.length ? vals : [0];
+  w = w || 48; h = h || 18;
+  const pad = 1;
+  const min = Math.min(...vals), max = Math.max(...vals);
+  const span = max - min || 1;
+  const pts = vals.map((v, i) => {
+    const x = pad + i * (w - 2 * pad) / Math.max(1, vals.length - 1);
+    const y = h - pad - ((v - min) / span) * (h - 2 * pad);
+    return x.toFixed(1) + ',' + y.toFixed(1);
+  }).join(' ');
+  const up = vals[vals.length - 1] >= vals[0];
+  return `<svg width="${w}" height="${h}" viewBox="0 0 ${w} ${h}"><polyline fill="none" stroke="${up ? '#0d9488' : '#e11d48'}" stroke-width="1.5" points="${pts}"/></svg>`;
+}
+
+function contribRelationGraph(trajId, atoms) {
+  if (!atoms.length) return { svg: '<span class="text-slate-400 text-xs">暂无原子</span>', skills: [], H: 40, top: 18, rowH: 78, chipH: 68, atomN: 0, skillN: 0 };
+  const skills = [];
+  atoms.forEach(a => (a.destinations || []).forEach(d => {
+    if (d.skill && !skills.includes(d.skill)) skills.push(d.skill);
+  }));
+  const rowH = 78, chipH = 68, top = 18;
+  const H = Math.max(atoms.length, skills.length || 1) * rowH + 12;
+  const ay = i => top + i * rowH + (Math.max(0, skills.length - atoms.length) * rowH) / 2;
+  const sy = i => top + i * rowH + (Math.max(0, atoms.length - skills.length) * rowH) / 2;
+  const midY = 8 + (H - 16) / 2;
+  const W = 300;
+  const edges = atoms.map((a, i) =>
+    `<path d="M90 ${midY} C 132 ${midY} 132 ${ay(i)} 158 ${ay(i)}" fill="none" stroke="#cbd5e1" stroke-width="1.5"/>`).join('')
+    + atoms.flatMap((a, i) => (a.destinations || []).map(d => {
+      const si = skills.indexOf(d.skill);
+      return `<path d="M176 ${ay(i)} C 228 ${ay(i)} 228 ${sy(si)} 280 ${sy(si)}" fill="none" stroke="#14b8a6" stroke-width="2"/>
+        <text x="226" y="${(ay(i) + sy(si)) / 2 - 4}" font-size="9" fill="#94a3b8" text-anchor="middle">${d.weightscore != null ? 'ws ' + esc(d.weightscore) : ''}</text>`;
+    })).join('');
+  const atomNodes = atoms.map((a, i) => {
+    const hit = (a.destinations || []).length;
+    return `<g>
+      <circle cx="167" cy="${ay(i)}" r="${hit ? 10 : 8}" fill="${hit ? '#0d9488' : '#e2e8f0'}"/>
+      <text x="167" y="${ay(i) + 3.2}" font-size="9.5" font-family="ui-monospace,monospace" text-anchor="middle" fill="${hit ? '#fff' : '#64748b'}">${esc(String(a.atom_id || '').slice(-2))}</text>
+      <title>${esc(a.atom_id)}</title>
+    </g>`;
+  }).join('');
+  const skillAnchors = skills.map((sk, i) =>
+    `<circle cx="288" cy="${sy(i)}" r="4.5" fill="#0d9488"/>`).join('');
+  const label = trajId.length > 12 ? trajId.slice(0, 11) + '…' : trajId;
+  const svg = `<svg viewBox="0 0 ${W} ${H}" width="${W}" height="${H}" style="display:block">
+      <rect x="8" y="${midY - 13}" width="80" height="26" rx="7" fill="#134e4a"/>
+      <text x="48" y="${midY + 3.5}" font-size="9.5" fill="#fff" text-anchor="middle" font-family="ui-monospace,monospace">${esc(label)}</text>
+      ${edges}${atomNodes}${skillAnchors}
+    </svg>`;
+  return { svg, skills, H, top, rowH, chipH, atomN: atoms.length, skillN: skills.length };
+}
+function contribSkillChips(skills, layout, metaMap) {
+  if (!skills.length) return '<span class="text-[11px] text-slate-400 px-1">暂无关联 skill</span>';
+  const top = layout.top + (Math.max(0, layout.atomN - layout.skillN) * layout.rowH) / 2;
+  const chipH = layout.chipH || 68;
+  return `<div style="position:relative;height:${layout.H}px;width:268px">${skills.map((sk, i) => {
+    const m = metaMap[sk] || {};
+    const y = top + i * layout.rowH - chipH / 2;
+    const recent = (m.recent || []).slice(0, 2).map(u => esc(u.user)).join(' · ');
+    const topU = m.top || {};
+    return `<button type="button" class="skill-chip graph-skill" data-skill="${esc(sk)}" style="position:absolute;left:0;top:${y}px">
+      <div class="min-w-0 flex-1">
+        <div class="nm">${esc(sk)}</div>
+        <div class="meta">${mySourceBadge(m)}<span class="text-[10px] text-slate-500">ux <b class="tabular-nums text-slate-700">${m.ux != null ? esc(m.ux) : '—'}</b></span></div>
+        <div class="text-[10px] text-slate-400 truncate leading-tight">最近 ${recent || '—'} · 最多 ${esc(topU.user || '—')}×${topU.count != null ? topU.count : 0}</div>
+      </div>
+      <div class="shrink-0 opacity-90">${sparkline(m.trend || [0])}</div>
+    </button>`;
+  }).join('')}</div>`;
+}
+
+async function renderContribDetail() {
+  const listEl = document.getElementById('contrib-traj-list');
+  const graphEl = document.getElementById('contrib-graph');
+  const skillsEl = document.getElementById('contrib-skills');
+  if (!listEl || !_contribOpen) return;
+  const offset = _trajPage * TRAJ_PAGE;
+  let d;
+  try {
+    d = await j(`/api/v1/dashboard/my/contributions/trajs?offset=${offset}&limit=${TRAJ_PAGE}`);
+  } catch (e) {
+    listEl.innerHTML = `<span class="text-[11px] text-rose-600">${esc(e.message)}</span>`;
+    return;
+  }
+  _contribPayload = d;
+  const total = d.total || 0;
+  const pages = Math.max(1, Math.ceil(total / TRAJ_PAGE));
+  if (_trajPage >= pages) _trajPage = pages - 1;
+  const trajs = d.trajs || [];
+  if (!trajs.find(t => t.traj_id === _contribTraj) && trajs[0]) _contribTraj = trajs[0].traj_id;
+  document.getElementById('traj-page-sum').textContent = `${total} 条`;
+  document.getElementById('traj-page-label').textContent = `${_trajPage + 1}/${pages}`;
+  document.getElementById('traj-up').disabled = _trajPage === 0;
+  document.getElementById('traj-down').disabled = _trajPage >= pages - 1;
+  listEl.innerHTML = trajs.map(t => {
+    const adopted = t.atoms.filter(a => (a.destinations || []).length).length;
+    const on = t.traj_id === _contribTraj;
+    return `<a href="javascript:void(0)" class="contrib-traj ${on ? 'on' : ''}" data-traj="${esc(t.traj_id)}">
+      <code class="text-[11px]">${esc(t.traj_id)}</code>
+      <span class="text-slate-400 ml-1">${t.atoms.length} 原子 · ${adopted} 采纳</span>
+    </a>`;
+  }).join('') || '<span class="text-[11px] text-slate-400">暂无轨迹</span>';
+  const cur = trajs.find(t => t.traj_id === _contribTraj) || trajs[0];
+  if (!cur) {
+    graphEl.innerHTML = '';
+    skillsEl.innerHTML = '';
+    return;
+  }
+  const g = contribRelationGraph(cur.traj_id, cur.atoms || []);
+  graphEl.innerHTML = g.svg;
+  skillsEl.innerHTML = contribSkillChips(g.skills, g, d.skill_meta || {});
+}
+function setContribOpen(on) {
+  _contribOpen = on;
+  const detail = document.getElementById('contrib-detail');
+  const btn = document.getElementById('contrib-toggle');
+  if (detail) detail.classList.toggle('hidden', !on);
+  if (btn) btn.textContent = on ? '收起' : '展开';
+  if (on) renderContribDetail().catch(console.error);
+}
+
+function renderRT() {
+  const total = _rtRows.length;
+  const pages = Math.max(1, Math.ceil(total / RT_PAGE));
+  if (_rtPage >= pages) _rtPage = pages - 1;
+  const start = _rtPage * RT_PAGE;
+  const slice = _rtRows.slice(start, start + RT_PAGE);
+  const VC = { '高价值': 'bg-emerald-100 text-emerald-700', '正常': 'bg-slate-100 text-slate-600' };
+  const sum = document.getElementById('rt-sum');
+  if (!_rtOpen) {
+    if (sum) sum.textContent = `${total} 条`;
+    return;
+  }
+  rows('my-rt-body', slice.map(r => `<tr>
+    <td class="py-2"><span class="skill-jump cursor-pointer text-teal-700" data-skill="${esc(r.skill)}">${esc(r.skill)}</span> ${mySourceBadge(r)}</td>
+    <td class="text-right tabular-nums">${r.exposures}</td><td class="text-right tabular-nums">${r.triggers}</td>
+    <td class="text-right tabular-nums">${pctf(r.rate)}</td>
+    <td class="pl-6"><span class="text-[10px] px-1.5 py-0.5 rounded ${VC[r.verdict] || 'bg-rose-100 text-rose-700'}">${esc(r.verdict)}</span></td></tr>`).join(''),
+    '暂无推荐记录');
+  if (sum) sum.textContent = total ? `${start + 1}–${start + slice.length} / ${total}` : '0 条';
+  const lab = document.getElementById('rt-page-label');
+  if (lab) lab.textContent = `${_rtPage + 1} / ${pages}`;
+  const prev = document.getElementById('rt-prev');
+  const next = document.getElementById('rt-next');
+  if (prev) prev.disabled = _rtPage === 0;
+  if (next) next.disabled = _rtPage >= pages - 1;
+}
+function setRtOpen(on) {
+  _rtOpen = on;
+  const body = document.getElementById('rt-body');
+  const btn = document.getElementById('rt-toggle');
+  if (body) body.classList.toggle('hidden', !on);
+  if (btn) btn.textContent = on ? '收起' : '展开';
+  renderRT();
+}
+
 async function loadMy() {
   if (!IDENT) return;
   const [m, ct, rt] = await Promise.all([
@@ -1357,39 +1558,48 @@ async function loadMy() {
   ]);
   document.getElementById('my-slot-sum').textContent = `${m.slots.length}/${m.total_slots} 槽位`;
   document.getElementById('my-slots').innerHTML = m.slots.map(s => `
-    <div class="flex items-center gap-2.5 px-3 py-2 rounded-xl ring-1 ring-slate-100 hover:bg-slate-50">
-      <span class="skill-jump cursor-pointer font-medium text-teal-700 underline decoration-teal-200 underline-offset-2" data-skill="${s.skill_name}">${s.skill_name}</span>
-      <span class="text-[10px] px-1.5 py-0.5 rounded ${BUCKET_CHIP[s.bucket] || 'bg-slate-100 text-slate-500'}">${bucketLabel(s)}</span>
-      <span class="text-[10px] text-slate-400">${s.side}</span>
-      <span class="flex-1"></span>
+    <div class="flex items-center gap-2.5 px-3 py-2.5 rounded-xl ring-1 ring-slate-100 hover:bg-slate-50">
+      <div class="min-w-0 flex-1">
+        <div class="flex items-center gap-2 flex-wrap">
+          <span class="skill-jump cursor-pointer font-medium text-teal-700 underline decoration-teal-200 underline-offset-2" data-skill="${esc(s.skill_name)}">${esc(s.skill_name)}</span>
+          <span class="text-[10px] px-1.5 py-0.5 rounded ${BUCKET_CHIP[s.bucket] || 'bg-slate-100 text-slate-500'}">${bucketLabel(s)}</span>
+          <span class="text-[10px] text-slate-400">${esc(s.side)}</span>
+        </div>
+        <div class="mt-1 flex items-center gap-1.5 flex-wrap">${mySourceBadge(s, true)}</div>
+      </div>
+      <span class="shrink-0 text-[10px] px-1.5 py-0.5 rounded bg-teal-50 text-teal-700 tabular-nums">我触发 ${s.my_triggers ?? 0} 次</span>
       ${s.bucket === 'pinned'
-        ? (s.user_removable ? `<button class="my-pref text-[11px] px-2 py-0.5 rounded ring-1 ring-slate-200 hover:bg-slate-50" data-skill="${s.skill_name}" data-act="clear">取消 pin</button>`
-                            : `<span class="text-[10px] text-slate-300 cursor-not-allowed" title="admin/全局 pin,不可取消">锁定</span>`)
-        : `<button class="my-pref text-[11px] px-2 py-0.5 rounded ring-1 ring-slate-200 hover:bg-slate-50" data-skill="${s.skill_name}" data-act="pin">pin</button>
-           <button class="my-pref text-[11px] px-2 py-0.5 rounded ring-1 ring-slate-200 hover:bg-slate-50 text-rose-600" data-skill="${s.skill_name}" data-act="block" title="不再推送">✕</button>`}
+        ? (s.user_removable ? `<button class="my-pref shrink-0 text-[11px] px-2 py-0.5 rounded ring-1 ring-slate-200 hover:bg-slate-50" data-skill="${esc(s.skill_name)}" data-act="clear">取消 pin</button>`
+                            : `<span class="shrink-0 text-[10px] text-slate-300 cursor-not-allowed" title="admin/全局 pin,不可取消">锁定</span>`)
+        : `<div class="shrink-0 flex gap-1.5">
+             <button class="my-pref text-[11px] px-2 py-0.5 rounded ring-1 ring-slate-200 hover:bg-slate-50" data-skill="${esc(s.skill_name)}" data-act="pin">pin</button>
+             <button class="my-pref text-[11px] px-2 py-0.5 rounded ring-1 ring-slate-200 hover:bg-slate-50 text-rose-600" data-skill="${esc(s.skill_name)}" data-act="block" title="不再推送">✕</button>
+           </div>`}
     </div>`).join('') || '<span class="text-slate-400">暂无槽位</span>';
   document.getElementById('my-blocked').innerHTML = m.blocked.map(b => `
-    <span class="inline-flex items-center gap-1.5 text-[11px] px-2 py-1 rounded-lg bg-rose-50 text-rose-700 ring-1 ring-rose-200">${b.skill_name}
-      <button class="my-pref font-medium" data-skill="${b.skill_name}" data-act="clear">恢复</button></span>`).join('')
+    <span class="inline-flex items-center gap-1.5 text-[11px] px-2 py-1 rounded-lg bg-rose-50 text-rose-700 ring-1 ring-rose-200">${esc(b.skill_name)}
+      <button class="my-pref font-medium" data-skill="${esc(b.skill_name)}" data-act="clear">恢复</button></span>`).join('')
     || '<span class="text-[11px] text-slate-400">无</span>';
   const st = ct.steps;
   document.getElementById('my-steps').innerHTML =
     [['轨迹', st.trajs], ['原子', st.atoms], ['被采纳', st.adopted_atoms], ['进入 skill', st.skills]]
-      .map(([k, v], i) => `${i ? '<span class="text-slate-300">→</span>' : ''}
-        <div class="px-4 py-2 rounded-xl bg-slate-50 ring-1 ring-slate-100 text-center">
-          <div class="text-lg font-semibold tabular-nums">${v}</div><div class="text-[10.5px] text-slate-400">${k}</div></div>`).join('');
-  document.getElementById('my-usage').innerHTML = ct.usage.map(u => `
-    <div class="flex items-center gap-2 text-[12.5px]"><span class="skill-jump cursor-pointer text-teal-700" data-skill="${u.skill}">${u.skill}</span>
-      <span class="text-[11px] text-slate-400">均分 ${u.avg_score ?? '—'}</span>
-      <span class="flex flex-wrap gap-1">${u.users.map(x => `<span class="text-[10px] px-1.5 py-0.5 rounded bg-slate-100 text-slate-600">${x.user}×${x.count}</span>`).join('')}</span></div>`).join('')
-    || '<span class="text-[11px] text-slate-400">还没有被他人使用的记录</span>';
-  const VC = { '高价值': 'bg-emerald-100 text-emerald-700', '正常': 'bg-slate-100 text-slate-600' };
-  rows('my-rt-body', rt.rows.map(r => `<tr>
-    <td class="py-2"><span class="skill-jump cursor-pointer text-teal-700" data-skill="${r.skill}">${r.skill}</span></td>
-    <td class="text-right tabular-nums">${r.exposures}</td><td class="text-right tabular-nums">${r.triggers}</td>
-    <td class="text-right tabular-nums">${pctf(r.rate)}</td>
-    <td class="pl-6"><span class="text-[10px] px-1.5 py-0.5 rounded ${VC[r.verdict] || 'bg-rose-100 text-rose-700'}">${r.verdict}</span></td></tr>`).join(''),
-    '暂无推荐记录');
+      .map(([k, v], i) => `${i ? '<span class="text-slate-300 text-xs">→</span>' : ''}
+        <div class="px-3 py-1.5 rounded-lg bg-slate-50 ring-1 ring-slate-100 text-center min-w-[4.5rem]">
+          <div class="text-base font-semibold tabular-nums leading-tight">${v}</div><div class="text-[10px] text-slate-400">${k}</div></div>`).join('');
+
+  _rtRows = (rt.rows || []).slice().sort((a, b) =>
+    (b.triggers - a.triggers) || (b.exposures - a.exposures) || String(a.skill).localeCompare(String(b.skill)));
+  // 附上来源：从槽位 meta 不够，历史推荐行暂用 native 兜底；有 skillhub 名在 slots 里则复用
+  const slotSrc = Object.fromEntries((m.slots || []).map(s => [s.skill_name, s]));
+  _rtRows.forEach(r => {
+    const s = slotSrc[r.skill];
+    if (s) { r.source = s.source; r.source_path = s.source_path; r.producer = s.producer; r.producer_trajs = s.producer_trajs; }
+  });
+  _rtPage = 0;
+  setRtOpen(false);
+  _trajPage = 0;
+  _contribTraj = null;
+  setContribOpen(true);
 }
 document.addEventListener('click', async e => {
   const b = e.target.closest('.my-pref');
@@ -1397,6 +1607,32 @@ document.addEventListener('click', async e => {
   try { await jpost('/api/v1/dashboard/my/prefs', { skill_name: b.dataset.skill, action: b.dataset.act }); await loadMy(); }
   catch (err) { alert(err.message); }
 });
+document.getElementById('contrib-toggle')?.addEventListener('click', () => setContribOpen(!_contribOpen));
+document.getElementById('contrib-traj-list')?.addEventListener('click', e => {
+  const a = e.target.closest('.contrib-traj');
+  if (!a) return;
+  _contribTraj = a.dataset.traj;
+  renderContribDetail().catch(console.error);
+});
+document.getElementById('contrib-skills')?.addEventListener('click', e => {
+  const g = e.target.closest('.graph-skill');
+  if (!g) return;
+  _skillBackHash = 'my';
+  location.hash = 'skill/' + encodeURIComponent(g.getAttribute('data-skill'));
+});
+document.getElementById('traj-up')?.addEventListener('click', () => {
+  _trajPage--;
+  _contribTraj = null;
+  renderContribDetail().catch(console.error);
+});
+document.getElementById('traj-down')?.addEventListener('click', () => {
+  _trajPage++;
+  _contribTraj = null;
+  renderContribDetail().catch(console.error);
+});
+document.getElementById('rt-toggle')?.addEventListener('click', () => setRtOpen(!_rtOpen));
+document.getElementById('rt-prev')?.addEventListener('click', () => { _rtPage--; renderRT(); });
+document.getElementById('rt-next')?.addEventListener('click', () => { _rtPage++; renderRT(); });
 
 // ── 管理 ────────────────────────────────────────────────────────
 async function loadAdmin() {
@@ -1706,45 +1942,93 @@ document.addEventListener('click', async e => {
   }
 });
 
-// ── 世界消息 feed(卡片式,按天分组;Q6 登录可见) ──────────────────
-let _feedBefore = null, _feedLastDay = null;
+// ── 世界消息 feed（三角翻页,每页 5;区分自己/他人） ──────────────
 function dayLabel(d) {
   const today = new Date(); today.setHours(0, 0, 0, 0);
   const day = new Date(d); day.setHours(0, 0, 0, 0);
   const diff = Math.round((today - day) / 86400000);
   return diff <= 0 ? '今天' : diff === 1 ? '昨天' : `${day.getMonth() + 1}-${String(day.getDate()).padStart(2, '0')}`;
 }
-async function loadWorldFeed(more) {
+function paintFeedPage() {
   const el = document.getElementById('world-feed');
-  if (!el || !IDENT) return;
-  const q = '/api/v1/dashboard/events?scope=world&limit=30' + (more && _feedBefore ? '&before_id=' + _feedBefore : '');
-  let d;
-  try { d = await j(q); }
-  catch (e) { el.innerHTML = `<span class="text-[11px] text-rose-600">${esc(e.message)}</span>`; return; }
-  const evs = d.events || [];
-  if (!more) { el.innerHTML = ''; _feedLastDay = null; }
-  if (!evs.length && !more) { el.innerHTML = '<span class="text-slate-400 text-xs">还没有团队动态</span>'; return; }
-  const frag = document.createElement('div');
+  if (!el) return;
+  const pages = _feedPages.length;
+  const sum = document.getElementById('feed-sum');
+  const lab = document.getElementById('feed-page-label');
+  const up = document.getElementById('feed-up');
+  const down = document.getElementById('feed-down');
+  if (!pages) {
+    el.innerHTML = '<span class="text-slate-400 text-xs">还没有团队动态</span>';
+    if (sum) sum.textContent = '';
+    if (lab) lab.textContent = '0/0';
+    if (up) up.disabled = true;
+    if (down) down.disabled = true;
+    return;
+  }
+  if (_feedPage >= pages) _feedPage = pages - 1;
+  if (_feedPage < 0) _feedPage = 0;
+  const evs = _feedPages[_feedPage] || [];
+  let lastDay = null;
+  el.innerHTML = '';
   evs.forEach(ev => {
     const dl = dayLabel(evDate(ev));
-    if (dl !== _feedLastDay) {
-      frag.insertAdjacentHTML('beforeend', `<div class="text-[10.5px] text-slate-400 font-medium mt-3 mb-1.5 first:mt-0">${esc(dl)}</div>`);
-      _feedLastDay = dl;
+    if (dl !== lastDay) {
+      el.insertAdjacentHTML('beforeend', `<div class="text-[10.5px] text-slate-400 font-medium mt-2.5 mb-1 first:mt-0">${esc(dl)}</div>`);
+      lastDay = dl;
     }
-    frag.insertAdjacentHTML('beforeend', `
-      <div class="flex items-start gap-2.5 px-3 py-2.5 rounded-xl ring-1 ring-slate-100 hover:bg-slate-50 mb-1.5 text-xs">
+    const mine = IDENT && ev.actor === IDENT.user;
+    const ring = mine ? 'ring-teal-200 bg-teal-50/40' : 'ring-slate-100';
+    el.insertAdjacentHTML('beforeend', `
+      <div class="flex items-start gap-2.5 px-3 py-2 rounded-xl ring-1 ${ring} hover:bg-slate-50 mb-1 text-xs">
         ${avatar(ev.actor || 'xs', 'sm')}
         <div class="min-w-0 flex-1">${evParts(ev).html}</div>
         <span class="text-[10.5px] text-slate-400 shrink-0" title="${esc(ev.ts)} UTC">${relTime(ev)}</span>
       </div>`);
   });
-  el.appendChild(frag);
-  if (evs.length) _feedBefore = evs[evs.length - 1].id;
-  const moreBtn = document.getElementById('feed-more');
-  if (moreBtn) moreBtn.classList.toggle('hidden', evs.length < 30);
+  const shownFrom = _feedPage * FEED_PAGE + 1;
+  const shownTo = shownFrom + evs.length - 1;
+  if (sum) sum.textContent = evs.length ? `${shownFrom}–${shownTo}` : '';
+  if (lab) lab.textContent = `${_feedPage + 1}/${_feedExhausted ? pages : (pages + '+')}`;
+  if (up) up.disabled = _feedPage === 0;
+  if (down) down.disabled = _feedPage >= pages - 1 && _feedExhausted;
 }
-const _feedMoreBtn = document.getElementById('feed-more');
-if (_feedMoreBtn) _feedMoreBtn.addEventListener('click', () => loadWorldFeed(true).catch(console.error));
+async function ensureFeedPage(idx) {
+  while (_feedPages.length <= idx && !_feedExhausted) {
+    const q = '/api/v1/dashboard/events?scope=world&limit=' + FEED_PAGE
+      + (_feedBefore ? '&before_id=' + _feedBefore : '');
+    const d = await j(q);
+    const evs = d.events || [];
+    if (!evs.length) { _feedExhausted = true; break; }
+    _feedPages.push(evs);
+    _feedBefore = evs[evs.length - 1].id;
+    if (evs.length < FEED_PAGE) _feedExhausted = true;
+  }
+}
+async function loadWorldFeed() {
+  const el = document.getElementById('world-feed');
+  if (!el || !IDENT) return;
+  _feedPages = [];
+  _feedPage = 0;
+  _feedBefore = null;
+  _feedExhausted = false;
+  try {
+    await ensureFeedPage(0);
+    paintFeedPage();
+  } catch (e) {
+    el.innerHTML = `<span class="text-[11px] text-rose-600">${esc(e.message)}</span>`;
+  }
+}
+document.getElementById('feed-up')?.addEventListener('click', () => {
+  _feedPage--;
+  paintFeedPage();
+});
+document.getElementById('feed-down')?.addEventListener('click', async () => {
+  try {
+    await ensureFeedPage(_feedPage + 1);
+    if (_feedPages[_feedPage + 1]) _feedPage++;
+    paintFeedPage();
+  } catch (e) { console.error(e); }
+});
 
 // ── 画像散点(图③):t-SNE 投影(邻域保持,簇分离比线性 PCA 明显),原子=圆点按簇着色,中心=◆,skill=▲ ──
 const CLUSTER_COLORS = ['#0d9488', '#6366f1', '#f59e0b', '#f43f5e', '#0ea5e9'];

--- a/src/xskill/dashboard/static/index.html
+++ b/src/xskill/dashboard/static/index.html
@@ -53,6 +53,23 @@
   .pm-log .dim{color:#94a3b8}
   .pm-btn{border:1px solid #e2e8f0;background:#fff;border-radius:7px;padding:4px 8px;cursor:pointer;font-size:11px;color:#334155}
   .pm-btn.ghost{background:transparent}
+  .feed-tri{display:inline-flex;align-items:center;justify-content:center;width:28px;height:22px;border-radius:6px;background:#f1f5f9;color:#64748b;border:none;cursor:pointer}
+  .feed-tri:hover:not(:disabled){background:#e2e8f0;color:#0f766e}
+  .feed-tri:disabled{opacity:.35;cursor:not-allowed}
+  .contrib-panel{background:#f8fafc;border-radius:12px;padding:8px 10px}
+  .contrib-traj{display:block;padding:6px 8px;border-radius:8px;border-left:3px solid transparent;color:#475569;font-size:12px;line-height:1.35}
+  .contrib-traj:hover{background:#f1f5f9}
+  .contrib-traj.on{background:#f0fdfa;border-left-color:#0d9488}
+  .contrib-traj.on code{color:#0f766e;font-weight:600}
+  .skill-chip{display:flex;align-items:center;gap:6px;width:268px;height:68px;box-sizing:border-box;padding:6px 8px;border-radius:10px;background:#f0fdfa;cursor:pointer;overflow:hidden;border:none;text-align:left}
+  .skill-chip:hover{background:#ccfbf1;box-shadow:0 0 0 1px #99f6e4}
+  .skill-chip .nm{font-size:11.5px;font-weight:600;color:#0f766e;line-height:1.2;word-break:break-all;display:-webkit-box;-webkit-line-clamp:2;-webkit-box-orient:vertical;overflow:hidden}
+  .skill-chip .meta{margin-top:1px;display:flex;align-items:center;gap:5px;flex-wrap:nowrap}
+  .src-badge{display:inline-block;padding:1px 6px;border-radius:6px;font-size:10px;font-weight:500;line-height:1.4;vertical-align:middle}
+  .src-native{background:#f1f5f9;color:#64748b}
+  .src-hub{background:#e0e7ff;color:#4338ca}
+  .src-upload{background:#fef3c7;color:#b45309}
+  .src-path{font-family:ui-monospace,SFMono-Regular,Menlo,monospace;font-size:10px;color:#94a3b8}
 </style></head>
 <body class="bg-slate-100 text-slate-900 text-[13px] leading-normal">
 <div class="flex min-h-screen">
@@ -301,37 +318,100 @@
       </div>
     </div>
 
-    <!-- ══ 我的（P2,登录后） ══ -->
+    <!-- ══ 我的（P2 + #174） ══ -->
     <div class="sec-page" id="pg-my">
       <div id="my-guard" class="bg-white rounded-2xl ring-1 ring-slate-200 p-5 text-slate-400">请先登录（左下角）。</div>
       <div id="my-body" class="hidden">
         <div class="bg-white rounded-2xl ring-1 ring-slate-200 p-5">
           <div class="flex items-baseline justify-between">
-            <h2 class="font-semibold text-sm">推给我的 <span class="font-normal text-[11px] text-slate-400 ml-2">槽位注入:blocked 排除 → pinned 占位 → ranked → recommended</span></h2>
+            <h2 class="font-semibold text-sm">推给我的</h2>
             <span class="text-[11px] text-slate-400" id="my-slot-sum">—</span>
           </div>
           <div id="my-slots" class="mt-3 space-y-2"><span class="text-slate-400">加载中…</span></div>
-          <div class="mt-4"><h3 class="text-[12.5px] font-medium text-slate-500">已屏蔽 <span class="font-normal text-[11px] text-slate-400">不再推送,可恢复</span></h3>
+          <div class="mt-4"><h3 class="text-[12.5px] font-medium text-slate-500">已屏蔽</h3>
             <div id="my-blocked" class="mt-2 flex flex-wrap gap-2"></div></div>
         </div>
-        <div class="bg-white rounded-2xl ring-1 ring-slate-200 p-5 mt-4">
-          <h2 class="font-semibold text-sm">我的贡献去向</h2>
-          <div id="my-steps" class="mt-3 flex items-center gap-3 overflow-x-auto"></div>
-          <div id="my-usage" class="mt-3 space-y-2"></div>
+
+        <div class="bg-white rounded-2xl ring-1 ring-slate-200 p-4 mt-4" id="contrib-card">
+          <div class="flex items-baseline justify-between">
+            <h2 class="font-semibold text-sm">我的贡献去向</h2>
+            <button type="button" id="contrib-toggle" class="text-[11px] px-2 py-0.5 rounded ring-1 ring-slate-200 hover:bg-slate-50 text-slate-500">收起</button>
+          </div>
+          <div id="my-steps" class="mt-2 flex items-center gap-2 overflow-x-auto"></div>
+          <div id="contrib-detail" class="mt-2.5">
+            <div class="contrib-panel">
+              <div class="grid grid-cols-12 gap-3">
+                <div class="col-span-12 md:col-span-4">
+                  <div class="flex items-baseline justify-between px-0.5">
+                    <h3 class="font-semibold text-sm text-slate-700">轨迹</h3>
+                    <span class="text-[11px] text-slate-400" id="traj-page-sum"></span>
+                  </div>
+                  <div class="mt-1 flex gap-2 items-start">
+                    <div class="flex flex-col items-center gap-0.5 shrink-0 pt-0.5">
+                      <button type="button" id="traj-up" class="feed-tri" title="上一页" aria-label="上一页">
+                        <svg width="12" height="8" viewBox="0 0 12 8" fill="currentColor"><path d="M6 0L12 8H0z"/></svg>
+                      </button>
+                      <span class="text-[10px] text-slate-400 tabular-nums leading-none py-1" id="traj-page-label"></span>
+                      <button type="button" id="traj-down" class="feed-tri" title="下一页" aria-label="下一页">
+                        <svg width="12" height="8" viewBox="0 0 12 8" fill="currentColor"><path d="M6 8L0 0h12z"/></svg>
+                      </button>
+                    </div>
+                    <div id="contrib-traj-list" class="min-w-0 flex-1 max-h-64 overflow-y-auto"></div>
+                  </div>
+                </div>
+                <div class="col-span-12 md:col-span-8">
+                  <h3 class="font-semibold text-sm text-slate-700 px-0.5">关系图</h3>
+                  <div class="mt-1 overflow-x-auto">
+                    <div class="flex items-start gap-1.5 min-w-max">
+                      <div id="contrib-graph"></div>
+                      <div id="contrib-skills" class="relative shrink-0" style="width:268px"></div>
+                    </div>
+                  </div>
+                </div>
+              </div>
+            </div>
+          </div>
         </div>
-        <div class="bg-white rounded-2xl ring-1 ring-slate-200 p-5 mt-4">
-          <h2 class="font-semibold text-sm">推荐 × 触发 <span class="font-normal text-[11px] text-slate-400 ml-2">曝光=去重推荐对;触发=我的轨迹打分记录</span></h2>
-          <div class="overflow-x-auto"><table class="w-full mt-2 text-[12.5px]">
-            <thead><tr class="text-[11px] text-slate-400 border-b border-slate-100"><th class="text-left font-medium py-2">技能</th><th class="text-right font-medium">推荐</th><th class="text-right font-medium">触发</th><th class="text-right font-medium">命中率</th><th class="text-left font-medium pl-6">结论</th></tr></thead>
-            <tbody id="my-rt-body" class="divide-y divide-slate-50"></tbody></table></div>
-        </div>
-        <!-- P3 世界消息:卡片式动态 feed,按天分组;只含 skill 名与动作 -->
+
         <div class="bg-white rounded-2xl ring-1 ring-slate-200 p-5 mt-4">
           <div class="flex items-baseline justify-between">
-            <h2 class="font-semibold text-sm">世界消息 <span class="font-normal text-[11px] text-slate-400 ml-2">团队动态 · 只含 skill 名与动作,不含轨迹内容</span></h2>
-            <button id="feed-more" class="text-[11px] text-slate-400 hover:bg-slate-50 px-1.5 py-0.5 rounded hidden">加载更早 ↓</button>
+            <h2 class="font-semibold text-sm">世界消息</h2>
+            <span class="text-[11px] text-slate-400" id="feed-sum"></span>
           </div>
-          <div id="world-feed" class="mt-3"><span class="text-slate-400">加载中…</span></div>
+          <div class="mt-3 flex gap-2.5 items-start">
+            <div class="flex flex-col items-center gap-0.5 shrink-0 pt-0.5">
+              <button type="button" id="feed-up" class="feed-tri" title="上一页" aria-label="上一页">
+                <svg width="12" height="8" viewBox="0 0 12 8" fill="currentColor"><path d="M6 0L12 8H0z"/></svg>
+              </button>
+              <span class="text-[10px] text-slate-400 tabular-nums leading-none py-1" id="feed-page-label"></span>
+              <button type="button" id="feed-down" class="feed-tri" title="下一页" aria-label="下一页">
+                <svg width="12" height="8" viewBox="0 0 12 8" fill="currentColor"><path d="M6 8L0 0h12z"/></svg>
+              </button>
+            </div>
+            <div id="world-feed" class="min-w-0 flex-1"><span class="text-slate-400">加载中…</span></div>
+          </div>
+        </div>
+
+        <div class="bg-white rounded-2xl ring-1 ring-slate-200 p-5 mt-4" id="rt-card">
+          <div class="flex items-baseline justify-between">
+            <h2 class="font-semibold text-sm">历史推荐</h2>
+            <div class="flex items-center gap-2">
+              <span class="text-[11px] text-slate-400" id="rt-sum"></span>
+              <button type="button" id="rt-toggle" class="text-[11px] px-2 py-0.5 rounded ring-1 ring-slate-200 hover:bg-slate-50 text-slate-500">展开</button>
+            </div>
+          </div>
+          <div id="rt-body" class="hidden mt-2">
+            <div class="overflow-x-auto"><table class="w-full text-[12.5px]">
+              <thead><tr class="text-[11px] text-slate-400 border-b border-slate-100"><th class="text-left font-medium py-2">技能</th><th class="text-right font-medium">推荐次数</th><th class="text-right font-medium">实际触发</th><th class="text-right font-medium">命中率</th><th class="text-left font-medium pl-6">结论</th></tr></thead>
+              <tbody id="my-rt-body" class="divide-y divide-slate-50"></tbody></table></div>
+            <div class="mt-3 flex items-center justify-between">
+              <span class="text-[11px] text-slate-400" id="rt-page-label"></span>
+              <div class="flex gap-1.5">
+                <button type="button" id="rt-prev" class="text-[11px] px-2 py-0.5 rounded ring-1 ring-slate-200 hover:bg-slate-50">上一页</button>
+                <button type="button" id="rt-next" class="text-[11px] px-2 py-0.5 rounded ring-1 ring-slate-200 hover:bg-slate-50">下一页</button>
+              </div>
+            </div>
+          </div>
         </div>
       </div>
     </div>

--- a/src/xskill/events.py
+++ b/src/xskill/events.py
@@ -59,6 +59,17 @@ def _traj_of_atom(atom_id: str) -> str:
     return stem if stem and idx.isdigit() else ""
 
 
+def _traj_user_map(db_path: Optional[Path] = None) -> dict[str, str]:
+    """filename stem → user_key。调用方批量算贡献人时只建一次。"""
+    with pooled_connection(db_path) as conn:
+        return {
+            (r["filename"][:-3] if r["filename"].endswith(".md")
+             else r["filename"]): (r["user_key"] or "")
+            for r in conn.execute(
+                "SELECT filename, user_key FROM trajectories").fetchall()
+        }
+
+
 def skill_contributors(skill: str, *, min_weight: int = CONTRIBUTOR_MIN_WEIGHT,
                        db_path: Optional[Path] = None) -> dict[str, int]:
     """某 skill 的贡献者 → 累计 weightscore(仅 ≥ min_weight 且 user_key 非空)。
@@ -66,13 +77,8 @@ def skill_contributors(skill: str, *, min_weight: int = CONTRIBUTOR_MIN_WEIGHT,
     贡献关系 = ``atom_adoption``(atom 被聚进 skill) 经 atom_id 内嵌的
     traj_id 归到 ``trajectories.user_key``(D5 canonical 身份键)。
     """
+    traj_user = _traj_user_map(db_path)
     with pooled_connection(db_path) as conn:
-        traj_user = {
-            (r["filename"][:-3] if r["filename"].endswith(".md")
-             else r["filename"]): (r["user_key"] or "")
-            for r in conn.execute(
-                "SELECT filename, user_key FROM trajectories").fetchall()
-        }
         rows = conn.execute(
             "SELECT atom_id, weightscore FROM atom_adoption WHERE skill=?",
             (skill,),
@@ -86,34 +92,59 @@ def skill_contributors(skill: str, *, min_weight: int = CONTRIBUTOR_MIN_WEIGHT,
     return {u: w for u, w in weights.items() if w >= min_weight}
 
 
+def _producer_from_by_user(by_user: dict[str, set[str]]) -> Optional[dict]:
+    if not by_user:
+        return None
+    user, trajs = max(by_user.items(), key=lambda kv: (len(kv[1]), kv[0]))
+    return {"user": user, "traj_count": len(trajs)}
+
+
 def skill_main_producer(skill: str, *,
-                        db_path: Optional[Path] = None) -> Optional[dict]:
+                        db_path: Optional[Path] = None,
+                        traj_user: Optional[dict[str, str]] = None,
+                        ) -> Optional[dict]:
     """蒸馏资产主要贡献人：对该 skill 贡献来源轨迹数最多的 user_key。
 
     返回 ``{"user": str, "traj_count": int}``；无人贡献时返回 ``None``。
+    批量场景请用 ``skill_main_producers``，避免反复全表扫 trajectories。
     """
+    return skill_main_producers([skill], db_path=db_path,
+                                traj_user=traj_user).get(skill)
+
+
+def skill_main_producers(skills,
+                         *,
+                         db_path: Optional[Path] = None,
+                         traj_user: Optional[dict[str, str]] = None,
+                         ) -> dict[str, dict]:
+    """批量主要贡献人：整次请求只扫一次 trajectories + 一次 IN 查询 adoption。
+
+    返回 ``{skill: {"user", "traj_count"}}``；无贡献的 skill 不出现在结果里。
+    """
+    names = [s for s in dict.fromkeys(skills or ()) if s]
+    if not names:
+        return {}
+    if traj_user is None:
+        traj_user = _traj_user_map(db_path)
+    placeholders = ",".join("?" * len(names))
     with pooled_connection(db_path) as conn:
-        traj_user = {
-            (r["filename"][:-3] if r["filename"].endswith(".md")
-             else r["filename"]): (r["user_key"] or "")
-            for r in conn.execute(
-                "SELECT filename, user_key FROM trajectories").fetchall()
-        }
         rows = conn.execute(
-            "SELECT atom_id FROM atom_adoption WHERE skill=?",
-            (skill,),
+            f"SELECT skill, atom_id FROM atom_adoption"
+            f" WHERE skill IN ({placeholders})",
+            names,
         ).fetchall()
-    by_user: dict[str, set[str]] = {}
+    by_skill: dict[str, dict[str, set[str]]] = {}
     for r in rows:
         traj = _traj_of_atom(r["atom_id"] or "")
         user = traj_user.get(traj, "") if traj else ""
         if not user or not traj:
             continue
-        by_user.setdefault(user, set()).add(traj)
-    if not by_user:
-        return None
-    user, trajs = max(by_user.items(), key=lambda kv: (len(kv[1]), kv[0]))
-    return {"user": user, "traj_count": len(trajs)}
+        by_skill.setdefault(r["skill"], {}).setdefault(user, set()).add(traj)
+    return {
+        skill: prod
+        for skill, by_user in by_skill.items()
+        if (prod := _producer_from_by_user(by_user)) is not None
+    }
 
 
 class EventStore:

--- a/src/xskill/events.py
+++ b/src/xskill/events.py
@@ -86,6 +86,36 @@ def skill_contributors(skill: str, *, min_weight: int = CONTRIBUTOR_MIN_WEIGHT,
     return {u: w for u, w in weights.items() if w >= min_weight}
 
 
+def skill_main_producer(skill: str, *,
+                        db_path: Optional[Path] = None) -> Optional[dict]:
+    """蒸馏资产主要贡献人：对该 skill 贡献来源轨迹数最多的 user_key。
+
+    返回 ``{"user": str, "traj_count": int}``；无人贡献时返回 ``None``。
+    """
+    with pooled_connection(db_path) as conn:
+        traj_user = {
+            (r["filename"][:-3] if r["filename"].endswith(".md")
+             else r["filename"]): (r["user_key"] or "")
+            for r in conn.execute(
+                "SELECT filename, user_key FROM trajectories").fetchall()
+        }
+        rows = conn.execute(
+            "SELECT atom_id FROM atom_adoption WHERE skill=?",
+            (skill,),
+        ).fetchall()
+    by_user: dict[str, set[str]] = {}
+    for r in rows:
+        traj = _traj_of_atom(r["atom_id"] or "")
+        user = traj_user.get(traj, "") if traj else ""
+        if not user or not traj:
+            continue
+        by_user.setdefault(user, set()).add(traj)
+    if not by_user:
+        return None
+    user, trajs = max(by_user.items(), key=lambda kv: (len(kv[1]), kv[0]))
+    return {"user": user, "traj_count": len(trajs)}
+
+
 class EventStore:
     """``events`` / ``event_targets`` / ``event_reads`` 三表的读写(registry.db)。"""
 

--- a/tests/test_dashboard_console_p2.py
+++ b/tests/test_dashboard_console_p2.py
@@ -268,6 +268,58 @@ def test_my_views_empty_db_do_not_crash(console_env):
     assert c.status_code == 200
     assert c.json()["steps"]["trajs"] == 0
     assert alice.get("/api/v1/dashboard/my/reco-trigger").json()["rows"] == []
+    t = alice.get("/api/v1/dashboard/my/contributions/trajs")
+    assert t.status_code == 200
+    body = t.json()
+    assert body["total"] == 0
+    assert body["trajs"] == []
+    m = alice.get("/api/v1/dashboard/my/manifest").json()
+    assert "slots" in m
+    for s in m["slots"]:
+        assert "my_triggers" in s
+        assert s["source"] in ("native", "upload", "skillhub")
+
+
+def test_my_contribution_trajs_paginates_user_trajs(console_env):
+    alice = console_env["alice"]
+    db = console_env["db"]
+    registry = console_env["registry"]
+    client_id = registry.find_by_user_name("alice")
+    sessions_dir = (
+        team_context().traj_root
+        / "clients"
+        / registry.dir_name_for(client_id)
+        / "sessions"
+    )
+    sessions_dir.mkdir(parents=True)
+    R.register_dir(
+        sessions_dir, label="alice", ecosystem="team_client", db_path=db,
+    )
+    with R.get_connection(db) as conn:
+        wd = conn.execute(
+            "SELECT id FROM watch_dirs WHERE path=?",
+            (str(sessions_dir.resolve()),),
+        ).fetchone()[0]
+        for i, name in enumerate(("t-c.md", "t-b.md", "t-a.md")):
+            conn.execute(
+                "INSERT INTO trajectories("
+                "watch_dir_id,filename,status,tasks_extracted,user_key,"
+                "discovered_at) VALUES(?,?,?,?,?,?)",
+                (wd, name, "done", 0, "alice",
+                 f"2026-07-{10 + i:02d} 00:00:00"),
+            )
+        conn.commit()
+    page = alice.get(
+        "/api/v1/dashboard/my/contributions/trajs?offset=0&limit=2"
+    ).json()
+    assert page["total"] == 3
+    assert len(page["trajs"]) == 2
+    # discovered_at 倒序 → t-a, t-b
+    assert [t["traj_id"] for t in page["trajs"]] == ["t-a", "t-b"]
+    page2 = alice.get(
+        "/api/v1/dashboard/my/contributions/trajs?offset=2&limit=2"
+    ).json()
+    assert [t["traj_id"] for t in page2["trajs"]] == ["t-c"]
 
 
 def test_users_matrix_lists_clients_with_version(console_env):

--- a/tests/test_dashboard_p3.py
+++ b/tests/test_dashboard_p3.py
@@ -24,6 +24,7 @@ from xskill.events import (
     CONTRIBUTOR_MIN_WEIGHT,
     EventStore,
     skill_contributors,
+    skill_main_producer,
     ux_band,
 )
 from xskill.pipeline import registry as R
@@ -66,6 +67,26 @@ def test_contributors_sum_and_threshold(reg_db):
     c2 = skill_contributors("skill-x", min_weight=1, db_path=reg_db)
     assert c2 == {"alice": 5, "bob": 1}
     assert CONTRIBUTOR_MIN_WEIGHT == 3
+
+
+def test_skill_main_producer_by_traj_count(reg_db):
+    """主要贡献人按贡献轨迹条数，而非 weightscore 总和。"""
+    # alice 1 条轨迹(2 atoms)、bob 1 条轨迹 → 并列按名字 alice 优先? 我们用 max(len, name)
+    # 给 bob 再加一条轨迹，bob 应胜出
+    conn = R.get_connection(reg_db)
+    wd = conn.execute("SELECT id FROM watch_dirs LIMIT 1").fetchone()[0]
+    conn.execute(
+        "INSERT INTO trajectories(watch_dir_id,filename,user_key) VALUES(?,?,?)",
+        (wd, "traj_b2.md", "bob"))
+    conn.commit()
+    conn.close()
+    R.record_atom_adoption(atom_id="atom_traj_b2_0001", skill="skill-x",
+                           weightscore=1, was_new=True, db_path=reg_db)
+    prod = skill_main_producer("skill-x", db_path=reg_db)
+    assert prod is not None
+    assert prod["user"] == "bob"
+    assert prod["traj_count"] == 2
+    assert skill_main_producer("no-such", db_path=reg_db) is None
 
 
 def test_feedback_dedup_by_traj(reg_db):

--- a/tests/test_dashboard_p3.py
+++ b/tests/test_dashboard_p3.py
@@ -71,6 +71,7 @@ def test_contributors_sum_and_threshold(reg_db):
 
 def test_skill_main_producer_by_traj_count(reg_db):
     """主要贡献人按贡献轨迹条数，而非 weightscore 总和。"""
+    from xskill.events import skill_main_producers
     # alice 1 条轨迹(2 atoms)、bob 1 条轨迹 → 并列按名字 alice 优先? 我们用 max(len, name)
     # 给 bob 再加一条轨迹，bob 应胜出
     conn = R.get_connection(reg_db)
@@ -87,6 +88,11 @@ def test_skill_main_producer_by_traj_count(reg_db):
     assert prod["user"] == "bob"
     assert prod["traj_count"] == 2
     assert skill_main_producer("no-such", db_path=reg_db) is None
+    # 批量接口与单 skill 一致，且同页多 skill 只扫一次 trajectories
+    batch = skill_main_producers(["skill-x", "no-such", "skill-x"],
+                                 db_path=reg_db)
+    assert batch["skill-x"] == prod
+    assert "no-such" not in batch
 
 
 def test_feedback_dedup_by_traj(reg_db):

--- a/tests/test_dashboard_standalone.py
+++ b/tests/test_dashboard_standalone.py
@@ -61,6 +61,7 @@ _BUILTIN_ONLY_OPERATIONS = {
     ("get", "/api/v1/dashboard/my/manifest"),
     ("post", "/api/v1/dashboard/my/prefs"),
     ("get", "/api/v1/dashboard/my/contributions"),
+    ("get", "/api/v1/dashboard/my/contributions/trajs"),
     ("get", "/api/v1/dashboard/my/reco-trigger"),
     ("get", "/api/v1/dashboard/events"),
     ("get", "/api/v1/dashboard/events/unread"),


### PR DESCRIPTION
## Summary
- 普通用户默认进入「我的」；模块顺序：推给我的 → 贡献去向 → 世界消息 → 历史推荐（默认折叠）
- 槽位展示来源 / 主要贡献人 / 右侧「我触发 N 次」；去掉浅色副标题与中间 usage 块
- 新增 `GET /my/contributions/trajs`：轨迹分页 + 关系图数据；前端三角翻页与 skill 芯片跳转详情
- 世界消息改为每页 5 条三角翻页并区分自己/他人；历史推荐按触发倒序、10 条/页
- 设计文档见 #177；交互参考 http://8.219.96.11:8774/

## Test plan
- [x] `pytest`：`test_skill_main_producer_by_traj_count`、`test_my_contribution_trajs_paginates_user_trajs`、`test_my_views_empty_db_do_not_crash`、standalone 路由清单、console p2 全绿
- [ ] 登录普通用户确认默认 `#my`
- [ ] 贡献去向三角翻页 + 点 skill 芯片回「我的」面包屑
- [ ] 历史推荐默认折叠，展开后按触发倒序分页
- [ ] 世界消息上下翻页、自己条目高亮

Closes #174


Made with [Cursor](https://cursor.com)