### PR TITLE
fix(canary): CanaryRouter hash seed/tiebreak + jam triple-gates

### DIFF
--- a/src/xskill/agents/skill_edit_agent.py
+++ b/src/xskill/agents/skill_edit_agent.py
@@ -330,7 +330,9 @@ class SkillEditAgent:
     llm_cfg: dict
     traj_root: Path
     threshold: int = C.ATOM_PROMOTION_THRESHOLD
-    jam_threshold: int = 50
+    jam_threshold: int = 50  # candidates Σws 地板（与 age/plateau 合取）
+    min_jam_age_sec: float = 1800.0
+    jam_plateau_sec: float = 600.0
     batch_size: int = 5
     retry_batch_size: int | None = None
     logs_dir: Path | None = None
@@ -382,8 +384,8 @@ class SkillEditAgent:
 
         守门顺序（任一失败即 return False）：
           1. 该 skill 有 staging 分支 → 灰度中：
-             - 候选累计 ws ≥ jam_threshold → 越过灰度强砍（jam 路径）
-             - 否则维持 hold
+             - age≥min_jam_age ∧ plateau≥jam_plateau ∧ ws≥jam_threshold → jam
+             - 否则维持 hold（并打门控日志）
           2. 无 staging 时：candidates 累计 weightscore < threshold → 没攒够
           3. 触发场景是 "create staging"（main 已存在）：
              - .ux_scores.jsonl 必须至少有 1 条 side=main → 证明 main 真有人用
@@ -393,11 +395,11 @@ class SkillEditAgent:
         main/jam 全过 → 保留旧渐进分支链，终态成功后摘除入口快照 atom_id。
         """
         from xskill.skill.git import current_branch, run_git
+        from xskill.canary import CanaryConfig, evaluate_jam_gates
 
         self._recover_crashed_turns()
 
-        # 守门 1（改）：staging 存在时，候选累计 ws ≥ jam_threshold 则越过灰度强砍；
-        # 未达到阈值时维持原先 hold 行为。
+        # 守门 1：staging 存在时——三条件合取才 jam；否则 hold。
         staging_exists = run_git(
             ["rev-parse", "--verify", "staging"], cwd=str(self.skill_dir),
         )[0] == 0
@@ -406,9 +408,31 @@ class SkillEditAgent:
             int(c.get("weightscore", 0))
             for c in (data.get("candidates", []) or [])
         )
-        jam = staging_exists and total_ws >= self.jam_threshold
-        if staging_exists and not jam:
-            return False
+        jam = False
+        if staging_exists:
+            jam_cfg = CanaryConfig(
+                jam_threshold=self.jam_threshold,
+                min_jam_age_sec=self.min_jam_age_sec,
+                jam_plateau_sec=self.jam_plateau_sec,
+            )
+            gates = evaluate_jam_gates(
+                self.skill_dir, total_ws=total_ws, config=jam_cfg,
+            )
+            logger.info(
+                "jam_gate %s: ok=%s age=%.1f plateau_s=%.1f "
+                "main_n=%s/%s staging_n=%s/%s ws=%s/%s "
+                "main_sha=%s staging_sha=%s reason=%s",
+                self.skill_dir.name, gates.get("ok"), gates.get("age"),
+                gates.get("plateau_s"),
+                gates.get("main_n"), gates.get("need"),
+                gates.get("staging_n"), gates.get("need"),
+                gates.get("ws"), gates.get("jam_threshold"),
+                gates.get("main_sha"), gates.get("staging_sha"),
+                gates.get("reason"),
+            )
+            jam = bool(gates.get("ok"))
+            if not jam:
+                return False
 
         if not staging_exists:
             cur = current_branch(str(self.skill_dir))

--- a/src/xskill/canary.py
+++ b/src/xskill/canary.py
@@ -24,6 +24,7 @@ from __future__ import annotations
 import hashlib
 import json
 import logging
+import math
 import os
 import shutil
 import threading
@@ -38,6 +39,7 @@ logger = logging.getLogger("xskill.canary")
 
 STAGING_BRANCH = "staging"
 UX_SCORES_FILENAME = ".ux_scores.jsonl"
+JAM_STATE_FILENAME = ".canary_jam_state.json"
 
 
 # ═══════════════════════════════════════════════════════════════════
@@ -56,12 +58,16 @@ class CanaryConfig:
     # total_samples: 每侧（main/staging）判定所需的总样本数（跨所有参与模型）。
     scope_top_n: int = 2
     total_samples: int = 20
-    # ── 轨迹堰塞强砍阈值（jam_threshold）─────────────────────────────
-    # staging 存在期间闸门一本会无条件 hold 所有 SkillEdit；候选累计 weightscore
-    # 攒到 jam_threshold 仍未等到灰度裁决 → 判定堰塞（疑似灰度错位/无真实流量），
-    # 越过灰度合并 main+staging+候选出新 main 并删 staging。必须 > 正常毕业阈值
-    # (ATOM_PROMOTION_THRESHOLD=10)，否则正常增量就会被误判堰塞。默认 50。
+    # ── 轨迹堰塞强砍（jam）三条件合取 ────────────────────────────────
+    # staging 存在期间 hold 普通 SkillEdit；仅当同时满足：
+    #   1) age(staging) >= min_jam_age_sec
+    #   2) 当前 (main_sha, staging_sha) 上 main_n/staging_n 平台期 >= jam_plateau_sec
+    #   3) candidates Σweightscore >= jam_threshold
+    # 才越过灰度强砍合并。三者缺一不可——避免「候选堆满就砍」抢走 A/B。
+    # jam_threshold 必须 > 正常毕业阈值 (ATOM_PROMOTION_THRESHOLD=10)。
     jam_threshold: int = 50
+    min_jam_age_sec: float = 1800.0      # 30min：最短灰度观察窗
+    jam_plateau_sec: float = 600.0       # 10min：当前 sha 对样本不涨
 
     @classmethod
     def from_dict(cls, d: dict | None) -> "CanaryConfig":
@@ -74,7 +80,138 @@ class CanaryConfig:
             scope_top_n=int(d.get("scope_top_n", 2)),
             total_samples=int(d.get("total_samples", 20)),
             jam_threshold=int(d.get("jam_threshold", 50)),
+            min_jam_age_sec=float(d.get("min_jam_age_sec", 1800.0)),
+            jam_plateau_sec=float(d.get("jam_plateau_sec", 600.0)),
         )
+
+
+def _ux_counts_for_shas(skill_dir: Path, *, m_sha: str, s_sha: str) -> tuple[int, int]:
+    """当前 main/staging sha 上各有多少条 ux 样本。"""
+    main_n = staging_n = 0
+    for s in load_ux_scores(skill_dir):
+        side = s.get("side")
+        sha = s.get("commit_sha") or ""
+        if side == "main" and sha == m_sha:
+            main_n += 1
+        elif side == "staging" and sha == s_sha:
+            staging_n += 1
+    return main_n, staging_n
+
+
+def _load_jam_state(skill_dir: Path) -> dict:
+    p = Path(skill_dir) / JAM_STATE_FILENAME
+    if not p.is_file():
+        return {}
+    try:
+        return json.loads(p.read_text(encoding="utf-8")) or {}
+    except Exception:
+        return {}
+
+
+def _save_jam_state(skill_dir: Path, state: dict) -> None:
+    p = Path(skill_dir) / JAM_STATE_FILENAME
+    try:
+        p.write_text(json.dumps(state, ensure_ascii=False), encoding="utf-8")
+    except Exception:
+        logger.debug("save jam state failed: %s", skill_dir, exc_info=True)
+
+
+def update_jam_plateau(
+    skill_dir: Path,
+    *,
+    main_sha: str,
+    staging_sha: str,
+    main_n: int,
+    staging_n: int,
+) -> float:
+    """按当前 (main_sha, staging_sha) 维护平台期，返回 plateau_s（秒）。
+
+    sha 对变化或样本数上涨 → 重置/推进 last_progress_ts；返回 now - last_progress。
+    """
+    import time
+    now = time.time()
+    st = _load_jam_state(skill_dir)
+    same = (
+        st.get("main_sha") == main_sha
+        and st.get("staging_sha") == staging_sha
+    )
+    if not same:
+        st = {
+            "main_sha": main_sha,
+            "staging_sha": staging_sha,
+            "main_n": main_n,
+            "staging_n": staging_n,
+            "last_progress_ts": now,
+        }
+    else:
+        prev_m = int(st.get("main_n") or 0)
+        prev_s = int(st.get("staging_n") or 0)
+        if main_n > prev_m or staging_n > prev_s:
+            st["last_progress_ts"] = now
+        st["main_n"] = main_n
+        st["staging_n"] = staging_n
+        st.setdefault("last_progress_ts", now)
+    _save_jam_state(skill_dir, st)
+    return max(0.0, now - float(st.get("last_progress_ts") or now))
+
+
+def evaluate_jam_gates(
+    skill_dir: Path,
+    *,
+    total_ws: int,
+    config: "CanaryConfig | None" = None,
+) -> dict:
+    """三条件合取判定是否允许 jam-merge。
+
+    返回 dict：ok / reason / age / plateau_s / main_n / staging_n / need / ws /
+    jam_threshold / main_sha / staging_sha。无论 ok 与否都应打日志。
+    """
+    cfg = config or CanaryConfig()
+    skill_dir = Path(skill_dir)
+    need = cfg.min_samples
+    m_sha = main_sha(skill_dir) or ""
+    s_sha = staging_sha(skill_dir) or ""
+    created = staging_created_at(skill_dir)
+    age = 0.0
+    if created is not None:
+        age = (datetime.now(timezone.utc) - created.astimezone(timezone.utc)).total_seconds()
+    main_n, staging_n = _ux_counts_for_shas(skill_dir, m_sha=m_sha, s_sha=s_sha)
+    plateau_s = update_jam_plateau(
+        skill_dir, main_sha=m_sha, staging_sha=s_sha,
+        main_n=main_n, staging_n=staging_n,
+    ) if (m_sha and s_sha) else 0.0
+
+    age_ok = age >= cfg.min_jam_age_sec
+    plateau_ok = plateau_s >= cfg.jam_plateau_sec
+    ws_ok = total_ws >= cfg.jam_threshold
+    ok = bool(m_sha and s_sha and age_ok and plateau_ok and ws_ok)
+
+    missing = []
+    if not (m_sha and s_sha):
+        missing.append("no_sha_pair")
+    if not age_ok:
+        missing.append(f"age<{cfg.min_jam_age_sec:.0f}s")
+    if not plateau_ok:
+        missing.append(f"plateau<{cfg.jam_plateau_sec:.0f}s")
+    if not ws_ok:
+        missing.append(f"ws<{cfg.jam_threshold}")
+    reason = "jam_gates_ok" if ok else ("hold: " + ",".join(missing))
+
+    return {
+        "ok": ok,
+        "reason": reason,
+        "age": round(age, 1),
+        "plateau_s": round(plateau_s, 1),
+        "main_n": main_n,
+        "staging_n": staging_n,
+        "need": need,
+        "ws": total_ws,
+        "jam_threshold": cfg.jam_threshold,
+        "min_jam_age_sec": cfg.min_jam_age_sec,
+        "jam_plateau_sec": cfg.jam_plateau_sec,
+        "main_sha": m_sha[:8] if m_sha else "",
+        "staging_sha": s_sha[:8] if s_sha else "",
+    }
 
 
 # ═══════════════════════════════════════════════════════════════════
@@ -391,6 +528,99 @@ def pick_side_scoped(traj_id: str, skill_name: str, probability: float,
     if user_model not in eligible:
         return "main"
     return pick_side(traj_id, skill_name, probability)
+
+
+# ═══════════════════════════════════════════════════════════════════
+# 有状态分流：CanaryRouter —— 在线偏差最小化 + pick_side hash 随机
+# ═══════════════════════════════════════════════════════════════════
+# pick_side 是无状态哈希：client 很少时（team-CS 常少量 worker）可能全落 main，
+# staging 饿死。CanaryRouter 按 skill 记账，新 client 选「加入后 staging 比例
+# 最接近 probability」的一侧。
+#
+# 随机手段沿用 pick_side（sha256），不用 random.random()：
+#   - 首个 client（种子）→ pick_side(client_id, skill, p)
+#   - 误差打平（破平）→ pick_side(client_id, skill, 0.5)
+# 高基数路径（traj_id）仍直接用 pick_side。
+
+
+class CanaryRouter:
+    """有状态灰度分流：偏差最小化配额 + sticky；种子/破平用 pick_side hash。"""
+
+    def __init__(self) -> None:
+        self._lock = threading.Lock()
+        # skill_name -> {"staging_sha", "probability", "sides": {client_id: side}}
+        self._skills: dict[str, dict] = {}
+
+    def assign(self, *, client_id: str, skill_name: str,
+               probability: float, staging_sha: str) -> str:
+        """返回 client 应走的 side；同 (client, skill, staging_sha, p) sticky。"""
+        with self._lock:
+            st = self._skills.get(skill_name)
+            if (st is None
+                    or st["staging_sha"] != staging_sha
+                    or st["probability"] != probability):
+                st = {
+                    "staging_sha": staging_sha,
+                    "probability": probability,
+                    "sides": {},
+                }
+                self._skills[skill_name] = st
+            sides = st["sides"]
+            cached = sides.get(client_id)
+            if cached is not None:
+                return cached
+            n_main = sum(1 for v in sides.values() if v == "main")
+            n_staging = sum(1 for v in sides.values() if v == "staging")
+            side = self._balanced_side(
+                n_main, n_staging, probability,
+                client_id=client_id, skill_name=skill_name,
+            )
+            sides[client_id] = side
+            logger.info(
+                "canary_assign skill=%s client=%s side=%s "
+                "main=%d staging=%d total=%d p=%.3f sha=%s",
+                skill_name, client_id, side,
+                n_main + (1 if side == "main" else 0),
+                n_staging + (1 if side == "staging" else 0),
+                n_main + n_staging + 1,
+                probability, (staging_sha or "")[:12],
+            )
+            return side
+
+    @staticmethod
+    def _balanced_side(n_main: int, n_staging: int, probability: float,
+                       *, client_id: str, skill_name: str) -> str:
+        if probability <= 0:
+            return "main"
+        if probability >= 1:
+            return "staging"
+        total = n_main + n_staging
+        if total == 0:
+            # 种子：沿用 pick_side 哈希伪随机（可复现）
+            return pick_side(client_id, skill_name, probability)
+        ratio_if_staging = (n_staging + 1) / (total + 1)
+        ratio_if_main = n_staging / (total + 1)
+        err_staging = abs(ratio_if_staging - probability)
+        err_main = abs(ratio_if_main - probability)
+        # 数学上对称时（如 p=0.5 且当前 1:1）浮点可能让一侧略小，
+        # 必须用 isclose 走 hash 破平，否则无法保证「破平=pick_side」。
+        if math.isclose(err_staging, err_main, rel_tol=0.0, abs_tol=1e-12):
+            return pick_side(client_id, skill_name, 0.5)
+        if err_staging < err_main:
+            return "staging"
+        return "main"
+
+    def counts(self, skill_name: str) -> dict[str, int]:
+        """当前账本人数：main / staging / total（观测用）。"""
+        with self._lock:
+            sides = (self._skills.get(skill_name) or {}).get("sides") or {}
+            n_main = sum(1 for v in sides.values() if v == "main")
+            n_staging = sum(1 for v in sides.values() if v == "staging")
+            return {"main": n_main, "staging": n_staging, "total": n_main + n_staging}
+
+    def reset(self) -> None:
+        with self._lock:
+            self._skills.clear()
 
 
 def read_skill_on_branch(skill_dir: Path, branch: str) -> str | None:

--- a/src/xskill/canary.py
+++ b/src/xskill/canary.py
@@ -39,7 +39,6 @@ logger = logging.getLogger("xskill.canary")
 
 STAGING_BRANCH = "staging"
 UX_SCORES_FILENAME = ".ux_scores.jsonl"
-JAM_STATE_FILENAME = ".canary_jam_state.json"
 
 
 # ═══════════════════════════════════════════════════════════════════
@@ -61,13 +60,14 @@ class CanaryConfig:
     # ── 轨迹堰塞强砍（jam）三条件合取 ────────────────────────────────
     # staging 存在期间 hold 普通 SkillEdit；仅当同时满足：
     #   1) age(staging) >= min_jam_age_sec
-    #   2) 当前 (main_sha, staging_sha) 上 main_n/staging_n 平台期 >= jam_plateau_sec
+    #   2) 当前 (main_sha, staging_sha) 上距最近一条 ux 分（没有则从 staging
+    #      创建起算）已超过 jam_plateau_sec
     #   3) candidates Σweightscore >= jam_threshold
     # 才越过灰度强砍合并。三者缺一不可——避免「候选堆满就砍」抢走 A/B。
     # jam_threshold 必须 > 正常毕业阈值 (ATOM_PROMOTION_THRESHOLD=10)。
     jam_threshold: int = 50
     min_jam_age_sec: float = 1800.0      # 30min：最短灰度观察窗
-    jam_plateau_sec: float = 600.0       # 10min：当前 sha 对样本不涨
+    jam_plateau_sec: float = 600.0       # 10min：该 sha 对最近一条 ux 分过了多久
 
     @classmethod
     def from_dict(cls, d: dict | None) -> "CanaryConfig":
@@ -85,74 +85,57 @@ class CanaryConfig:
         )
 
 
-def _ux_counts_for_shas(skill_dir: Path, *, m_sha: str, s_sha: str) -> tuple[int, int]:
-    """当前 main/staging sha 上各有多少条 ux 样本。"""
+def _ux_rows_for_shas(
+    scores: list[dict], *, m_sha: str, s_sha: str,
+) -> tuple[int, int, datetime | None]:
+    """当前 main/staging sha 上的样本数，以及这些样本里最晚的 scored_at。"""
     main_n = staging_n = 0
-    for s in load_ux_scores(skill_dir):
-        side = s.get("side")
-        sha = s.get("commit_sha") or ""
+    last: datetime | None = None
+    for row in scores:
+        side = row.get("side")
+        sha = row.get("commit_sha") or ""
         if side == "main" and sha == m_sha:
             main_n += 1
         elif side == "staging" and sha == s_sha:
             staging_n += 1
-    return main_n, staging_n
+        else:
+            continue
+        raw = row.get("scored_at") or ""
+        if not raw:
+            continue
+        try:
+            ts = _parse_git_iso(str(raw))
+        except ValueError:
+            continue
+        if last is None or ts > last:
+            last = ts
+    return main_n, staging_n, last
 
 
-def _load_jam_state(skill_dir: Path) -> dict:
-    p = Path(skill_dir) / JAM_STATE_FILENAME
-    if not p.is_file():
-        return {}
-    try:
-        return json.loads(p.read_text(encoding="utf-8")) or {}
-    except Exception:
-        return {}
-
-
-def _save_jam_state(skill_dir: Path, state: dict) -> None:
-    p = Path(skill_dir) / JAM_STATE_FILENAME
-    try:
-        p.write_text(json.dumps(state, ensure_ascii=False), encoding="utf-8")
-    except Exception:
-        logger.debug("save jam state failed: %s", skill_dir, exc_info=True)
-
-
-def update_jam_plateau(
+def _jam_plateau_seconds(
     skill_dir: Path,
     *,
-    main_sha: str,
-    staging_sha: str,
-    main_n: int,
-    staging_n: int,
+    last_scored: datetime | None,
 ) -> float:
-    """按当前 (main_sha, staging_sha) 维护平台期，返回 plateau_s（秒）。
-
-    sha 对变化或样本数上涨 → 重置/推进 last_progress_ts；返回 now - last_progress。
-    """
-    import time
-    now = time.time()
-    st = _load_jam_state(skill_dir)
-    same = (
-        st.get("main_sha") == main_sha
-        and st.get("staging_sha") == staging_sha
-    )
-    if not same:
-        st = {
-            "main_sha": main_sha,
-            "staging_sha": staging_sha,
-            "main_n": main_n,
-            "staging_n": staging_n,
-            "last_progress_ts": now,
-        }
+    """距该 sha 对最近一条 ux 分过了多久；没有分则从 staging 创建起算。"""
+    now = datetime.now(timezone.utc)
+    if last_scored is not None:
+        anchor = last_scored.astimezone(timezone.utc)
     else:
-        prev_m = int(st.get("main_n") or 0)
-        prev_s = int(st.get("staging_n") or 0)
-        if main_n > prev_m or staging_n > prev_s:
-            st["last_progress_ts"] = now
-        st["main_n"] = main_n
-        st["staging_n"] = staging_n
-        st.setdefault("last_progress_ts", now)
-    _save_jam_state(skill_dir, st)
-    return max(0.0, now - float(st.get("last_progress_ts") or now))
+        created = staging_created_at(skill_dir)
+        if created is None:
+            return 0.0
+        anchor = created.astimezone(timezone.utc)
+    return max(0.0, (now - anchor).total_seconds())
+
+
+def _drop_legacy_jam_state(skill_dir: Path) -> None:
+    """旧版曾写过 sidecar；现在平台期从 jsonl 现算，碰到就删掉。"""
+    leftover = Path(skill_dir) / ".canary_jam_state.json"
+    try:
+        leftover.unlink(missing_ok=True)
+    except OSError:
+        logger.debug("drop leftover jam state failed: %s", skill_dir, exc_info=True)
 
 
 def evaluate_jam_gates(
@@ -168,6 +151,7 @@ def evaluate_jam_gates(
     """
     cfg = config or CanaryConfig()
     skill_dir = Path(skill_dir)
+    _drop_legacy_jam_state(skill_dir)
     need = cfg.min_samples
     m_sha = main_sha(skill_dir) or ""
     s_sha = staging_sha(skill_dir) or ""
@@ -175,11 +159,14 @@ def evaluate_jam_gates(
     age = 0.0
     if created is not None:
         age = (datetime.now(timezone.utc) - created.astimezone(timezone.utc)).total_seconds()
-    main_n, staging_n = _ux_counts_for_shas(skill_dir, m_sha=m_sha, s_sha=s_sha)
-    plateau_s = update_jam_plateau(
-        skill_dir, main_sha=m_sha, staging_sha=s_sha,
-        main_n=main_n, staging_n=staging_n,
-    ) if (m_sha and s_sha) else 0.0
+    scores = load_ux_scores(skill_dir) if (m_sha or s_sha) else []
+    main_n, staging_n, last_scored = _ux_rows_for_shas(
+        scores, m_sha=m_sha, s_sha=s_sha,
+    )
+    plateau_s = (
+        _jam_plateau_seconds(skill_dir, last_scored=last_scored)
+        if (m_sha and s_sha) else 0.0
+    )
 
     age_ok = age >= cfg.min_jam_age_sec
     plateau_ok = plateau_s >= cfg.jam_plateau_sec

--- a/src/xskill/pipeline/runner.py
+++ b/src/xskill/pipeline/runner.py
@@ -520,7 +520,7 @@ class DirectoryWatcher:
         # 被并发跑两个 maybe_run（第二个进来时前一个多半仍在改 candidates/git）。
         from xskill.skill import candidates as candidate_buffer
         from xskill.skill.git import current_branch, run_git
-        from xskill.canary import load_ux_scores
+        from xskill.canary import evaluate_jam_gates, load_ux_scores
 
         skill_dirs = [
             d for d in self.skill_dir.iterdir()
@@ -529,8 +529,7 @@ class DirectoryWatcher:
         if not skill_dirs:
             return
 
-        jam_threshold = CanaryConfig.from_dict(
-            self.config.get("canary", {})).jam_threshold
+        jam_cfg = CanaryConfig.from_dict(self.config.get("canary", {}))
         edit_threshold = (
             int(threshold)
             if threshold is not None
@@ -577,9 +576,15 @@ class DirectoryWatcher:
                     ["rev-parse", "--verify", "staging"],
                     cwd=str(skill_path),
                 )[0] == 0
-                jam = staging_exists and total_ws >= jam_threshold
-                if staging_exists and not jam:
-                    return False
+                # jam：age ∧ plateau ∧ ws 三条件合取（见 evaluate_jam_gates）
+                jam = False
+                if staging_exists:
+                    gates = evaluate_jam_gates(
+                        skill_path, total_ws=total_ws, config=jam_cfg,
+                    )
+                    jam = bool(gates.get("ok"))
+                    if not jam:
+                        return False
                 if jam:
                     return True
                 ready = bool(
@@ -659,7 +664,9 @@ class DirectoryWatcher:
                     llm_cfg=skill_llm_cfg,
                     traj_root=traj_root,
                     logs_dir=self.logs_dir,
-                    jam_threshold=jam_threshold,
+                    jam_threshold=jam_cfg.jam_threshold,
+                    min_jam_age_sec=jam_cfg.min_jam_age_sec,
+                    jam_plateau_sec=jam_cfg.jam_plateau_sec,
                     batch_size=self.skill_edit_batch_size,
                     retry_batch_size=self._skill_edit_retry_batch_sizes.get(d),
                     **({} if threshold is None else {"threshold": threshold}),
@@ -705,7 +712,7 @@ class DirectoryWatcher:
         ``main_staging``（产灰度候选）、``staging_main``（Jam 强砍回 main）。
         读失败不拖垮真任务——退回 submit 时的静态元数据（仅 skill 名）。
         """
-        from xskill.canary import CanaryConfig
+        from xskill.canary import CanaryConfig, evaluate_jam_gates
         from xskill.skill import candidates as candidate_buffer
         from xskill.skill.git import current_branch, run_git
 
@@ -723,12 +730,12 @@ class DirectoryWatcher:
         staging_exists = run_git(
             ["rev-parse", "--verify", "staging"], cwd=str(d),
         )[0] == 0
-        jam_threshold = CanaryConfig.from_dict(
-            self.config.get("canary", {}),
-        ).jam_threshold
+        jam_cfg = CanaryConfig.from_dict(self.config.get("canary", {}))
         branch = current_branch(str(d)) or ""
         meta["branch"] = branch
-        if staging_exists and total_ws >= jam_threshold:
+        if staging_exists and evaluate_jam_gates(
+            d, total_ws=total_ws, config=jam_cfg,
+        ).get("ok"):
             meta["xfer"] = "staging_main"
         elif branch == "main":
             meta["xfer"] = "main_staging"

--- a/src/xskill/team/server/skill_manifest.py
+++ b/src/xskill/team/server/skill_manifest.py
@@ -1,7 +1,9 @@
 """skill_manifest.py — 给一个 client 现算它该持有的 ≤100 个 skill slot（SP1）
 
-server 端**不存"账本表"**。manifest = ``pick_side`` 纯函数 + skill git
-状态（has_staging / main_sha / staging_sha）的实时投影，每次 sync 现算。
+server 端的 skill 槽位投影不存表：ranked/recommended 排序 + skill git 状态
+（main_sha / staging_sha）每次 sync 现算。**唯一例外是灰度 side 决策**——由
+``CanaryRouter`` 有状态记账（在线偏差最小化），因为无状态 ``pick_side`` 在
+client 基数很小时会把 staging 饿死到 0。
 
 slot 结构 = 80 ranked + 20 recommended：
 - ranked      —— 按 ux_score（main 侧近 30 天均分）滑窗取高分。
@@ -9,8 +11,9 @@ slot 结构 = 80 ranked + 20 recommended：
                  从候选里取 cosine 最近邻（``profile_reco.py``）。无画像
                  （冷启动）或非 team server 调用 → 退回 ux 排序往下取。
 
-灰度归因：某 skill 有 staging 分支 → side = pick_side(client_id, name, p)，
-确定性伪随机，同 client 同 skill 在整轮灰度内 side 钉死。无 staging → main。
+灰度归因：某 skill 有 staging 分支 → side = CanaryRouter.assign(client_id,
+name, p, staging_sha)；同 client 同 staging 版本内 side 钉死。无 staging → main。
+种子/破平随机沿用 pick_side 的 hash（见 canary.CanaryRouter）。
 """
 from __future__ import annotations
 
@@ -23,7 +26,7 @@ from functools import partial
 from pathlib import Path
 from typing import Callable
 
-from xskill.canary import main_sha, pick_side, staging_sha
+from xskill.canary import CanaryRouter, main_sha, staging_sha
 from xskill.skill.skill import Skill
 from xskill.skill.repo import SkillRepo
 from xskill.team.shared.protocol import SkillSlot, SyncResponse
@@ -31,8 +34,11 @@ from xskill.team.shared.protocol import SkillSlot, SyncResponse
 _logger = logging.getLogger("xskill.team.manifest")
 
 # §5 SkillRecommendEngine 单例（team server init 时 set_recommend_engine 注入）。
-# 为 None 时退回既有 pick_side + RECOMMENDER 画像路径（非 team / 测试场景）。
+# 为 None 时退回既有 RECOMMENDER 画像路径（非 team / 测试场景）。
 _engine = None
+
+# team-CS 有状态灰度分流；server 单进程单例，重启后账本清空可接受。
+_ROUTER = CanaryRouter()
 
 
 def repo_search_id(skill_name: str) -> str:
@@ -253,13 +259,15 @@ def _resolve_slot(
         (main_sha(skill.path) or "", staging_sha(skill.path))
     )
     if cached_staging:
-        if _engine is not None:
-            from xskill.recommend.client_user import ClientUser
-            side = _engine.resolve_side(
-                skill, ClientUser(client_id), refs=(cached_main, cached_staging),
-            )
-        else:
-            side = pick_side(client_id, skill.name, probability)
+        # team-CS：有状态 CanaryRouter（hash 种子/破平），避免小基数饿死 staging。
+        # SkillRecommendEngine.resolve_side 仍供推荐链路其它调用方使用；manifest
+        # 槽位 side 以 Router 账本为准（同 client / staging_sha / p sticky）。
+        side = _ROUTER.assign(
+            client_id=client_id,
+            skill_name=skill.name,
+            probability=probability,
+            staging_sha=cached_staging or "",
+        )
         sha = cached_staging if side == "staging" else cached_main
     else:
         side = "main"

--- a/tests/test_canary.py
+++ b/tests/test_canary.py
@@ -382,3 +382,120 @@ def test_jam_threshold_default_is_50():
 
 def test_jam_threshold_read_from_dict():
     assert canary.CanaryConfig.from_dict({"jam_threshold": 30}).jam_threshold == 30
+
+
+def test_jam_gate_defaults_include_age_and_plateau():
+    cfg = canary.CanaryConfig.from_dict({})
+    assert cfg.min_jam_age_sec == 1800.0
+    assert cfg.jam_plateau_sec == 600.0
+
+
+def test_evaluate_jam_gates_requires_age_plateau_and_ws(tmp_path):
+    """仅 ws 达标但 age/plateau 未达标 → ok=False；三闸都开 → ok=True。"""
+    sd = _init_repo(tmp_path / "skill")
+    initial = canary.main_sha(sd)
+    _commit(sd, "staging body", "staging cand")
+    assert canary.route_main_history_to_staging(sd, initial)
+
+    cfg_hold = canary.CanaryConfig(
+        jam_threshold=50, min_jam_age_sec=1800.0, jam_plateau_sec=600.0,
+    )
+    hold = canary.evaluate_jam_gates(sd, total_ws=60, config=cfg_hold)
+    assert hold["ok"] is False
+    assert "age<" in hold["reason"] or "plateau<" in hold["reason"]
+
+    cfg_ok = canary.CanaryConfig(
+        jam_threshold=50, min_jam_age_sec=0.0, jam_plateau_sec=0.0,
+    )
+    ok = canary.evaluate_jam_gates(sd, total_ws=60, config=cfg_ok)
+    assert ok["ok"] is True
+    assert ok["reason"] == "jam_gates_ok"
+
+    still_hold = canary.evaluate_jam_gates(sd, total_ws=10, config=cfg_ok)
+    assert still_hold["ok"] is False
+    assert "ws<" in still_hold["reason"]
+
+
+# ──────────────────────────────────────────────────────
+# CanaryRouter —— 有状态均衡 + pick_side hash 种子/破平
+# ──────────────────────────────────────────────────────
+
+def test_canary_router_locks_client_side():
+    """同 client 同 (staging_sha, probability) → 永远同一 side。"""
+    r = canary.CanaryRouter()
+    sides = {r.assign(client_id="c1", skill_name="s", probability=0.5,
+                      staging_sha="sha-X") for _ in range(10)}
+    assert len(sides) == 1
+
+
+def test_canary_router_probability_zero_all_main():
+    r = canary.CanaryRouter()
+    for i in range(10):
+        assert r.assign(client_id=f"c{i}", skill_name="s", probability=0.0,
+                        staging_sha="sha") == "main"
+
+
+def test_canary_router_probability_one_all_staging():
+    r = canary.CanaryRouter()
+    for i in range(10):
+        assert r.assign(client_id=f"c{i}", skill_name="s", probability=1.0,
+                        staging_sha="sha") == "staging"
+
+
+def test_canary_router_guarantees_staging_share_p05():
+    """p=0.5 + 3 client：staging 必拿到 1~2 个，永远不会被饿死到 0。"""
+    for _ in range(200):
+        r = canary.CanaryRouter()
+        sides = [r.assign(client_id=f"c{i}", skill_name="s", probability=0.5,
+                          staging_sha="sha") for i in range(3)]
+        n_staging = sides.count("staging")
+        assert 1 <= n_staging <= 2
+
+
+def test_canary_router_guarantees_staging_share_p02():
+    """p=0.2 + 5 client：恰好 1 个 staging。"""
+    for _ in range(200):
+        r = canary.CanaryRouter()
+        sides = [r.assign(client_id=f"c{i}", skill_name="s", probability=0.2,
+                          staging_sha="sha") for i in range(5)]
+        assert sides.count("staging") == 1
+
+
+def test_canary_router_ratio_tracks_probability_many_clients():
+    """100 client 下运行比例贴近 probability（误差 ≤ 2%）。"""
+    for p in (0.2, 0.3, 0.5, 0.7):
+        r = canary.CanaryRouter()
+        sides = [r.assign(client_id=f"c{i}", skill_name="s", probability=p,
+                          staging_sha="sha") for i in range(100)]
+        ratio = sides.count("staging") / 100
+        assert abs(ratio - p) <= 0.02
+
+
+def test_canary_router_resets_on_staging_sha_change():
+    r = canary.CanaryRouter()
+    first = r.assign(client_id="c1", skill_name="s", probability=1.0,
+                     staging_sha="sha-OLD")
+    assert first == "staging"
+    second = r.assign(client_id="c1", skill_name="s", probability=0.0,
+                      staging_sha="sha-NEW")
+    assert second == "main"
+
+
+def test_canary_router_resets_on_probability_change():
+    r = canary.CanaryRouter()
+    r.assign(client_id="c1", skill_name="s", probability=0.0, staging_sha="sha")
+    forced = r.assign(client_id="c1", skill_name="s", probability=1.0,
+                      staging_sha="sha")
+    assert forced == "staging"
+
+
+def test_canary_router_seed_equals_pick_side():
+    for cid in ("w0", "alpha", "client-deadbeef"):
+        for skill in ("s", "openpyxl-excel-automation"):
+            for p in (0.2, 0.5, 0.7):
+                r = canary.CanaryRouter()
+                got = r.assign(
+                    client_id=cid, skill_name=skill,
+                    probability=p, staging_sha="sha-seed",
+                )
+                assert got == canary.pick_side(cid, skill, p)

--- a/tests/test_canary.py
+++ b/tests/test_canary.py
@@ -414,6 +414,46 @@ def test_evaluate_jam_gates_requires_age_plateau_and_ws(tmp_path):
     still_hold = canary.evaluate_jam_gates(sd, total_ws=10, config=cfg_ok)
     assert still_hold["ok"] is False
     assert "ws<" in still_hold["reason"]
+    assert not (sd / ".canary_jam_state.json").exists()
+
+
+def test_jam_plateau_uses_ux_jsonl_not_sidecar(tmp_path):
+    """平台期从 .ux_scores.jsonl 的 scored_at 现算，不写 .canary_jam_state.json。"""
+    import json
+    from datetime import timedelta
+
+    sd = _init_repo(tmp_path / "skill")
+    initial = canary.main_sha(sd)
+    _commit(sd, "staging body", "staging cand")
+    assert canary.route_main_history_to_staging(sd, initial)
+    leftover = sd / ".canary_jam_state.json"
+    leftover.write_text("{}", encoding="utf-8")
+
+    cfg = canary.CanaryConfig(
+        jam_threshold=50, min_jam_age_sec=0.0, jam_plateau_sec=600.0,
+    )
+    fresh = canary.evaluate_jam_gates(sd, total_ws=60, config=cfg)
+    assert fresh["ok"] is False
+    assert "plateau<" in fresh["reason"]
+    assert not leftover.exists()
+
+    old = (datetime.now(timezone.utc) - timedelta(hours=1)).isoformat(timespec="seconds")
+    m_sha = canary.main_sha(sd)
+    s_sha = canary.staging_sha(sd)
+    (sd / ".ux_scores.jsonl").write_text(
+        json.dumps({
+            "traj_id": "t-old", "skill_name": "skill", "side": "main",
+            "commit_sha": m_sha, "score": 8, "reasons": "", "scored_at": old,
+        }) + "\n" + json.dumps({
+            "traj_id": "t-old-s", "skill_name": "skill", "side": "staging",
+            "commit_sha": s_sha, "score": 7, "reasons": "", "scored_at": old,
+        }) + "\n",
+        encoding="utf-8",
+    )
+    aged = canary.evaluate_jam_gates(sd, total_ws=60, config=cfg)
+    assert aged["ok"] is True
+    assert aged["plateau_s"] >= 600.0
+    assert not (sd / ".canary_jam_state.json").exists()
 
 
 # ──────────────────────────────────────────────────────

--- a/tests/test_canary_router_hash.py
+++ b/tests/test_canary_router_hash.py
@@ -1,0 +1,280 @@
+"""验证 CanaryRouter：在线偏差最小化 + pick_side hash 种子/破平。
+
+不依赖 pytest，可用::
+
+    python -m unittest tests.test_canary_router_hash -v
+
+或在打榜镜像内挂载本文件执行（见 run_canary_router_hash_tests.sh）。
+"""
+from __future__ import annotations
+
+import hashlib
+import itertools
+import unittest
+
+from xskill.canary import CanaryRouter, pick_side
+
+
+def _hash_r(traj_id: str, skill_name: str) -> float:
+    h = hashlib.sha256(f"{traj_id}:{skill_name}".encode("utf-8")).digest()
+    return int.from_bytes(h[:4], "big") / (1 << 32)
+
+
+class TestPickSideHashBaseline(unittest.TestCase):
+    """旧 pick_side：可复现，但小 N 会饿死一侧。"""
+
+    def test_pick_side_deterministic(self):
+        a = pick_side("client-a", "skill-x", 0.5)
+        b = pick_side("client-a", "skill-x", 0.5)
+        self.assertEqual(a, b)
+
+    def test_pick_side_matches_manual_hash(self):
+        cid, skill, p = "w0", "openpyxl-excel-automation", 0.5
+        r = _hash_r(cid, skill)
+        expected = "staging" if r < p else "main"
+        self.assertEqual(pick_side(cid, skill, p), expected)
+
+    def test_pick_side_can_starve_three_workers_p05(self):
+        """证明旧算法在 N=3、p=0.5 下确实会出现全 main / 全 staging。"""
+        starved_main = False
+        starved_staging = False
+        # 穷举一批合成 id，足够撞到全偏一侧
+        for a, b, c in itertools.product(range(80), repeat=3):
+            ids = [f"worker-{a}", f"worker-{b}", f"worker-{c}"]
+            # 要求三个 distinct，否则不是 3 worker
+            if len(set(ids)) < 3:
+                continue
+            sides = [pick_side(i, "s", 0.5) for i in ids]
+            n_st = sides.count("staging")
+            if n_st == 0:
+                starved_main = True
+            if n_st == 3:
+                starved_staging = True
+            if starved_main and starved_staging:
+                break
+        self.assertTrue(
+            starved_main,
+            "expected to find a 3-client set that pick_side maps all to main",
+        )
+        self.assertTrue(
+            starved_staging,
+            "expected to find a 3-client set that pick_side maps all to staging",
+        )
+
+
+class TestCanaryRouterHash(unittest.TestCase):
+    """新算法：偏差最小化 + pick_side 作种子/破平。"""
+
+    def test_seed_equals_pick_side(self):
+        r = CanaryRouter()
+        for cid in ("w0", "alpha", "client-deadbeef", "0"):
+            for skill in ("s", "openpyxl-excel-automation"):
+                for p in (0.2, 0.3, 0.5, 0.7):
+                    rr = CanaryRouter()
+                    got = rr.assign(
+                        client_id=cid, skill_name=skill,
+                        probability=p, staging_sha="sha-seed",
+                    )
+                    self.assertEqual(
+                        got, pick_side(cid, skill, p),
+                        msg=f"seed mismatch cid={cid} skill={skill} p={p}",
+                    )
+
+    def test_tiebreak_equals_pick_side_half(self):
+        """main=1,staging=1 后再来第三人：误差打平，必须用 pick_side(..., 0.5)。"""
+        # 构造：先让 c_main 进 main、c_st 进 staging。
+        # 选一对 seed，使第一个按 p=0.5 为 main，第二个被偏差最小化补到 staging。
+        found = False
+        for i in range(500):
+            c0, c1, c2 = f"tie-a-{i}", f"tie-b-{i}", f"tie-c-{i}"
+            if pick_side(c0, "s", 0.5) != "main":
+                continue
+            r = CanaryRouter()
+            s0 = r.assign(client_id=c0, skill_name="s", probability=0.5,
+                          staging_sha="sha-tie")
+            s1 = r.assign(client_id=c1, skill_name="s", probability=0.5,
+                          staging_sha="sha-tie")
+            if s0 != "main" or s1 != "staging":
+                continue
+            s2 = r.assign(client_id=c2, skill_name="s", probability=0.5,
+                          staging_sha="sha-tie")
+            self.assertEqual(s2, pick_side(c2, "s", 0.5))
+            found = True
+            break
+        self.assertTrue(found, "could not construct 1:1 ledger for tie-break test")
+
+    def test_sticky(self):
+        r = CanaryRouter()
+        first = r.assign(client_id="c1", skill_name="s", probability=0.5,
+                         staging_sha="sha-X")
+        for _ in range(20):
+            self.assertEqual(
+                r.assign(client_id="c1", skill_name="s", probability=0.5,
+                         staging_sha="sha-X"),
+                first,
+            )
+
+    def test_reset_on_staging_sha_change(self):
+        r = CanaryRouter()
+        self.assertEqual(
+            r.assign(client_id="c1", skill_name="s", probability=1.0,
+                     staging_sha="sha-OLD"),
+            "staging",
+        )
+        self.assertEqual(
+            r.assign(client_id="c1", skill_name="s", probability=0.0,
+                     staging_sha="sha-NEW"),
+            "main",
+        )
+
+    def test_reset_on_probability_change(self):
+        r = CanaryRouter()
+        r.assign(client_id="c1", skill_name="s", probability=0.0, staging_sha="sha")
+        self.assertEqual(
+            r.assign(client_id="c1", skill_name="s", probability=1.0,
+                     staging_sha="sha"),
+            "staging",
+        )
+
+    def test_never_starve_n3_p05(self):
+        """相对 pick_side 的核心收益：3 worker @ p=0.5 永不 3:0 / 0:3。"""
+        for trial in range(500):
+            r = CanaryRouter()
+            ids = [f"c{trial}-{i}" for i in range(3)]
+            sides = [
+                r.assign(client_id=cid, skill_name="s", probability=0.5,
+                         staging_sha=f"sha-{trial}")
+                for cid in ids
+            ]
+            n_st = sides.count("staging")
+            self.assertGreaterEqual(n_st, 1, msg=sides)
+            self.assertLessEqual(n_st, 2, msg=sides)
+
+    def test_router_fixes_known_pick_side_starvation_sets(self):
+        """把 pick_side 会全 main / 全 staging 的三元组交给 Router，必须两侧都有。"""
+        all_main_set = None
+        all_staging_set = None
+        for a, b, c in itertools.product(range(60), repeat=3):
+            ids = [f"worker-{a}", f"worker-{b}", f"worker-{c}"]
+            if len(set(ids)) < 3:
+                continue
+            sides = [pick_side(i, "s", 0.5) for i in ids]
+            if sides.count("staging") == 0 and all_main_set is None:
+                all_main_set = ids
+            if sides.count("staging") == 3 and all_staging_set is None:
+                all_staging_set = ids
+            if all_main_set and all_staging_set:
+                break
+        self.assertIsNotNone(all_main_set)
+        self.assertIsNotNone(all_staging_set)
+
+        for label, ids in (("all_main", all_main_set),
+                           ("all_staging", all_staging_set)):
+            r = CanaryRouter()
+            sides = [
+                r.assign(client_id=cid, skill_name="s", probability=0.5,
+                         staging_sha=f"fix-{label}")
+                for cid in ids
+            ]
+            n_st = sides.count("staging")
+            self.assertTrue(
+                1 <= n_st <= 2,
+                msg=f"{label}: pick_side={ [pick_side(i,'s',0.5) for i in ids] } "
+                    f"router={sides}",
+            )
+
+    def test_reproducible_across_routers(self):
+        ids = ["w0", "w1", "w2"]
+        seqs = []
+        for _ in range(3):
+            r = CanaryRouter()
+            seqs.append([
+                r.assign(client_id=cid, skill_name="s", probability=0.5,
+                         staging_sha="sha-same")
+                for cid in ids
+            ])
+        self.assertEqual(seqs[0], seqs[1])
+        self.assertEqual(seqs[1], seqs[2])
+
+    def test_counts_helper(self):
+        r = CanaryRouter()
+        r.assign(client_id="a", skill_name="s", probability=0.5, staging_sha="sha")
+        r.assign(client_id="b", skill_name="s", probability=0.5, staging_sha="sha")
+        r.assign(client_id="c", skill_name="s", probability=0.5, staging_sha="sha")
+        c = r.counts("s")
+        self.assertEqual(c["total"], 3)
+        self.assertEqual(c["main"] + c["staging"], 3)
+        self.assertGreaterEqual(c["staging"], 1)
+        self.assertGreaterEqual(c["main"], 1)
+
+    def test_no_random_in_router_balanced_side(self):
+        """实现约束：Router 平衡逻辑不依赖 random.random。"""
+        import inspect
+        from xskill import canary as canary_mod
+        src = inspect.getsource(canary_mod.CanaryRouter._balanced_side)
+        self.assertNotIn("random.random", src)
+        self.assertIn("pick_side", src)
+
+    def test_p02_five_clients_one_staging(self):
+        for trial in range(100):
+            r = CanaryRouter()
+            sides = [
+                r.assign(client_id=f"c{trial}-{i}", skill_name="s",
+                         probability=0.2, staging_sha=f"sha-{trial}")
+                for i in range(5)
+            ]
+            self.assertEqual(sides.count("staging"), 1, msg=sides)
+
+
+class TestManifestWiring(unittest.TestCase):
+    """确认 team-CS manifest 接到 CanaryRouter，而不是直接 pick_side。"""
+
+    def test_manifest_exports_router(self):
+        from xskill.team.server import skill_manifest as sm
+        self.assertTrue(hasattr(sm, "_ROUTER"))
+        self.assertIsInstance(sm._ROUTER, CanaryRouter)
+
+    def test_manifest_source_uses_assign(self):
+        import xskill.team.server.skill_manifest as sm
+        from pathlib import Path
+        src = Path(sm.__file__).read_text(encoding="utf-8")
+        self.assertIn("_ROUTER.assign", src)
+        self.assertIn("CanaryRouter", src)
+        # 有 staging 时不应再直接 pick_side(client_id, ...)
+        resolve = src.split("def _resolve_slot", 1)[1].split("def build_manifest", 1)[0]
+        self.assertNotIn("pick_side(", resolve)
+
+
+class TestStarvationRateComparison(unittest.TestCase):
+    """统计对照：同批三元组上 pick_side vs Router 的饿死率。"""
+
+    def test_starvation_rate_table(self):
+        n_trials = 2000
+        pick_starve = 0
+        router_starve = 0
+        for t in range(n_trials):
+            ids = [f"stat-{t}-0", f"stat-{t}-1", f"stat-{t}-2"]
+            ps = [pick_side(i, "s", 0.5) for i in ids]
+            if ps.count("staging") in (0, 3):
+                pick_starve += 1
+            r = CanaryRouter()
+            rs = [
+                r.assign(client_id=i, skill_name="s", probability=0.5,
+                         staging_sha=f"stat-{t}")
+                for i in ids
+            ]
+            if rs.count("staging") in (0, 3):
+                router_starve += 1
+        # pick_side 理论约 25%；允许统计波动
+        self.assertGreater(pick_starve, n_trials * 0.10)
+        self.assertEqual(router_starve, 0)
+        # 打印便于人工看报告（unittest 默认会显示）
+        print(
+            f"\n[starvation @{n_trials} trials p=0.5 N=3] "
+            f"pick_side={pick_starve} ({pick_starve/n_trials:.1%}) "
+            f"CanaryRouter={router_starve} ({router_starve/n_trials:.1%})"
+        )
+
+
+if __name__ == "__main__":
+    unittest.main(verbosity=2)

--- a/tests/test_skill_edit_agent.py
+++ b/tests/test_skill_edit_agent.py
@@ -597,6 +597,7 @@ def test_jam_merge_fires_above_threshold_and_discards_staging(tmp_path):
     agent = SkillEditAgent(
         skill_dir=sd, store=None, agno_agent_factory=_JamMergeStubAgno,
         llm_cfg={}, traj_root=tmp_path, jam_threshold=50,
+        min_jam_age_sec=0, jam_plateau_sec=0,
     )
     assert agent.maybe_run() is True
     assert _JamMergeStubAgno.invoked is True
@@ -620,6 +621,7 @@ def test_no_jam_below_threshold_keeps_staging(tmp_path):
     agent = SkillEditAgent(
         skill_dir=sd, store=None, agno_agent_factory=_JamMergeStubAgno,
         llm_cfg={}, traj_root=tmp_path, jam_threshold=50,
+        min_jam_age_sec=0, jam_plateau_sec=0,
     )
     assert agent.maybe_run() is False          # 维持 hold
     assert _JamMergeStubAgno.invoked is False
@@ -640,6 +642,7 @@ def test_jam_merge_without_main_commit_keeps_candidates_and_staging(tmp_path):
     agent = SkillEditAgent(
         skill_dir=sd, store=None, agno_agent_factory=_JamNoCommitStubAgno,
         llm_cfg={}, traj_root=tmp_path, jam_threshold=50,
+        min_jam_age_sec=0, jam_plateau_sec=0,
     )
 
     assert agent.maybe_run() is False
@@ -712,6 +715,7 @@ def test_jam_merge_rematerializes_missing_staging_body(tmp_path):
         skill_dir=sd, store=None,
         agno_agent_factory=lambda **kw: _JamMergeRematerializeStubAgno(**kw),
         llm_cfg={}, traj_root=tmp_path, jam_threshold=50,
+        min_jam_age_sec=0, jam_plateau_sec=0,
     )
     result = agent.maybe_run()
     assert result is True, "jam-merge with re-materialization should succeed"

--- a/tests/test_skill_edit_batch_turns.py
+++ b/tests/test_skill_edit_batch_turns.py
@@ -289,6 +289,7 @@ class TestFourTerminalScenariosMultiTurn:
             skill_dir=skill_dir, store=None,
             agno_agent_factory=_make_progressive_factory(observed),
             llm_cfg={}, traj_root=tmp_path, jam_threshold=50,
+            min_jam_age_sec=0, jam_plateau_sec=0,
         )
         assert agent.maybe_run() is True
         assert len(observed) == 3

--- a/tests/test_skilledit_parallel.py
+++ b/tests/test_skilledit_parallel.py
@@ -149,12 +149,14 @@ def _make_watcher_with_config(tmp_path, skill_root, factory, config):
 
 
 def test_runner_passes_jam_threshold(monkeypatch, tmp_path):
-    """runner 构造 SkillEditAgent 时，把 config.canary.jam_threshold 注入。"""
+    """runner 构造 SkillEditAgent 时，把 config.canary jam 三闸参数注入。"""
     import xskill.agents.skill_edit_agent as SEA
     captured = {}
     real_init = SEA.SkillEditAgent.__init__
     def spy_init(self, *a, **kw):
         captured["jam_threshold"] = kw.get("jam_threshold")
+        captured["min_jam_age_sec"] = kw.get("min_jam_age_sec")
+        captured["jam_plateau_sec"] = kw.get("jam_plateau_sec")
         return real_init(self, *a, **kw)
     monkeypatch.setattr(SEA.SkillEditAgent, "__init__", spy_init)
 
@@ -167,7 +169,11 @@ def test_runner_passes_jam_threshold(monkeypatch, tmp_path):
     factory = _make_barrier_agno(1, noop_barrier)
     config = {
         "llm": {"base_url": "x", "model": "y", "api_key": "z"},
-        "canary": {"jam_threshold": 33},
+        "canary": {
+            "jam_threshold": 33,
+            "min_jam_age_sec": 12,
+            "jam_plateau_sec": 34,
+        },
     }
     w = _make_watcher_with_config(tmp_path, skill_root, factory, config)
     w._check_pending_skill_edits()
@@ -176,6 +182,8 @@ def test_runner_passes_jam_threshold(monkeypatch, tmp_path):
     assert captured.get("jam_threshold") == 33, (
         f"jam_threshold was not wired from config; captured={captured!r}"
     )
+    assert captured.get("min_jam_age_sec") == 12
+    assert captured.get("jam_plateau_sec") == 34
 
 
 def test_runner_remembers_n1_retry_until_a_checkpoint_succeeds(tmp_path):

--- a/tests/test_team_skill_manifest.py
+++ b/tests/test_team_skill_manifest.py
@@ -8,7 +8,7 @@ import numpy as np
 
 from xskill.pipeline.atom import AtomTask, AtomTaskStore
 from xskill.team.server.profile_reco import ClientProfileRecommender
-from xskill.team.server.skill_manifest import build_manifest
+from xskill.team.server.skill_manifest import build_manifest, _ROUTER
 
 
 def _git(args, cwd):
@@ -127,6 +127,7 @@ def test_manifest_main_only_skill_has_main_side(tmp_path):
 
 
 def test_manifest_staging_side_is_deterministic_per_client(tmp_path):
+    _ROUTER.reset()
     skill_dir = tmp_path / "skill"
     skill_dir.mkdir()
     _make_skill(skill_dir, "graying", with_staging=True)
@@ -140,6 +141,26 @@ def test_manifest_staging_side_is_deterministic_per_client(tmp_path):
     forced = build_manifest(client_id="cid-A", skill_dir=skill_dir,
                             probability=1.0, ranked_slots=80, total_slots=100).slots[0]
     assert forced.side == "staging"
+    _ROUTER.reset()
+
+
+def test_manifest_guarantees_staging_traffic_with_few_clients(tmp_path):
+    """3 个 worker + 唯一 staging skill：至少 1 个 worker 拿到 staging。
+
+    旧的无状态 pick_side 会把 3 个 client 全哈希到 main；CanaryRouter 把
+    staging 份额锁进总量，保证 ≥1。
+    """
+    _ROUTER.reset()
+    skill_dir = tmp_path / "skill"
+    skill_dir.mkdir()
+    _make_skill(skill_dir, "only-skill", with_staging=True)
+    sides = [
+        build_manifest(client_id=f"worker-{i}", skill_dir=skill_dir,
+                       probability=0.5, ranked_slots=80, total_slots=100).slots[0].side
+        for i in range(3)
+    ]
+    assert sides.count("staging") >= 1
+    _ROUTER.reset()
 
 
 # ═══════════════════════════════════════════════════════════════════


### PR DESCRIPTION
## Summary
- Fixes #207: team-CS small-cardinality staging starvation and premature jam on weightscore alone.
- Adds `CanaryRouter` with online deviation-minimizing assignment; empty-ledger seed and `math.isclose` tiebreak both use `pick_side` (hash), not `random` — supersedes open PR #65 semantics.
- Wires `skill_manifest._resolve_slot` to `_ROUTER.assign(..., staging_sha=...)`.
- Jam now requires age ∧ plateau ∧ ws via `evaluate_jam_gates` in runner scheduling/meta and SkillEditAgent (defaults 1800s / 600s / 50).
- Out of scope: `val_block` / val composite, SkillEdit v7, usage patches.

## Test plan
- [x] `pytest tests/test_canary.py tests/test_canary_router_hash.py tests/test_team_skill_manifest.py tests/test_skilledit_parallel.py tests/test_skill_edit_agent.py tests/test_skill_edit_batch_turns.py` (116 passed)
- [x] Confirm team-CS sync with few clients assigns ≥1 staging at p=0.5
- [x] Confirm jam holds when only ws is met; fires when age+plateau+ws all met


Made with [Cursor](https://cursor.com)