### PR TITLE
feat: team 模式下 xskill generate 按指令即时生成或改写技能

### DIFF
--- a/src/xskill/agents/__init__.py
+++ b/src/xskill/agents/__init__.py
@@ -5,6 +5,7 @@
 - ``task_agent``            轨迹按用户意图切分为 AtomTask
 - ``task_cluster_agent``    把 AtomTask 路由到匹配的 skill
 - ``skill_edit_agent``      从攒够的候选合成 / 更新 SKILL.md
+- ``generate_agent``        用户点名即时生成或改写 skill（直接提交 main）
 - ``user_edit_absorb_agent``  吸收用户手改为 ground truth
 - ``agno_factory``          创建 agno.Agent 的共享工厂（模型路由 / SSL）
 - ``agent_tools``           agent 工具和运行时依赖

--- a/src/xskill/agents/agent_tools.py
+++ b/src/xskill/agents/agent_tools.py
@@ -84,6 +84,8 @@ class AgentToolContext:
     grep_fallback_warned: bool = False
     # 实例 registry.db；skills_catalog 写出口从此取库，禁止隐式摸全局库。
     registry_db_path: Path | None = None
+    extra_read_roots: tuple[Path, ...] = ()
+    generate_user_id: str | None = None
 
     def __post_init__(self) -> None:
         object.__setattr__(
@@ -97,6 +99,8 @@ class AgentToolContext:
                 "registry_db_path",
                 Path(self.registry_db_path),
             )
+        extra = tuple(Path(p) for p in (self.extra_read_roots or ()))
+        object.__setattr__(self, "extra_read_roots", extra)
 
 
 _EMPTY_AGENT_TOOL_CONTEXT = AgentToolContext()
@@ -123,6 +127,8 @@ def create_agent_tool_context(
     skill_edit_skill_name=None,
     skill_edit_batch_ids=(),
     registry_db_path=None,
+    extra_read_roots=(),
+    generate_user_id=None,
 ) -> AgentToolContext:
     """Create an immutable context without changing the current task."""
     return AgentToolContext(
@@ -153,6 +159,10 @@ def create_agent_tool_context(
         ),
         registry_db_path=(
             Path(registry_db_path) if registry_db_path is not None else None
+        ),
+        extra_read_roots=tuple(Path(p) for p in (extra_read_roots or ())),
+        generate_user_id=(
+            str(generate_user_id) if generate_user_id else None
         ),
     )
 
@@ -263,6 +273,8 @@ class AgentToolConfig:
             "skill_edit_batch_ids": current.skill_edit_batch_ids,
             "grep_fallback_warned": current.grep_fallback_warned,
             "registry_db_path": current.registry_db_path,
+            "extra_read_roots": current.extra_read_roots,
+            "generate_user_id": current.generate_user_id,
         }
 
     def restore(self, snapshot: dict) -> None:
@@ -280,6 +292,8 @@ class AgentToolConfig:
             skill_edit_skill_name=snapshot.get("skill_edit_skill_name"),
             skill_edit_batch_ids=snapshot.get("skill_edit_batch_ids") or (),
             registry_db_path=snapshot.get("registry_db_path"),
+            extra_read_roots=snapshot.get("extra_read_roots") or (),
+            generate_user_id=snapshot.get("generate_user_id"),
         ))
         if not snapshot.get("configured", True):
             current = _AGENT_TOOL_CONTEXT.get()
@@ -425,18 +439,78 @@ SENSITIVE_NAME_TOKENS = frozenset({
 })
 
 
+_READ_FILES: contextvars.ContextVar[set[str]] = contextvars.ContextVar(
+    "xskill_agent_read_files",
+)
+_GENERATE_COMMITTED: contextvars.ContextVar[list[str]] = contextvars.ContextVar(
+    "xskill_generate_committed_skills",
+)
+
+
+def reset_generate_session() -> None:
+    """Clear per-run read tracking and generate commit ledger."""
+    _READ_FILES.set(set())
+    _GENERATE_COMMITTED.set([])
+
+
+def generate_committed_skills() -> list[str]:
+    try:
+        return list(_GENERATE_COMMITTED.get())
+    except LookupError:
+        return []
+
+
+def _read_file_ledger() -> set[str]:
+    try:
+        return _READ_FILES.get()
+    except LookupError:
+        ledger: set[str] = set()
+        _READ_FILES.set(ledger)
+        return ledger
+
+
+def _mark_file_read(path: Path) -> None:
+    try:
+        _read_file_ledger().add(str(path.resolve()))
+    except OSError:
+        logger.debug("mark_file_read failed for %s", path, exc_info=True)
+
+
+def _file_was_read(path: Path) -> bool:
+    try:
+        return str(path.resolve()) in _read_file_ledger()
+    except OSError:
+        return False
+
+
+def _record_generate_commit(skill_name: str) -> None:
+    try:
+        committed = _GENERATE_COMMITTED.get()
+    except LookupError:
+        committed = []
+        _GENERATE_COMMITTED.set(committed)
+    if skill_name not in committed:
+        committed.append(skill_name)
+
+
 def _allowed_read_roots() -> list[Path]:
     """探索类工具（read_file / list_files / grep_files）共用的只读根集合。"""
+    ctx = current_agent_tool_context()
+    extra = tuple(ctx.extra_read_roots or ())
+    if extra:
+        roots = [Path(p).resolve() for p in extra]
+        if ctx.spill_root is not None:
+            roots.append(Path(ctx.spill_root).resolve())
+        return list(dict.fromkeys(roots))
     roots: list[Path] = []
-    configured_root = agent_tool_config.skill_dir or agent_tool_config.atom_skill_dir
+    configured_root = ctx.skill_dir or ctx.atom_skill_dir
     if configured_root is not None:
         roots.append(Path(configured_root).parent.resolve())
-    elif not current_agent_tool_context().configured:
+    elif not ctx.configured:
         from xskill.config import XSKILL_HOME
         roots.append(XSKILL_HOME.resolve())
-    spill_root = current_agent_tool_context().spill_root
-    if spill_root is not None:
-        roots.append(Path(spill_root).resolve())
+    if ctx.spill_root is not None:
+        roots.append(Path(ctx.spill_root).resolve())
     return list(dict.fromkeys(roots))
 
 
@@ -596,6 +670,7 @@ def read_file(path: str, offset: int = 1, limit: int = 200) -> str:
             f"line_range: [{line_offset}, {line_end_exclusive})\n"
             "--- file content ---\n"
         )
+        _mark_file_read(resolved)
         if len(selected) > 10000:
             return (
                 header + selected[:10000]
@@ -818,7 +893,100 @@ def write_file(path: str, content: str) -> str:
     p.parent.mkdir(parents=True, exist_ok=True)
     p.write_text(content, encoding="utf-8")
     logger.info(f"✏️  wrote: {p} ({len(content)} bytes)")
+    _mark_file_read(resolved)
     return f"wrote: {p} ({len(content)} chars)"
+
+
+@tool(name="edit")
+def edit_file(path: str, old_string: str, new_string: str) -> str:
+    """Replace one exact substring in a skill file the agent already read.
+
+    The file must have been read in this run via read_file or skill_read
+    (write_file also counts).  New files that do not exist yet should use
+    write_file instead.
+    """
+    if agent_tool_config.atom_skill_dir is not None:
+        skill_dir = agent_tool_config.atom_skill_dir
+    else:
+        skill_dir = agent_tool_config.skill_dir
+    if skill_dir is None:
+        return "error: skill directory is not configured"
+    try:
+        resolved = Path(path).resolve()
+        resolved.relative_to(Path(skill_dir).resolve())
+    except (OSError, ValueError):
+        return f"error: writes restricted to the skill repository (tried: {path})"
+    if ".git" in resolved.parts:
+        return f"error: writes into .git/ are forbidden (tried: {path})"
+    if not resolved.is_file():
+        return (
+            f"error: file not found ({path}). "
+            "Create new files with write_file first."
+        )
+    if not _file_was_read(resolved):
+        return (
+            f"error: this file has not been read in this run ({resolved}). "
+            "Call read_file or skill_read on it before edit."
+        )
+    if old_string == "":
+        return "error: old_string must not be empty"
+    if old_string == new_string:
+        return "error: old_string and new_string are identical"
+    try:
+        original = resolved.read_text(encoding="utf-8")
+    except OSError as error:
+        return f"error: read failed ({error})"
+    count = original.count(old_string)
+    if count == 0:
+        return "error: old_string was not found in the file"
+    if count > 1:
+        return (
+            f"error: old_string matched {count} times; "
+            "provide a unique snippet"
+        )
+    updated = original.replace(old_string, new_string, 1)
+    if resolved.name == "SKILL.md":
+        try:
+            fm, body = fm_parse_strict(updated)
+        except FrontmatterError as error:
+            return (
+                f"error: SKILL.md frontmatter 非法，未写盘 —— {error}\n"
+                "请修正后再调用 edit。"
+            )
+        _sanitize_frontmatter_dates(fm)
+        updated = fm_serialize(fm, body)
+    resolved.write_text(updated, encoding="utf-8")
+    logger.info("edited: %s", resolved)
+    return f"edited: {resolved}"
+
+
+@tool(name="commit_generate_main")
+def commit_generate_main(skill_name: str, message: str) -> str:
+    """Commit the named skill onto main no matter the current git state.
+
+    Creates the repository and the main branch when they do not exist.
+    Empty or stub content is allowed.  Never opens a staging branch.
+    The initiating user id is prepended to the commit message.
+    """
+    from xskill.skill.git import commit_generate_to_main_branch
+
+    skill_dir = agent_tool_config.atom_skill_dir or agent_tool_config.skill_dir
+    if skill_dir is None:
+        return "error: skill directory is not configured"
+    slug = _slugify(skill_name)
+    if not slug:
+        return "error: skill_name 不能为空"
+    target = Path(skill_dir) / slug
+    msg = (message or "").strip() or "generate"
+    user_id = current_agent_tool_context().generate_user_id or "unknown"
+    prefixed = f"generate-by: {user_id}\n\n{msg}"
+    try:
+        sha = commit_generate_to_main_branch(str(target), prefixed)
+    except Exception as error:  # noqa: BLE001 — tool must return error text
+        logger.exception("commit_generate_main failed for %s", slug)
+        return f"error: commit_generate_main 失败: {error}"
+    _record_generate_commit(slug)
+    return f"committed to main: {slug} {sha[:12]}"
 
 
 # ═══════════════════════════════════════════════════════════════════
@@ -1029,6 +1197,7 @@ def skill_read(skill_name: str) -> str:
     markdown_path = skill_path / "SKILL.md"
     if markdown_path.is_file():
         markdown_text = markdown_path.read_text(encoding="utf-8")
+        _mark_file_read(markdown_path)
         body = (f"--- SKILL.md ({len(markdown_text.splitlines())} lines) ---\n"
                 f"{markdown_text}")
     else:

--- a/src/xskill/agents/context_budget.py
+++ b/src/xskill/agents/context_budget.py
@@ -60,8 +60,12 @@ CJK_TOKENS_PER_CHAR_BY_FAMILY = {
 }
 _TRIMMABLE_TOOLS = (
     "look", "readfile", "read_file", "atom_task_read", "read_traj", "skill_read",
+    "grep_files", "list_files", "edit",
 )
-_SPILLABLE_TOOLS = ("readfile", "read_file", "atom_task_read", "read_traj", "skill_read")
+_SPILLABLE_TOOLS = (
+    "readfile", "read_file", "atom_task_read", "read_traj", "skill_read",
+    "grep_files", "edit",
+)
 _TRIM_MARK = "[…look 旧结果已剪裁,需要可重新 look…]"
 _COMPACT_MARK = "[compacted_skill_edit_agent_memory]"
 

--- a/src/xskill/agents/generate_agent.py
+++ b/src/xskill/agents/generate_agent.py
@@ -1,0 +1,154 @@
+"""GenerateAgent —— 用户点名、直接写主干的 skill 生成代理。
+
+和 SkillEditAgent 同类（Agno + 同一套工具上下文），但由
+``xskill generate`` 启动，不靠候选缓冲攒分。读轨迹靠 list/grep/read；
+写完用 ``commit_generate_main`` 落到 main。
+"""
+from __future__ import annotations
+
+import logging
+from dataclasses import dataclass
+from pathlib import Path
+from typing import Any, Callable
+
+logger = logging.getLogger("xskill.generate_agent")
+
+SYSTEM_PROMPT = """你是 XSkill 的 GenerateAgent。用户通过 `xskill generate` 发来一条指令，
+要你立刻新建或改写一个 skill，并且提交到主干分支 main。
+
+skill 是一份给其他编码代理阅读的说明书：SKILL.md 必写，还可以在
+scripts/ 下放可执行脚本、在 references/ 下放长参考材料。价值是少踩坑、
+少试错，而不是把某一次操作过程复述一遍。
+
+# 这次任务
+
+发起人用户 ID：{user_id}
+
+用户指令：
+{instruction}
+
+优先阅读范围：{name_hint}
+这不是禁读名单。磁盘上你能读到的轨迹目录都可以搜；上面列出的人只是
+用户希望你先看的范围。
+
+# 你可以读的目录
+
+{read_roots_block}
+
+用 list_files 摸清结构，用 grep_files 按关键词搜索，用 read_file 按行精读。
+看某个已有 skill 的现状用 skill_read。
+
+# 怎么写
+
+- 新建：先 new_skill_folder(name, description)，再用 write_file 写出完整
+  SKILL.md 和脚本。
+- 改已有文件：必须先 read_file 或 skill_read，再 edit(path, old_string, new_string)。
+  没读过会报错。新建尚不存在的文件用 write_file。
+- 写完必须调用 commit_generate_main(skill_name, message)。它会把结果提交到
+  main：没有 main 就创建，目录几乎是空的也允许提交。不要调用任何灰度
+  （staging）提交工具。
+- commit message 写清你新建还是改了哪个 skill、依据是什么。系统会自动在
+  前面加上发起人 ID。
+- 轨迹里若有密钥、token、密码、内网地址，不要原样写进 skill，用占位符。
+
+# 可用工具
+
+- list_files(path)
+- grep_files(pattern, path="", glob="", max_results=100)
+- read_file(path, offset=1, limit=200)
+- skill_read(skill_name)
+- write_file(path, content)
+- edit(path, old_string, new_string)
+- new_skill_folder(skill_name, description)
+- commit_generate_main(skill_name, message)
+"""
+
+
+def _name_hint(preferred_names: list[str]) -> str:
+    names = [n.strip() for n in preferred_names if n and n.strip()]
+    if not names:
+        return "未指定，可以看全部轨迹。"
+    return "请优先看这些人的轨迹：" + "、".join(names)
+
+
+def _read_roots_block(roots: list[Path]) -> str:
+    if not roots:
+        return "（当前没有配置可读目录）"
+    return "\n".join(f"- {path}" for path in roots)
+
+
+@dataclass
+class GenerateAgent:
+    skill_dir: Path
+    agno_agent_factory: Callable[..., Any]
+    llm_cfg: dict
+    logs_dir: Path | None
+    extra_read_roots: tuple[Path, ...] = ()
+
+    def _trace_path(self, user_id: str, job_id: str) -> Path | None:
+        if self.logs_dir is None:
+            return None
+        return (
+            self.logs_dir
+            / "agents"
+            / "generate_agents"
+            / user_id
+            / f"{job_id}.log"
+        )
+
+    def run(
+        self,
+        *,
+        instruction: str,
+        user_id: str,
+        job_id: str,
+        preferred_names: list[str] | None = None,
+    ) -> str:
+        from xskill.agents import agent_tools
+        from xskill.agents.agent_trace import trace_to
+        from xskill.agents.context_budget import (
+            DEFAULT_MAX_CONTEXT,
+            TRIM_TRIGGER_RATIO,
+        )
+
+        preferred_names = preferred_names or []
+        sysprompt = SYSTEM_PROMPT.format(
+            user_id=user_id,
+            instruction=instruction.strip(),
+            name_hint=_name_hint(preferred_names),
+            read_roots_block=_read_roots_block(list(self.extra_read_roots)),
+        )
+        tools = [
+            agent_tools.list_files,
+            agent_tools.grep_files,
+            agent_tools.read_file,
+            agent_tools.skill_read,
+            agent_tools.write_file,
+            agent_tools.edit_file,
+            agent_tools.new_skill_folder,
+            agent_tools.commit_generate_main,
+        ]
+        agent = self.agno_agent_factory(instructions=[sysprompt], tools=tools)
+        max_context = int(
+            (self.llm_cfg or {}).get("max_context") or DEFAULT_MAX_CONTEXT
+        )
+        spill_limit = int(max_context * TRIM_TRIGGER_RATIO)
+        compact_raw = (self.llm_cfg or {}).get("compact_token_limit")
+        compact_limit = (
+            max(int(compact_raw), spill_limit)
+            if compact_raw not in (None, "")
+            else None
+        )
+        user_msg = (
+            f"发起人: {user_id}\n"
+            f"指令: {instruction.strip()}\n"
+            f"{_name_hint(preferred_names)}"
+        )
+        with trace_to(
+            self._trace_path(user_id, job_id),
+            append=True,
+            spill_token_limit=spill_limit,
+            compact_token_limit=compact_limit,
+        ):
+            result = agent.run(user_msg)
+        return getattr(result, "content", "") or ""

--- a/src/xskill/cli.py
+++ b/src/xskill/cli.py
@@ -1534,6 +1534,122 @@ def cmd_upload(args, http=None, headers=None) -> int:
     return 0
 
 
+def _parse_sse_block(block: str) -> dict | None:
+    import json as _json
+    for line in block.splitlines():
+        if line.startswith("data:"):
+            payload = line[5:].strip()
+            if not payload:
+                continue
+            try:
+                parsed = _json.loads(payload)
+            except _json.JSONDecodeError:
+                return None
+            if isinstance(parsed, dict):
+                return parsed
+    return None
+
+
+def cmd_generate(args, http=None, headers=None) -> int:
+    """`xskill generate "指令"` —— 在 team server 上即时生成或改写 skill。"""
+    import httpx
+
+    instruction = " ".join(args.instruction).strip()
+    if not instruction:
+        print("error: instruction 不能为空", file=sys.stderr)
+        return 2
+    names = [
+        part.strip()
+        for part in str(getattr(args, "name", "") or "").split(",")
+        if part.strip()
+    ]
+    if http is None:
+        http, headers = _team_client_http_and_headers()
+        if http is None:
+            return 1
+    try:
+        resp = http.post(
+            "/api/v1/team/generate",
+            json={"instruction": instruction, "names": names},
+            headers=headers,
+        )
+        if resp.status_code == 404:
+            print(
+                "error: server 版本过旧，不支持 generate，请管理员先升级 server",
+                file=sys.stderr,
+            )
+            return 1
+        if resp.status_code != 200:
+            print(
+                f"error: generate 提交失败 HTTP {resp.status_code}: "
+                f"{resp.text[:300]}",
+                file=sys.stderr,
+            )
+            return 1
+        job_id = resp.json().get("job_id")
+        if not job_id:
+            print("error: server 未返回 job_id", file=sys.stderr)
+            return 1
+        stream_timeout = httpx.Timeout(None)
+        with httpx.Client(
+            base_url=str(http.base_url),
+            timeout=stream_timeout,
+            trust_env=False,
+        ) as stream_http:
+            with stream_http.stream(
+                "GET",
+                f"/api/v1/team/generate/{job_id}/events",
+                headers=headers,
+            ) as stream:
+                if stream.status_code != 200:
+                    print(
+                        f"error: 无法读取 generate 日志 HTTP {stream.status_code}",
+                        file=sys.stderr,
+                    )
+                    return 1
+                buffer = ""
+                final = None
+                for text in stream.iter_text():
+                    buffer += text
+                    while "\n\n" in buffer:
+                        block, buffer = buffer.split("\n\n", 1)
+                        event = _parse_sse_block(block)
+                        if event is None:
+                            continue
+                        if event.get("type") == "log":
+                            chunk = event.get("chunk") or ""
+                            if chunk:
+                                sys.stdout.write(chunk)
+                                sys.stdout.flush()
+                        elif event.get("type") == "done":
+                            final = event
+                if final is None and buffer.strip():
+                    final = _parse_sse_block(buffer)
+    except (httpx.HTTPError, OSError) as network_error:
+        print(
+            f"error: 无法连接 team server（{type(network_error).__name__}），"
+            "server 可能未响应，请检查网络或联系管理员",
+            file=sys.stderr,
+        )
+        return 1
+    if not final:
+        print("error: generate 结束但没有收到完成事件", file=sys.stderr)
+        return 1
+    if not final.get("ok"):
+        err = final.get("error") or "generate 失败"
+        print(f"error: {err}", file=sys.stderr)
+        return 1
+    skills = final.get("skill_names") or []
+    pinned = final.get("pinned") or []
+    if skills:
+        print("generate 完成: " + "、".join(skills))
+    else:
+        print("generate 完成")
+    if pinned:
+        print("已钉到发起人推荐列表: " + "、".join(pinned))
+    return 0
+
+
 def cmd_read(args, xskill) -> int:
     """`xskill read <PATH> --eco ngagent` —— 批量把 db 文件桥接入库。"""
     del xskill  # CLI handler signature compatibility.
@@ -1732,6 +1848,19 @@ def build_parser() -> argparse.ArgumentParser:
     p_upload.add_argument("path", type=str, help="包含 SKILL.md 的 skill 目录")
     p_upload.add_argument("--json", action="store_true", help="机读 JSON 输出")
 
+    p_gen = sub.add_parser(
+        "generate",
+        help="按指令在 team server 上即时生成或改写 skill（直接提交主干）",
+    )
+    p_gen.add_argument(
+        "instruction", nargs="+", metavar="PROMPT",
+        help="给生成代理的定向指令",
+    )
+    p_gen.add_argument(
+        "--name", default="",
+        help="优先阅读的工号，逗号分隔；不传则提示词里写可看全量",
+    )
+
     p_init = sub.add_parser(
         "init",
         help="一站式引导：装 xskill 使用指南 skill 到各 agent + 连上 team server",
@@ -1927,6 +2056,8 @@ def main() -> int:
         return cmd_download(args)
     if args.command == "upload":
         return cmd_upload(args)
+    if args.command == "generate":
+        return cmd_generate(args)
 
     # stats 只读 registry，不需要 config.yaml / llm.api_key / facade
     if args.command == "stats":

--- a/src/xskill/cli.py
+++ b/src/xskill/cli.py
@@ -1621,6 +1621,8 @@ def cmd_generate(args, http=None, headers=None) -> int:
                             if chunk:
                                 sys.stdout.write(chunk)
                                 sys.stdout.flush()
+                        elif event.get("type") == "ping":
+                            continue
                         elif event.get("type") == "done":
                             final = event
                 if final is None and buffer.strip():

--- a/src/xskill/dashboard/pipeline_live.py
+++ b/src/xskill/dashboard/pipeline_live.py
@@ -19,6 +19,7 @@ from xskill.utils.status_file import AGENT_WORKER_STATUS_FILE, read_status_file
 logger = logging.getLogger(__name__)
 
 # 监看展示的三池（embed 不进概念稿：读库事实，不占席位色块）。
+# generate 不另开线程池：与 SkillEdit 共用 edit 席位，整形时拆成第四栏。
 MONITORED_POOLS = ("split", "cluster", "edit")
 
 # 日志尾巴默认/上限行数。
@@ -32,6 +33,8 @@ _KIND_TO_LOG_SUBPATH = {
     "skill": ("agents", "skill_edit_agents", "skills"),
     # TaskAgent 拆分轨迹的逐轮 trace
     "traj": ("agents", "task_agents"),
+    # GenerateAgent：实际文件在 generate_agents/<user_id>/<job_id>.log
+    "generate": ("agents", "generate_agents"),
 }
 
 
@@ -94,6 +97,11 @@ def pipeline_live(db_path: Optional[Path]) -> dict:
 
     watcher = stats.get("watcher") or {}
     cluster = stats.get("cluster") or {}
+    generate_stats = stats.get("generate") or {}
+    edit_pool = pools.get("edit")
+    if edit_pool is not None:
+        pools["generate"] = _project_generate_pool(edit_pool, generate_stats)
+        pools["edit"] = _hide_generate_tasks(edit_pool)
     return {
         "running": bool(watcher.get("running")),
         "ok": bool(payload.get("ok")),
@@ -105,6 +113,61 @@ def pipeline_live(db_path: Optional[Path]) -> dict:
         "pending_atoms": int(cluster.get("pending_atoms") or 0),
         "pools": pools,
     }
+
+
+def _is_generate_task(task: object) -> bool:
+    return isinstance(task, dict) and task.get("kind") == "generate"
+
+
+def _project_generate_pool(edit: dict, generate_stats: dict) -> dict:
+    """从 edit 池席位里抽出 generate 任务，做成流水线第四栏。
+
+    席位下标与 edit 对齐：同一 worker 只在一栏里显示为占用。
+    """
+    workers = int(edit.get("workers") or 0)
+    seats = []
+    for seat in edit.get("seats") or []:
+        if isinstance(seat, dict) and _is_generate_task(seat.get("task")):
+            seats.append(seat)
+        else:
+            seats.append(None)
+    if len(seats) < workers:
+        seats.extend([None] * (workers - len(seats)))
+    elif len(seats) > workers:
+        seats = seats[:workers]
+    queue = [
+        task for task in (edit.get("queue") or [])
+        if _is_generate_task(task)
+    ]
+    return {
+        "workers": workers,
+        "llm_weight": edit.get("llm_weight"),
+        "batch_size": None,
+        "seats": seats,
+        "queue": queue,
+        "queued": len(queue),
+        "completed": int(generate_stats.get("completed") or 0),
+        "failed": int(generate_stats.get("failed") or 0),
+        "shared_pool": "edit",
+    }
+
+
+def _hide_generate_tasks(edit: dict) -> dict:
+    """SkillEdit 栏不重复展示 generate 占用的席位。"""
+    seats = []
+    for seat in edit.get("seats") or []:
+        if isinstance(seat, dict) and _is_generate_task(seat.get("task")):
+            seats.append(None)
+        else:
+            seats.append(seat)
+    queue = [
+        task for task in (edit.get("queue") or [])
+        if not _is_generate_task(task)
+    ]
+    out = dict(edit)
+    out["seats"] = seats
+    out["queue"] = queue
+    return out
 
 
 def _safe_log_name(name: str) -> str:
@@ -125,16 +188,20 @@ def tail_task_log(
 ) -> dict:
     """读单个任务的 agent trace 尾巴。
 
-    ``kind`` 只认 ``skill`` / ``traj``；cluster 批没有独立日志文件（概念稿
-    的 Cluster 详情展示本批 atom id 列表，不走本端点）。文件不存在是正常
-    情况（任务刚起跑 / logs_dir 未配），返回显式空态而非 404 错误页。
+    ``kind`` 认 ``skill`` / ``traj`` / ``generate``；cluster 批没有独立日志
+    文件（概念稿的 Cluster 详情展示本批 atom id 列表，不走本端点）。文件不
+    存在是正常情况（任务刚起跑 / logs_dir 未配），返回显式空态而非 404。
     """
     if kind not in _KIND_TO_LOG_SUBPATH:
         raise ValueError(f"kind 必须是 {sorted(_KIND_TO_LOG_SUBPATH)} 之一")
     name = _safe_log_name(name)
     tail = max(1, min(int(tail), MAX_LOG_TAIL))
     root = status_root_for(db_path) / "logs"
-    path = root.joinpath(*_KIND_TO_LOG_SUBPATH[kind]) / f"{name}.log"
+    if kind == "generate":
+        matches = list(root.joinpath(*_KIND_TO_LOG_SUBPATH[kind]).glob(f"*/{name}.log"))
+        path = matches[0] if matches else root.joinpath(*_KIND_TO_LOG_SUBPATH[kind], name + ".log")
+    else:
+        path = root.joinpath(*_KIND_TO_LOG_SUBPATH[kind]) / f"{name}.log"
     if not path.is_file():
         return {
             "kind": kind,

--- a/src/xskill/dashboard/router.py
+++ b/src/xskill/dashboard/router.py
@@ -218,7 +218,7 @@ def build_dashboard_router(db_path: Optional[Path] = None, *,
 
     @router.get("/api/v1/dashboard/pipeline/live")
     def pipeline_live_ep() -> dict:
-        """三池实时监看：固定席位 + 排队预览（agent-worker 状态文件只读整形）。
+        """四栏实时监看：split / cluster / SkillEdit / Generate（后两栏共用 edit 池）。
 
         公网只读实例剥掉任务级身份（skill/traj/atom 名），只留席位占用与
         计时——与 ``dirs``/``tags`` 的白名单裁剪同一套；日志尾巴属内容级，

--- a/src/xskill/dashboard/static/app.js
+++ b/src/xskill/dashboard/static/app.js
@@ -1195,7 +1195,7 @@ async function loadCanary() {
     '还没有灰度使用记录');
 }
 
-// ═════════════ 流水线 Monitor（三池固定席位实时事实板） ═════════════
+// ═════════════ 流水线 Monitor（四栏固定席位：后两栏共用 edit 池） ═════════════
 // 数据：pipeline/live（agent-worker 状态文件只读整形，~5s 粒度），3s 轮询；
 // 点选席位/任务后 pipeline/log 轮询日志尾巴。禁止 fallback：状态文件缺失、
 // 日志不存在、席位已腾空一律显式空态，绝不编造。
@@ -1203,6 +1203,7 @@ const PM_POOLS = [
   { key: 'split', title: 'Split', subtitle: '轨迹', weight: true, batch: false },
   { key: 'cluster', title: 'Cluster', subtitle: 'atom 批', weight: true, batch: true },
   { key: 'edit', title: 'SkillEditAgent', subtitle: 'A→B 转移', weight: true, batch: true },
+  { key: 'generate', title: 'GenerateAgent', subtitle: '与 SkillEdit 共用席位', weight: true, batch: false, shared: 'edit' },
 ];
 const PM_XFER = {
   baby_main: { from: 'baby', to: 'main', tip: '冷启动消化后 graduate' },
@@ -1248,7 +1249,8 @@ function pmRenderBubbles() {
   }
   const llm = d.llm || {};
   const quotaWait = (llm.rate_limit_waiting || 0) + (llm.retry_waiting || 0);
-  const failed = PM_POOLS.reduce((n, p) => n + ((d.pools[p.key] || {}).failed || 0), 0);
+  const failed = PM_POOLS.filter(p => !p.shared).reduce(
+    (n, p) => n + ((d.pools[p.key] || {}).failed || 0), 0);
   const hbAge = Math.max(0, Date.now() / 1000 - (d.heartbeat_at || 0));
   let html = `<div class="pm-bubble ${d.running && d.ok !== false ? '' : 'bad'} ring-1 ring-slate-200">`
     + `<span class="pm-dot"></span><span class="k">心跳</span>`
@@ -1285,6 +1287,13 @@ function pmTaskCard(task, poolKey, selKey) {
       <div class="nm">本批 ${ids.length} 个原子</div>
       <div class="inf">${task._age != null ? pmAgeText(task._age) : '排队中'}</div>
       <div class="mt-1 flex flex-wrap gap-1">${preview}${ids.length > 4 ? `<span class="inf">+${ids.length - 4}</span>` : ''}</div>
+    </div>`;
+  }
+  if (task.kind === 'generate') {
+    const preview = task.instruction || '';
+    return `<div class="pm-card${sel}"${open}${style}>
+      <div class="nm font-mono">${esc(task.user_id || task.job_id || '?')}</div>
+      <div class="inf">${preview ? esc(preview) + ' · ' : ''}${task._age != null ? pmAgeText(task._age) : '排队中'}</div>
     </div>`;
   }
   // traj（拆分代理没有任务名，只有轨迹 id）
@@ -1371,7 +1380,7 @@ function pmRenderDrawer() {
   const age = pmAgeText(pmSeatAge(seat));
   const def = PM_POOLS.find(p => p.key === pmSelected.pool);
   // 抽屉随 live 轮询重渲染：同一任务的日志内容与滚动位置要保住，否则每 3s 闪回/跳底
-  const hasStream = task.kind === 'skill' || task.kind === 'traj';
+  const hasStream = task.kind === 'skill' || task.kind === 'traj' || task.kind === 'generate';
   const existingEl = (hasStream && pmLogKey) ? document.getElementById('pm-log') : null;
   const existingLog = existingEl ? existingEl.innerHTML : '';
   const stickBottom = pmLogNearBottom(existingEl);
@@ -1389,6 +1398,11 @@ function pmRenderDrawer() {
     head = `<h2 class="font-mono text-sm font-semibold break-all">${esc(task.traj_id || '?')}</h2>
       <div class="text-[11px] text-slate-400 mt-0.5">${def.title} · ${esc(task.watch_dir || '')} · 席位 ${pmSelected.seat + 1} · 已跑 ${age}</div>`;
     logHtml = logPane;
+  } else if (task.kind === 'generate') {
+    head = `<h2 class="font-mono text-sm font-semibold break-all">${esc(task.user_id || task.job_id || '?')}</h2>
+      <div class="text-[11px] text-slate-400 mt-0.5">${def.title} · 席位 ${pmSelected.seat + 1} · 已跑 ${age}</div>
+      <div class="text-xs text-slate-600 mt-1">${esc(task.instruction || '')}</div>`;
+    logHtml = logPane;
   } else {  // atom_batch：Cluster 批没有独立日志，展示本批原子名单（概念稿语义）
     const ids = (task.atom_ids || []).map(a => `<code class="font-mono text-[11px] text-teal-700">${esc(a)}</code>`).join(' · ');
     head = `<h2 class="text-sm font-semibold">本批 ${(task.atom_ids || []).length} 个原子</h2>
@@ -1404,6 +1418,7 @@ function pmRenderDrawer() {
     newLog.scrollTop = stickBottom ? newLog.scrollHeight : savedScroll;
   }
   if (task.kind === 'skill' || task.kind === 'traj') pmStartLog(task.kind, task.kind === 'skill' ? task.skill_name : task.traj_id);
+  else if (task.kind === 'generate') pmStartLog('generate', task.job_id);
   else pmStopLog();
 }
 

--- a/src/xskill/dashboard/static/index.html
+++ b/src/xskill/dashboard/static/index.html
@@ -26,7 +26,8 @@
   .pm-bubble.warn .pm-dot{background:#f59e0b}
   .pm-bubble.bad .pm-dot{background:#f43f5e}
   .pm-stages{display:grid;grid-template-columns:1fr;gap:10px;align-items:stretch}
-  @media (min-width:1100px){.pm-stages{grid-template-columns:1fr 1fr 1.35fr}}
+  @media (min-width:1100px){.pm-stages{grid-template-columns:1fr 1fr}}
+  @media (min-width:1500px){.pm-stages{grid-template-columns:1fr 1fr 1.2fr 1.2fr}}
   .pm-stage{background:#fff;border-radius:12px;padding:10px;min-height:340px;display:flex;flex-direction:column;gap:7px}
   .pm-seats{display:grid;grid-template-columns:repeat(auto-fill,minmax(22px,1fr));gap:4px}
   .pm-seat{aspect-ratio:1;border-radius:5px;border:1px solid #cbd5e1;background:#f8fafc;transition:background-color .4s ease,border-color .4s ease}

--- a/src/xskill/pipeline/runner.py
+++ b/src/xskill/pipeline/runner.py
@@ -213,6 +213,9 @@ class DirectoryWatcher:
             "skills_edited": 0,      # v2: 触发的 SkillEdit 次数
             "scores": 0, "errors": 0, "retries": 0,
         }
+        # generate 与 SkillEdit 共用 edit 池；完成/失败单独记，给流水线第四栏。
+        self._generate_completed = 0
+        self._generate_failed = 0
 
     def start(self):
         if self._thread and self._thread.is_alive():
@@ -277,6 +280,10 @@ class DirectoryWatcher:
             "pool_config": {
                 name: dict(self.pool_config.get(name) or {})
                 for name in ("split", "cluster", "edit")
+            },
+            "generate": {
+                "completed": self._generate_completed,
+                "failed": self._generate_failed,
             },
             "cluster": {
                 "pending_atoms": len(self.pending_atoms),
@@ -373,6 +380,10 @@ class DirectoryWatcher:
                         wd["id"], dir_path, consumed_index, **kw,
                     )
 
+        # ── Step 5a: 用户点名的 generate 入队到 SkillEdit 同一线程池 ──
+        # 先于自动 SkillEdit 提交，避免后台整理把用户任务挤到池外。
+        self._submit_generate_jobs()
+
         # ── Step 5: 独立扫所有 skill 目录的 candidates buffer ──
         # 这步与具体 atom 处理解耦：即便某些 atom cluster 失败，buffer
         # 已满阈值的 skill 仍能在每轮 scan 中被检出 + 触发 SkillEdit。
@@ -404,6 +415,59 @@ class DirectoryWatcher:
         # CS 模式的分桶在 client 的 reconcile_skill_sides 里按 client_id 做。
         if not self.server_mode:
             self._reconcile_skill_sides()
+
+    def _submit_generate_jobs(self):
+        """把 web 进程入队的 generate 任务提交到 SkillEdit 同一线程池。
+
+        不另开池：占 edit 席位、走 edit 的 llm_weight。pending 文件在
+        ``<home>/generate_jobs/pending/``，与 logs 同级，web 与 worker 都能见。
+        """
+        if self.skill_dir is None or not self.skill_dir.is_dir():
+            return
+        from xskill.team.server import generate_jobs as gen_jobs
+
+        inflight = {
+            info.get("job_id")
+            for info in self._futures.values()
+            if info.get("stage") == "generate" and info.get("job_id")
+        }
+        gen_jobs.reclaim_orphans(self.logs_dir, inflight)
+        for pending_path in gen_jobs.list_pending_paths(self.logs_dir):
+            job = gen_jobs.try_claim(self.logs_dir, pending_path)
+            if job is None:
+                continue
+            job_id = job.get("job_id") or pending_path.stem
+            if job_id in inflight:
+                gen_jobs.release_claim(self.logs_dir, job_id)
+                continue
+
+            def _run(claimed=job):
+                traj_root = None
+                if self.server_mode:
+                    from xskill.config import get_team_trajectories_dir
+                    try:
+                        traj_root = get_team_trajectories_dir()
+                    except Exception:
+                        logger.debug(
+                            "generate traj_root unavailable", exc_info=True,
+                        )
+                gen_jobs.run_claimed_generate_job(
+                    claimed,
+                    skill_dir=self.skill_dir,
+                    config=self.config,
+                    db_path=self.db_path,
+                    logs_dir=self.logs_dir,
+                    traj_root=traj_root,
+                )
+
+            fut = self._pools["edit"].submit(
+                _run,
+                task=gen_jobs.monitor_task(job),
+            )
+            if fut is None:
+                gen_jobs.release_claim(self.logs_dir, job_id)
+                break
+            self._futures[fut] = {"stage": "generate", "job_id": job_id}
 
     def _run_skill_edit_step(self):
         """Step 5 的冷启动感知封装：hold 只等 rebuild 快照内轨迹到终态。"""
@@ -2084,6 +2148,19 @@ class DirectoryWatcher:
                     # Successful writes now have durable ``clustered`` markers;
                     # failures and silent drops are eligible for the next scan.
                     self.claimed_atoms.difference_update(atom_ids)
+                continue
+            if stage == "generate":
+                job_id = info.get("job_id") or ""
+                try:
+                    fut.result(timeout=0)
+                    self._generate_completed += 1
+                except Exception:
+                    self._generate_failed += 1
+                    self._stats["errors"] += 1
+                    logger.exception("generate future failed: %s", job_id)
+                finally:
+                    from xskill.team.server import generate_jobs as gen_jobs
+                    gen_jobs.finish_claim(self.logs_dir, job_id)
                 continue
             if stage == "skill_edit":
                 # SkillEditAgent.maybe_run() 自己吞异常返回 (d, False)——正常

--- a/src/xskill/skill/git.py
+++ b/src/xskill/skill/git.py
@@ -2130,6 +2130,54 @@ def commit_changes(skill_dir: str, message: str) -> bool:
     return False
 
 
+def commit_generate_to_main_branch(skill_dir: str, message: str) -> str:
+    """Put the current worktree onto main and commit, creating either if needed.
+
+    Empty commits are allowed.  Staging is never created.  Returns the full
+    commit SHA (hex string).
+    """
+    from dulwich import porcelain
+
+    root = Path(skill_dir)
+    root.mkdir(parents=True, exist_ok=True)
+    with skill_repo_lock(skill_dir):
+        if not (root / ".git").is_dir():
+            repo = porcelain.init(str(root), bare=False)
+            try:
+                _write_repo_identity(repo)
+            finally:
+                repo.close()
+        with _open_repo(skill_dir) as repo:
+            if not _has_branch(repo, "main"):
+                code, err = _checkout_branch(repo, "main", create=True)
+                if code != 0:
+                    raise RuntimeError(
+                        f"failed to create main branch: {err or code}"
+                    )
+            elif _current_branch_name(repo) != "main":
+                try:
+                    head_sha = repo.refs[b"HEAD"]
+                except KeyError:
+                    head_sha = None
+                if head_sha is not None:
+                    _branch_force_create(repo, "main", head_sha)
+                repo.refs.set_symbolic_ref(b"HEAD", _ref_for_branch("main"))
+            _stage_all(repo, root)
+            sha, err = _do_commit(repo, message, allow_empty=True)
+            if sha is None:
+                raise RuntimeError(
+                    f"commit_generate_to_main_branch commit 失败: {err}"
+                )
+    full_sha = sha.decode("ascii", errors="strict")
+    logger.info(
+        "generate commit on main: %s %s: %s",
+        root.name, full_sha[:7], message.splitlines()[0] if message else "",
+    )
+    from xskill.skill.catalog_store import notify_native_upsert
+    notify_native_upsert(skill_dir)
+    return full_sha
+
+
 def current_branch(skill_dir: str) -> str:
     with _open_repo(skill_dir) as repo:
         return _current_branch_name(repo)

--- a/src/xskill/team/server/api.py
+++ b/src/xskill/team/server/api.py
@@ -30,7 +30,7 @@ import zipfile
 
 from dulwich.errors import NotGitRepository, ObjectMissing
 from fastapi import APIRouter, File, Form, Header, HTTPException, Request, UploadFile
-from fastapi.responses import FileResponse, JSONResponse, Response
+from fastapi.responses import FileResponse, JSONResponse, Response, StreamingResponse
 from starlette.concurrency import run_in_threadpool
 
 from xskill import __version__ as XSKILL_VERSION
@@ -48,7 +48,7 @@ from xskill.team.server.skill_manifest import (
     repo_search_id,
 )
 from xskill.team.shared.protocol import (
-    PushEditResponse, RegisterRequest, RegisterResponse,
+    GenerateAccepted, GenerateRequest, PushEditResponse, RegisterRequest, RegisterResponse,
     UploadRejection, UploadRequest, UploadResponse,
 )
 from xskill.utils.sanitize import sanitize_trajectory_text
@@ -1426,3 +1426,62 @@ async def team_push_edit(
     except Exception:  # pylint: disable=broad-exception-caught
         logger.debug("push-edit event emit skipped", exc_info=True)
     return PushEditResponse(branch=f"user-staging/{client_id}", ref_sha=sha)
+
+
+@router.post("/generate", response_model=GenerateAccepted)
+def team_generate(
+    req: GenerateRequest,
+    x_xskill_token: str | None = Header(default=None),
+    x_xskill_client: str | None = Header(default=None),
+    x_xskill_version: str | None = Header(default=None),
+) -> GenerateAccepted:
+    client_id = _auth(x_xskill_token, x_xskill_client, x_xskill_version)
+    instruction = (req.instruction or "").strip()
+    if not instruction:
+        raise HTTPException(status_code=400, detail="instruction 不能为空")
+    row = (_ctx.client_registry.get(client_id) or {}) if _ctx.client_registry else {}
+    user_id = (row.get("user_name") or "").strip() or client_id
+    names = [n.strip() for n in (req.names or []) if str(n).strip()]
+    from xskill.config import get_logs_dir
+    from xskill.team.server.generate_jobs import (
+        create_job, start_generate_job_thread,
+    )
+
+    job = create_job(
+        client_id=client_id,
+        user_id=user_id,
+        instruction=instruction,
+        preferred_names=names,
+        logs_dir=get_logs_dir(),
+    )
+    config = {}
+    try:
+        from xskill.api import app as app_mod
+        config = app_mod._config or {}
+    except Exception:
+        logger.debug("generate using empty config snapshot", exc_info=True)
+    start_generate_job_thread(job["job_id"], ctx=_ctx, config=config)
+    return GenerateAccepted(job_id=job["job_id"])
+
+
+@router.get("/generate/{job_id}/events")
+def team_generate_events(
+    job_id: str,
+    x_xskill_token: str | None = Header(default=None),
+    x_xskill_client: str | None = Header(default=None),
+    x_xskill_version: str | None = Header(default=None),
+):
+    client_id = _auth(x_xskill_token, x_xskill_client, x_xskill_version)
+    from xskill.team.server.generate_jobs import get_job, iter_job_events
+
+    job = get_job(job_id)
+    if job is None:
+        raise HTTPException(status_code=404, detail="unknown generate job")
+    if job.get("client_id") != client_id:
+        raise HTTPException(status_code=403, detail="job belongs to another client")
+
+    def event_stream():
+        for event in iter_job_events(job_id):
+            yield f"data: {json.dumps(event, ensure_ascii=False)}\n\n"
+
+    return StreamingResponse(event_stream(), media_type="text/event-stream")

--- a/src/xskill/team/server/api.py
+++ b/src/xskill/team/server/api.py
@@ -1444,23 +1444,18 @@ def team_generate(
     names = [n.strip() for n in (req.names or []) if str(n).strip()]
     from xskill.config import get_logs_dir
     from xskill.team.server.generate_jobs import (
-        create_job, start_generate_job_thread,
+        create_job, enqueue_generate_job,
     )
 
+    logs_dir = get_logs_dir()
     job = create_job(
         client_id=client_id,
         user_id=user_id,
         instruction=instruction,
         preferred_names=names,
-        logs_dir=get_logs_dir(),
+        logs_dir=logs_dir,
     )
-    config = {}
-    try:
-        from xskill.api import app as app_mod
-        config = app_mod._config or {}
-    except Exception:
-        logger.debug("generate using empty config snapshot", exc_info=True)
-    start_generate_job_thread(job["job_id"], ctx=_ctx, config=config)
+    enqueue_generate_job(job, logs_dir=logs_dir)
     return GenerateAccepted(job_id=job["job_id"])
 
 

--- a/src/xskill/team/server/generate_jobs.py
+++ b/src/xskill/team/server/generate_jobs.py
@@ -1,0 +1,302 @@
+"""team server 上的 generate 任务：落盘日志、后台跑代理、流式给客户端。"""
+from __future__ import annotations
+
+import json
+import logging
+import threading
+import time
+import uuid
+from pathlib import Path
+from typing import Any, Iterator
+
+logger = logging.getLogger("xskill.team.generate")
+
+_JOBS: dict[str, dict[str, Any]] = {}
+_JOBS_LOCK = threading.Lock()
+
+
+def _job_dir(logs_dir: Path, user_id: str) -> Path:
+    path = logs_dir / "agents" / "generate_agents" / user_id
+    path.mkdir(parents=True, exist_ok=True)
+    return path
+
+
+def create_job(
+    *,
+    client_id: str,
+    user_id: str,
+    instruction: str,
+    preferred_names: list[str],
+    logs_dir: Path,
+) -> dict[str, Any]:
+    job_id = uuid.uuid4().hex
+    log_path = _job_dir(logs_dir, user_id) / f"{job_id}.log"
+    log_path.write_text("", encoding="utf-8")
+    job = {
+        "job_id": job_id,
+        "client_id": client_id,
+        "user_id": user_id,
+        "instruction": instruction,
+        "preferred_names": list(preferred_names),
+        "status": "running",
+        "log_path": str(log_path),
+        "skill_names": [],
+        "pinned": [],
+        "error": "",
+        "created_at": time.time(),
+    }
+    with _JOBS_LOCK:
+        _JOBS[job_id] = job
+    _write_status(job)
+    return dict(job)
+
+
+def get_job(job_id: str) -> dict[str, Any] | None:
+    with _JOBS_LOCK:
+        job = _JOBS.get(job_id)
+        return dict(job) if job is not None else None
+
+
+def _update_job(job_id: str, **fields: Any) -> dict[str, Any] | None:
+    with _JOBS_LOCK:
+        job = _JOBS.get(job_id)
+        if job is None:
+            return None
+        job.update(fields)
+        snapshot = dict(job)
+    _write_status(snapshot)
+    return snapshot
+
+
+def _write_status(job: dict[str, Any]) -> None:
+    log_path = Path(job["log_path"])
+    status_path = log_path.with_suffix(".status.json")
+    payload = {
+        key: job[key]
+        for key in (
+            "job_id", "client_id", "user_id", "status",
+            "skill_names", "pinned", "error", "created_at",
+        )
+        if key in job
+    }
+    try:
+        status_path.write_text(
+            json.dumps(payload, ensure_ascii=False, indent=2),
+            encoding="utf-8",
+        )
+    except OSError:
+        logger.warning("failed to write generate status %s", status_path, exc_info=True)
+
+
+def collect_read_roots(skill_dir: Path, traj_root: Path | None) -> list[Path]:
+    roots: list[Path] = [Path(skill_dir)]
+    if traj_root is not None:
+        roots.append(Path(traj_root))
+        clients = Path(traj_root) / "clients"
+        if clients.is_dir():
+            roots.append(clients)
+    try:
+        from xskill.pipeline.registry import list_watch_dirs
+        for row in list_watch_dirs():
+            path = Path(row["path"])
+            if path.is_dir():
+                roots.append(path)
+    except Exception:
+        logger.debug("list_watch_dirs unavailable for generate roots", exc_info=True)
+    unique: list[Path] = []
+    seen: set[str] = set()
+    for path in roots:
+        key = str(path.resolve()) if path.exists() else str(path)
+        if key in seen:
+            continue
+        seen.add(key)
+        unique.append(path)
+    return unique
+
+
+def pin_generated_skills(
+    *,
+    user_id: str,
+    skill_names: list[str],
+    db_path: Path | None,
+    max_pinned: int | None,
+) -> list[str]:
+    from xskill.pipeline.registry import PinQuotaExceeded, set_skill_pref
+
+    pinned: list[str] = []
+    for name in skill_names:
+        try:
+            set_skill_pref(
+                user_key=user_id,
+                skill_name=name,
+                pref="pinned",
+                set_by=user_id,
+                max_pinned=max_pinned,
+                db_path=db_path,
+            )
+            pinned.append(name)
+        except PinQuotaExceeded as error:
+            logger.warning("generate pin quota exceeded for %s: %s", name, error)
+        except Exception:
+            logger.exception("generate pin failed for %s", name)
+    try:
+        from xskill.team.server import api as server_api
+        with server_api._MANIFEST_CONTROL_CACHE_LOCK:
+            server_api._MANIFEST_CONTROL_CACHE.clear()
+    except Exception:
+        logger.debug("could not invalidate manifest cache after generate pin", exc_info=True)
+    return pinned
+
+
+def run_generate_job(job_id: str, *, ctx: Any, config: dict | None) -> None:
+    """Run one generate job in the current thread. Tests may call this directly."""
+    job = get_job(job_id)
+    if job is None:
+        return
+    try:
+        _run_generate_job_body(job, ctx=ctx, config=config or {})
+    except Exception as error:  # noqa: BLE001 — job must end in failed, not crash thread
+        logger.exception("generate job %s failed", job_id)
+        _update_job(job_id, status="failed", error=str(error))
+
+
+def _run_generate_job_body(job: dict[str, Any], *, ctx: Any, config: dict) -> None:
+    from xskill.agents import agent_tools
+    from xskill.agents.agno_factory import make_default_factory
+    from xskill.agents.generate_agent import GenerateAgent
+    from xskill.config import get_logs_dir, get_registry_db_path
+
+    skill_dir = Path(ctx.skill_dir)
+    traj_root = Path(ctx.traj_root) if ctx.traj_root is not None else None
+    extra_roots = collect_read_roots(skill_dir, traj_root)
+    logs_dir = get_logs_dir()
+    spill_root = (
+        logs_dir / "agents" / "generate_agents" / job["user_id"] / "spill" / job["job_id"]
+    )
+    spill_root.mkdir(parents=True, exist_ok=True)
+    db_path = get_registry_db_path()
+    agent_tools.reset_generate_session()
+    tool_context = agent_tools.create_agent_tool_context(
+        skill_dir=skill_dir,
+        data_dir=skill_dir,
+        config=config,
+        atom_skill_dir=skill_dir,
+        default_traj_root=traj_root,
+        spill_root=spill_root,
+        extra_read_roots=tuple(extra_roots),
+        generate_user_id=job["user_id"],
+        registry_db_path=db_path,
+    )
+    llm_cfg = {**(config.get("llm") or {}), **(config.get("llm_skill") or {})}
+    factory = make_default_factory(
+        config, spill_root=spill_root,
+    )
+    agent = GenerateAgent(
+        skill_dir=skill_dir,
+        agno_agent_factory=factory,
+        llm_cfg=llm_cfg,
+        logs_dir=logs_dir,
+        extra_read_roots=tuple(extra_roots),
+    )
+    token = agent_tools.bind_agent_tool_context(tool_context)
+    try:
+        agent.run(
+            instruction=job["instruction"],
+            user_id=job["user_id"],
+            job_id=job["job_id"],
+            preferred_names=job.get("preferred_names") or [],
+        )
+        skill_names = agent_tools.generate_committed_skills()
+    finally:
+        agent_tools.reset_agent_tool_context(token)
+
+    if not skill_names:
+        _update_job(
+            job["job_id"],
+            status="failed",
+            error="generate 结束但没有 commit_generate_main 提交任何 skill",
+        )
+        return
+    max_pinned = None
+    try:
+        from xskill.config import team_server_slots_config
+        max_pinned = team_server_slots_config(config)["skill_slots"]
+    except Exception:
+        logger.debug("skill_slots unavailable for generate pin quota", exc_info=True)
+    pinned = pin_generated_skills(
+        user_id=job["user_id"],
+        skill_names=skill_names,
+        db_path=db_path,
+        max_pinned=max_pinned,
+    )
+    _update_job(
+        job["job_id"],
+        status="succeeded",
+        skill_names=skill_names,
+        pinned=pinned,
+        error="",
+    )
+
+
+def start_generate_job_thread(job_id: str, *, ctx: Any, config: dict | None) -> None:
+    thread = threading.Thread(
+        target=run_generate_job,
+        args=(job_id,),
+        kwargs={"ctx": ctx, "config": config},
+        name=f"xskill-generate-{job_id[:8]}",
+        daemon=True,
+    )
+    thread.start()
+
+
+def iter_job_events(
+    job_id: str,
+    *,
+    poll_seconds: float = 0.2,
+    idle_timeout: float = 3600.0,
+) -> Iterator[dict[str, Any]]:
+    """Yield log chunks then a terminal event. Blocking generator."""
+    job = get_job(job_id)
+    if job is None:
+        yield {"type": "done", "ok": False, "error": "unknown job_id"}
+        return
+    log_path = Path(job["log_path"])
+    offset = 0
+    started = time.time()
+    while True:
+        try:
+            data = log_path.read_bytes()
+        except OSError:
+            data = b""
+        if len(data) > offset:
+            chunk = data[offset:].decode("utf-8", errors="replace")
+            offset = len(data)
+            yield {"type": "log", "chunk": chunk}
+            started = time.time()
+        current = get_job(job_id) or job
+        if current.get("status") != "running":
+            try:
+                data = log_path.read_bytes()
+            except OSError:
+                data = b""
+            if len(data) > offset:
+                chunk = data[offset:].decode("utf-8", errors="replace")
+                yield {"type": "log", "chunk": chunk}
+            yield {
+                "type": "done",
+                "ok": current.get("status") == "succeeded",
+                "skill_names": current.get("skill_names") or [],
+                "pinned": current.get("pinned") or [],
+                "error": current.get("error") or "",
+            }
+            return
+        if time.time() - started > idle_timeout:
+            yield {
+                "type": "done",
+                "ok": False,
+                "error": "generate 等待日志超时",
+                "skill_names": [],
+                "pinned": [],
+            }
+            return
+        time.sleep(poll_seconds)

--- a/src/xskill/team/server/generate_jobs.py
+++ b/src/xskill/team/server/generate_jobs.py
@@ -253,16 +253,20 @@ def iter_job_events(
     job_id: str,
     *,
     poll_seconds: float = 0.2,
-    idle_timeout: float = 3600.0,
+    ping_every: float = 15.0,
 ) -> Iterator[dict[str, Any]]:
-    """Yield log chunks then a terminal event. Blocking generator."""
+    """Yield log chunks then a terminal event. Blocking generator.
+
+    Stays open until the job leaves ``running``. Quiet periods emit ping
+    events so proxies and the CLI do not treat a long model call as death.
+    """
     job = get_job(job_id)
     if job is None:
         yield {"type": "done", "ok": False, "error": "unknown job_id"}
         return
     log_path = Path(job["log_path"])
     offset = 0
-    started = time.time()
+    last_emit = time.time()
     while True:
         try:
             data = log_path.read_bytes()
@@ -272,7 +276,7 @@ def iter_job_events(
             chunk = data[offset:].decode("utf-8", errors="replace")
             offset = len(data)
             yield {"type": "log", "chunk": chunk}
-            started = time.time()
+            last_emit = time.time()
         current = get_job(job_id) or job
         if current.get("status") != "running":
             try:
@@ -290,13 +294,7 @@ def iter_job_events(
                 "error": current.get("error") or "",
             }
             return
-        if time.time() - started > idle_timeout:
-            yield {
-                "type": "done",
-                "ok": False,
-                "error": "generate 等待日志超时",
-                "skill_names": [],
-                "pinned": [],
-            }
-            return
+        if time.time() - last_emit >= ping_every:
+            yield {"type": "ping"}
+            last_emit = time.time()
         time.sleep(poll_seconds)

--- a/src/xskill/team/server/generate_jobs.py
+++ b/src/xskill/team/server/generate_jobs.py
@@ -1,4 +1,4 @@
-"""team server 上的 generate 任务：落盘日志、后台跑代理、流式给客户端。"""
+"""team server 上的 generate 任务：入队到 agent-worker 的 SkillEdit 池，流式给客户端。"""
 from __future__ import annotations
 
 import json
@@ -13,12 +13,46 @@ logger = logging.getLogger("xskill.team.generate")
 
 _JOBS: dict[str, dict[str, Any]] = {}
 _JOBS_LOCK = threading.Lock()
+_ACTIVE_STATUSES = ("queued", "running")
 
 
 def _job_dir(logs_dir: Path, user_id: str) -> Path:
     path = logs_dir / "agents" / "generate_agents" / user_id
     path.mkdir(parents=True, exist_ok=True)
     return path
+
+
+def jobs_root(logs_dir: Path) -> Path:
+    """web 进程与 agent-worker 共用的入队目录（与 logs 同级）。"""
+    return Path(logs_dir).expanduser().resolve().parent / "generate_jobs"
+
+
+def _pending_dir(logs_dir: Path) -> Path:
+    path = jobs_root(logs_dir) / "pending"
+    path.mkdir(parents=True, exist_ok=True)
+    return path
+
+
+def _claimed_dir(logs_dir: Path) -> Path:
+    path = jobs_root(logs_dir) / "claimed"
+    path.mkdir(parents=True, exist_ok=True)
+    return path
+
+
+def _atomic_write_json(path: Path, payload: dict[str, Any]) -> None:
+    path.parent.mkdir(parents=True, exist_ok=True)
+    tmp = path.with_name(path.name + ".tmp")
+    tmp.write_text(json.dumps(payload, ensure_ascii=False, indent=2), encoding="utf-8")
+    tmp.replace(path)
+
+
+def _status_path(log_path: Path) -> Path:
+    return log_path.with_suffix(".status.json")
+
+
+def _instruction_preview(text: str) -> str:
+    one = " ".join((text or "").split())
+    return one[:80]
 
 
 def create_job(
@@ -38,7 +72,7 @@ def create_job(
         "user_id": user_id,
         "instruction": instruction,
         "preferred_names": list(preferred_names),
-        "status": "running",
+        "status": "queued",
         "log_path": str(log_path),
         "skill_names": [],
         "pinned": [],
@@ -51,10 +85,175 @@ def create_job(
     return dict(job)
 
 
+def enqueue_generate_job(job: dict[str, Any], *, logs_dir: Path) -> None:
+    """把任务写进 pending，供 agent-worker 的 edit 池领取。"""
+    payload = {
+        "job_id": job["job_id"],
+        "client_id": job["client_id"],
+        "user_id": job["user_id"],
+        "instruction": job["instruction"],
+        "preferred_names": list(job.get("preferred_names") or []),
+        "log_path": job["log_path"],
+        "created_at": job.get("created_at") or time.time(),
+        "status": "queued",
+    }
+    path = _pending_dir(logs_dir) / f"{job['job_id']}.json"
+    _atomic_write_json(path, payload)
+
+
+def list_pending_paths(logs_dir: Path) -> list[Path]:
+    pending = jobs_root(logs_dir) / "pending"
+    if not pending.is_dir():
+        return []
+    return sorted(
+        (p for p in pending.glob("*.json") if p.is_file()),
+        key=lambda p: p.stat().st_mtime,
+    )
+
+
+def try_claim(logs_dir: Path, pending_path: Path) -> dict[str, Any] | None:
+    claimed = _claimed_dir(logs_dir) / pending_path.name
+    try:
+        pending_path.replace(claimed)
+    except FileNotFoundError:
+        return None
+    except OSError:
+        logger.warning("generate claim failed for %s", pending_path, exc_info=True)
+        return None
+    try:
+        return json.loads(claimed.read_text(encoding="utf-8"))
+    except (OSError, json.JSONDecodeError):
+        logger.warning("generate claimed file unreadable %s", claimed, exc_info=True)
+        return None
+
+
+def release_claim(logs_dir: Path, job_id: str) -> None:
+    claimed = _claimed_dir(logs_dir) / f"{job_id}.json"
+    if not claimed.is_file():
+        return
+    pending = _pending_dir(logs_dir) / claimed.name
+    try:
+        claimed.replace(pending)
+    except OSError:
+        logger.warning("generate release claim failed for %s", job_id, exc_info=True)
+
+
+def finish_claim(logs_dir: Path, job_id: str) -> None:
+    claimed = _claimed_dir(logs_dir) / f"{job_id}.json"
+    try:
+        claimed.unlink(missing_ok=True)
+    except TypeError:
+        # Python 3.9: Path.unlink 无 missing_ok
+        try:
+            claimed.unlink()
+        except FileNotFoundError:
+            pass
+    except OSError:
+        logger.warning("generate finish claim failed for %s", job_id, exc_info=True)
+
+
+def reclaim_orphans(logs_dir: Path, inflight_ids: set[str]) -> None:
+    """进程重启后：已结束的 claimed 丢掉，未结束的退回 pending。"""
+    claimed_dir = jobs_root(logs_dir) / "claimed"
+    if not claimed_dir.is_dir():
+        return
+    for path in list(claimed_dir.glob("*.json")):
+        job_id = path.stem
+        if job_id in inflight_ids:
+            continue
+        try:
+            job = json.loads(path.read_text(encoding="utf-8"))
+        except (OSError, json.JSONDecodeError):
+            continue
+        status = ""
+        log_path = job.get("log_path")
+        if log_path:
+            disk = _read_status_file(Path(log_path))
+            status = str((disk or {}).get("status") or "")
+        if status in ("succeeded", "failed"):
+            try:
+                path.unlink()
+            except OSError:
+                pass
+            continue
+        try:
+            path.replace(_pending_dir(logs_dir) / path.name)
+        except OSError:
+            logger.warning("generate reclaim failed for %s", job_id, exc_info=True)
+
+
+def monitor_task(job: dict[str, Any]) -> dict[str, Any]:
+    """流水线席位元数据（给 BoundedExecutor 的 task=）。"""
+    return {
+        "kind": "generate",
+        "job_id": job["job_id"],
+        "user_id": job.get("user_id") or "",
+        "instruction": _instruction_preview(str(job.get("instruction") or "")),
+    }
+
+
 def get_job(job_id: str) -> dict[str, Any] | None:
     with _JOBS_LOCK:
-        job = _JOBS.get(job_id)
-        return dict(job) if job is not None else None
+        cached = _JOBS.get(job_id)
+        job = dict(cached) if cached is not None else None
+    if job is None:
+        job = _find_job_on_disk(job_id)
+    if job is None:
+        return None
+    return _refresh_from_status(job)
+
+
+def _find_job_on_disk(job_id: str) -> dict[str, Any] | None:
+    from xskill.config import get_logs_dir
+
+    logs_dir = get_logs_dir()
+    root = logs_dir / "agents" / "generate_agents"
+    if root.is_dir():
+        matches = list(root.glob(f"*/{job_id}.status.json"))
+        if matches:
+            try:
+                payload = json.loads(matches[0].read_text(encoding="utf-8"))
+            except (OSError, json.JSONDecodeError):
+                payload = {}
+            payload.setdefault("job_id", job_id)
+            payload["log_path"] = str(matches[0].with_name(f"{job_id}.log"))
+            return payload
+    for sub in ("pending", "claimed"):
+        path = jobs_root(logs_dir) / sub / f"{job_id}.json"
+        if not path.is_file():
+            continue
+        try:
+            return json.loads(path.read_text(encoding="utf-8"))
+        except (OSError, json.JSONDecodeError):
+            return None
+    return None
+
+
+def _read_status_file(log_path: Path) -> dict[str, Any] | None:
+    status_path = _status_path(Path(log_path))
+    try:
+        return json.loads(status_path.read_text(encoding="utf-8"))
+    except (OSError, json.JSONDecodeError):
+        return None
+
+
+def _refresh_from_status(job: dict[str, Any]) -> dict[str, Any]:
+    log_path = job.get("log_path")
+    if not log_path:
+        return job
+    disk = _read_status_file(Path(log_path))
+    if not disk:
+        return job
+    for key in ("status", "skill_names", "pinned", "error", "client_id", "user_id"):
+        if key in disk:
+            job[key] = disk[key]
+    with _JOBS_LOCK:
+        cached = _JOBS.get(job["job_id"])
+        if cached is not None:
+            for key in ("status", "skill_names", "pinned", "error"):
+                if key in disk:
+                    cached[key] = disk[key]
+    return job
 
 
 def _update_job(job_id: str, **fields: Any) -> dict[str, Any] | None:
@@ -70,7 +269,6 @@ def _update_job(job_id: str, **fields: Any) -> dict[str, Any] | None:
 
 def _write_status(job: dict[str, Any]) -> None:
     log_path = Path(job["log_path"])
-    status_path = log_path.with_suffix(".status.json")
     payload = {
         key: job[key]
         for key in (
@@ -80,15 +278,16 @@ def _write_status(job: dict[str, Any]) -> None:
         if key in job
     }
     try:
-        status_path.write_text(
-            json.dumps(payload, ensure_ascii=False, indent=2),
-            encoding="utf-8",
-        )
+        _atomic_write_json(_status_path(log_path), payload)
     except OSError:
-        logger.warning("failed to write generate status %s", status_path, exc_info=True)
+        logger.warning("failed to write generate status %s", log_path, exc_info=True)
 
 
-def collect_read_roots(skill_dir: Path, traj_root: Path | None) -> list[Path]:
+def collect_read_roots(
+    skill_dir: Path,
+    traj_root: Path | None,
+    db_path: Path | None = None,
+) -> list[Path]:
     roots: list[Path] = [Path(skill_dir)]
     if traj_root is not None:
         roots.append(Path(traj_root))
@@ -97,7 +296,8 @@ def collect_read_roots(skill_dir: Path, traj_root: Path | None) -> list[Path]:
             roots.append(clients)
     try:
         from xskill.pipeline.registry import list_watch_dirs
-        for row in list_watch_dirs():
+        kw = {"db_path": db_path} if db_path is not None else {}
+        for row in list_watch_dirs(**kw):
             path = Path(row["path"])
             if path.is_dir():
                 roots.append(path)
@@ -154,27 +354,73 @@ def run_generate_job(job_id: str, *, ctx: Any, config: dict | None) -> None:
     if job is None:
         return
     try:
-        _run_generate_job_body(job, ctx=ctx, config=config or {})
+        traj_root = Path(ctx.traj_root) if getattr(ctx, "traj_root", None) is not None else None
+        _run_generate_job_body(
+            job,
+            skill_dir=Path(ctx.skill_dir),
+            traj_root=traj_root,
+            config=config or {},
+        )
     except Exception as error:  # noqa: BLE001 — job must end in failed, not crash thread
         logger.exception("generate job %s failed", job_id)
         _update_job(job_id, status="failed", error=str(error))
 
 
-def _run_generate_job_body(job: dict[str, Any], *, ctx: Any, config: dict) -> None:
+def run_claimed_generate_job(
+    job: dict[str, Any],
+    *,
+    skill_dir: Path,
+    config: dict | None,
+    db_path: Path | None = None,
+    logs_dir: Path | None = None,
+    traj_root: Path | None = None,
+) -> None:
+    """agent-worker edit 池线程入口：认领后的 payload 跑完并写 status 文件。"""
+    job_id = job["job_id"]
+    with _JOBS_LOCK:
+        stored = dict(job)
+        stored.setdefault("status", "running")
+        stored.setdefault("skill_names", [])
+        stored.setdefault("pinned", [])
+        stored.setdefault("error", "")
+        _JOBS[job_id] = stored
+    _update_job(job_id, status="running")
+    try:
+        _run_generate_job_body(
+            get_job(job_id) or stored,
+            skill_dir=Path(skill_dir),
+            traj_root=Path(traj_root) if traj_root is not None else None,
+            config=config or {},
+            db_path=db_path,
+            logs_dir=logs_dir,
+        )
+    except Exception as error:  # noqa: BLE001
+        logger.exception("generate job %s failed", job_id)
+        _update_job(job_id, status="failed", error=str(error))
+
+
+def _run_generate_job_body(
+    job: dict[str, Any],
+    *,
+    skill_dir: Path,
+    traj_root: Path | None,
+    config: dict,
+    db_path: Path | None = None,
+    logs_dir: Path | None = None,
+) -> None:
     from xskill.agents import agent_tools
     from xskill.agents.agno_factory import make_default_factory
     from xskill.agents.generate_agent import GenerateAgent
     from xskill.config import get_logs_dir, get_registry_db_path
 
-    skill_dir = Path(ctx.skill_dir)
-    traj_root = Path(ctx.traj_root) if ctx.traj_root is not None else None
-    extra_roots = collect_read_roots(skill_dir, traj_root)
-    logs_dir = get_logs_dir()
+    skill_dir = Path(skill_dir)
+    extra_roots = collect_read_roots(skill_dir, traj_root, db_path=db_path)
+    logs_dir = Path(logs_dir) if logs_dir is not None else get_logs_dir()
     spill_root = (
         logs_dir / "agents" / "generate_agents" / job["user_id"] / "spill" / job["job_id"]
     )
     spill_root.mkdir(parents=True, exist_ok=True)
-    db_path = get_registry_db_path()
+    resolved_db = Path(db_path) if db_path is not None else get_registry_db_path()
     agent_tools.reset_generate_session()
     tool_context = agent_tools.create_agent_tool_context(
         skill_dir=skill_dir,
@@ -185,7 +431,7 @@ def _run_generate_job_body(job: dict[str, Any], *, ctx: Any, config: dict) -> No
         spill_root=spill_root,
         extra_read_roots=tuple(extra_roots),
         generate_user_id=job["user_id"],
-        registry_db_path=db_path,
+        registry_db_path=resolved_db,
     )
     llm_cfg = {**(config.get("llm") or {}), **(config.get("llm_skill") or {})}
     factory = make_default_factory(
@@ -226,7 +472,7 @@ def _run_generate_job_body(job: dict[str, Any], *, ctx: Any, config: dict) -> No
     pinned = pin_generated_skills(
         user_id=job["user_id"],
         skill_names=skill_names,
-        db_path=db_path,
+        db_path=resolved_db,
         max_pinned=max_pinned,
     )
     _update_job(
@@ -238,17 +484,6 @@ def _run_generate_job_body(job: dict[str, Any], *, ctx: Any, config: dict) -> No
     )
 
 
-def start_generate_job_thread(job_id: str, *, ctx: Any, config: dict | None) -> None:
-    thread = threading.Thread(
-        target=run_generate_job,
-        args=(job_id,),
-        kwargs={"ctx": ctx, "config": config},
-        name=f"xskill-generate-{job_id[:8]}",
-        daemon=True,
-    )
-    thread.start()
-
-
 def iter_job_events(
     job_id: str,
     *,
@@ -257,8 +492,10 @@ def iter_job_events(
 ) -> Iterator[dict[str, Any]]:
     """Yield log chunks then a terminal event. Blocking generator.
 
-    Stays open until the job leaves ``running``. Quiet periods emit ping
-    events so proxies and the CLI do not treat a long model call as death.
+    Stays open until the job leaves ``queued`` / ``running``. Quiet periods
+    emit ping events so proxies and the CLI do not treat a long model call
+    as death. Status is re-read from the status file so the web process can
+    see the terminal state written by agent-worker.
     """
     job = get_job(job_id)
     if job is None:
@@ -278,7 +515,7 @@ def iter_job_events(
             yield {"type": "log", "chunk": chunk}
             last_emit = time.time()
         current = get_job(job_id) or job
-        if current.get("status") != "running":
+        if current.get("status") not in _ACTIVE_STATUSES:
             try:
                 data = log_path.read_bytes()
             except OSError:

--- a/src/xskill/team/shared/protocol.py
+++ b/src/xskill/team/shared/protocol.py
@@ -7,6 +7,8 @@ C 与 S 之间所有 HTTP body 的单一事实源。端点：
   GET  /api/v1/team/sync              (query)          -> SyncResponse
   GET  /api/v1/team/skill/{n}/bundle  (query)          -> application/octet-stream
   POST /api/v1/team/push-edit         (multipart)      -> PushEditResponse
+  POST /api/v1/team/generate          GenerateRequest  -> {job_id}
+  GET  /api/v1/team/generate/{id}/events  SSE 日志流
 
 鉴权（除 register 外所有端点）：HTTP header
   X-Xskill-Token   = server join token
@@ -95,3 +97,13 @@ class SyncResponse(BaseModel):
 class PushEditResponse(BaseModel):
     branch: str            # user-staging/<client_id>
     ref_sha: str
+
+
+class GenerateRequest(BaseModel):
+    instruction: str
+    names: list[str] = Field(default_factory=list)
+
+
+class GenerateAccepted(BaseModel):
+    job_id: str
+

--- a/tests/test_dashboard_pipeline_live.py
+++ b/tests/test_dashboard_pipeline_live.py
@@ -89,7 +89,7 @@ def test_full_status_shapes_three_monitored_pools(tmp_path):
     assert body["pid"] == 1234
     assert body["pending_atoms"] == 6
     assert body["llm"]["inflight"] == 2
-    assert set(body["pools"]) == {"split", "cluster", "edit"}
+    assert set(body["pools"]) == {"split", "cluster", "edit", "generate"}
 
     split = body["pools"]["split"]
     assert split["workers"] == 2
@@ -107,6 +107,12 @@ def test_full_status_shapes_three_monitored_pools(tmp_path):
     edit = body["pools"]["edit"]
     assert edit["seats"][0]["task"]["xfer"] == "baby_main"
     assert edit["failed"] == 0
+
+    generate = body["pools"]["generate"]
+    assert generate["workers"] == 3
+    assert generate["shared_pool"] == "edit"
+    assert generate["seats"] == [None, None, None]
+    assert generate["llm_weight"] == 1
 
 
 def test_legacy_worker_without_seat_bookkeeping_gets_explicit_empty_seats(tmp_path):
@@ -129,7 +135,39 @@ def test_empty_stats_means_worker_not_reporting(tmp_path):
     assert body["error"] == "boom"
 
 
-# ── tail_task_log ─────────────────────────────────────────────────
+def test_generate_seats_are_projected_out_of_edit_pool(tmp_path):
+    stats = _full_stats()
+    now = stats["heartbeat_at"]
+    stats["pools"]["edit"]["seats"][1] = {
+        "seat": 1, "started_at": now - 3,
+        "task": {"kind": "generate", "job_id": "abc123", "user_id": "alice",
+                 "instruction": "写一个发票技能"},
+    }
+    stats["pools"]["edit"]["queue"] = [
+        {"kind": "generate", "job_id": "def456", "user_id": "bob",
+         "instruction": "改现有 skill"},
+    ]
+    stats["generate"] = {"completed": 4, "failed": 1}
+    _write_status(tmp_path, stats)
+    body = pipeline_live(tmp_path / "r.db")
+    edit = body["pools"]["edit"]
+    generate = body["pools"]["generate"]
+    assert edit["seats"][0]["task"]["skill_name"] == "alpha"
+    assert edit["seats"][1] is None
+    assert generate["seats"][1]["task"]["job_id"] == "abc123"
+    assert generate["seats"][0] is None
+    assert generate["queue"][0]["job_id"] == "def456"
+    assert generate["completed"] == 4
+    assert generate["failed"] == 1
+
+
+def test_tail_log_reads_generate_job(tmp_path):
+    log_dir = tmp_path / "logs" / "agents" / "generate_agents" / "alice"
+    log_dir.mkdir(parents=True)
+    (log_dir / "jobdeadbeef.log").write_text("TURN 1\nthinking\n", encoding="utf-8")
+    body = tail_task_log(tmp_path / "r.db", kind="generate", name="jobdeadbeef")
+    assert body["exists"] is True
+    assert body["lines"] == ["TURN 1", "thinking"]
 
 def test_tail_log_missing_file_is_explicit_empty_state(tmp_path):
     body = tail_task_log(tmp_path / "r.db", kind="skill", name="nope")

--- a/tests/test_generate_command.py
+++ b/tests/test_generate_command.py
@@ -19,7 +19,7 @@ from xskill.skill.git import (
 from xskill.team.server import api as server_api
 from xskill.team.server.client_registry import ClientRegistry
 from xskill.team.server.generate_jobs import (
-    create_job, iter_job_events, pin_generated_skills,
+    create_job, enqueue_generate_job, iter_job_events, pin_generated_skills,
 )
 
 
@@ -161,6 +161,58 @@ def test_iter_job_events_pings_while_running(tmp_path: Path):
             break
     assert "ping" in seen
     assert "done" not in seen
+    assert job["status"] == "queued"
+
+
+def test_enqueue_writes_pending_file(tmp_path: Path):
+    logs = tmp_path / "logs"
+    logs.mkdir()
+    job = create_job(
+        client_id="c1",
+        user_id="alice",
+        instruction="写一个发票技能",
+        preferred_names=["alice"],
+        logs_dir=logs,
+    )
+    enqueue_generate_job(job, logs_dir=logs)
+    pending = tmp_path / "generate_jobs" / "pending" / f"{job['job_id']}.json"
+    assert pending.is_file()
+    payload = json.loads(pending.read_text(encoding="utf-8"))
+    assert payload["instruction"] == "写一个发票技能"
+    assert payload["user_id"] == "alice"
+
+
+def test_iter_job_events_follows_status_file(tmp_path: Path):
+    import threading
+    import time
+
+    logs = tmp_path / "logs"
+    logs.mkdir()
+    job = create_job(
+        client_id="c1",
+        user_id="alice",
+        instruction="x",
+        preferred_names=[],
+        logs_dir=logs,
+    )
+    status_path = Path(job["log_path"]).with_suffix(".status.json")
+
+    def flip():
+        time.sleep(0.04)
+        payload = json.loads(status_path.read_text(encoding="utf-8"))
+        payload["status"] = "succeeded"
+        payload["skill_names"] = ["invoice-check"]
+        payload["pinned"] = ["invoice-check"]
+        status_path.write_text(json.dumps(payload), encoding="utf-8")
+
+    threading.Thread(target=flip, daemon=True).start()
+    events = list(iter_job_events(
+        job["job_id"], poll_seconds=0.01, ping_every=1.0,
+    ))
+    done = events[-1]
+    assert done["type"] == "done"
+    assert done["ok"] is True
+    assert done["skill_names"] == ["invoice-check"]
 
 
 @pytest.fixture
@@ -180,12 +232,11 @@ def team_client(tmp_path, monkeypatch):
         register_dir=lambda path, label: None,
     )
 
-    def fake_start(job_id, *, ctx, config):
-        from xskill.team.server.generate_jobs import _update_job, get_job
-        job = get_job(job_id)
+    def fake_enqueue(job, *, logs_dir):
+        from xskill.team.server.generate_jobs import _update_job
         Path(job["log_path"]).write_text("round 1 thinking\n", encoding="utf-8")
         _update_job(
-            job_id,
+            job["job_id"],
             status="succeeded",
             skill_names=["invoice-check"],
             pinned=["invoice-check"],
@@ -193,8 +244,8 @@ def team_client(tmp_path, monkeypatch):
         )
 
     monkeypatch.setattr(
-        "xskill.team.server.generate_jobs.start_generate_job_thread",
-        fake_start,
+        "xskill.team.server.generate_jobs.enqueue_generate_job",
+        fake_enqueue,
     )
     app = FastAPI()
     app.include_router(server_api.router)
@@ -301,3 +352,64 @@ def test_generate_cli_parser_and_stream(monkeypatch, capsys):
     out = capsys.readouterr().out
     assert "thinking" in out
     assert "invoice-check" in out
+
+
+def test_generate_jobs_submit_to_edit_pool(tmp_path, monkeypatch):
+    import time
+
+    from xskill.pipeline.runner import DirectoryWatcher
+
+    logs = tmp_path / "logs"
+    logs.mkdir()
+    skill_dir = tmp_path / "skill"
+    skill_dir.mkdir()
+    job = create_job(
+        client_id="c1",
+        user_id="alice",
+        instruction="写一个发票技能",
+        preferred_names=[],
+        logs_dir=logs,
+    )
+    enqueue_generate_job(job, logs_dir=logs)
+    held = []
+
+    def fake_run(claimed, **kwargs):
+        held.append(claimed["job_id"])
+        time.sleep(0.25)
+
+    monkeypatch.setattr(
+        "xskill.team.server.generate_jobs.run_claimed_generate_job",
+        fake_run,
+    )
+    watcher = DirectoryWatcher(
+        llm=None, embed_client=None, config={},
+        skill_dir=skill_dir, poll_interval=1,
+        logs_dir=logs, xskill_home=tmp_path, home_root=tmp_path,
+        pool_config={
+            "split": {"workers": 1, "llm_weight": 1},
+            "cluster": {"workers": 1, "batch_size": 1, "llm_weight": 1},
+            "edit": {"workers": 2, "batch_size": 1, "llm_weight": 1},
+            "embed": {"workers": 1},
+        },
+    )
+    watcher._submit_generate_jobs()
+    deadline = time.time() + 2
+    generate_seats = []
+    while time.time() < deadline:
+        generate_seats = [
+            seat for seat in watcher._pools["edit"].status["seats"]
+            if seat and (seat.get("task") or {}).get("kind") == "generate"
+        ]
+        if generate_seats:
+            break
+        time.sleep(0.02)
+    assert generate_seats
+    assert generate_seats[0]["task"]["job_id"] == job["job_id"]
+    assert generate_seats[0]["task"]["user_id"] == "alice"
+    for fut in list(watcher._futures):
+        fut.result(timeout=2)
+    watcher._harvest()
+    assert held == [job["job_id"]]
+    assert watcher._generate_completed == 1
+    claimed = tmp_path / "generate_jobs" / "claimed" / f"{job['job_id']}.json"
+    assert not claimed.exists()

--- a/tests/test_generate_command.py
+++ b/tests/test_generate_command.py
@@ -18,7 +18,9 @@ from xskill.skill.git import (
 )
 from xskill.team.server import api as server_api
 from xskill.team.server.client_registry import ClientRegistry
-from xskill.team.server.generate_jobs import pin_generated_skills
+from xskill.team.server.generate_jobs import (
+    create_job, iter_job_events, pin_generated_skills,
+)
 
 
 def _call_tool(tool, *args, **kwargs):
@@ -138,6 +140,27 @@ def test_pin_generated_skills(tmp_path: Path):
     assert pinned == ["invoice-check"]
     rows = prefs_for("alice", db_path=db)
     assert any(r["skill_name"] == "invoice-check" and r["pref"] == "pinned" for r in rows)
+
+
+def test_iter_job_events_pings_while_running(tmp_path: Path):
+    logs = tmp_path / "logs"
+    logs.mkdir()
+    job = create_job(
+        client_id="c1",
+        user_id="alice",
+        instruction="x",
+        preferred_names=[],
+        logs_dir=logs,
+    )
+    seen = []
+    for event in iter_job_events(
+        job["job_id"], poll_seconds=0.01, ping_every=0.02,
+    ):
+        seen.append(event["type"])
+        if event["type"] == "ping":
+            break
+    assert "ping" in seen
+    assert "done" not in seen
 
 
 @pytest.fixture

--- a/tests/test_generate_command.py
+++ b/tests/test_generate_command.py
@@ -1,0 +1,280 @@
+"""generate 快路径：直接提交 main、edit 先读后改、team API 与 CLI。"""
+from __future__ import annotations
+
+import json
+from pathlib import Path
+
+import pytest
+from fastapi import FastAPI
+from fastapi.testclient import TestClient
+
+from xskill.agents import agent_tools
+from xskill.cli import build_parser, cmd_generate
+from xskill.pipeline.registry import prefs_for
+from xskill.skill.git import (
+    commit_generate_to_main_branch,
+    current_branch,
+    init_skill_repo_on_baby,
+)
+from xskill.team.server import api as server_api
+from xskill.team.server.client_registry import ClientRegistry
+from xskill.team.server.generate_jobs import pin_generated_skills
+
+
+def _call_tool(tool, *args, **kwargs):
+    entrypoint = tool if callable(tool) else getattr(tool, "entrypoint")
+    return entrypoint(*args, **kwargs)
+
+
+def _bind_skill_ctx(tmp_path: Path, **extra):
+    skill_dir = tmp_path / "skill"
+    skill_dir.mkdir()
+    ctx = agent_tools.create_agent_tool_context(
+        skill_dir=skill_dir,
+        atom_skill_dir=skill_dir,
+        extra_read_roots=extra.get("extra_read_roots", (skill_dir,)),
+        generate_user_id=extra.get("generate_user_id", "alice"),
+        registry_db_path=extra.get("registry_db_path"),
+    )
+    agent_tools.reset_generate_session()
+    return skill_dir, ctx
+
+
+def test_commit_generate_creates_main_from_empty_dir(tmp_path: Path):
+    target = tmp_path / "empty-skill"
+    sha = commit_generate_to_main_branch(str(target), "generate-by: alice\n\ninit")
+    assert sha
+    assert current_branch(str(target)) == "main"
+    second = commit_generate_to_main_branch(str(target), "generate-by: alice\n\nagain")
+    assert second != sha
+    assert current_branch(str(target)) == "main"
+
+
+def test_commit_generate_promotes_baby_to_main(tmp_path: Path):
+    skill_dir = tmp_path / "skill"
+    skill_dir.mkdir()
+    init_skill_repo_on_baby(str(skill_dir / "demo"), name="demo", description="d")
+    assert current_branch(str(skill_dir / "demo")) == "baby"
+    commit_generate_to_main_branch(str(skill_dir / "demo"), "generate-by: bob\n\npublish")
+    assert current_branch(str(skill_dir / "demo")) == "main"
+
+
+def test_edit_requires_prior_read(tmp_path: Path):
+    skill_dir, ctx = _bind_skill_ctx(tmp_path)
+    target = skill_dir / "demo"
+    target.mkdir()
+    skill_md = target / "SKILL.md"
+    skill_md.write_text(
+        "---\nname: demo\ndescription: hello world\n---\n\n# Demo\n\nold line\n",
+        encoding="utf-8",
+    )
+    with agent_tools.use_agent_tool_context(ctx):
+        denied = _call_tool(
+            agent_tools.edit_file,
+            path=str(skill_md),
+            old_string="old line",
+            new_string="new line",
+        )
+        assert denied.startswith("error:")
+        assert "has not been read" in denied
+        _call_tool(agent_tools.read_file, str(skill_md))
+        ok = _call_tool(
+            agent_tools.edit_file,
+            path=str(skill_md),
+            old_string="old line",
+            new_string="new line",
+        )
+        assert ok.startswith("edited:")
+    assert "new line" in skill_md.read_text(encoding="utf-8")
+
+
+def test_generate_read_roots_include_traj_not_parent_secrets(tmp_path: Path):
+    skill_dir, ctx = _bind_skill_ctx(tmp_path)
+    traj = tmp_path / "team_trajectories" / "clients" / "alice" / "sessions"
+    traj.mkdir(parents=True)
+    (traj / "traj_1.md").write_text("invoice workflow\n", encoding="utf-8")
+    secret = tmp_path / "config.yaml"
+    secret.write_text("api_key: nope\n", encoding="utf-8")
+    ctx = agent_tools.create_agent_tool_context(
+        skill_dir=skill_dir,
+        atom_skill_dir=skill_dir,
+        extra_read_roots=(skill_dir, tmp_path / "team_trajectories"),
+    )
+    with agent_tools.use_agent_tool_context(ctx):
+        hit = _call_tool(
+            agent_tools.grep_files,
+            pattern="invoice",
+            path=str(tmp_path / "team_trajectories"),
+        )
+        assert "invoice" in hit
+        blocked = _call_tool(agent_tools.read_file, str(secret))
+        assert blocked.startswith("error:")
+
+
+def test_commit_generate_main_tool_prefixes_user(tmp_path: Path):
+    skill_dir, ctx = _bind_skill_ctx(tmp_path)
+    with agent_tools.use_agent_tool_context(ctx):
+        result = _call_tool(
+            agent_tools.commit_generate_main,
+            skill_name="fresh-skill",
+            message="created from generate",
+        )
+    assert result.startswith("committed to main: fresh-skill")
+    repo = skill_dir / "fresh-skill"
+    assert current_branch(str(repo)) == "main"
+    assert agent_tools.generate_committed_skills() == ["fresh-skill"]
+
+
+def test_pin_generated_skills(tmp_path: Path):
+    db = tmp_path / "registry.db"
+    from xskill.pipeline.registry import register_dir
+    register_dir(tmp_path / "wd", label="t", db_path=db)
+    pinned = pin_generated_skills(
+        user_id="alice",
+        skill_names=["invoice-check"],
+        db_path=db,
+        max_pinned=10,
+    )
+    assert pinned == ["invoice-check"]
+    rows = prefs_for("alice", db_path=db)
+    assert any(r["skill_name"] == "invoice-check" and r["pref"] == "pinned" for r in rows)
+
+
+@pytest.fixture
+def team_client(tmp_path, monkeypatch):
+    skill_dir = tmp_path / "skill"
+    skill_dir.mkdir()
+    traj_root = tmp_path / "team_traj"
+    logs = tmp_path / "logs"
+    logs.mkdir()
+    monkeypatch.setattr("xskill.config.get_logs_dir", lambda: logs)
+    reg = ClientRegistry(tmp_path / "clients.db")
+    server_api.init_team_context(
+        join_token="secret-token",
+        client_registry=reg,
+        skill_dir=skill_dir,
+        traj_root=traj_root,
+        register_dir=lambda path, label: None,
+    )
+
+    def fake_start(job_id, *, ctx, config):
+        from xskill.team.server.generate_jobs import _update_job, get_job
+        job = get_job(job_id)
+        Path(job["log_path"]).write_text("round 1 thinking\n", encoding="utf-8")
+        _update_job(
+            job_id,
+            status="succeeded",
+            skill_names=["invoice-check"],
+            pinned=["invoice-check"],
+            error="",
+        )
+
+    monkeypatch.setattr(
+        "xskill.team.server.generate_jobs.start_generate_job_thread",
+        fake_start,
+    )
+    app = FastAPI()
+    app.include_router(server_api.router)
+    return TestClient(app), logs
+
+
+def test_generate_api_streams_log_and_done(team_client):
+    client, _logs = team_client
+    registered = client.post(
+        "/api/v1/team/register",
+        json={"token": "secret-token", "client_label": "alice",
+              "hostname": "a", "user_name": "alice"},
+    )
+    assert registered.status_code == 200
+    cid = registered.json()["client_id"]
+    hdr = {"X-Xskill-Token": "secret-token", "X-Xskill-Client": cid}
+    started = client.post(
+        "/api/v1/team/generate",
+        headers=hdr,
+        json={"instruction": "写一个发票核对技能", "names": ["alice"]},
+    )
+    assert started.status_code == 200
+    job_id = started.json()["job_id"]
+    with client.stream(
+        "GET", f"/api/v1/team/generate/{job_id}/events", headers=hdr,
+    ) as stream:
+        assert stream.status_code == 200
+        body = "".join(stream.iter_text())
+    assert "thinking" in body
+    assert '"type": "done"' in body or '"type":"done"' in body
+    assert "invoice-check" in body
+
+
+def test_generate_cli_parser_and_stream(monkeypatch, capsys):
+    parser = build_parser()
+    args = parser.parse_args(
+        ["generate", "--name", "alice,bob", "写一个", "发票技能"],
+    )
+    assert args.command == "generate"
+    assert args.name == "alice,bob"
+    assert args.instruction == ["写一个", "发票技能"]
+
+    class FakeResp:
+        def __init__(self, status_code, payload):
+            self.status_code = status_code
+            self._payload = payload
+            self.text = json.dumps(payload)
+
+        def json(self):
+            return self._payload
+
+    class FakeStream:
+        status_code = 200
+
+        def __enter__(self):
+            return self
+
+        def __exit__(self, *exc):
+            return False
+
+        def iter_text(self):
+            events = [
+                {"type": "log", "chunk": "thinking...\n"},
+                {"type": "done", "ok": True,
+                 "skill_names": ["invoice-check"],
+                 "pinned": ["invoice-check"], "error": ""},
+            ]
+            for event in events:
+                yield f"data: {json.dumps(event)}\n\n"
+
+    class FakeClient:
+        base_url = "http://server"
+
+        def __init__(self, **kwargs):
+            del kwargs
+
+        def __enter__(self):
+            return self
+
+        def __exit__(self, *exc):
+            return False
+
+        def post(self, url, json=None, headers=None):
+            assert url == "/api/v1/team/generate"
+            assert json["instruction"] == "写一个 发票技能"
+            assert json["names"] == ["alice", "bob"]
+            return FakeResp(200, {"job_id": "abc"})
+
+        def stream(self, method, url, headers=None):
+            assert method == "GET"
+            assert url.endswith("/abc/events")
+            return FakeStream()
+
+        def close(self):
+            return None
+
+    class FakeOuter(FakeClient):
+        pass
+
+    import httpx
+    monkeypatch.setattr(httpx, "Client", FakeClient)
+    rc = cmd_generate(args, http=FakeOuter(), headers={})
+    assert rc == 0
+    out = capsys.readouterr().out
+    assert "thinking" in out
+    assert "invoice-check" in out


### PR DESCRIPTION
## Summary
- 为已 connect 的 team 客户端增加 `xskill generate`：把用户指令交给 server 上的生成代理，阻塞并流式打印思维过程日志。
- 代理复用 list/grep/read/write/new_skill_folder，新做先读后改的 edit，以及无论当前 git 状态都提交到 main 的 commit 工具。
- 提交成功后把技能钉到发起人自己的推荐列表；commit message 带上 `generate-by: <user_id>`。

Closes #215

## Test plan
- [x] `pytest tests/test_generate_command.py tests/test_team_server_api.py tests/test_agent_tool_context_isolation.py`
- [x] 已 connect 的客户端：`xskill generate --name 张三 "写一个……技能"`，终端能看到日志，结束后 skill 仓库有 main、发起人偏好里能看到 pin
- [x] 未 connect 时报错方式和 `xskill search` 一致
- [x] 改已有技能时不出现 staging 分支


Made with [Cursor](https://cursor.com)