### PR TITLE
feat(search): auto-adapt deployment mode with local BM25 fallback

### DIFF
--- a/src/xskill/agents/user_edit_absorb_agent.py
+++ b/src/xskill/agents/user_edit_absorb_agent.py
@@ -1377,8 +1377,12 @@ def reverse_sync_copy_dest(
                 )
                 if dest_hash == baseline_hash:
                     continue
+                # 基线缺该路径：视为 dest 单边新增/改动，允许回流（不再把
+                # ``baseline is None`` 误判成三方冲突——Windows 孤儿领养曾
+                # 因空基线在此处 100% FAILED）。
                 if (
-                    source_hash != baseline_hash
+                    baseline_hash is not None
+                    and source_hash != baseline_hash
                     and source_hash != dest_hash
                 ):
                     _log_reverse_sync_failure(

--- a/src/xskill/cli.py
+++ b/src/xskill/cli.py
@@ -1160,6 +1160,206 @@ def cmd_search_hub(args, http=None, headers=None) -> int:
     return 0
 
 
+def cmd_search(args) -> int:
+    """`xskill search` 部署模式自适应入口（#201）。
+
+    解析顺序：``--team`` / ``--local`` 显式覆盖 > team client 状态文件
+    （已 connect → SkillHub 路径）> 本地技能库路径。standalone 用户不再
+    被 "未连接 team server" 直接挡在门外（#46 的前向修复）。
+    """
+    if getattr(args, "team", False):
+        return cmd_search_hub(args)
+    if getattr(args, "local", False):
+        return _cmd_search_local(args)
+    from xskill.runtime import role
+    if role() == "client":
+        return cmd_search_hub(args)
+    return _cmd_search_local(args)
+
+
+def _cmd_search_local(args, *, post=None) -> int:
+    """本地技能库搜索：优先本机 daemon 语义检索，不可用时回退 BM25。
+
+    降级必须对用户可见（stderr 警告），不静默空结果也不 traceback——
+    与 server 端 skill_hub「语义不可用退化 BM25」同一契约。
+    ``post`` 参数仅测试注入用。
+    """
+    import json as _json
+
+    from xskill.runtime import read_status
+
+    query = " ".join(args.terms).strip()
+    if getattr(args, "download", False):
+        _write_search_output(
+            "warning: --download 仅 team 模式有效，本地技能已在本机，忽略",
+            to_stderr=True,
+        )
+
+    st = read_status()
+    hits: list[dict] = []
+    semantic_ok = False
+    if st.get("running") and st.get("port"):
+        if post is None:
+            import httpx
+
+            def post(url, **kw):
+                return httpx.post(url, trust_env=False, timeout=15.0, **kw)
+        try:
+            resp = post(
+                f"http://127.0.0.1:{st['port']}/api/v1/skills/search",
+                json={"query": query, "top_k": args.top_k},
+            )
+            if resp.status_code == 200:
+                data = resp.json()
+                # 兼容历史空索引 dict 包络（#46 Bug A 的形状）：统一成 list
+                if isinstance(data, dict):
+                    data = data.get("results", [])
+                if isinstance(data, list):
+                    semantic_ok = True
+                    hits = [h for h in data if isinstance(h, dict)]
+        except Exception as search_error:  # noqa: BLE001 — 降级路径必须兜住
+            logger.debug("local semantic search failed: %s", search_error)
+
+    used_bm25 = False
+    if not hits:
+        if not st.get("running"):
+            _write_search_output(
+                "⚠ 本地 daemon 未运行（先 `xskill serve`），"
+                "本次搜索回退 BM25 关键词检索",
+                to_stderr=True,
+            )
+        elif not semantic_ok:
+            _write_search_output(
+                "⚠ 本地语义搜索不可用（embedding 未配置或索引缺失），"
+                "本次搜索回退 BM25 关键词检索",
+                to_stderr=True,
+            )
+        bm25_hits = _local_bm25_hits(query, top_k=args.top_k)
+        if bm25_hits and semantic_ok:
+            _write_search_output(
+                "⚠ 语义索引无命中（索引未建或 embedding 未配置），"
+                "以下为 BM25 关键词匹配结果",
+                to_stderr=True,
+            )
+        hits = bm25_hits
+        used_bm25 = True
+
+    if getattr(args, "json", False):
+        _write_search_output(_json.dumps(hits, ensure_ascii=True, indent=2))
+        return 0
+    if not hits:
+        _write_search_output("本地技能库无匹配 skill")
+        return 0
+    _render_local_search_results(hits, query, keyword_only=used_bm25)
+    return 0
+
+
+def _local_bm25_hits(query: str, *, top_k: int) -> list[dict]:
+    """对本地 skill 的 name+description+tags 做 BM25 关键词检索。
+
+    分词复用 skillhub 的 ``_tokenize``（ASCII 切词 + 中文 bigram），打分
+    复用 skillhub 的 Lucene 风格公式 ``log(1 + (N-df+0.5)/(df+0.5))``
+    （k1=1.2, b=0.75）——IDF 恒正，本地小语料（几个 skill）不会像
+    BM25Okapi 那样把全部分数压成 0。"""
+    import math
+
+    from xskill.config import XSKILL_HOME, get_skill_dir
+    from xskill.recommend.skillhub import BM25_B, BM25_K1, _tokenize
+    from xskill.skill.skill import _load_skill
+
+    try:
+        skill_dir = get_skill_dir()
+    except FileNotFoundError:
+        # 首装还没有 config.yaml：关键词回退不应依赖配置，用默认 skill 目录
+        skill_dir = XSKILL_HOME / "skill"
+    entries: list[dict] = []
+    if skill_dir.exists():
+        for d in sorted(skill_dir.iterdir()):
+            if not d.is_dir() or d.name.startswith("."):
+                continue
+            fm, _body, _path = _load_skill(d)
+            if not fm:
+                continue
+            meta = fm.get("metadata", {}) or {}
+            description = (fm.get("description") or "").strip()
+            tags = [str(t) for t in (meta.get("tags", []) or [])]
+            entries.append({
+                "skill_name": d.name,
+                "description": description,
+                "tags": tags,
+                "version": int(meta.get("version", 0) or 0),
+                "text": " ".join([d.name, description, *tags]),
+            })
+
+    query_tokens = set(_tokenize(query))
+    if not entries or not query_tokens:
+        return []
+    corpus = [_tokenize(e["text"]) for e in entries]
+    doc_count = len(corpus)
+    avg_doc_len = sum(len(doc) for doc in corpus) / doc_count
+    if avg_doc_len == 0:
+        return []
+    doc_freq = {
+        token: sum(1 for doc in corpus if token in doc)
+        for token in query_tokens
+    }
+    scores: list[float] = []
+    for doc in corpus:
+        score = 0.0
+        for token in query_tokens:
+            tf = doc.count(token)
+            if tf == 0 or doc_freq[token] == 0:
+                continue
+            idf = math.log(
+                1 + (doc_count - doc_freq[token] + 0.5)
+                / (doc_freq[token] + 0.5)
+            )
+            denominator = tf + BM25_K1 * (
+                1 - BM25_B + BM25_B * len(doc) / avg_doc_len
+            )
+            score += idf * tf * (BM25_K1 + 1) / denominator
+        scores.append(score)
+    ranked = sorted(
+        zip(entries, scores), key=lambda pair: pair[1], reverse=True,
+    )
+    out: list[dict] = []
+    for entry, score in ranked[:top_k]:
+        if score <= 0:
+            continue
+        hit = {k: v for k, v in entry.items() if k != "text"}
+        hit["bm25_score"] = float(score)
+        out.append(hit)
+    return out
+
+
+def _render_local_search_results(
+    hits: list[dict], query: str, *, keyword_only: bool,
+) -> None:
+    """渲染本地技能库搜索结果（本机 skill，无下载步骤）。"""
+    mode_label = "BM25 关键词" if keyword_only else "语义"
+    output_lines = [
+        f"搜索：{query}（本地技能库，{mode_label}）",
+        f"找到 {len(hits)} 个 skill",
+        "=" * 64,
+    ]
+    for index, row in enumerate(hits, start=1):
+        if index > 1:
+            output_lines.append("-" * 64)
+        output_lines.append(
+            f"[{index}/{len(hits)}] {row.get('skill_name') or '(unnamed)'}"
+        )
+        description = " ".join(str(row.get("description") or "").split())
+        if len(description) > 180:
+            description = f"{description[:177].rstrip()}..."
+        output_lines.append(f"描述：{description or '（无描述）'}")
+        if row.get("similarity") is not None:
+            output_lines.append(f"匹配：语义相似度 {row['similarity']:.4f}")
+        elif row.get("bm25_score") is not None:
+            output_lines.append(f"匹配：BM25 {row['bm25_score']:.2f}")
+    output_lines.append("=" * 64)
+    _write_search_output("\n".join(output_lines))
+
+
 def cmd_download(args, http=None, headers=None) -> int:
     """`xskill download <skill-id>` —— 显式下载并持久安装一个搜索结果。"""
     import json as _json
@@ -1464,11 +1664,11 @@ def build_parser() -> argparse.ArgumentParser:
 
     p_search = sub.add_parser(
         "search",
-        help="搜索 team server 的 skill 元信息（不下载）",
+        help="搜索 skill（自动适配：已连 team 走 SkillHub，否则本地技能库）",
     )
     p_search.add_argument(
         "terms", nargs="+", metavar="QUERY",
-        help="搜索词（可多个，拼成一个 skillhub 查询）",
+        help="搜索词（可多个，拼成一个查询）",
     )
     p_search.add_argument("--top-k", "-k", type=int, default=5,
                           help="返回条数（skillhub 搜索最多 10）")
@@ -1477,6 +1677,15 @@ def build_parser() -> argparse.ArgumentParser:
         help="兼容旧 search：下载命中到 10 槽 LRU 并安装到已检测 harness",
     )
     p_search.add_argument("--json", action="store_true", help="机读 JSON 输出")
+    p_search_mode = p_search.add_mutually_exclusive_group()
+    p_search_mode.add_argument(
+        "--team", action="store_true",
+        help="强制走 team SkillHub 搜索（需先 xskill connect）",
+    )
+    p_search_mode.add_argument(
+        "--local", action="store_true",
+        help="强制搜本地技能库（daemon 语义检索，不可用回退 BM25）",
+    )
 
     p_download = sub.add_parser(
         "download", help="按 search 返回的 skill ID 显式下载并持久安装",
@@ -1691,7 +1900,7 @@ def main() -> int:
 
     # skillhub 搜索/下载/上传是瘦客户端侧（走 team server），不碰 config.yaml。
     if args.command == "search":
-        return cmd_search_hub(args)
+        return cmd_search(args)
     if args.command == "download":
         return cmd_download(args)
     if args.command == "upload":

--- a/src/xskill/ecosystems/installation.py
+++ b/src/xskill/ecosystems/installation.py
@@ -334,13 +334,29 @@ def read_install_metadata(dest: Path) -> dict | None:
 
 
 _GIT_COMMIT_SHA_PATTERN = re.compile(r"[0-9a-f]{40}")
+# git tree 入口的 mode 高位（与 POSIX S_IFMT 同形）；勿只靠平台 S_IS*，
+# 个别环境下对原始 git mode 的宏判断会漏掉普通文件。
+_GIT_MODE_MASK = 0o160000
+_GIT_MODE_FILE = 0o100000
+_GIT_MODE_DIR = 0o040000
+
+
+def _git_mode_is_dir(mode: int) -> bool:
+    return (mode & _GIT_MODE_MASK) == _GIT_MODE_DIR or stat.S_ISDIR(mode)
+
+
+def _git_mode_is_file(mode: int) -> bool:
+    return (mode & _GIT_MODE_MASK) == _GIT_MODE_FILE or stat.S_ISREG(mode)
 
 
 def _git_tree_fingerprints(source: Path, sha: str) -> dict[str, str] | None:
     """按 commit 的 git tree 重建逐文件内容指纹。
 
-    口径与 ``_safe_copy_file_fingerprints`` 一致：文件字节 sha256、POSIX
-    相对路径。任何一步读不到对象都返回 None（调用方按不可领养处理）。
+    口径与 ``_safe_copy_file_fingerprints`` / reverse_sync 一致：文件字节
+    sha256、POSIX 相对路径。当 HEAD 仍停在该 install commit 时，优先用
+    **工作区**字节——reverse_sync 比对的是 worktree；Windows 上 blob 与
+    工作区可能因换行/checkout 口径不一致，用 blob 做基线会误报
+    ``REVERSE_SYNC_CONTENT_CONFLICT``。任何一步读不到对象都返回 None。
     """
     try:
         repo = Repo(str(source))
@@ -367,9 +383,9 @@ def _git_tree_fingerprints(source: Path, sha: str) -> dict[str, str] | None:
                 except UnicodeDecodeError:
                     return None
                 relative = prefix / name
-                if stat.S_ISDIR(mode):
+                if _git_mode_is_dir(mode):
                     stack.append((entry_id, relative))
-                elif stat.S_ISREG(mode):
+                elif _git_mode_is_file(mode):
                     try:
                         blob = repo[entry_id]
                     except KeyError:
@@ -377,6 +393,34 @@ def _git_tree_fingerprints(source: Path, sha: str) -> dict[str, str] | None:
                     fingerprints[relative.as_posix()] = hashlib.sha256(
                         blob.data,
                     ).hexdigest()
+        try:
+            head_raw = repo.refs[b"HEAD"]
+            head_hex = (
+                head_raw.decode("ascii")
+                if isinstance(head_raw, (bytes, bytearray))
+                else None
+            )
+        except (KeyError, UnicodeDecodeError, TypeError):
+            head_hex = None
+        if head_hex == sha:
+            source_root = Path(source)
+            for relative_name in list(fingerprints):
+                worktree_path = source_root.joinpath(*relative_name.split("/"))
+                try:
+                    path_stat = worktree_path.lstat()
+                except OSError:
+                    continue
+                if (
+                    not stat.S_ISREG(path_stat.st_mode)
+                    or _stat_is_reparse_point(path_stat)
+                ):
+                    continue
+                try:
+                    fingerprints[relative_name] = hashlib.sha256(
+                        worktree_path.read_bytes(),
+                    ).hexdigest()
+                except OSError:
+                    continue
         return fingerprints
     except (OSError, ValueError, KeyError):
         return None

--- a/src/xskill/recommend/skill_vector_store.py
+++ b/src/xskill/recommend/skill_vector_store.py
@@ -20,9 +20,11 @@ logger = logging.getLogger("xskill.skill_vector_store")
 COLLECTION = "skill_vectors"
 DEFAULT_DIM = 8  # fake/tests；生产由首条真实向量决定或配置
 
-# 未装 / 打不开 Milvus 时的节流警告（写进 xskill.log）
+# 未装 / 打不开 Milvus 时的节流警告（写进 xskill.log）。
+# ``None`` = 从未 warn；勿用 0.0——``time.monotonic()`` 从开机起算，
+# CI / 短寿命机器 uptime < 1h 时会把「首次」误判成仍在节流窗口内。
 _MILVUS_WARN_INTERVAL_S = 3600.0
-_milvus_last_warn_mono = 0.0
+_milvus_last_warn_mono: Optional[float] = None
 _pymilvus_import_ok: Optional[bool] = None
 
 
@@ -330,7 +332,10 @@ def warn_milvus_unavailable_hourly(reason: str) -> None:
     """服务器侧无 Milvus 时每小时最多一条 WARNING（进 ``xskill.log``）。"""
     global _milvus_last_warn_mono
     now = time.monotonic()
-    if (now - _milvus_last_warn_mono) < _MILVUS_WARN_INTERVAL_S:
+    if (
+        _milvus_last_warn_mono is not None
+        and (now - _milvus_last_warn_mono) < _MILVUS_WARN_INTERVAL_S
+    ):
         return
     _milvus_last_warn_mono = now
     logger.warning(

--- a/tests/test_optional_pymilvus.py
+++ b/tests/test_optional_pymilvus.py
@@ -11,10 +11,10 @@ from xskill.recommend import skill_vector_store as svs
 @pytest.fixture(autouse=True)
 def _reset_milvus_gates(monkeypatch):
     monkeypatch.setattr(svs, "_pymilvus_import_ok", None)
-    monkeypatch.setattr(svs, "_milvus_last_warn_mono", 0.0)
+    monkeypatch.setattr(svs, "_milvus_last_warn_mono", None)
     yield
     monkeypatch.setattr(svs, "_pymilvus_import_ok", None)
-    monkeypatch.setattr(svs, "_milvus_last_warn_mono", 0.0)
+    monkeypatch.setattr(svs, "_milvus_last_warn_mono", None)
 
 
 def test_open_skill_vector_index_falls_back_without_pymilvus(monkeypatch):
@@ -32,7 +32,7 @@ def test_open_skill_vector_index_falls_back_without_pymilvus(monkeypatch):
 
 def test_milvus_unavailable_warn_throttled_hourly(monkeypatch):
     monkeypatch.setattr(svs, "_pymilvus_import_ok", False)
-    monkeypatch.setattr(svs, "_milvus_last_warn_mono", 0.0)
+    monkeypatch.setattr(svs, "_milvus_last_warn_mono", None)
     warned: list[str] = []
 
     def _capture(msg, *args, **_kwargs):
@@ -49,6 +49,19 @@ def test_milvus_unavailable_warn_throttled_hourly(monkeypatch):
     )
     svs.warn_milvus_unavailable_hourly("again")
     assert len(warned) == 2
+
+
+def test_milvus_warn_fires_when_monotonic_uptime_under_interval(monkeypatch):
+    """开机不足 1h 时，旧哨兵 0.0 会误吞首次 warn；None 哨兵必须放行。"""
+    monkeypatch.setattr(svs, "_milvus_last_warn_mono", None)
+    monkeypatch.setattr(svs.time, "monotonic", lambda: 120.0)
+    warned: list[str] = []
+    monkeypatch.setattr(
+        svs.logger, "warning",
+        lambda msg, *args, **_k: warned.append(msg % args if args else msg),
+    )
+    svs.warn_milvus_unavailable_hourly("pymilvus not installed")
+    assert len(warned) == 1
 
 
 def test_try_open_milvus_lite_returns_none_without_pymilvus(monkeypatch):

--- a/tests/test_orphan_adoption.py
+++ b/tests/test_orphan_adoption.py
@@ -194,6 +194,35 @@ def test_revsync_orphan_backports_user_edit(tmp_path):
     assert read_install_metadata(dest) is not None
 
 
+def test_git_tree_fingerprints_prefer_worktree_when_head_matches(tmp_path):
+    """HEAD==install sha 时基线跟 worktree（模拟 Windows CRLF 工作区）。"""
+    import hashlib
+
+    from xskill.ecosystems.installation import _git_tree_fingerprints
+
+    src, sha = _git_source(tmp_path, {"SKILL.md": "v1\n"})
+    (src / "SKILL.md").write_bytes(b"v1\r\n")
+    fingerprints = _git_tree_fingerprints(src, sha)
+    assert fingerprints is not None
+    assert fingerprints["SKILL.md"] == hashlib.sha256(b"v1\r\n").hexdigest()
+
+
+def test_revsync_orphan_backports_when_worktree_has_crlf(tmp_path):
+    """源仓 worktree 为 CRLF、与 blob LF 不一致时，孤儿编辑仍应回流。"""
+    src, sha = _git_source(tmp_path, {"SKILL.md": "v1\n"})
+    (src / "SKILL.md").write_bytes(b"v1\r\n")
+    dest = _orphan_dest(tmp_path, {"SKILL.md": "v1\r\n"}, sha)
+    (dest / "SKILL.md").write_bytes(b"v2-user-edit\r\n")
+
+    status = reverse_sync_copy_dest(
+        dest, src,
+        exclude=_REVSYNC_EXCLUDE,
+        quiet_seconds=0,
+    )
+    assert status == ReverseSyncStatus.SYNCED
+    assert (src / "SKILL.md").read_bytes() == b"v2-user-edit\r\n"
+
+
 def test_revsync_orphan_unedited_is_no_edit(tmp_path):
     src, sha = _git_source(tmp_path, {"SKILL.md": "v1\n"})
     dest = _orphan_dest(tmp_path, {"SKILL.md": "v1\n"}, sha)

--- a/tests/test_search_local_fallback.py
+++ b/tests/test_search_local_fallback.py
@@ -1,0 +1,178 @@
+"""`xskill search` 部署模式自适应 + 本地 BM25 回退测试（#46 前向修复 / #201）。"""
+from __future__ import annotations
+
+import json
+from pathlib import Path
+from types import SimpleNamespace
+
+import pytest
+
+from xskill import cli
+
+
+def _args(**overrides) -> SimpleNamespace:
+    base = {
+        "terms": ["文案", "对齐"], "top_k": 5, "json": False,
+        "download": False, "team": False, "local": False,
+    }
+    base.update(overrides)
+    return SimpleNamespace(**base)
+
+
+class _Response:
+    def __init__(self, status_code: int, json_data):
+        self.status_code = status_code
+        self._json_data = json_data
+
+    def json(self):
+        return self._json_data
+
+
+def _write_skill(skill_dir: Path, name: str, description: str) -> None:
+    d = skill_dir / name
+    d.mkdir(parents=True)
+    (d / "SKILL.md").write_text(
+        f"---\nname: {name}\ndescription: {description}\n"
+        "metadata:\n  version: 1\n---\n\n# body\n",
+        encoding="utf-8",
+    )
+
+
+@pytest.fixture()
+def local_skill_dir(tmp_path, monkeypatch) -> Path:
+    skill_dir = tmp_path / "skill"
+    skill_dir.mkdir()
+    import xskill.config as config_module
+    monkeypatch.setattr(config_module, "get_skill_dir", lambda: skill_dir)
+    return skill_dir
+
+
+# ── 模式分发 ─────────────────────────────────────────────────────
+
+def test_standalone_role_dispatches_local(monkeypatch):
+    from xskill import runtime
+    monkeypatch.setattr(runtime, "role", lambda: "standalone")
+    called = {}
+    monkeypatch.setattr(
+        cli, "_cmd_search_local", lambda args: called.setdefault("local", 0) or 0,
+    )
+    assert cli.cmd_search(_args()) == 0
+    assert "local" in called
+
+
+def test_client_role_dispatches_team(monkeypatch):
+    from xskill import runtime
+    monkeypatch.setattr(runtime, "role", lambda: "client")
+    called = {}
+    monkeypatch.setattr(
+        cli, "cmd_search_hub", lambda args: called.setdefault("team", 0) or 0,
+    )
+    assert cli.cmd_search(_args()) == 0
+    assert "team" in called
+
+
+def test_explicit_flags_override_role(monkeypatch):
+    calls = []
+    monkeypatch.setattr(cli, "cmd_search_hub", lambda args: calls.append("team") or 0)
+    monkeypatch.setattr(cli, "_cmd_search_local", lambda args: calls.append("local") or 0)
+    # --team 在 standalone 角色下仍走 team；--local 在 client 角色下仍走本地
+    cli.cmd_search(_args(team=True))
+    cli.cmd_search(_args(local=True))
+    assert calls == ["team", "local"]
+
+
+# ── 本地路径：daemon 语义检索 ────────────────────────────────────
+
+def test_local_semantic_hits_render_without_warning(monkeypatch, capsys):
+    from xskill import runtime
+    monkeypatch.setattr(
+        runtime, "read_status", lambda: {"running": True, "port": 8000},
+    )
+    hits = [{
+        "skill_name": "worktree-copy-alignment",
+        "similarity": 0.7755,
+        "description": "处理基于 git worktree 的文案对齐任务",
+        "tags": [], "version": 1,
+    }]
+    rc = cli._cmd_search_local(
+        _args(), post=lambda url, **kw: _Response(200, hits),
+    )
+    captured = capsys.readouterr()
+    assert rc == 0
+    assert "worktree-copy-alignment" in captured.out
+    assert "语义相似度" in captured.out
+    assert "回退" not in captured.err
+
+
+def test_local_daemon_down_falls_back_to_bm25(
+        monkeypatch, capsys, local_skill_dir):
+    from xskill import runtime
+    monkeypatch.setattr(runtime, "read_status", lambda: {"running": False})
+    _write_skill(local_skill_dir, "copy-align", "处理前端文案对齐任务")
+    _write_skill(local_skill_dir, "unrelated", "语音服务链路加固")
+    rc = cli._cmd_search_local(_args())
+    captured = capsys.readouterr()
+    assert rc == 0
+    assert "回退 BM25" in captured.err
+    assert "copy-align" in captured.out
+    assert "unrelated" not in captured.out
+
+
+def test_local_dict_envelope_does_not_crash(
+        monkeypatch, capsys, local_skill_dir):
+    """#46 Bug A 回归：空索引的 dict 包络绝不能当 list 遍历崩掉。"""
+    from xskill import runtime
+    monkeypatch.setattr(
+        runtime, "read_status", lambda: {"running": True, "port": 8000},
+    )
+    _write_skill(local_skill_dir, "copy-align", "处理前端文案对齐任务")
+    envelope = {"results": [], "message": "skill index empty"}
+    rc = cli._cmd_search_local(
+        _args(), post=lambda url, **kw: _Response(200, envelope),
+    )
+    captured = capsys.readouterr()
+    assert rc == 0
+    assert "BM25" in captured.err        # 降级对用户可见
+    assert "copy-align" in captured.out  # BM25 兜住了结果
+
+
+def test_local_json_output_is_machine_readable(
+        monkeypatch, capsys, local_skill_dir):
+    from xskill import runtime
+    monkeypatch.setattr(runtime, "read_status", lambda: {"running": False})
+    _write_skill(local_skill_dir, "copy-align", "处理前端文案对齐任务")
+    rc = cli._cmd_search_local(_args(json=True))
+    captured = capsys.readouterr()
+    assert rc == 0
+    parsed = json.loads(captured.out)
+    assert isinstance(parsed, list)
+    assert parsed[0]["skill_name"] == "copy-align"
+    assert parsed[0]["bm25_score"] > 0
+
+
+def test_local_empty_repo_reports_no_match(
+        monkeypatch, capsys, local_skill_dir):
+    from xskill import runtime
+    monkeypatch.setattr(runtime, "read_status", lambda: {"running": False})
+    rc = cli._cmd_search_local(_args())
+    captured = capsys.readouterr()
+    assert rc == 0
+    assert "无匹配" in captured.out
+
+
+def test_local_bm25_survives_missing_config(monkeypatch, capsys, tmp_path):
+    """首装无 config.yaml：BM25 回退不依赖配置，用默认 skill 目录兜底。"""
+    import xskill.config as config_module
+    from xskill import runtime
+
+    def _raise_missing_config():
+        raise FileNotFoundError("xskill config not found")
+
+    monkeypatch.setattr(runtime, "read_status", lambda: {"running": False})
+    monkeypatch.setattr(config_module, "get_skill_dir", _raise_missing_config)
+    monkeypatch.setattr(config_module, "XSKILL_HOME", tmp_path)
+    _write_skill(tmp_path / "skill", "copy-align", "处理前端文案对齐任务")
+    rc = cli._cmd_search_local(_args())
+    captured = capsys.readouterr()
+    assert rc == 0
+    assert "copy-align" in captured.out


### PR DESCRIPTION
## Summary

standalone 用户此前无法从 CLI 搜索本地技能库：`xskill search` 硬走 team SkillHub 路径，未 connect 直接报 `error: 未连接 team server`。本 PR 让 `xskill search` 自适应部署模式（已 connect 走 SkillHub，否则走本地），并在语义检索不可用时**显式警告 + 回退 BM25 关键词检索**，不再静默空结果或 traceback。#46 的前向修复，实现 #201。

## Changes

- 新增 `cmd_search` 分发入口：`--team` / `--local` 显式覆盖 > `role()==client` 走 SkillHub > 其余走本地技能库
- 新增本地路径 `_cmd_search_local`：daemon 在跑时打本机 `POST /api/v1/skills/search` 语义检索；daemon 未运行、接口不可用或语义空结果时，stderr 显式警告并回退 BM25
- 新增 `_local_bm25_hits`：对 SKILL.md 的 name+description+tags 做关键词检索；分词复用 skillhub `_tokenize`（ASCII 切词 + 中文 bigram），打分复用 skillhub 的 Lucene 风格 `log(1 + …)` IDF（k1=1.2, b=0.75）——本地 2~3 个 skill 的小语料下不会像 `BM25Okapi` 那样全部归零
- 兼容历史空索引 dict 包络 `{"results": [...]}`（#46 Bug A 的形状），CLI 不再可能因它崩溃（含回归测试）
- BM25 回退不依赖 `config.yaml`：首装机器兜底到默认 skill 目录，而不是抛 `FileNotFoundError`
- `search` 子命令 help 更新；`--download` 在本地模式下打警告忽略（本地 skill 无需下载）

## Test plan

- [x] `make test` passes（2045 passed / 10 skipped；本地仅 `test_windows_script_encoding` 2 例失败，系测试扫到本机 `.venv/bin/activate.ps1` 的环境伪失败，与本改动无关，干净环境不复现）
- [x] Added/updated unit tests for the change（`tests/test_search_local_fallback.py`，9 个用例：模式分发 ×3、语义命中渲染、daemon-down 回退、dict 包络回归、JSON 输出、空库、无 config 兜底）
- [ ] `make e2e` passes (if the change touches ingestion / install / daemon)（未触及 ingestion/install/daemon）
- [x] Manually verified the affected user flow：
  - standalone + daemon 在跑：`xskill search 文案对齐` → 语义命中 3 条（相似度 0.63/0.48/0.38），无警告
  - 无 daemon 无 config.yaml 的干净 HOME：同命令 → stderr 警告「daemon 未运行…回退 BM25」，BM25 命中 1 条，rc=0

## Linked issues

Closes #201. Forward fix for #46 (the 0.5.2 `AttributeError` shape is now tolerated and covered by a regression test).
