### PR TITLE
feat: xskill import and experimental skill scripting

### DIFF
--- a/src/xskill/agents/__init__.py
+++ b/src/xskill/agents/__init__.py
@@ -6,6 +6,7 @@
 - ``task_cluster_agent``    把 AtomTask 路由到匹配的 skill
 - ``skill_edit_agent``      从攒够的候选合成 / 更新 SKILL.md
 - ``generate_agent``        用户点名即时生成或改写 skill（直接提交 main）
+- ``skill_scripting_agent`` 实验性：把主干技能改得更偏可执行脚本
 - ``user_edit_absorb_agent``  吸收用户手改为 ground truth
 - ``agno_factory``          创建 agno.Agent 的共享工厂（模型路由 / SSL）
 - ``agent_tools``           agent 工具和运行时依赖

--- a/src/xskill/agents/skill_scripting_agent.py
+++ b/src/xskill/agents/skill_scripting_agent.py
@@ -1,0 +1,173 @@
+"""SkillScriptingAgent —— 把已有主干技能改得更偏可执行脚本（#213 实验性）。
+
+形态接近 SkillEditAgent，提示词不同：可执行步骤进 scripts/，正文只留何时
+调用、怎么调、参数和坑。提交走 commit_update_main，不开灰度、不用 jam 门。
+"""
+from __future__ import annotations
+
+import logging
+from dataclasses import dataclass
+from pathlib import Path
+from typing import Any, Callable
+
+logger = logging.getLogger("xskill.agents.skill_scripting_agent")
+
+_SYSTEM_PROMPT = """你是 SkillScriptingAgent。用户点了「脚本化（实验性）」，要把
+当前这份已经在主干上的技能改得更偏可执行脚本。
+
+# 你的目标
+
+读现有 SKILL.md 和目录里的脚本、参考材料，把能机械执行的步骤写成
+``scripts/`` 下的参数化脚本（Python 或 shell）。不要把本机路径、用户名、
+一次运行里的文件名写死；用参数或环境变量。正文 SKILL.md 只保留：
+
+- 何时该用这个技能
+- 调用哪个脚本、传什么参数
+- 关键坑和验证方式
+
+不要新开灰度分支，不要调 commit_to_staging。写完必须调
+``commit_update_main(skill_name, message)`` 把改动直接提交到主干。
+
+# 目录约定
+
+- ``<skill_dir>/SKILL.md`` — 必产物，frontmatter schema 不变
+- ``<skill_dir>/scripts/`` — 可执行脚本（参数化）
+- ``<skill_dir>/references/`` — 长参考材料（可选）
+
+# 纪律
+
+- 不要删掉仍有用的 when / 坑；只是把步骤从正文搬进脚本。
+- 正文仍要合法 frontmatter（name、description）。
+- 不要改 ``.candidates.yml``、``.ux_scores.jsonl`` 这些运行时辅助文件。
+"""
+
+
+@dataclass
+class SkillScriptingAgent:
+    skill_dir: Path
+    agno_agent_factory: Callable[..., Any]
+    llm_cfg: dict
+    logs_dir: Path | None = None
+
+    def __post_init__(self) -> None:
+        self.skill_dir = Path(self.skill_dir)
+        if self.logs_dir is not None:
+            self.logs_dir = Path(self.logs_dir)
+
+    def _trace_path(self) -> Path | None:
+        if self.logs_dir is None:
+            return None
+        return (
+            self.logs_dir
+            / "agents"
+            / "skill_edit_agents"
+            / "skills"
+            / f"{self.skill_dir.name}.log"
+        )
+
+    def run(self) -> bool:
+        """把当前主干技能脚本化并提交。成功返回 True。"""
+        from xskill.agents import agent_tools
+        from xskill.canary import has_staging
+        from xskill.skill.frontmatter import FrontmatterError, parse_strict
+        from xskill.skill.git import (
+            commit_update_main_branch,
+            current_branch,
+            ensure_head_on_main,
+            run_git,
+        )
+
+        if has_staging(self.skill_dir):
+            logger.info("scripting skip (staging exists): %s", self.skill_dir.name)
+            return False
+        branch = current_branch(str(self.skill_dir)) or ""
+        if branch == "baby":
+            logger.info("scripting skip (baby): %s", self.skill_dir.name)
+            return False
+        ensure_head_on_main(self.skill_dir)
+
+        skill_md = self.skill_dir / "SKILL.md"
+        mtime_before = skill_md.stat().st_mtime if skill_md.is_file() else 0
+        size_before = skill_md.stat().st_size if skill_md.is_file() else 0
+        code, sha_before, _ = run_git(["rev-parse", "HEAD"], cwd=str(self.skill_dir))
+        sha_before = sha_before.strip() if code == 0 else ""
+
+        lines = [
+            f"skill_name: {self.skill_dir.name}",
+            f"skill_base_path: {self.skill_dir}",
+            "当前在主干。写完调用 commit_update_main。",
+            "",
+            "# 当前 skill 文件树",
+        ]
+        entries = 0
+        for path in sorted(self.skill_dir.rglob("*")):
+            rel = path.relative_to(self.skill_dir)
+            if ".git" in rel.parts:
+                continue
+            if rel.name in {".candidates.yml", ".ux_scores.jsonl", ".lock",
+                            ".scripting_requested"}:
+                continue
+            suffix = "/" if path.is_dir() else ""
+            lines.append(f"- {rel.as_posix()}{suffix}")
+            entries += 1
+            if entries >= 80:
+                lines.append("- ... truncated")
+                break
+        user_msg = "\n".join(lines)
+        tools = [
+            agent_tools.skill_read,
+            agent_tools.read_file,
+            agent_tools.list_files,
+            agent_tools.grep_files,
+            agent_tools.write_file,
+            agent_tools.commit_update_main,
+        ]
+        agent = self.agno_agent_factory(instructions=[_SYSTEM_PROMPT], tools=tools)
+        from xskill.agents.agent_trace import trace_to
+        from xskill.agents.context_budget import (
+            DEFAULT_MAX_CONTEXT,
+            TRIM_TRIGGER_RATIO,
+        )
+
+        max_context = int(
+            (self.llm_cfg or {}).get("max_context") or DEFAULT_MAX_CONTEXT
+        )
+        spill_limit = int(max_context * TRIM_TRIGGER_RATIO)
+        with trace_to(self._trace_path(), append=True, spill_token_limit=spill_limit):
+            agent.run(user_msg)
+
+        if not skill_md.is_file() or skill_md.stat().st_size == 0:
+            logger.warning("scripting left empty SKILL.md: %s", self.skill_dir.name)
+            return False
+        try:
+            parse_strict(skill_md.read_text(encoding="utf-8"))
+        except FrontmatterError as exc:
+            logger.warning(
+                "scripting wrote invalid SKILL.md: %s — %s",
+                self.skill_dir.name, exc,
+            )
+            return False
+
+        wrote = (
+            skill_md.stat().st_mtime > mtime_before
+            or skill_md.stat().st_size != size_before
+        )
+        code, sha_after, _ = run_git(["rev-parse", "HEAD"], cwd=str(self.skill_dir))
+        sha_after = sha_after.strip() if code == 0 else ""
+        if sha_after and sha_after != sha_before:
+            logger.info("scripting committed on main: %s %s", self.skill_dir.name, sha_after[:8])
+            return True
+        if wrote:
+            ok = commit_update_main_branch(
+                str(self.skill_dir),
+                f"scripting: {self.skill_dir.name}",
+            )
+            if ok:
+                return True
+            logger.warning(
+                "scripting wrote files but commit_update_main_branch returned false: %s",
+                self.skill_dir.name,
+            )
+            return False
+        logger.warning("scripting made no file or commit change: %s", self.skill_dir.name)
+        return False

--- a/src/xskill/canary.py
+++ b/src/xskill/canary.py
@@ -716,6 +716,50 @@ def append_ux_score(
     return True
 
 
+def clear_current_main_round_scores(
+    skill_dir: Path,
+    *,
+    commit_sha: str,
+    limit: int = 5,
+) -> int:
+    """删掉当前这一轮挂在旧主干 sha 上的体验分（最多 ``limit`` 条，默认 5）。
+
+    只动这一侧、这一次 sha 的最近几条。更早提交上的分全部留着。灰度侧不动。
+    """
+    if not commit_sha:
+        return 0
+    skill_dir = Path(skill_dir)
+    rows = load_ux_scores(skill_dir)
+    matching = [
+        (i, row) for i, row in enumerate(rows)
+        if row.get("side") == "main" and row.get("commit_sha") == commit_sha
+    ]
+    matching.sort(key=lambda item: str(item[1].get("scored_at") or ""), reverse=True)
+    drop_idx = {i for i, _ in matching[: max(0, int(limit))]}
+    if not drop_idx:
+        return 0
+    kept = [row for i, row in enumerate(rows) if i not in drop_idx]
+    p = _ux_scores_path(skill_dir)
+    text = "".join(
+        json.dumps(row, ensure_ascii=False) + "\n" for row in kept
+    )
+    p.write_text(text, encoding="utf-8")
+    dropped = [row for i, row in matching if i in drop_idx]
+    try:
+        from xskill.pipeline.ux_scores_store import delete_ux_scores_for_sha
+        delete_ux_scores_for_sha(
+            Path(skill_dir).name, side="main", commit_sha=commit_sha,
+            scored_at_values=[str(r.get("scored_at") or "") for r in dropped],
+        )
+    except Exception:
+        logger.debug("ux_scores db delete after import failed", exc_info=True)
+    logger.info(
+        "cleared %d current-round main ux scores for %s sha=%s",
+        len(drop_idx), skill_dir.name, commit_sha[:8],
+    )
+    return len(drop_idx)
+
+
 def _mirror_ux_score_to_db(record: dict) -> None:
     """写盘成功后旁路入库；失败只打日志，由定时盘→库任务兜底。"""
     try:

--- a/src/xskill/cli.py
+++ b/src/xskill/cli.py
@@ -1652,6 +1652,188 @@ def cmd_generate(args, http=None, headers=None) -> int:
     return 0
 
 
+def _is_thin_team_client() -> bool:
+    """已 connect 且本机没有 standalone/server 的 watch_dirs → 瘦客户端。"""
+    from xskill.config import get_team_client_state_path
+    return (
+        get_team_client_state_path().is_file()
+        and _standalone_watch_dir_count() == 0
+    )
+
+
+def _local_import_skill_dir():
+    from xskill.config import CONFIG_PATH, XSKILL_HOME, get_skill_dir
+    if CONFIG_PATH.is_file():
+        try:
+            return get_skill_dir()
+        except Exception:
+            pass
+    return XSKILL_HOME / "skill"
+
+
+def _print_import_result(imported, *, json_mode: bool) -> None:
+    import json as _json
+    if json_mode:
+        print(_json.dumps({
+            "name": imported.name,
+            "sha": imported.sha,
+            "existed": imported.existed,
+            "baby_overwritten": imported.baby_overwritten,
+            "staging_kept": imported.staging_kept,
+            "main_round_scores_cleared": imported.main_round_scores_cleared,
+            "stash_path": imported.stash_path,
+            "warnings": imported.warnings,
+        }, ensure_ascii=False, indent=2))
+        return
+    verb = "更新" if imported.existed else "纳入"
+    print(f"imported: {imported.name}  ({verb} 主干 {imported.sha[:8]})")
+    if imported.baby_overwritten:
+        print("  原来停在预备分支 baby 的草稿已被这次导入覆盖")
+    if imported.staging_kept:
+        print("  灰度分支 staging 仍在，继续和新主干对比"
+              f"（清了当前轮主干体验分 {imported.main_round_scores_cleared} 条）")
+    if imported.stash_path:
+        print(f"  未提交内容已拷到 {imported.stash_path}，本机已换成这次导入的版本")
+    for warning in imported.warnings:
+        print(f"warning: {warning}", file=sys.stderr)
+
+
+def cmd_import(args, http=None, headers=None) -> int:
+    """`xskill import <路径>` —— 把已有技能目录纳入自有仓，不是 upload。"""
+    from pathlib import Path
+    from xskill.config import XSKILL_HOME
+    from xskill.skill.importer import discover_import_sources, import_skill_path
+
+    source = Path(args.path).expanduser()
+    try:
+        sources = discover_import_sources(source)
+    except FileNotFoundError as missing:
+        print(f"error: {missing}", file=sys.stderr)
+        return 2
+
+    if _is_thin_team_client():
+        return _cmd_import_team(
+            args, sources, http=http, headers=headers,
+        )
+
+    home = Path.home()
+    skill_dir = _local_import_skill_dir()
+    try:
+        results = import_skill_path(
+            skill_dir, source, install=True, home_root=home,
+            stash_home=XSKILL_HOME,
+        )
+    except (FileNotFoundError, ValueError, RuntimeError) as failed:
+        print(f"error: {failed}", file=sys.stderr)
+        return 1
+    for imported in results:
+        _print_import_result(imported, json_mode=args.json)
+    return 0
+
+
+def _cmd_import_team(args, sources, *, http=None, headers=None) -> int:
+    import httpx
+    from pathlib import Path
+    from xskill.config import (
+        XSKILL_HOME,
+        get_team_client_history_path,
+        get_team_client_state_path,
+    )
+    from xskill.skill.importer import (
+        HARNESS_IMPORT_WARNING,
+        ImportResult,
+        is_harness_skill_path,
+        maybe_stash_overwrite_dir,
+        pack_import_zip,
+    )
+    from xskill.team.client.import_follow import follow_imported_skill
+    from xskill.team.client.state import load_client_state
+
+    if http is None:
+        http, headers = _team_client_http_and_headers()
+        if http is None:
+            return 1
+        http.timeout = 120.0
+
+    skill_dir = XSKILL_HOME / "skill"
+    home = Path.home()
+    state = load_client_state(get_team_client_state_path())
+    history_path = get_team_client_history_path(state.server_url)
+
+    for source in sources:
+        name = source.name
+        if is_harness_skill_path(source, home_root=home):
+            print(f"warning: {HARNESS_IMPORT_WARNING}", file=sys.stderr)
+        stash = maybe_stash_overwrite_dir(
+            source, name, home_root=XSKILL_HOME,
+        )
+        working = skill_dir / name
+        if working.exists() and working.resolve() != source.resolve():
+            extra = maybe_stash_overwrite_dir(
+                working, name, home_root=XSKILL_HOME,
+            )
+            stash = stash or extra
+        payload = pack_import_zip(source, include_git=True)
+        if len(payload) > 50 * 1024 * 1024:
+            print(f"error: {name} 打包后超过 50MB", file=sys.stderr)
+            return 2
+        try:
+            resp = http.post(
+                "/api/v1/team/skills/import",
+                files={"file": (f"{name}.zip", payload, "application/zip")},
+                data={"name": name},
+                headers=headers,
+            )
+        except (httpx.HTTPError, OSError) as network_error:
+            print(f"error: 无法连接 team server（{type(network_error).__name__}: "
+                  f"{network_error}）", file=sys.stderr)
+            return 1
+        if resp.status_code == 404:
+            print("error: server 版本过旧，不支持技能纳入（需含 /skills/import）",
+                  file=sys.stderr)
+            return 1
+        if resp.status_code != 200:
+            print(f"error: 纳入失败 HTTP {resp.status_code}: {resp.text[:300]}",
+                  file=sys.stderr)
+            return 1
+        body = resp.json()
+        imported = ImportResult(
+            name=body.get("name") or name,
+            existed=bool(body.get("existed")),
+            sha=str(body.get("sha") or ""),
+            baby_overwritten=bool(body.get("baby_overwritten")),
+            staging_kept=bool(body.get("staging_kept")),
+            main_round_scores_cleared=int(
+                body.get("main_round_scores_cleared") or 0
+            ),
+            stash_path=str(stash) if stash else "",
+        )
+        if is_harness_skill_path(source, home_root=home):
+            imported.warnings.append(HARNESS_IMPORT_WARNING)
+        try:
+            follow_imported_skill(
+                http=http,
+                headers=headers,
+                skill_dir=skill_dir,
+                name=imported.name,
+                sha=imported.sha,
+                home_root=home,
+                history_path=history_path,
+            )
+        except RuntimeError as follow_error:
+            print(f"error: 本机跟上这次主干失败: {follow_error}", file=sys.stderr)
+            return 1
+        _print_import_result(imported, json_mode=args.json)
+    return 0
+
+
+def cmd_read(args, xskill) -> int:
+    """`xskill read <PATH> --eco ngagent` —— 批量把 db 文件桥接入库。"""
+    del xskill  # CLI handler signature compatibility.
+    from xskill.pipeline.db_ingest import read_db_files
+    try:
+
+
 def cmd_read(args, xskill) -> int:
     """`xskill read <PATH> --eco ngagent` —— 批量把 db 文件桥接入库。"""
     del xskill  # CLI handler signature compatibility.
@@ -1863,6 +2045,12 @@ def build_parser() -> argparse.ArgumentParser:
         help="优先阅读的工号，逗号分隔；不传则提示词里写可看全量",
     )
 
+    p_import = sub.add_parser(
+        "import", help="把已有技能目录纳入自有仓（不是 upload）",
+    )
+    p_import.add_argument("path", type=str, help="技能目录，或含多个技能的父目录")
+    p_import.add_argument("--json", action="store_true", help="机读 JSON 输出")
+
     p_init = sub.add_parser(
         "init",
         help="一站式引导：装 xskill 使用指南 skill 到各 agent + 连上 team server",
@@ -2060,6 +2248,8 @@ def main() -> int:
         return cmd_upload(args)
     if args.command == "generate":
         return cmd_generate(args)
+    if args.command == "import":
+        return cmd_import(args)
 
     # stats 只读 registry，不需要 config.yaml / llm.api_key / facade
     if args.command == "stats":

--- a/src/xskill/cli.py
+++ b/src/xskill/cli.py
@@ -1832,13 +1832,6 @@ def cmd_read(args, xskill) -> int:
     del xskill  # CLI handler signature compatibility.
     from xskill.pipeline.db_ingest import read_db_files
     try:
-
-
-def cmd_read(args, xskill) -> int:
-    """`xskill read <PATH> --eco ngagent` —— 批量把 db 文件桥接入库。"""
-    del xskill  # CLI handler signature compatibility.
-    from xskill.pipeline.db_ingest import read_db_files
-    try:
         summary = read_db_files(
             args.path,
             eco=args.eco,

--- a/src/xskill/dashboard/router.py
+++ b/src/xskill/dashboard/router.py
@@ -9,10 +9,11 @@ import json
 from pathlib import Path
 from typing import Optional
 
-from fastapi import APIRouter, HTTPException
+from fastapi import APIRouter, Depends, HTTPException
 from fastapi.responses import HTMLResponse, Response
 
 from xskill.dashboard.metrics import DashboardMetrics, skills_catalog_page
+from xskill.dashboard.auth import require_admin
 from xskill.pipeline.registry import (
     harness_share,
     list_watch_dirs,
@@ -180,9 +181,22 @@ def build_dashboard_router(db_path: Optional[Path] = None, *,
     @sensitive_router.get("/api/v1/dashboard/skill/{name}/detail")
     def skill_detail(name: str) -> dict:
         """该 skill 真实总触发 + 每版本统计(触发/UX/工具/token) + 按用户 + 趋势。"""
+        root = _skill_path(skill_dir, name)
         d = metrics.skill_detail(name)
-        d["versions_git"] = _git_versions(_skill_path(skill_dir, name))
+        d["versions_git"] = _git_versions(root)
+        from xskill.skill.scripting import scripting_status
+        d["scripting"] = scripting_status(root)
         return d
+
+    @sensitive_router.post("/api/v1/dashboard/skill/{name}/scripting")
+    def skill_scripting(name: str, _ident=Depends(require_admin)) -> dict:
+        """写 ``.scripting_requested``，由 agent-worker 扫到后脚本化主干。"""
+        from xskill.skill.scripting import request_scripting
+        root = _skill_path(skill_dir, name)
+        try:
+            return request_scripting(root)
+        except ValueError as exc:
+            raise HTTPException(status_code=409, detail=str(exc)) from exc
 
     @sensitive_router.get("/api/v1/dashboard/skill/{name}/graph")
     def skill_graph(name: str) -> dict:

--- a/src/xskill/dashboard/static/app.js
+++ b/src/xskill/dashboard/static/app.js
@@ -456,6 +456,13 @@ async function openSkill(name) {
     heads.main ? `<span class="inline-flex items-center gap-1.5 px-2.5 py-1 rounded-lg bg-white ring-1 ring-slate-200 text-xs font-medium text-slate-600">main <code class="text-slate-400">${esc(heads.main.slice(0, 7))}</code></span>` : '',
     heads.staging ? `<span class="inline-flex items-center gap-1.5 px-2.5 py-1 rounded-lg bg-amber-50 ring-1 ring-amber-200 text-xs font-medium text-amber-700"><span class="w-1.5 h-1.5 rounded-full bg-amber-400"></span>staging 灰度中 <code class="opacity-60">${esc(heads.staging.slice(0, 7))}</code></span>` : '',
   ].join(' ');
+  const sc = d.scripting || {};
+  let scriptBtn = '';
+  if (typeof IDENT !== 'undefined' && IDENT && IDENT.role === 'admin') {
+    const disabled = !sc.enabled;
+    const title = sc.reason || '把当前主干技能改得更偏可执行脚本';
+    scriptBtn = `<button type="button" class="px-2.5 py-1 rounded-lg text-xs ring-1 ${disabled ? 'bg-slate-50 text-slate-400 ring-slate-200 cursor-not-allowed' : 'bg-white text-teal-800 ring-teal-200 hover:bg-teal-50'}" data-skill-scripting="${esc(name)}" ${disabled ? 'disabled' : ''} title="${esc(title)}">脚本化（实验性）</button>`;
+  }
 
   const vrows = (d.versions || []).map(v =>
     `<tr><td class="py-2"><code class="text-[11px]">${esc((v.sha || '').slice(0, 8))}</code></td>`
@@ -488,7 +495,7 @@ async function openSkill(name) {
           · 贡献原子 <b class="text-slate-800 tabular-nums">${(lin.atoms || []).length}</b> 个
           ${lin.avg_ux != null ? `· 血缘平均 ux <b class="text-slate-800 tabular-nums">${lin.avg_ux}</b>` : ''}</div>
       </div>
-      <div class="flex gap-2">${headChips}</div>
+      <div class="flex gap-2 items-center flex-wrap">${headChips}${scriptBtn}</div>
     </div>
 
     <div class="grid grid-cols-12 gap-4 mt-4">
@@ -1209,6 +1216,7 @@ const PM_XFER = {
   baby_main: { from: 'baby', to: 'main', tip: '冷启动消化后 graduate' },
   main_staging: { from: 'main', to: 'staging', tip: '产灰度候选' },
   staging_main: { from: 'staging', to: 'main', tip: 'Jam 强砍回 main' },
+  main_scripting: { from: 'main', to: 'scripting', tip: '把主干技能脚本化（实验性）', label: 'main scripting' },
 };
 const PM_POLL_MS = 3000, PM_LOG_MS = 2500;
 let pmState = null;      // 最近一次 live 响应
@@ -1274,9 +1282,14 @@ function pmTaskCard(task, poolKey, selKey) {
   const style = queued ? ' style="cursor:default"' : '';
   if (task.kind === 'skill') {
     const x = PM_XFER[task.xfer];
+    const xferHtml = x
+      ? (x.label
+        ? `<div class="pm-xfer pm-xfer-${task.xfer}">${esc(x.label)}</div>`
+        : `<div class="pm-xfer pm-xfer-${task.xfer}">${x.from} <span class="arrow">→</span> ${x.to}</div>`)
+      : '';
     return `<div class="pm-card${sel}"${open}${style}>
       <div class="nm font-mono">${esc(task.skill_name)}</div>
-      ${x ? `<div class="pm-xfer pm-xfer-${task.xfer}">${x.from} <span class="arrow">→</span> ${x.to}</div>` : ''}
+      ${xferHtml}
       <div class="inf">${task.candidates != null ? `cand <b>${esc(task.candidates)}</b> · ` : ''}${task.weightscore != null ? `ws <b>${esc(task.weightscore)}</b> · ` : ''}${task._age != null ? pmAgeText(task._age) : '排队中'}</div>
     </div>`;
   }
@@ -1389,9 +1402,14 @@ function pmRenderDrawer() {
   let head = '', logHtml = '';
   if (task.kind === 'skill') {
     const x = PM_XFER[task.xfer];
+    const xferHead = x
+      ? (x.label
+        ? `<span class="pm-xfer pm-xfer-${task.xfer}" style="margin-top:0">${esc(x.label)}</span>`
+        : `<span class="pm-xfer pm-xfer-${task.xfer}" style="margin-top:0">${x.from} <span class="arrow">→</span> ${x.to}</span>`)
+      : '';
     head = `<h2 class="font-mono text-sm font-semibold break-all">${esc(task.skill_name)}</h2>
       <div class="text-[11px] text-slate-400 mt-0.5">${def.title} · 席位 ${pmSelected.seat + 1} · 已跑 ${age}</div>
-      ${x ? `<div class="flex items-center gap-2 flex-wrap mt-1"><span class="pm-xfer pm-xfer-${task.xfer}" style="margin-top:0">${x.from} <span class="arrow">→</span> ${x.to}</span><span class="text-xs text-slate-500">${x.tip}</span>
+      ${x ? `<div class="flex items-center gap-2 flex-wrap mt-1">${xferHead}<span class="text-xs text-slate-500">${x.tip}</span>
       <span class="text-[11px] text-slate-400">${task.candidates != null ? `cand ${esc(task.candidates)} · ` : ''}${task.weightscore != null ? `ws ${esc(task.weightscore)}` : ''}</span></div>` : ''}`;
     logHtml = logPane;
   } else if (task.kind === 'traj') {
@@ -1612,6 +1630,19 @@ document.addEventListener('click', async e => {
       rb.title = '诱饵清单: ' + ((data.catalog || []).join(', ') || '空');
     } catch (err) { rb.textContent = '错误'; }
     rb.disabled = false;
+    return;
+  }
+  const scriptBtn = e.target.closest('[data-skill-scripting]');
+  if (scriptBtn && !scriptBtn.disabled) {
+    scriptBtn.disabled = true;
+    scriptBtn.textContent = '已排队…';
+    jpost('api/v1/dashboard/skill/' + encodeURIComponent(scriptBtn.dataset.skillScripting) + '/scripting', {})
+      .then(() => { scriptBtn.textContent = '脚本化进行中'; })
+      .catch(err => {
+        scriptBtn.disabled = false;
+        scriptBtn.textContent = '脚本化（实验性）';
+        scriptBtn.title = String(err && err.message ? err.message : err);
+      });
     return;
   }
   const pinTr = e.target.closest('#ustatus-body tr[data-uid]');

--- a/src/xskill/dashboard/static/index.html
+++ b/src/xskill/dashboard/static/index.html
@@ -44,6 +44,7 @@
   .pm-xfer-baby_main{background:#e0f2fe;color:#0369a1}
   .pm-xfer-main_staging{background:#ecfdf5;color:#047857}
   .pm-xfer-staging_main{background:#fff7ed;color:#c2410c}
+  .pm-xfer-main_scripting{background:#f5f3ff;color:#6d28d9}
   .pm-foot{margin-top:auto;padding-top:6px;border-top:1px dashed #e2e8f0;color:#94a3b8;font-size:10.5px;display:flex;justify-content:space-between}
   .pm-drawer{margin-top:10px;background:#fff;border-radius:12px;padding:12px;display:flex;flex-direction:column;gap:8px}
   .pm-drawer.empty{align-items:center;justify-content:center;color:#94a3b8;min-height:140px;text-align:center}

--- a/src/xskill/pipeline/runner.py
+++ b/src/xskill/pipeline/runner.py
@@ -390,6 +390,7 @@ class DirectoryWatcher:
         # 不放在 _scan_dir 内是因为 skill_dir 不是 watch_dir，跟 wd 循环
         # 无关——每个 watcher 只有一个全局 skill_dir。
         self._run_skill_edit_step()
+        self._check_scripting_requests()
 
         # ── Step 6: 灰度判定独立轮询 ──
         # 对每个 staging 分支存在的 skill 跑 AtomCanary.check_and_decide：
@@ -752,7 +753,7 @@ class DirectoryWatcher:
 
         skill_edit_in_flight = {
             info.get("skill_dir") for info in self._futures.values()
-            if info.get("stage") == "skill_edit"
+            if info.get("stage") in ("skill_edit", "skill_scripting")
         }
         for d in skill_dirs:
             if d in skill_edit_in_flight:
@@ -846,6 +847,127 @@ class DirectoryWatcher:
             self._install_skill_to_all_detected(d)
         except Exception:
             logger.exception("install after SkillEdit failed: %s", d.name)
+
+    def _check_scripting_requests(self) -> None:
+        """扫 ``.scripting_requested``，丢进和编辑代理同一个 worker 池。"""
+        if self.skill_dir is None or not self.skill_dir.is_dir():
+            return
+        from xskill.skill.scripting import has_scripting_request
+
+        requested = [
+            skill_path for skill_path in sorted(self.skill_dir.iterdir())
+            if skill_path.is_dir()
+            and not skill_path.name.startswith(".")
+            and has_scripting_request(skill_path)
+        ]
+        if not requested:
+            return
+        from xskill.agents import agent_tools
+        from xskill.agents.skill_scripting_agent import SkillScriptingAgent
+        from xskill.skill.scripting import (
+            clear_scripting_request,
+            scripting_gate_reason,
+        )
+
+        factory = self._factory()
+        base_llm_cfg = self.config.get("llm", {}) or {}
+        skill_llm_override = self.config.get("llm_skill", {}) or {}
+        skill_llm_cfg = {
+            **base_llm_cfg,
+            **{
+                key: value
+                for key, value in skill_llm_override.items()
+                if value not in (None, "")
+            },
+        }
+        stores = []
+        for wd in list_watch_dirs(**self._db_kw()):
+            try:
+                stores.append(self._store_for(Path(wd["path"])))
+            except Exception:
+                logger.warning(
+                    "failed to open atom store for scripting: %s",
+                    wd.get("path"),
+                    exc_info=True,
+                )
+        store = stores[0] if stores else None
+        traj_root = Path(stores[0].root) if stores else self.skill_dir
+        tool_context = agent_tools.create_agent_tool_context(
+            skill_dir=self.skill_dir,
+            data_dir=self.skill_dir,
+            config=self.config,
+            atom_skill_dir=self.skill_dir,
+            atom_store=store,
+            default_traj_root=traj_root,
+            spill_root=self.spill_root,
+            usage_ledger=self.usage_ledger,
+            registry_db_path=self.db_path,
+        )
+        busy = {
+            info.get("skill_dir") for info in self._futures.values()
+            if info.get("stage") in ("skill_edit", "skill_scripting")
+        }
+
+        def _run_scripting(skill_path: Path):
+            with agent_tools.use_agent_tool_context(tool_context):
+                agent = SkillScriptingAgent(
+                    skill_dir=skill_path,
+                    agno_agent_factory=factory,
+                    llm_cfg=skill_llm_cfg,
+                    logs_dir=self.logs_dir,
+                )
+                try:
+                    return skill_path, bool(agent.run())
+                except Exception:
+                    logger.exception("SkillScriptingAgent failed: %s", skill_path.name)
+                    return skill_path, False
+
+        for skill_path in requested:
+            if skill_path in busy:
+                continue
+            gate = scripting_gate_reason(skill_path)
+            if gate:
+                logger.info(
+                    "scripting request dropped for %s: %s",
+                    skill_path.name, gate,
+                )
+                clear_scripting_request(skill_path)
+                continue
+            fut = self._pools["edit"].submit(
+                _run_scripting,
+                skill_path,
+                task={"kind": "skill", "skill_name": skill_path.name,
+                      "xfer": "main_scripting"},
+                task_factory=lambda d=skill_path: {
+                    "kind": "skill",
+                    "skill_name": d.name,
+                    "xfer": "main_scripting",
+                },
+            )
+            if fut is None:
+                break
+            self._futures[fut] = {"stage": "skill_scripting", "skill_dir": skill_path}
+            busy.add(skill_path)
+
+    def _on_skill_scripting_done(self, result) -> None:
+        from xskill.skill.scripting import clear_scripting_request
+
+        skill_path, ok = result
+        clear_scripting_request(skill_path)
+        if not ok:
+            logger.warning("scripting did not update main: %s", skill_path.name)
+            return
+        logger.info("SkillScriptingAgent updated main: %s", skill_path.name)
+        try:
+            from xskill.team.server.skill_manifest import invalidate_manifest_cache
+            if self.skill_dir is not None:
+                invalidate_manifest_cache(self.skill_dir)
+        except Exception:
+            logger.debug("invalidate manifest after scripting failed", exc_info=True)
+        try:
+            self._install_skill_to_all_detected(skill_path)
+        except Exception:
+            logger.exception("install after scripting failed: %s", skill_path.name)
 
     def _drain_futures(self, stage: str | None = None, timeout: float = 30.0) -> None:
         """阻塞等到 ``self._futures`` 里指定 stage（``None`` = 全部）的 future
@@ -2178,6 +2300,16 @@ class DirectoryWatcher:
                     self._stats["errors"] += 1
                     logger.exception(
                         "skill_edit future failed: %s",
+                        info.get("skill_dir"),
+                    )
+                continue
+            if stage == "skill_scripting":
+                try:
+                    self._on_skill_scripting_done(fut.result(timeout=0))
+                except Exception:
+                    self._stats["errors"] += 1
+                    logger.exception(
+                        "skill_scripting future failed: %s",
                         info.get("skill_dir"),
                     )
                 continue

--- a/src/xskill/pipeline/ux_scores_store.py
+++ b/src/xskill/pipeline/ux_scores_store.py
@@ -79,6 +79,37 @@ def insert_ux_score(
         return cur.rowcount > 0
 
 
+def delete_ux_scores_for_sha(
+    skill_name: str,
+    *,
+    side: str,
+    commit_sha: str,
+    scored_at_values: list[str] | None = None,
+    db_path: Optional[Path] = None,
+) -> int:
+    """删掉某技能某一侧、某一提交上的体验分（import 换主干时清当前轮）。"""
+    if not skill_name or not commit_sha:
+        return 0
+    with pooled_connection(db_path) as conn:
+        if scored_at_values:
+            deleted = 0
+            for scored_at in scored_at_values:
+                cur = conn.execute(
+                    "DELETE FROM ux_scores WHERE skill_name = ? AND side = ? "
+                    "AND commit_sha = ? AND scored_at = ?",
+                    (skill_name, side, commit_sha, scored_at),
+                )
+                deleted += cur.rowcount
+            conn.commit()
+            return deleted
+        cur = conn.execute(
+            "DELETE FROM ux_scores WHERE skill_name = ? AND side = ? AND commit_sha = ?",
+            (skill_name, side, commit_sha),
+        )
+        conn.commit()
+        return cur.rowcount
+
+
 def insert_ux_scores_many(
     records: list[dict],
     *,

--- a/src/xskill/skill/git.py
+++ b/src/xskill/skill/git.py
@@ -304,6 +304,9 @@ SKILL_GITIGNORE = """# xskill v2 skill 仓库的 ignore 规则
 
 # 旧锁文件
 .lock
+
+# 详情页「脚本化」请求标记（watcher 消费，不进版本库）
+.scripting_requested
 """
 
 
@@ -525,6 +528,8 @@ def _stage_all(repo: Repo, root: Path) -> bool:
         # （.gitignore 可能没这条）这里硬编码兜底跳过，绝不版本化高频写入的
         # 优化实验数据。
         if ".description_optimization" in parts:
+            continue
+        if rel.name == ".scripting_requested" or parts[0] == ".scripting_requested":
             continue
         rel_str = str(rel).replace(os.sep, "/")
         if _is_ignored(rel_str, ignore_patterns):
@@ -1994,6 +1999,75 @@ def commit_update_main_branch(skill_dir: str, message: str) -> bool:
     from xskill.skill.catalog_store import notify_native_upsert
     notify_native_upsert(skill_dir)
     return True
+
+
+def ensure_head_on_main(skill_dir: str | Path) -> None:
+    """让 HEAD 落在 main。没有 main 时从 master 或最新分支建出 main。
+
+    工作区在「从已有分支切过去」时会 hard reset 到该分支树；调用方若已经
+    把工作区换成导入正文，应先保证目标 main 的树就是当前工作区（例如
+    刚 copytree 进来的仓，checkout main 只是对齐 HEAD）。
+    """
+    skill_dir = Path(skill_dir)
+    with skill_repo_lock(skill_dir):
+        with _open_repo(skill_dir) as repo:
+            if _has_branch(repo, "main"):
+                code, err = _checkout_branch(repo, "main")
+                if code != 0:
+                    raise RuntimeError(f"checkout main failed: {err}")
+                return
+            source = None
+            if _has_branch(repo, "master"):
+                source = "master"
+            else:
+                newest_name = None
+                newest_time = None
+                for name in _list_branches(repo):
+                    sha = repo.refs[_ref_for_branch(name)]
+                    try:
+                        commit = repo[sha]
+                    except KeyError:
+                        continue
+                    if not isinstance(commit, Commit):
+                        continue
+                    ts = int(getattr(commit, "commit_time", 0) or 0)
+                    if newest_time is None or ts >= newest_time:
+                        newest_name, newest_time = name, ts
+                source = newest_name
+            if source is None:
+                repo.refs.set_symbolic_ref(b"HEAD", _ref_for_branch("main"))
+                return
+            repo.refs[_ref_for_branch("main")] = repo.refs[_ref_for_branch(source)]
+            code, err = _checkout_branch(repo, "main")
+            if code != 0:
+                raise RuntimeError(f"checkout new main failed: {err}")
+
+
+def init_imported_repo_on_main(skill_dir: str | Path, message: str) -> None:
+    """把已有工作区初始化成 per-skill git，第一笔提交落在 main（不走 baby）。"""
+    skill_dir = Path(skill_dir)
+    skill_dir.mkdir(parents=True, exist_ok=True)
+    with skill_repo_lock(skill_dir):
+        repo = porcelain.init(str(skill_dir), bare=False)
+        try:
+            _write_repo_identity(repo)
+            gi = skill_dir / ".gitignore"
+            if not gi.is_file():
+                gi.write_text(SKILL_GITIGNORE, encoding="utf-8")
+            repo.refs.set_symbolic_ref(b"HEAD", _ref_for_branch("main"))
+            _stage_all(repo, skill_dir)
+            sha, err = _do_commit(repo, message)
+            if sha is None:
+                raise RuntimeError(f"init imported repo commit failed: {err}")
+            cur = _current_branch_name(repo)
+            if cur and cur != "main":
+                repo.refs[_ref_for_branch("main")] = repo.refs[_ref_for_branch(cur)]
+                del repo.refs[_ref_for_branch(cur)]
+                repo.refs.set_symbolic_ref(b"HEAD", _ref_for_branch("main"))
+        finally:
+            repo.close()
+    from xskill.skill.catalog_store import notify_native_upsert
+    notify_native_upsert(skill_dir)
 
 
 def commit_progressive_turn(skill_dir: str, turn_branch: str, message: str) -> bool:

--- a/src/xskill/skill/importer.py
+++ b/src/xskill/skill/importer.py
@@ -1,0 +1,380 @@
+"""把用户已有技能目录纳入自有仓（#213）。
+
+落点永远是 ``skill_dir/<name>/``。同名不删整个目录，只换成源目录里的技能
+文件，再在现有 main 上多一次提交。辅助文件（体验分、candidates 等）不动。
+"""
+from __future__ import annotations
+
+import logging
+import shutil
+import tempfile
+from dataclasses import dataclass, field
+from datetime import datetime, timezone
+from pathlib import Path
+
+from xskill.skill.git import (
+    SKILL_GITIGNORE,
+    commit_update_main_branch,
+    current_branch,
+    ensure_head_on_main,
+    init_imported_repo_on_main,
+    run_git,
+    skill_repo_lock,
+)
+
+logger = logging.getLogger("xskill.skill.importer")
+
+RUNTIME_SIDECARS = frozenset({
+    ".candidates.yml",
+    ".ux_scores.jsonl",
+    ".lock",
+    ".canary_jam_state.json",
+    ".scripting_requested",
+})
+RUNTIME_SIDECAR_DIRS = frozenset({
+    ".git",
+    ".canary",
+    ".description_optimization",
+    ".repo_locks",
+})
+
+HARNESS_SKILL_PARENTS = (
+    Path(".claude") / "skills",
+    Path(".agents") / "skills",
+    Path(".cursor") / "skills",
+    Path(".codex") / "skills",
+    Path(".cac") / "skills",
+    Path(".config") / "opencode" / "skills",
+    Path(".trae") / "skills",
+    Path(".trae-cn") / "skills",
+)
+
+HARNESS_IMPORT_WARNING = (
+    "源目录是编程代理技能目录。纳入完成后，这份目录会被换成自有仓里的新版本。"
+    "若有未提交或未跟踪的内容，会先整份拷到 ~/.xskill/import-stash/<技能名>/<时间>/。"
+)
+
+
+@dataclass
+class ImportResult:
+    name: str
+    existed: bool
+    sha: str = ""
+    baby_overwritten: bool = False
+    staging_kept: bool = False
+    main_round_scores_cleared: int = 0
+    warnings: list[str] = field(default_factory=list)
+    stash_path: str = ""
+
+
+def is_skill_source_dir(path: Path) -> bool:
+    return (path / "SKILL.md").is_file() or (path / "skill.md").is_file()
+
+
+def discover_import_sources(path: Path) -> list[Path]:
+    """单个技能目录，或父目录下每个含 SKILL.md 的子目录。"""
+    path = Path(path).expanduser()
+    if not path.exists():
+        raise FileNotFoundError(f"source not found: {path}")
+    resolved = path.resolve()
+    if is_skill_source_dir(resolved):
+        return [resolved]
+    if not resolved.is_dir():
+        raise FileNotFoundError(f"source not found: {path}")
+    found = [
+        child.resolve()
+        for child in sorted(resolved.iterdir())
+        if child.is_dir() and is_skill_source_dir(child)
+    ]
+    if not found:
+        raise FileNotFoundError(
+            f"{path} 下没有 SKILL.md，也不是含多个技能的父目录",
+        )
+    return found
+
+
+def is_harness_skill_path(path: Path, *, home_root: Path | None = None) -> bool:
+    """源目录是不是编程代理技能目录（或其符号链接解析到那里）。"""
+    home = Path(home_root) if home_root is not None else Path.home()
+    try:
+        real = Path(path).expanduser().resolve()
+    except OSError:
+        return False
+    for rel in HARNESS_SKILL_PARENTS:
+        parent = (home / rel).resolve()
+        try:
+            if real.parent == parent:
+                return True
+        except OSError:
+            continue
+        # 用户给的是符号链接本身、尚未 resolve 到自有仓时也算。
+        try:
+            given = Path(path).expanduser()
+            if given.parent.resolve() == parent:
+                return True
+        except OSError:
+            continue
+    return False
+
+
+def source_has_dirty_or_untracked(path: Path) -> bool:
+    if not (Path(path) / ".git").is_dir():
+        return False
+    code, out, _ = run_git(["status", "--porcelain"], cwd=str(path))
+    return code == 0 and bool(out.strip())
+
+
+def stash_import_dir(path: Path, name: str, *, home_root: Path | None = None) -> Path:
+    """整份拷到 ~/.xskill/import-stash/<name>/<时间>/。拷贝不移动。"""
+    from xskill.config import XSKILL_HOME
+
+    root = Path(home_root) if home_root is not None else XSKILL_HOME
+    stamp = datetime.now(timezone.utc).strftime("%Y%m%dT%H%M%SZ")
+    dest = root / "import-stash" / name / stamp
+    dest.parent.mkdir(parents=True, exist_ok=True)
+    shutil.copytree(path, dest, symlinks=True, dirs_exist_ok=False)
+    logger.info(
+        "import stash: copied %s -> %s (uncommitted or untracked kept)",
+        path, dest,
+    )
+    return dest
+
+
+def maybe_stash_overwrite_dir(
+    path: Path,
+    name: str,
+    *,
+    home_root: Path | None = None,
+) -> Path | None:
+    """即将被盖掉且有脏文件时整份拷走。返回 stash 路径。"""
+    path = Path(path)
+    if not path.exists():
+        return None
+    if not source_has_dirty_or_untracked(path):
+        return None
+    return stash_import_dir(path, name, home_root=home_root)
+
+
+def _ignore_runtime(src: str, names: list[str]) -> set[str]:
+    del src
+    skipped = set()
+    for name in names:
+        if name in RUNTIME_SIDECARS or name in RUNTIME_SIDECAR_DIRS:
+            skipped.add(name)
+    return skipped
+
+
+def _ignore_new_skill_keep_git(src: str, names: list[str]) -> set[str]:
+    """新技能带源仓历史时保留 .git，其余运行时辅助文件仍丢掉。"""
+    del src
+    skipped = set()
+    for name in names:
+        if name in RUNTIME_SIDECARS:
+            skipped.add(name)
+        elif name in RUNTIME_SIDECAR_DIRS and name != ".git":
+            skipped.add(name)
+    return skipped
+
+
+def _replace_skill_files(source: Path, target: Path) -> None:
+    """把目标工作区技能文件换成源目录那份。不动 .git 和辅助文件。"""
+    for child in list(target.iterdir()):
+        if child.name in RUNTIME_SIDECARS or child.name in RUNTIME_SIDECAR_DIRS:
+            continue
+        if child.is_dir():
+            shutil.rmtree(child)
+        else:
+            child.unlink()
+    for child in source.iterdir():
+        if child.name in RUNTIME_SIDECARS or child.name in RUNTIME_SIDECAR_DIRS:
+            continue
+        dest = target / child.name
+        if child.is_dir():
+            shutil.copytree(child, dest, symlinks=True)
+        elif child.is_file():
+            shutil.copy2(child, dest)
+
+
+def _target_has_git(target: Path) -> bool:
+    return (target / ".git").is_dir()
+
+
+def import_one_skill(
+    skill_dir: Path,
+    source: Path,
+    *,
+    commit_message: str | None = None,
+) -> ImportResult:
+    """把一个源技能目录落入 ``skill_dir / source.name``。"""
+    source = Path(source).resolve()
+    if not is_skill_source_dir(source):
+        raise FileNotFoundError(f"not a skill directory (missing SKILL.md): {source}")
+    name = source.name
+    skill_root = Path(skill_dir)
+    skill_root.mkdir(parents=True, exist_ok=True)
+    target = skill_root / name
+    message = commit_message or f"import: {name} from {source}"
+
+    if target.exists() and source == target.resolve():
+        tmp = Path(tempfile.mkdtemp(prefix="xskill-import-src."))
+        copied = tmp / name
+        try:
+            shutil.copytree(source, copied, symlinks=True)
+            return import_one_skill(
+                skill_dir, copied, commit_message=message,
+            )
+        finally:
+            shutil.rmtree(tmp, ignore_errors=True)
+
+    existed = target.is_dir() and _target_has_git(target)
+    result = ImportResult(name=name, existed=existed)
+
+    if not existed:
+        if target.exists():
+            shutil.rmtree(target)
+        source_git = (source / ".git").is_dir()
+        ignore = _ignore_new_skill_keep_git if source_git else _ignore_runtime
+        shutil.copytree(source, target, ignore=ignore, symlinks=True)
+        if source_git:
+            ensure_head_on_main(target)
+            gi = target / ".gitignore"
+            if not gi.is_file():
+                gi.write_text(SKILL_GITIGNORE, encoding="utf-8")
+            _replace_skill_files(source, target)
+            commit_update_main_branch(str(target), message)
+        else:
+            init_imported_repo_on_main(target, message)
+        code, sha, _ = run_git(["rev-parse", "HEAD"], cwd=str(target))
+        result.sha = sha.strip() if code == 0 else ""
+        logger.info("imported new skill %s sha=%s", name, result.sha[:8])
+        return result
+
+    with skill_repo_lock(target):
+        branch = current_branch(str(target)) or ""
+        if branch == "baby":
+            result.baby_overwritten = True
+            logger.info("import overwriting baby draft: %s", name)
+
+        from xskill.canary import clear_current_main_round_scores, has_staging, main_sha
+        result.staging_kept = has_staging(target)
+        old_main = main_sha(target) or ""
+        if result.staging_kept and old_main:
+            result.main_round_scores_cleared = clear_current_main_round_scores(
+                target, commit_sha=old_main,
+            )
+
+        ensure_head_on_main(target)
+        _replace_skill_files(source, target)
+        committed = commit_update_main_branch(str(target), message)
+        if not committed:
+            logger.info("import %s: worktree already matched, nothing to commit", name)
+
+    code, sha, _ = run_git(["rev-parse", "HEAD"], cwd=str(target))
+    result.sha = sha.strip() if code == 0 else ""
+    logger.info("imported existing skill %s sha=%s staging=%s",
+                name, result.sha[:8], result.staging_kept)
+    return result
+
+
+def pack_import_zip(source: Path, *, include_git: bool = True) -> bytes:
+    """打源目录 zip。默认带 .git；跳过运行时辅助文件。"""
+    import io
+    import zipfile
+
+    source = Path(source).resolve()
+    buf = io.BytesIO()
+    skip_top = set(RUNTIME_SIDECAR_DIRS)
+    if include_git:
+        skip_top.discard(".git")
+    with zipfile.ZipFile(buf, "w", compression=zipfile.ZIP_DEFLATED) as zf:
+        for file_path in sorted(source.rglob("*")):
+            if not file_path.is_file():
+                continue
+            rel = file_path.relative_to(source)
+            parts = rel.parts
+            if any(part == "__pycache__" for part in parts):
+                continue
+            if rel.name in RUNTIME_SIDECARS:
+                continue
+            if parts and parts[0] in skip_top:
+                continue
+            zf.write(file_path, rel.as_posix())
+    return buf.getvalue()
+
+
+def extract_import_zip(payload: bytes, dest: Path, *, max_files: int = 20000) -> Path:
+    """解压到 dest，拒绝路径穿越。"""
+    import io
+    import zipfile
+
+    dest = Path(dest)
+    dest.mkdir(parents=True, exist_ok=True)
+    root = dest.resolve()
+    with zipfile.ZipFile(io.BytesIO(payload)) as archive:
+        files = [info for info in archive.infolist() if not info.is_dir()]
+        if len(files) > max_files:
+            raise ValueError(f"import archive contains more than {max_files} files")
+        for info in archive.infolist():
+            target = (dest / info.filename).resolve()
+            try:
+                target.relative_to(root)
+            except ValueError as exc:
+                raise ValueError(f"unsafe archive path: {info.filename}") from exc
+            if info.is_dir():
+                target.mkdir(parents=True, exist_ok=True)
+                continue
+            target.parent.mkdir(parents=True, exist_ok=True)
+            with archive.open(info) as src, open(target, "wb") as dst:
+                shutil.copyfileobj(src, dst)
+    return dest
+
+
+def import_skill_path(
+    skill_dir: Path,
+    source_path: Path,
+    *,
+    install: bool = True,
+    home_root: Path | None = None,
+    stash_home: Path | None = None,
+) -> list[ImportResult]:
+    """发现路径下的技能并逐个纳入。独立部署走这条；团队部署只在 server 上落仓。"""
+    results = []
+    home = Path(home_root) if home_root is not None else Path.home()
+    for source in discover_import_sources(source_path):
+        name = source.name
+        target = Path(skill_dir) / name
+        result_warnings: list[str] = []
+        stash_path = ""
+        if is_harness_skill_path(source, home_root=home):
+            result_warnings.append(HARNESS_IMPORT_WARNING)
+        overwrite_paths = []
+        if target.exists():
+            overwrite_paths.append(target.resolve())
+        try:
+            real_source = source.resolve()
+        except OSError:
+            real_source = source
+        if real_source not in overwrite_paths and source.exists():
+            overwrite_paths.append(source)
+        stash_dirs: list[str] = []
+        for path in overwrite_paths:
+            stashed = maybe_stash_overwrite_dir(
+                path, name, home_root=stash_home,
+            )
+            if stashed is not None:
+                stash_dirs.append(str(stashed))
+                logger.info(
+                    "import %s: stashed %s -> %s before overwrite",
+                    name, path, stashed,
+                )
+        stash_path = stash_dirs[0] if stash_dirs else ""
+        imported = import_one_skill(skill_dir, source)
+        imported.warnings.extend(result_warnings)
+        imported.stash_path = stash_path
+        if install:
+            from xskill.team.client.daemon import install_skill_to_ecosystems
+            install_skill_to_ecosystems(
+                Path(skill_dir) / imported.name, home_root=home,
+            )
+        results.append(imported)
+    return results

--- a/src/xskill/skill/repo.py
+++ b/src/xskill/skill/repo.py
@@ -371,18 +371,12 @@ def search_skill_index(*, skill_dir: Path, query: str, embed_client, top_k: int 
     return results
 
 
+from xskill.skill.importer import import_skill_path
+
+
 def import_skill(skill_dir: Path, source_path: Path) -> str:
-    """Copy a skill directory into ./skill/ and commit."""
-    source = Path(source_path)
-    if not source.is_dir():
-        raise FileNotFoundError(f"source not found: {source}")
-
-    name = source.name
-    target = skill_dir / name
-    if target.exists():
-        shutil.rmtree(target)
-    shutil.copytree(source, target)
-
-    commit_changes(str(skill_dir), f"import skill: {name}")
-    logger.info(f"imported: {name}")
-    return name
+    """把源目录纳入自有仓。返回第一个纳入的技能名（兼容旧 API）。"""
+    results = import_skill_path(skill_dir, source_path, install=False)
+    if not results:
+        raise FileNotFoundError(f"no skill imported from {source_path}")
+    return results[0].name

--- a/src/xskill/skill/scripting.py
+++ b/src/xskill/skill/scripting.py
@@ -1,0 +1,72 @@
+"""详情页「脚本化（实验性）」请求标记。
+
+看板进程写 ``.scripting_requested``，agent-worker 子进程扫到后丢进编辑池。
+标记 gitignore，不进版本库。
+"""
+from __future__ import annotations
+
+import logging
+from pathlib import Path
+
+from xskill.canary import has_staging
+from xskill.skill.git import current_branch, run_git
+
+logger = logging.getLogger("xskill.skill.scripting")
+
+MARKER_NAME = ".scripting_requested"
+
+
+def marker_path(skill_path: Path) -> Path:
+    return Path(skill_path) / MARKER_NAME
+
+
+def has_scripting_request(skill_path: Path) -> bool:
+    return marker_path(skill_path).is_file()
+
+
+def scripting_gate_reason(skill_path: Path) -> str:
+    """不能跑脚本化的原因（不含「已有请求标记」）。空字符串表示可以跑。"""
+    skill_path = Path(skill_path)
+    if not (skill_path / ".git").is_dir():
+        return "不是自产技能仓"
+    code, _, _ = run_git(["rev-parse", "--verify", "main"], cwd=str(skill_path))
+    branch = current_branch(str(skill_path)) or ""
+    if code != 0 or branch == "baby":
+        return "还在预备分支，等升到主干后再脚本化"
+    if has_staging(skill_path):
+        return "正在灰度对比，这一期不和灰度抢同一份主干"
+    return ""
+
+
+def scripting_status(skill_path: Path) -> dict:
+    """给详情页按钮用：能否点、不能点的原因。"""
+    skill_path = Path(skill_path)
+    requested = has_scripting_request(skill_path)
+    gate = scripting_gate_reason(skill_path)
+    if gate:
+        return {"enabled": False, "reason": gate, "requested": requested}
+    if requested:
+        return {
+            "enabled": False,
+            "reason": "脚本化已在排队或进行中",
+            "requested": True,
+        }
+    return {"enabled": True, "reason": "", "requested": False}
+
+
+def request_scripting(skill_path: Path) -> dict:
+    """写入请求标记。条件不满足时抛 ValueError。"""
+    status = scripting_status(skill_path)
+    if not status["enabled"]:
+        raise ValueError(status["reason"] or "scripting not available")
+    marker_path(skill_path).write_text("requested\n", encoding="utf-8")
+    logger.info("scripting requested: %s", Path(skill_path).name)
+    return {"ok": True, "requested": True}
+
+
+def clear_scripting_request(skill_path: Path) -> None:
+    path = marker_path(skill_path)
+    try:
+        path.unlink()
+    except FileNotFoundError:
+        return

--- a/src/xskill/team/client/import_follow.py
+++ b/src/xskill/team/client/import_follow.py
@@ -1,0 +1,48 @@
+"""团队客户端在 import 之后跟到这次导入产生的主干。"""
+from __future__ import annotations
+
+import logging
+from pathlib import Path
+
+from xskill.ecosystems._history import InstallHistory
+from xskill.team.client.daemon import install_skill_to_ecosystems
+from xskill.team.shared.git_bundle import apply_repo_bundle
+from xskill.team.shared.reconcile import reconcile_skill_side
+
+logger = logging.getLogger("xskill.team.client.import_follow")
+
+
+def follow_imported_skill(
+    *,
+    http,
+    headers: dict,
+    skill_dir: Path,
+    name: str,
+    sha: str,
+    home_root: Path,
+    history_path: Path,
+) -> None:
+    """拉 bundle，把本机 ``_active`` 切到这次导入的主干，并装到编程代理目录。"""
+    if not sha:
+        raise RuntimeError(f"import follow missing sha for {name}")
+    response = http.get(f"/api/v1/team/skill/{name}/bundle", headers=headers)
+    if response.status_code != 200:
+        raise RuntimeError(
+            f"import follow bundle failed HTTP {response.status_code}: "
+            f"{response.text[:300]}"
+        )
+    dest = Path(skill_dir) / name
+    apply_repo_bundle(response.content, dest)
+    history = InstallHistory(history_path)
+    result = reconcile_skill_side(
+        repo_dir=dest,
+        target_side="main",
+        target_sha=sha,
+        history=history,
+        on_changed=lambda repo: install_skill_to_ecosystems(
+            repo, home_root=home_root,
+        ),
+    )
+    if result == "already_aligned":
+        install_skill_to_ecosystems(dest, home_root=home_root)
+    logger.info("import follow %s -> main %s (%s)", name, sha[:8], result)

--- a/src/xskill/team/server/api.py
+++ b/src/xskill/team/server/api.py
@@ -1240,6 +1240,62 @@ def _skillhub_result_source(source_path: str) -> str:
     return "skillhub"
 
 
+@router.post("/skills/import")
+async def team_skills_import(
+    file: UploadFile = File(...),
+    name: str = Form(...),
+    x_xskill_token: str | None = Header(default=None),
+    x_xskill_client: str | None = Header(default=None),
+) -> dict:
+    """把技能目录纳入 server 自有仓。不要和 skill_hub/upload 混用。"""
+    client_id = _auth(x_xskill_token, x_xskill_client)
+    if _ctx.skill_dir is None:
+        raise HTTPException(status_code=503, detail="skill_dir not configured")
+    from xskill.recommend.skillhub import safe_id_part
+    skill_name = safe_id_part(name)
+    if not skill_name:
+        raise HTTPException(status_code=400, detail="invalid skill name")
+    payload = await file.read()
+    if len(payload) > 50 * 1024 * 1024:
+        raise HTTPException(status_code=413, detail="import archive exceeds 50MB")
+    result = await run_in_threadpool(_import_skill_archive, payload, skill_name)
+    logger.info("native import from %s: %s sha=%s existed=%s",
+                client_id, result["name"], result.get("sha", "")[:8],
+                result.get("existed"))
+    return result
+
+
+_IMPORT_ARCHIVE_MAX_FILES = 20000
+
+
+def _import_skill_archive(payload: bytes, skill_name: str) -> dict:
+    from xskill.skill.importer import extract_import_zip, import_one_skill
+    from xskill.team.server.skill_manifest import invalidate_manifest_cache
+
+    tmp_dir = Path(tempfile.mkdtemp(prefix="xskill-import."))
+    try:
+        source = tmp_dir / skill_name
+        extract_import_zip(payload, source, max_files=_IMPORT_ARCHIVE_MAX_FILES)
+        imported = import_one_skill(_ctx.skill_dir, source)
+        invalidate_manifest_cache(_ctx.skill_dir)
+        return {
+            "name": imported.name,
+            "sha": imported.sha,
+            "existed": imported.existed,
+            "baby_overwritten": imported.baby_overwritten,
+            "staging_kept": imported.staging_kept,
+            "main_round_scores_cleared": imported.main_round_scores_cleared,
+        }
+    except HTTPException:
+        raise
+    except FileNotFoundError as missing:
+        raise HTTPException(status_code=400, detail=str(missing)) from missing
+    except ValueError as bad:
+        raise HTTPException(status_code=400, detail=str(bad)) from bad
+    finally:
+        shutil.rmtree(tmp_dir, ignore_errors=True)
+
+
 @router.post("/skill_hub/upload")
 async def team_skill_hub_upload(
     file: UploadFile = File(...),

--- a/tests/test_dashboard_standalone.py
+++ b/tests/test_dashboard_standalone.py
@@ -48,6 +48,7 @@ _BUILTIN_ONLY_OPERATIONS = {
     ("get", "/api/v1/dashboard/skillhub/{name}/ux/atoms"),
     ("get", "/api/v1/dashboard/skill/{name}/trigger/cases"),
     ("post", "/api/v1/dashboard/skill/{name}/trigger/rerun"),
+    ("post", "/api/v1/dashboard/skill/{name}/scripting"),
     ("get", "/api/v1/dashboard/traj/{traj_id}"),
     ("get", "/api/v1/dashboard/traj/{traj_id}/atoms"),
     ("get", "/api/v1/dashboard/traj/{traj_id}/atom/{atom_id}"),
@@ -217,6 +218,9 @@ def test_standalone_hides_sensitive_and_write_routes(tmp_path, monkeypatch):
     ).status_code == 404
     assert client.post(
         "/api/v1/dashboard/skill/demo/trigger/rerun",
+    ).status_code == 404
+    assert client.post(
+        "/api/v1/dashboard/skill/demo/scripting",
     ).status_code == 404
     assert client.post("/api/v1/dashboard/login", json={}).status_code == 404
     assert client.post("/api/v1/dashboard/my/prefs", json={}).status_code == 404

--- a/tests/test_import_skill.py
+++ b/tests/test_import_skill.py
@@ -1,0 +1,405 @@
+"""#213 xskill import 落仓：四种情形、体验分禁令、stash、upload 不变。"""
+from __future__ import annotations
+
+import io
+import json
+import zipfile
+from pathlib import Path
+from types import SimpleNamespace
+
+import pytest
+from fastapi import FastAPI
+from fastapi.testclient import TestClient
+
+from xskill.canary import has_staging, load_ux_scores, main_sha
+from xskill.skill.git import (
+    commit_to_staging_branch,
+    commit_update_main_branch,
+    current_branch,
+    init_imported_repo_on_main,
+    init_skill_repo_on_baby,
+    run_git,
+)
+from xskill.skill.importer import (
+    HARNESS_IMPORT_WARNING,
+    discover_import_sources,
+    import_one_skill,
+    import_skill_path,
+    is_harness_skill_path,
+    pack_import_zip,
+    source_has_dirty_or_untracked,
+    stash_import_dir,
+)
+from xskill.skill.scripting import (
+    has_scripting_request,
+    request_scripting,
+    scripting_gate_reason,
+    scripting_status,
+)
+from xskill.team.server import api as server_api
+from xskill.team.server.client_registry import ClientRegistry
+
+
+TOKEN = "secret-token"
+
+
+def _skill_md(name: str, body: str) -> str:
+    return (
+        f"---\nname: {name}\ndescription: {name} helper\n---\n{body}\n"
+    )
+
+
+def _write_skill(path: Path, name: str, body: str) -> Path:
+    path.mkdir(parents=True, exist_ok=True)
+    (path / "SKILL.md").write_text(_skill_md(name, body), encoding="utf-8")
+    return path
+
+
+def _log_subjects(repo: Path, n: int = 20) -> str:
+    code, out, err = run_git(["log", "--oneline", f"-{n}"], cwd=str(repo))
+    assert code == 0, err
+    return out
+
+
+def _write_ux_row(skill_dir: Path, *, side: str, sha: str, traj_id: str,
+                  scored_at: str, score: float = 8.0) -> None:
+    p = skill_dir / ".ux_scores.jsonl"
+    rec = {
+        "traj_id": traj_id,
+        "skill_name": skill_dir.name,
+        "side": side,
+        "commit_sha": sha,
+        "score": score,
+        "reasons": "t",
+        "scored_at": scored_at,
+    }
+    with p.open("a", encoding="utf-8") as handle:
+        handle.write(json.dumps(rec, ensure_ascii=False) + "\n")
+
+
+def test_discover_parent_and_single(tmp_path):
+    parent = tmp_path / "skills"
+    _write_skill(parent / "alpha", "alpha", "# a")
+    _write_skill(parent / "beta", "beta", "# b")
+    (parent / "notes.txt").write_text("no", encoding="utf-8")
+    found = discover_import_sources(parent)
+    assert [p.name for p in found] == ["alpha", "beta"]
+    assert discover_import_sources(parent / "alpha") == [parent / "alpha"]
+
+
+def test_standalone_new_skill_keeps_source_git_history(tmp_path):
+    source = _write_skill(tmp_path / "src" / "foo", "foo", "# v1")
+    init_imported_repo_on_main(source, "first commit")
+    (source / "SKILL.md").write_text(_skill_md("foo", "# v2"), encoding="utf-8")
+    commit_update_main_branch(str(source), "second commit")
+    skill_dir = tmp_path / "skill"
+    imported = import_one_skill(skill_dir, source)
+    dest = skill_dir / "foo"
+    assert imported.existed is False
+    assert current_branch(str(dest)) == "main"
+    subjects = _log_subjects(dest)
+    assert "first commit" in subjects
+    assert "second commit" in subjects
+    assert "# v2" in (dest / "SKILL.md").read_text(encoding="utf-8")
+
+
+def test_standalone_new_skill_without_git_starts_on_main(tmp_path):
+    source = _write_skill(tmp_path / "src" / "bar", "bar", "# only")
+    (source / "scripts").mkdir()
+    (source / "scripts" / "run.sh").write_text("echo hi\n", encoding="utf-8")
+    skill_dir = tmp_path / "skill"
+    imported = import_one_skill(skill_dir, source)
+    dest = skill_dir / "bar"
+    assert imported.sha
+    assert current_branch(str(dest)) == "main"
+    assert (dest / "scripts" / "run.sh").is_file()
+    assert (dest / ".git").is_dir()
+
+
+def test_standalone_existing_replaces_files_keeps_history_and_sidecars(tmp_path):
+    skill_dir = tmp_path / "skill"
+    dest = _write_skill(skill_dir / "foo", "foo", "# old body")
+    init_imported_repo_on_main(dest, "original main")
+    (dest / ".ux_scores.jsonl").write_text(
+        json.dumps({"traj_id": "old", "skill_name": "foo", "side": "main",
+                    "commit_sha": "abc", "score": 9, "scored_at": "2020-01-01T00:00:00+00:00"})
+        + "\n",
+        encoding="utf-8",
+    )
+    (dest / ".candidates.yml").write_text("candidates: []\n", encoding="utf-8")
+    old_sha = main_sha(dest)
+
+    source = _write_skill(tmp_path / "incoming" / "foo", "foo", "# new body only")
+    (source / "scripts").mkdir()
+    (source / "scripts" / "do.py").write_text("print(1)\n", encoding="utf-8")
+    imported = import_one_skill(skill_dir, source)
+    assert imported.existed is True
+    text = (dest / "SKILL.md").read_text(encoding="utf-8")
+    assert "# new body only" in text
+    assert "# old body" not in text
+    assert (dest / "scripts" / "do.py").is_file()
+    subjects = _log_subjects(dest)
+    assert "original main" in subjects
+    assert main_sha(dest) != old_sha
+    scores = load_ux_scores(dest)
+    assert any(row.get("traj_id") == "old" for row in scores)
+    assert (dest / ".candidates.yml").read_text(encoding="utf-8") == "candidates: []\n"
+
+
+def test_import_overwrites_baby_without_error(tmp_path, caplog):
+    import logging
+    skill_dir = tmp_path / "skill"
+    dest = skill_dir / "foo"
+    dest.mkdir(parents=True)
+    init_skill_repo_on_baby(str(dest), name="foo", description="draft")
+    assert current_branch(str(dest)) == "baby"
+    source = _write_skill(tmp_path / "incoming" / "foo", "foo", "# finished")
+    with caplog.at_level(logging.INFO, logger="xskill.skill.importer"):
+        imported = import_one_skill(skill_dir, source)
+    assert imported.baby_overwritten is True
+    assert current_branch(str(dest)) == "main"
+    assert "# finished" in (dest / "SKILL.md").read_text(encoding="utf-8")
+    assert "overwriting baby" in caplog.text
+
+
+def test_same_name_with_staging_clears_only_current_main_round(tmp_path):
+    skill_dir = tmp_path / "skill"
+    dest = _write_skill(skill_dir / "foo", "foo", "# main v1")
+    init_imported_repo_on_main(dest, "older main")
+    older = main_sha(dest)
+    (dest / "SKILL.md").write_text(_skill_md("foo", "# main v2"), encoding="utf-8")
+    commit_update_main_branch(str(dest), "current main")
+    current = main_sha(dest)
+    (dest / "SKILL.md").write_text(_skill_md("foo", "# staging cand"), encoding="utf-8")
+    assert commit_to_staging_branch(str(dest), "staging candidate") is True
+    staging = run_git(["rev-parse", "staging"], cwd=str(dest))[1].strip()
+    assert has_staging(dest)
+
+    for i in range(5):
+        _write_ux_row(
+            dest, side="main", sha=current, traj_id=f"cur{i}",
+            scored_at=f"2026-08-01T00:0{i}:00+00:00",
+        )
+    _write_ux_row(
+        dest, side="main", sha=older, traj_id="hist",
+        scored_at="2026-07-01T00:00:00+00:00", score=7.0,
+    )
+    _write_ux_row(
+        dest, side="staging", sha=staging, traj_id="stg1",
+        scored_at="2026-08-02T00:00:00+00:00", score=6.0,
+    )
+
+    source = _write_skill(tmp_path / "incoming" / "foo", "foo", "# imported")
+    imported = import_one_skill(skill_dir, source)
+    assert imported.staging_kept is True
+    assert imported.main_round_scores_cleared == 5
+    assert has_staging(dest)
+    rows = load_ux_scores(dest)
+    main_current = [
+        r for r in rows if r.get("side") == "main" and r.get("commit_sha") == current
+    ]
+    assert main_current == []
+    assert any(r.get("traj_id") == "hist" for r in rows)
+    assert any(r.get("traj_id") == "stg1" for r in rows)
+    assert "# imported" in (dest / "SKILL.md").read_text(encoding="utf-8")
+    assert "original main" in _log_subjects(dest) or "older main" in _log_subjects(dest)
+
+
+def test_harness_path_and_stash(tmp_path):
+    home = tmp_path / "home"
+    source = _write_skill(home / ".claude" / "skills" / "foo", "foo", "# h")
+    init_imported_repo_on_main(source, "tracked")
+    (source / "dirty.txt").write_text("untracked", encoding="utf-8")
+    assert is_harness_skill_path(source, home_root=home)
+    assert source_has_dirty_or_untracked(source)
+    stash = stash_import_dir(source, "foo", home_root=tmp_path / "xskill")
+    assert (stash / "dirty.txt").read_text(encoding="utf-8") == "untracked"
+    assert (source / "dirty.txt").is_file()
+    elsewhere = _write_skill(tmp_path / "other" / "foo", "foo", "# e")
+    assert not is_harness_skill_path(elsewhere, home_root=home)
+
+
+def test_import_skill_path_warns_only_for_harness(tmp_path, monkeypatch):
+    home = tmp_path / "home"
+    xhome = tmp_path / "xskill"
+    skill_dir = xhome / "skill"
+    harness = _write_skill(home / ".claude" / "skills" / "foo", "foo", "# h")
+    init_imported_repo_on_main(harness, "h1")
+    (harness / "wip.txt").write_text("dirty", encoding="utf-8")
+    results = import_skill_path(
+        skill_dir, harness, install=False, home_root=home, stash_home=xhome,
+    )
+    assert HARNESS_IMPORT_WARNING in results[0].warnings
+    assert results[0].stash_path
+    assert Path(results[0].stash_path).is_dir()
+
+    other = _write_skill(tmp_path / "disk" / "bar", "bar", "# o")
+    results2 = import_skill_path(
+        skill_dir, other, install=False, home_root=home, stash_home=xhome,
+    )
+    assert results2[0].warnings == []
+    assert results2[0].stash_path == ""
+    assert other.is_dir()
+
+
+def test_cli_import_has_no_agents_flag():
+    from xskill.cli import build_parser
+    args = build_parser().parse_args(["import", "/tmp/foo"])
+    assert args.command == "import"
+    assert args.path == "/tmp/foo"
+    with pytest.raises(SystemExit):
+        build_parser().parse_args(["import", "/tmp/foo", "--agents", "claude-code"])
+
+
+def test_cmd_import_standalone(tmp_path, monkeypatch, capsys):
+    from xskill import cli
+    from xskill.skill.importer import ImportResult
+
+    skill_dir = tmp_path / "skill"
+    source = _write_skill(tmp_path / "incoming" / "zz", "zz", "# z")
+    monkeypatch.setattr(cli, "_is_thin_team_client", lambda: False)
+    monkeypatch.setattr(cli, "_local_import_skill_dir", lambda: skill_dir)
+    monkeypatch.setattr(
+        "xskill.team.client.daemon.install_skill_to_ecosystems",
+        lambda *a, **k: [],
+    )
+    args = SimpleNamespace(path=str(source), json=False)
+    assert cli.cmd_import(args) == 0
+    out = capsys.readouterr().out
+    assert "imported: zz" in out
+    assert (skill_dir / "zz" / "SKILL.md").is_file()
+    assert isinstance(ImportResult(name="zz", existed=False), ImportResult)
+
+
+def _team_client(tmp_path: Path) -> TestClient:
+    skill_dir = tmp_path / "skill"
+    skill_dir.mkdir(exist_ok=True)
+    server_api.init_team_context(
+        join_token=TOKEN,
+        client_registry=ClientRegistry(tmp_path / "clients.db"),
+        skill_dir=skill_dir,
+        traj_root=tmp_path / "team_traj",
+        register_dir=lambda path, label: None,
+        skillhub=None,
+    )
+    app = FastAPI()
+    app.include_router(server_api.router)
+    return TestClient(app)
+
+
+def _register(client: TestClient) -> dict:
+    r = client.post("/api/v1/team/register", json={
+        "token": TOKEN, "client_label": "t", "hostname": "h",
+    })
+    assert r.status_code == 200
+    return {"X-Xskill-Token": TOKEN, "X-Xskill-Client": r.json()["client_id"]}
+
+
+def test_team_import_new_skill_keeps_history_not_skillhub(tmp_path):
+    client = _team_client(tmp_path)
+    hdr = _register(client)
+    source = _write_skill(tmp_path / "incoming" / "foo", "foo", "# v1")
+    init_imported_repo_on_main(source, "source first")
+    (source / "SKILL.md").write_text(_skill_md("foo", "# v2"), encoding="utf-8")
+    commit_update_main_branch(str(source), "source second")
+    payload = pack_import_zip(source, include_git=True)
+    r = client.post(
+        "/api/v1/team/skills/import",
+        files={"file": ("foo.zip", payload, "application/zip")},
+        data={"name": "foo"},
+        headers=hdr,
+    )
+    assert r.status_code == 200, r.text
+    body = r.json()
+    assert body["existed"] is False
+    dest = tmp_path / "skill" / "foo"
+    assert (dest / "SKILL.md").is_file()
+    subjects = _log_subjects(dest)
+    assert "source first" in subjects
+    upload = client.post(
+        "/api/v1/team/skill_hub/upload",
+        files={"file": ("foo.zip", payload, "application/zip")},
+        headers=hdr,
+    )
+    assert upload.status_code == 503
+
+
+def test_team_import_existing_keeps_server_git(tmp_path):
+    client = _team_client(tmp_path)
+    hdr = _register(client)
+    dest = _write_skill(tmp_path / "skill" / "foo", "foo", "# server old")
+    init_imported_repo_on_main(dest, "server original")
+    source = _write_skill(tmp_path / "incoming" / "foo", "foo", "# from client")
+    init_imported_repo_on_main(source, "client history should not overlay")
+    r = client.post(
+        "/api/v1/team/skills/import",
+        files={"file": ("foo.zip", pack_import_zip(source), "application/zip")},
+        data={"name": "foo"},
+        headers=hdr,
+    )
+    assert r.status_code == 200, r.text
+    assert r.json()["existed"] is True
+    subjects = _log_subjects(dest)
+    assert "server original" in subjects
+    text = (dest / "SKILL.md").read_text(encoding="utf-8")
+    assert "# from client" in text
+    assert "# server old" not in text
+
+
+def test_upload_still_strips_git(tmp_path):
+    """对照：upload 打包仍应丢掉 .git（与 import 的 pack_import_zip 不同）。"""
+    from xskill import cli
+    skill_dir = tmp_path / "s"
+    _write_skill(skill_dir, "keep-git", "# body")
+    (skill_dir / ".git").mkdir()
+    (skill_dir / ".git" / "HEAD").write_text("ref: refs/heads/main\n", encoding="utf-8")
+    args = SimpleNamespace(path=str(skill_dir), json=False)
+
+    class _Capture:
+        def __init__(self):
+            self.files = None
+
+        def post(self, url, files=None, headers=None):
+            self.files = files
+            self.url = url
+            return SimpleNamespace(
+                status_code=200,
+                json=lambda: {
+                    "display_name": "keep-git",
+                    "skill_id": "id",
+                    "stored_path": "/hub/keep-git",
+                },
+                text="",
+            )
+
+    cap = _Capture()
+    assert cli.cmd_upload(args, http=cap, headers={}) == 0
+    assert cap.url.endswith("/skill_hub/upload")
+    payload = cap.files["file"][1]
+    with zipfile.ZipFile(io.BytesIO(payload)) as zf:
+        names = zf.namelist()
+    assert "SKILL.md" in names
+    assert not any(n.startswith(".git/") or n == ".git" for n in names)
+
+
+def test_scripting_button_gates(tmp_path):
+    dest = _write_skill(tmp_path / "skill" / "foo", "foo", "# main")
+    init_imported_repo_on_main(dest, "main1")
+    status = scripting_status(dest)
+    assert status["enabled"] is True
+    request_scripting(dest)
+    assert has_scripting_request(dest)
+    assert scripting_status(dest)["enabled"] is False
+
+    baby = tmp_path / "skill" / "baby"
+    baby.mkdir(parents=True)
+    init_skill_repo_on_baby(str(baby), name="baby", description="d")
+    assert "预备分支" in scripting_gate_reason(baby)
+    with pytest.raises(ValueError):
+        request_scripting(baby)
+
+    staged = _write_skill(tmp_path / "skill" / "stg", "stg", "# m")
+    init_imported_repo_on_main(staged, "m")
+    (staged / "SKILL.md").write_text(_skill_md("stg", "# s"), encoding="utf-8")
+    assert commit_to_staging_branch(str(staged), "cand")
+    assert "灰度" in scripting_gate_reason(staged)


### PR DESCRIPTION
## Summary
- Add `xskill import` to land a user-written skill onto the owned per-skill git repo (not skillhub). Same-name replacement commits on existing main, keeps sidecars, copies source git history for new skills, and stashes dirty harness dirs.
- Team clients POST `/api/v1/team/skills/import`; the importer's machine follows the new main sha. Upload behavior is unchanged.
- Native skill detail gets an admin-only experimental scripting button that writes `.scripting_requested`; the edit pool runs a main-only scripting agent (`main scripting` pill).

Closes #213

## Test plan
- [x] `tests/test_import_skill.py` four landing cases, UX round clear, stash, upload still strips `.git`
- [x] dashboard standalone route allowlist includes scripting POST
- [ ] `xskill import <skill-dir>` on standalone
- [ ] team client import follows returned main
- [ ] detail page scripting button disabled on baby and staging

Made with [Cursor](https://cursor.com)