### PR TITLE
feat(dashboard): 推送对象 + 热路径迁表（skills_catalog / ux_scores）

### DIFF
--- a/docs/8780-mock-vs-branch-diff.md
+++ b/docs/8780-mock-vs-branch-diff.md
@@ -1,0 +1,130 @@
+# 8780 Mock vs `fix/skill-routing-api` Branch — UI/UX/API Gap Inventory
+
+**Audited:** 2026-08-05 (re-audit after implementation round)  
+**Mock (source of truth):** `/home/admin/xskill-recommend-version-viz/` → http://8.219.96.11:8780/  
+**Branch:** `/home/admin/.cursor/worktrees/xskill-optional-pymilvus` (`fix/skill-routing-api`)  
+**Baseline reference:** `origin/main` static (shipped ~a6)
+
+---
+
+## Summary verdict
+
+**CONVERGED** — all prior **P0** and **P1** gaps from the first inventory are now **DONE** in the branch. Static `app.js` / `index.html` match mock on every user-visible routing, admin, skills-search, and my-page control that was in scope.
+
+Remaining differences are **P2 / mock-only / intentional prod behavior** (no `mock-api.js`, no fake harness injection, push defaults bound from API not hardcoded `45`, optional cache-bust query params).
+
+**Severity counts (remaining gaps only):**
+
+| Severity | Count | Meaning |
+|----------|------:|---------|
+| **P0** | 0 | — |
+| **P1** | 0 | — |
+| **P2** | 6 | Mock-only demo data, cosmetic HTML, or prod-intentional defaults |
+
+`app.js` diff vs mock: ~21 net lines (mostly comment removal, `jc` cache for skills fetch, prod push defaults `0`/`100` vs mock `45`, no client-side `harnesses` fallback). No functional P0/P1 hunks left.
+
+---
+
+## Already aligned
+
+| Area | Evidence |
+|------|----------|
+| Sidebar branding & nav | `index.html:98-111` — identical teal `x` logo, `xskill` / `控制台`, same SVG nav icons |
+| Skill routing REST API | `console.py:561-1296` — `_skill_routing_table`, GET `/skill/{name}/routing`, `/routing/users`, `/routing/user/{user}`; tests in `tests/test_skill_routing.py` |
+| Graph HEAD → routing focus | `static/app.js:293` `data-gside`; `:303` legend 「点黄点看推送对象」; `:858` `focusSkillRouting`; `:1551-1567` HEAD click → focus + conditional scroll |
+| 「当前推送对象」panel + layout | `static/app.js:502-503` `#skill-routing` in **right column** (`lg:col-span-7`); `:768-847` staging/main columns, typeahead, pagers |
+| Evolution path hint + HEAD subcopy | `static/app.js:498` 「点黄点 / main HEAD 看推送给谁；其它节点看 diff」; `:295` 「· 点击看推送给谁」 on HEAD rows |
+| Manifest `side_mutable` | `console.py:304-325` `_side_mutable` + emit on slots; `tests/test_skill_routing.py:196` asserts `True` for canary skill |
+| Admin assignment API | `console.py:1194-1201` `GET /admin/user/{user_key}/assignment`; `static/app.js:2413` fetch; test `:191-197` |
+| Admin matrix slot counts | `console.py:1175-1177,1191` `current_slots` / `staging_slots` / `total_users`; `static/app.js:2377-2378` renders columns |
+| Admin drawer side chips | `static/app.js:2425` conditional on `s.side_mutable` (now populated by API) |
+| Skills search UI + page size | `index.html:233` `#skills-q`; `static/app.js:190-198` `SKILLS_PAGE_SIZE=10`, debounced `?q=` |
+| Skills API `q` substring | `router.py:145-146`; `catalog_store.py:688-791` SQL `LIKE`; `tests/test_skill_routing.py:206-220` |
+| Trigger-rate collapsible | `index.html:250-254` `#trigger-rate-toggle` / `#trigger-rate-body` hidden; `static/app.js:2286-2293` toggle |
+| My page star pin + side chips | `static/app.js:2052-2071` `_mySlotRowHtml`; `:2252-2272` delegated `.my-row-side` / `.my-row-pin` / `.my-row-unpin` |
+| Admin colspan 9 | `index.html:506` `colspan="9"` |
+| Route user placeholder | `static/app.js:807` 「输入关键字，如 alice / user-0」 |
+| Push input focus-select | `static/app.js:2326` `focus` → `select()` |
+| Routing row admin/self prefs | `static/app.js:630-648`, `2402-2418` — `_routePref` → `/admin/prefs` or `/my/prefs` |
+| My manifest + take_n | `console.py:679-771`, `static/app.js:2096-2184` — `server_push`, `take_n`, local slice `applyTakeNToSlots` |
+| My settings API | `console.py:728-771` — GET/POST `/my/settings` with `take_n` clamped to `skill_slots` |
+| My uploads / commits APIs + sections | `console.py:817-943`, `index.html:415-439`, `loadMyUploads` / `loadMyCommits` |
+| Push stepper chrome | `index.html:347-365`, CSS `.push-ctl` / `.push-step` |
+| Commit status pills | CSS `.commit-pill.live\|canary\|absorbed`, `_commitPill` |
+| Admin drawer shell | `static/app.js:2400-2445` — 「{user} 的当前推送」, prefs pin/block, `adm-side` buttons |
+| Trigger / lineage / graph APIs | Mock `mock-api.js` mirrors dashboard routes; branch has real implementations |
+
+---
+
+## Remaining gaps
+
+| Area | Severity | Mock evidence | Branch evidence | Notes |
+|------|----------|---------------|-----------------|-------|
+| Entire `mock-api.js` | **P2** | `xskill-recommend-version-viz/mock-api.js` | Not in branch | Prod uses FastAPI; do not ship |
+| Client `harnesses` injection | **P2** | `mock-api.js:293-299`; mock `app.js` `applyTakeNToSlots` fills `['claude-code','codex']` | `static/app.js:2096-2100` spreads slot as-is, no fallback | Mock demo only; prod should come from server when tracked |
+| HTML default `my-push-val` `45` | **P2** | `index.html:356` mock `value="45"` | `index.html:355` `value="0"` | Branch correctly binds from `/my/settings` / manifest |
+| Index script cache bust | **P2** | `index.html:560-561` `?v=29` | `index.html:559` bare `app.js` | Optional prod mount nicety |
+| CSS section comment | **P2** | `index.html:73` 「偏好：推送步进 + …」 | Comment omitted | Cosmetic |
+| `total_users` API field, no UI pager | **P2** | `mock-api.js:949` returns `100`, UI still shows 20 rows | `console.py:1191` returns count; `loadAdmin` renders all registry rows, no pager | Both sides lack admin user pagination UI; API field present on branch |
+
+---
+
+## Out of scope / mock-only (do not ship)
+
+| Item | Mock location | Why skip |
+|------|---------------|----------|
+| 100 synthetic users (`user-001`…) | `mock-api.js:6-12`, `:931-950` | Stress-test pagination; prod uses real ClientRegistry |
+| Hardcoded skill catalog (`web-flask`, `skill-01`…) | `mock-api.js:13-97` | Demo fixtures |
+| Fake trajectories/atoms | `mock-api.js:100-126` | Demo only |
+| Deterministic `resolveSide` hash for 100 users | `mock-api.js:214-218` | Mock convenience; prod uses real `pick_side` |
+| Inline Tailwind comment `app.js?v=3` | `index.html:5` mock comment | Doc string only |
+
+---
+
+## API contract quick reference (routing-related)
+
+| Endpoint | Mock | Branch | Gap |
+|----------|------|--------|-----|
+| `GET /skill/{name}/routing` | counts + has_staging | ✅ `console.py:1242-1252` | — |
+| `GET /skill/{name}/routing/users` | filter, offset, limit, `q` | ✅ `:1254-1286` | — |
+| `GET /skill/{name}/routing/user/{user}` | single row | ✅ `:1288-1296` | — |
+| `GET /my/manifest` | slots + `side_mutable` | ✅ `:679-726`, `:325` | — |
+| `GET/POST /my/settings` | take_n, server_slots | ✅ `:728-771` | — |
+| `GET /admin/users-matrix` | current_slots, staging_slots, total_users | ✅ `:1138-1192` | — |
+| `GET /admin/user/{user}/assignment` | `{ slots: [...] }` | ✅ `:1194-1201` | — |
+| `GET /skills?q=` | substring search | ✅ `router.py:145`, `catalog_store.py:722+` | — |
+
+---
+
+## Verification log
+
+**Date:** 2026-08-05
+
+| Check | Result | Notes |
+|-------|--------|-------|
+| `side_mutable` in `_pack_manifest_slots` | **PASS** | `console.py:304-325`; test asserts on assignment response |
+| `GET /admin/user/{user}/assignment` | **PASS** | Route at `:1194`; frontend `openAdminDrawer` `:2413` |
+| `admin/users-matrix` slot fields | **PASS** | `current_slots`, `staging_slots`, `total_users` at `:1175-1191` |
+| `GET /skills?q=` | **PASS** | `router.py:146`, `catalog_store.py:722-791`; test accepts `q=alp` |
+| Graph `data-gside` + `focusSkillRouting` | **PASS** | `static/app.js:293,858,1551-1567` |
+| Legend / hint copy | **PASS** | `:303`, `:498`, `:295` match mock strings |
+| `#skill-routing` right column | **PASS** | `:502-503` inside `lg:col-span-7` |
+| Skills search + page 10 + trigger collapse | **PASS** | `index.html:233,250-254`; `app.js:190,2286` |
+| My star/side UI + handlers | **PASS** | `:2052-2071`, `:2252-2272` |
+| Admin colspan 9, route placeholder, push focus-select | **PASS** | `index.html:506`; `app.js:807,2326` |
+| `pytest tests/test_skill_routing.py` | **SKIP** | Host Python lacks `from __future__ import annotations`; static + grep audit used instead |
+| `diff mock/app.js branch/static/app.js` | **PASS (P2 only)** | No missing P0/P1 hunks; ~21-line delta (defaults, comments, harness fallback) |
+
+---
+
+## File diff summary
+
+| File | Relationship |
+|------|----------------|
+| `index.html` | Aligned on all P0/P1 hunks; P2 only: no `mock-api.js`, no `?v=29`, push default `0` not `45`, CSS comment |
+| `app.js` | Functionally aligned; ~21 lines behind mock (prod defaults, no harness injection, comment/`jc` deltas) |
+| `mock-api.js` | Mock-only (not in branch) |
+| `console.py` | Aligned on assignment, matrix fields, `side_mutable` |
+| `router.py` / `catalog_store.py` | Aligned on `q` search |
+
+*Re-audit only — no code fixes applied.*

--- a/src/xskill/dashboard/console.py
+++ b/src/xskill/dashboard/console.py
@@ -22,6 +22,7 @@ from xskill.pipeline.registry import (
     GLOBAL_PREF_KEY,
     PinQuotaExceeded,
     clear_skill_pref,
+    clear_skill_pref_side,
     dashboard_visible_trajectory_sql,
     effective_prefs,
     get_client_take_n,
@@ -45,6 +46,18 @@ logger = logging.getLogger("xskill.dashboard.console")
 _RECO_TRIGGER_TTL_SECONDS = 5.0
 _reco_trigger_cache = SingleFlightTtlCache(
     ttl_seconds=_RECO_TRIGGER_TTL_SECONDS, max_entries=32)
+
+# skill 详情「当前推送对象」：按注册 client 现算 manifest，短 TTL + 单飞
+_ROUTING_TTL_SECONDS = 5.0
+_routing_cache = SingleFlightTtlCache(
+    ttl_seconds=_ROUTING_TTL_SECONDS, max_entries=64)
+_routing_epoch = 0
+
+
+def _bump_routing_epoch() -> None:
+    """prefs / 分发变更后使 routing 缓存失效。"""
+    global _routing_epoch
+    _routing_epoch += 1
 
 
 def _team_ctx():
@@ -269,13 +282,14 @@ def _pack_manifest_slots(resp_slots, *, user: str, prefs: dict,
                          skill_dir: Path, db_path: Optional[Path],
                          registry) -> list[dict]:
     """把 SyncResponse.slots 打成看板行（含 source / pin / my_triggers）。"""
+    from xskill.canary import staging_sha
+    from xskill.events import skill_main_producers
     trigger_by_skill = {
         r["skill"]: int(r.get("triggers") or 0)
         for r in reco_trigger_for_users(
             db_path=db_path, skill_dir=Path(skill_dir),
             registry=registry).get(user, [])
     }
-    from xskill.events import skill_main_producers
     native_names = []
     slot_srcs = []
     for s in resp_slots:
@@ -284,9 +298,21 @@ def _pack_manifest_slots(resp_slots, *, user: str, prefs: dict,
         if src["source"] == "native":
             native_names.append(s.skill_name)
     producers = skill_main_producers(native_names, db_path=db_path)
+    has_stg: dict[str, bool] = {}
+    root = Path(skill_dir)
+
+    def _side_mutable(name: str, source: str) -> bool:
+        if source != "native":
+            return False
+        if name not in has_stg:
+            path = root / name
+            has_stg[name] = bool(path.is_dir() and staging_sha(path))
+        return has_stg[name]
+
     slots = []
     for i, (s, src) in enumerate(zip(resp_slots, slot_srcs), start=1):
         meta = prefs["pin_meta"].get(s.skill_name, {})
+        side_ov = (prefs.get("side") or {}).get(s.skill_name)
         row = {
             "skill_name": s.skill_name, "side": s.side, "sha": s.sha,
             "bucket": s.bucket,
@@ -295,6 +321,8 @@ def _pack_manifest_slots(resp_slots, *, user: str, prefs: dict,
             "my_triggers": trigger_by_skill.get(s.skill_name, 0),
             "pin_scope": meta.get("scope", ""),
             "pin_set_by": meta.get("set_by", ""),
+            "overridden": bool(side_ov),
+            "side_mutable": _side_mutable(s.skill_name, src["source"]),
             "user_removable": (
                 s.bucket != "pinned" or meta.get("set_by") == user),
             "rank": i,
@@ -307,6 +335,29 @@ def _pack_manifest_slots(resp_slots, *, user: str, prefs: dict,
                 row["producer_trajs"] = prod["traj_count"]
         slots.append(row)
     return slots
+
+
+def _manifest_slots_for_user(ctx, *, user: str,
+                             db_path: Optional[Path]) -> list[dict]:
+    """为任意 user 现算并打包当前推送槽位（与 /my/manifest 同源）。"""
+    from xskill.team.server.api import live_manifest_tuning
+    from xskill.team.server.skill_manifest import build_manifest
+    prefs = effective_prefs(user, db_path=db_path)
+    client_id = ctx.client_registry.find_by_user_name(user) or user
+    total_slots, ranked_slots, probability = live_manifest_tuning()
+    resp = build_manifest(
+        client_id=client_id,
+        skill_dir=ctx.skill_dir,
+        probability=probability,
+        ranked_slots=ranked_slots,
+        total_slots=total_slots,
+        traj_root=ctx.traj_root,
+        prefs=prefs,
+        retired=retired_skills(db_path=db_path),
+    )
+    return _pack_manifest_slots(
+        resp.slots, user=user, prefs=prefs, skill_dir=ctx.skill_dir,
+        db_path=db_path, registry=ctx.client_registry)
 
 
 def _user_upload_dirs(user: str, ctx) -> list[tuple[str, Path]]:
@@ -438,12 +489,13 @@ def _commit_status_for_push(ev: dict, *, skill_dir: Path,
 # 请求模型
 # ---------------------------------------------------------------------------
 
-PrefAction = Literal["pin", "block", "clear"]
+PrefAction = Literal["pin", "block", "clear", "clear_side"]
 
 
 class MyPrefRequest(BaseModel):
     skill_name: str
     action: PrefAction
+    side: Optional[str] = None  # pin 时可钉 main|staging
 
 
 class MySettingsRequest(BaseModel):
@@ -456,6 +508,7 @@ class AdminPrefRequest(BaseModel):
     user_key: str          # user_name 或 '*global*'
     skill_name: str
     action: PrefAction
+    side: Optional[str] = None  # pin 时可钉 main|staging
 
 
 class DeleteSkillRequest(BaseModel):
@@ -528,6 +581,126 @@ def _team_change_is_hot_only(old_cfg: dict, new_cfg: dict) -> bool:
         old_server.pop(key, None)
         new_server.pop(key, None)
     return old_server == new_server
+
+
+def _normalize_pref_side(side: Optional[str]) -> Optional[str]:
+    """校验 prefs.side；``None`` 原样返回（表示不改）。"""
+    if side is None:
+        return None
+    s = str(side).strip()
+    if s not in ("", "main", "staging"):
+        raise HTTPException(
+            status_code=400, detail="side 必须是 main|staging 或空串")
+    return s
+
+
+def _skill_routing_table(ctx, *, skill_name: str, db_path: Optional[Path]) -> dict:
+    """现算某 skill 对所有已注册 client 的推送路由（与 /sync 同源 build_manifest）。"""
+    from xskill.canary import main_sha, pick_side, staging_sha
+    from xskill.team.server.api import live_manifest_tuning
+    from xskill.team.server.skill_manifest import build_manifest
+
+    skill_path = Path(ctx.skill_dir) / skill_name
+    if not skill_path.is_dir():
+        raise HTTPException(status_code=404, detail="skill not found")
+    m_sha = main_sha(skill_path) or ""
+    s_sha = staging_sha(skill_path)
+    has_staging = bool(s_sha)
+    total_slots, ranked_slots, probability = live_manifest_tuning()
+    retired = retired_skills(db_path=db_path)
+    users: list[dict] = []
+    for client in ctx.client_registry.list():
+        client_id = client["client_id"]
+        user = (client.get("user_name") or "").strip() or client_id
+        prefs = effective_prefs(user, db_path=db_path)
+        resp = build_manifest(
+            client_id=client_id,
+            skill_dir=ctx.skill_dir,
+            probability=probability,
+            ranked_slots=ranked_slots,
+            total_slots=total_slots,
+            traj_root=ctx.traj_root,
+            prefs=prefs,
+            retired=retired,
+        )
+        hit = next(
+            (s for s in resp.slots if s.skill_name == skill_name), None)
+        side_ov = (prefs.get("side") or {}).get(skill_name)
+        pinned = skill_name in (prefs.get("pin_meta") or {})
+        if hit is not None:
+            users.append({
+                "user": user,
+                "client_id": client_id,
+                "in_manifest": True,
+                "bucket": hit.bucket,
+                "side": hit.side or "main",
+                "sha": hit.sha or "",
+                "overridden": bool(side_ov),
+                "pinned": pinned or hit.bucket == "pinned",
+            })
+            continue
+        would = "main"
+        if has_staging:
+            would = side_ov if side_ov in ("main", "staging") else pick_side(
+                client_id, skill_name, probability)
+        sha = (s_sha if would == "staging" and s_sha else m_sha) or ""
+        users.append({
+            "user": user,
+            "client_id": client_id,
+            "in_manifest": False,
+            "bucket": None,
+            "side": would,
+            "sha": sha,
+            "overridden": bool(side_ov),
+            "pinned": pinned,
+        })
+    staging_n = sum(
+        1 for u in users if u["in_manifest"] and u["side"] == "staging")
+    main_n = sum(
+        1 for u in users if u["in_manifest"] and u["side"] != "staging")
+    out_n = sum(1 for u in users if not u["in_manifest"])
+    return {
+        "skill": skill_name,
+        "has_staging": has_staging,
+        "counts": {
+            "staging": staging_n,
+            "main": main_n,
+            "out": out_n,
+            "in_manifest": staging_n + main_n,
+            "users": len(users),
+        },
+        "page_size_default": 8,
+        "users": users,
+    }
+
+
+def _cached_skill_routing(ctx, *, skill_name: str,
+                          db_path: Optional[Path]) -> dict:
+    key = (str(db_path or ""), str(ctx.skill_dir), skill_name,
+           len(ctx.client_registry.list()), _routing_epoch)
+    return _routing_cache.get_or_build(
+        key,
+        lambda: _skill_routing_table(
+            ctx, skill_name=skill_name, db_path=db_path),
+    )
+
+
+def _filter_routing_users(users: list[dict], *, filter_name: str,
+                          q: str) -> list[dict]:
+    qn = (q or "").strip().lower()
+    if qn:
+        return [u for u in users if qn in (u.get("user") or "").lower()]
+    if filter_name == "staging":
+        return [u for u in users
+                if u.get("in_manifest") and u.get("side") == "staging"]
+    if filter_name == "main":
+        return [u for u in users
+                if u.get("in_manifest") and u.get("side") != "staging"]
+    if filter_name == "out":
+        return [u for u in users if not u.get("in_manifest")]
+    if filter_name == "all":
+        return list(users)
+    return [u for u in users if u.get("in_manifest")]
 
 
 # ---------------------------------------------------------------------------
@@ -647,22 +820,31 @@ def build_console_router(db_path: Optional[Path] = None) -> APIRouter:
         gprefs = {r["skill_name"]: r for r in
                   prefs_for(GLOBAL_PREF_KEY, db_path=db_path)}
         if req.skill_name in gprefs and gprefs[req.skill_name]["pref"] == "pinned" \
-                and req.action in ("block", "clear"):
+                and req.action in ("block", "clear", "clear_side"):
             raise HTTPException(
                 status_code=403, detail="全局 pin 的条目普通用户不可取消/屏蔽")
         if req.action == "clear":
             if not clear_skill_pref(user_key=user, skill_name=req.skill_name,
                                     db_path=db_path):
                 raise HTTPException(status_code=404, detail="没有这条偏好")
+            _bump_routing_epoch()
             return {"ok": True}
+        if req.action == "clear_side":
+            if not clear_skill_pref_side(
+                    user_key=user, skill_name=req.skill_name, db_path=db_path):
+                raise HTTPException(status_code=404, detail="没有这条偏好")
+            _bump_routing_epoch()
+            return {"ok": True}
+        side = _normalize_pref_side(req.side)
         pref = "pinned" if req.action == "pin" else "blocked"
         try:
             set_skill_pref(user_key=user, skill_name=req.skill_name, pref=pref,
-                           set_by=user,
+                           set_by=user, side=side,
                            max_pinned=_total_slots(), db_path=db_path)
         except PinQuotaExceeded as e:
             # D8/2.4d:超量在写入侧拒绝——409 冲突,永不进 sync 路径
             raise HTTPException(status_code=409, detail=str(e)) from e
+        _bump_routing_epoch()
         if req.action == "pin":
             _emit_pin_event(db_path, actor=user, skill=req.skill_name,
                             target_user=user, scope="user")
@@ -955,11 +1137,12 @@ def build_console_router(db_path: Optional[Path] = None) -> APIRouter:
 
     @router.get("/admin/users-matrix")
     def admin_users_matrix(_=Depends(require_admin)):
-        """用户 × 推送/配置矩阵：被推荐数/pinned·blocked 计数/触发率。
+        """用户 × 推送/配置矩阵：当前推送槽 / 灰度槽 / pinned·blocked / 触发率。
 
         偏好走 ``manifest_control_plane_snapshot`` 一次性取全表再按 user_key 分组
         （口径同 ``prefs_for``：只算该用户自己的行，全局行单独出 global_pinned），
-        不再每个用户各查一次库（N+1）。
+        不再每个用户各查一次库（N+1）。``current_slots`` / ``staging_slots`` 与
+        /sync 同源现算。
         """
         ctx = _require_team_ctx()
         table = reco_trigger_for_users(
@@ -977,6 +1160,7 @@ def build_console_router(db_path: Optional[Path] = None) -> APIRouter:
             rt = table.get(user, [])
             n_exp = sum(r["exposures"] for r in rt)
             n_trig = sum(r["triggers"] for r in rt)
+            slots = _manifest_slots_for_user(ctx, user=user, db_path=db_path)
             rows.append({
                 "client_id": client["client_id"],
                 "user": user,
@@ -988,6 +1172,9 @@ def build_console_router(db_path: Optional[Path] = None) -> APIRouter:
                 "ingest_pause_reason": client.get("ingest_pause_reason") or "",
                 "exposures": n_exp,
                 "triggers": n_trig,
+                "current_slots": len(slots),
+                "staging_slots": sum(
+                    1 for s in slots if (s.get("side") or "main") == "staging"),
                 "rate": round(n_trig / n_exp, 3) if n_exp else None,
                 "pinned": sum(1 for p in prefs.values() if p == "pinned"),
                 "blocked": sum(1 for p in prefs.values() if p == "blocked"),
@@ -998,7 +1185,20 @@ def build_console_router(db_path: Optional[Path] = None) -> APIRouter:
         global_pins = [pref_row["skill_name"] for pref_row in snapshot["prefs"]
                        if pref_row["user_key"] == GLOBAL_PREF_KEY
                        and pref_row["pref"] == "pinned"]
-        return {"users": rows, "global_pinned": global_pins}
+        return {
+            "users": rows,
+            "global_pinned": global_pins,
+            "total_users": len(rows),
+        }
+
+    @router.get("/admin/user/{user_key}/assignment")
+    def admin_user_assignment(user_key: str, _=Depends(require_admin)):
+        """管理抽屉：某用户当前推送槽位（与 /my/manifest 同源现算）。"""
+        ctx = _require_team_ctx()
+        if not user_key:
+            raise HTTPException(status_code=400, detail="user_key required")
+        slots = _manifest_slots_for_user(ctx, user=user_key, db_path=db_path)
+        return {"user": user_key, "slots": slots}
 
     @router.put("/admin/client/{client_id}/ingest")
     def admin_client_ingest(
@@ -1068,20 +1268,86 @@ def build_console_router(db_path: Optional[Path] = None) -> APIRouter:
             if not clear_skill_pref(user_key=req.user_key,
                                     skill_name=req.skill_name, db_path=db_path):
                 raise HTTPException(status_code=404, detail="没有这条偏好")
+            _bump_routing_epoch()
             return {"ok": True}
+        if req.action == "clear_side":
+            if not clear_skill_pref_side(
+                    user_key=req.user_key, skill_name=req.skill_name,
+                    db_path=db_path):
+                raise HTTPException(status_code=404, detail="没有这条偏好")
+            _bump_routing_epoch()
+            return {"ok": True}
+        side = _normalize_pref_side(req.side)
         pref = "pinned" if req.action == "pin" else "blocked"
         try:
             set_skill_pref(user_key=req.user_key, skill_name=req.skill_name,
-                           pref=pref, set_by=ident["user"],
+                           pref=pref, set_by=ident["user"], side=side,
                            max_pinned=_total_slots(), db_path=db_path)
         except PinQuotaExceeded as e:
             raise HTTPException(status_code=409, detail=str(e)) from e
+        _bump_routing_epoch()
         if req.action == "pin":
             _emit_pin_event(
                 db_path, actor=ident["user"], skill=req.skill_name,
                 target_user=req.user_key,
                 scope="global" if req.user_key == GLOBAL_PREF_KEY else "admin")
         return {"ok": True}
+
+    @router.get("/skill/{name}/routing")
+    def skill_routing(name: str, _=Depends(require_user)):
+        """技能详情「当前推送对象」元信息：counts + has_staging（不含全量用户）。"""
+        ctx = _require_team_ctx()
+        table = _cached_skill_routing(ctx, skill_name=name, db_path=db_path)
+        return {
+            "skill": table["skill"],
+            "has_staging": table["has_staging"],
+            "counts": table["counts"],
+            "page_size_default": table["page_size_default"],
+        }
+
+    @router.get("/skill/{name}/routing/users")
+    def skill_routing_users(
+        name: str,
+        q: str = "",
+        filter: str = "in",
+        limit: int = 8,
+        offset: int = 0,
+        _=Depends(require_user),
+    ):
+        """分页 / typeahead 检索某 skill 的推送用户。"""
+        ctx = _require_team_ctx()
+        table = _cached_skill_routing(ctx, skill_name=name, db_path=db_path)
+        lim = max(1, min(50, int(limit or 8)))
+        off = max(0, int(offset or 0))
+        qn = (q or "").strip()
+        filtered = _filter_routing_users(
+            table["users"], filter_name=filter or "in", q=qn)
+        if qn:
+            hits = filtered[:lim]
+            return {
+                "skill": name, "q": qn, "users": hits,
+                "total": len(hits), "truncated": True,
+            }
+        page = filtered[off:off + lim]
+        return {
+            "skill": name,
+            "filter": filter or "in",
+            "users": page,
+            "total": len(filtered),
+            "offset": off,
+            "limit": lim,
+            "has_more": off + lim < len(filtered),
+        }
+
+    @router.get("/skill/{name}/routing/user/{user}")
+    def skill_routing_user(name: str, user: str, _=Depends(require_user)):
+        """单用户对该 skill 的路由行。"""
+        ctx = _require_team_ctx()
+        table = _cached_skill_routing(ctx, skill_name=name, db_path=db_path)
+        for row in table["users"]:
+            if row.get("user") == user:
+                return {"skill": name, **row}
+        raise HTTPException(status_code=404, detail="user not found")
 
     @router.get("/admin/cluster-graph")
     def admin_cluster_graph(_=Depends(require_admin)):

--- a/src/xskill/dashboard/metrics.py
+++ b/src/xskill/dashboard/metrics.py
@@ -467,10 +467,11 @@ def skills_catalog(skill_dir: Path, skillhub=None, *, db_path=None) -> list[dict
 
 def skills_catalog_page(skill_dir: Path, skillhub=None, *,
                         limit: int = 0, offset: int = 0,
-                        name: str = "", db_path=None) -> dict:
+                        name: str = "", q: str = "", db_path=None) -> dict:
     """分页读取技能清单（查投影表，不扫盘）。
 
     - ``name`` 非空：精确匹配该名字。
+    - ``q`` 非空：name/description 子串模糊。
     - ``limit`` > 0：返回 ``[offset:offset+limit]``。
     - 否则：返回 ``[offset:]``（``limit=0`` 向后兼容）。
 
@@ -479,7 +480,7 @@ def skills_catalog_page(skill_dir: Path, skillhub=None, *,
     from xskill.skill.catalog_store import page_skills_catalog
     return page_skills_catalog(
         skill_dir, skillhub=skillhub,
-        limit=limit, offset=offset, name=name, db_path=db_path,
+        limit=limit, offset=offset, name=name, q=q, db_path=db_path,
     )
 
 

--- a/src/xskill/dashboard/router.py
+++ b/src/xskill/dashboard/router.py
@@ -142,7 +142,8 @@ def build_dashboard_router(db_path: Optional[Path] = None, *,
         return {"tags": tag_rows}
 
     @router.get("/api/v1/dashboard/skills")
-    def skills(limit: int = 0, offset: int = 0, name: str = "") -> dict:
+    def skills(limit: int = 0, offset: int = 0, name: str = "",
+               q: str = "") -> dict:
         """skill 库存清单(分析式：读 skill 目录,不依赖埋点)。
 
         自产 git 技能标 ``source="native"``；skillhub 三方技能（启用时）合入
@@ -151,13 +152,14 @@ def build_dashboard_router(db_path: Optional[Path] = None, *,
 
         **分页**(海量 skill,如 1 万条,别让前端一次性拉全量炸锅):``limit``>0 时只返回
         ``skills[offset:offset+limit]`` 这一页;``limit``=0(默认)返回全部,向后兼容。
-        ``total`` / ``by_state`` 始终按**全量**统计(概览计数准确),``skills`` 只含当前页。
+        ``by_state`` 始终按**全量**统计(概览计数准确)；有 ``q``/``name`` 时
+        ``total`` 为过滤后条数，``skills`` 只含当前页。
         列表读 ``skills_catalog`` 投影表（写出口 UPSERT；冷启动对该 root 一次性
         backfill），翻页不再扫盘。
         """
         page = skills_catalog_page(
             skill_dir, skillhub=_build_skillhub(),
-            limit=limit, offset=offset, name=name, db_path=db_path)
+            limit=limit, offset=offset, name=name, q=q, db_path=db_path)
         if expose_sensitive:
             return page
         for index, row in enumerate(page["skills"]):

--- a/src/xskill/dashboard/static/app.js
+++ b/src/xskill/dashboard/static/app.js
@@ -185,14 +185,24 @@ const sourceBadge = s => s.source === 'skillhub'
 
 // 海量 skill(如 1 万条)分页:一次只拉/渲一页,别让前端一次性渲 1 万行 DOM 炸锅。
 let skillsPage = 0;
-const SKILLS_PAGE_SIZE = 100;
+let skillsQ = '';
+let _skillsQTimer = null;
+const SKILLS_PAGE_SIZE = 10;
 
 async function loadSkills() {
   const off = skillsPage * SKILLS_PAGE_SIZE;
-  const d = await jc(`api/v1/dashboard/skills?limit=${SKILLS_PAGE_SIZE}&offset=${off}`);
+  const qEl = document.getElementById('skills-q');
+  if (qEl && qEl.value !== skillsQ) skillsQ = qEl.value;
+  const q = (skillsQ || '').trim();
+  const sp = new URLSearchParams({
+    limit: String(SKILLS_PAGE_SIZE),
+    offset: String(off),
+  });
+  if (q) sp.set('q', q);
+  const d = await jc(`api/v1/dashboard/skills?${sp}`);
   const bs = d.by_state || {};
   const parts = Object.keys(bs).sort().map(k => `${k} ${bs[k]}`).join(' · ');
-  put('skills.summary', `共 ${d.total} 个${parts ? ' · ' + parts : ''}`);
+  put('skills.summary', `${q ? '匹配' : '共'} ${d.total} 个${parts ? ' · ' + parts : ''}`);
   rows('skills-body', (d.skills || []).map(s =>
     `<tr class="hover:bg-slate-50 cursor-pointer" data-skill-row="${esc(s.name)}">`
     + `<td class="py-2.5 font-medium text-teal-700">${esc(s.name)}${sourceBadge(s)}</td>`
@@ -200,7 +210,7 @@ async function loadSkills() {
     + `<td class="text-slate-500 max-w-[480px] truncate" title="${esc(s.description)}">${esc(s.description) || '—'}</td>`
     + `<td class="text-right tabular-nums">v${esc(s.version)}</td>`
     + `<td class="text-right tabular-nums">${s.candidates || 0}</td></tr>`).join(''),
-    '技能库还是空的');
+    q ? '无匹配技能' : '技能库还是空的');
   renderSkillsPager(d.total || 0);
 }
 
@@ -280,9 +290,9 @@ function renderGraph(g) {
     }
     const rej = (n.lanes || []).includes('rejected') && n.decision !== 'rejected'
       ? ' <span class="px-1.5 py-0.5 rounded bg-rose-50 text-rose-600 text-[10px]">rejected</span>' : '';
-    return `<div class="h-12 flex items-center justify-between gap-2 rounded-lg px-2 -mx-2 cursor-pointer hover:bg-slate-50 ${rowCls}" data-gnode="${esc(n.sha)}">
+    return `<div class="h-12 flex items-center justify-between gap-2 rounded-lg px-2 -mx-2 cursor-pointer hover:bg-slate-50 ${rowCls}" data-gnode="${esc(n.sha)}" data-gside="${n.is_head_staging ? 'staging' : (n.is_head_main ? 'main' : '')}">
       <div class="min-w-0"><div class="font-medium truncate">${esc(n.subject) || '(无提交说明)'}${rej}</div>
-        <div class="text-[11px] ${subCls}">${esc(sub)}</div></div>
+        <div class="text-[11px] ${subCls}">${esc(sub)}${n.is_head_staging ? ' · 点击看推送给谁' : (n.is_head_main ? ' · 点击看推送给谁' : '')}</div></div>
       <code class="text-[11px] text-slate-400 shrink-0">${esc(n.sha.slice(0, 7))}</code></div>`;
   }).join('');
   const unloc = (g.decisions_unlocated || []).length;
@@ -290,7 +300,7 @@ function renderGraph(g) {
     <div class="flex gap-4 mt-3 pt-3 border-t border-slate-100 text-[11px] text-slate-500 flex-wrap">
       <span class="flex items-center gap-1.5"><span class="w-2.5 h-2.5 rounded-full bg-emerald-500"></span>晋升</span>
       <span class="flex items-center gap-1.5"><span class="w-2.5 h-2.5 rounded-full bg-rose-500"></span>回滚</span>
-      <span class="flex items-center gap-1.5"><span class="w-2.5 h-2.5 rounded-full bg-amber-400"></span>观察中</span>
+      <span class="flex items-center gap-1.5"><span class="w-2.5 h-2.5 rounded-full bg-amber-400"></span>观察中（点黄点看推送对象）</span>
       <span class="flex items-center gap-1.5"><span class="w-2.5 h-2.5 rounded-full bg-white ring-2 ring-slate-300"></span>普通提交</span>
       ${(g.nodes || []).length > 30 ? '<span class="text-slate-400">仅显示最近 30 个节点</span>' : ''}
     </div>
@@ -481,17 +491,16 @@ async function openSkill(name) {
       <div class="flex gap-2">${headChips}</div>
     </div>
 
-    <div id="skill-routing" class="mt-4 hidden"></div>
-
     <div class="grid grid-cols-12 gap-4 mt-4">
       <div class="col-span-12 lg:col-span-5 rounded-2xl ring-1 ring-slate-200 p-5">
         <div class="flex items-baseline justify-between">
           <h3 class="font-semibold text-sm">进化路径</h3>
-          <span class="text-[11px] text-slate-400">点击节点查看该版本 diff</span>
+          <span class="text-[11px] text-slate-400">点黄点 / main HEAD 看推送给谁；其它节点看 diff</span>
         </div>
         ${g ? renderGraph(g) : '<div class="text-slate-400 text-xs mt-3">非 git 仓，暂无进化路径</div>'}
       </div>
       <div class="col-span-12 lg:col-span-7 space-y-4">
+        <div id="skill-routing" class="hidden"></div>
         <div class="rounded-2xl ring-1 ring-slate-200 p-5">
           <h3 class="font-semibold text-sm">得分趋势 <span class="font-normal text-[11px] text-slate-400 ml-2">ux 日均 · 悬停节点看当日样本数</span></h3>
           ${renderDual(daily)}
@@ -545,63 +554,310 @@ async function openSkill(name) {
   loadSkillRouting(name).catch(console.error);
 }
 
-async function loadSkillRouting(name) {
+const ROUTE_PAGE_SIZE = 6;
+function _routeColState() {
+  return { page: 0, users: [], total: 0, seq: 0 };
+}
+let _routeState = {
+  skill: null, meta: null, focusSide: null,
+  cols: { staging: _routeColState(), main: _routeColState() },
+  q: '', suggest: [], suggestSeq: 0,
+};
+let _routeSuggestTimer = null;
+
+function _routeUsersUrl(extra) {
+  const sp = new URLSearchParams(extra);
+  return 'api/v1/dashboard/skill/' + encodeURIComponent(_routeState.skill) + '/routing/users?' + sp.toString();
+}
+
+function _routePushPill(u) {
+  return u.in_manifest
+    ? `<span class="text-[10px] px-1.5 py-0.5 rounded bg-emerald-50 text-emerald-700 ring-1 ring-emerald-100 shrink-0">推送</span>`
+    : `<span class="text-[10px] px-1.5 py-0.5 rounded bg-slate-100 text-slate-500 ring-1 ring-slate-200 shrink-0">未推送</span>`;
+}
+
+function _routeCanEdit(user) {
+  if (!IDENT) return false;
+  if (IDENT.role === 'admin') return true;
+  return IDENT.user === user;
+}
+
+function _routeUserRowHtml(u) {
+  const skill = _routeState.skill || '';
+  const hasStaging = !!(_routeState.meta && _routeState.meta.has_staging);
+  const curSide = u.side || 'main';
+  const canEdit = _routeCanEdit(u.user);
+  let sideCtl;
+  if (hasStaging && canEdit) {
+    const sideBtn = (side, label) => {
+      const on = curSide === side;
+      return `<button type="button" class="route-row-side px-1.5 py-0.5 ${on ? (side === 'staging' ? 'bg-amber-400 text-white' : 'bg-teal-600 text-white') : 'bg-white text-slate-500 hover:bg-slate-50'}"
+        data-user="${esc(u.user)}" data-side="${side}" data-skill="${esc(skill)}" title="pin 到 ${label}">${label}</button>`;
+    };
+    sideCtl = `<div class="inline-flex rounded-md ring-1 ring-slate-200 overflow-hidden text-[10px]">${sideBtn('main', 'main')}${sideBtn('staging', 'staging')}</div>`;
+  } else if (hasStaging) {
+    sideCtl = `<span class="text-[10px] px-1.5 py-0.5 rounded-md ${curSide === 'staging' ? 'bg-amber-50 text-amber-700 ring-1 ring-amber-200' : 'bg-slate-100 text-slate-500'}">${esc(curSide)}</span>`;
+  } else {
+    sideCtl = `<span class="text-[10px] text-slate-400 px-1">main</span>`;
+  }
+  const starCls = !u.pinned
+    ? 'text-slate-300' + (canEdit ? ' hover:text-amber-300' : '')
+    : (u.overridden ? 'text-violet-500' + (canEdit ? ' hover:text-violet-600' : '') : 'text-amber-400' + (canEdit ? ' hover:text-amber-500' : ''));
+  const starSvg = u.pinned
+    ? `<svg width="16" height="16" viewBox="0 0 16 16" fill="currentColor" aria-hidden="true"><path d="M8 1.2l1.76 3.56 3.93.57-2.84 2.77.67 3.91L8 10.16l-3.52 1.85.67-3.91L2.3 5.33l3.93-.57L8 1.2z"/></svg>`
+    : `<svg width="16" height="16" viewBox="0 0 16 16" fill="none" stroke="currentColor" stroke-width="1.4" aria-hidden="true"><path d="M8 1.2l1.76 3.56 3.93.57-2.84 2.77.67 3.91L8 10.16l-3.52 1.85.67-3.91L2.3 5.33l3.93-.57L8 1.2z"/></svg>`;
+  let starBtn;
+  if (!canEdit) {
+    starBtn = `<span class="inline-flex items-center justify-center w-7 h-7 ${starCls} opacity-70" title="${u.pinned ? '已 pin（只读）' : '未 pin（只读）'}">${starSvg}</span>`;
+  } else if (u.pinned) {
+    starBtn = `<button type="button" class="route-row-unpin inline-flex items-center justify-center w-7 h-7 rounded-md hover:bg-slate-50 ${starCls}"
+        data-user="${esc(u.user)}" data-skill="${esc(skill)}" title="已 pin · 点击取消" aria-label="取消 pin">${starSvg}</button>`;
+  } else {
+    starBtn = `<button type="button" class="route-row-pin inline-flex items-center justify-center w-7 h-7 rounded-md hover:bg-slate-50 ${starCls}"
+        data-user="${esc(u.user)}" data-side="${esc(curSide)}" data-skill="${esc(skill)}" title="未 pin · 点击 pin 到当前 side" aria-label="pin">${starSvg}</button>`;
+  }
+  return `<div class="route-user-row flex items-center gap-2 py-2 border-b border-slate-50 last:border-0" data-user="${esc(u.user)}">
+    ${avatar(u.user, 'sm')}
+    <div class="min-w-0 flex-1">
+      <div class="text-[12.5px] font-medium flex items-center gap-1.5 flex-wrap">
+        <span>${esc(u.user)}</span>
+        ${_routePushPill(u)}
+        ${u.overridden ? '<span class="text-[10px] px-1.5 py-0.5 rounded bg-violet-100 text-violet-700">pinned</span>' : ''}
+      </div>
+      <div class="text-[10.5px] text-slate-400 mt-0.5 flex items-center gap-1.5">
+        ${u.sha ? `<code>${esc(String(u.sha).slice(0, 7))}</code>` : '<span>—</span>'}
+        ${u.in_manifest ? '' : '<span>不在 manifest</span>'}
+      </div>
+    </div>
+    <div class="shrink-0 flex items-center gap-1.5">
+      ${sideCtl}
+      ${starBtn}
+    </div>
+  </div>`;
+}
+
+async function _routePref(user, action, side) {
+  const skill = _routeState.skill;
+  if (!skill || !user) return;
+  if (!_routeCanEdit(user)) {
+    throw new Error('无权配置其他用户：仅管理员可代操作，普通用户只能改自己');
+  }
+  const body = { user_key: user, skill_name: skill, action };
+  if (side) body.side = side;
+  if (IDENT && IDENT.role === 'admin') {
+    await jpost('/api/v1/dashboard/admin/prefs', body);
+  } else {
+    await jpost('/api/v1/dashboard/my/prefs', body);
+  }
+  const sg = document.getElementById('route-suggest');
+  if (sg) { sg.classList.add('hidden'); sg.innerHTML = ''; }
+  await loadSkillRouting(skill, _routeState.focusSide);
+  if (IDENT && IDENT.role === 'admin' && typeof loadAdmin === 'function') {
+    await loadAdmin().catch(() => {});
+  }
+}
+
+function _paintColPager(col) {
+  const st = _routeState.cols[col];
+  if (!st) return;
+  const pages = Math.max(1, Math.ceil(st.total / ROUTE_PAGE_SIZE));
+  const atFirst = st.page <= 0;
+  const atLast = st.page >= pages - 1;
+  const box = document.getElementById('route-pager-' + col);
+  if (!box) return;
+  const mk = (dir, label, disabled, title) =>
+    `<button type="button" data-route-col="${col}" data-route-page="${dir}" title="${title}" ${disabled ? 'disabled' : ''}
+      class="route-page-btn w-6 h-6 inline-flex items-center justify-center rounded-md ring-1 ring-slate-200 text-[11px] leading-none
+      ${disabled ? 'text-slate-300 cursor-not-allowed' : 'text-slate-700 hover:bg-white'}">${label}</button>`;
+  box.innerHTML = `
+    ${mk('up', '▲', atFirst, '上一页')}
+    <span class="text-[10.5px] text-slate-500 tabular-nums px-1">${st.page + 1}/${pages}</span>
+    ${mk('down', '▼', atLast, '下一页')}
+    <span class="text-[10px] text-slate-400 ml-1">${st.total} 人</span>`;
+  box.querySelectorAll('.route-page-btn').forEach(btn => {
+    btn.onclick = (ev) => {
+      ev.preventDefault();
+      ev.stopPropagation();
+      if (btn.disabled) return;
+      _routeGoColPage(col, btn.dataset.routePage === 'up' ? -1 : 1);
+    };
+  });
+}
+
+function _paintColList(col) {
+  const st = _routeState.cols[col];
+  const body = document.getElementById('route-list-' + col);
+  if (!body || !st) return;
+  body.innerHTML = (st.users || []).map(_routeUserRowHtml).join('')
+    || `<div class="text-[11px] text-slate-400 py-3">当前无人被推送此${col === 'staging' ? '灰度' : '主干'}版本</div>`;
+  _paintColPager(col);
+}
+
+function _routeGoColPage(col, delta) {
+  const st = _routeState.cols[col];
+  if (!st) return;
+  const pages = Math.max(1, Math.ceil(st.total / ROUTE_PAGE_SIZE));
+  const next = Math.max(0, Math.min(pages - 1, st.page + delta));
+  if (next === st.page) return;
+  st.page = next;
+  _fetchRouteCol(col).catch(console.error);
+}
+
+async function _fetchRouteCol(col) {
+  if (!_routeState.skill || !_routeState.cols[col]) return;
+  const st = _routeState.cols[col];
+  const seq = ++st.seq;
+  const body = document.getElementById('route-list-' + col);
+  if (body) body.innerHTML = `<div class="text-[11px] text-slate-400 py-3">加载中…</div>`;
+  try {
+    const d = await j(_routeUsersUrl({
+      filter: col,
+      offset: String(st.page * ROUTE_PAGE_SIZE),
+      limit: String(ROUTE_PAGE_SIZE),
+    }));
+    if (seq !== st.seq) return;
+    st.users = d.users || [];
+    st.total = d.total || 0;
+    const pages = Math.max(1, Math.ceil(st.total / ROUTE_PAGE_SIZE));
+    if (st.page >= pages) {
+      st.page = pages - 1;
+      return _fetchRouteCol(col);
+    }
+    _paintColList(col);
+  } catch (err) {
+    if (seq !== st.seq) return;
+    if (body) body.innerHTML = `<div class="text-[11px] text-rose-600 py-3">${esc(err.message)}</div>`;
+  }
+}
+
+async function _fetchRouteCols() {
+  const jobs = [_fetchRouteCol('main')];
+  if (_routeState.meta && _routeState.meta.has_staging) jobs.unshift(_fetchRouteCol('staging'));
+  await Promise.all(jobs);
+}
+
+async function _fetchRouteSuggest(q) {
+  const box = document.getElementById('route-suggest');
+  if (!box || !_routeState.skill) return;
+  q = (q || '').trim();
+  if (q.length < 1) {
+    box.classList.add('hidden');
+    box.innerHTML = '';
+    _routeState.suggest = [];
+    return;
+  }
+  const seq = ++_routeState.suggestSeq;
+  box.classList.remove('hidden');
+  box.innerHTML = `<div class="px-3 py-2 text-[11px] text-slate-400">检索中…</div>`;
+  try {
+    const d = await j(_routeUsersUrl({ q, limit: '8' }));
+    if (seq !== _routeState.suggestSeq) return;
+    _routeState.suggest = d.users || [];
+    if (!_routeState.suggest.length) {
+      box.innerHTML = `<div class="px-3 py-2 text-[11px] text-slate-400">无匹配（最多返回 8 条）</div>`;
+      return;
+    }
+    box.innerHTML = `<div class="px-2">${_routeState.suggest.map(_routeUserRowHtml).join('')}</div>`;
+  } catch (err) {
+    if (seq !== _routeState.suggestSeq) return;
+    box.innerHTML = `<div class="px-3 py-2 text-[11px] text-rose-600">${esc(err.message)}</div>`;
+  }
+}
+
+async function loadSkillRouting(name, focusSide) {
   const box = document.getElementById('skill-routing');
   if (!box) return;
-  let d;
+  let meta;
   try {
-    d = await j('api/v1/dashboard/skill/' + encodeURIComponent(name) + '/routing');
+    meta = await j('api/v1/dashboard/skill/' + encodeURIComponent(name) + '/routing');
   } catch (_e) {
     box.classList.add('hidden');
     box.innerHTML = '';
     return;
   }
-  const stg = d.staging || [];
-  const main = d.main || [];
-  if (!d.has_staging && !stg.length && !main.length) {
-    box.classList.add('hidden');
-    return;
+  const keep = _routeState.skill === name;
+  _routeState.skill = name;
+  _routeState.meta = meta;
+  _routeState.suggest = [];
+  _routeState.focusSide = (focusSide === 'staging' || focusSide === 'main') ? focusSide : null;
+  if (!keep) {
+    _routeState.q = '';
+    _routeState.cols = { staging: _routeColState(), main: _routeColState() };
   }
+  const c = meta.counts || {};
+  const focusCls = (side) => (_routeState.focusSide === side
+    ? (side === 'staging' ? 'ring-2 ring-amber-200 bg-amber-50' : 'ring-2 ring-slate-300 bg-slate-50')
+    : '');
   box.classList.remove('hidden');
-  const row = (u) => `
-    <div class="flex items-center gap-2 py-2 border-b border-slate-50 last:border-0">
-      ${avatar(u.user, 'sm')}
-      <div class="min-w-0 flex-1">
-        <div class="text-[12.5px] font-medium">${esc(u.user)}</div>
-        <div class="text-[10.5px] text-slate-400 flex items-center gap-1.5">
-          <span class="text-[10px] px-1.5 py-0.5 rounded ${BUCKET_CHIP[u.bucket] || 'bg-slate-100 text-slate-500'}">${esc(u.bucket || '')}</span>
-          ${u.sha ? `<code>${esc(String(u.sha).slice(0, 7))}</code>` : ''}
-          ${u.overridden ? '<span class="text-[10px] px-1.5 py-0.5 rounded bg-violet-100 text-violet-700">pin 覆盖</span>' : '<span>pick_side</span>'}
-        </div>
-      </div>
-    </div>`;
   box.innerHTML = `
-    <div class="rounded-2xl ring-1 ring-slate-200 p-5">
+    <div class="rounded-2xl ring-1 ring-slate-200 p-5" id="skill-routing-card" data-skill="${esc(name)}">
       <div class="flex items-baseline justify-between flex-wrap gap-2">
-        <h3 class="font-semibold text-sm">灰度路由</h3>
-        <span class="text-[11px] text-slate-400">${d.has_staging ? 'staging ' + stg.length + ' · main ' + main.length : '无 staging'}</span>
+        <h3 class="font-semibold text-sm">当前推送对象</h3>
+        <span class="text-[11px] text-slate-400">${meta.has_staging
+          ? `staging ${c.staging || 0} · main ${c.main || 0} · manifest ${c.in_manifest || 0}/${c.users || 0}`
+          : `无 staging · 仅 main ${c.main || 0}`}</span>
       </div>
-      <div class="grid grid-cols-1 md:grid-cols-2 gap-4 mt-3">
-        <div>
-          <div class="text-[11px] text-amber-700 font-medium mb-1">staging</div>
-          <div class="rounded-xl ring-1 ring-amber-100 bg-amber-50/40 px-3 max-h-56 overflow-y-auto">${stg.map(row).join('') || '<div class="text-[11px] text-slate-400 py-2">无人</div>'}</div>
-        </div>
-        <div>
-          <div class="text-[11px] text-slate-500 font-medium mb-1">main</div>
-          <div class="rounded-xl ring-1 ring-slate-100 px-3 max-h-56 overflow-y-auto">${main.map(row).join('') || '<div class="text-[11px] text-slate-400 py-2">无人</div>'}</div>
+
+      <div class="mt-3 relative max-w-md">
+        <div class="text-[11px] text-slate-400 mb-1">检索用户 <span class="text-slate-300">· ${
+          IDENT && IDENT.role === 'admin'
+            ? '管理员可代 pin / 配 side · ≤8'
+            : '仅可配置自己 · 他人只读 · ≤8'
+        }</span></div>
+        <input id="route-user-q" value="${esc(_routeState.q)}" autocomplete="off" placeholder="输入关键字，如 alice / user-0"
+          class="w-full ring-1 ring-slate-200 rounded-lg px-2.5 py-1.5 text-[12.5px] outline-none focus:ring-teal-500 bg-white">
+        <div id="route-suggest" class="hidden absolute z-20 left-0 right-0 mt-1 bg-white rounded-xl ring-1 ring-slate-200 shadow-lg max-h-72 overflow-y-auto"></div>
+      </div>
+
+      <div class="grid grid-cols-1 ${meta.has_staging ? 'md:grid-cols-2' : ''} gap-4 mt-4">
+        ${meta.has_staging ? `<div id="route-panel-staging" class="rounded-xl p-1 ${focusCls('staging')}">
+          <div class="flex items-center justify-between gap-2 px-2 mb-1">
+            <div class="text-[11px] font-medium text-slate-600 flex items-center gap-1.5">
+              <span class="inline-flex items-center gap-1 px-1.5 py-0.5 rounded-md bg-amber-50 text-amber-700 ring-1 ring-amber-200">
+                <span class="w-1.5 h-1.5 rounded-full bg-amber-400"></span>staging
+              </span>
+              <span>灰度版推送给</span>
+            </div>
+            <div id="route-pager-staging" class="flex items-center"></div>
+          </div>
+          <div id="route-list-staging" class="rounded-xl ring-1 ring-amber-200 bg-amber-50 px-3 min-h-[8rem]"></div>
+        </div>` : ''}
+        <div id="route-panel-main" class="rounded-xl p-1 ${focusCls('main')}">
+          <div class="flex items-center justify-between gap-2 px-2 mb-1">
+            <div class="text-[11px] font-medium text-slate-600 flex items-center gap-1.5">
+              <span class="inline-flex items-center px-1.5 py-0.5 rounded-md bg-slate-100 text-slate-600 ring-1 ring-slate-200">main</span>
+              <span>主干版推送给</span>
+            </div>
+            <div id="route-pager-main" class="flex items-center"></div>
+          </div>
+          <div id="route-list-main" class="rounded-xl ring-1 ring-slate-200 bg-white px-3 min-h-[8rem]"></div>
         </div>
       </div>
-      ${d.has_staging ? `<div class="mt-3 pt-3 border-t border-slate-100 flex flex-wrap items-end gap-2">
-        <div><div class="text-[11px] text-slate-400 mb-1">强制路由</div>
-          <select id="route-user" class="ring-1 ring-slate-200 rounded-lg px-2 py-1 text-[12px] outline-none focus:ring-teal-500">${[...stg, ...main].map(u => `<option value="${esc(u.user)}">${esc(u.user)}</option>`).join('')}</select></div>
-        <div class="inline-flex rounded-lg ring-1 ring-slate-200 overflow-hidden text-[11px]" id="route-side">
-          <button type="button" data-side="main" class="route-side-btn px-2.5 py-1 bg-teal-600 text-white">main</button>
-          <button type="button" data-side="staging" class="route-side-btn px-2.5 py-1 bg-white text-slate-500 hover:bg-slate-50">staging</button>
-        </div>
-        <button id="route-pin" class="px-2.5 py-1 rounded-lg bg-teal-600 hover:bg-teal-700 text-white text-[11px]" data-skill="${esc(name)}">pin 到该版本</button>
-        <button id="route-clear" class="px-2.5 py-1 rounded-lg ring-1 ring-slate-200 hover:bg-slate-50 text-[11px]" data-skill="${esc(name)}">清除覆盖</button>
-      </div>` : ''}
     </div>`;
+  await _fetchRouteCols();
+  if (_routeState.focusSide) {
+    const panel = document.getElementById('route-panel-' + _routeState.focusSide);
+    if (panel) panel.scrollIntoView({ behavior: 'smooth', block: 'nearest' });
+  }
+  const qEl = document.getElementById('route-user-q');
+  if (qEl) {
+    qEl.oninput = () => {
+      _routeState.q = qEl.value;
+      clearTimeout(_routeSuggestTimer);
+      _routeSuggestTimer = setTimeout(() => _fetchRouteSuggest(_routeState.q), 180);
+    };
+    qEl.onkeydown = (ev) => {
+      if (ev.key === 'Escape') {
+        const sg = document.getElementById('route-suggest');
+        if (sg) { sg.classList.add('hidden'); sg.innerHTML = ''; }
+      }
+    };
+  }
+}
+
+function focusSkillRouting(side) {
+  if (!_curSkill) return;
+  loadSkillRouting(_curSkill, side).catch(console.error);
 }
 
 // 三方(skillhub)技能详情：无 git / 无灰度 staging / 无进化路径，只有按
@@ -1294,6 +1550,10 @@ document.addEventListener('click', async e => {
   if (step && _curTraj) { openAtom(_curTraj, step.dataset.atom).catch(console.error); return; }
   const gn = e.target.closest('[data-gnode]');
   if (gn && _curSkill) {
+    const side = gn.dataset.gside;
+    if (side === 'staging' || side === 'main') {
+      focusSkillRouting(side);
+    }
     const pv = document.getElementById('skill-preview');
     if (pv) {
       pv.innerHTML = '<span class="text-slate-400 text-xs">加载 diff…</span>';
@@ -1301,7 +1561,9 @@ document.addEventListener('click', async e => {
         const r = await j('api/v1/dashboard/skill/' + encodeURIComponent(_curSkill) + '/diff?sha=' + encodeURIComponent(gn.dataset.gnode));
         pv.innerHTML = renderDiff(r.diff);
       } catch (err) { pv.innerHTML = `<span class="text-rose-600 text-xs">${esc(err.message)}</span>`; }
-      pv.scrollIntoView({ behavior: 'smooth', block: 'nearest' });
+      if (!(side === 'staging' || side === 'main')) {
+        pv.scrollIntoView({ behavior: 'smooth', block: 'nearest' });
+      }
     }
     return;
   }
@@ -1356,15 +1618,17 @@ document.getElementById('traj-input').addEventListener('keydown', e => {
   if (e.key === 'Enter') document.getElementById('traj-open').click();
 });
 
+// ═════════════ P2:登录/角色 + 我的/管理/设置 ═════════════
+// IDENT 必须在 route()/启动加载之前声明：route() 会同步读 IDENT 决定默认页，
+// 若 let 还在暂时性死区会抛错，后面的 loadSkills 等整段启动逻辑都不会跑。
+let IDENT = null;   // {user, role} | null
+
 // ── 启动：各端点独立加载，单个失败不拖垮整页 ───────────────────
 route();
 for (const f of [loadOverview, loadRates, loadPipeline, loadDomain, loadCost,
   loadSkills, loadDirs, loadUsersStatus, loadTags, loadCanary]) {
   f().catch(e => console.error(e));
 }
-
-// ═════════════ P2:登录/角色 + 我的/管理/设置 ═════════════
-let IDENT = null;   // {user, role} | null
 
 async function jpost(u, body, method) {
   const r = await fetch(u, { method: method || 'POST',
@@ -1777,29 +2041,57 @@ let _myServerPushDefault = 100;
 let _myPrefSaving = false;
 let _myPrefSaveTimer = null;
 
+function _myStarSvg(filled) {
+  return filled
+    ? `<svg width="16" height="16" viewBox="0 0 16 16" fill="currentColor" aria-hidden="true"><path d="M8 1.2l1.76 3.56 3.93.57-2.84 2.77.67 3.91L8 10.16l-3.52 1.85.67-3.91L2.3 5.33l3.93-.57L8 1.2z"/></svg>`
+    : `<svg width="16" height="16" viewBox="0 0 16 16" fill="none" stroke="currentColor" stroke-width="1.4" aria-hidden="true"><path d="M8 1.2l1.76 3.56 3.93.57-2.84 2.77.67 3.91L8 10.16l-3.52 1.85.67-3.91L2.3 5.33l3.93-.57L8 1.2z"/></svg>`;
+}
+
 function _mySlotRowHtml(s) {
+  const curSide = s.side || 'main';
   const pinned = s.bucket === 'pinned';
   const locked = pinned && !s.user_removable;
+  const mutable = !!s.side_mutable;
+  let sideCtl;
+  if (mutable && !locked) {
+    const sideBtn = (side, label) => {
+      const on = curSide === side;
+      return `<button type="button" class="my-row-side px-1.5 py-0.5 ${on ? (side === 'staging' ? 'bg-amber-400 text-white' : 'bg-teal-600 text-white') : 'bg-white text-slate-500 hover:bg-slate-50'}"
+        data-skill="${esc(s.skill_name)}" data-side="${side}" title="pin 到 ${label}">${label}</button>`;
+    };
+    sideCtl = `<div class="inline-flex rounded-md ring-1 ring-slate-200 overflow-hidden text-[10px]">${sideBtn('main', 'main')}${sideBtn('staging', 'staging')}</div>`;
+  } else {
+    sideCtl = `<span class="text-[10px] px-1.5 py-0.5 rounded-md ${curSide === 'staging' ? 'bg-amber-50 text-amber-700 ring-1 ring-amber-200' : 'bg-slate-100 text-slate-500'}">${esc(curSide)}</span>`;
+  }
+  let starBtn;
+  if (locked) {
+    starBtn = `<span class="inline-flex items-center justify-center w-7 h-7 text-amber-400 opacity-70" title="admin/全局 pin，不可取消">${_myStarSvg(true)}</span>`;
+  } else if (pinned) {
+    starBtn = `<button type="button" class="my-row-unpin inline-flex items-center justify-center w-7 h-7 rounded-md text-amber-400 hover:text-amber-500 hover:bg-slate-50"
+      data-skill="${esc(s.skill_name)}" title="已 pin · 点击取消" aria-label="取消 pin">${_myStarSvg(true)}</button>`;
+  } else {
+    starBtn = `<button type="button" class="my-row-pin inline-flex items-center justify-center w-7 h-7 rounded-md text-slate-300 hover:text-amber-300 hover:bg-slate-50"
+      data-skill="${esc(s.skill_name)}" data-side="${esc(curSide)}" title="未 pin · 点击 pin 到当前 side" aria-label="pin">${_myStarSvg(false)}</button>`;
+  }
+  const rank = s.rank != null
+    ? `<span class="text-[10px] text-slate-400 tabular-nums shrink-0">#${s.rank}</span>`
+    : '';
   return `<div class="flex items-center gap-2.5 px-3 py-2.5 rounded-xl ring-1 ring-slate-100 hover:bg-slate-50">
-    ${s.rank != null ? `<span class="text-[10px] text-slate-400 tabular-nums shrink-0">#${s.rank}</span>` : ''}
+    ${rank}
     <div class="min-w-0 flex-1">
       <div class="flex items-center gap-2 flex-wrap">
         <span class="skill-jump cursor-pointer font-medium text-teal-700 underline decoration-teal-200 underline-offset-2" data-skill="${esc(s.skill_name)}">${esc(s.skill_name)}</span>
         <span class="text-[10px] px-1.5 py-0.5 rounded ${BUCKET_CHIP[s.bucket] || 'bg-slate-100 text-slate-500'}">${bucketLabel(s)}</span>
-        <span class="text-[10px] px-1.5 py-0.5 rounded ${s.side === 'staging' ? 'bg-amber-50 text-amber-700 ring-1 ring-amber-100' : 'bg-slate-100 text-slate-500'}">${esc(s.side || 'main')}</span>
         ${s.sha ? `<code class="text-[10px] text-slate-400">${esc(String(s.sha).slice(0, 7))}</code>` : ''}
       </div>
       <div class="mt-1 flex items-center gap-1.5 flex-wrap">${mySourceBadge(s, true)}</div>
     </div>
     <span class="shrink-0 text-[10px] px-1.5 py-0.5 rounded bg-teal-50 text-teal-700 tabular-nums">我触发 ${s.my_triggers ?? 0} 次</span>
-    ${pinned
-      ? (locked
-        ? `<span class="shrink-0 text-[10px] text-slate-300 cursor-not-allowed" title="admin/全局 pin,不可取消">锁定</span>`
-        : `<button class="my-pref shrink-0 text-[11px] px-2 py-0.5 rounded ring-1 ring-slate-200 hover:bg-slate-50" data-skill="${esc(s.skill_name)}" data-act="clear">取消 pin</button>`)
-      : `<div class="shrink-0 flex gap-1.5">
-           <button class="my-pref text-[11px] px-2 py-0.5 rounded ring-1 ring-slate-200 hover:bg-slate-50" data-skill="${esc(s.skill_name)}" data-act="pin">pin</button>
-           <button class="my-pref text-[11px] px-2 py-0.5 rounded ring-1 ring-slate-200 hover:bg-slate-50 text-rose-600" data-skill="${esc(s.skill_name)}" data-act="block" title="不再推送">✕</button>
-         </div>`}
+    <div class="shrink-0 flex items-center gap-1.5">
+      ${sideCtl}
+      ${starBtn}
+      ${!pinned ? `<button type="button" class="my-pref text-[11px] px-1.5 py-0.5 rounded ring-1 ring-slate-200 hover:bg-slate-50 text-rose-600" data-skill="${esc(s.skill_name)}" data-act="block" title="不再推送">✕</button>` : ''}
+    </div>
   </div>`;
 }
 
@@ -1959,12 +2251,57 @@ async function loadMy() {
   setContribOpen(true);
 }
 document.addEventListener('click', async e => {
+  const side = e.target.closest('.my-row-side');
+  if (side) {
+    try {
+      await jpost('/api/v1/dashboard/my/prefs', {
+        skill_name: side.dataset.skill, action: 'pin', side: side.dataset.side || 'main',
+      });
+      await loadMy();
+    } catch (err) { alert(err.message); }
+    return;
+  }
+  const pin = e.target.closest('.my-row-pin');
+  if (pin) {
+    try {
+      await jpost('/api/v1/dashboard/my/prefs', {
+        skill_name: pin.dataset.skill, action: 'pin', side: pin.dataset.side || 'main',
+      });
+      await loadMy();
+    } catch (err) { alert(err.message); }
+    return;
+  }
+  const unpin = e.target.closest('.my-row-unpin');
+  if (unpin) {
+    try {
+      await jpost('/api/v1/dashboard/my/prefs', { skill_name: unpin.dataset.skill, action: 'clear' });
+      await loadMy();
+    } catch (err) { alert(err.message); }
+    return;
+  }
   const b = e.target.closest('.my-pref');
   if (!b) return;
   try { await jpost('/api/v1/dashboard/my/prefs', { skill_name: b.dataset.skill, action: b.dataset.act }); await loadMy(); }
   catch (err) { alert(err.message); }
 });
 document.getElementById('contrib-toggle')?.addEventListener('click', () => setContribOpen(!_contribOpen));
+document.getElementById('trigger-rate-toggle')?.addEventListener('click', () => {
+  const body = document.getElementById('trigger-rate-body');
+  const chev = document.getElementById('trigger-rate-chevron');
+  const btn = document.getElementById('trigger-rate-toggle');
+  if (!body) return;
+  const open = body.classList.toggle('hidden') === false;
+  if (btn) btn.setAttribute('aria-expanded', open ? 'true' : 'false');
+  if (chev) chev.textContent = open ? '▼ 收起' : '▶ 展开';
+});
+document.getElementById('skills-q')?.addEventListener('input', e => {
+  skillsQ = e.target.value;
+  clearTimeout(_skillsQTimer);
+  _skillsQTimer = setTimeout(() => {
+    skillsPage = 0;
+    loadSkills().catch(console.error);
+  }, 180);
+});
 document.getElementById('contrib-traj-list')?.addEventListener('click', e => {
   const a = e.target.closest('.contrib-traj');
   if (!a) return;
@@ -1988,6 +2325,7 @@ function bumpPushCount(delta) {
 document.getElementById('my-push-up')?.addEventListener('click', () => bumpPushCount(1));
 document.getElementById('my-push-down')?.addEventListener('click', () => bumpPushCount(-1));
 document.getElementById('my-push-val')?.addEventListener('change', () => commitPushValEdit());
+document.getElementById('my-push-val')?.addEventListener('focus', e => e.target.select());
 document.getElementById('my-push-val')?.addEventListener('keydown', e => {
   if (e.key === 'Enter') { e.preventDefault(); e.target.blur(); }
   if (e.key === 'Escape') {
@@ -2157,37 +2495,22 @@ document.addEventListener('click', async e => {
     } catch (err) { alert(err.message); }
     return;
   }
-  const rsb = e.target.closest('.route-side-btn');
-  if (rsb) {
-    const wrap = document.getElementById('route-side');
-    if (wrap) wrap.querySelectorAll('.route-side-btn').forEach(b => {
-      const on = b.dataset.side === rsb.dataset.side;
-      b.className = 'route-side-btn px-2.5 py-1 ' + (on ? 'bg-teal-600 text-white' : 'bg-white text-slate-500 hover:bg-slate-50');
-    });
-    wrap && (wrap.dataset.side = rsb.dataset.side);
+  const rside = e.target.closest('.route-row-side');
+  if (rside) {
+    try { await _routePref(rside.dataset.user, 'pin', rside.dataset.side || 'main'); }
+    catch (err) { alert(err.message); }
     return;
   }
-  if (e.target.id === 'route-pin') {
-    const user = (document.getElementById('route-user') || {}).value;
-    const side = (document.getElementById('route-side') || {}).dataset.side || 'main';
-    if (!user) return;
-    try {
-      await jpost('/api/v1/dashboard/admin/prefs', {
-        user_key: user, skill_name: e.target.dataset.skill, action: 'pin', side,
-      });
-      await loadSkillRouting(e.target.dataset.skill); await loadAdmin();
-    } catch (err) { alert(err.message); }
+  const rpin = e.target.closest('.route-row-pin');
+  if (rpin) {
+    try { await _routePref(rpin.dataset.user, 'pin', rpin.dataset.side || 'main'); }
+    catch (err) { alert(err.message); }
     return;
   }
-  if (e.target.id === 'route-clear') {
-    const user = (document.getElementById('route-user') || {}).value;
-    if (!user) return;
-    try {
-      await jpost('/api/v1/dashboard/admin/prefs', {
-        user_key: user, skill_name: e.target.dataset.skill, action: 'clear_side',
-      });
-      await loadSkillRouting(e.target.dataset.skill); await loadAdmin();
-    } catch (err) { alert(err.message); }
+  const runpin = e.target.closest('.route-row-unpin');
+  if (runpin) {
+    try { await _routePref(runpin.dataset.user, 'clear'); }
+    catch (err) { alert(err.message); }
     return;
   }
   const gd = e.target.closest('.gpin-del');

--- a/src/xskill/dashboard/static/app.js
+++ b/src/xskill/dashboard/static/app.js
@@ -1520,11 +1520,10 @@ function route() {
     openSkill(parts[1]).catch(console.error);
     return;
   }
-  // #174：普通用户默认进「我的」；admin 保持总览
+  // #174：仅「无 hash」时普通用户默认进「我的」；显式 #overview / 点总览应可打开，不得再劫持
   let pg = parts[0] || '';
-  if (!pg || pg === 'overview') {
-    if (IDENT && IDENT.role !== 'admin') pg = 'my';
-    else pg = pg || 'overview';
+  if (!pg) {
+    pg = (IDENT && IDENT.role !== 'admin') ? 'my' : 'overview';
   }
   showPage(pg);
 }
@@ -1662,10 +1661,10 @@ async function initIdent() {
   applyIdent();
   if (IDENT) { loadMy().catch(console.error); initEvents(); }
   if (IDENT && IDENT.role === 'admin') { loadAdmin().catch(console.error); loadSettings().catch(console.error); }
-  // 登录后若仍停在空/#overview，普通用户跳到「我的」
+  // 登录后若仍无落地 hash，普通用户默认进「我的」（不抢显式 #overview）
   if (IDENT && IDENT.role !== 'admin') {
     const h = (location.hash || '').replace(/^#/, '');
-    if (!h || h === 'overview') location.hash = '#my';
+    if (!h) location.hash = '#my';
   }
 }
 

--- a/src/xskill/dashboard/static/index.html
+++ b/src/xskill/dashboard/static/index.html
@@ -227,9 +227,13 @@
     <!-- ══ 技能库 ══ -->
     <div class="sec-page" id="pg-skills">
       <div class="bg-white rounded-2xl ring-1 ring-slate-200 p-5">
-        <div class="flex items-baseline justify-between">
+        <div class="flex items-baseline justify-between gap-3 flex-wrap">
           <h2 class="font-semibold text-sm">技能库</h2>
-          <span class="text-[11px] text-slate-400" data-m="skills.summary">—</span>
+          <div class="flex items-center gap-2">
+            <input id="skills-q" autocomplete="off" placeholder="检索技能名 / 描述"
+              class="ring-1 ring-slate-200 rounded-lg px-2.5 py-1 text-[12px] outline-none focus:ring-teal-500 w-52 bg-white">
+            <span class="text-[11px] text-slate-400" data-m="skills.summary">—</span>
+          </div>
         </div>
         <div class="overflow-x-auto">
         <table class="w-full mt-2 text-[12.5px]">
@@ -242,12 +246,13 @@
         </div>
       </div>
 
-      <div class="bg-white rounded-2xl ring-1 ring-slate-200 p-5 mt-4">
-        <div class="flex items-baseline justify-between">
+      <div class="bg-white rounded-2xl ring-1 ring-slate-200 p-5 mt-4" id="trigger-rate-card">
+        <button type="button" id="trigger-rate-toggle" class="w-full flex items-center justify-between gap-2 text-left" aria-expanded="false">
           <h2 class="font-semibold text-sm">单 skill 触发率 <span class="font-normal text-[11px] text-slate-400 ml-2">去重 (client, skill) 推荐对 → 之后被采用</span></h2>
-        </div>
-        <div class="overflow-x-auto">
-        <table class="w-full mt-2 text-[12.5px]">
+          <span id="trigger-rate-chevron" class="text-[11px] text-slate-400 shrink-0">▶ 展开</span>
+        </button>
+        <div id="trigger-rate-body" class="hidden overflow-x-auto mt-2">
+        <table class="w-full text-[12.5px]">
           <thead><tr class="text-[11px] text-slate-400 border-b border-slate-100">
             <th class="text-left font-medium py-2">技能</th><th class="text-right font-medium">曝光对</th><th class="text-right font-medium">采用对</th><th class="text-right font-medium">触发率</th></tr></thead>
           <tbody id="trigger-body" class="divide-y divide-slate-50"><tr><td colspan="4" class="py-2 text-slate-400">加载中…</td></tr></tbody></table>
@@ -498,7 +503,7 @@
           </div>
           <div class="overflow-x-auto"><table class="w-full mt-2 text-[12.5px]">
             <thead><tr class="text-[11px] text-slate-400 border-b border-slate-100"><th class="text-left font-medium py-2">用户</th><th class="text-left font-medium">版本</th><th class="text-right font-medium">当前推送</th><th class="text-right font-medium">灰度</th><th class="text-right font-medium">触发率</th><th class="text-right font-medium">pinned·blocked</th><th class="text-left font-medium pl-6">轨迹处理</th><th class="text-left font-medium pl-6">停推建议</th><th class="text-right font-medium">操作</th></tr></thead>
-            <tbody id="admin-users-body" class="divide-y divide-slate-50"><tr><td colspan="8" class="py-2 text-slate-400">加载中…</td></tr></tbody></table></div>
+            <tbody id="admin-users-body" class="divide-y divide-slate-50"><tr><td colspan="9" class="py-2 text-slate-400">加载中…</td></tr></tbody></table></div>
           <div id="admin-drawer" class="hidden mt-3 rounded-xl ring-1 ring-slate-200 bg-slate-50 p-4"></div>
         </div>
         <!-- P3 画像聚类 graph -->

--- a/src/xskill/pipeline/registry.py
+++ b/src/xskill/pipeline/registry.py
@@ -206,6 +206,8 @@ CREATE TABLE IF NOT EXISTS skill_prefs (
     skill_name TEXT NOT NULL,
     pref       TEXT NOT NULL CHECK(pref IN ('pinned','blocked')),
     set_by     TEXT DEFAULT '',
+    -- pin 时可钉 side（main|staging）；空串=走 pick_side / resolve_side
+    side       TEXT NOT NULL DEFAULT '',
     ts         TEXT DEFAULT (datetime('now')),
     PRIMARY KEY (user_key, skill_name)
 );
@@ -568,6 +570,14 @@ def _migrate(conn: sqlite3.Connection) -> None:
             "ALTER TABLE skills_catalog ADD COLUMN content_sha TEXT NOT NULL DEFAULT ''"
         )
 
+    # skill_prefs.side：pin 时可钉灰度侧（空=自动分流）
+    cur = conn.execute("PRAGMA table_info(skill_prefs)")
+    pref_cols = {row[1] for row in cur.fetchall()}
+    if "side" not in pref_cols:
+        conn.execute(
+            "ALTER TABLE skill_prefs ADD COLUMN side TEXT NOT NULL DEFAULT ''"
+        )
+
     # Backfill status from has_meta/has_embedding —— **只在首次补 status 列时跑一次**。
     # 以前每次 get_connection 都跑这条,会把任何 status='discovered' 的**活行**
     # （rebuild 重置 / error 重试 / 僵尸清理刚翻回的）在下次连接时打回 'indexed'，
@@ -653,6 +663,7 @@ class PinQuotaExceeded(ValueError):
 
 def set_skill_pref(*, user_key: str, skill_name: str, pref: str, set_by: str,
                    max_pinned: Optional[int] = None,
+                   side: Optional[str] = None,
                    db_path: Optional[Path] = None) -> None:
     """写入/覆盖一条偏好(pinned|blocked)。
 
@@ -660,23 +671,48 @@ def set_skill_pref(*, user_key: str, skill_name: str, pref: str, set_by: str,
     pinned + 全局 pinned 合计(去重,含本次)不得超过 max_pinned,超量抛
     ``PinQuotaExceeded``,超量状态根本不可能入库;全局 pin 则对**全员**
     逐一校验合计。sync 读路径永远不需要处理该错误。
+
+    ``side``: 仅 pin 有意义；``None``=更新时保留原 side / 新建为空；
+    ``''``=清除 side 覆盖；``main``|``staging``=钉到该侧。blocked 写入时
+    强制清空 side。
     """
     if pref not in ("pinned", "blocked"):
         raise ValueError(f"pref 必须是 pinned|blocked,得到 {pref!r}")
     if not user_key or not skill_name:
         raise ValueError("user_key/skill_name 不能为空")
+    if side is not None and side not in ("", "main", "staging"):
+        raise ValueError(f"side 必须是 main|staging|空串,得到 {side!r}")
     with pooled_connection(db_path) as conn:
         if pref == "pinned" and max_pinned is not None:
             _check_pin_quota(conn, user_key=user_key, skill_name=skill_name,
                              max_pinned=max_pinned)
-        conn.execute(
-            "INSERT INTO skill_prefs(user_key,skill_name,pref,set_by)"
-            " VALUES(?,?,?,?)"
-            " ON CONFLICT(user_key,skill_name)"
-            " DO UPDATE SET pref=excluded.pref, set_by=excluded.set_by,"
-            "               ts=datetime('now')",
-            (user_key, skill_name, pref, set_by),
-        )
+        if pref == "blocked":
+            side_val = ""
+            update_side = True
+        elif side is None:
+            side_val = ""
+            update_side = False
+        else:
+            side_val = side
+            update_side = True
+        if update_side:
+            conn.execute(
+                "INSERT INTO skill_prefs(user_key,skill_name,pref,set_by,side)"
+                " VALUES(?,?,?,?,?)"
+                " ON CONFLICT(user_key,skill_name)"
+                " DO UPDATE SET pref=excluded.pref, set_by=excluded.set_by,"
+                "               side=excluded.side, ts=datetime('now')",
+                (user_key, skill_name, pref, set_by, side_val),
+            )
+        else:
+            conn.execute(
+                "INSERT INTO skill_prefs(user_key,skill_name,pref,set_by,side)"
+                " VALUES(?,?,?,?,?)"
+                " ON CONFLICT(user_key,skill_name)"
+                " DO UPDATE SET pref=excluded.pref, set_by=excluded.set_by,"
+                "               ts=datetime('now')",
+                (user_key, skill_name, pref, set_by, side_val),
+            )
         conn.commit()
     try:
         from xskill.recommend.recommend_store import mark_recommend_dirty
@@ -684,6 +720,29 @@ def set_skill_pref(*, user_key: str, skill_name: str, pref: str, set_by: str,
         mark_recommend_dirty(user_key, reason=f"pref_{pref}", db_path=db_path)
     except Exception:  # pylint: disable=broad-exception-caught
         logger.debug("mark recommend dirty after pref failed", exc_info=True)
+
+
+def clear_skill_pref_side(*, user_key: str, skill_name: str,
+                          db_path: Optional[Path] = None) -> bool:
+    """清除 pin 的 side 覆盖（保留 pin）。无 pinned 行 → False。"""
+    with pooled_connection(db_path) as conn:
+        cur = conn.execute(
+            "UPDATE skill_prefs SET side='', ts=datetime('now')"
+            " WHERE user_key=? AND skill_name=? AND pref='pinned'",
+            (user_key, skill_name),
+        )
+        conn.commit()
+        cleared = cur.rowcount > 0
+    if cleared:
+        try:
+            from xskill.recommend.recommend_store import mark_recommend_dirty
+
+            mark_recommend_dirty(
+                user_key, reason="pref_side_cleared", db_path=db_path)
+        except Exception:  # pylint: disable=broad-exception-caught
+            logger.debug(
+                "mark recommend dirty after clear side failed", exc_info=True)
+    return cleared
 
 
 def _check_pin_quota(conn, *, user_key: str, skill_name: str,
@@ -740,7 +799,7 @@ def prefs_for(user_key: str, *, db_path: Optional[Path] = None) -> list[dict]:
     """某 user_key(或 '*global*')的全部偏好行。"""
     with pooled_connection(db_path) as conn:
         return [dict(r) for r in conn.execute(
-            "SELECT user_key, skill_name, pref, set_by, ts FROM skill_prefs"
+            "SELECT user_key, skill_name, pref, set_by, side, ts FROM skill_prefs"
             " WHERE user_key=? ORDER BY ts",
             (user_key,),
         ).fetchall()]
@@ -781,15 +840,17 @@ def set_client_take_n(user_key: str, take_n: int, *, max_n: int,
 
 def effective_prefs(user_key: str, *, db_path: Optional[Path] = None) -> dict:
     """manifest 注入用的合并视图:{'pinned': [...有序...], 'blocked': set,
-    'pin_meta': {skill: set_by}}。
+    'pin_meta': {skill: set_by}, 'side': {skill: main|staging}}。
 
     合并规则:全局行先于用户行(admin 全局 pin 排最前);同一 skill 用户行
     与全局行冲突时,**blocked 优先**(任何一侧屏蔽即不分发——全局屏蔽用户
     不能自行恢复;用户自己屏蔽的全局推荐仅对自己生效)。
+    side 覆盖同序合并：后写的用户行覆盖全局；用户 pin 且 side 为空则清除
+    该 skill 的 side 覆盖。
     """
     with pooled_connection(db_path) as conn:
         rows = [dict(r) for r in conn.execute(
-            "SELECT user_key, skill_name, pref, set_by, ts FROM skill_prefs"
+            "SELECT user_key, skill_name, pref, set_by, side, ts FROM skill_prefs"
             " WHERE user_key IN (?, ?) ORDER BY CASE user_key WHEN ? THEN 0"
             " ELSE 1 END, ts",
             (GLOBAL_PREF_KEY, user_key, GLOBAL_PREF_KEY),
@@ -797,15 +858,25 @@ def effective_prefs(user_key: str, *, db_path: Optional[Path] = None) -> dict:
     blocked = {r["skill_name"] for r in rows if r["pref"] == "blocked"}
     pinned: list[str] = []
     pin_meta: dict = {}
+    side_map: dict[str, str] = {}
     for r in rows:
-        if r["pref"] == "pinned" and r["skill_name"] not in blocked \
-                and r["skill_name"] not in pinned:
-            pinned.append(r["skill_name"])
-            pin_meta[r["skill_name"]] = {
+        name = r["skill_name"]
+        if r["pref"] == "pinned" and name not in blocked:
+            if name not in pinned:
+                pinned.append(name)
+            pin_meta[name] = {
                 "set_by": r["set_by"],
                 "scope": "global" if r["user_key"] == GLOBAL_PREF_KEY else "user",
             }
-    return {"pinned": pinned, "blocked": blocked, "pin_meta": pin_meta}
+            ov = (r.get("side") or "").strip()
+            if ov in ("main", "staging"):
+                side_map[name] = ov
+            elif r["user_key"] != GLOBAL_PREF_KEY:
+                side_map.pop(name, None)
+    return {
+        "pinned": pinned, "blocked": blocked,
+        "pin_meta": pin_meta, "side": side_map,
+    }
 
 
 def manifest_control_plane_snapshot(
@@ -814,7 +885,7 @@ def manifest_control_plane_snapshot(
     """一次查询取得 manifest 所需的全部偏好和下线状态。"""
     with pooled_connection(db_path) as conn:
         rows = [dict(row) for row in conn.execute(
-            "SELECT user_key, skill_name, pref, set_by, ts FROM skill_prefs"
+            "SELECT user_key, skill_name, pref, set_by, side, ts FROM skill_prefs"
             " ORDER BY CASE user_key WHEN ? THEN 0 ELSE 1 END, ts",
             (GLOBAL_PREF_KEY,),
         ).fetchall()]

--- a/src/xskill/skill/catalog_store.py
+++ b/src/xskill/skill/catalog_store.py
@@ -685,16 +685,18 @@ def page_skills_catalog(
     limit: int = 0,
     offset: int = 0,
     name: str = "",
+    q: str = "",
     db_path: Optional[Path] = None,
 ) -> dict:
-    """分页读投影表；形状与旧 skills_catalog_page 一致。"""
+    """分页读投影表；形状与旧 skills_catalog_page 一致。
+
+    ``name`` 精确匹配；``q`` 对 name/description 做子串模糊（忽略大小写）。
+    ``by_state`` 始终按全库统计；``total`` 在有 ``q``/``name`` 时为过滤后条数。
+    """
     ensure_skills_catalog(skill_dir, skillhub=skillhub, db_path=db_path)
     root = _root_key(skill_dir)
+    qn = (q or "").strip()
     with pooled_connection(db_path) as conn:
-        total = conn.execute(
-            "SELECT COUNT(*) AS n FROM skills_catalog WHERE root_key=?",
-            (root,),
-        ).fetchone()["n"]
         by_state_rows = conn.execute(
             """
             SELECT state, COUNT(*) AS n FROM skills_catalog
@@ -716,7 +718,44 @@ def page_skills_catalog(
                 """,
                 (root, name),
             ).fetchall()
+            total = len(selected)
+        elif qn:
+            like = f"%{qn}%"
+            total = conn.execute(
+                """
+                SELECT COUNT(*) AS n FROM skills_catalog
+                WHERE root_key=? AND (
+                    name LIKE ? COLLATE NOCASE
+                    OR IFNULL(description, '') LIKE ? COLLATE NOCASE
+                )
+                """,
+                (root, like, like),
+            ).fetchone()["n"]
+            query = f"""
+                SELECT name, state, source, description, version, candidates_count,
+                       hub, skill_id, search_id, use_count
+                FROM skills_catalog
+                WHERE root_key=? AND (
+                    name LIKE ? COLLATE NOCASE
+                    OR IFNULL(description, '') LIKE ? COLLATE NOCASE
+                )
+                ORDER BY {_STATE_ORDER_SQL},
+                         CASE WHEN source='skillhub' THEN hub ELSE '' END,
+                         name
+            """
+            params: list = [root, like, like]
+            if limit > 0:
+                query += " LIMIT ? OFFSET ?"
+                params.extend([limit, offset])
+            elif offset > 0:
+                query += " LIMIT -1 OFFSET ?"
+                params.append(offset)
+            selected = conn.execute(query, params).fetchall()
         else:
+            total = conn.execute(
+                "SELECT COUNT(*) AS n FROM skills_catalog WHERE root_key=?",
+                (root,),
+            ).fetchone()["n"]
             query = f"""
                 SELECT name, state, source, description, version, candidates_count,
                        hub, skill_id, search_id, use_count
@@ -726,7 +765,7 @@ def page_skills_catalog(
                          CASE WHEN source='skillhub' THEN hub ELSE '' END,
                          name
             """
-            params: list = [root]
+            params = [root]
             if limit > 0:
                 query += " LIMIT ? OFFSET ?"
                 params.extend([limit, offset])
@@ -741,10 +780,13 @@ def page_skills_catalog(
         if not stored.get("skill_id"):
             stored["skill_id"] = stored.get("search_id") or ""
         skills.append(catalog_api_row(stored))
-    return {
+    out = {
         "total": int(total),
         "by_state": by_state,
         "offset": offset,
         "limit": limit,
         "skills": skills,
     }
+    if qn:
+        out["q"] = qn
+    return out

--- a/src/xskill/team/server/skill_manifest.py
+++ b/src/xskill/team/server/skill_manifest.py
@@ -346,6 +346,7 @@ def build_manifest(
         persist_recommendations=False,
     )
 
+    side_overrides = prefs.get("side") or {}
     slots: list[SkillSlot] = []
     for idx, skill in enumerate(chosen):
         if idx < len(pinned):
@@ -358,6 +359,26 @@ def build_manifest(
             skill, client_id, probability, bucket, refs=catalog.refs,
         )
         if slot is not None:
+            ov = side_overrides.get(slot.skill_name)
+            if ov in ("main", "staging") and not (
+                    isinstance(skill, dict) and skill.get("source") == "skillhub"):
+                cached_main, cached_staging = (
+                    catalog.refs[skill.name] if skill.name in catalog.refs else
+                    (main_sha(skill.path) or "", staging_sha(skill.path))
+                )
+                if ov == "staging" and not cached_staging:
+                    ov = "main"
+                new_sha = cached_staging if ov == "staging" else cached_main
+                if new_sha:
+                    slot = SkillSlot(
+                        skill_name=slot.skill_name,
+                        side=ov,
+                        sha=new_sha,
+                        bucket=slot.bucket,
+                        source=slot.source,
+                        display_name=slot.display_name,
+                        source_path=slot.source_path,
+                    )
             slots.append(slot)
     # 埋点：只记画像推荐位(recommended bucket)。team server 将写入提交给
     # 独立的有界单线程 executor，避免 SQLite 写锁进入 /sync 响应路径；直接

--- a/tests/test_skill_routing.py
+++ b/tests/test_skill_routing.py
@@ -1,0 +1,220 @@
+"""技能详情「当前推送对象」routing API + pin side 覆盖。"""
+from __future__ import annotations
+
+import subprocess
+from pathlib import Path
+
+import pytest
+from fastapi import FastAPI
+from fastapi.testclient import TestClient
+
+from xskill.dashboard.auth import (
+    build_auth_router, configure_auth, ensure_dashboard_secret,
+)
+from xskill.dashboard import console as console_mod
+from xskill.dashboard.console import build_console_router
+from xskill.pipeline import registry as R
+from xskill.team.server.api import init_team_context
+from xskill.team.server.client_registry import ClientRegistry
+from xskill.team.server.skill_manifest import _reset_manifest_cache_for_tests
+
+
+def _git(args, cwd):
+    subprocess.run(["git"] + args, cwd=str(cwd),
+                   capture_output=True, text=True, check=True)
+
+
+def _make_skill(root: Path, name: str, *, with_staging: bool = False) -> Path:
+    d = root / name
+    d.mkdir(parents=True)
+    _git(["init", "-q"], d)
+    _git(["checkout", "-q", "-b", "main"], d)
+    _git(["config", "user.email", "t@t"], d)
+    _git(["config", "user.name", "t"], d)
+    (d / "SKILL.md").write_text(f"# {name}\n", encoding="utf-8")
+    _git(["add", "."], d)
+    _git(["commit", "-q", "-m", "v1"], d)
+    if with_staging:
+        _git(["checkout", "-q", "-b", "staging"], d)
+        (d / "SKILL.md").write_text(f"# {name} staging\n", encoding="utf-8")
+        _git(["add", "."], d)
+        _git(["commit", "-q", "-m", "staging"], d)
+        _git(["checkout", "-q", "main"], d)
+    return d
+
+
+@pytest.fixture()
+def routing_env(tmp_path):
+    skills = tmp_path / "skills"
+    skills.mkdir()
+    for n in ("alpha", "beta", "gamma"):
+        _make_skill(skills, n, with_staging=(n == "alpha"))
+    db = tmp_path / "r.db"
+    reg = ClientRegistry(tmp_path / "c.db")
+    alice_cid = reg.register(user_name="alice")
+    bob_cid = reg.register(user_name="bob")
+    alice_token = reg.ensure_dashboard_token(alice_cid)
+
+    def configure_watch_dir(path: Path, label: str, auto_index: bool) -> None:
+        R.register_dir(
+            path, label=label, auto_index=auto_index,
+            ecosystem="team_client", db_path=db,
+        )
+
+    init_team_context(
+        join_token="jt", client_registry=reg, skill_dir=skills,
+        traj_root=tmp_path / "traj",
+        register_dir=lambda path, label: configure_watch_dir(path, label, True),
+        configure_watch_dir=configure_watch_dir)
+    from xskill.api import app as app_mod
+    app_mod._config = {
+        "team": {"server": {"skill_slots": 3, "ranked_slots": 2}},
+        "canary": {"probability": 0.5},
+    }
+    configure_auth(
+        secret=ensure_dashboard_secret(tmp_path / "sec.json"),
+        admins=["boss"], admin_password="pw",
+        registry_provider=lambda: reg)
+    app = FastAPI()
+    app.include_router(build_auth_router())
+    app.include_router(build_console_router(db_path=db))
+    _reset_manifest_cache_for_tests()
+    console_mod._bump_routing_epoch()
+
+    alice = TestClient(app)
+    assert alice.post("/api/v1/dashboard/login",
+                      json={"user_name": "alice", "secret": alice_token}
+                      ).status_code == 200
+    boss = TestClient(app)
+    assert boss.post("/api/v1/dashboard/login",
+                     json={"user_name": "boss", "secret": "pw"}
+                     ).status_code == 200
+    return {
+        "alice": alice, "boss": boss, "db": db, "skills": skills,
+        "registry": reg, "alice_cid": alice_cid, "bob_cid": bob_cid,
+    }
+
+
+def test_routing_meta_and_users(routing_env):
+    boss = routing_env["boss"]
+    r = boss.get("/api/v1/dashboard/skill/alpha/routing")
+    assert r.status_code == 200
+    meta = r.json()
+    assert meta["skill"] == "alpha"
+    assert meta["has_staging"] is True
+    assert "counts" in meta
+    assert "staging" not in meta  # 全量列表禁止出现在 meta
+    assert meta["counts"]["users"] == 2
+    assert meta["counts"]["in_manifest"] == meta["counts"]["staging"] + meta["counts"]["main"]
+
+    ru = boss.get("/api/v1/dashboard/skill/alpha/routing/users",
+                  params={"filter": "in", "limit": 8})
+    assert ru.status_code == 200
+    body = ru.json()
+    assert body["total"] == meta["counts"]["in_manifest"]
+    assert len(body["users"]) <= 8
+    names = {u["user"] for u in body["users"]}
+    assert names <= {"alice", "bob"}
+    for u in body["users"]:
+        assert u["in_manifest"] is True
+        assert u["side"] in ("main", "staging")
+        assert u["sha"]
+
+
+def test_routing_pin_side_override(routing_env):
+    boss = routing_env["boss"]
+    r = boss.post("/api/v1/dashboard/admin/prefs", json={
+        "user_key": "alice", "skill_name": "alpha",
+        "action": "pin", "side": "staging",
+    })
+    assert r.status_code == 200, r.text
+
+    row = boss.get("/api/v1/dashboard/skill/alpha/routing/user/alice").json()
+    assert row["in_manifest"] is True
+    assert row["side"] == "staging"
+    assert row["overridden"] is True
+    assert row["pinned"] is True
+
+    stg = boss.get("/api/v1/dashboard/skill/alpha/routing/users",
+                   params={"filter": "staging"}).json()
+    assert any(u["user"] == "alice" for u in stg["users"])
+
+    # clear_side 保留 pin，清覆盖
+    assert boss.post("/api/v1/dashboard/admin/prefs", json={
+        "user_key": "alice", "skill_name": "alpha", "action": "clear_side",
+    }).status_code == 200
+    row2 = boss.get("/api/v1/dashboard/skill/alpha/routing/user/alice").json()
+    assert row2["pinned"] is True
+    assert row2["overridden"] is False
+
+
+def test_routing_typeahead_and_404(routing_env):
+    alice = routing_env["alice"]
+    q = alice.get("/api/v1/dashboard/skill/alpha/routing/users",
+                  params={"q": "ali", "limit": 8})
+    assert q.status_code == 200
+    hits = q.json()["users"]
+    assert any(u["user"] == "alice" for u in hits)
+
+    assert alice.get("/api/v1/dashboard/skill/nope/routing").status_code == 404
+
+
+def test_user_can_pin_own_side_via_my_prefs(routing_env):
+    alice = routing_env["alice"]
+    r = alice.post("/api/v1/dashboard/my/prefs", json={
+        "skill_name": "alpha", "action": "pin", "side": "main",
+    })
+    assert r.status_code == 200, r.text
+    row = alice.get("/api/v1/dashboard/skill/alpha/routing/user/alice").json()
+    assert row["side"] == "main"
+    assert row["overridden"] is True
+    assert row["pinned"] is True
+
+
+def test_no_staging_skill_routing(routing_env):
+    boss = routing_env["boss"]
+    meta = boss.get("/api/v1/dashboard/skill/beta/routing").json()
+    assert meta["has_staging"] is False
+    assert meta["counts"]["staging"] == 0
+    users = boss.get("/api/v1/dashboard/skill/beta/routing/users",
+                     params={"filter": "main"}).json()
+    for u in users["users"]:
+        assert u["side"] == "main"
+
+
+def test_admin_assignment_and_matrix_slots(routing_env):
+    boss = routing_env["boss"]
+    assert boss.post("/api/v1/dashboard/admin/prefs", json={
+        "user_key": "alice", "skill_name": "alpha",
+        "action": "pin", "side": "staging",
+    }).status_code == 200
+    assign = boss.get("/api/v1/dashboard/admin/user/alice/assignment").json()
+    assert assign["user"] == "alice"
+    assert assign["slots"]
+    alpha = next(s for s in assign["slots"] if s["skill_name"] == "alpha")
+    assert alpha["side"] == "staging"
+    assert alpha["side_mutable"] is True
+    assert alpha["overridden"] is True
+
+    matrix = boss.get("/api/v1/dashboard/admin/users-matrix").json()
+    alice = next(u for u in matrix["users"] if u["user"] == "alice")
+    assert alice["current_slots"] >= 1
+    assert alice["staging_slots"] >= 1
+    assert "exposures" in alice  # 历史字段仍保留
+
+
+def test_skills_q_substring(routing_env):
+    alice = routing_env["alice"]
+    # /skills 挂在 dashboard router（非 console）；走同一 app 的公开只读端点
+    from xskill.dashboard.router import build_dashboard_router
+    from fastapi import FastAPI
+    from fastapi.testclient import TestClient
+    app = FastAPI()
+    app.include_router(build_dashboard_router(db_path=routing_env["db"]))
+    client = TestClient(app)
+    # 投影表依赖 skill_dir=db 旁 skill/；此处仅校验 q 参数被接受
+    r = client.get("/api/v1/dashboard/skills", params={"q": "alp", "limit": 10})
+    assert r.status_code == 200
+    body = r.json()
+    assert "skills" in body
+    assert "total" in body


### PR DESCRIPTION
## Summary

本 PR 承接看板控制面两轮工作，后续开发继续挂在本分支 / 本 MR 上。

### 已合入本分支方向（routing + 开机）

- 技能详情「当前推送对象」routing API（`/routing`、`/routing/users`、pin/side）与前端双栏 UI
- `GET /skills?q=` 子串检索；我的页 / 管理矩阵 side 展示
- 修复 `let IDENT` TDZ：开机不再 `ReferenceError`，`loadSkills` 等可正常启动

### 热路径迁表（零 FS 回退）——补丁已在现网验证 skills 侧

原则：**Web 热路径禁止**读 `.ux_scores.jsonl`、全仓 `SkillRepo`/`iterdir`、请求内 `ensure_*` 扫盘；表未就绪 → 空/降级 + enqueue worker，禁止请求线程 backfill。

| 能力 | 行为 |
| --- | --- |
| `/skills` 分页 | 只读 `skills_catalog`；`page_skills_catalog` 用 `_ensure_or_enqueue_catalog`，**不**调旧 `ensure_skills_catalog` |
| `load_usage_records` | 只读 `ux_scores`；未就绪 `sync_pending` + dirty，禁 jsonl fallback |
| console packing / routing / admin skills / uploads | 改读 catalog；上传成功 upsert |
| pipeline candidates | `candidates_weightscore` 列 + SQL；禁全仓扫 `.candidates.yml`（pipeline 进度条） |
| `build_manifest` | catalog 快照；未就绪 dirty + 空 |
| 缓存 TTL | usage / reco-trigger / routing 等提到 **60s** |

现网 site-packages 补丁（基于 a6 原版、含本 PR 前序 + 迁表）：  
`http://8.219.96.11:8796/a6-fs-to-db.site.diff`  
（开发机下载用；**不是**现网地址。）

本地 worktree 上迁表相关改动若尚未全部 push，以分支后续 commit 为准；开发续作仍走本 MR。

---

## 现网排查结论（重要，续作依据）

**现网**：格力内网 `http://7.220.144.233:9961`（Agent / 本机 Docker / `hub.xskill.wiki` **都不是**现网）。

### `/skills` 迁表后服务端已快

在现网容器内实测（迁表代码已确认：`_ensure_or_enqueue_catalog`，无旧 ensure）：

| 探测 | 耗时 |
| --- | --- |
| `127.0.0.1:8000` skills `limit=10` | **~55–62ms** |
| 外网口 `7.220.144.233:9961` 同接口 | **~0.85–1.5s**（含回环/网络，不是几十秒） |
| `total` / `catalog_status` | `68401` / `ok`；`by_state` 含 skillhub ~68k |

结论：**skills 列表服务端不是「几十秒」瓶颈**；迁表补丁在 skills 路径上有效。

### 浏览器仍慢的根因（与 skills 无矛盾）

F12 曾见并行请求例如：

- `my/contributions/trajs?limit=5` → **~24s**
- `my/commits` → ~12s
- `my/uploads` / `usage` / `events` → 数秒
- `skills` 夹在中间 → 显示数秒（单 worker **排队**），单独 curl skills 仍是几十 ms

登录后前端会拉「我的」一整波（`loadMy` / trajs / uploads / commits / events…），与技能库请求抢同一 serve 进程。

**`trajs` 鲸鱼**：`TrajExplorer._atom_destinations` 对每个 atom 仍可能 **`skill_dir.iterdir()` + 逐 skill 读 `.candidates.yml`**（全仓 FS）。迁表补丁**未**消掉这条路径——这是下一刀。

### 前端 `jc()` 永久缓存（次要）

```js
const jc = u => (_cache[u] ||= j(u));
```

同一 URL 在 SPA 内存里永缓存 → 再点「同一页」瞬间；Ctrl+R 清空后又慢。会放大「服务端热起来了」的错觉，但**解释不了**单独 curl 已快、浏览器整页仍卡（主因仍是 trajs 等 + 排队）。

### ORDER BY CASE（更次要）

68k 行上 `ORDER BY CASE state …` 会走 temp B-Tree，现网单次 skills ~60ms 量级可接受；优化方向是持久化 `state_rank` + 覆盖索引，优先级低于 trajs 扫盘。

---

## 下一刀（接续本 MR）

1. **P0**：`_atom_destinations` / `my/contributions/trajs` 去全仓 candidates 扫盘（只读 `atom_adoption` + catalog 投影）
2. **P1**：登录后「我的」请求降并发 / 懒加载（进技能库时不要被 trajs 堵死）
3. **P1**：技能库列表改 `j()` 或短 TTL，避免 `jc` 永久缓存误导体感
4. **P2**：`skills_catalog` 排序键列 + 索引，把 ~60ms 再压一截

---

## Test plan

- [x] 现网：skills 单独 curl ~60ms；`catalog_status=ok`；代码含 `_ensure_or_enqueue_catalog`
- [ ] 现网：并行 `trajs`+`skills` 时 skills 被拉长；串行 skills 仍快（排队证据）
- [ ] 改 trajs 后：`my/contributions/trajs?limit=5` 降到秒级以下，浏览器进控制台不再卡几十秒
- [ ] `pytest`：`test_dashboard_ux_db_cutover` / metrics / console / skills_pagination / skill_routing / manifest catalog
- [ ] 打开看板：无 IDENT TDZ；技能详情「当前推送对象」可用
- [ ] admin pin/side；普通用户写权限边界

## 环境备忘

| 环境 | 地址 | 可否当现网结论 |
| --- | --- | --- |
| 格力现网 | `http://7.220.144.233:9961` | 是（用户侧） |
| 本机 Docker / serve | 本机 | 否 |
| `hub.xskill.wiki` | 开发测试示例 | 否 |