### PR TITLE
docs(openspec): user skill import proposal (discussion)

### DIFF
--- a/openspec/changes/user-skill-import/.openspec.yaml
+++ b/openspec/changes/user-skill-import/.openspec.yaml
@@ -1,0 +1,3 @@
+schema: spec-driven
+created: 2026-08-13
+status: discussion

--- a/openspec/changes/user-skill-import/design.md
+++ b/openspec/changes/user-skill-import/design.md
@@ -1,8 +1,8 @@
 # Design — User Skill Import
 
-> 状态：**主干已拍板**（#211 维护者评论 + #213），见 §5；`specs/` 已按拍板改为终稿口径。
-> 剩余待确认的行为细节收敛在 §6。与本文早期草案冲突处（Q1 走 baby、Q2 拒绝）以 #213 为准。
-> 实现等 #209、#210 合入 main 后再开 PR（理由见 #213）。
+> 状态：**主要设计已确认**（#211 维护者评论 + #213），见 §5；`specs/` 已据此改为最终表述。
+> 尚未确定的行为细节汇总在 §6。与本文早期草案不一致之处（Q1 进入 baby、Q2 同名拒绝）
+> 以 #213 为准。实现待 #209、#210 合入 main 后再提交 PR（理由见 #213）。
 
 ## 1. Context（现状）
 
@@ -17,11 +17,11 @@
 
 导入若只丢文件、不做 git/catalog，后续 canary / reverse-sync / search 会 silently 残缺。
 
-### 1.2 已有相关入口（避免重复造轮）
+### 1.2 已有相关入口（避免重复建设）
 
 ```text
                     ┌─────────────────────────────┐
-  外部 SKILL.md ──► │ A. POST /skills/import       │──► skill_dir (半残)
+  外部 SKILL.md ──► │ A. POST /skills/import       │──► skill_dir (不完整)
                     │    import_skill(copytree)    │
                     └─────────────────────────────┘
 
@@ -48,12 +48,12 @@
 ### 方案 S1 — CLI / API 受控导入（推荐作主路径）
 
 ```text
-xskill skill import ~/.claude/skills/my-foo
+xskill import ~/.claude/skills/my-foo
         │
         ├─ parse_strict(SKILL.md)
-        ├─ resolve name（frontmatter.name 优先，冲突策略见 Q2）
+        ├─ resolve name（frontmatter.name 优先，同名策略见 §5 Q2）
         ├─ materialize into skill_dir/<name>/
-        ├─ ensure git（见 Q1：baby vs main）
+        ├─ ensure git（§5 Q1：直接进入 main）
         ├─ catalog upsert
         ├─ optional: rebuild/index touch
         └─ optional: install_to_detected_harnesses
@@ -62,10 +62,10 @@ xskill skill import ~/.claude/skills/my-foo
 | 优点 | 缺点 |
 |---|---|
 | 边界清晰、可测、可报错（符合 no-fallback） | 用户多一步命令 |
-| 易做批量 `--from claude-user` | 要教用户别裸 cp |
+| 批量导入即传入父目录路径 | 需要引导用户不要手工 cp |
 | 与现有 API 可共用实现 | |
 
-**Server 侧**：`xskill skill import` 在 server 主机执行（或 admin API 收 zip），写入 server `skill_dir`；client 下一轮 sync 拉取。这比「让每个 client 自己 cp 到 server 盘」现实。
+**Server 侧**（已被 §5 Q5 取代）：client 执行 `xskill import`，经新增 API 写入 server `skill_dir`；随后由 bundle 机制分发给各 client。
 
 ### 方案 S2 — 允许 `cp` + 启动/扫描 heal
 
@@ -80,7 +80,7 @@ xskill skill import ~/.claude/skills/my-foo
 | 脚本友好 | 权限/恶意路径/重名覆盖难控 |
 | | 和 harness 目录互相 cp 易造成环（xskill→claude→再 cp 回） |
 
-**建议**：S2 最多作为 **检测 + 提示「请运行 xskill skill import --heal」**，不要静默改盘。
+**建议**：S2 最多作为 **检测并提示「请运行 xskill import --heal」**，不自动修改磁盘内容。
 
 ### 方案 S3 — 仅 Team upload 扩展（不推荐单独做）
 
@@ -88,10 +88,11 @@ xskill skill import ~/.claude/skills/my-foo
 
 ### 推荐组合（已被 #213 采纳的形态）
 
-- **主：S1**（CLI + 共用库函数 + API 对齐），CLI 定名顶层 `xskill import <path>`
-- **辅：对裸 cp 只检测告警 / `--heal` 显式修复**（弱化 S2，终稿见 §6 R6）
-- **Team：`upload`→hub 不动；client `xskill import` 经新 API 写 server `skill_dir`。
-  #213 明确不做 `upload --target=hub|repo` 开关——两条命令、两处落点**
+- **主：S1**（CLI + 共用库函数 + API 对齐），CLI 确定为顶层命令 `xskill import <path>`
+- **辅：对手工 cp 仅检测并告警，由 `--heal` 显式修复**（弱化 S2，最终结论见 §6 R6）
+- **Team：`upload` 进入 hub 的行为不变；client 执行 `xskill import` 经新增 API 写入
+  server 的 `skill_dir`。#213 明确不扩展 `upload --target=hub|repo`——
+  两条命令分别对应两个写入位置，语义不合并**
 
 ## 3. 目标架构（S1）
 
@@ -142,77 +143,83 @@ xskill skill import ~/.claude/skills/my-foo
 ### 3.3 不推荐的用户操作（文档写死）
 
 ```bash
-# 不支持作为官方路径（可能 dig 出半残仓）
+# 不支持作为官方路径（可能产生不完整的仓库）
 cp -r ~/.claude/skills/foo ~/.xskill/skill/foo
 
 # 官方
-xskill skill import ~/.claude/skills/foo
-xskill skill import --from claude-user          # 批量，P1
+xskill import ~/.claude/skills/foo        # 单个
+xskill import ~/.claude/skills/           # 批量：直接传入父目录
 ```
 
 ## 4. 与 `xskill upload` / SkillHub 的边界
 
-| 命令/能力 | 落点 | 谁能搜到 | 谁能被 sync 安装 |
+| 命令/能力 | 写入位置 | 检索可见范围 | 是否参与 sync 安装 |
 |---|---|---|---|
-| `skill import` | 自有 `skill_dir` | 本地 search；team 则进 manifest | 是（仓内 skill） |
+| `xskill import` | 自有 `skill_dir` | 本地 search；team 则进 manifest | 是（仓内 skill） |
 | `upload` | `user_skill_hub/<user>/` | team search（旁路） | 视现网 manifest 是否纳入 hub |
 | SkillHub dir 扫描 | `skillhub_skills/` | 相关性推荐 | 通常不走 git 灰度 |
 
 提案要求：**命名与帮助文案禁止混用「导入」「上传」**。
 
-## 5. 拍板结果（Q1–Q7 → #211 维护者评论 + #213）
+## 5. 已确认的设计决定（Q1–Q7 对照 #211 维护者评论与 #213）
 
 | 原问题 | 结论 | 出处 |
 |---|---|---|
-| Q1 初始分支 | **直接 main**。用户导入的是成品，不走 baby 再蒸馏。`--as-baby` 不做 | #213 |
-| Q2 重名 | **不拒绝、不覆盖**：在现有 main 上**追加一次 commit**，工作区变成上传内容形状；git 历史与盘上 `.ux_scores.jsonl` / `.candidates.yml` sidecar 全保留。目标停在 baby 或有 staging → 拒绝并说明 | #213 |
-| Q3 源自带 `.git` | **新名字**：同步源仓，最新 `main`（缺 main 取最新分支 HEAD）为演进起点，目标仓保证有 `main`。**同名**：以目标仓历史为准，源历史写进 commit message，不换仓 | #211 评论 + #213 |
-| Q4 默认 install | **未拍板** → 移入 §6 R4 | — |
-| Q5 server 入口 | client 走 **CLI `xskill import` → 新 API 送 server `skill_dir`**（不是 `skill_hub/upload`，也不是 `upload --target`）；随后走既有 bundle 分发 + client 留档 checkout | #211 评论 + #213 |
-| Q6 裸 `cp` | #213 未推翻草案建议：**检测 + 提示，不静默 heal**（终稿待 §6 R6 一并确认） | 草案默认 |
-| Q7 与 #4 边界 | 本提案只覆盖「进入 xskill 自有仓」；UserSkill/projectSkill 挂载另议 | 草案默认，未被推翻 |
+| Q1 初始分支 | **直接进入 main**。用户导入的是成型的 skill，不经过 baby 阶段再蒸馏；不提供 `--as-baby` | #213 |
+| Q2 同名 | **既不拒绝，也不覆盖**：在现有 main 上**追加一次 commit**，工作区替换为上传内容；git 历史与磁盘上的 `.ux_scores.jsonl`、`.candidates.yml` 辅助文件全部保留。目标处于 baby 阶段或存在 staging 时拒绝并说明原因 | #213 |
+| Q3 源目录自带 `.git` | **新名称**：同步源仓库，以最新 `main`（无 `main` 时取最新分支的 HEAD）作为演进起点，并保证目标仓库存在 `main`。**同名**：以目标仓库历史为准，源仓库历史摘要写入 commit message，不替换仓库 | #211 评论 + #213 |
+| Q4 是否默认安装到 harness | **尚未确定**，移入 §6 R4 | — |
+| Q5 server 端入口 | client 执行 **CLI `xskill import`，经新增 API 写入 server 的 `skill_dir`**（不使用 `skill_hub/upload`，也不扩展 `upload --target`）；随后沿用既有 bundle 分发，client 留档后 checkout 服务端版本 | #211 评论 + #213 |
+| Q6 手工 `cp` 的处理 | #213 未否定草案建议：**检测并提示，不自动修复**（最终结论与 §6 R6 一并确认） | 草案建议 |
+| Q7 与 #4 的边界 | 本提案仅覆盖「进入 xskill 自有技能仓库」；UserSkill 与 projectSkill 的挂载问题另行讨论 | 草案建议，未被否定 |
 
-CLI 形态定为顶层 **`xskill import <path>`**；同时支持单 skill 目录与多 skill 父目录；
-**不做** `--agents` / `--from <生态>` 扫描旗标（误导入风险）。同名策略与「纳入自有仓后
-还能改写（脚本化）」在 #213 同期设计，实现等 #209 / #210 合入。
+CLI 形式确定为顶层命令 **`xskill import <path>`**；同时支持单个 skill 目录与包含多个
+skill 的父目录；**不提供** `--agents`、`--from <生态>` 等扫描参数（存在误导入风险）。
+同名策略与「纳入仓库后的改写（脚本化）」在 #213 中一并设计，实现待 #209、#210 合入。
 
-## 6. 剩余待确认的行为细节（新 Open Questions，建议默认可直接反对）
+## 6. 尚未确定的行为细节（新的 Open Questions，各附建议默认，欢迎否决）
 
-拍板把主干钉死了，但把 import 写成可实现的 spec 还差下面这些。每条附建议默认：
+主要设计已经确定，但要把 import 写成可以实现的规格，还需要确定以下各项。
+每条均附建议默认值：
 
-**R1 — 单/批判定与混合目录**
-根有 `SKILL.md` → 单 skill；否则扫一层子目录取含 `SKILL.md` 者，不递归。
-*混合情况*（根有 `SKILL.md`，子目录里也有）：按单 skill 处理，子目录视为该 skill 的资产。
+**R1 — 单个与批量的判定规则，以及混合目录**
+源目录根下有 `SKILL.md` 时按单个 skill 处理；否则仅扫描一层子目录，含 `SKILL.md`
+的子目录视为待导入项，不向更深层递归。
+*混合情况*（根目录与子目录同时含 `SKILL.md`）：按单个 skill 处理，子目录视为该
+skill 自身的资产文件。
 
-**R2 — skill 名字以谁为准**
-建议：`frontmatter.name`（过 slug 校验）为准；与源目录 basename 不一致时以 frontmatter
-为准并在输出中提示。slug 非法 → 拒绝（不自动改名）。
+**R2 — skill 名称以何者为准**
+建议：以 `frontmatter.name`（须通过 slug 规则校验）为准；与源目录名不一致时，
+采用 frontmatter 中的名称并在输出中提示。名称不符合 slug 规则时拒绝导入，不自动改名。
 
-**R3 — 源仓工作区是脏的（有未提交修改）**
-建议：以**工作区字节**为准导入（用户看到什么就导入什么），历史照搬后在顶上补一个
-「import: uncommitted changes」commit；而不是静默取 HEAD 丢掉用户最新编辑。
+**R3 — 源仓库工作区存在未提交修改**
+建议：以**工作区的实际文件内容**为准导入（用户看到的内容即导入的内容），
+同步历史后在其上追加一个说明性 commit（如 "import: uncommitted changes"）；
+不应默默取 HEAD 内容而丢弃用户最新的未提交编辑。
 
-**R4 — 是否默认 install 到已检测 harness（原 Q4）**
-建议：默认安装（与蒸馏 skill 毕业后的 `_install_skill_to_all_detected` 对齐），
-但**防环**：源路径若已位于某 harness 的 skills 目录内，跳过该 harness 的安装
-（目标已存在同路径，symlink 回源会成环或自指）。
+**R4 — 是否默认安装到已检测的 harness（原 Q4）**
+建议：默认安装（与蒸馏 skill 晋升后的 `_install_skill_to_all_detected` 行为一致），
+同时**防止循环安装**：若源路径本身位于某个 harness 的 skills 目录内，
+跳过对该 harness 的安装，避免符号链接指回源目录形成循环或自我引用。
 
-**R5 — team 模式下谁有权 import 到 server 仓**
-import 直接改 server 自有仓的 main，比 upload（hub 旁路）权限敏感。
-建议：默认所有已 connect 成员可导入**新名字**；**同名追加 commit** 是否限 admin，请拍板。
+**R5 — team 模式下的导入权限**
+import 直接修改 server 仓库的 main 分支，权限敏感度高于 upload（后者仅进入检索池）。
+建议：默认允许所有已连接成员导入**新名称**的 skill；**同名追加 commit** 是否仅限
+管理员执行，请维护者确认。
 
-**R6 — 裸 `cp` 的终稿（原 Q6）**
-建议维持：watcher 检测到 `skill_dir` 下无 `.git` 的目录 → 日志警告 + 提示
-`xskill import --heal <dir>`；不静默改盘。
+**R6 — 手工 `cp` 的最终处理方式（原 Q6）**
+建议维持草案方案：watcher 检测到 `skill_dir` 下存在无 `.git` 的目录时，
+输出警告日志并提示执行 `xskill import --heal <dir>`；不自动修改磁盘内容。
 
-**R7 — 幂等**
-同名且上传内容与当前 main 树完全一致：建议 no-op 并提示「已是最新」，不产生空 commit。
+**R7 — 幂等性**
+同名且上传内容与当前 main 树完全一致时：建议不做任何修改，提示「内容已是最新」，
+不产生空 commit。
 
-**R8 — 大小与敏感文件**
-建议沿用 upload 的 20MB 上限；默认排除 `.env` / `*.pem` 等常见秘密文件并警告。
+**R8 — 体积与敏感文件限制**
+建议沿用 upload 的 20MB 上限；默认排除 `.env`、`*.pem` 等常见敏感文件并输出警告。
 
-**R9 — `metadata.origin: imported` 标记（#213 未提）**
-建议保留：写入 `origin: imported`，旧 skill 无字段视为非导入，前向兼容。
+**R9 — `metadata.origin: imported` 来源标记（#213 未涉及）**
+建议保留：写入 `origin: imported`；无该字段的存量 skill 视为非导入来源，保持前向兼容。
 
 ## 7. 风险
 

--- a/openspec/changes/user-skill-import/design.md
+++ b/openspec/changes/user-skill-import/design.md
@@ -1,6 +1,8 @@
 # Design — User Skill Import
 
-> 状态：讨论草案。§5 Open Questions 拍板后补齐 `specs/` SHALL 细则并拆实现 tasks。
+> 状态：**主干已拍板**（#211 维护者评论 + #213），见 §5；`specs/` 已按拍板改为终稿口径。
+> 剩余待确认的行为细节收敛在 §6。与本文早期草案冲突处（Q1 走 baby、Q2 拒绝）以 #213 为准。
+> 实现等 #209、#210 合入 main 后再开 PR（理由见 #213）。
 
 ## 1. Context（现状）
 
@@ -84,11 +86,12 @@ xskill skill import ~/.claude/skills/my-foo
 
 把 `upload` 扩展成「可选写入 server skill_dir」。无法覆盖 standalone；且 hub 与自有仓语义继续缠在一起。
 
-### 推荐组合
+### 推荐组合（已被 #213 采纳的形态）
 
-- **主：S1**（CLI + 共用库函数 + API 对齐）  
-- **辅：对裸 cp 只检测告警 / `--heal` 显式修复**（弱化 S2）  
-- **Team：保留 `upload`→hub；另增「admin import 进 server 仓」或 `import --to server`（P2）**
+- **主：S1**（CLI + 共用库函数 + API 对齐），CLI 定名顶层 `xskill import <path>`
+- **辅：对裸 cp 只检测告警 / `--heal` 显式修复**（弱化 S2，终稿见 §6 R6）
+- **Team：`upload`→hub 不动；client `xskill import` 经新 API 写 server `skill_dir`。
+  #213 明确不做 `upload --target=hub|repo` 开关——两条命令、两处落点**
 
 ## 3. 目标架构（S1）
 
@@ -157,57 +160,73 @@ xskill skill import --from claude-user          # 批量，P1
 
 提案要求：**命名与帮助文案禁止混用「导入」「上传」**。
 
-## 5. Open Questions（请在 issue 回复）
+## 5. 拍板结果（Q1–Q7 → #211 维护者评论 + #213）
 
-**Q1 — 导入后初始分支？**
+| 原问题 | 结论 | 出处 |
+|---|---|---|
+| Q1 初始分支 | **直接 main**。用户导入的是成品，不走 baby 再蒸馏。`--as-baby` 不做 | #213 |
+| Q2 重名 | **不拒绝、不覆盖**：在现有 main 上**追加一次 commit**，工作区变成上传内容形状；git 历史与盘上 `.ux_scores.jsonl` / `.candidates.yml` sidecar 全保留。目标停在 baby 或有 staging → 拒绝并说明 | #213 |
+| Q3 源自带 `.git` | **新名字**：同步源仓，最新 `main`（缺 main 取最新分支 HEAD）为演进起点，目标仓保证有 `main`。**同名**：以目标仓历史为准，源历史写进 commit message，不换仓 | #211 评论 + #213 |
+| Q4 默认 install | **未拍板** → 移入 §6 R4 | — |
+| Q5 server 入口 | client 走 **CLI `xskill import` → 新 API 送 server `skill_dir`**（不是 `skill_hub/upload`，也不是 `upload --target`）；随后走既有 bundle 分发 + client 留档 checkout | #211 评论 + #213 |
+| Q6 裸 `cp` | #213 未推翻草案建议：**检测 + 提示，不静默 heal**（终稿待 §6 R6 一并确认） | 草案默认 |
+| Q7 与 #4 边界 | 本提案只覆盖「进入 xskill 自有仓」；UserSkill/projectSkill 挂载另议 | 草案默认，未被推翻 |
 
-- (a) 直接 **main**（用户已有成品，默认可分发）  
-- (b) **baby**（强制走一遍 SkillEdit/晋升，更一致但烦）  
-- (c) 默认 main，`--as-baby` 可选  
+CLI 形态定为顶层 **`xskill import <path>`**；同时支持单 skill 目录与多 skill 父目录；
+**不做** `--agents` / `--from <生态>` 扫描旗标（误导入风险）。同名策略与「纳入自有仓后
+还能改写（脚本化）」在 #213 同期设计，实现等 #209 / #210 合入。
 
-**Q2 — 重名？**
+## 6. 剩余待确认的行为细节（新 Open Questions，建议默认可直接反对）
 
-- (a) 拒绝（默认）  
-- (b) `--force` 覆盖（丢本地仓）  
-- (c) `--rename` / 自动后缀  
+拍板把主干钉死了，但把 import 写成可实现的 spec 还差下面这些。每条附建议默认：
 
-**Q3 — 源目录已有 `.git`？**
+**R1 — 单/批判定与混合目录**
+根有 `SKILL.md` → 单 skill；否则扫一层子目录取含 `SKILL.md` 者，不递归。
+*混合情况*（根有 `SKILL.md`，子目录里也有）：按单 skill 处理，子目录视为该 skill 的资产。
 
-- (a) 丢弃历史，按 xskill 布局重建  
-- (b) 尽量保留 remote/history（复杂，易和外置 remote 冲突）  
+**R2 — skill 名字以谁为准**
+建议：`frontmatter.name`（过 slug 校验）为准；与源目录 basename 不一致时以 frontmatter
+为准并在输出中提示。slug 非法 → 拒绝（不自动改名）。
 
-**Q4 — 是否默认 `install` 到已检测 harness？**
+**R3 — 源仓工作区是脏的（有未提交修改）**
+建议：以**工作区字节**为准导入（用户看到什么就导入什么），历史照搬后在顶上补一个
+「import: uncommitted changes」commit；而不是静默取 HEAD 丢掉用户最新编辑。
 
-- (a) 默认安装  
-- (b) 默认不装，`--install` 才装  
-- (c) 若源路径已是某 harness 的 skill 目录，只入仓、不再 symlink 回去（防环）  
+**R4 — 是否默认 install 到已检测 harness（原 Q4）**
+建议：默认安装（与蒸馏 skill 毕业后的 `_install_skill_to_all_detected` 对齐），
+但**防环**：源路径若已位于某 harness 的 skills 目录内，跳过该 harness 的安装
+（目标已存在同路径，symlink 回源会成环或自指）。
 
-**Q5 — Server 导入主入口？**
+**R5 — team 模式下谁有权 import 到 server 仓**
+import 直接改 server 自有仓的 main，比 upload（hub 旁路）权限敏感。
+建议：默认所有已 connect 成员可导入**新名字**；**同名追加 commit** 是否限 admin，请拍板。
 
-- (a) 仅在 server 主机跑 CLI  
-- (b) 鉴权 API 收 zip（admin）  
-- (c) 扩展 `upload` 增加 `?target=repo|hub`  
+**R6 — 裸 `cp` 的终稿（原 Q6）**
+建议维持：watcher 检测到 `skill_dir` 下无 `.git` 的目录 → 日志警告 + 提示
+`xskill import --heal <dir>`；不静默改盘。
 
-**Q6 — 裸 `cp` 策略？**
+**R7 — 幂等**
+同名且上传内容与当前 main 树完全一致：建议 no-op 并提示「已是最新」，不产生空 commit。
 
-- (a) 不支持；文档明确  
-- (b) 检测 + 提示 `--heal`  
-- (c) 自动 heal（最不推荐）  
+**R8 — 大小与敏感文件**
+建议沿用 upload 的 20MB 上限；默认排除 `.env` / `*.pem` 等常见秘密文件并警告。
 
-**Q7 — 与 #4 UserSkill/projectSkill？**
+**R9 — `metadata.origin: imported` 标记（#213 未提）**
+建议保留：写入 `origin: imported`，旧 skill 无字段视为非导入，前向兼容。
 
-本提案是否只声明「导入进入 xskill 自有仓 = user-scoped 可复用 skill」，project-scoped 另开提案？
-
-## 6. 风险
+## 7. 风险
 
 - **环装**：从 `~/.claude/skills/x` import 后再 install 回 CC → 需 path 判断。  
 - **覆盖用户未提交编辑**：`--force` 必须二次确认或 dry-run。  
 - **大目录 / 密钥**：导入应跳过常见秘密文件（`.env`）或限制大小（对齐 upload 20MB）。  
 - **旧 `import_skill` 行为变更**：可能有隐藏调用方；实现时先搜全仓调用再改。
 
-## 7. 测试设计（拍板后落地）
+## 8. 测试设计（对齐 #213 验收）
 
-- 单元：校验失败不落盘；重名策略；name 取自 frontmatter  
-- 集成：import 后 `SkillRepo` 可迭代、catalog 有行、可选 index  
-- 回归：不破坏 `upload` hub 路径  
-- BDD（可选）：`skill_import.feature` — Given 外部 SKILL.md When import Then 仓内可 search
+- 单元：校验失败不落盘；同名追加 commit 后 `git log` 仍含导入前 commit、
+  盘上 `.ux_scores.jsonl` 旧 `commit_sha` 原样；baby/staging 时拒绝；
+  不再 `rmtree`、不再对父目录 commit；name 取自 frontmatter
+- 集成：新 skill import 后 per-skill git、在 main、catalog 有行；
+  team 下 client 能 checkout 到 server 端 sha（旧副本有留档 commit）
+- 回归：`xskill upload` 行为不变（仍进 hub，不进自有仓）
+- BDD（建议）：`skill_import.feature` — 单/批/同名/灰度拒绝 四组场景

--- a/openspec/changes/user-skill-import/design.md
+++ b/openspec/changes/user-skill-import/design.md
@@ -1,0 +1,213 @@
+# Design — User Skill Import
+
+> 状态：讨论草案。§5 Open Questions 拍板后补齐 `specs/` SHALL 细则并拆实现 tasks。
+
+## 1. Context（现状）
+
+### 1.1 自有仓模型（导入必须对齐）
+
+每个 skill 在 `~/.xskill/skill/<name>/`（配置 `skill_dir`）下是**独立 git 仓库**：
+
+- 蒸馏路径：`init_skill_repo_on_baby` → baby → SkillEdit → main/staging  
+- catalog：`skills_catalog` 投影  
+- 检索：`.skill_index.pkl`（description embedding）  
+- client：sync/install 到各 harness（`~/.claude/skills` 等常为 symlink/copy）
+
+导入若只丢文件、不做 git/catalog，后续 canary / reverse-sync / search 会 silently 残缺。
+
+### 1.2 已有相关入口（避免重复造轮）
+
+```text
+                    ┌─────────────────────────────┐
+  外部 SKILL.md ──► │ A. POST /skills/import       │──► skill_dir (半残)
+                    │    import_skill(copytree)    │
+                    └─────────────────────────────┘
+
+                    ┌─────────────────────────────┐
+  外部目录 ────────► │ B. xskill upload            │──► skillhub/user_skill_hub/
+                    │    (team only, zip)          │    （检索旁路，非自有仓）
+                    └─────────────────────────────┘
+
+                    ┌─────────────────────────────┐
+  用户 cp ─────────► │ C. 裸拷贝 skill_dir         │──► 无契约，不保证可管理
+                    └─────────────────────────────┘
+```
+
+本提案要补的是清晰的 **「入自有仓」管道 D**，并决定 A/C 是废弃、heal、还是降级。
+
+### 1.3 用户故事
+
+1. **Standalone 个人**：我在 Claude Code 里攒了一批 `~/.claude/skills/*`，想让 xskill 接管版本/进化，同时继续给 CC 用。  
+2. **Team 成员**：我想把本地写好的 skill 交给 server 仓（或 hub），同事 sync 能装到。  
+3. **迁移**：从另一台机器 / 备份目录批量迁入。
+
+## 2. 方案对比（请维护者选主路径）
+
+### 方案 S1 — CLI / API 受控导入（推荐作主路径）
+
+```text
+xskill skill import ~/.claude/skills/my-foo
+        │
+        ├─ parse_strict(SKILL.md)
+        ├─ resolve name（frontmatter.name 优先，冲突策略见 Q2）
+        ├─ materialize into skill_dir/<name>/
+        ├─ ensure git（见 Q1：baby vs main）
+        ├─ catalog upsert
+        ├─ optional: rebuild/index touch
+        └─ optional: install_to_detected_harnesses
+```
+
+| 优点 | 缺点 |
+|---|---|
+| 边界清晰、可测、可报错（符合 no-fallback） | 用户多一步命令 |
+| 易做批量 `--from claude-user` | 要教用户别裸 cp |
+| 与现有 API 可共用实现 | |
+
+**Server 侧**：`xskill skill import` 在 server 主机执行（或 admin API 收 zip），写入 server `skill_dir`；client 下一轮 sync 拉取。这比「让每个 client 自己 cp 到 server 盘」现实。
+
+### 方案 S2 — 允许 `cp` + 启动/扫描 heal
+
+用户可 `cp -r my-skill ~/.xskill/skill/`；`serve` / watcher 周期性：
+
+- 发现无 `.git` 的 skill 目录 → 自动 `git init` + 初始 commit  
+- catalog 补齐；坏 SKILL.md → **报错日志，不静默**
+
+| 优点 | 缺点 |
+|---|---|
+| 心智负担低 | 与「坏输入抛错」张力大；半导入状态多 |
+| 脚本友好 | 权限/恶意路径/重名覆盖难控 |
+| | 和 harness 目录互相 cp 易造成环（xskill→claude→再 cp 回） |
+
+**建议**：S2 最多作为 **检测 + 提示「请运行 xskill skill import --heal」**，不要静默改盘。
+
+### 方案 S3 — 仅 Team upload 扩展（不推荐单独做）
+
+把 `upload` 扩展成「可选写入 server skill_dir」。无法覆盖 standalone；且 hub 与自有仓语义继续缠在一起。
+
+### 推荐组合
+
+- **主：S1**（CLI + 共用库函数 + API 对齐）  
+- **辅：对裸 cp 只检测告警 / `--heal` 显式修复**（弱化 S2）  
+- **Team：保留 `upload`→hub；另增「admin import 进 server 仓」或 `import --to server`（P2）**
+
+## 3. 目标架构（S1）
+
+```text
+                    ┌──────────────────────────────────────┐
+                    │  xskill.skill.importing              │
+                    │  import_external_skill(src, opts)    │
+                    └─────────────┬────────────────────────┘
+                                  │
+           ┌──────────────────────┼──────────────────────┐
+           ▼                      ▼                      ▼
+    CLI skill import      POST /skills/import      (P2) admin zip API
+           │                      │                      │
+           └──────────────────────┴──────────────────────┘
+                                  │
+                                  ▼
+                         ~/.xskill/skill/<name>/
+                         (git + SKILL.md + …)
+                                  │
+              ┌───────────────────┼───────────────────┐
+              ▼                   ▼                   ▼
+         catalog_store      skill_index (opt)   install harness (opt)
+```
+
+### 3.1 校验（硬门槛）
+
+导入前 MUST：
+
+1. `SKILL.md` 存在且 `parse_strict` 通过（name/description 合法 YAML）  
+2. `frontmatter.name` 符合 slug 规则（与仓内惯例一致）  
+3. 源目录不是 `skill_dir` 自身的子路径（防自拷）  
+4. 默认排除 `.git`（源若是 git 仓：Q3 是否保留历史）
+
+失败 → CLI exit≠0 / API 4xx，**不写半成品目录**（或写入事务：先 staging tmp 再 replace）。
+
+### 3.2 与蒸馏 skill 的共存（前向兼容）
+
+| 字段/行为 | 蒸馏 skill | 导入 skill |
+|---|---|---|
+| git main/staging/baby | 有 | MUST 有等价可解析布局 |
+| `metadata.source_atoms` | 常有 | 可空；SHOULD 标 `origin: imported` |
+| SkillEdit / canary | 适用 | 适用（导入后即一等公民） |
+| SkillHub 旁路 | 否 | 否（在自有仓，不是 hub） |
+| search / sync | 适用 | 适用 |
+
+旧 skill 无 `origin` 字段时，默认视为 `distilled`（兼容读）。
+
+### 3.3 不推荐的用户操作（文档写死）
+
+```bash
+# 不支持作为官方路径（可能 dig 出半残仓）
+cp -r ~/.claude/skills/foo ~/.xskill/skill/foo
+
+# 官方
+xskill skill import ~/.claude/skills/foo
+xskill skill import --from claude-user          # 批量，P1
+```
+
+## 4. 与 `xskill upload` / SkillHub 的边界
+
+| 命令/能力 | 落点 | 谁能搜到 | 谁能被 sync 安装 |
+|---|---|---|---|
+| `skill import` | 自有 `skill_dir` | 本地 search；team 则进 manifest | 是（仓内 skill） |
+| `upload` | `user_skill_hub/<user>/` | team search（旁路） | 视现网 manifest 是否纳入 hub |
+| SkillHub dir 扫描 | `skillhub_skills/` | 相关性推荐 | 通常不走 git 灰度 |
+
+提案要求：**命名与帮助文案禁止混用「导入」「上传」**。
+
+## 5. Open Questions（请在 issue 回复）
+
+**Q1 — 导入后初始分支？**
+
+- (a) 直接 **main**（用户已有成品，默认可分发）  
+- (b) **baby**（强制走一遍 SkillEdit/晋升，更一致但烦）  
+- (c) 默认 main，`--as-baby` 可选  
+
+**Q2 — 重名？**
+
+- (a) 拒绝（默认）  
+- (b) `--force` 覆盖（丢本地仓）  
+- (c) `--rename` / 自动后缀  
+
+**Q3 — 源目录已有 `.git`？**
+
+- (a) 丢弃历史，按 xskill 布局重建  
+- (b) 尽量保留 remote/history（复杂，易和外置 remote 冲突）  
+
+**Q4 — 是否默认 `install` 到已检测 harness？**
+
+- (a) 默认安装  
+- (b) 默认不装，`--install` 才装  
+- (c) 若源路径已是某 harness 的 skill 目录，只入仓、不再 symlink 回去（防环）  
+
+**Q5 — Server 导入主入口？**
+
+- (a) 仅在 server 主机跑 CLI  
+- (b) 鉴权 API 收 zip（admin）  
+- (c) 扩展 `upload` 增加 `?target=repo|hub`  
+
+**Q6 — 裸 `cp` 策略？**
+
+- (a) 不支持；文档明确  
+- (b) 检测 + 提示 `--heal`  
+- (c) 自动 heal（最不推荐）  
+
+**Q7 — 与 #4 UserSkill/projectSkill？**
+
+本提案是否只声明「导入进入 xskill 自有仓 = user-scoped 可复用 skill」，project-scoped 另开提案？
+
+## 6. 风险
+
+- **环装**：从 `~/.claude/skills/x` import 后再 install 回 CC → 需 path 判断。  
+- **覆盖用户未提交编辑**：`--force` 必须二次确认或 dry-run。  
+- **大目录 / 密钥**：导入应跳过常见秘密文件（`.env`）或限制大小（对齐 upload 20MB）。  
+- **旧 `import_skill` 行为变更**：可能有隐藏调用方；实现时先搜全仓调用再改。
+
+## 7. 测试设计（拍板后落地）
+
+- 单元：校验失败不落盘；重名策略；name 取自 frontmatter  
+- 集成：import 后 `SkillRepo` 可迭代、catalog 有行、可选 index  
+- 回归：不破坏 `upload` hub 路径  
+- BDD（可选）：`skill_import.feature` — Given 外部 SKILL.md When import Then 仓内可 search

--- a/openspec/changes/user-skill-import/proposal.md
+++ b/openspec/changes/user-skill-import/proposal.md
@@ -1,8 +1,10 @@
 # Feature: 导入用户已有 Skill（User Skill Import）
 
-> 状态：**设计草案（讨论中）**。本提案只做前向兼容的能力边界与入口选型，
-> 实现等 Open Questions（见 `design.md`）拍板后再开实现 PR。
-> 关联讨论：Issue（本提案提交后挂链）、相邻议题 [#4 UserSkill vs projectSkill](https://github.com/SkillNerds/xskill/issues/4)。
+> 状态：**主干已拍板**（[#211 维护者评论](https://github.com/SkillNerds/xskill/issues/211) + [#213](https://github.com/SkillNerds/xskill/issues/213)）：
+> CLI 定名顶层 `xskill import <path>`；新 skill 直接 main；同名在现有 main 上追加 commit；
+> team 下 client 经新 API 写 server `skill_dir` 再 bundle 推回。剩余行为细节见 `design.md` §6。
+> 实现等 #209、#210 合入 main 后再开 PR。
+> 相邻议题 [#4 UserSkill vs projectSkill](https://github.com/SkillNerds/xskill/issues/4)。
 
 ## Why
 
@@ -37,9 +39,9 @@ skill（`~/.claude/skills/`、`~/.agents/skills/`、团队共享目录、从别�
    - 明确 **不推荐** 用户裸 `cp`；若检测到「仓内无 git 的外来目录」，给出修复命令
 
 2. **P1 批量 / 生态源**  
-   - `xskill skill import --from claude-user`（扫 `~/.claude/skills/*`）  
-   - `--from agents`（`~/.agents/skills`）  
-   - 目录批量：`import <parent-dir> --all`
+   - 批量 = **直接给父目录路径**：`xskill import ~/.claude/skills/`（一次收入多个）  
+   - **不做** `--from claude-user` / `--agents` 这类生态扫描旗标（#213：误导入风险；
+     路径本身就是最明确的授权）
 
 3. **P2 Team / Server**  
    - 复用或收敛 `upload` →「进 hub」vs「进 server 自有仓」两条语义，避免再分叉  

--- a/openspec/changes/user-skill-import/proposal.md
+++ b/openspec/changes/user-skill-import/proposal.md
@@ -1,0 +1,85 @@
+# Feature: 导入用户已有 Skill（User Skill Import）
+
+> 状态：**设计草案（讨论中）**。本提案只做前向兼容的能力边界与入口选型，
+> 实现等 Open Questions（见 `design.md`）拍板后再开实现 PR。
+> 关联讨论：Issue（本提案提交后挂链）、相邻议题 [#4 UserSkill vs projectSkill](https://github.com/SkillNerds/xskill/issues/4)。
+
+## Why
+
+xskill 今天的主路径是「轨迹 → 原子 → 蒸馏出 skill」。大量用户手里**已经有**可复用的
+skill（`~/.claude/skills/`、`~/.agents/skills/`、团队共享目录、从别处拷来的
+`SKILL.md` 包），却没有一条**一等公民**的导入路径，把这些 skill 干净地纳入
+`~/.xskill/skill/` 仓（带 git 生命周期、catalog、索引、harness 安装、team 分发）。
+
+现状是半成品拼盘，体验断裂：
+
+| 已有入口 | 能做什么 | 缺口 |
+|---|---|---|
+| `POST /api/v1/skills/import` + `import_skill()` | 服务端按路径 `copytree` 进 `skill_dir` | 无 CLI；不校验 frontmatter；按目录名命名；对父目录 `commit_changes`（与「每 skill 独立 git 仓」模型不一致）；覆盖即删；不触发 catalog/index/install |
+| `xskill upload <dir>` | zip 上传到 team **user_skill_hub**（可被 search） | 不是进本地蒸馏仓；standalone 无用；不参与 canary/SkillEdit 主仓语义 |
+| 用户手工 `cp` 到 `~/.xskill/skill/<name>/` | 文件出现在磁盘上 | 无 baby/main 初始化、无 catalog UPSERT、无 `.skill_index.pkl`、可能不被 harness 安装；脏 layout 难排查 |
+| SkillHub 扫描 `skillhub_skills/` | 三方检索池 | 明确是「旁路检索」，不是「自有仓 skill」 |
+
+结果：用户无法把「我已经写好的 skill」低摩擦地变成 xskill 可管理、可进化、可分发的对象。
+这是产品缺口，不是单纯文档问题。
+
+## What Changes（提案目标，非已实现）
+
+引入 **User Skill Import** 能力：把外部 skill 目录（或 zip）纳入 xskill 自有 skill 仓，
+并保证与后续蒸馏 / canary / sync / search **前向兼容**。
+
+建议交付分层（拍板后拆 PR）：
+
+1. **P0 本地一等入口（standalone + client）**  
+   - CLI：`xskill skill import <path> [--name] [--force|--skip-existing]`（名称待定）  
+   - 校验 `SKILL.md`（`parse_strict`）、规范化 name、初始化/对齐 git（baby 或直接 main，见 Open Q）  
+   - 写 catalog、可选触发 index 增量、可选装到已检测 harness  
+   - 明确 **不推荐** 用户裸 `cp`；若检测到「仓内无 git 的外来目录」，给出修复命令
+
+2. **P1 批量 / 生态源**  
+   - `xskill skill import --from claude-user`（扫 `~/.claude/skills/*`）  
+   - `--from agents`（`~/.agents/skills`）  
+   - 目录批量：`import <parent-dir> --all`
+
+3. **P2 Team / Server**  
+   - 复用或收敛 `upload` →「进 hub」vs「进 server 自有仓」两条语义，避免再分叉  
+   - 管理员 CLI / API：从路径或 zip 导入 server `skill_dir`（带鉴权）
+
+4. **文档与前向兼容**  
+   - 在 northbound-api / README 区分：`import`（入自有仓）≠ `upload`（入 user_skill_hub）≠ SkillHub 扫描  
+   - metadata 增加 `origin: imported | distilled | skillhub`（或等价），便于日后策略分流且不破坏旧 skill
+
+## Non-Goals（本提案不做）
+
+- 不解决 [#4](https://github.com/SkillNerds/xskill/issues/4) 的 UserSkill vs projectSkill 挂载优先级（可并列讨论，但本提案只覆盖「进入 xskill 仓」）。
+- 不自动把导入 skill 改写为蒸馏风格长文；导入后默认可信原样，SkillEdit 另议。
+- 不在本提案实现「从任意 URL 拉 skill 市场」。
+
+## Capabilities
+
+### New Capabilities
+
+- `user-skill-import`: 将外部 skill 目录/zip 校验并纳入 `skill_dir`；CLI 为一等入口；导入后具备与蒸馏 skill 兼容的仓布局（git + catalog + 可选 index/install）。
+
+### Modified Capabilities
+
+- 收紧/修正现有 `import_skill` / `POST /skills/import`：与新 CLI 共用同一实现，修复「父目录 commit」等与现行仓模型不一致处。
+- 文档厘清 `upload`（hub）与 `import`（自有仓）边界。
+
+## Impact（预估）
+
+- `src/xskill/skill/repo.py`：`import_skill` 重做或旁路新实现  
+- `src/xskill/cli.py`：新增 `skill import`（或顶层 `import-skill`）  
+- `src/xskill/api/app.py`：`/skills/import` 对齐新语义（路径/zip）  
+- `src/xskill/skill/catalog_store.py` / index / ecosystems install：导入后钩子  
+- `tests/`：校验失败、重名策略、无 SKILL.md、批量 from claude-user  
+- **不新增重依赖**
+
+## 请维护者拍板（摘要）
+
+完整选项与取舍见 `design.md`。核心二选一（可组合）：
+
+1. **主推 CLI/API 受控导入**（推荐）：禁止把裸 `cp` 当支持路径；提供 `xskill skill import`。  
+2. **允许 `cp` + 守护扫描**：用户可拷进 `skill_dir`，watcher/serve 启动时 heal（git init + catalog）。运维简单，但脏状态与权限边界更糊。
+
+以及：导入后落 **main** 还是 **baby**、重名策略、是否默认装 harness、team 是否与 `upload` 合并语义。

--- a/openspec/changes/user-skill-import/proposal.md
+++ b/openspec/changes/user-skill-import/proposal.md
@@ -1,10 +1,11 @@
 # Feature: 导入用户已有 Skill（User Skill Import）
 
-> 状态：**主干已拍板**（[#211 维护者评论](https://github.com/SkillNerds/xskill/issues/211) + [#213](https://github.com/SkillNerds/xskill/issues/213)）：
-> CLI 定名顶层 `xskill import <path>`；新 skill 直接 main；同名在现有 main 上追加 commit；
-> team 下 client 经新 API 写 server `skill_dir` 再 bundle 推回。剩余行为细节见 `design.md` §6。
-> 实现等 #209、#210 合入 main 后再开 PR。
-> 相邻议题 [#4 UserSkill vs projectSkill](https://github.com/SkillNerds/xskill/issues/4)。
+> 状态：**主要设计已确认**（[#211 维护者评论](https://github.com/SkillNerds/xskill/issues/211) + [#213](https://github.com/SkillNerds/xskill/issues/213)）：
+> CLI 为顶层命令 `xskill import <path>`；新 skill 导入后直接位于 main；
+> 同名导入在现有 main 上追加一次 commit；team 模式下 client 经新增 API 写入
+> server 的 `skill_dir`，再由 bundle 机制推回本地。尚未确定的行为细节见 `design.md` §6。
+> 实现待 #209、#210 合入 main 后再提交 PR。
+> 相邻议题：[#4 UserSkill vs projectSkill](https://github.com/SkillNerds/xskill/issues/4)。
 
 ## Why
 
@@ -13,7 +14,7 @@ skill（`~/.claude/skills/`、`~/.agents/skills/`、团队共享目录、从别�
 `SKILL.md` 包），却没有一条**一等公民**的导入路径，把这些 skill 干净地纳入
 `~/.xskill/skill/` 仓（带 git 生命周期、catalog、索引、harness 安装、team 分发）。
 
-现状是半成品拼盘，体验断裂：
+现状是多个不完整的入口并存，体验割裂：
 
 | 已有入口 | 能做什么 | 缺口 |
 |---|---|---|
@@ -30,11 +31,11 @@ skill（`~/.claude/skills/`、`~/.agents/skills/`、团队共享目录、从别�
 引入 **User Skill Import** 能力：把外部 skill 目录（或 zip）纳入 xskill 自有 skill 仓，
 并保证与后续蒸馏 / canary / sync / search **前向兼容**。
 
-建议交付分层（拍板后拆 PR）：
+建议分层交付（设计确认后拆分为多个 PR）：
 
 1. **P0 本地一等入口（standalone + client）**  
-   - CLI：`xskill skill import <path> [--name] [--force|--skip-existing]`（名称待定）  
-   - 校验 `SKILL.md`（`parse_strict`）、规范化 name、初始化/对齐 git（baby 或直接 main，见 Open Q）  
+   - CLI：顶层命令 `xskill import <path>`（已确认）  
+   - 校验 `SKILL.md`（`parse_strict`）、规范化 name、初始化/对齐 git（已确认：直接进入 main）  
    - 写 catalog、可选触发 index 增量、可选装到已检测 harness  
    - 明确 **不推荐** 用户裸 `cp`；若检测到「仓内无 git 的外来目录」，给出修复命令
 
@@ -43,9 +44,9 @@ skill（`~/.claude/skills/`、`~/.agents/skills/`、团队共享目录、从别�
    - **不做** `--from claude-user` / `--agents` 这类生态扫描旗标（#213：误导入风险；
      路径本身就是最明确的授权）
 
-3. **P2 Team / Server**  
-   - 复用或收敛 `upload` →「进 hub」vs「进 server 自有仓」两条语义，避免再分叉  
-   - 管理员 CLI / API：从路径或 zip 导入 server `skill_dir`（带鉴权）
+3. **P2 Team / Server**（已确认方向）  
+   - `upload` 与 `import` 语义不合并：前者进 hub，后者经新增 API 写入 server `skill_dir`  
+   - client 端 `xskill import` 上送、server 落库、bundle 推回；权限细节见 `design.md` §6 R5
 
 4. **文档与前向兼容**  
    - 在 northbound-api / README 区分：`import`（入自有仓）≠ `upload`（入 user_skill_hub）≠ SkillHub 扫描  
@@ -71,17 +72,16 @@ skill（`~/.claude/skills/`、`~/.agents/skills/`、团队共享目录、从别�
 ## Impact（预估）
 
 - `src/xskill/skill/repo.py`：`import_skill` 重做或旁路新实现  
-- `src/xskill/cli.py`：新增 `skill import`（或顶层 `import-skill`）  
+- `src/xskill/cli.py`：新增顶层命令 `xskill import`  
 - `src/xskill/api/app.py`：`/skills/import` 对齐新语义（路径/zip）  
 - `src/xskill/skill/catalog_store.py` / index / ecosystems install：导入后钩子  
-- `tests/`：校验失败、重名策略、无 SKILL.md、批量 from claude-user  
+- `tests/`：校验失败、同名追加 commit、无 SKILL.md、父目录批量导入  
 - **不新增重依赖**
 
-## 请维护者拍板（摘要）
+## 决定情况（摘要）
 
-完整选项与取舍见 `design.md`。核心二选一（可组合）：
-
-1. **主推 CLI/API 受控导入**（推荐）：禁止把裸 `cp` 当支持路径；提供 `xskill skill import`。  
-2. **允许 `cp` + 守护扫描**：用户可拷进 `skill_dir`，watcher/serve 启动时 heal（git init + catalog）。运维简单，但脏状态与权限边界更糊。
-
-以及：导入后落 **main** 还是 **baby**、重名策略、是否默认装 harness、team 是否与 `upload` 合并语义。
+主要问题已有结论（见 `design.md` §5）：采用 CLI/API 受控导入，命令为顶层
+`xskill import <path>`；导入后直接位于 main；同名在现有 main 上追加一次 commit；
+`upload` 与 `import` 语义不合并。尚待维护者确认的行为细节见 `design.md` §6（R1–R9），
+其中优先级较高的是：源仓库存在未提交修改时的处理（R3）、是否默认安装到 harness
+及循环安装防护（R4）、team 模式下的导入权限（R5）。

--- a/openspec/changes/user-skill-import/specs/user-skill-import/spec.md
+++ b/openspec/changes/user-skill-import/specs/user-skill-import/spec.md
@@ -1,130 +1,137 @@
 ## ADDED Requirements
 
-> 口径标记：**【已拍板】** = 来自 #213 与 #211 维护者结论，终稿；
-> **【建议默认】** = 本稿为剩余细节补的默认行为，待确认（汇总见 `design.md` §6）。
-> 与旧草案冲突处（重名拒绝、baby 起步）以本版为准。
+> 标记说明：**【已确认】** = 来自 #211 维护者评论与 #213 的结论，为最终表述；
+> **【建议默认】** = 本文档为尚未确定的细节提出的默认行为，待维护者确认（汇总见 `design.md` §6）。
+> 与早期草案不一致之处（同名拒绝、导入后进入 baby 分支），以本版本为准。
 
-### Requirement: `xskill import` 是把已有 skill 纳入自有仓的一等入口【已拍板】
+### Requirement: `xskill import` 是将已有 skill 纳入自有技能仓库的正式入口【已确认】
 
-用一句话说：用户手里已经写好的 skill，跑一条命令就变成 xskill 管理的 skill——
-有 git 历史、进 catalog、能被搜索、能进化、team 下能分发。
+概述：用户已经写好的 skill，通过一条命令即可纳入 xskill 管理——具备 git 历史、
+写入 catalog、可被搜索、参与技能进化，team 部署下可分发给其他成员。
 
-- CLI 形态为顶层 `xskill import <path>`。
-- 落点是配置的 `skill_dir`（默认 `~/.xskill/skill/`），每个 skill 一个独立 git 仓。
-- 不写 skillhub；`xskill upload` 行为不变（仍只进 `user_skill_hub`，不能替代 import）。
-- 重写后的 `import_skill()` 与 `POST /api/v1/skills/import` 和 CLI 共用同一实现；
-  旧实现的 `rmtree` 顶替与「对父目录 `~/.xskill/skill/` 做 commit」两个行为删除。
+- CLI 形式为顶层命令 `xskill import <path>`。
+- 目标位置是配置项 `skill_dir`（默认 `~/.xskill/skill/`），每个 skill 是一个独立的 git 仓库。
+- 不写入 skillhub；`xskill upload` 行为保持不变（仍然只进入 `user_skill_hub`，不能替代 import）。
+- 重写后的 `import_skill()`、`POST /api/v1/skills/import` 与 CLI 共用同一实现；
+  旧实现中的两个行为予以删除：删除整个目录后重建（`rmtree` + `copytree`），
+  以及对父目录 `~/.xskill/skill/` 执行 commit。
 
 #### Scenario: 导入一个合法 skill
 
-- **当** 用户执行 `xskill import ~/.claude/skills/foo` 且 `SKILL.md` 通过 `parse_strict`
-- **那么** `skill_dir/foo/` 成为独立 git 仓，内容即导入内容
-- **且** catalog（`notify_native_upsert`）有该 skill 的行，随后可被本地 search 命中
+- **当** 用户执行 `xskill import ~/.claude/skills/foo`，且其 `SKILL.md` 通过 `parse_strict` 校验
+- **那么** `skill_dir/foo/` 成为独立 git 仓库，内容与导入内容一致
+- **且** catalog（`notify_native_upsert`）中存在该 skill 的记录，随后可被本地搜索命中
 
-#### Scenario: upload 不因此改变
+#### Scenario: upload 行为不受影响
 
 - **当** 用户执行 `xskill upload <dir>`
-- **那么** 行为保持现状：zip 进 team `user_skill_hub`，不进自有仓，不参与进化
+- **那么** 行为与现状一致：打包后进入 team `user_skill_hub`，不进入自有技能仓库，不参与技能进化
 
-### Requirement: 同时接受单 skill 目录与多 skill 父目录【已拍板】，判定与批量语义【建议默认】
+### Requirement: 同时接受单个 skill 目录与包含多个 skill 的父目录【已确认】；判定规则与批量语义【建议默认】
 
-`xskill import ~/.claude/skills/foo`（单个）和 `xskill import ~/.claude/skills/`
-（一次收多个）都要能用。不提供 `--agents` / `--from <生态>` 这类扫描旗标——
-误导入风险太大，路径本身就是最明确的授权。
+`xskill import ~/.claude/skills/foo`（单个）与 `xskill import ~/.claude/skills/`
+（一次导入多个）均须支持。不提供 `--agents`、`--from <生态>` 之类的扫描参数：
+此类参数容易造成误导入，而路径本身已经是最明确的授权表达。
 
 判定规则【建议默认】：
 
-- 源目录根下有 `SKILL.md` → 按**单 skill** 导入。
-- 否则扫**一层**子目录，含 `SKILL.md` 的子目录即候选；更深层不递归。
-- 两者都不成立 → 报错退出，不落任何盘。
+- 源目录根下存在 `SKILL.md`：按**单个 skill** 导入。
+- 否则仅扫描**一层**子目录，含 `SKILL.md` 的子目录视为待导入项；更深层级不递归。
+- 两者均不满足：报错退出，不写入任何文件。
 
 批量语义【建议默认】：
 
-- 先列出将要导入的 skill 清单；TTY 下需用户确认，`--yes` 跳过确认；提供 `--dry-run`。
-- 逐个导入，单个失败**不中断**其余；结束时输出 成功/失败/跳过 汇总，有失败则 exit 非零。
+- 执行前列出将要导入的 skill 清单；交互式终端下需要用户确认，`--yes` 可跳过确认；提供 `--dry-run`。
+- 逐个导入，单项失败**不中断**其余项；结束时输出成功、失败、跳过的汇总，存在失败项时退出码非零。
 
-#### Scenario: 父目录批量导入部分失败
+#### Scenario: 批量导入中存在失败项
 
-- **当** `xskill import ~/.claude/skills/` 中 3 个候选有 1 个 `parse_strict` 失败
-- **那么** 其余 2 个正常入仓，失败项打出原因
-- **且** 退出码非零，失败项在 `skill_dir` 无半成品目录
+- **当** `xskill import ~/.claude/skills/` 的 3 个待导入项中有 1 个未通过 `parse_strict` 校验
+- **那么** 其余 2 个正常入库，失败项输出具体原因
+- **且** 退出码非零，失败项在 `skill_dir` 中不留下任何不完整的目录
 
-### Requirement: 新 skill 导入后直接是 main【已拍板】
+### Requirement: 新 skill 导入后直接位于 main 分支【已确认】
 
-用户导入的是成品，不走 baby 再蒸馏一遍。
+用户导入的是已经成型的 skill，不需要经过 baby 分支再蒸馏一次。
 
-- 仓里还没有这个名字：建独立 git 仓，导入内容为**原始 main**。
-- 源目录自带 `.git` 且有 `main` 或 `master`：同步该仓库到目标仓，以最新 `main`
-  （没有 `main` 则取最新分支的 HEAD）作为演进起点，并保证目标仓存在 `main` 分支。
-- 源目录无 git：初始化新仓，首个 commit 即导入内容。
+- 仓库中尚无同名 skill 时：建立独立 git 仓库，导入内容作为**初始 main**。
+- 源目录自带 `.git` 且存在 `main` 或 `master` 分支：将该仓库同步到目标仓库，
+  以最新的 `main`（若无 `main`，取最新分支的 HEAD）作为后续演进的起点，
+  并保证目标仓库存在 `main` 分支。
+- 源目录没有 git：初始化新仓库，首个 commit 即导入内容。
 
-#### Scenario: 带 git 历史的源
+#### Scenario: 源目录带有 git 历史
 
-- **当** 源目录是 git 仓且含 `main` 分支
-- **那么** 目标仓保留其历史，`main` HEAD 与源最新 `main` 一致
-- **且** 后续 SkillEdit / canary 基于该 HEAD 演进
+- **当** 源目录是 git 仓库且含 `main` 分支
+- **那么** 目标仓库保留其提交历史，`main` 的 HEAD 与源仓库最新 `main` 一致
+- **且** 后续 SkillEdit 与灰度发布均基于该 HEAD 演进
 
-### Requirement: 同名导入 = 在现有 main 上追加一次 commit【已拍板】
+### Requirement: 同名导入等于在现有 main 上追加一次 commit【已确认】
 
-这是旧草案「重名拒绝 / --force 覆盖」的替代终稿。核心约束：**git 历史与 UX
-台账不能丢**（`.ux_scores.jsonl` 按 commit_sha 挂分，删仓 = 版本表与进化路径断链）。
+本条替代早期草案中的「同名拒绝 / `--force` 覆盖」。核心约束：**git 历史与 UX
+评分记录不能丢失**——`.ux_scores.jsonl` 按 commit sha 记录评分，删除仓库
+将导致版本统计与进化路径无法对应到历史节点。
 
-- 禁止删目录顶替（`rmtree` + `copytree` 不允许出现在任何路径）。
-- 把工作区改成上传内容的形状（`SKILL.md`、`scripts/`、`references/` 等），
-  在现有 main 上**追加一次 commit**；导入前的历史全部保留。
-- 目标仓 `.git` 与盘上 sidecar（`.ux_scores.jsonl`、`.candidates.yml`）不被覆盖、不被删除。
-- 源目录即使自带 git，同名场景**以目标仓历史为准**；源历史摘要写进 commit message，不换仓。
-- 目标仓正停在 baby、或存在 staging 灰度：**拒绝**这次同名导入，并说明原因
-  （不在灰度中改 main 树，不静默覆盖 baby 草稿）。
+- 禁止通过删除目录再重建的方式覆盖（任何代码路径中不得出现 `rmtree` 后重建）。
+- 将工作区内容替换为上传内容（`SKILL.md`、`scripts/`、`references/` 等），
+  在现有 main 上**追加一次 commit**；导入之前的全部历史保留。
+- 目标仓库的 `.git`，以及磁盘上的辅助文件（`.ux_scores.jsonl`、`.candidates.yml`），
+  不被覆盖、不被删除。
+- 源目录即使自带 git，同名场景下**以目标仓库的历史为准**；源仓库的历史摘要
+  写入 commit message，不替换仓库。
+- 目标仓库正处于 baby 阶段、或存在 staging 灰度版本时：**拒绝**本次同名导入，
+  并说明原因（不在灰度进行期间修改 main，也不覆盖 baby 阶段的草稿）。
 
-#### Scenario: 同名导入保住历史与 UX
+#### Scenario: 同名导入保留历史与 UX 记录
 
-- **当** `skill_dir/foo` 已存在（main，无 staging），用户再次 `xskill import .../foo`
-- **那么** `git log` 中导入前的 commit 仍在，新 HEAD 是一次新 commit
-- **且** 盘上 `.ux_scores.jsonl` 旧 `commit_sha` 记录原样保留
+- **当** `skill_dir/foo` 已存在（位于 main，无 staging），用户再次执行 `xskill import .../foo`
+- **那么** `git log` 中保留导入之前的全部 commit，新的 HEAD 是一次新增 commit
+- **且** 磁盘上 `.ux_scores.jsonl` 中旧 commit sha 的评分记录原样保留
 
-#### Scenario: 灰度中拒绝同名导入
+#### Scenario: 灰度进行期间拒绝同名导入
 
-- **当** 目标 skill 存在 staging（或停在 baby）
-- **那么** 本次导入失败并说明「灰度/草稿进行中」
-- **且** 目标仓不发生任何写入
+- **当** 目标 skill 存在 staging 版本（或处于 baby 阶段）
+- **那么** 本次导入失败，并说明「该 skill 正处于灰度或草稿阶段」
+- **且** 目标仓库不发生任何写入
 
-### Requirement: 校验失败不落半成品，源目录只读【校验已在旧稿，源只读为建议默认】
+### Requirement: 校验失败不留下不完整目录；源目录只读【校验规则沿用早期草案；源目录只读为建议默认】
 
-- `SKILL.md` 缺失或 `parse_strict` 失败：CLI exit 非零 / API 4xx，`skill_dir`
-  不留半成品目录（先落临时目录再原子就位）。
-- 导入过程 **不修改源目录**【建议默认】：team 模式的「本地留档 + checkout 服务端版本」
-  作用于 client 在 `skill_dir` 的自有仓副本，**不是**用户的源目录
-  （`~/.claude/skills/foo` 等原样不动）。
+- `SKILL.md` 缺失或未通过 `parse_strict`：CLI 退出码非零 / API 返回 4xx，
+  `skill_dir` 中不留下不完整的目录（先写入临时目录，校验通过后原子移入）。
+- 导入过程**不修改源目录**【建议默认】：team 模式中「本地留档、切换到服务端版本」
+  的操作对象是 client 在 `skill_dir` 下的仓库副本，**不是**用户的源目录
+  （`~/.claude/skills/foo` 等保持原样）。
 
 #### Scenario: 校验失败
 
-- **当** 源目录无 `SKILL.md` 或其 frontmatter 非法
-- **那么** 导入失败并给出可操作的错误信息
+- **当** 源目录缺少 `SKILL.md`，或其 frontmatter 不是合法 YAML
+- **那么** 导入失败，并输出可据以修正的错误信息
 - **且** `skill_dir` 与源目录均无任何变化
 
-### Requirement: team 模式下 import 的落点与回推【已拍板】
+### Requirement: team 模式下 import 的写入位置与版本回推【已确认】
 
-- standalone：写本机 `skill_dir`。
-- team client：`xskill import` 把包送到 **server 的 `skill_dir`**（新 API，
-  不是 `skill_hub/upload`）；server 按上述新建/同名规则落仓。
-- 随后走既有 bundle 分发（`make_repo_bundle` / `apply_repo_bundle` +
-  `reconcile_skill_side`）：client 对本地旧副本先 commit 留档，再 checkout
-  服务端推回的 sha。两种部署模式下用户可感知的行为一致，只是落点不同。
+- standalone 模式：写入本机 `skill_dir`。
+- team 模式：client 执行 `xskill import` 时，将内容通过**新增 API** 发送到
+  **server 的 `skill_dir`**（不使用 `skill_hub/upload`）；server 按上述
+  新建 / 同名规则写入仓库。
+- 随后沿用既有的 bundle 分发机制（`make_repo_bundle` / `apply_repo_bundle` +
+  `reconcile_skill_side`）：client 先对本地旧副本执行一次留档 commit，
+  再 checkout 到服务端返回的 sha。两种部署模式下用户可感知的行为一致，
+  区别仅在写入位置。
 
 #### Scenario: team 成员导入
 
-- **当** 已 connect 的 client 执行 `xskill import ./my-skill`
-- **那么** skill 落在 server `skill_dir` 并成为（或追加进）该名字的 main
-- **且** 下一轮 sync 后，client 本地副本 checkout 到 server 端新 sha，旧副本有留档 commit
+- **当** 已连接 team server 的 client 执行 `xskill import ./my-skill`
+- **那么** 该 skill 写入 server 的 `skill_dir`，成为（或以追加 commit 的方式合入）该名称的 main
+- **且** 下一轮同步后，client 本地副本 checkout 到服务端的新 sha，旧副本保留留档 commit
 
-### Requirement: 导入 skill 带来源标记【建议默认，#213 未提】
+### Requirement: 导入的 skill 携带来源标记【建议默认，#213 未涉及】
 
-- 导入落盘的 `metadata` 带 `origin: imported`（键名可在实现期定）；
-  无该字段的存量 skill 读取时视为非导入，前向兼容。
+- 导入写入的 `metadata` 中包含来源标记（如 `origin: imported`，键名可在实现阶段确定）；
+  没有该字段的存量 skill 在读取时视为非导入来源，保持前向兼容。
 
-#### Scenario: origin 标记
+#### Scenario: 来源标记
 
 - **当** 一次导入成功
-- **那么** 该 skill 的 metadata 可被识别为外部导入来源
-- **且** 旧 skill（无该字段）加载行为不变
+- **那么** 该 skill 的 metadata 可被识别为外部导入
+- **且** 无该字段的既有 skill 加载行为不变

--- a/openspec/changes/user-skill-import/specs/user-skill-import/spec.md
+++ b/openspec/changes/user-skill-import/specs/user-skill-import/spec.md
@@ -1,58 +1,130 @@
 ## ADDED Requirements
 
-> 草案：Open Questions（`design.md` §5）未拍板前，下列 SHALL 以「推荐默认」表述；
-> 维护者回复后改为终稿。
+> 口径标记：**【已拍板】** = 来自 #213 与 #211 维护者结论，终稿；
+> **【建议默认】** = 本稿为剩余细节补的默认行为，待确认（汇总见 `design.md` §6）。
+> 与旧草案冲突处（重名拒绝、baby 起步）以本版为准。
 
-### Requirement: 受控导入是进入自有 skill 仓的一等入口
+### Requirement: `xskill import` 是把已有 skill 纳入自有仓的一等入口【已拍板】
 
-系统 SHALL 提供受控导入能力，将外部 skill 目录纳入配置的 `skill_dir`（自有仓），
-使其随后可被 catalog、检索、（可选）harness 安装与 team sync 以与蒸馏 skill
-兼容的方式对待。
+用一句话说：用户手里已经写好的 skill，跑一条命令就变成 xskill 管理的 skill——
+有 git 历史、进 catalog、能被搜索、能进化、team 下能分发。
 
-裸拷贝进 `skill_dir` SHALL NOT 被文档宣称为支持的导入路径。
+- CLI 形态为顶层 `xskill import <path>`。
+- 落点是配置的 `skill_dir`（默认 `~/.xskill/skill/`），每个 skill 一个独立 git 仓。
+- 不写 skillhub；`xskill upload` 行为不变（仍只进 `user_skill_hub`，不能替代 import）。
+- 重写后的 `import_skill()` 与 `POST /api/v1/skills/import` 和 CLI 共用同一实现；
+  旧实现的 `rmtree` 顶替与「对父目录 `~/.xskill/skill/` 做 commit」两个行为删除。
 
-#### Scenario: CLI 导入合法 skill 目录
+#### Scenario: 导入一个合法 skill
 
-- **当** 用户执行官方导入命令且源目录含通过 `parse_strict` 的 `SKILL.md`
-- **那么** 系统 SHALL 在 `skill_dir/<name>/` 物化该 skill
-- **且** 该目录 SHALL 具备可被现有 `SkillRepo` / git 辅助函数识别的仓布局
+- **当** 用户执行 `xskill import ~/.claude/skills/foo` 且 `SKILL.md` 通过 `parse_strict`
+- **那么** `skill_dir/foo/` 成为独立 git 仓，内容即导入内容
+- **且** catalog（`notify_native_upsert`）有该 skill 的行，随后可被本地 search 命中
 
-#### Scenario: 校验失败不落盘
-
-- **当** `SKILL.md` 缺失或 `parse_strict` 失败
-- **那么** 导入 SHALL 失败并返回非零 / HTTP 4xx
-- **且** SHALL NOT 在 `skill_dir` 留下半成品目录
-
-### Requirement: 导入与 upload/SkillHub 语义分离
-
-`import`（入自有仓）与 `xskill upload`（入 `user_skill_hub`）以及 SkillHub 目录扫描
-SHALL 在 CLI 帮助与 API 文档中区分命名与落点；SHALL NOT 将三者描述为同一操作。
-
-#### Scenario: upload 不写入自有仓
+#### Scenario: upload 不因此改变
 
 - **当** 用户执行 `xskill upload <dir>`
-- **那么** 行为 SHALL 保持将 zip 写入 team `user_skill_hub`（既有语义）
-- **且** SHALL NOT 被文档称为「导入到 ~/.xskill/skill」
+- **那么** 行为保持现状：zip 进 team `user_skill_hub`，不进自有仓，不参与进化
 
-### Requirement: 导入 skill 携带可兼容的来源标记
+### Requirement: 同时接受单 skill 目录与多 skill 父目录【已拍板】，判定与批量语义【建议默认】
 
-导入写入的 skill frontmatter/metadata SHALL 可被识别为外部导入来源
-（例如 `metadata.origin: imported`，具体键名实现阶段确定），以便后续策略分流。
-缺失该字段的存量 skill SHALL 被读取逻辑视为非导入（兼容默认）。
+`xskill import ~/.claude/skills/foo`（单个）和 `xskill import ~/.claude/skills/`
+（一次收多个）都要能用。不提供 `--agents` / `--from <生态>` 这类扫描旗标——
+误导入风险太大，路径本身就是最明确的授权。
 
-#### Scenario: 新导入带 origin
+判定规则【建议默认】：
 
-- **当** 一次受控导入成功
-- **那么** 落盘 `SKILL.md` 的 metadata SHALL 包含约定的导入来源标记
-- **且** 既有无该字段的 skill SHALL 仍可被 `SkillRepo` 正常加载
+- 源目录根下有 `SKILL.md` → 按**单 skill** 导入。
+- 否则扫**一层**子目录，含 `SKILL.md` 的子目录即候选；更深层不递归。
+- 两者都不成立 → 报错退出，不落任何盘。
 
-### Requirement: 重名默认拒绝
+批量语义【建议默认】：
 
-当目标 `skill_dir/<name>` 已存在时，默认导入 SHALL 拒绝并说明冲突；
-覆盖 MUST 仅在显式强制旗标下发生（旗标名称实现阶段确定）。
+- 先列出将要导入的 skill 清单；TTY 下需用户确认，`--yes` 跳过确认；提供 `--dry-run`。
+- 逐个导入，单个失败**不中断**其余；结束时输出 成功/失败/跳过 汇总，有失败则 exit 非零。
 
-#### Scenario: 重名拒绝
+#### Scenario: 父目录批量导入部分失败
 
-- **当** 目标名已存在且未传强制覆盖旗标
-- **那么** 导入 SHALL 失败
-- **且** 已存在目录内容 SHALL NOT 被修改
+- **当** `xskill import ~/.claude/skills/` 中 3 个候选有 1 个 `parse_strict` 失败
+- **那么** 其余 2 个正常入仓，失败项打出原因
+- **且** 退出码非零，失败项在 `skill_dir` 无半成品目录
+
+### Requirement: 新 skill 导入后直接是 main【已拍板】
+
+用户导入的是成品，不走 baby 再蒸馏一遍。
+
+- 仓里还没有这个名字：建独立 git 仓，导入内容为**原始 main**。
+- 源目录自带 `.git` 且有 `main` 或 `master`：同步该仓库到目标仓，以最新 `main`
+  （没有 `main` 则取最新分支的 HEAD）作为演进起点，并保证目标仓存在 `main` 分支。
+- 源目录无 git：初始化新仓，首个 commit 即导入内容。
+
+#### Scenario: 带 git 历史的源
+
+- **当** 源目录是 git 仓且含 `main` 分支
+- **那么** 目标仓保留其历史，`main` HEAD 与源最新 `main` 一致
+- **且** 后续 SkillEdit / canary 基于该 HEAD 演进
+
+### Requirement: 同名导入 = 在现有 main 上追加一次 commit【已拍板】
+
+这是旧草案「重名拒绝 / --force 覆盖」的替代终稿。核心约束：**git 历史与 UX
+台账不能丢**（`.ux_scores.jsonl` 按 commit_sha 挂分，删仓 = 版本表与进化路径断链）。
+
+- 禁止删目录顶替（`rmtree` + `copytree` 不允许出现在任何路径）。
+- 把工作区改成上传内容的形状（`SKILL.md`、`scripts/`、`references/` 等），
+  在现有 main 上**追加一次 commit**；导入前的历史全部保留。
+- 目标仓 `.git` 与盘上 sidecar（`.ux_scores.jsonl`、`.candidates.yml`）不被覆盖、不被删除。
+- 源目录即使自带 git，同名场景**以目标仓历史为准**；源历史摘要写进 commit message，不换仓。
+- 目标仓正停在 baby、或存在 staging 灰度：**拒绝**这次同名导入，并说明原因
+  （不在灰度中改 main 树，不静默覆盖 baby 草稿）。
+
+#### Scenario: 同名导入保住历史与 UX
+
+- **当** `skill_dir/foo` 已存在（main，无 staging），用户再次 `xskill import .../foo`
+- **那么** `git log` 中导入前的 commit 仍在，新 HEAD 是一次新 commit
+- **且** 盘上 `.ux_scores.jsonl` 旧 `commit_sha` 记录原样保留
+
+#### Scenario: 灰度中拒绝同名导入
+
+- **当** 目标 skill 存在 staging（或停在 baby）
+- **那么** 本次导入失败并说明「灰度/草稿进行中」
+- **且** 目标仓不发生任何写入
+
+### Requirement: 校验失败不落半成品，源目录只读【校验已在旧稿，源只读为建议默认】
+
+- `SKILL.md` 缺失或 `parse_strict` 失败：CLI exit 非零 / API 4xx，`skill_dir`
+  不留半成品目录（先落临时目录再原子就位）。
+- 导入过程 **不修改源目录**【建议默认】：team 模式的「本地留档 + checkout 服务端版本」
+  作用于 client 在 `skill_dir` 的自有仓副本，**不是**用户的源目录
+  （`~/.claude/skills/foo` 等原样不动）。
+
+#### Scenario: 校验失败
+
+- **当** 源目录无 `SKILL.md` 或其 frontmatter 非法
+- **那么** 导入失败并给出可操作的错误信息
+- **且** `skill_dir` 与源目录均无任何变化
+
+### Requirement: team 模式下 import 的落点与回推【已拍板】
+
+- standalone：写本机 `skill_dir`。
+- team client：`xskill import` 把包送到 **server 的 `skill_dir`**（新 API，
+  不是 `skill_hub/upload`）；server 按上述新建/同名规则落仓。
+- 随后走既有 bundle 分发（`make_repo_bundle` / `apply_repo_bundle` +
+  `reconcile_skill_side`）：client 对本地旧副本先 commit 留档，再 checkout
+  服务端推回的 sha。两种部署模式下用户可感知的行为一致，只是落点不同。
+
+#### Scenario: team 成员导入
+
+- **当** 已 connect 的 client 执行 `xskill import ./my-skill`
+- **那么** skill 落在 server `skill_dir` 并成为（或追加进）该名字的 main
+- **且** 下一轮 sync 后，client 本地副本 checkout 到 server 端新 sha，旧副本有留档 commit
+
+### Requirement: 导入 skill 带来源标记【建议默认，#213 未提】
+
+- 导入落盘的 `metadata` 带 `origin: imported`（键名可在实现期定）；
+  无该字段的存量 skill 读取时视为非导入，前向兼容。
+
+#### Scenario: origin 标记
+
+- **当** 一次导入成功
+- **那么** 该 skill 的 metadata 可被识别为外部导入来源
+- **且** 旧 skill（无该字段）加载行为不变

--- a/openspec/changes/user-skill-import/specs/user-skill-import/spec.md
+++ b/openspec/changes/user-skill-import/specs/user-skill-import/spec.md
@@ -1,0 +1,58 @@
+## ADDED Requirements
+
+> 草案：Open Questions（`design.md` §5）未拍板前，下列 SHALL 以「推荐默认」表述；
+> 维护者回复后改为终稿。
+
+### Requirement: 受控导入是进入自有 skill 仓的一等入口
+
+系统 SHALL 提供受控导入能力，将外部 skill 目录纳入配置的 `skill_dir`（自有仓），
+使其随后可被 catalog、检索、（可选）harness 安装与 team sync 以与蒸馏 skill
+兼容的方式对待。
+
+裸拷贝进 `skill_dir` SHALL NOT 被文档宣称为支持的导入路径。
+
+#### Scenario: CLI 导入合法 skill 目录
+
+- **当** 用户执行官方导入命令且源目录含通过 `parse_strict` 的 `SKILL.md`
+- **那么** 系统 SHALL 在 `skill_dir/<name>/` 物化该 skill
+- **且** 该目录 SHALL 具备可被现有 `SkillRepo` / git 辅助函数识别的仓布局
+
+#### Scenario: 校验失败不落盘
+
+- **当** `SKILL.md` 缺失或 `parse_strict` 失败
+- **那么** 导入 SHALL 失败并返回非零 / HTTP 4xx
+- **且** SHALL NOT 在 `skill_dir` 留下半成品目录
+
+### Requirement: 导入与 upload/SkillHub 语义分离
+
+`import`（入自有仓）与 `xskill upload`（入 `user_skill_hub`）以及 SkillHub 目录扫描
+SHALL 在 CLI 帮助与 API 文档中区分命名与落点；SHALL NOT 将三者描述为同一操作。
+
+#### Scenario: upload 不写入自有仓
+
+- **当** 用户执行 `xskill upload <dir>`
+- **那么** 行为 SHALL 保持将 zip 写入 team `user_skill_hub`（既有语义）
+- **且** SHALL NOT 被文档称为「导入到 ~/.xskill/skill」
+
+### Requirement: 导入 skill 携带可兼容的来源标记
+
+导入写入的 skill frontmatter/metadata SHALL 可被识别为外部导入来源
+（例如 `metadata.origin: imported`，具体键名实现阶段确定），以便后续策略分流。
+缺失该字段的存量 skill SHALL 被读取逻辑视为非导入（兼容默认）。
+
+#### Scenario: 新导入带 origin
+
+- **当** 一次受控导入成功
+- **那么** 落盘 `SKILL.md` 的 metadata SHALL 包含约定的导入来源标记
+- **且** 既有无该字段的 skill SHALL 仍可被 `SkillRepo` 正常加载
+
+### Requirement: 重名默认拒绝
+
+当目标 `skill_dir/<name>` 已存在时，默认导入 SHALL 拒绝并说明冲突；
+覆盖 MUST 仅在显式强制旗标下发生（旗标名称实现阶段确定）。
+
+#### Scenario: 重名拒绝
+
+- **当** 目标名已存在且未传强制覆盖旗标
+- **那么** 导入 SHALL 失败
+- **且** 已存在目录内容 SHALL NOT 被修改

--- a/openspec/changes/user-skill-import/tasks.md
+++ b/openspec/changes/user-skill-import/tasks.md
@@ -1,0 +1,27 @@
+# Tasks — User Skill Import
+
+> 骨架。等 `design.md` §5 Open Questions 拍板后再拆可执行 PR。
+
+## 讨论期（当前）
+
+- [x] 0.1 撰写 `proposal.md` / `design.md` / 草案 `specs/` / 本 tasks
+- [ ] 0.2 开 GitHub Issue，挂 OpenSpec 路径，请维护者答 Q1–Q7
+- [ ] 0.3 （可选）docs-only PR：仅合入 `openspec/changes/user-skill-import/**` 便于审阅
+
+## P0 — 受控导入 MVP（拍板后）
+
+- [ ] 1.1 实现 `import_external_skill()`（校验、事务落盘、git 布局、catalog）
+- [ ] 1.2 修正/替换旧 `import_skill` + 对齐 `POST /skills/import`
+- [ ] 1.3 CLI `xskill skill import <path>`（含重名/force）
+- [ ] 1.4 单测 + 文档（README / northbound-api 区分 import vs upload）
+- [ ] 1.5 环装防护（源已在 harness skills 目录时的行为）
+
+## P1 — 批量源
+
+- [ ] 2.1 `--from claude-user` / `--from agents` / `--all`
+- [ ] 2.2 可选 index touch + `--install`
+
+## P2 — Server / Team
+
+- [ ] 3.1 Admin 导入进 server `skill_dir`（CLI 或 zip API）
+- [ ] 3.2 与 `upload` 文案/帮助彻底拆分；必要时 `upload --target=hub|repo`

--- a/openspec/changes/user-skill-import/tasks.md
+++ b/openspec/changes/user-skill-import/tasks.md
@@ -1,34 +1,39 @@
 # Tasks — User Skill Import
 
-> 主干已拍板（#211 评论 + #213）。实现等 #209、#210 合入 main 后再开 PR；
-> 开工前先在 issue 确认 `design.md` §6 的 R1–R9。
+> 主要设计已确认（#211 维护者评论 + #213）。实现待 #209、#210 合入 main 后再提交 PR；
+> 动工前请先在 issue 中确认 `design.md` §6 的 R1–R9。
 
-## 讨论期
+## 讨论阶段
 
 - [x] 0.1 撰写 `proposal.md` / `design.md` / 草案 `specs/` / 本 tasks
-- [x] 0.2 开 GitHub Issue #211，挂 OpenSpec 路径
-- [x] 0.3 docs-only draft PR #212
-- [x] 0.4 按 #211 维护者评论 + #213 拍板更新四份文档（Q1–Q7 → 终稿；剩余细节收敛为 R1–R9）
+- [x] 0.2 建立 GitHub Issue #211，附 OpenSpec 路径
+- [x] 0.3 建立 docs-only draft PR #212
+- [x] 0.4 按 #211 维护者评论与 #213 的结论更新四份文档
+      （Q1–Q7 改为最终表述；尚未确定的细节整理为 R1–R9）
 - [ ] 0.5 维护者确认 R1–R9（`design.md` §6）
 
-## P0 — `xskill import` MVP（#209/#210 合入后）
+## P0 — `xskill import` MVP（#209 / #210 合入后）
 
-- [ ] 1.1 重写 `import_skill()`（src/xskill/skill/repo.py）：去掉 rmtree 与父目录 commit；
-      校验、事务落盘、新名建仓（源带 git 则同步、保证 main）、同名追加 commit、
-      baby/staging 拒绝、catalog upsert
-- [ ] 1.2 CLI 顶层 `xskill import <path>`：单/批判定、清单确认（--yes / --dry-run）、
-      逐个失败不中断 + 汇总退出码
+- [ ] 1.1 重写 `import_skill()`（`src/xskill/skill/repo.py`）：移除目录删除重建与
+      父目录 commit；实现校验、临时目录原子写入、新名称建仓（源带 git 时同步仓库
+      并保证 main 分支）、同名追加 commit、baby/staging 阶段拒绝、catalog 更新
+- [ ] 1.2 CLI 顶层命令 `xskill import <path>`：单个/批量判定、导入清单确认
+      （`--yes` / `--dry-run`）、单项失败不中断并汇总退出码
 - [ ] 1.3 `POST /api/v1/skills/import` 对齐同一实现
-- [ ] 1.4 单测 + BDD `skill_import.feature`（单/批/同名保历史保 UX/灰度拒绝）
-- [ ] 1.5 install 与防环（R4 拍板后）
-- [ ] 1.6 文档：README / northbound-api 区分 import（自有仓）≠ upload（hub）≠ SkillHub 扫描
+- [ ] 1.4 单元测试 + BDD `skill_import.feature`
+      （单个 / 批量 / 同名保留历史与 UX 记录 / 灰度阶段拒绝）
+- [ ] 1.5 harness 安装与循环安装防护（R4 确认后）
+- [ ] 1.6 文档：README 与 northbound-api 中区分
+      import（自有技能仓库）、upload（hub）、SkillHub 扫描（检索池）三者语义
 
 ## P1 — Team
 
-- [ ] 2.1 client → server 的 import API（新端点，非 skill_hub/upload；权限按 R5 拍板）
-- [ ] 2.2 server 落仓后 bundle 分发 + client 旧副本留档 commit、checkout 服务端 sha
+- [ ] 2.1 client 到 server 的导入 API（新增端点，不使用 `skill_hub/upload`；
+      权限按 R5 的结论执行）
+- [ ] 2.2 server 写入仓库后经 bundle 分发；client 对旧副本留档 commit 后
+      checkout 服务端版本
 
 ## P2 — 周边
 
-- [ ] 3.1 裸 cp 检测 + `--heal`（R6 终稿后）
-- [ ] 3.2 与 #213 脚本化共用「main 追加 commit + catalog + 推送」的实现收敛
+- [ ] 3.1 手工 cp 的检测与 `--heal`（R6 确认后）
+- [ ] 3.2 与 #213 的脚本化功能共用「main 上追加 commit + catalog 更新 + 推送」的实现

--- a/openspec/changes/user-skill-import/tasks.md
+++ b/openspec/changes/user-skill-import/tasks.md
@@ -5,8 +5,8 @@
 ## 讨论期（当前）
 
 - [x] 0.1 撰写 `proposal.md` / `design.md` / 草案 `specs/` / 本 tasks
-- [ ] 0.2 开 GitHub Issue，挂 OpenSpec 路径，请维护者答 Q1–Q7
-- [ ] 0.3 （可选）docs-only PR：仅合入 `openspec/changes/user-skill-import/**` 便于审阅
+- [x] 0.2 开 GitHub Issue #211，挂 OpenSpec 路径，请维护者答 Q1–Q7
+- [x] 0.3 docs-only draft PR #212：`openspec/changes/user-skill-import/**`
 
 ## P0 — 受控导入 MVP（拍板后）
 

--- a/openspec/changes/user-skill-import/tasks.md
+++ b/openspec/changes/user-skill-import/tasks.md
@@ -1,27 +1,34 @@
 # Tasks — User Skill Import
 
-> 骨架。等 `design.md` §5 Open Questions 拍板后再拆可执行 PR。
+> 主干已拍板（#211 评论 + #213）。实现等 #209、#210 合入 main 后再开 PR；
+> 开工前先在 issue 确认 `design.md` §6 的 R1–R9。
 
-## 讨论期（当前）
+## 讨论期
 
 - [x] 0.1 撰写 `proposal.md` / `design.md` / 草案 `specs/` / 本 tasks
-- [x] 0.2 开 GitHub Issue #211，挂 OpenSpec 路径，请维护者答 Q1–Q7
-- [x] 0.3 docs-only draft PR #212：`openspec/changes/user-skill-import/**`
+- [x] 0.2 开 GitHub Issue #211，挂 OpenSpec 路径
+- [x] 0.3 docs-only draft PR #212
+- [x] 0.4 按 #211 维护者评论 + #213 拍板更新四份文档（Q1–Q7 → 终稿；剩余细节收敛为 R1–R9）
+- [ ] 0.5 维护者确认 R1–R9（`design.md` §6）
 
-## P0 — 受控导入 MVP（拍板后）
+## P0 — `xskill import` MVP（#209/#210 合入后）
 
-- [ ] 1.1 实现 `import_external_skill()`（校验、事务落盘、git 布局、catalog）
-- [ ] 1.2 修正/替换旧 `import_skill` + 对齐 `POST /skills/import`
-- [ ] 1.3 CLI `xskill skill import <path>`（含重名/force）
-- [ ] 1.4 单测 + 文档（README / northbound-api 区分 import vs upload）
-- [ ] 1.5 环装防护（源已在 harness skills 目录时的行为）
+- [ ] 1.1 重写 `import_skill()`（src/xskill/skill/repo.py）：去掉 rmtree 与父目录 commit；
+      校验、事务落盘、新名建仓（源带 git 则同步、保证 main）、同名追加 commit、
+      baby/staging 拒绝、catalog upsert
+- [ ] 1.2 CLI 顶层 `xskill import <path>`：单/批判定、清单确认（--yes / --dry-run）、
+      逐个失败不中断 + 汇总退出码
+- [ ] 1.3 `POST /api/v1/skills/import` 对齐同一实现
+- [ ] 1.4 单测 + BDD `skill_import.feature`（单/批/同名保历史保 UX/灰度拒绝）
+- [ ] 1.5 install 与防环（R4 拍板后）
+- [ ] 1.6 文档：README / northbound-api 区分 import（自有仓）≠ upload（hub）≠ SkillHub 扫描
 
-## P1 — 批量源
+## P1 — Team
 
-- [ ] 2.1 `--from claude-user` / `--from agents` / `--all`
-- [ ] 2.2 可选 index touch + `--install`
+- [ ] 2.1 client → server 的 import API（新端点，非 skill_hub/upload；权限按 R5 拍板）
+- [ ] 2.2 server 落仓后 bundle 分发 + client 旧副本留档 commit、checkout 服务端 sha
 
-## P2 — Server / Team
+## P2 — 周边
 
-- [ ] 3.1 Admin 导入进 server `skill_dir`（CLI 或 zip API）
-- [ ] 3.2 与 `upload` 文案/帮助彻底拆分；必要时 `upload --target=hub|repo`
+- [ ] 3.1 裸 cp 检测 + `--heal`（R6 终稿后）
+- [ ] 3.2 与 #213 脚本化共用「main 追加 commit + catalog + 推送」的实现收敛


### PR DESCRIPTION
## Summary

- OpenSpec draft for **importing user-owned skills** into xskill-managed `skill_dir`
- Compares CLI/API controlled import vs bare `cp`, and clarifies boundaries vs `upload` / SkillHub
- **Discussion only** — no runtime code; waiting on maintainer answers to Open Questions

Tracking issue: https://github.com/SkillNerds/xskill/issues/211

## Test plan

- [ ] N/A (docs-only)
- [ ] Maintainer review of `openspec/changes/user-skill-import/**`