### PR TITLE
fix: reject empty trajectory content on submit

### DIFF
--- a/src/xskill/ecosystems/_shared.py
+++ b/src/xskill/ecosystems/_shared.py
@@ -672,10 +672,15 @@ def submit_trajectory(
     traj_dir = Path(traj_dir) if traj_dir else get_traj_dir()
     traj_dir.mkdir(parents=True, exist_ok=True)
 
+    if not str(content or "").strip():
+        raise ValueError("trajectory content must be non-empty")
+
     if not traj_id:
         traj_id = generate_traj_id(traj_dir)
 
     md_content, json_metadata = adapt_trajectory(content, format, metadata)
+    if not str(md_content or "").strip():
+        raise ValueError("trajectory content must be non-empty")
 
     # 落盘前清洗：去 ANSI 转义 + 控制字符（终端/tool 原始输出常掺入），
     # 保证 splitlines 行数 == \n 行数（atom offset 与人类行号一致）、不喂垃圾给模型。

--- a/tests/test_submit_rejects_empty.py
+++ b/tests/test_submit_rejects_empty.py
@@ -1,0 +1,18 @@
+import pytest
+
+from xskill.ecosystems._shared import submit_trajectory
+
+
+def test_submit_rejects_empty_content(tmp_path):
+    with pytest.raises(ValueError, match="non-empty"):
+        submit_trajectory(content="", format="markdown", traj_dir=tmp_path)
+
+
+def test_submit_rejects_whitespace_content(tmp_path):
+    with pytest.raises(ValueError, match="non-empty"):
+        submit_trajectory(content="   \n  \n", format="raw", traj_dir=tmp_path)
+
+
+def test_submit_rejects_empty_json_object(tmp_path):
+    with pytest.raises(ValueError, match="non-empty"):
+        submit_trajectory(content="{}", format="json", traj_dir=tmp_path)


### PR DESCRIPTION
## Summary
- Reject blank/whitespace input and empty adapted markdown before writing traj files.
- Add unit tests for empty, whitespace, and `{}` JSON submits.

Closes #27