### PR TITLE
fix(dashboard): 开机前初始化 IDENT，修复空骨架未登录态

### DIFF
--- a/src/xskill/dashboard/static/app.js
+++ b/src/xskill/dashboard/static/app.js
@@ -1294,15 +1294,18 @@ document.getElementById('traj-input').addEventListener('keydown', e => {
   if (e.key === 'Enter') document.getElementById('traj-open').click();
 });
 
+// ═════════════ P2:登录/角色 + 我的/管理/设置 ═════════════
+// IDENT 必须在首次 route() 之前完成初始化：route() 会读它决定默认落地页
+// （普通用户 → 我的）。若放在 route() 之后，开机即 ReferenceError，后续
+// load* 与 initIdent 全部中断，表现为未登录空骨架，仅流水线页仍可用。
+let IDENT = null;   // {user, role} | null
+
 // ── 启动：各端点独立加载，单个失败不拖垮整页 ───────────────────
 route();
 for (const f of [loadOverview, loadRates, loadPipeline, loadDomain, loadCost,
   loadSkills, loadDirs, loadUsersStatus, loadTags, loadCanary]) {
   f().catch(e => console.error(e));
 }
-
-// ═════════════ P2:登录/角色 + 我的/管理/设置 ═════════════
-let IDENT = null;   // {user, role} | null
 
 async function jpost(u, body, method) {
   const r = await fetch(u, { method: method || 'POST',


### PR DESCRIPTION
## Summary
- Fixes #186
- 将 IDENT 的声明挪到首次 route 调用之前，避免 Temporal Dead Zone 导致开机 ReferenceError
- 恢复后续数据加载与 initIdent，免密链接进入后可正常显示身份与首屏数据

## 背景
PR 180 让普通用户默认进入我的页，route 会读 IDENT，但声明顺序反了。a4 起复现；流水线页不读 IDENT，所以一直正常。

## Test plan
- 打开看板首页，控制台无 Cannot access IDENT before initialization
- 免密链接进入后顶栏显示用户身份
- 总览与技能列表会发出请求（冷启动耗时不在本 PR 范围）
- 流水线页仍可用

Made with [Cursor](https://cursor.com)