### PR TITLE
feat(search): surface SkillHub empty/degraded search status

### DIFF
--- a/src/xskill/agents/user_edit_absorb_agent.py
+++ b/src/xskill/agents/user_edit_absorb_agent.py
@@ -1377,8 +1377,12 @@ def reverse_sync_copy_dest(
                 )
                 if dest_hash == baseline_hash:
                     continue
+                # 基线缺该路径：视为 dest 单边新增/改动，允许回流（不再把
+                # ``baseline is None`` 误判成三方冲突——Windows 孤儿领养曾
+                # 因空基线在此处 100% FAILED）。
                 if (
-                    source_hash != baseline_hash
+                    baseline_hash is not None
+                    and source_hash != baseline_hash
                     and source_hash != dest_hash
                 ):
                     _log_reverse_sync_failure(

--- a/src/xskill/cli.py
+++ b/src/xskill/cli.py
@@ -706,6 +706,22 @@ def _write_search_output(text: str, *, to_stderr: bool = False) -> None:
         stream.write("\n")
 
 
+def _emit_skillhub_search_meta_warnings(
+    search_meta: dict, *, has_results: bool,
+) -> None:
+    """根据 skill_hub/search 的 meta 向 stderr 提示空库 / BM25 降级。"""
+    if search_meta.get("corpus_empty") and not has_results:
+        _write_search_output(
+            "warning: skillhub 暂无可搜索的 skill（库为空）",
+            to_stderr=True,
+        )
+    if search_meta.get("degraded_to_bm25"):
+        _write_search_output(
+            "warning: 语义检索不可用，已降级为 BM25 关键词搜索",
+            to_stderr=True,
+        )
+
+
 _DOWNLOAD_AGENT_OPTIONS = (
     ("claude_code", "claude-code", "Claude Code"),
     ("codex", "codex", "Codex"),
@@ -1097,12 +1113,18 @@ def cmd_search_hub(args, http=None, headers=None) -> int:
                     "\n".join(error_lines), to_stderr=True,
                 )
             return 1
-        results = resp.json().get("results", [])
+        payload = resp.json()
+        results = payload.get("results", [])
+        search_meta = payload.get("meta") or {}
+        _emit_skillhub_search_meta_warnings(search_meta, has_results=bool(results))
         if not results:
             if args.json:
                 _write_search_output("[]")
             else:
-                _write_search_output("skillhub 无匹配 skill")
+                if search_meta.get("corpus_empty"):
+                    _write_search_output("skillhub 暂无可搜索的 skill")
+                else:
+                    _write_search_output("skillhub 无匹配 skill")
             return 0
         if getattr(args, "download", False):
             from xskill.config import XSKILL_HOME

--- a/src/xskill/ecosystems/installation.py
+++ b/src/xskill/ecosystems/installation.py
@@ -334,13 +334,29 @@ def read_install_metadata(dest: Path) -> dict | None:
 
 
 _GIT_COMMIT_SHA_PATTERN = re.compile(r"[0-9a-f]{40}")
+# git tree 入口的 mode 高位（与 POSIX S_IFMT 同形）；勿只靠平台 S_IS*，
+# 个别环境下对原始 git mode 的宏判断会漏掉普通文件。
+_GIT_MODE_MASK = 0o160000
+_GIT_MODE_FILE = 0o100000
+_GIT_MODE_DIR = 0o040000
+
+
+def _git_mode_is_dir(mode: int) -> bool:
+    return (mode & _GIT_MODE_MASK) == _GIT_MODE_DIR or stat.S_ISDIR(mode)
+
+
+def _git_mode_is_file(mode: int) -> bool:
+    return (mode & _GIT_MODE_MASK) == _GIT_MODE_FILE or stat.S_ISREG(mode)
 
 
 def _git_tree_fingerprints(source: Path, sha: str) -> dict[str, str] | None:
     """按 commit 的 git tree 重建逐文件内容指纹。
 
-    口径与 ``_safe_copy_file_fingerprints`` 一致：文件字节 sha256、POSIX
-    相对路径。任何一步读不到对象都返回 None（调用方按不可领养处理）。
+    口径与 ``_safe_copy_file_fingerprints`` / reverse_sync 一致：文件字节
+    sha256、POSIX 相对路径。当 HEAD 仍停在该 install commit 时，优先用
+    **工作区**字节——reverse_sync 比对的是 worktree；Windows 上 blob 与
+    工作区可能因换行/checkout 口径不一致，用 blob 做基线会误报
+    ``REVERSE_SYNC_CONTENT_CONFLICT``。任何一步读不到对象都返回 None。
     """
     try:
         repo = Repo(str(source))
@@ -367,9 +383,9 @@ def _git_tree_fingerprints(source: Path, sha: str) -> dict[str, str] | None:
                 except UnicodeDecodeError:
                     return None
                 relative = prefix / name
-                if stat.S_ISDIR(mode):
+                if _git_mode_is_dir(mode):
                     stack.append((entry_id, relative))
-                elif stat.S_ISREG(mode):
+                elif _git_mode_is_file(mode):
                     try:
                         blob = repo[entry_id]
                     except KeyError:
@@ -377,6 +393,34 @@ def _git_tree_fingerprints(source: Path, sha: str) -> dict[str, str] | None:
                     fingerprints[relative.as_posix()] = hashlib.sha256(
                         blob.data,
                     ).hexdigest()
+        try:
+            head_raw = repo.refs[b"HEAD"]
+            head_hex = (
+                head_raw.decode("ascii")
+                if isinstance(head_raw, (bytes, bytearray))
+                else None
+            )
+        except (KeyError, UnicodeDecodeError, TypeError):
+            head_hex = None
+        if head_hex == sha:
+            source_root = Path(source)
+            for relative_name in list(fingerprints):
+                worktree_path = source_root.joinpath(*relative_name.split("/"))
+                try:
+                    path_stat = worktree_path.lstat()
+                except OSError:
+                    continue
+                if (
+                    not stat.S_ISREG(path_stat.st_mode)
+                    or _stat_is_reparse_point(path_stat)
+                ):
+                    continue
+                try:
+                    fingerprints[relative_name] = hashlib.sha256(
+                        worktree_path.read_bytes(),
+                    ).hexdigest()
+                except OSError:
+                    continue
         return fingerprints
     except (OSError, ValueError, KeyError):
         return None

--- a/src/xskill/recommend/engine.py
+++ b/src/xskill/recommend/engine.py
@@ -303,8 +303,17 @@ class SkillRecommendEngine:
 
     def search_team_skills(self, query: str, limit: int, catalog) -> list[dict]:
         """在自产 + SkillHub 的统一 BM25/semantic/RRF corpus 中搜索。"""
+        results, _meta = self.search_team_skills_with_meta(query, limit, catalog)
+        return results
+
+    def search_team_skills_with_meta(
+        self, query: str, limit: int, catalog,
+    ) -> tuple[list[dict], dict]:
+        """同 ``search_team_skills``，附带 SkillHub 检索元信息。"""
         corpus = self.repo_search_corpus(catalog)
-        return self.skillhub.search(query, limit, supplemental=corpus)
+        return self.skillhub.search_with_meta(
+            query, limit, supplemental=corpus,
+        )
 
     def _skill_index(self) -> dict:
         if self._skill_index_cache is None:

--- a/src/xskill/recommend/skill_vector_store.py
+++ b/src/xskill/recommend/skill_vector_store.py
@@ -20,9 +20,11 @@ logger = logging.getLogger("xskill.skill_vector_store")
 COLLECTION = "skill_vectors"
 DEFAULT_DIM = 8  # fake/tests；生产由首条真实向量决定或配置
 
-# 未装 / 打不开 Milvus 时的节流警告（写进 xskill.log）
+# 未装 / 打不开 Milvus 时的节流警告（写进 xskill.log）。
+# ``None`` = 从未 warn；勿用 0.0——``time.monotonic()`` 从开机起算，
+# CI / 短寿命机器 uptime < 1h 时会把「首次」误判成仍在节流窗口内。
 _MILVUS_WARN_INTERVAL_S = 3600.0
-_milvus_last_warn_mono = 0.0
+_milvus_last_warn_mono: Optional[float] = None
 _pymilvus_import_ok: Optional[bool] = None
 
 
@@ -330,7 +332,10 @@ def warn_milvus_unavailable_hourly(reason: str) -> None:
     """服务器侧无 Milvus 时每小时最多一条 WARNING（进 ``xskill.log``）。"""
     global _milvus_last_warn_mono
     now = time.monotonic()
-    if (now - _milvus_last_warn_mono) < _MILVUS_WARN_INTERVAL_S:
+    if (
+        _milvus_last_warn_mono is not None
+        and (now - _milvus_last_warn_mono) < _MILVUS_WARN_INTERVAL_S
+    ):
         return
     _milvus_last_warn_mono = now
     logger.warning(

--- a/src/xskill/recommend/skillhub.py
+++ b/src/xskill/recommend/skillhub.py
@@ -514,6 +514,13 @@ class SkillHub:
         with open(self.index_cache_path, "wb") as index_file:
             pickle.dump(data, index_file)
 
+    @staticmethod
+    def _search_meta(*, corpus_empty: bool, degraded_to_bm25: bool) -> dict:
+        return {
+            "corpus_empty": bool(corpus_empty),
+            "degraded_to_bm25": bool(degraded_to_bm25),
+        }
+
     def search(
         self,
         query: str,
@@ -527,23 +534,44 @@ class SkillHub:
         已缓存向量、绝不现算 corpus；query embed 受并发信号量 + 短超时 + LRU 三护栏
         约束，慢/挂的 embed API 最多让语义位失效，请求自然退化为纯 BM25。
         """
+        results, _meta = self.search_with_meta(
+            query, limit, supplemental=supplemental,
+        )
+        return results
+
+    def search_with_meta(
+        self,
+        query: str,
+        limit: int = 5,
+        *,
+        supplemental: SearchCorpus | None = None,
+    ) -> tuple[list[dict], dict]:
+        """同 ``search``，额外返回 ``corpus_empty`` / ``degraded_to_bm25`` 元信息。"""
         normalized_query = query.strip().lower()
         if not normalized_query:
-            return []
+            return [], self._search_meta(
+                corpus_empty=False, degraded_to_bm25=False,
+            )
         index_bundle = self._search_index_bundle(supplemental=supplemental)
         return self._search_bundle(normalized_query, int(limit), index_bundle)
 
     def _search_bundle(
         self, normalized_query: str, limit: int, index_bundle: dict,
-    ) -> list[dict]:
+    ) -> tuple[list[dict], dict]:
         """在已构建的统一索引上复用 BM25、semantic、RRF 与结果缓存。"""
         entries = index_bundle["entries"]
         if not entries:
-            return []
+            return [], self._search_meta(
+                corpus_empty=True, degraded_to_bm25=False,
+            )
         query_tokens = _tokenize(normalized_query)
         bm25_rank_by_index = self._bm25_ranks(index_bundle, query_tokens)
         semantic_rank_by_index = self._semantic_ranks(
             index_bundle, normalized_query,
+        )
+        degraded_to_bm25 = not bool(semantic_rank_by_index)
+        meta = self._search_meta(
+            corpus_empty=False, degraded_to_bm25=degraded_to_bm25,
         )
         result_cache_key = (
             normalized_query, int(limit), bool(semantic_rank_by_index),
@@ -552,7 +580,7 @@ class SkillHub:
             index_bundle, result_cache_key,
         )
         if cached_results is not None:
-            return cached_results
+            return cached_results, meta
         score_groups = self._fusion_score_groups(
             index_bundle, normalized_query,
             bm25_rank_by_index, semantic_rank_by_index,
@@ -573,7 +601,7 @@ class SkillHub:
             result_entry["ux_avg"] = self._ux_avg_for_entry(result_entry)
             results.append(result_entry)
         self._cache_search_results(index_bundle, result_cache_key, results)
-        return results
+        return results, meta
 
     @staticmethod
     def _entry_exact_keys(entry: dict) -> set[str]:
@@ -625,9 +653,20 @@ class SkillHub:
         stale snapshot or cache miss returns ``None`` so the caller can offload
         :meth:`search` to a worker thread.
         """
+        packed = self.cached_search_with_meta(query, limit)
+        if packed is None:
+            return None
+        return packed[0]
+
+    def cached_search_with_meta(
+        self, query: str, limit: int = 5,
+    ) -> tuple[list[dict], dict] | None:
+        """同 ``cached_search``，命中时附带 ``search_with_meta`` 同构元信息。"""
         normalized_query = query.strip().lower()
         if not normalized_query:
-            return []
+            return [], self._search_meta(
+                corpus_empty=False, degraded_to_bm25=False,
+            )
         now = time.monotonic()
         index_bundle = self._search_index
         if (
@@ -645,7 +684,11 @@ class SkillHub:
                 (normalized_query, int(limit), has_semantic_rank),
             )
             if cached_results is not None:
-                return cached_results
+                corpus_empty = not bool(index_bundle.get("entries"))
+                return cached_results, self._search_meta(
+                    corpus_empty=corpus_empty,
+                    degraded_to_bm25=not has_semantic_rank,
+                )
         return None
 
     @staticmethod

--- a/src/xskill/team/server/api.py
+++ b/src/xskill/team/server/api.py
@@ -1049,14 +1049,17 @@ async def team_skill_hub_search(
                 engine, query, bounded_limit, client_id, probability,
             )
 
-        matches = hub.cached_search(query, bounded_limit)
-        hot_cache_hit = matches is not None
+        packed = hub.cached_search_with_meta(query, bounded_limit)
+        hot_cache_hit = packed is not None
         if hot_cache_hit:
             await asyncio.sleep(0)
+            matches, search_meta = packed
         else:
-            matches = await run_in_threadpool(hub.search, query, bounded_limit)
+            matches, search_meta = await run_in_threadpool(
+                hub.search_with_meta, query, bounded_limit,
+            )
         payload = _format_team_search_results(
-            matches, None, client_id, probability,
+            matches, None, client_id, probability, meta=search_meta,
         )
         if hot_cache_hit:
             await asyncio.sleep(0)
@@ -1113,14 +1116,18 @@ def _search_and_format_team_skills(
         and not getattr(engine.skillhub, "enabled", False)
     ):
         raise HTTPException(status_code=503, detail="no searchable skill source")
-    matches = engine.search_team_skills(query, limit, catalog)
+    matches, search_meta = engine.search_team_skills_with_meta(
+        query, limit, catalog,
+    )
     return _format_team_search_results(
-        matches, catalog, client_id, probability,
+        matches, catalog, client_id, probability, meta=search_meta,
     )
 
 
 def _format_team_search_results(
     matches: list[dict], catalog, client_id: str, probability: float,
+    *,
+    meta: dict | None = None,
 ) -> dict:
     """把统一排名命中投影为既有 search/install 响应契约。"""
     results: list[dict] = []
@@ -1165,7 +1172,13 @@ def _format_team_search_results(
                 "staging_assigned": side == "staging",
             })
         results.append(result)
-    return {"results": results}
+    payload = {"results": results}
+    if meta is not None:
+        payload["meta"] = {
+            "corpus_empty": bool(meta.get("corpus_empty")),
+            "degraded_to_bm25": bool(meta.get("degraded_to_bm25")),
+        }
+    return payload
 
 
 def _pin_repo_search_grant(

--- a/tests/test_optional_pymilvus.py
+++ b/tests/test_optional_pymilvus.py
@@ -11,10 +11,10 @@ from xskill.recommend import skill_vector_store as svs
 @pytest.fixture(autouse=True)
 def _reset_milvus_gates(monkeypatch):
     monkeypatch.setattr(svs, "_pymilvus_import_ok", None)
-    monkeypatch.setattr(svs, "_milvus_last_warn_mono", 0.0)
+    monkeypatch.setattr(svs, "_milvus_last_warn_mono", None)
     yield
     monkeypatch.setattr(svs, "_pymilvus_import_ok", None)
-    monkeypatch.setattr(svs, "_milvus_last_warn_mono", 0.0)
+    monkeypatch.setattr(svs, "_milvus_last_warn_mono", None)
 
 
 def test_open_skill_vector_index_falls_back_without_pymilvus(monkeypatch):
@@ -32,7 +32,7 @@ def test_open_skill_vector_index_falls_back_without_pymilvus(monkeypatch):
 
 def test_milvus_unavailable_warn_throttled_hourly(monkeypatch):
     monkeypatch.setattr(svs, "_pymilvus_import_ok", False)
-    monkeypatch.setattr(svs, "_milvus_last_warn_mono", 0.0)
+    monkeypatch.setattr(svs, "_milvus_last_warn_mono", None)
     warned: list[str] = []
 
     def _capture(msg, *args, **_kwargs):
@@ -49,6 +49,19 @@ def test_milvus_unavailable_warn_throttled_hourly(monkeypatch):
     )
     svs.warn_milvus_unavailable_hourly("again")
     assert len(warned) == 2
+
+
+def test_milvus_warn_fires_when_monotonic_uptime_under_interval(monkeypatch):
+    """开机不足 1h 时，旧哨兵 0.0 会误吞首次 warn；None 哨兵必须放行。"""
+    monkeypatch.setattr(svs, "_milvus_last_warn_mono", None)
+    monkeypatch.setattr(svs.time, "monotonic", lambda: 120.0)
+    warned: list[str] = []
+    monkeypatch.setattr(
+        svs.logger, "warning",
+        lambda msg, *args, **_k: warned.append(msg % args if args else msg),
+    )
+    svs.warn_milvus_unavailable_hourly("pymilvus not installed")
+    assert len(warned) == 1
 
 
 def test_try_open_milvus_lite_returns_none_without_pymilvus(monkeypatch):

--- a/tests/test_orphan_adoption.py
+++ b/tests/test_orphan_adoption.py
@@ -194,6 +194,35 @@ def test_revsync_orphan_backports_user_edit(tmp_path):
     assert read_install_metadata(dest) is not None
 
 
+def test_git_tree_fingerprints_prefer_worktree_when_head_matches(tmp_path):
+    """HEAD==install sha 时基线跟 worktree（模拟 Windows CRLF 工作区）。"""
+    import hashlib
+
+    from xskill.ecosystems.installation import _git_tree_fingerprints
+
+    src, sha = _git_source(tmp_path, {"SKILL.md": "v1\n"})
+    (src / "SKILL.md").write_bytes(b"v1\r\n")
+    fingerprints = _git_tree_fingerprints(src, sha)
+    assert fingerprints is not None
+    assert fingerprints["SKILL.md"] == hashlib.sha256(b"v1\r\n").hexdigest()
+
+
+def test_revsync_orphan_backports_when_worktree_has_crlf(tmp_path):
+    """源仓 worktree 为 CRLF、与 blob LF 不一致时，孤儿编辑仍应回流。"""
+    src, sha = _git_source(tmp_path, {"SKILL.md": "v1\n"})
+    (src / "SKILL.md").write_bytes(b"v1\r\n")
+    dest = _orphan_dest(tmp_path, {"SKILL.md": "v1\r\n"}, sha)
+    (dest / "SKILL.md").write_bytes(b"v2-user-edit\r\n")
+
+    status = reverse_sync_copy_dest(
+        dest, src,
+        exclude=_REVSYNC_EXCLUDE,
+        quiet_seconds=0,
+    )
+    assert status == ReverseSyncStatus.SYNCED
+    assert (src / "SKILL.md").read_bytes() == b"v2-user-edit\r\n"
+
+
 def test_revsync_orphan_unedited_is_no_edit(tmp_path):
     src, sha = _git_source(tmp_path, {"SKILL.md": "v1\n"})
     dest = _orphan_dest(tmp_path, {"SKILL.md": "v1\n"}, sha)

--- a/tests/test_search_cli_output.py
+++ b/tests/test_search_cli_output.py
@@ -136,6 +136,46 @@ def test_search_plain_output_is_compact_and_read_only(capsys):
     assert "已安装到" not in output
 
 
+def test_search_warns_on_bm25_degradation(capsys):
+    class _MetaHttp:
+        def get(self, *_args, **_kwargs):
+            return _Response(200, json_data={
+                "results": [_result("bm25-only")],
+                "meta": {"corpus_empty": False, "degraded_to_bm25": True},
+            })
+
+    return_code = cli.cmd_search_hub(
+        SimpleNamespace(
+            terms=["bm25"], top_k=5, json=False, download=False,
+        ),
+        http=_MetaHttp(), headers={},
+    )
+    captured = capsys.readouterr()
+    assert return_code == 0
+    assert "bm25-only" in captured.out
+    assert "降级为 BM25" in captured.err
+
+
+def test_search_warns_on_empty_corpus(capsys):
+    class _EmptyHttp:
+        def get(self, *_args, **_kwargs):
+            return _Response(200, json_data={
+                "results": [],
+                "meta": {"corpus_empty": True, "degraded_to_bm25": False},
+            })
+
+    return_code = cli.cmd_search_hub(
+        SimpleNamespace(
+            terms=["anything"], top_k=5, json=False, download=False,
+        ),
+        http=_EmptyHttp(), headers={},
+    )
+    captured = capsys.readouterr()
+    assert return_code == 0
+    assert "暂无可搜索" in captured.out
+    assert "库为空" in captured.err
+
+
 def test_search_download_uses_legacy_search_slots(
     tmp_path, monkeypatch, capsys,
 ):

--- a/tests/test_skill_hub_search_upload.py
+++ b/tests/test_skill_hub_search_upload.py
@@ -32,7 +32,13 @@ class _FailingSearchHub:
     def cached_search(self, _query: str, _limit: int):
         return None
 
+    def cached_search_with_meta(self, _query: str, _limit: int):
+        return None
+
     def search(self, _query: str, _limit: int):
+        raise self.error
+
+    def search_with_meta(self, _query: str, _limit: int):
         raise self.error
 
 
@@ -42,7 +48,16 @@ class _CombinedSearchEngine:
         self.ranked = ranked
 
     def search_team_skills(self, _query: str, limit: int, _catalog):
-        return self.ranked[:limit]
+        results, _meta = self.search_team_skills_with_meta(
+            _query, limit, _catalog,
+        )
+        return results
+
+    def search_team_skills_with_meta(self, _query: str, limit: int, _catalog):
+        return self.ranked[:limit], {
+            "corpus_empty": False,
+            "degraded_to_bm25": False,
+        }
 
 
 def _write_hub_skill(hub_dir: Path, folder: str, name: str, description: str) -> Path:

--- a/tests/test_skillhub_hybrid_search.py
+++ b/tests/test_skillhub_hybrid_search.py
@@ -596,10 +596,41 @@ def test_endpoint_adds_source_ux_and_match_fields(tmp_path):
     response = http.get("/api/v1/team/skill_hub/search",
                         params={"query": "docker"}, headers=headers)
     assert response.status_code == 200
-    top = response.json()["results"][0]
+    payload = response.json()
+    top = payload["results"][0]
     assert top["source"] == "skillhub"
     assert top["ux_avg"] is None
     assert top["match"] == {"bm25_rank": 1, "semantic_rank": None}
+    assert payload["meta"] == {
+        "corpus_empty": False,
+        "degraded_to_bm25": True,
+    }
+
+
+def test_endpoint_meta_marks_empty_corpus(tmp_path):
+    hub_dir = tmp_path / "hub"
+    hub_dir.mkdir()
+    hub = SkillHub(enabled=True, hub_dir=hub_dir, embed_client=None)
+    http = _make_team_client(tmp_path, skillhub=hub)
+    _cid, headers = _register(http)
+    response = http.get("/api/v1/team/skill_hub/search",
+                        params={"query": "docker"}, headers=headers)
+    assert response.status_code == 200
+    payload = response.json()
+    assert payload["results"] == []
+    assert payload["meta"] == {
+        "corpus_empty": True,
+        "degraded_to_bm25": False,
+    }
+
+
+def test_search_with_meta_reports_bm25_degradation(tmp_path):
+    hub_dir = tmp_path / "hub"
+    _write_hub_skill(hub_dir, "a", "alpha", "alpha docs")
+    hub = SkillHub(enabled=True, hub_dir=hub_dir, embed_client=None)
+    results, meta = hub.search_with_meta("alpha", limit=3)
+    assert results
+    assert meta == {"corpus_empty": False, "degraded_to_bm25": True}
 
 
 def test_endpoint_serves_hot_result_without_anyio_worker(tmp_path, monkeypatch):


### PR DESCRIPTION
## Summary
- `SkillHub.search_with_meta` / API `GET /skill_hub/search` now include `meta.corpus_empty` and `meta.degraded_to_bm25` (backward-compatible additive field).
- CLI `xskill search` prints stderr warnings for empty library and BM25 degradation, and clarifies empty-corpus stdout copy.
- Keeps JSON stdout as a bare results array for existing clients.

## Test plan
- [x] `pytest tests/test_search_cli_output.py tests/test_skillhub_hybrid_search.py tests/test_skill_hub_search_upload.py -q`
- [ ] CI on this PR


Made with [Cursor](https://cursor.com)