### PR TITLE
fix(install): heal orphan dests frozen by failed ledger migration

### DIFF
--- a/scripts/diagnose_install_health.py
+++ b/scripts/diagnose_install_health.py
@@ -1,0 +1,416 @@
+#!/usr/bin/env python3
+"""xskill 安装健康诊断（只读，零副作用）——验证孤儿 dest 自愈假设。
+
+设计约束：
+- 不修改任何文件；账本 SQLite 先复制到临时目录再只读打开，不碰活库。
+- 不向任何 skill 目录、生态目录写数据；stdout 之外唯一输出是 --json 指定的报告。
+- 无第三方依赖；有 dulwich 或 git 命令时会额外校验 git 对象与三方比对。
+
+验证的假设（对应 fix/orphan-dest-revsync-storm）：
+  H1 存在孤儿 dest：无账本行、无 sidecar。
+  H2 孤儿 dest 内有老 meta（.xskill-install-meta.json）且带合法 source_sha。
+  H3 source_sha 对应的 git 对象还在源仓里（领养能成功）。
+  H4 按重建基线做三方比对，预测回流结果：NO_EDIT / SYNCED(回灌) / CONFLICT。
+
+用法：
+  python diagnose_install_health.py            # 人类可读报告
+  python diagnose_install_health.py --json report.json
+"""
+from __future__ import annotations
+
+import argparse
+import hashlib
+import json
+import os
+import shutil
+import sqlite3
+import stat
+import subprocess
+import sys
+import tempfile
+import time
+from pathlib import Path
+
+LEDGER_DB = Path("~/.xskill/installations.sqlite").expanduser()
+SOURCE_ROOT = Path("~/.xskill/skill").expanduser()
+LEGACY_META_NAME = ".xskill-install-meta.json"
+SIDECAR_PREFIX = ".xskill-install-meta-"
+MARKER_NAME = ".xskill-install-identity.json"
+QUIET_SECONDS = 180
+
+ECOSYSTEM_ROOTS = [
+    Path("~/.claude/skills").expanduser(),
+    Path("~/.agents/skills").expanduser(),
+    Path("~/.cac/skills").expanduser(),
+    Path("~/.config/opencode/skills").expanduser(),
+    Path("~/.cursor/skills").expanduser(),
+    Path("~/.trae-cn/skills").expanduser(),
+    Path("~/.trae/skills").expanduser(),
+]
+
+# 与 reverse_sync_copy_dest 默认 exclude 对齐
+FP_EXCLUDE_FIRST_SEGMENT = {".git", LEGACY_META_NAME, MARKER_NAME}
+
+
+def dest_key(path: Path) -> str:
+    """与 install_ledger.dest_key 同算法。"""
+    return os.path.normcase(os.path.abspath(os.path.normpath(str(path))))
+
+
+def sha256_file(path: Path) -> str | None:
+    try:
+        digest = hashlib.sha256()
+        with path.open("rb") as fh:
+            while True:
+                chunk = fh.read(1024 * 1024)
+                if not chunk:
+                    break
+                digest.update(chunk)
+        return digest.hexdigest()
+    except OSError:
+        return None
+
+
+def dir_fingerprints(root: Path) -> dict[str, str]:
+    """目录逐文件 sha256（POSIX 相对路径），跳过 exclude 第一段与软链。"""
+    out: dict[str, str] = {}
+    for dirpath, dirnames, filenames in os.walk(root):
+        rel_dir = Path(dirpath).relative_to(root)
+        dirnames[:] = sorted(
+            d for d in dirnames
+            if not (rel_dir == Path() and d in FP_EXCLUDE_FIRST_SEGMENT)
+        )
+        for name in sorted(filenames):
+            rel = rel_dir / name
+            if rel.parts and rel.parts[0] in FP_EXCLUDE_FIRST_SEGMENT:
+                continue
+            full = Path(dirpath) / name
+            try:
+                if full.is_symlink():
+                    continue
+                st = full.lstat()
+                if not stat.S_ISREG(st.st_mode):
+                    continue
+            except OSError:
+                continue
+            digest = sha256_file(full)
+            if digest is not None:
+                out[rel.as_posix()] = digest
+    return out
+
+
+def load_ledger_rows() -> tuple[dict[str, dict], dict[str, int], str | None]:
+    """复制账本到临时目录后只读打开。返回 (by_dest_key, job_stats, error)。"""
+    if not LEDGER_DB.is_file():
+        return {}, {"removal_jobs": 0}, f"账本不存在: {LEDGER_DB}"
+    tmpdir = Path(tempfile.mkdtemp(prefix="xskill-diag-"))
+    try:
+        copies = []
+        for suffix in ("", "-wal", "-shm"):
+            src = Path(str(LEDGER_DB) + suffix)
+            if src.is_file():
+                dst = tmpdir / (LEDGER_DB.name + suffix)
+                shutil.copyfile(src, dst)
+                copies.append(dst)
+        conn = sqlite3.connect(f"file:{tmpdir / LEDGER_DB.name}?mode=ro", uri=True)
+        try:
+            rows = {}
+            for row in conn.execute(
+                "SELECT dest_key, skill_name, mode, source, source_sha,"
+                " installed_at, generation FROM installations"
+                " WHERE status='active'",
+            ):
+                rows[row[0]] = {
+                    "skill_name": row[1], "mode": row[2], "source": row[3],
+                    "source_sha": row[4], "installed_at": row[5],
+                    "generation": row[6],
+                }
+            jobs = conn.execute(
+                "SELECT COUNT(*) FROM removal_jobs"
+                " WHERE state IN ('pending','deleting')",
+            ).fetchone()[0]
+            return rows, {"removal_jobs": jobs}, None
+        finally:
+            conn.close()
+    except sqlite3.Error as exc:
+        return {}, {"removal_jobs": 0}, f"账本读取失败: {exc}"
+    finally:
+        shutil.rmtree(tmpdir, ignore_errors=True)
+
+
+def read_legacy_meta(dest: Path) -> dict | None:
+    try:
+        parsed = json.loads((dest / LEGACY_META_NAME).read_text(encoding="utf-8"))
+    except (OSError, ValueError, TypeError, UnicodeDecodeError):
+        return None
+    return parsed if isinstance(parsed, dict) else None
+
+
+def git_tree_fingerprints(source: Path, sha: str) -> dict[str, str] | None:
+    """优先 dulwich，退回 git CLI；都不可用返回 None。"""
+    try:
+        from dulwich.objects import Commit
+        from dulwich.repo import Repo
+        repo = Repo(str(source))
+        try:
+            obj = repo[sha.encode("ascii")]
+            if not isinstance(obj, Commit):
+                return None
+            out: dict[str, str] = {}
+            stack = [(obj.tree, Path())]
+            while stack:
+                tree_id, prefix = stack.pop()
+                tree = repo[tree_id]
+                for raw_name, mode, entry_id in tree.iteritems():
+                    name = raw_name.decode("utf-8", errors="strict")
+                    rel = prefix / name
+                    if stat.S_ISDIR(mode):
+                        stack.append((entry_id, rel))
+                    elif stat.S_ISREG(mode):
+                        out[rel.as_posix()] = hashlib.sha256(
+                            repo[entry_id].data,
+                        ).hexdigest()
+            return out
+        finally:
+            repo.close()
+    except Exception:
+        pass
+    git = shutil.which("git")
+    if git is None:
+        return None
+    try:
+        listing = subprocess.run(
+            [git, "-C", str(source), "ls-tree", "-r", "-z", sha],
+            capture_output=True, check=True, timeout=60,
+        )
+        out = {}
+        for entry in listing.stdout.decode("utf-8", "strict").split("\0"):
+            if not entry:
+                continue
+            meta, rel = entry.split("\t", 1)
+            mode = meta.split(" ", 1)[0]
+            if not stat.S_ISREG(int(mode, 8)):
+                continue
+            blob = subprocess.run(
+                [git, "-C", str(source), "cat-file", "blob", f"{sha}:{rel}"],
+                capture_output=True, check=True, timeout=60,
+            )
+            out[Path(rel).as_posix()] = hashlib.sha256(blob.stdout).hexdigest()
+        return out
+    except (subprocess.SubprocessError, ValueError, UnicodeDecodeError):
+        return None
+
+
+def predict_revsync(
+    dest: Path, source: Path, baseline: dict[str, str], installed_at: float,
+) -> dict:
+    """按 reverse_sync_copy_dest 的判定顺序做干跑，预测本轮结果。"""
+    dest_fp = dir_fingerprints(dest)
+    source_fp = dir_fingerprints(source)
+    if not dest_fp:
+        return {"verdict": "NO_EDIT", "backport": [], "conflict": []}
+    max_mtime = 0.0
+    for dirpath, dirnames, filenames in os.walk(dest):
+        rel_dir = Path(dirpath).relative_to(dest)
+        dirnames[:] = [d for d in dirnames if d not in FP_EXCLUDE_FIRST_SEGMENT]
+        for name in filenames:
+            rel = rel_dir / name
+            if rel.parts and rel.parts[0] in FP_EXCLUDE_FIRST_SEGMENT:
+                continue
+            try:
+                max_mtime = max(max_mtime, (Path(dirpath) / name).lstat().st_mtime)
+            except OSError:
+                pass
+    if max_mtime - installed_at < 1.0:
+        return {"verdict": "NO_EDIT", "backport": [], "conflict": []}
+    backport, conflict = [], []
+    for rel, dest_hash in dest_fp.items():
+        base_hash = baseline.get(rel)
+        if dest_hash == base_hash:
+            continue  # 未动（source 前进与否都不回灌）
+        src_hash = source_fp.get(rel)
+        if src_hash == dest_hash:
+            continue  # 已收敛（上次回灌成功）
+        if src_hash != base_hash:
+            conflict.append(rel)  # 双边分叉
+        else:
+            backport.append(rel)  # dest 单边变更
+    if conflict:
+        return {"verdict": "CONFLICT", "backport": backport, "conflict": conflict}
+    if not backport:
+        return {"verdict": "NO_EDIT", "backport": [], "conflict": []}
+    newest = 0.0
+    for rel in backport:
+        try:
+            newest = max(newest, (dest / rel).lstat().st_mtime)
+        except OSError:
+            pass
+    if time.time() - newest < QUIET_SECONDS:
+        return {
+            "verdict": "RECENT_EDIT(下轮回灌)",
+            "backport": backport, "conflict": [],
+        }
+    return {"verdict": "SYNCED(回灌)", "backport": backport, "conflict": []}
+
+
+def classify_dest(dest: Path, root: Path, ledger: dict[str, dict]) -> dict:
+    name = dest.name
+    info: dict = {"dest": str(dest), "name": name}
+    row = ledger.get(dest_key(dest))
+    if row is not None:
+        info["category"] = "HEALTHY(有账本行)"
+        info["row"] = row
+        return info
+    sidecar = root / f"{SIDECAR_PREFIX}{name}.json"
+    if sidecar.is_file():
+        info["category"] = "SIDECAR(待迁移或迁移失败保留)"
+        return info
+    try:
+        if dest.is_symlink():
+            info["category"] = "LINK(软链,不涉及)"
+            return info
+    except OSError:
+        pass
+    meta = read_legacy_meta(dest)
+    if meta is None:
+        try:
+            has_marker = (dest / MARKER_NAME).is_file()
+        except OSError:
+            has_marker = False
+        if has_marker:
+            info["category"] = "ORPHAN_NO_META(marker在,确为xskill安装,需重装)"
+        else:
+            info["category"] = "NO_TRACE(无xskill痕迹,可能非受管)"
+        return info
+    sha = meta.get("source_sha")
+    installed_at = meta.get("installed_at")
+    if (
+        not isinstance(sha, str) or len(sha) != 40
+        or any(c not in "0123456789abcdef" for c in sha)
+    ):
+        info["category"] = "ORPHAN_BAD_SHA(无法自愈,需重装)"
+        return info
+    if isinstance(installed_at, bool) or not isinstance(installed_at, (int, float)):
+        installed_at = None
+    info.update({
+        "category": "ORPHAN_ADOPTABLE",
+        "source_sha": sha,
+        "installed_at": installed_at,
+    })
+    return info
+
+
+def main() -> int:
+    parser = argparse.ArgumentParser(description=__doc__)
+    parser.add_argument("--json", metavar="PATH", help="同时写 JSON 报告")
+    args = parser.parse_args()
+
+    print("=" * 68)
+    print("xskill 安装健康诊断（只读 / 不修改任何文件与账本）")
+    print("=" * 68)
+    print(f"time        : {time.strftime('%Y-%m-%d %H:%M:%S')}")
+    print(f"ledger      : {LEDGER_DB}")
+    print(f"source root : {SOURCE_ROOT}")
+
+    ledger, job_stats, ledger_err = load_ledger_rows()
+    if ledger_err:
+        print(f"账本        : {ledger_err}")
+        if "不存在" in ledger_err:
+            print("注意        : 本机未跑过新版 daemon, 无账本时 NO_TRACE 类别"
+                  "大概率是非受管目录, 不代表故障")
+    else:
+        print(f"账本        : {len(ledger)} 条 active 安装, "
+              f"{job_stats['removal_jobs']} 条未完成卸装")
+
+    report: dict = {"ledger_error": ledger_err, "dests": []}
+    summary: dict[str, int] = {}
+    orphans: list[dict] = []
+
+    for root in ECOSYSTEM_ROOTS:
+        if not root.is_dir():
+            continue
+        try:
+            children = sorted(
+                p for p in root.iterdir()
+                if p.is_dir() and not p.name.startswith(".")
+            )
+        except OSError:
+            continue
+        sidecars = [
+            p for p in root.iterdir()
+            if p.name.startswith(SIDECAR_PREFIX) and p.name.endswith(".json")
+        ]
+        print(f"\n[生态根] {root}  ({len(children)} 个 dest, "
+              f"{len(sidecars)} 个遗留 sidecar)")
+        for dest in children:
+            info = classify_dest(dest, root, ledger)
+            report["dests"].append(info)
+            summary[info["category"]] = summary.get(info["category"], 0) + 1
+            mark = {
+                "HEALTHY(有账本行)": "  ok ",
+                "LINK(软链,不涉及)": "  ok ",
+            }.get(info["category"], "  !! ")
+            print(f"  {mark}{info['name']:<36} {info['category']}")
+            if info["category"] == "ORPHAN_ADOPTABLE":
+                orphans.append(info)
+
+    print("\n" + "-" * 68)
+    print("[汇总]")
+    for category, count in sorted(summary.items()):
+        print(f"  {count:>4}  {category}")
+
+    healed, frozen = 0, 0
+    if orphans:
+        print("\n" + "-" * 68)
+        print("[孤儿干跑] 按修复版逻辑预测第一轮回流结果（不执行任何写操作）")
+    for info in orphans:
+        name = info["name"]
+        source = SOURCE_ROOT / name
+        line = f"  {name}: "
+        if info.get("installed_at") is None:
+            line += "老 meta 缺 installed_at → 仍冻结(REVERSE_SYNC 安全跳过)"
+            frozen += 1
+        elif not source.is_dir():
+            line += f"找不到源仓 {source} → 仍冻结"
+            frozen += 1
+        else:
+            baseline = git_tree_fingerprints(source, info["source_sha"])
+            if baseline is None:
+                line += "git 对象已丢失(或本机无 git/dulwich) → 仍冻结,需重装"
+                frozen += 1
+            else:
+                pred = predict_revsync(
+                    Path(info["dest"]), source, baseline, info["installed_at"],
+                )
+                info["prediction"] = pred["verdict"]
+                detail = ""
+                if pred["backport"]:
+                    detail += f", 回灌 {len(pred['backport'])} 个文件"
+                    detail += f" {pred['backport'][:5]}"
+                if pred["conflict"]:
+                    detail += f", 冲突 {len(pred['conflict'])} 个 {pred['conflict'][:5]}"
+                line += f"领养 OK → {pred['verdict']}{detail}"
+                if pred["verdict"].startswith("CONFLICT"):
+                    frozen += 1
+                else:
+                    healed += 1
+        print(line)
+
+    print("\n" + "=" * 68)
+    print(f"[结论] 孤儿 {len(orphans)} 个: 预计首轮自愈 {healed}, 仍冻结 {frozen}")
+    if ledger_err is None and not orphans and not any(
+        k.startswith("ORPHAN") or k.startswith("SIDECAR") for k in summary
+    ):
+        print("[结论] 未发现孤儿 dest,DAMAGED 风暴假设在本机不成立")
+    print("=" * 68)
+
+    if args.json:
+        Path(args.json).write_text(
+            json.dumps(report, ensure_ascii=False, indent=2), encoding="utf-8",
+        )
+        print(f"JSON 报告已写入 {args.json}")
+    return 0
+
+
+if __name__ == "__main__":
+    sys.exit(main())

--- a/src/xskill/agents/user_edit_absorb_agent.py
+++ b/src/xskill/agents/user_edit_absorb_agent.py
@@ -352,18 +352,14 @@ def _read_install_meta_ts(dest_dir: Path) -> tuple[bool, Optional[float]]:
     from xskill.ecosystems.installation import (
         InstallationMetadataError,
         read_install_metadata,
-        read_install_metadata_file,
     )
 
     try:
         data = read_install_metadata(dest_dir)
-        if data is None:
-            data = read_install_metadata_file(
-                dest_dir / _OPENCLAW_INSTALL_META,
-                dest_dir,
-            )
     except InstallationMetadataError:
         return False, None
+    if data is None:
+        data = _read_legacy_meta_lenient(dest_dir / _OPENCLAW_INSTALL_META)
     if data is None:
         return True, None
     installed_timestamp = data.get("installed_at")
@@ -373,6 +369,23 @@ def _read_install_meta_ts(dest_dir: Path) -> tuple[bool, Optional[float]]:
     ):
         return False, None
     return True, float(installed_timestamp)
+
+
+def _read_legacy_meta_lenient(meta_path: Path) -> Optional[dict]:
+    """宽松读 openclaw 老位置 meta，只作 installed_at 数据源。
+
+    该文件由 ``install_to_openclaw`` 为 canary 比对而写，只有
+    source_sha/side/installed_at/ecosystem 四个字段——不是安装账格式，
+    不能过 ``read_install_metadata_file`` 的严格校验（必报 DAMAGED）。
+    这里只取其 dict，取不到就当没有（安全跳过，不算读失败）。
+    """
+    try:
+        parsed = json.loads(meta_path.read_text(encoding="utf-8"))
+    except (OSError, ValueError, TypeError, UnicodeDecodeError):
+        return None
+    if not isinstance(parsed, dict):
+        return None
+    return parsed
 
 
 def _is_reparse_point(file_stat: os.stat_result) -> bool:
@@ -1278,8 +1291,18 @@ def reverse_sync_copy_dest(
     并发：copy 期间 dest 也可能继续变化。锁只保护 source；任何扫描/复制异常
     返回 ``FAILED``，调用安装器必须保留 dest，供下一轮安全重试。
     """
-    from xskill.ecosystems.installation import read_copy_install_baseline
+    from xskill.ecosystems.installation import (
+        adopt_orphan_copy_install,
+        read_copy_install_baseline,
+    )
     from xskill.skill.git import skill_repo_lock
+
+    # 孤儿自愈：迁移失败留下的存量 dest 没有账本行，先按生态目录内老 meta
+    # 的 source_sha 从 git 重建安装基线登记；失败则维持原冻结语义。
+    adopt_orphan_copy_install(
+        dest_dir, source_dir,
+        legacy_meta_path=Path(dest_dir) / _OPENCLAW_INSTALL_META,
+    )
 
     try:
         with skill_repo_lock(source_dir):

--- a/src/xskill/ecosystems/install_ledger.py
+++ b/src/xskill/ecosystems/install_ledger.py
@@ -565,13 +565,19 @@ class InstallLedger(_SqliteStore):
                         dest = root / dest_name
                         if self._import_sidecar(entry, dest):
                             stats["installs_imported"] += 1
-                        entry.unlink(missing_ok=True)
-                        stats["files_removed"] += 1
+                            entry.unlink(missing_ok=True)
+                            stats["files_removed"] += 1
+                        else:
+                            # 导入失败必须保留原文件等下轮重试：账本行缺失时
+                            # sidecar 是该 dest 唯一的安装记录，删掉即成孤儿。
+                            stats["errors"] += 1
                     elif ".removal-transaction-" in name:
                         if self._import_removal_record(entry, root):
                             stats["removals_imported"] += 1
-                        entry.unlink(missing_ok=True)
-                        stats["files_removed"] += 1
+                            entry.unlink(missing_ok=True)
+                            stats["files_removed"] += 1
+                        else:
+                            stats["errors"] += 1
                     elif ".removing-" in name or name.startswith(
                         ".xskill-removing-target-",
                     ):

--- a/src/xskill/ecosystems/installation.py
+++ b/src/xskill/ecosystems/installation.py
@@ -333,6 +333,137 @@ def read_install_metadata(dest: Path) -> dict | None:
     return meta
 
 
+_GIT_COMMIT_SHA_PATTERN = re.compile(r"[0-9a-f]{40}")
+
+
+def _git_tree_fingerprints(source: Path, sha: str) -> dict[str, str] | None:
+    """按 commit 的 git tree 重建逐文件内容指纹。
+
+    口径与 ``_safe_copy_file_fingerprints`` 一致：文件字节 sha256、POSIX
+    相对路径。任何一步读不到对象都返回 None（调用方按不可领养处理）。
+    """
+    try:
+        repo = Repo(str(source))
+    except (NotGitRepository, OSError):
+        return None
+    try:
+        try:
+            obj = repo[sha.encode("ascii")]
+        except KeyError:
+            return None
+        if not isinstance(obj, Commit):
+            return None
+        fingerprints: dict[str, str] = {}
+        stack: list[tuple[bytes, Path]] = [(obj.tree, Path())]
+        while stack:
+            tree_id, prefix = stack.pop()
+            try:
+                tree = repo[tree_id]
+            except KeyError:
+                return None
+            for raw_name, mode, entry_id in tree.iteritems():
+                try:
+                    name = raw_name.decode("utf-8", errors="strict")
+                except UnicodeDecodeError:
+                    return None
+                relative = prefix / name
+                if stat.S_ISDIR(mode):
+                    stack.append((entry_id, relative))
+                elif stat.S_ISREG(mode):
+                    try:
+                        blob = repo[entry_id]
+                    except KeyError:
+                        return None
+                    fingerprints[relative.as_posix()] = hashlib.sha256(
+                        blob.data,
+                    ).hexdigest()
+        return fingerprints
+    except (OSError, ValueError, KeyError):
+        return None
+    finally:
+        repo.close()
+
+
+def adopt_orphan_copy_install(
+    dest: Path,
+    source: Path,
+    *,
+    legacy_meta_path: Path | None = None,
+) -> bool:
+    """孤儿 dest（无账本行、无 sidecar）按 legacy meta 的 source_sha 从 git
+    重建安装时基线并登记账本；成功返回 True。
+
+    历史迁移失败的存量 dest 只剩生态目录内老 meta（canary 比对数据）。
+    其中的 source_sha 记录了安装那一刻的源 commit——从 git object 取回该
+    提交的文件内容算指纹，三方回流就能区分 dest 侧用户编辑与 source 侧
+    前进，基线不靠猜。登记后清掉 dest 内旧 marker，账本此后是唯一身份
+    来源。任何一步拿不到数据都返回 False，维持原冻结状态（安全方向）。
+    """
+    from xskill.ecosystems.install_ledger import get_default_ledger
+
+    try:
+        if read_install_metadata(dest) is not None:
+            return False
+    except InstallationMetadataError:
+        return False
+    if legacy_meta_path is None:
+        return False
+    try:
+        legacy = json.loads(legacy_meta_path.read_text(encoding="utf-8"))
+    except (OSError, ValueError, TypeError, UnicodeDecodeError):
+        return False
+    if not isinstance(legacy, dict):
+        return False
+    source_sha = legacy.get("source_sha")
+    if (
+        not isinstance(source_sha, str)
+        or _GIT_COMMIT_SHA_PATTERN.fullmatch(source_sha) is None
+    ):
+        return False
+    fingerprints = _git_tree_fingerprints(Path(source), source_sha)
+    if fingerprints is None:
+        return False
+    try:
+        resolved_source = str(Path(source).resolve())
+    except OSError:
+        return False
+    installed_at = legacy.get("installed_at")
+    if isinstance(installed_at, bool) or not isinstance(
+        installed_at, (int, float),
+    ):
+        installed_at = None
+    try:
+        get_default_ledger().record_install(
+            dest,
+            skill_name=Path(dest).name,
+            mode="copy",
+            source=resolved_source,
+            source_sha=source_sha,
+            installation_id=secrets.token_hex(16),
+            content_identity=_content_identity(Path(source), source_sha),
+            baseline_identity=_copy_baseline_identity(fingerprints),
+            file_fingerprints=fingerprints,
+            installed_at=installed_at,
+        )
+    except Exception:  # pylint: disable=broad-exception-caught
+        logger.exception(
+            "orphan copy install adoption failed path_hash=%s",
+            _path_hash(Path(dest)),
+        )
+        return False
+    try:
+        marker = Path(dest) / COPY_INSTALL_MARKER_NAME
+        if marker.is_symlink() or marker.is_file():
+            marker.unlink(missing_ok=True)
+    except OSError:
+        pass
+    logger.info(
+        "orphan copy install adopted path_hash=%s",
+        _path_hash(Path(dest)),
+    )
+    return True
+
+
 def _validated_head_sha(repo: Repo, skill_path: Path) -> str | None:
     """读取并校验已打开仓库的 HEAD；不负责关闭 repo。"""
     try:

--- a/tests/test_orphan_adoption.py
+++ b/tests/test_orphan_adoption.py
@@ -1,0 +1,207 @@
+"""孤儿 dest 自愈回归：迁移保留 + legacy meta 宽松读 + git 基线领养。
+
+生产事故根因（v0.6.29a3 Windows 客户端 DAMAGED 风暴）：
+1. 迁移把导入失败的 sidecar 也删了 → dest 变孤儿（无账本行无旁证）。
+2. revsync 兼容路径拿 canary 比对 meta 过严格校验 → 必报
+   INSTALL_METADATA_DAMAGED → revsync FAILED → 冻结。
+3. 孤儿没有基线，三方回流无从谈起。
+
+本文件覆盖三处修复：迁移只删导入成功的文件；老 meta 宽松取 installed_at；
+按 source_sha 从 git tree 重建安装基线并登记账本。
+"""
+from __future__ import annotations
+
+import json
+import time
+from pathlib import Path
+
+from dulwich import porcelain
+
+from xskill.agents.user_edit_absorb_agent import (
+    ReverseSyncStatus,
+    _read_install_meta_ts,
+    reverse_sync_copy_dest,
+)
+from xskill.ecosystems.install_ledger import InstallLedger
+from xskill.ecosystems.installation import (
+    COPY_INSTALL_MARKER_NAME,
+    adopt_orphan_copy_install,
+    read_copy_install_baseline,
+    read_install_metadata,
+    write_install_metadata,
+)
+
+_LEGACY_META_NAME = ".xskill-install-meta.json"
+_REVSYNC_EXCLUDE = frozenset({".git", _LEGACY_META_NAME})
+
+
+def _git_source(tmp_path: Path, files: dict[str, str]) -> tuple[Path, str]:
+    src = tmp_path / "src" / "demo"
+    src.mkdir(parents=True)
+    for rel, text in files.items():
+        target = src / rel
+        target.parent.mkdir(parents=True, exist_ok=True)
+        target.write_text(text, encoding="utf-8")
+    repo = porcelain.init(str(src), bare=False)
+    try:
+        porcelain.add(repo)
+        sha = porcelain.commit(
+            repo,
+            message=b"install snapshot",
+            author=b"t <t@example.com>",
+            committer=b"t <t@example.com>",
+        )
+    finally:
+        repo.close()
+    return src, sha.decode("ascii")
+
+
+def _orphan_dest(tmp_path: Path, files: dict[str, str], sha: str) -> Path:
+    dest = tmp_path / "eco" / "demo"
+    dest.mkdir(parents=True)
+    for rel, text in files.items():
+        target = dest / rel
+        target.parent.mkdir(parents=True, exist_ok=True)
+        target.write_text(text, encoding="utf-8")
+    legacy = {
+        "source_sha": sha,
+        "side": "main",
+        "installed_at": time.time() - 100,
+        "ecosystem": "openclaw",
+    }
+    (dest / _LEGACY_META_NAME).write_text(
+        json.dumps(legacy), encoding="utf-8",
+    )
+    return dest
+
+
+def test_migration_keeps_failed_sidecar_for_retry(tmp_path):
+    """导入失败的 sidecar 必须保留等下轮重试，不再无脑删成孤儿。"""
+    root = tmp_path / "skills"
+    (root / "demo").mkdir(parents=True)
+    sidecar = root / ".xskill-install-meta-demo.json"
+    sidecar.write_text('{"mode":"copy"}', encoding="utf-8")
+    ledger = InstallLedger(tmp_path / "installations.sqlite")
+
+    stats = ledger.migrate_from_sidecars([root])
+    assert stats["installs_imported"] == 0
+    assert stats["files_removed"] == 0
+    assert stats["errors"] == 1
+    assert sidecar.exists()
+    assert ledger.read_install(root / "demo") is None
+
+    src = tmp_path / "src" / "demo"
+    src.mkdir(parents=True)
+    (src / "SKILL.md").write_text("x", encoding="utf-8")
+    valid = {
+        "mode": "copy",
+        "source": str(src.resolve()),
+        "source_sha": "",
+        "installed_at": time.time(),
+        "installation_id": "a" * 32,
+        "content_identity": "b" * 64,
+        "baseline_identity": "c" * 64,
+        "file_fingerprints": {"SKILL.md": "d" * 64},
+    }
+    sidecar.write_text(json.dumps(valid), encoding="utf-8")
+    stats = ledger.migrate_from_sidecars([root])
+    assert stats["installs_imported"] == 1
+    assert stats["files_removed"] == 1
+    assert not sidecar.exists()
+    assert ledger.read_install(root / "demo") is not None
+
+
+def test_legacy_canary_meta_read_leniently(tmp_path):
+    """canary 比对 meta（无 mode 等安装账字段）宽松取 installed_at。"""
+    dest = tmp_path / "eco" / "demo"
+    dest.mkdir(parents=True)
+    ts = time.time() - 50
+    (dest / _LEGACY_META_NAME).write_text(
+        json.dumps({
+            "source_sha": "e" * 40,
+            "side": "main",
+            "installed_at": ts,
+            "ecosystem": "openclaw",
+        }),
+        encoding="utf-8",
+    )
+    ok, installed_at = _read_install_meta_ts(dest)
+    assert ok is True
+    assert installed_at == ts
+
+    (dest / _LEGACY_META_NAME).write_text("not json{", encoding="utf-8")
+    ok, installed_at = _read_install_meta_ts(dest)
+    assert ok is True
+    assert installed_at is None
+
+
+def test_adopt_orphan_rebuilds_baseline_from_git(tmp_path):
+    src, sha = _git_source(tmp_path, {"SKILL.md": "v1\n", "notes/a.txt": "a\n"})
+    dest = _orphan_dest(tmp_path, {"SKILL.md": "v1\n", "notes/a.txt": "a\n"}, sha)
+
+    adopted = adopt_orphan_copy_install(
+        dest, src, legacy_meta_path=dest / _LEGACY_META_NAME,
+    )
+    assert adopted is True
+    meta = read_install_metadata(dest)
+    assert meta is not None
+    assert meta["mode"] == "copy"
+    assert meta["source_sha"] == sha
+    baseline = read_copy_install_baseline(dest)
+    assert set(baseline) == {"SKILL.md", "notes/a.txt"}
+    assert not (dest / COPY_INSTALL_MARKER_NAME).exists()
+
+
+def test_adopt_orphan_skipped_when_ledger_row_exists(tmp_path):
+    src, sha = _git_source(tmp_path, {"SKILL.md": "v1\n"})
+    dest = _orphan_dest(tmp_path, {"SKILL.md": "v1\n"}, sha)
+    write_install_metadata(dest, src, "copy")
+    before = read_install_metadata(dest)
+    assert before is not None
+
+    adopted = adopt_orphan_copy_install(
+        dest, src, legacy_meta_path=dest / _LEGACY_META_NAME,
+    )
+    assert adopted is False
+    after = read_install_metadata(dest)
+    assert after is not None
+    assert after["installation_id"] == before["installation_id"]
+
+
+def test_adopt_orphan_refused_without_source_sha(tmp_path):
+    src, _ = _git_source(tmp_path, {"SKILL.md": "v1\n"})
+    dest = _orphan_dest(tmp_path, {"SKILL.md": "v1\n"}, "not-a-sha")
+    adopted = adopt_orphan_copy_install(
+        dest, src, legacy_meta_path=dest / _LEGACY_META_NAME,
+    )
+    assert adopted is False
+    assert read_install_metadata(dest) is None
+
+
+def test_revsync_orphan_backports_user_edit(tmp_path):
+    """端到端：孤儿 dest 的用户编辑经领养基线三方比较后灌回 source。"""
+    src, sha = _git_source(tmp_path, {"SKILL.md": "v1\n"})
+    dest = _orphan_dest(tmp_path, {"SKILL.md": "v1\n"}, sha)
+    (dest / "SKILL.md").write_text("v2-user-edit\n", encoding="utf-8")
+
+    status = reverse_sync_copy_dest(
+        dest, src,
+        exclude=_REVSYNC_EXCLUDE,
+        quiet_seconds=0,
+    )
+    assert status == ReverseSyncStatus.SYNCED
+    assert (src / "SKILL.md").read_text(encoding="utf-8") == "v2-user-edit\n"
+    assert read_install_metadata(dest) is not None
+
+
+def test_revsync_orphan_unedited_is_no_edit(tmp_path):
+    src, sha = _git_source(tmp_path, {"SKILL.md": "v1\n"})
+    dest = _orphan_dest(tmp_path, {"SKILL.md": "v1\n"}, sha)
+
+    status = reverse_sync_copy_dest(
+        dest, src,
+        exclude=_REVSYNC_EXCLUDE,
+        quiet_seconds=0,
+    )
+    assert status == ReverseSyncStatus.NO_EDIT
+    assert (src / "SKILL.md").read_text(encoding="utf-8") == "v1\n"


### PR DESCRIPTION
## Summary

Production clients on `0.6.29a3` are flooding `INSTALL_METADATA_DAMAGED` + `REVERSE_SYNC_FAILED`. Affected skills are permanently skipped as `pending user edit`; reverse sync never recovers.

Root causes, both in the install-ledger migration:

- `migrate_from_sidecars` deleted sidecar files **even when their import failed**. The dest then has no ledger row and no surviving metadata: an orphan.
- The reverse-sync compatibility path ran the openclaw legacy meta file (`dest/.xskill-install-meta.json`, canary comparison data with only `source_sha/side/installed_at/ecosystem`) through the **strict install-metadata validator**, which always rejects it. Every round logs DAMAGED and the skill stays frozen.

## Fixes

- **Migration** (`install_ledger.py`): sidecars are unlinked only after a successful import; failures are kept for the next retry.
- **Compat reader** (`user_edit_absorb_agent.py`): the legacy meta is parsed leniently for `installed_at` instead of being fed to the strict validator. No more DAMAGED from this path.
- **Orphan adoption** (`installation.py` + revsync hook): the legacy meta's `source_sha` records the install-time commit, so the real baseline is rebuilt from the git tree and registered in the ledger. Three-way reverse sync then works: dest-side user edits are backported to source, source-side progress is preserved. Any missing data keeps the skill safely frozen, never deleted.

## Test plan

- [x] 7 new regression tests in `tests/test_orphan_adoption.py` (migration retry, lenient read, adoption from git sha, end-to-end revsync backport of a user edit)
- [x] `test_install_ledger` / `test_install_fallback*` / `test_ecosystem_ngagent` / `test_user_edit_absorb` / `test_team_client` / `test_openclaw_adapter` / `test_canary_rotation`: 197 passed, no regressions
- [ ] CI

Made with [Cursor](https://cursor.com)