### PR TITLE
feat(recommend): recommend-heavy worker + Milvus Lite isolation

### DIFF
--- a/pyproject.toml
+++ b/pyproject.toml
@@ -46,6 +46,8 @@ dependencies = [
     # ``python:3.9-slim``）默认没装 git，SkillEditAgent 等链路又要跑 git
     # init/commit/branch；走 dulwich 后零依赖系统 git。
     "dulwich>=0.21",
+    # 嵌入式向量索引（Milvus Lite）：技能检索/推荐 KNN，替代 numpy 全库乘。
+    "pymilvus>=2.4.2",
     # Python 3.9 上 pydantic 需要它来求值 `X | Y` 联合注解（PEP 604 语法
     # 3.10 才原生支持）；3.10+ 不安装。
     "eval_type_backport; python_version < '3.10'",

--- a/src/xskill/_workers.py
+++ b/src/xskill/_workers.py
@@ -1,13 +1,13 @@
 """内部子进程 worker(**非用户 CLI**)。
 
-agent-worker 是常驻子进程；画像重计算仍是短命子进程。web 进程的
+agent-worker 是常驻子进程；``recommend-heavy``（含画像刷新 + Milvus 对账 +
+脏用户推荐预计算）是定时短命子进程。web 进程的
 ``IntervalSubprocessScheduler`` 用
 ``[sys.executable, "-m", "xskill._workers", <kind>]`` 启动它们，重计算与 web
 事件循环保持 GIL 隔离。
 
 这些是**内部管道**,刻意不注册进 ``xskill`` 用户 CLI(``cli.build_parser``)——用户
-``xskill --help`` 看不到它们。调度器直接调本模块的 SDK 函数
-(``run_agent_worker_forever`` / ``run_profile_refresh_once``),或经
+``xskill --help`` 看不到它们。调度器直接调本模块的 SDK 函数，或经
 ``python -m xskill._workers`` 入口。
 """
 from __future__ import annotations
@@ -301,7 +301,7 @@ def run_ecosystem_ingest_loop(
         wait_event.wait(interval)
 
 
-def run_profile_refresh_once() -> int:
+def run_profile_refresh_once(*, engine=None) -> int:
     """遍历所有 client 重算画像落库即退,状态落 profile_refresh_status.json。
 
     复用 ProfileRefreshService(短命形态:批量提交所有 client → wait_idle → stop),
@@ -318,7 +318,8 @@ def run_profile_refresh_once() -> int:
     status_path = XSKILL_HOME / PROFILE_STATUS_FILE
     service = None
     try:
-        engine = build_recommend_engine(config)
+        if engine is None:
+            engine = build_recommend_engine(config)
         client_ids = [row["client_id"] for row in engine.client_registry.list()]
         # 批量任务:settle_delay=0 立即算(settle 是给在线 sync 突发让路用的,批量无此需求)。
         service = ProfileRefreshService(
@@ -339,6 +340,37 @@ def run_profile_refresh_once() -> int:
     finally:
         if service is not None:
             service.stop(timeout=pr_cfg["shutdown_timeout"])
+
+
+def run_recommend_heavy_once() -> int:
+    """合并重活：画像刷新 → Milvus 对账 → 脏用户推荐预计算。
+
+    替代原先仅跑 profile-refresh 的短命子进程；Web /sync 只读
+    ``client_recommend_slots``，不再请求内 ``get_skill_for_client``。
+    """
+    from xskill.config import XSKILL_HOME, load_config
+    from xskill.recommend.heavy_worker import run_recommend_heavy_once as _heavy_tick
+    from xskill.team.server.engine_factory import build_recommend_engine
+    from xskill.utils.status_file import PROFILE_STATUS_FILE, write_status_file
+
+    status_path = XSKILL_HOME / PROFILE_STATUS_FILE
+    try:
+        config = load_config()
+        engine = build_recommend_engine(config)
+        profile_rc = run_profile_refresh_once(engine=engine)
+        heavy = _heavy_tick(engine=engine)
+        metrics = {
+            "profile_rc": profile_rc,
+            "vector_upserted": heavy.get("vector", {}).get("upserted", 0),
+            "vector_deleted": heavy.get("vector", {}).get("deleted", 0),
+            "recommends": heavy.get("recommends", 0),
+        }
+        write_status_file(status_path, metrics, ok=profile_rc == 0)
+        return 0 if profile_rc == 0 else profile_rc
+    except Exception as exc:  # noqa: BLE001 — 顶层任务边界
+        logger.exception("recommend heavy once failed")
+        write_status_file(status_path, {}, ok=False, error=str(exc))
+        return 1
 
 
 def run_ux_scores_sync_once() -> int:
@@ -372,6 +404,7 @@ def main(argv: list[str] | None = None) -> int:
     p_ingest.add_argument("--loop", action="store_true")
     p_ingest.add_argument("--interval", type=float, default=0.5)
     sub.add_parser("profile-refresh")
+    sub.add_parser("recommend-heavy")
     sub.add_parser("ux-scores-sync")
     args = parser.parse_args(argv)
 
@@ -387,7 +420,10 @@ def main(argv: list[str] | None = None) -> int:
         return run_ecosystem_ingest_once(home=args.home)
     if args.kind == "ux-scores-sync":
         return run_ux_scores_sync_once()
-    return run_profile_refresh_once()
+    if args.kind in ("recommend-heavy", "profile-refresh"):
+        # profile-refresh 入口保留兼容，实际走合并重活（画像+向量+推荐）。
+        return run_recommend_heavy_once()
+    return run_recommend_heavy_once()
 
 
 if __name__ == "__main__":

--- a/src/xskill/api/app.py
+++ b/src/xskill/api/app.py
@@ -1122,13 +1122,12 @@ def create_app(home_root: Path | str | None = None,
                     app,
                     max_workers=team_sync_cfg["workers"],
                 )
-                # 画像刷新改为定时短命子进程(python -m xskill._workers profile-refresh):重计算
-                # (含散点物化子系统)全在独立子进程,web 进程不再起常驻 worker 线程,
-                # GIL 与事件循环隔离。/sync 只读已落库画像(profile_refresh_service=None
-                # 时 api.team_sync 的入队守卫自然跳过)。
+                # 重活合并：画像 + Milvus 对账 + 脏用户推荐预计算，全在独立子进程。
+                # Web /sync 只读已落库画像与 client_recommend_slots
+                # (profile_refresh_service=None 时 api.team_sync 入队守卫跳过)。
                 profile_scheduler = IntervalSubprocessScheduler(
-                    "profile-refresh",
-                    [_sys.executable, "-m", "xskill._workers", "profile-refresh"],
+                    "recommend-heavy",
+                    [_sys.executable, "-m", "xskill._workers", "recommend-heavy"],
                     interval=profile_refresh_cfg["interval"],
                     timeout=profile_refresh_cfg["timeout"],
                 )
@@ -1136,7 +1135,7 @@ def create_app(home_root: Path | str | None = None,
                 _schedulers.append(profile_scheduler)
                 logger.info(
                     "team server context ready (traj_root=%s, "
-                    "profile refresh every %.0fs via subprocess)",
+                    "recommend-heavy every %.0fs via subprocess)",
                     traj_root, profile_refresh_cfg["interval"],
                 )
             except Exception:

--- a/src/xskill/pipeline/registry.py
+++ b/src/xskill/pipeline/registry.py
@@ -238,6 +238,7 @@ CREATE TABLE IF NOT EXISTS skills_catalog (
     hub               TEXT NOT NULL DEFAULT '',
     skill_id          TEXT NOT NULL DEFAULT '',
     use_count         INTEGER NOT NULL DEFAULT 0,
+    content_sha       TEXT NOT NULL DEFAULT '',
     updated_at        TEXT DEFAULT (datetime('now'))
 );
 CREATE INDEX IF NOT EXISTS idx_skills_catalog_root
@@ -251,6 +252,22 @@ CREATE TABLE IF NOT EXISTS skills_catalog_meta (
     root_key      TEXT PRIMARY KEY,
     backfilled_at TEXT NOT NULL,
     skillhub_key  TEXT NOT NULL DEFAULT ''
+);
+
+-- 预计算推荐结果：/sync 只读；重活进程写入（脏算）。
+CREATE TABLE IF NOT EXISTS client_recommend_slots (
+    user_key     TEXT PRIMARY KEY,
+    slots_json   TEXT NOT NULL DEFAULT '[]',
+    fingerprint  TEXT NOT NULL DEFAULT '',
+    computed_at  TEXT NOT NULL,
+    stale        INTEGER NOT NULL DEFAULT 0
+);
+
+-- 推荐脏队列：仅重活进程消费。
+CREATE TABLE IF NOT EXISTS recommend_dirty (
+    user_key   TEXT PRIMARY KEY,
+    reason     TEXT NOT NULL DEFAULT '',
+    marked_at  TEXT NOT NULL
 );
 
 -- P3-3.1 events:四类既有事实源的消费者(D7),通知+世界消息共用。
@@ -535,6 +552,15 @@ def _migrate(conn: sqlite3.Connection) -> None:
         )
         # 已有行历史上都是用户手动 register，标 'manual'
         conn.execute("UPDATE watch_dirs SET ecosystem='manual' WHERE ecosystem IS NULL")
+
+    # skills_catalog.content_sha：与 Milvus 向量索引对齐的一致性键
+    cur = conn.execute("PRAGMA table_info(skills_catalog)")
+    sc_cols = {row[1] for row in cur.fetchall()}
+    if "content_sha" not in sc_cols:
+        conn.execute(
+            "ALTER TABLE skills_catalog ADD COLUMN content_sha TEXT NOT NULL DEFAULT ''"
+        )
+
     # Backfill status from has_meta/has_embedding —— **只在首次补 status 列时跑一次**。
     # 以前每次 get_connection 都跑这条,会把任何 status='discovered' 的**活行**
     # （rebuild 重置 / error 重试 / 僵尸清理刚翻回的）在下次连接时打回 'indexed'，
@@ -645,6 +671,12 @@ def set_skill_pref(*, user_key: str, skill_name: str, pref: str, set_by: str,
             (user_key, skill_name, pref, set_by),
         )
         conn.commit()
+    try:
+        from xskill.recommend.recommend_store import mark_recommend_dirty
+
+        mark_recommend_dirty(user_key, reason=f"pref_{pref}", db_path=db_path)
+    except Exception:  # pylint: disable=broad-exception-caught
+        logger.debug("mark recommend dirty after pref failed", exc_info=True)
 
 
 def _check_pin_quota(conn, *, user_key: str, skill_name: str,
@@ -686,7 +718,15 @@ def clear_skill_pref(*, user_key: str, skill_name: str,
             (user_key, skill_name),
         )
         conn.commit()
-        return cur.rowcount > 0
+        deleted = cur.rowcount > 0
+    if deleted:
+        try:
+            from xskill.recommend.recommend_store import mark_recommend_dirty
+
+            mark_recommend_dirty(user_key, reason="pref_cleared", db_path=db_path)
+        except Exception:  # pylint: disable=broad-exception-caught
+            logger.debug("mark recommend dirty after clear pref failed", exc_info=True)
+    return deleted
 
 
 def prefs_for(user_key: str, *, db_path: Optional[Path] = None) -> list[dict]:

--- a/src/xskill/recommend/engine.py
+++ b/src/xskill/recommend/engine.py
@@ -682,13 +682,47 @@ class SkillRecommendEngine:
 
     # ── 5.6 find_friend ──────────────────────────────────────────
     def relevance_search(self, query_vec, top_k: int = 5) -> list[tuple[str, bool]]:
-        """在合并检索池（可分发 + 三方 skill）做 KNN，返回 ``(name, is_skillhub)``。"""
+        """在合并检索池（可分发 + 三方 skill）做 KNN，返回 ``(name, is_skillhub)``。
+
+        优先读重活进程维护的 Milvus Lite 索引；不可用时退回原 numpy 全库乘。
+        """
+        milvus_hits = self._relevance_search_milvus(query_vec, top_k=top_k)
+        if milvus_hits is not None:
+            return milvus_hits
         names, embs, is_hub = self._combined_relevance()
         if embs.shape[0] == 0:
             return []
         sims = embs @ np.asarray(query_vec, dtype=float)
         order = np.argsort(-sims)[:top_k]
         return [(names[i], is_hub.get(names[i], False)) for i in order]
+
+    def _relevance_search_milvus(
+        self, query_vec, *, top_k: int,
+    ) -> Optional[list[tuple[str, bool]]]:
+        try:
+            from xskill.config import XSKILL_HOME
+            from xskill.recommend.skill_vector_store import (
+                default_vector_db_path,
+                open_skill_vector_index,
+            )
+
+            path = default_vector_db_path(XSKILL_HOME)
+            if not path.is_file():
+                return None
+            index = open_skill_vector_index(path, dim=len(query_vec))
+            hits = index.search(list(map(float, query_vec)), top_k=top_k)
+        except Exception:  # pylint: disable=broad-exception-caught
+            logger.debug("milvus relevance_search unavailable", exc_info=True)
+            return None
+        out: list[tuple[str, bool]] = []
+        for catalog_key, _score in hits:
+            is_hub = catalog_key.startswith("skillhub:")
+            name = catalog_key.split(":", 1)[-1] if ":" in catalog_key else catalog_key
+            row = index.get(catalog_key)
+            if row and row.get("name"):
+                name = row["name"]
+            out.append((name, is_hub))
+        return out
 
     def load_client_user(
         self, user_id: str, *, include_recommended: bool = True,

--- a/src/xskill/recommend/heavy_worker.py
+++ b/src/xskill/recommend/heavy_worker.py
@@ -1,0 +1,227 @@
+"""重活进程：Milvus 对账 + 脏用户推荐预计算（与 Web GIL 隔离）。"""
+from __future__ import annotations
+
+import logging
+from pathlib import Path
+from typing import Optional
+
+logger = logging.getLogger("xskill.recommend.heavy_worker")
+
+
+def _load_catalog_rows(db_path: Path) -> list[dict]:
+    from xskill.pipeline.registry import pooled_connection
+
+    with pooled_connection(db_path) as conn:
+        rows = conn.execute(
+            """
+            SELECT catalog_key, name, source, description, content_sha, skill_id
+            FROM skills_catalog
+            """
+        ).fetchall()
+    return [dict(r) for r in rows]
+
+
+def run_vector_reconcile(
+    *,
+    db_path: Path,
+    vector_db_path: Path,
+    embed=None,
+    memory_index=None,
+) -> dict:
+    from xskill.recommend.skill_vector_store import (
+        DEFAULT_DIM,
+        fake_embed,
+        open_skill_vector_index,
+        reconcile_catalog_to_index,
+    )
+
+    rows = _load_catalog_rows(db_path)
+    embed_fn = embed or (lambda text: fake_embed(text, DEFAULT_DIM))
+    index = memory_index or open_skill_vector_index(vector_db_path, dim=DEFAULT_DIM)
+    stats = reconcile_catalog_to_index(index, rows, embed=embed_fn)
+    logger.info(
+        "vector reconcile: upserted=%s deleted=%s skipped=%s",
+        stats["upserted"], stats["deleted"], stats["skipped"],
+    )
+    return stats
+
+
+def _skill_name_from_index(vector_index, catalog_key: str) -> str:
+    row = vector_index.get(catalog_key)
+    if row:
+        name = (row.get("name") or "").strip()
+        if name:
+            return name
+        if row.get("source") == "skillhub" and ":" in catalog_key:
+            return catalog_key.split(":", 1)[-1]
+    if ":" in catalog_key:
+        return catalog_key.split(":", 1)[-1]
+    return catalog_key
+
+
+def compute_recommend_for_user(
+    user_key: str,
+    *,
+    db_path: Path,
+    vector_index,
+    top_k: int = 20,
+    profile_centers: Optional[list[list[float]]] = None,
+) -> list[str]:
+    """用画像中心向量在索引里 search；无中心则写空推荐（sync 侧走 ranked/ux）。"""
+    from xskill.recommend.recommend_store import save_recommend_slots
+
+    if not profile_centers:
+        save_recommend_slots(user_key, [], fingerprint="no_profile", db_path=db_path)
+        return []
+    names: list[str] = []
+    seen: set[str] = set()
+    for center in profile_centers:
+        for catalog_key, _score in vector_index.search(center, top_k=top_k):
+            name = _skill_name_from_index(vector_index, catalog_key)
+            if name in seen:
+                continue
+            seen.add(name)
+            names.append(name)
+            if len(names) >= top_k:
+                break
+        if len(names) >= top_k:
+            break
+    save_recommend_slots(
+        user_key, names, fingerprint=f"centers={len(profile_centers)}", db_path=db_path,
+    )
+    return names
+
+
+def _user_key_for_client(engine, client_id: str) -> str:
+    reg = getattr(engine, "client_registry", None)
+    if reg is not None:
+        try:
+            name = reg.user_name_for(client_id)
+            if name:
+                return name
+        except Exception:  # pylint: disable=broad-exception-caught
+            pass
+    return client_id
+
+
+def _client_id_for_user_key(engine, user_key: str) -> str:
+    """推荐表键 → 画像键（client_id）。"""
+    if not user_key:
+        return user_key
+    reg = getattr(engine, "client_registry", None)
+    if reg is None:
+        return user_key
+    try:
+        for row in reg.list():
+            cid = row["client_id"]
+            if cid == user_key:
+                return cid
+            try:
+                if reg.user_name_for(cid) == user_key:
+                    return cid
+            except Exception:  # pylint: disable=broad-exception-caught
+                continue
+    except Exception:  # pylint: disable=broad-exception-caught
+        logger.debug("client_id resolve failed for %s", user_key, exc_info=True)
+    return user_key
+
+
+def _load_profile_centers(engine, client_id: str) -> Optional[list[list[float]]]:
+    try:
+        user = engine.load_client_user(client_id, include_recommended=False)
+        ci = user.client_interest
+        if ci is None or ci.feature_tensor is None:
+            return None
+        return [list(map(float, row)) for row in ci.feature_tensor]
+    except Exception:  # pylint: disable=broad-exception-caught
+        logger.debug("profile centers unavailable for %s", client_id, exc_info=True)
+        return None
+
+
+def process_dirty_recommends(
+    *,
+    db_path: Path,
+    vector_index,
+    engine,
+    limit: int = 32,
+) -> int:
+    from xskill.recommend.recommend_store import (
+        clear_recommend_dirty,
+        list_dirty_user_keys,
+        save_recommend_slots,
+    )
+
+    keys = list_dirty_user_keys(limit=limit, db_path=db_path)
+    done = 0
+    for user_key in keys:
+        try:
+            client_id = _client_id_for_user_key(engine, user_key)
+            centers = _load_profile_centers(engine, client_id)
+            compute_recommend_for_user(
+                user_key,
+                db_path=db_path,
+                vector_index=vector_index,
+                profile_centers=centers,
+            )
+            done += 1
+        except Exception:  # pylint: disable=broad-exception-caught
+            logger.exception("recommend dirty failed user_key=%s", user_key)
+            clear_recommend_dirty(user_key, db_path=db_path)
+            save_recommend_slots(user_key, [], fingerprint="error", db_path=db_path)
+    return done
+
+
+def _embed_fn_from_engine(engine):
+    """从引擎 embed_client 构造 embed(text)->list[float]；不可用则 None。"""
+    client = getattr(engine, "embed_client", None)
+    if client is None or not hasattr(client, "encode"):
+        return None
+
+    def _embed(text: str) -> list[float]:
+        vec = client.encode(text)
+        return [float(x) for x in vec]
+
+    return _embed
+
+
+def run_recommend_heavy_once(
+    *,
+    engine,
+    db_path: Path | None = None,
+    vector_db_path: Path | None = None,
+    memory_index=None,
+    mark_catalog_dirty: bool = True,
+) -> dict:
+    """对账向量索引并消化推荐脏队列（画像刷新由调用方先跑）。"""
+    from xskill.config import XSKILL_HOME, get_registry_db_path
+    from xskill.recommend.recommend_store import mark_all_recommend_dirty
+    from xskill.recommend.skill_vector_store import (
+        DEFAULT_DIM,
+        default_vector_db_path,
+        fake_embed,
+        open_skill_vector_index,
+    )
+
+    registry = Path(db_path) if db_path else get_registry_db_path()
+    vdb = Path(vector_db_path) if vector_db_path else default_vector_db_path(XSKILL_HOME)
+    embed_fn = _embed_fn_from_engine(engine)
+    if embed_fn is None:
+        embed_fn = lambda text: fake_embed(text, DEFAULT_DIM)  # noqa: E731
+        dim = DEFAULT_DIM
+    else:
+        dim = len(embed_fn("dimension probe"))
+    index = memory_index or open_skill_vector_index(vdb, dim=dim)
+    vec_stats = run_vector_reconcile(
+        db_path=registry,
+        vector_db_path=vdb,
+        embed=embed_fn,
+        memory_index=index,
+    )
+    if mark_catalog_dirty and (
+        vec_stats.get("upserted", 0) or vec_stats.get("deleted", 0)
+    ):
+        mark_all_recommend_dirty(reason="catalog_vector_changed", db_path=registry)
+    n = process_dirty_recommends(
+        db_path=registry, vector_index=index, engine=engine,
+    )
+    return {"vector": vec_stats, "recommends": n}

--- a/src/xskill/recommend/recommend_store.py
+++ b/src/xskill/recommend/recommend_store.py
@@ -1,0 +1,155 @@
+"""预计算推荐结果表：重活进程写，/sync 只读。"""
+from __future__ import annotations
+
+import json
+import logging
+from pathlib import Path
+from typing import Optional
+
+from xskill.pipeline.registry import pooled_connection
+
+logger = logging.getLogger("xskill.recommend_store")
+
+
+def mark_recommend_dirty(
+    user_key: str,
+    *,
+    reason: str = "",
+    db_path: Optional[Path] = None,
+) -> None:
+    if not user_key:
+        return
+    with pooled_connection(db_path) as conn:
+        conn.execute(
+            """
+            INSERT INTO recommend_dirty(user_key, reason, marked_at)
+            VALUES (?, ?, datetime('now'))
+            ON CONFLICT(user_key) DO UPDATE SET
+                reason=excluded.reason,
+                marked_at=datetime('now')
+            """,
+            (user_key, reason),
+        )
+        conn.execute(
+            """
+            UPDATE client_recommend_slots SET stale=1
+            WHERE user_key=?
+            """,
+            (user_key,),
+        )
+        conn.commit()
+
+
+def mark_all_recommend_dirty(
+    *,
+    reason: str = "catalog_changed",
+    db_path: Optional[Path] = None,
+) -> int:
+    """技能全集变化且无法细粒度归因时：标所有已有推荐行脏。"""
+    with pooled_connection(db_path) as conn:
+        conn.execute(
+            "UPDATE client_recommend_slots SET stale=1"
+        )
+        rows = conn.execute(
+            "SELECT user_key FROM client_recommend_slots"
+        ).fetchall()
+        for row in rows:
+            conn.execute(
+                """
+                INSERT INTO recommend_dirty(user_key, reason, marked_at)
+                VALUES (?, ?, datetime('now'))
+                ON CONFLICT(user_key) DO UPDATE SET
+                    reason=excluded.reason,
+                    marked_at=datetime('now')
+                """,
+                (row["user_key"], reason),
+            )
+        conn.commit()
+        return len(rows)
+
+
+def list_dirty_user_keys(
+    *,
+    limit: int = 64,
+    db_path: Optional[Path] = None,
+) -> list[str]:
+    with pooled_connection(db_path) as conn:
+        rows = conn.execute(
+            """
+            SELECT user_key FROM recommend_dirty
+            ORDER BY marked_at ASC
+            LIMIT ?
+            """,
+            (limit,),
+        ).fetchall()
+    return [r["user_key"] for r in rows]
+
+
+def clear_recommend_dirty(
+    user_key: str,
+    *,
+    db_path: Optional[Path] = None,
+) -> None:
+    with pooled_connection(db_path) as conn:
+        conn.execute(
+            "DELETE FROM recommend_dirty WHERE user_key=?",
+            (user_key,),
+        )
+        conn.commit()
+
+
+def save_recommend_slots(
+    user_key: str,
+    skill_names: list[str],
+    *,
+    fingerprint: str = "",
+    db_path: Optional[Path] = None,
+) -> None:
+    payload = json.dumps(list(skill_names), ensure_ascii=False)
+    with pooled_connection(db_path) as conn:
+        conn.execute(
+            """
+            INSERT INTO client_recommend_slots(
+                user_key, slots_json, fingerprint, computed_at, stale
+            ) VALUES (?, ?, ?, datetime('now'), 0)
+            ON CONFLICT(user_key) DO UPDATE SET
+                slots_json=excluded.slots_json,
+                fingerprint=excluded.fingerprint,
+                computed_at=datetime('now'),
+                stale=0
+            """,
+            (user_key, payload, fingerprint),
+        )
+        conn.execute(
+            "DELETE FROM recommend_dirty WHERE user_key=?",
+            (user_key,),
+        )
+        conn.commit()
+
+
+def load_recommend_slots(
+    user_key: str,
+    *,
+    db_path: Optional[Path] = None,
+) -> Optional[list[str]]:
+    """读推荐结果；过期也返回上一份（stale 不阻断）。无行则 None。"""
+    if not user_key:
+        return None
+    with pooled_connection(db_path) as conn:
+        row = conn.execute(
+            """
+            SELECT slots_json FROM client_recommend_slots
+            WHERE user_key=?
+            """,
+            (user_key,),
+        ).fetchone()
+    if row is None:
+        return None
+    try:
+        data = json.loads(row["slots_json"] or "[]")
+    except json.JSONDecodeError:
+        logger.warning("bad slots_json for user_key=%s", user_key)
+        return None
+    if not isinstance(data, list):
+        return None
+    return [str(x) for x in data]

--- a/src/xskill/recommend/skill_vector_store.py
+++ b/src/xskill/recommend/skill_vector_store.py
@@ -1,0 +1,314 @@
+"""技能向量索引：Milvus Lite（嵌入式）+ 与 skills_catalog 最终一致。
+
+业务真相在 SQLite ``skills_catalog``；本模块只维护检索索引。
+主键与 ``catalog_key`` 对齐；``content_sha`` 变了才 re-embed/upsert。
+"""
+from __future__ import annotations
+
+import hashlib
+import logging
+from pathlib import Path
+from typing import Callable, Iterable, Optional, Protocol, Sequence
+
+logger = logging.getLogger("xskill.skill_vector_store")
+
+COLLECTION = "skill_vectors"
+DEFAULT_DIM = 8  # fake/tests；生产由首条真实向量决定或配置
+
+
+def content_sha_for_text(text: str) -> str:
+    return hashlib.sha256(text.encode("utf-8")).hexdigest()[:16]
+
+
+def fake_embed(text: str, dim: int = DEFAULT_DIM) -> list[float]:
+    """确定性伪向量（测试/无 embed client 时用）。"""
+    digest = hashlib.sha256(text.encode("utf-8")).digest()
+    vals = []
+    for i in range(dim):
+        vals.append(((digest[i % len(digest)] + i * 13) % 256) / 255.0)
+    # L2 normalize
+    norm = sum(v * v for v in vals) ** 0.5 or 1.0
+    return [v / norm for v in vals]
+
+
+def _safe_int_id(catalog_key: str) -> int:
+    """Milvus 常用 int64 主键；由 catalog_key 稳定哈希得到。"""
+    digest = hashlib.sha256(catalog_key.encode("utf-8")).digest()
+    return int.from_bytes(digest[:8], "big") & 0x7FFFFFFFFFFFFFFF
+
+
+class SkillVectorIndex(Protocol):
+    def upsert(
+        self,
+        catalog_key: str,
+        vector: Sequence[float],
+        *,
+        content_sha: str,
+        source: str,
+        name: str,
+    ) -> None: ...
+
+    def delete(self, catalog_key: str) -> None: ...
+
+    def get(self, catalog_key: str) -> Optional[dict]: ...
+
+    def list_keys(self) -> set[str]: ...
+
+    def search(
+        self, vector: Sequence[float], *, top_k: int = 10,
+        exclude_keys: Optional[set[str]] = None,
+    ) -> list[tuple[str, float]]: ...
+
+
+class MemorySkillVectorIndex:
+    """纯内存实现：单测不依赖 pymilvus。"""
+
+    def __init__(self, dim: int = DEFAULT_DIM) -> None:
+        self.dim = dim
+        self._rows: dict[str, dict] = {}
+
+    def upsert(
+        self,
+        catalog_key: str,
+        vector: Sequence[float],
+        *,
+        content_sha: str,
+        source: str,
+        name: str,
+    ) -> None:
+        self._rows[catalog_key] = {
+            "catalog_key": catalog_key,
+            "vector": list(vector),
+            "content_sha": content_sha,
+            "source": source,
+            "name": name,
+        }
+
+    def delete(self, catalog_key: str) -> None:
+        self._rows.pop(catalog_key, None)
+
+    def get(self, catalog_key: str) -> Optional[dict]:
+        row = self._rows.get(catalog_key)
+        return dict(row) if row else None
+
+    def list_keys(self) -> set[str]:
+        return set(self._rows)
+
+    def search(
+        self, vector: Sequence[float], *, top_k: int = 10,
+        exclude_keys: Optional[set[str]] = None,
+    ) -> list[tuple[str, float]]:
+        import numpy as np
+
+        q = np.asarray(vector, dtype=float)
+        qn = float(np.linalg.norm(q)) or 1.0
+        q = q / qn
+        scored: list[tuple[str, float]] = []
+        skip = exclude_keys or set()
+        for key, row in self._rows.items():
+            if key in skip:
+                continue
+            v = np.asarray(row["vector"], dtype=float)
+            vn = float(np.linalg.norm(v)) or 1.0
+            scored.append((key, float(q @ (v / vn))))
+        scored.sort(key=lambda x: -x[1])
+        return scored[:top_k]
+
+
+class MilvusLiteSkillVectorIndex:
+    """``~/.xskill/skill_vectors.db`` 嵌入式 Milvus Lite。"""
+
+    def __init__(self, db_path: Path | str, *, dim: int = DEFAULT_DIM) -> None:
+        from pymilvus import DataType, MilvusClient
+
+        self.db_path = Path(db_path)
+        self.db_path.parent.mkdir(parents=True, exist_ok=True)
+        self.dim = int(dim)
+        self._client = MilvusClient(str(self.db_path))
+        self._ensure_collection()
+
+    def _ensure_collection(self) -> None:
+        from pymilvus import DataType
+
+        if self._client.has_collection(COLLECTION):
+            return
+        schema = self._client.create_schema(auto_id=False, enable_dynamic_field=True)
+        schema.add_field("id", DataType.INT64, is_primary=True)
+        schema.add_field("catalog_key", DataType.VARCHAR, max_length=512)
+        schema.add_field("content_sha", DataType.VARCHAR, max_length=64)
+        schema.add_field("source", DataType.VARCHAR, max_length=32)
+        schema.add_field("name", DataType.VARCHAR, max_length=512)
+        schema.add_field("vector", DataType.FLOAT_VECTOR, dim=self.dim)
+        index_params = self._client.prepare_index_params()
+        index_params.add_index(field_name="vector", metric_type="COSINE", index_type="FLAT")
+        self._client.create_collection(
+            collection_name=COLLECTION, schema=schema, index_params=index_params,
+        )
+
+    def upsert(
+        self,
+        catalog_key: str,
+        vector: Sequence[float],
+        *,
+        content_sha: str,
+        source: str,
+        name: str,
+    ) -> None:
+        if len(vector) != self.dim:
+            raise ValueError(f"vector dim {len(vector)} != {self.dim}")
+        self._client.upsert(
+            collection_name=COLLECTION,
+            data=[{
+                "id": _safe_int_id(catalog_key),
+                "catalog_key": catalog_key,
+                "content_sha": content_sha,
+                "source": source,
+                "name": name,
+                "vector": list(vector),
+            }],
+        )
+
+    def delete(self, catalog_key: str) -> None:
+        self._client.delete(
+            collection_name=COLLECTION,
+            ids=[_safe_int_id(catalog_key)],
+        )
+
+    def get(self, catalog_key: str) -> Optional[dict]:
+        rows = self._client.get(
+            collection_name=COLLECTION,
+            ids=[_safe_int_id(catalog_key)],
+        )
+        if not rows:
+            return None
+        row = rows[0]
+        return {
+            "catalog_key": row.get("catalog_key", catalog_key),
+            "content_sha": row.get("content_sha", ""),
+            "source": row.get("source", ""),
+            "name": row.get("name", ""),
+            "vector": row.get("vector"),
+        }
+
+    def list_keys(self) -> set[str]:
+        # query all catalog_key；Lite 小规模可接受
+        try:
+            rows = self._client.query(
+                collection_name=COLLECTION,
+                filter="",
+                output_fields=["catalog_key"],
+                limit=16384,
+            )
+        except Exception:  # pylint: disable=broad-exception-caught
+            rows = self._client.query(
+                collection_name=COLLECTION,
+                filter="id >= 0",
+                output_fields=["catalog_key"],
+                limit=16384,
+            )
+        return {r["catalog_key"] for r in rows if r.get("catalog_key")}
+
+    def search(
+        self, vector: Sequence[float], *, top_k: int = 10,
+        exclude_keys: Optional[set[str]] = None,
+    ) -> list[tuple[str, float]]:
+        results = self._client.search(
+            collection_name=COLLECTION,
+            data=[list(vector)],
+            limit=max(top_k * 3, top_k),
+            output_fields=["catalog_key"],
+        )
+        skip = exclude_keys or set()
+        out: list[tuple[str, float]] = []
+        for hits in results:
+            for hit in hits:
+                key = hit.get("catalog_key") or hit.get("entity", {}).get("catalog_key")
+                if not key or key in skip:
+                    continue
+                score = float(hit.get("distance", hit.get("score", 0.0)))
+                out.append((key, score))
+                if len(out) >= top_k:
+                    return out
+        return out
+
+
+EmbedFn = Callable[[str], list[float]]
+
+
+def indexable_catalog_rows(rows: Iterable[dict]) -> list[dict]:
+    """过滤应写入向量索引的投影行（需非空 description）。"""
+    out = []
+    for row in rows:
+        desc = (row.get("description") or "").strip()
+        if not desc:
+            continue
+        sha = row.get("content_sha") or content_sha_for_text(desc)
+        out.append({**row, "content_sha": sha, "description": desc})
+    return out
+
+
+def sync_row_to_index(
+    index: SkillVectorIndex,
+    row: dict,
+    *,
+    embed: EmbedFn,
+) -> None:
+    desc = row["description"]
+    sha = row["content_sha"]
+    key = row["catalog_key"]
+    existing = index.get(key)
+    if existing and existing.get("content_sha") == sha:
+        return
+    index.upsert(
+        key,
+        embed(desc),
+        content_sha=sha,
+        source=row.get("source") or "",
+        name=row.get("name") or "",
+    )
+
+
+def delete_from_index(index: SkillVectorIndex, catalog_key: str) -> None:
+    index.delete(catalog_key)
+
+
+def reconcile_catalog_to_index(
+    index: SkillVectorIndex,
+    catalog_rows: Sequence[dict],
+    *,
+    embed: EmbedFn,
+) -> dict:
+    """对账：投影表 → Milvus。返回 {upserted, deleted, skipped}。"""
+    wanted = {
+        r["catalog_key"]: r for r in indexable_catalog_rows(catalog_rows)
+    }
+    existing_keys = index.list_keys()
+    upserted = deleted = skipped = 0
+    for key, row in wanted.items():
+        cur = index.get(key)
+        if cur and cur.get("content_sha") == row["content_sha"]:
+            skipped += 1
+            continue
+        sync_row_to_index(index, row, embed=embed)
+        upserted += 1
+    for key in existing_keys - set(wanted):
+        index.delete(key)
+        deleted += 1
+    return {"upserted": upserted, "deleted": deleted, "skipped": skipped}
+
+
+def default_vector_db_path(xskill_home: Path | None = None) -> Path:
+    home = Path(xskill_home) if xskill_home else Path.home() / ".xskill"
+    return home.expanduser().resolve() / "skill_vectors.db"
+
+
+def open_skill_vector_index(
+    db_path: Path | str | None = None,
+    *,
+    dim: int = DEFAULT_DIM,
+    memory: bool = False,
+) -> SkillVectorIndex:
+    if memory:
+        return MemorySkillVectorIndex(dim=dim)
+    path = Path(db_path) if db_path else default_vector_db_path()
+    return MilvusLiteSkillVectorIndex(path, dim=dim)

--- a/src/xskill/recommend/skillhub.py
+++ b/src/xskill/recommend/skillhub.py
@@ -783,7 +783,11 @@ class SkillHub:
 
     def _semantic_ranks(self, index_bundle: dict,
                         normalized_query: str) -> dict[int, int]:
-        """对有缓存向量的文档按 query↔description cosine 降序给出 1-based 排名。"""
+        """对有缓存向量的文档按 query↔description cosine 降序给出 1-based 排名。
+
+        编排（BM25/RRF/缓存）不变；向量召回优先走 Milvus Lite，不可用时
+        退回原 ``corpus_matrix @ query``。
+        """
         rank_cache = index_bundle["semantic_rank_cache"]
         rank_cache_lock = index_bundle["semantic_rank_cache_lock"]
         with rank_cache_lock:
@@ -797,14 +801,23 @@ class SkillHub:
         if not present_indices:
             return {}
         query_vector = self._embed_query(normalized_query, index_bundle["fingerprint"])
-        if query_vector is None or query_vector.shape[0] != corpus_matrix.shape[1]:
+        if query_vector is None:
             return {}
-        similarities = corpus_matrix @ query_vector
-        order = np.argsort(-similarities)
-        ranks = {
-            present_indices[position]: rank
-            for rank, position in enumerate(order.tolist(), start=1)
-        }
+
+        milvus_ranks = self._semantic_ranks_milvus(
+            index_bundle, query_vector, present_indices,
+        )
+        if milvus_ranks is not None:
+            ranks = milvus_ranks
+        else:
+            if query_vector.shape[0] != corpus_matrix.shape[1]:
+                return {}
+            similarities = corpus_matrix @ query_vector
+            order = np.argsort(-similarities)
+            ranks = {
+                present_indices[position]: rank
+                for rank, position in enumerate(order.tolist(), start=1)
+            }
         with rank_cache_lock:
             cached = rank_cache.get(normalized_query)
             if cached is not None:
@@ -814,6 +827,59 @@ class SkillHub:
             while len(rank_cache) > SEARCH_RANK_CACHE_CAPACITY:
                 rank_cache.popitem(last=False)
         return ranks
+
+    def _semantic_ranks_milvus(
+        self,
+        index_bundle: dict,
+        query_vector: np.ndarray,
+        present_indices: list[int],
+    ) -> dict[int, int] | None:
+        """用 Milvus search 产出与 ``present_indices`` 对齐的 1-based 排名。"""
+        try:
+            from xskill.config import XSKILL_HOME
+            from xskill.recommend.skill_vector_store import (
+                default_vector_db_path,
+                open_skill_vector_index,
+            )
+
+            path = default_vector_db_path(XSKILL_HOME)
+            if not path.is_file():
+                return None
+            index = open_skill_vector_index(path, dim=int(query_vector.shape[0]))
+            hits = index.search(
+                [float(x) for x in query_vector.tolist()],
+                top_k=max(len(present_indices), 1),
+            )
+        except Exception:  # pylint: disable=broad-exception-caught
+            logger.debug("milvus semantic ranks unavailable", exc_info=True)
+            return None
+        entries = index_bundle["entries"]
+        # name / skill_id / catalog_key → entry index
+        key_to_idx: dict[str, int] = {}
+        for idx in present_indices:
+            entry = entries[idx]
+            for key in (
+                entry.get("name"),
+                entry.get("skill_id"),
+                entry.get("display_name"),
+            ):
+                if key:
+                    key_to_idx[str(key)] = idx
+        ranks: dict[int, int] = {}
+        rank = 1
+        for catalog_key, _score in hits:
+            name = catalog_key.split(":", 1)[-1] if ":" in catalog_key else catalog_key
+            row = index.get(catalog_key)
+            candidates = [name]
+            if row and row.get("name"):
+                candidates.insert(0, row["name"])
+            for cand in candidates:
+                idx = key_to_idx.get(cand)
+                if idx is not None and idx not in ranks:
+                    ranks[idx] = rank
+                    rank += 1
+                    break
+        return ranks or None
 
     def _embed_query(self, normalized_query: str,
                      fingerprint: tuple) -> np.ndarray | None:

--- a/src/xskill/skill/catalog_store.py
+++ b/src/xskill/skill/catalog_store.py
@@ -150,13 +150,15 @@ def _read_native_row(
     main_sha = _ref_sha(skill_path, "main")
     staging_sha = _ref_sha(skill_path, "staging")
     distributable = 1 if state in ("main", "staging") and skill_md.is_file() else 0
+    desc_cut = description[:300]
+    from xskill.recommend.skill_vector_store import content_sha_for_text
     return {
         "catalog_key": _native_catalog_key(skill_path.name),
         "name": skill_path.name,
         "repo_name": skill_path.name,
         "source": _SOURCE_NATIVE,
         "state": state,
-        "description": description[:300],
+        "description": desc_cut,
         "version": version,
         "candidates": candidates_count,
         "candidates_count": int(candidates_count),
@@ -167,6 +169,7 @@ def _read_native_row(
         "hub": "",
         "skill_id": "",
         "use_count": 0,
+        "content_sha": content_sha_for_text(desc_cut) if desc_cut else "",
         "root_key": _root_key(skill_path.parent),
     }
 
@@ -201,20 +204,26 @@ def _skillhub_fingerprint(skillhub) -> str:
 
 
 def _skillhub_rows(skillhub) -> list[dict]:
+    from xskill.recommend.skill_vector_store import content_sha_for_text
+
     rows: list[dict] = []
     for entry in _skillhub_entries(skillhub):
         description = str(entry.get("description") or "").strip().replace("\n", " ")
+        desc_cut = description[:300]
         skill_id = entry.get("skill_id") or entry.get("name") or ""
         name = entry.get("display_name") or entry.get("name") or ""
         hub = entry.get("source_path") or ""
         use_count = entry.get("use_count", 0) or 0
+        sha = entry.get("content_sha") or (
+            content_sha_for_text(desc_cut) if desc_cut else ""
+        )
         rows.append({
             "catalog_key": _skillhub_catalog_key(str(skill_id)),
             "name": name,
             "repo_name": name,
             "source": _SOURCE_SKILLHUB,
             "state": "skillhub",
-            "description": description[:300],
+            "description": desc_cut,
             "version": 0,
             "candidates": 0,
             "candidates_count": 0,
@@ -225,6 +234,7 @@ def _skillhub_rows(skillhub) -> list[dict]:
             "hub": hub,
             "skill_id": str(skill_id),
             "use_count": use_count,
+            "content_sha": sha,
             "root_key": "",
         })
     rows.sort(key=operator.itemgetter("hub", "name"))
@@ -272,13 +282,20 @@ def catalog_api_row(stored: dict) -> dict:
 
 
 def _upsert_row(conn, row: dict) -> None:
+    from xskill.recommend.skill_vector_store import content_sha_for_text
+
+    description = row["description"]
+    content_sha = row.get("content_sha") or (
+        content_sha_for_text(description) if description else ""
+    )
     conn.execute(
         """
         INSERT INTO skills_catalog(
             catalog_key, root_key, name, repo_name, source, state,
             description, version, candidates_count, main_sha, staging_sha,
-            distributable, search_id, hub, skill_id, use_count, updated_at
-        ) VALUES (?,?,?,?,?,?,?,?,?,?,?,?,?,?,?,?,datetime('now'))
+            distributable, search_id, hub, skill_id, use_count, content_sha,
+            updated_at
+        ) VALUES (?,?,?,?,?,?,?,?,?,?,?,?,?,?,?,?,?,datetime('now'))
         ON CONFLICT(catalog_key) DO UPDATE SET
             root_key=excluded.root_key,
             name=excluded.name,
@@ -295,6 +312,7 @@ def _upsert_row(conn, row: dict) -> None:
             hub=excluded.hub,
             skill_id=excluded.skill_id,
             use_count=excluded.use_count,
+            content_sha=excluded.content_sha,
             updated_at=datetime('now')
         """,
         (
@@ -304,7 +322,7 @@ def _upsert_row(conn, row: dict) -> None:
             row["repo_name"],
             row["source"],
             row["state"],
-            row["description"],
+            description,
             int(row["version"] or 0),
             int(row["candidates_count"]),
             row["main_sha"],
@@ -314,6 +332,7 @@ def _upsert_row(conn, row: dict) -> None:
             row.get("hub") or "",
             row.get("skill_id") or "",
             int(row.get("use_count") or 0),
+            content_sha,
         ),
     )
 

--- a/src/xskill/team/server/profile_refresh.py
+++ b/src/xskill/team/server/profile_refresh.py
@@ -292,6 +292,24 @@ class ProfileRefreshService:
             if changed and self._scatter_enabled:
                 for scatter_method in ("tsne", "umap"):
                     self.submit_scatter(client_id, scatter_method)
+            if changed:
+                try:
+                    from xskill.recommend.recommend_store import mark_recommend_dirty
+
+                    user_key = client_id
+                    reg = getattr(self.engine, "client_registry", None)
+                    if reg is not None:
+                        try:
+                            name = reg.user_name_for(client_id)
+                            if name:
+                                user_key = name
+                        except Exception:  # pylint: disable=broad-exception-caught
+                            pass
+                    mark_recommend_dirty(user_key, reason="profile_changed")
+                except Exception:  # pylint: disable=broad-exception-caught
+                    logger.debug(
+                        "mark recommend dirty failed for %s", client_id, exc_info=True,
+                    )
 
             with self._condition:
                 self._states.pop(client_id, None)

--- a/src/xskill/team/server/skill_manifest.py
+++ b/src/xskill/team/server/skill_manifest.py
@@ -403,6 +403,25 @@ def _record_recommendation_telemetry(
         _logger.debug("recommendation exposure telemetry skipped", exc_info=True)
 
 
+def _recommend_user_key(client_id: str) -> str:
+    """推荐结果表键：有名用 user_name，匿名用 client_id。"""
+    if _engine is not None and getattr(_engine, "client_registry", None) is not None:
+        try:
+            name = _engine.client_registry.user_name_for(client_id)
+            if name:
+                return name
+        except Exception:  # pylint: disable=broad-exception-caught
+            pass
+    try:
+        from xskill.team.server.api import team_context
+        name = team_context().client_registry.user_name_for(client_id)
+        if name:
+            return name
+    except Exception:  # pylint: disable=broad-exception-caught
+        pass
+    return client_id
+
+
 def _pick_recommended(
     *,
     client_id: str,
@@ -418,11 +437,11 @@ def _pick_recommended(
 ) -> list[Skill]:
     """选 ``recommended`` bucket 的 skill。
 
-    候选 = distributable 里不在 ranked-80 的（``recommend`` 内部再排除该
-    client 已用过的）。有画像 → 按质心 cosine 最近邻；无画像 / 非 team
-    server 调用 → 退回 ux 排序往下接着取。
+    team server 路径：只读重活进程预写的 ``client_recommend_slots``，
+    **禁止**请求内 ``get_skill_for_client`` / numpy 全库乘。过期或缺失时
+    返回上一份成功结果；无行则 ux 尾部补齐（与冷启动语义一致）。
     """
-    del ranked  # Preserve the established helper signature.
+    del ranked, skill_dir, candidate_refs, persist_recommendations
     if reco_slots <= 0:
         return []
 
@@ -430,55 +449,44 @@ def _pick_recommended(
     if traj_root is None:
         return ux_tail[:reco_slots]  # 非 team server：无 traj_root，按 ux 取
 
-    # §5 优先走 SkillRecommendEngine（注入时）；否则退回既有 RECOMMENDER 画像路径。
-    if _engine is not None:
-        # 索引缺失时（rebuild --force 后到 /reindex 前的窗口）不能进引擎——
-        # _combined_relevance 会 raise。退回 ux_tail（与既有 RECOMMENDER 守卫一致）。
-        if not (skill_dir / ".skill_index.pkl").is_file() and not _engine._skillhub_entries():
-            return ux_tail[:reco_slots]
-        user = _engine.load_client_user(client_id, include_recommended=False)
-        if user.client_interest is not None and user.client_interest.feature_tensor is not None:
-            picked = _engine.get_skill_for_client(
-                user, reco_slots, exclude_names=ranked_names,
-                candidate_pool=candidate_pool, candidate_refs=candidate_refs,
-                persist_recommendations=persist_recommendations,
-                candidate_pool_quality_ordered=True,
-            )
-            # get_skill_for_client 已记录推荐 + resolve side；只取 reco_slots 个
-            return picked[:reco_slots]
-        # 冷启动（无画像）→ ux_tail（与既有 RECOMMENDER 冷启动语义一致）
-        # team server 的 /sync 必须保持纯缓存路径，不得再落到下方会
-        # 扫描 atom store 的旧 RECOMMENDER。
-        return ux_tail[:reco_slots]
+    # 预计算推荐表（重活进程写入）；stale 也返回上一份。
+    try:
+        from xskill.recommend.recommend_store import load_recommend_slots
 
-    # 延迟 import：profile_reco 依赖 numpy + atom store，非 team 路径不付代价。
-    from xskill.team.server.profile_reco import RECOMMENDER
+        reco_names = load_recommend_slots(_recommend_user_key(client_id))
+    except Exception:  # pylint: disable=broad-exception-caught
+        _logger.debug("recommend slots load failed", exc_info=True)
+        reco_names = None
 
-    skill_index_path = skill_dir / ".skill_index.pkl"
-    if not skill_index_path.is_file():
-        # 没建 skill 向量索引 → 算不出质心。退回 ux 排序。
-        return ux_tail[:reco_slots]
-
-    candidate_names = [s.name for s in ux_tail]
-    reco_names = RECOMMENDER.recommend(
-        client_id=client_id,
-        traj_root=Path(traj_root),
-        skill_index_path=skill_index_path,
-        candidate_names=candidate_names,
-        limit=reco_slots,
-    )
-    if reco_names is None:
-        return ux_tail[:reco_slots]  # 冷启动：无画像，退回 ux 排序
-
-    by_name = {s.name: s for s in ux_tail}
-    picked = [by_name[n] for n in reco_names if n in by_name]
-    if len(picked) < reco_slots:
-        # 画像推荐出的候选不足 reco_slots（候选池本身就小）→ 用 ux 排序补齐。
-        # 不是 error-masking：候选池耗尽是真实情况，补齐保证 slot 数稳定。
-        picked_names = {s.name for s in picked}
-        for s in ux_tail:
+    if reco_names:
+        by_name = {s.name: s for s in ux_tail}
+        for s in candidate_pool or []:
+            by_name.setdefault(s.name, s)
+        picked: list = []
+        picked_names: set[str] = set()
+        for n in reco_names:
+            if n in ranked_names or n in picked_names:
+                continue
+            item = by_name.get(n)
+            if item is None and _engine is not None:
+                try:
+                    item = _engine.skillhub.entry(n)
+                except Exception:  # pylint: disable=broad-exception-caught
+                    item = None
+            if item is None:
+                continue
+            picked.append(item)
+            picked_names.add(n)
             if len(picked) >= reco_slots:
                 break
-            if s.name not in picked_names:
-                picked.append(s)
-    return picked[:reco_slots]
+        if len(picked) < reco_slots:
+            for s in ux_tail:
+                if len(picked) >= reco_slots:
+                    break
+                if s.name not in picked_names and s.name not in ranked_names:
+                    picked.append(s)
+                    picked_names.add(s.name)
+        return picked[:reco_slots]
+
+    # 无预计算结果（冷启动 / 尚未跑重活）→ ux_tail，绝不现算 KNN。
+    return ux_tail[:reco_slots]

--- a/tests/test_server_no_llm_fallback.py
+++ b/tests/test_server_no_llm_fallback.py
@@ -244,13 +244,14 @@ def test_team_server_schedules_only_server_watcher(
         record.name: record for record in scheduler_records
     }
     assert set(records_by_name) == {
-        "profile-refresh", "agent-worker", "ux-scores-sync",
+        "recommend-heavy", "agent-worker", "ux-scores-sync",
     }
     watcher_command = records_by_name["agent-worker"].command
     assert watcher_command[-1] == "--server"
     assert "--home" not in watcher_command
     assert records_by_name["agent-worker"].keyword_arguments["persistent"] is True
-    assert "persistent" not in records_by_name["profile-refresh"].keyword_arguments
+    assert "persistent" not in records_by_name["recommend-heavy"].keyword_arguments
+    assert records_by_name["recommend-heavy"].command[-1] == "recommend-heavy"
     assert "persistent" not in records_by_name["ux-scores-sync"].keyword_arguments
     assert records_by_name["ux-scores-sync"].command[-1] == "ux-scores-sync"
     assert "ecosystem-ingest" not in records_by_name

--- a/tests/test_skill_vector_consistency.py
+++ b/tests/test_skill_vector_consistency.py
@@ -1,0 +1,291 @@
+"""skills_catalog ↔ 向量索引最终一致性（TC1–TC10）。
+
+默认用 MemorySkillVectorIndex + fake_embed，不依赖本机 pymilvus / 外网。
+"""
+from __future__ import annotations
+
+from pathlib import Path
+
+import pytest
+
+from xskill.pipeline.registry import get_connection, pooled_connection
+from xskill.recommend.recommend_store import (
+    load_recommend_slots,
+    mark_recommend_dirty,
+    save_recommend_slots,
+)
+from xskill.recommend.skill_vector_store import (
+    DEFAULT_DIM,
+    MemorySkillVectorIndex,
+    content_sha_for_text,
+    fake_embed,
+    reconcile_catalog_to_index,
+)
+
+
+def _upsert_catalog(db: Path, row: dict) -> None:
+    with pooled_connection(db) as conn:
+        conn.execute(
+            """
+            INSERT INTO skills_catalog(
+                catalog_key, root_key, name, repo_name, source, state,
+                description, version, candidates_count, main_sha, staging_sha,
+                distributable, search_id, hub, skill_id, use_count, content_sha,
+                updated_at
+            ) VALUES (?,?,?,?,?,?,?,?,?,?,?,?,?,?,?,?,?,datetime('now'))
+            ON CONFLICT(catalog_key) DO UPDATE SET
+                description=excluded.description,
+                content_sha=excluded.content_sha,
+                source=excluded.source,
+                name=excluded.name,
+                skill_id=excluded.skill_id,
+                updated_at=datetime('now')
+            """,
+            (
+                row["catalog_key"],
+                row.get("root_key") or "",
+                row["name"],
+                row.get("repo_name") or "",
+                row.get("source") or "native",
+                row.get("state") or "main",
+                row["description"],
+                row.get("version") or "",
+                int(row.get("candidates_count") or 0),
+                row.get("main_sha") or "",
+                row.get("staging_sha") or "",
+                int(row.get("distributable") or 1),
+                row.get("search_id") or "",
+                row.get("hub") or "",
+                row.get("skill_id") or "",
+                int(row.get("use_count") or 0),
+                row["content_sha"],
+            ),
+        )
+        conn.commit()
+
+
+def _delete_catalog(db: Path, catalog_key: str) -> None:
+    with pooled_connection(db) as conn:
+        conn.execute(
+            "DELETE FROM skills_catalog WHERE catalog_key=?", (catalog_key,),
+        )
+        conn.commit()
+
+
+def _load_catalog(db: Path) -> list[dict]:
+    with pooled_connection(db) as conn:
+        rows = conn.execute(
+            """
+            SELECT catalog_key, name, source, description, content_sha, skill_id
+            FROM skills_catalog
+            """
+        ).fetchall()
+    return [dict(r) for r in rows]
+
+
+def _row(key: str, desc: str, *, source: str = "native", name: str | None = None) -> dict:
+    return {
+        "catalog_key": key,
+        "name": name or key.split(":", 1)[-1],
+        "source": source,
+        "description": desc,
+        "content_sha": content_sha_for_text(desc),
+        "skill_id": key.split(":", 1)[-1] if source == "skillhub" else "",
+    }
+
+
+@pytest.fixture()
+def registry_db(tmp_path: Path) -> Path:
+    db = tmp_path / "registry.db"
+    # 触发 schema（含 skills_catalog / client_recommend_slots）
+    conn = get_connection(db)
+    conn.close()
+    return db
+
+
+@pytest.fixture()
+def index() -> MemorySkillVectorIndex:
+    return MemorySkillVectorIndex(dim=DEFAULT_DIM)
+
+
+def _reconcile(db: Path, index: MemorySkillVectorIndex) -> dict:
+    return reconcile_catalog_to_index(
+        index, _load_catalog(db), embed=lambda t: fake_embed(t, DEFAULT_DIM),
+    )
+
+
+def test_tc1_insert_aligns(registry_db, index):
+    row = _row("native:alpha", "alpha skill for networking")
+    _upsert_catalog(registry_db, row)
+    stats = _reconcile(registry_db, index)
+    assert stats["upserted"] == 1
+    got = index.get("native:alpha")
+    assert got is not None
+    assert got["content_sha"] == row["content_sha"]
+
+
+def test_tc2_update_reembeds(registry_db, index):
+    row = _row("native:alpha", "old description text")
+    _upsert_catalog(registry_db, row)
+    _reconcile(registry_db, index)
+    old_vec = list(index.get("native:alpha")["vector"])
+
+    updated = _row("native:alpha", "brand new description about databases")
+    _upsert_catalog(registry_db, updated)
+    stats = _reconcile(registry_db, index)
+    assert stats["upserted"] == 1
+    got = index.get("native:alpha")
+    assert got["content_sha"] == updated["content_sha"]
+    assert list(got["vector"]) != old_vec
+    assert len(index.list_keys()) == 1
+
+
+def test_tc3_delete_aligns(registry_db, index):
+    row = _row("native:alpha", "to be deleted")
+    _upsert_catalog(registry_db, row)
+    _reconcile(registry_db, index)
+    _delete_catalog(registry_db, "native:alpha")
+    stats = _reconcile(registry_db, index)
+    assert stats["deleted"] == 1
+    assert index.get("native:alpha") is None
+
+
+def test_tc4_reconcile_fills_hole(registry_db, index):
+    row = _row("native:hole", "exists only in catalog")
+    _upsert_catalog(registry_db, row)
+    # 不对账前 Milvus/index 为空
+    assert index.get("native:hole") is None
+    stats = _reconcile(registry_db, index)
+    assert stats["upserted"] == 1
+    assert index.get("native:hole")["content_sha"] == row["content_sha"]
+
+
+def test_tc5_reconcile_clears_ghost(registry_db, index):
+    index.upsert(
+        "native:ghost",
+        fake_embed("ghost", DEFAULT_DIM),
+        content_sha="deadbeef",
+        source="native",
+        name="ghost",
+    )
+    stats = _reconcile(registry_db, index)
+    assert stats["deleted"] == 1
+    assert index.get("native:ghost") is None
+
+
+def test_tc6_reconcile_repairs_stale_sha(registry_db, index):
+    row = _row("native:stale", "fresh description")
+    _upsert_catalog(registry_db, row)
+    index.upsert(
+        "native:stale",
+        fake_embed("old description", DEFAULT_DIM),
+        content_sha="stale_sha_value",
+        source="native",
+        name="stale",
+    )
+    stats = _reconcile(registry_db, index)
+    assert stats["upserted"] == 1
+    assert index.get("native:stale")["content_sha"] == row["content_sha"]
+
+
+def test_tc7_mixed_native_skillhub(registry_db, index):
+    _upsert_catalog(registry_db, _row("native:n1", "native one"))
+    _upsert_catalog(
+        registry_db,
+        _row("skillhub:hub-1", "hub skill desc", source="skillhub", name="Hub Skill"),
+    )
+    _reconcile(registry_db, index)
+    assert index.get("native:n1")["source"] == "native"
+    assert index.get("skillhub:hub-1")["source"] == "skillhub"
+    assert len(index.list_keys()) == 2
+
+
+def test_tc8_empty_description_not_indexed(registry_db, index):
+    _upsert_catalog(
+        registry_db,
+        {
+            "catalog_key": "native:empty",
+            "name": "empty",
+            "source": "native",
+            "description": "",
+            "content_sha": "",
+            "skill_id": "",
+        },
+    )
+    stats = _reconcile(registry_db, index)
+    assert stats["upserted"] == 0
+    assert index.get("native:empty") is None
+
+
+def test_tc9_double_upsert_single_key(registry_db, index):
+    row = _row("native:dup", "first")
+    _upsert_catalog(registry_db, row)
+    _reconcile(registry_db, index)
+    row2 = _row("native:dup", "second version")
+    _upsert_catalog(registry_db, row2)
+    _reconcile(registry_db, index)
+    _reconcile(registry_db, index)
+    assert len(index.list_keys()) == 1
+    assert index.get("native:dup")["content_sha"] == row2["content_sha"]
+
+
+def test_tc10_readonly_catalog_page_does_not_mutate_index(
+    registry_db, index, tmp_path, monkeypatch,
+):
+    """看板只读投影表时不应写向量索引。"""
+    row = _row("native:ro", "readonly probe")
+    _upsert_catalog(registry_db, row)
+    _reconcile(registry_db, index)
+    before = {k: dict(v) for k, v in index._rows.items()}
+
+    writes = {"n": 0}
+    orig_upsert = index.upsert
+    orig_delete = index.delete
+
+    def counting_upsert(*a, **k):
+        writes["n"] += 1
+        return orig_upsert(*a, **k)
+
+    def counting_delete(*a, **k):
+        writes["n"] += 1
+        return orig_delete(*a, **k)
+
+    monkeypatch.setattr(index, "upsert", counting_upsert)
+    monkeypatch.setattr(index, "delete", counting_delete)
+
+    from xskill.skill import catalog_store
+
+    # 跳过扫盘回填：本测只验证只读分页不碰向量索引
+    monkeypatch.setattr(catalog_store, "ensure_skills_catalog", lambda *a, **k: None)
+    skill_dir = tmp_path / "skills"
+    skill_dir.mkdir()
+    page = catalog_store.page_skills_catalog(
+        skill_dir, limit=10, offset=0, db_path=registry_db,
+    )
+    assert "items" in page or "skills" in page or isinstance(page, dict)
+    assert writes["n"] == 0
+    assert index._rows == before
+
+
+def test_recommend_slots_stale_still_readable(registry_db):
+    save_recommend_slots("alice", ["a", "b"], db_path=registry_db)
+    mark_recommend_dirty("alice", reason="test", db_path=registry_db)
+    assert load_recommend_slots("alice", db_path=registry_db) == ["a", "b"]
+
+
+def test_heavy_compute_recommend_from_centers(registry_db, index):
+    from xskill.recommend.heavy_worker import compute_recommend_for_user
+
+    _upsert_catalog(registry_db, _row("native:net", "network debugging tools"))
+    _upsert_catalog(registry_db, _row("native:db", "database migration helpers"))
+    _reconcile(registry_db, index)
+    center = fake_embed("network debugging tools", DEFAULT_DIM)
+    names = compute_recommend_for_user(
+        "bob",
+        db_path=registry_db,
+        vector_index=index,
+        profile_centers=[center],
+        top_k=1,
+    )
+    assert names
+    assert load_recommend_slots("bob", db_path=registry_db) == names

--- a/tests/test_skillhub.py
+++ b/tests/test_skillhub.py
@@ -353,6 +353,10 @@ class TestEngineSkillhubPool:
             mean_tensor=q,
             used_skills=[],
         )
+        entry = eng.skillhub.index()[0]
+        # /sync 只读预计算推荐表（重活进程写入），不再请求内 KNN。
+        from xskill.recommend.recommend_store import save_recommend_slots
+        save_recommend_slots("client-one", [entry["skill_id"]])
         set_recommend_engine(eng)
         try:
             resp = build_manifest(
@@ -368,7 +372,6 @@ class TestEngineSkillhubPool:
 
         assert len(resp.slots) == 1
         slot = resp.slots[0]
-        entry = eng.skillhub.index()[0]
         assert slot.source == "skillhub"
         assert slot.skill_name == entry["skill_id"]
         assert slot.display_name == "foo"
@@ -417,6 +420,10 @@ class TestEngineSkillhubPool:
                 hub_dir, "hub-a/foo", "django migration helper", name="foo",
             )
             eng.skillhub._scan_snapshot_expires_at = 0.0  # 模拟 TTL 到期：增删最迟 5s 后被扫到
+            # 重活进程写入推荐表后，下一轮 /sync 才能看到 skillhub 槽位
+            from xskill.recommend.recommend_store import save_recommend_slots
+            entry = eng.skillhub.index()[0]
+            save_recommend_slots("client-one", [entry["skill_id"]])
             second = build_manifest(
                 client_id="client-one",
                 skill_dir=skill_dir,

--- a/tests/test_team_skill_manifest.py
+++ b/tests/test_team_skill_manifest.py
@@ -355,29 +355,23 @@ def test_build_manifest_cold_start_recommended_equals_ux(tmp_path):
 
 
 def test_build_manifest_warm_recommended_is_profile_driven(tmp_path):
-    """暖路径：有画像 → recommended 受画像影响，且排除 ranked / 已用。"""
+    """暖路径：/sync 只读重活预写的推荐表（不在请求内算质心 KNN）。"""
+    from xskill.recommend.recommend_store import save_recommend_slots
+
     skill_dir = tmp_path / "skill"
     skill_dir.mkdir()
     names = [f"skill-{i:02d}" for i in range(30)]
     for nm in names:
         _make_skill(skill_dir, nm)
-    # 自造索引：让 ux 尾部（ranked 之外）有一个主题簇
-    emb = np.zeros((30, 30), dtype=np.float32)
-    for i in range(30):
-        emb[i, i] = 1.0
-    # 把 skill-25 / skill-26 拉到同一维度（主题簇），client 用过 skill-25
-    emb[25, :] = 0.0
-    emb[26, :] = 0.0
-    emb[25, 5] = 1.0
-    emb[26, 5] = 1.0
-    with open(skill_dir / ".skill_index.pkl", "wb") as f:
-        pickle.dump({"skill_names": names, "embeddings": emb,
-                     "texts": names, "method": "test"}, f)
+    _write_skill_index(skill_dir, names)
 
     traj_root = tmp_path / "traj"
-    # client 用过 skill-25（会落在 ranked 之外，因为所有 skill ux 相同→按名排序，
-    # ranked_slots=20 时 skill-00..19 进 ranked，skill-20..29 是候选）
-    _save_atom(traj_root, "cid-warm", "traj_a", 1, ["skill-25"])
+    # ranked_slots=20 → skill-00..19 进 ranked；推荐表由重活进程写入
+    # （此处模拟画像结果：skill-26 最相关，且不含已用 skill-25）
+    save_recommend_slots(
+        "cid-warm",
+        ["skill-26", "skill-27", "skill-28", "skill-29", "skill-24"],
+    )
 
     resp = build_manifest(client_id="cid-warm", skill_dir=skill_dir,
                           probability=0.2, ranked_slots=20, total_slots=25,
@@ -385,7 +379,6 @@ def test_build_manifest_warm_recommended_is_profile_driven(tmp_path):
     ranked = {s.skill_name for s in resp.slots if s.bucket == "ranked"}
     reco = [s.skill_name for s in resp.slots if s.bucket == "recommended"]
     assert len(reco) == 5
-    assert all(n not in ranked for n in reco)        # 不在 ranked-80
-    assert "skill-25" not in reco                    # 排除已用
-    # skill-26 与 client 质心同向（cosine=1），别的候选 cosine=0 → 必排第一
+    assert all(n not in ranked for n in reco)
+    assert "skill-25" not in reco
     assert reco[0] == "skill-26"


### PR DESCRIPTION
## Summary
- Add a merged `recommend-heavy` subprocess (profile refresh + Milvus Lite reconcile + dirty-user recommend precompute) so Web `/sync` no longer runs request-time `get_skill_for_client` / numpy full-corpus KNN.
- Introduce `client_recommend_slots` / `recommend_dirty`, `skills_catalog.content_sha`, and `~/.xskill/skill_vectors.db` (Milvus Lite) with eventual-consistency reconcile; `/sync` reads last-good recommended slots (stale-ok).
- Keep search orchestration; vector recall prefers Milvus when the index file exists. Cover catalog↔index consistency with TC1–TC10.

## Test plan
- [x] `PYTHONPATH=src python3.11 -m pytest tests/test_skill_vector_consistency.py -q`
- [x] Related: `test_skillhub.py::TestEngineSkillhubPool`, `test_server_no_llm_fallback.py`, `test_recommend_gaps.py`, `test_manifest_cache.py`, `test_profile_refresh_once.py`
- [ ] On a team serve host: confirm scheduler spawns `xskill._workers recommend-heavy`; `/sync` stacks no longer show walk/vstack/`get_skill_for_client`
- [ ] Dashboard `#skills` stays responsive under concurrent client sync


Made with [Cursor](https://cursor.com)