### PR TITLE
fix(skillhub): exact match → Top1

### DIFF
--- a/src/xskill/recommend/skillhub.py
+++ b/src/xskill/recommend/skillhub.py
@@ -560,6 +560,11 @@ class SkillHub:
         ordered_indices = self._rank_score_groups(
             score_groups, entries, limit,
         )
+        # 精确命中（display_name / skill_id / 去 hash 的 id / 目录名）置顶，
+        # 避免长名称里的热词（如 bootstrap）被 RRF 挤出 TopN。
+        ordered_indices = self._promote_exact_matches(
+            normalized_query, entries, ordered_indices, limit,
+        )
         results: list[dict] = []
         for entry_index in ordered_indices:
             result_entry = dict(entries[entry_index])
@@ -569,6 +574,48 @@ class SkillHub:
             results.append(result_entry)
         self._cache_search_results(index_bundle, result_cache_key, results)
         return results
+
+    @staticmethod
+    def _entry_exact_keys(entry: dict) -> set[str]:
+        """可与规范化 query 精确相等的键集合。"""
+        keys: set[str] = set()
+        display = str(entry.get("display_name") or "").strip().lower()
+        if display:
+            keys.add(display)
+        skill_id = str(entry.get("skill_id") or entry.get("name") or "").strip().lower()
+        if skill_id:
+            keys.add(skill_id)
+            stem = skill_id.split("@", 1)[0].strip()
+            if stem:
+                keys.add(stem)
+        source_path = str(entry.get("source_path") or "").strip().lower()
+        if source_path:
+            keys.add(source_path)
+            keys.add(Path(source_path).name)
+        return keys
+
+    @classmethod
+    def _promote_exact_matches(
+        cls,
+        normalized_query: str,
+        entries: list[dict],
+        ordered_indices: list[int],
+        limit: int,
+    ) -> list[int]:
+        """精确命中插到最前；多条精确命中时按 skill_id 稳定排序。"""
+        if not normalized_query or limit <= 0:
+            return ordered_indices
+        exact = [
+            idx for idx, entry in enumerate(entries)
+            if normalized_query in cls._entry_exact_keys(entry)
+        ]
+        if not exact:
+            return ordered_indices
+        exact.sort(key=lambda idx: str(entries[idx].get("skill_id") or ""))
+        exact_set = set(exact)
+        rest = [idx for idx in ordered_indices if idx not in exact_set]
+        # 精确命中也可能不在 RRF 截断窗口内，必须从全量 entries 拉回
+        return (exact + rest)[:limit]
 
     def cached_search(self, query: str, limit: int = 5) -> list[dict] | None:
         """Return a current final-result cache hit without scanning or ranking.

--- a/tests/test_skillhub_hybrid_search.py
+++ b/tests/test_skillhub_hybrid_search.py
@@ -116,6 +116,30 @@ def test_bm25_orders_matches_and_name_outranks_description(tmp_path):
     assert all(result["semantic_rank"] is None for result in results)
 
 
+def test_exact_display_name_promoted_to_top1_over_hot_token_crowd(tmp_path):
+    """精确 name 命中必须 Top1，即使热词 bootstrap 让其它 skill RRF 更靠前。"""
+    hub_dir = tmp_path / "hub"
+    # 一堆只吃 bootstrap 热词的干扰项
+    for i in range(8):
+        _write_hub_skill(
+            hub_dir, f"noise-{i}", f"Workspace Bootstrap {i}",
+            "bootstrap workspace helper tools",
+        )
+    _write_hub_skill(
+        hub_dir, "user_skill_hub/u1/repo-doc-governance-bootstrap",
+        "repo-doc-governance-bootstrap",
+        "文档治理 DOCUMENT_MAP 闭环",
+    )
+    hub = SkillHub(enabled=True, hub_dir=hub_dir, embed_client=None)
+    results = hub.search("repo-doc-governance-bootstrap", limit=5)
+    assert results, "expected search hits"
+    assert results[0]["display_name"] == "repo-doc-governance-bootstrap"
+    # skill_id 去 hash 精确命中同样置顶
+    skill_id = results[0]["skill_id"]
+    by_id = hub.search(skill_id, limit=3)
+    assert by_id[0]["skill_id"] == skill_id
+
+
 def test_supplemental_repo_and_skillhub_share_global_bm25_rank(tmp_path):
     hub_dir = tmp_path / "hub"
     _write_hub_skill(hub_dir, "hub-alpha", "alpha", "shared")


### PR DESCRIPTION
## Summary
- After RRF fusion, promote exact hits on `display_name` / `skill_id` (and id stem) / `source_path` (and basename) to the front of search results
- Exact hits outside the RRF cut window are pulled back from the full entry list so a precise name query is not drowned by hot tokens (e.g. `bootstrap`)

## Test plan
- [x] `pytest tests/test_skillhub_hybrid_search.py::test_exact_display_name_promoted_to_top1_over_hot_token_crowd`
- [ ] Search exact long skill name on a busy hub → result[0] is that skill
- [ ] Search by full `skill_id` → same skill Top1


Made with [Cursor](https://cursor.com)