### PR TITLE
fix: reject empty trajectory submissions

### DIFF
--- a/src/xskill/ecosystems/_shared.py
+++ b/src/xskill/ecosystems/_shared.py
@@ -669,6 +669,14 @@ def submit_trajectory(
     ``ingest.mask_patterns``（默认空 = 不替换）。命中段在写 md 之前替换为
     占位符——剥掉评测 harness 的固定外壳，防聚类被任务外壳吸住。
     """
+    if not isinstance(content, str) or not content.strip():
+        raise ValueError("trajectory content must be non-empty")
+
+    if format == "json":
+        data = json.loads(content)
+        if not data:
+            raise ValueError("trajectory content must be non-empty")
+
     traj_dir = Path(traj_dir) if traj_dir else get_traj_dir()
     traj_dir.mkdir(parents=True, exist_ok=True)
 

--- a/tests/test_trajectory_submit_validation.py
+++ b/tests/test_trajectory_submit_validation.py
@@ -1,0 +1,72 @@
+from __future__ import annotations
+
+from types import SimpleNamespace
+
+import pytest
+from fastapi import HTTPException
+
+from xskill.ecosystems import submit_trajectory
+
+
+@pytest.mark.parametrize(
+    ("content", "format"),
+    [
+        ("", "markdown"),
+        ("  \n\t", "markdown"),
+        ("", "raw"),
+        ("  \n\t", "raw"),
+        ("{}", "json"),
+    ],
+)
+def test_submit_rejects_empty_trajectories_without_writing_files(
+    tmp_path, content, format
+):
+    with pytest.raises(ValueError, match="content"):
+        submit_trajectory(content=content, format=format, traj_dir=tmp_path)
+
+    assert list(tmp_path.iterdir()) == []
+
+
+def test_submit_accepts_json_with_a_message(tmp_path):
+    result = submit_trajectory(
+        content='{"messages":[{"role":"user","content":"hello"}]}',
+        format="json",
+        traj_dir=tmp_path,
+    )
+
+    assert result["status"] == "stored"
+    assert "hello" in (tmp_path / "traj_0001.md").read_text(encoding="utf-8")
+
+
+@pytest.mark.asyncio
+@pytest.mark.parametrize("content", ["", "  \n\t"])
+async def test_api_rejects_empty_content_before_resolving_watch_directory(
+    tmp_path, monkeypatch, content
+):
+    import xskill.api.app as api_app
+    import xskill.ecosystems._shared as shared
+
+    monkeypatch.setattr(api_app, "_ensure_loaded", lambda: None)
+    monkeypatch.setattr(api_app, "_config", {})
+    monkeypatch.setattr(api_app, "_skill_dir", tmp_path / "skill")
+    def fail_get_traj_dir():
+        raise AssertionError("invalid content should fail before resolving a watch directory")
+
+    monkeypatch.setattr(shared, "get_traj_dir", fail_get_traj_dir)
+
+    app = api_app.create_app(home_root=tmp_path)
+    route = next(
+        route for route in app.routes
+        if getattr(route, "path", None) == "/api/v1/trajectories/submit"
+    )
+
+    with pytest.raises(HTTPException) as exc_info:
+        await route.endpoint(SimpleNamespace(
+            content=content,
+            format="markdown",
+            metadata=None,
+            traj_id=None,
+        ))
+
+    assert exc_info.value.status_code == 400
+    assert list(tmp_path.iterdir()) == []


### PR DESCRIPTION
## Summary  Reject empty trajectory submissions before resolving a watch directory or writing files.  ## Changes  - Reject empty and whitespace-only content at the shared `submit_trajectory` boundary. - Reject an empty JSON object, which otherwise becomes an empty `# Trajectory` document. - Add regression coverage for markdown, raw, JSON, and the HTTP submission path.  ## Test plan  - [x] Added/updated unit tests for the change - [x] `python -m pytest -q tests/test_trajectory_submit_validation.py tests/test_sanitize.py --timeout=15` (17 passed) - [x] `python -m py_compile src/xskill/ecosystems/_shared.py tests/test_trajectory_submit_validation.py` - [ ] `make test` passes — the full 2,051-test run exceeded the local Windows timeout before completion - [ ] `make e2e` passes — not run locally  ## Linked issues  Closes #27  

## AI assistance

AI assistance was used for repository research, implementation, and test drafting. The diff and validation results are documented here for maintainer review.