### PR TITLE
fix(deps): pymilvus 改为可选，避免阻断 client 自动更新

### DIFF
--- a/pyproject.toml
+++ b/pyproject.toml
@@ -46,14 +46,18 @@ dependencies = [
     # ``python:3.9-slim``）默认没装 git，SkillEditAgent 等链路又要跑 git
     # init/commit/branch；走 dulwich 后零依赖系统 git。
     "dulwich>=0.21",
-    # 嵌入式向量索引（Milvus Lite）：技能检索/推荐 KNN，替代 numpy 全库乘。
-    "pymilvus>=2.4.2",
     # Python 3.9 上 pydantic 需要它来求值 `X | Y` 联合注解（PEP 604 语法
     # 3.10 才原生支持）；3.10+ 不安装。
     "eval_type_backport; python_version < '3.10'",
 ]
 
 [project.optional-dependencies]
+# 嵌入式向量索引（Milvus Lite）。非必需：缺省走 numpy / 内存 fallback，
+# 大库上会更慢。team server 建议：pip install 'xskill[milvus]'。
+# 不进主依赖——pymilvus 体积大、部分环境装不上，曾阻断 client 自动更新。
+milvus = [
+    "pymilvus>=2.4.2",
+]
 dev = [
     "pytest>=7",
     "pytest-timeout>=2",

--- a/src/xskill/recommend/engine.py
+++ b/src/xskill/recommend/engine.py
@@ -703,13 +703,20 @@ class SkillRecommendEngine:
             from xskill.config import XSKILL_HOME
             from xskill.recommend.skill_vector_store import (
                 default_vector_db_path,
-                open_skill_vector_index,
+                pymilvus_available,
+                try_open_milvus_lite_index,
+                warn_milvus_unavailable_hourly,
             )
 
+            if not pymilvus_available():
+                warn_milvus_unavailable_hourly("pymilvus not installed")
+                return None
             path = default_vector_db_path(XSKILL_HOME)
             if not path.is_file():
                 return None
-            index = open_skill_vector_index(path, dim=len(query_vec))
+            index = try_open_milvus_lite_index(path, dim=len(query_vec))
+            if index is None:
+                return None
             hits = index.search(list(map(float, query_vec)), top_k=top_k)
         except Exception:  # pylint: disable=broad-exception-caught
             logger.debug("milvus relevance_search unavailable", exc_info=True)

--- a/src/xskill/recommend/heavy_worker.py
+++ b/src/xskill/recommend/heavy_worker.py
@@ -210,6 +210,7 @@ def run_recommend_heavy_once(
         dim = DEFAULT_DIM
     else:
         dim = len(embed_fn("dimension probe"))
+    # open_skill_vector_index：无 pymilvus 时退回内存索引并 hourly warn
     index = memory_index or open_skill_vector_index(vdb, dim=dim)
     vec_stats = run_vector_reconcile(
         db_path=registry,

--- a/src/xskill/recommend/skill_vector_store.py
+++ b/src/xskill/recommend/skill_vector_store.py
@@ -1,12 +1,17 @@
-"""技能向量索引：Milvus Lite（嵌入式）+ 与 skills_catalog 最终一致。
+"""技能向量索引：Milvus Lite（嵌入式，可选）+ 与 skills_catalog 最终一致。
 
 业务真相在 SQLite ``skills_catalog``；本模块只维护检索索引。
 主键与 ``catalog_key`` 对齐；``content_sha`` 变了才 re-embed/upsert。
+
+``pymilvus`` 为 optional extra（``xskill[milvus]``）。未安装时：
+- 检索侧走引擎/skillhub 的 numpy 全库乘 fallback；
+- 重活进程用内存索引对账（不落 ``skill_vectors.db``），并每小时 warn 一次。
 """
 from __future__ import annotations
 
 import hashlib
 import logging
+import time
 from pathlib import Path
 from typing import Callable, Iterable, Optional, Protocol, Sequence
 
@@ -14,6 +19,11 @@ logger = logging.getLogger("xskill.skill_vector_store")
 
 COLLECTION = "skill_vectors"
 DEFAULT_DIM = 8  # fake/tests；生产由首条真实向量决定或配置
+
+# 未装 / 打不开 Milvus 时的节流警告（写进 xskill.log）
+_MILVUS_WARN_INTERVAL_S = 3600.0
+_milvus_last_warn_mono = 0.0
+_pymilvus_import_ok: Optional[bool] = None
 
 
 def content_sha_for_text(text: str) -> str:
@@ -302,13 +312,71 @@ def default_vector_db_path(xskill_home: Path | None = None) -> Path:
     return home.expanduser().resolve() / "skill_vectors.db"
 
 
+def pymilvus_available() -> bool:
+    """``pymilvus`` 是否可 import（不探测 Lite 运行时是否能开库）。"""
+    global _pymilvus_import_ok
+    if _pymilvus_import_ok is not None:
+        return _pymilvus_import_ok
+    try:
+        import pymilvus  # noqa: F401
+    except ImportError:
+        _pymilvus_import_ok = False
+    else:
+        _pymilvus_import_ok = True
+    return _pymilvus_import_ok
+
+
+def warn_milvus_unavailable_hourly(reason: str) -> None:
+    """服务器侧无 Milvus 时每小时最多一条 WARNING（进 ``xskill.log``）。"""
+    global _milvus_last_warn_mono
+    now = time.monotonic()
+    if (now - _milvus_last_warn_mono) < _MILVUS_WARN_INTERVAL_S:
+        return
+    _milvus_last_warn_mono = now
+    logger.warning(
+        "Milvus Lite unavailable (%s); skill vector search uses slower "
+        "numpy/in-memory fallback and may hurt recommend/search performance "
+        "on large catalogs. Prefer: pip install 'xskill[milvus]' "
+        "(or pip install 'pymilvus>=2.4.2').",
+        reason,
+    )
+
+
+def try_open_milvus_lite_index(
+    db_path: Path | str | None = None,
+    *,
+    dim: int = DEFAULT_DIM,
+) -> Optional[SkillVectorIndex]:
+    """仅打开真正的 Milvus Lite；不可用返回 ``None``（并可能 hourly warn）。"""
+    if not pymilvus_available():
+        warn_milvus_unavailable_hourly("pymilvus not installed")
+        return None
+    path = Path(db_path) if db_path else default_vector_db_path()
+    try:
+        return MilvusLiteSkillVectorIndex(path, dim=dim)
+    except Exception as exc:  # pylint: disable=broad-exception-caught
+        warn_milvus_unavailable_hourly(
+            f"open failed: {type(exc).__name__}: {exc}",
+        )
+        logger.debug("MilvusLiteSkillVectorIndex open failed", exc_info=True)
+        return None
+
+
 def open_skill_vector_index(
     db_path: Path | str | None = None,
     *,
     dim: int = DEFAULT_DIM,
     memory: bool = False,
 ) -> SkillVectorIndex:
+    """打开向量索引。
+
+    - ``memory=True``：测试用纯内存。
+    - 默认尝试 Milvus Lite；``pymilvus`` 未装或开库失败 → 内存索引 + 节流 warn
+      （不落盘；引擎检索侧另有 numpy fallback）。
+    """
     if memory:
         return MemorySkillVectorIndex(dim=dim)
-    path = Path(db_path) if db_path else default_vector_db_path()
-    return MilvusLiteSkillVectorIndex(path, dim=dim)
+    milvus = try_open_milvus_lite_index(db_path, dim=dim)
+    if milvus is not None:
+        return milvus
+    return MemorySkillVectorIndex(dim=dim)

--- a/src/xskill/recommend/skillhub.py
+++ b/src/xskill/recommend/skillhub.py
@@ -840,13 +840,22 @@ class SkillHub:
             from xskill.config import XSKILL_HOME
             from xskill.recommend.skill_vector_store import (
                 default_vector_db_path,
-                open_skill_vector_index,
+                pymilvus_available,
+                try_open_milvus_lite_index,
+                warn_milvus_unavailable_hourly,
             )
 
+            if not pymilvus_available():
+                warn_milvus_unavailable_hourly("pymilvus not installed")
+                return None
             path = default_vector_db_path(XSKILL_HOME)
             if not path.is_file():
                 return None
-            index = open_skill_vector_index(path, dim=int(query_vector.shape[0]))
+            index = try_open_milvus_lite_index(
+                path, dim=int(query_vector.shape[0]),
+            )
+            if index is None:
+                return None
             hits = index.search(
                 [float(x) for x in query_vector.tolist()],
                 top_k=max(len(present_indices), 1),

--- a/tests/test_optional_pymilvus.py
+++ b/tests/test_optional_pymilvus.py
@@ -1,0 +1,63 @@
+"""pymilvus 为 optional extra：未安装时不崩，并节流 warn。"""
+from __future__ import annotations
+
+import logging
+
+import pytest
+
+from xskill.recommend import skill_vector_store as svs
+
+
+@pytest.fixture(autouse=True)
+def _reset_milvus_gates(monkeypatch):
+    monkeypatch.setattr(svs, "_pymilvus_import_ok", None)
+    monkeypatch.setattr(svs, "_milvus_last_warn_mono", 0.0)
+    yield
+    monkeypatch.setattr(svs, "_pymilvus_import_ok", None)
+    monkeypatch.setattr(svs, "_milvus_last_warn_mono", 0.0)
+
+
+def test_open_skill_vector_index_falls_back_without_pymilvus(monkeypatch, caplog):
+    monkeypatch.setattr(svs, "_pymilvus_import_ok", False)
+    with caplog.at_level(logging.WARNING, logger="xskill.skill_vector_store"):
+        index = svs.open_skill_vector_index(memory=False, dim=4)
+    assert isinstance(index, svs.MemorySkillVectorIndex)
+    assert any("Milvus Lite unavailable" in r.message for r in caplog.records)
+
+
+def test_milvus_unavailable_warn_throttled_hourly(monkeypatch, caplog):
+    monkeypatch.setattr(svs, "_pymilvus_import_ok", False)
+    monkeypatch.setattr(svs, "_milvus_last_warn_mono", 0.0)
+    with caplog.at_level(logging.WARNING, logger="xskill.skill_vector_store"):
+        svs.warn_milvus_unavailable_hourly("pymilvus not installed")
+        svs.warn_milvus_unavailable_hourly("pymilvus not installed")
+    warns = [r for r in caplog.records if "Milvus Lite unavailable" in r.message]
+    assert len(warns) == 1
+    # 人为拨回时钟后应再 warn
+    monkeypatch.setattr(
+        svs, "_milvus_last_warn_mono",
+        svs._milvus_last_warn_mono - svs._MILVUS_WARN_INTERVAL_S - 1,
+    )
+    with caplog.at_level(logging.WARNING, logger="xskill.skill_vector_store"):
+        svs.warn_milvus_unavailable_hourly("again")
+    warns = [r for r in caplog.records if "Milvus Lite unavailable" in r.message]
+    assert len(warns) == 2
+
+
+def test_try_open_milvus_lite_returns_none_without_pymilvus(monkeypatch):
+    monkeypatch.setattr(svs, "_pymilvus_import_ok", False)
+    assert svs.try_open_milvus_lite_index(dim=4) is None
+
+
+def test_pyproject_keeps_pymilvus_optional_only():
+    """主依赖不得再硬拉 pymilvus（否则阻断 client 自动更新）。"""
+    from pathlib import Path
+    import tomllib
+
+    text = Path("pyproject.toml").read_text(encoding="utf-8")
+    data = tomllib.loads(text)
+    deps = "\n".join(data["project"]["dependencies"])
+    assert "pymilvus" not in deps
+    extras = data["project"]["optional-dependencies"]
+    assert "milvus" in extras
+    assert any("pymilvus" in x for x in extras["milvus"])


### PR DESCRIPTION
## Summary
- 将 ``pymilvus`` 从主依赖挪到 optional extra：``pip install 'xskill[milvus]'``
- 未安装时检索/推荐走既有 numpy / 内存 fallback，不阻断 ``pip install -U xskill`` / client 自动更新
- 服务器侧不可用时，``xskill.log`` **每小时最多一条** WARNING，提示大库性能问题并建议安装 Milvus Lite

## 背景
#189 把 ``pymilvus`` 写进主依赖后，部分用户环境装不上该包，导致自动更新核验失败。

## Test plan
- [x] ``tests/test_optional_pymilvus.py``（fallback + 1h 节流 + pyproject 断言）
- [x] ``tests/test_skill_vector_consistency.py``
- [ ] 无 pymilvus 环境：``pip install xskill==<新版>`` 成功；client updater 可完成
- [ ] team server 未装 milvus：跑 recommend-heavy / 搜索后 ``~/.xskill/logs/xskill.log`` 出现 hourly warn
- [ ] server 侧 ``pip install 'xskill[milvus]'`` 后走 Milvus Lite 路径


Made with [Cursor](https://cursor.com)