### PR TITLE
fix: 旧安装账本混入倒退序号时仍能 import 并装回 harness

### DIFF
--- a/patches/install-history-legacy-mix.patch
+++ b/patches/install-history-legacy-mix.patch
@@ -1,0 +1,213 @@
+diff --git a/src/xskill/ecosystems/_history.py b/src/xskill/ecosystems/_history.py
+index d4748b8..35e6ca8 100644
+--- a/src/xskill/ecosystems/_history.py
++++ b/src/xskill/ecosystems/_history.py
+@@ -38,6 +38,10 @@ from typing import Any, Callable, Iterable, Optional
+ 
+ logger = logging.getLogger("xskill.ecosystems.install_history")
+ 
++# 旧账本没有 append_sequence，升级后 sidecar 可能落后于行号。
++# 中间几条序号倒退或一行坏 JSON 不应把整台机器的安装停掉。
++_SKIP_BAD_HISTORY_LINES = 64
++
+ 
+ def fsync_directory(directory: Path) -> None:
+     """在 POSIX 上持久化 rename/unlink 元数据；Windows 不支持目录 fsync。"""
+@@ -463,6 +467,8 @@ class InstallHistory:
+         self._index_cache_initialized = False
+         self._sequence_validated = False
+         self._sequence_floor = 0
++        self._seq_file_size: int | None = None
++        self._skipped_bad_lines = 0
+ 
+     @property
+     def _history_lock_path(self) -> Path:
+@@ -614,6 +620,8 @@ class InstallHistory:
+                 f"install history cannot be decoded: {self.path}"
+             ) from exc
+         records: list[dict] = []
++        if starting_line_number == 1 and previous_sequence == 0:
++            self._skipped_bad_lines = 0
+         for line_number, raw_line in enumerate(
+             lines,
+             start=starting_line_number,
+@@ -625,42 +633,49 @@ class InstallHistory:
+             try:
+                 record = json.loads(line)
+             except json.JSONDecodeError as exc:
+-                logger.error(
+-                    "invalid install history JSON path=%s line=%d error_type=%s",
+-                    self.path,
++                self._skip_or_raise(
+                     line_number,
+-                    type(exc).__name__,
++                    reason="invalid_json",
++                    error_type=type(exc).__name__,
+                 )
+-                raise InstallHistoryCorruptError(
+-                    f"invalid install history JSON at line {line_number}"
+-                ) from exc
++                continue
+             if not isinstance(record, dict):
+-                logger.error(
+-                    "invalid install history schema path=%s line=%d",
+-                    self.path,
+-                    line_number,
+-                )
+-                raise InstallHistoryCorruptError(
+-                    f"install history line {line_number} is not an object"
+-                )
++                self._skip_or_raise(line_number, reason="not_object")
++                continue
+             append_sequence = record.get("append_sequence", line_number)
+             if (
+-                not isinstance(append_sequence, int)
++                isinstance(append_sequence, bool)
++                or not isinstance(append_sequence, int)
+                 or append_sequence <= previous_sequence
+             ):
+-                logger.error(
+-                    "non-monotonic install history sequence path=%s line=%d",
+-                    self.path,
+-                    line_number,
+-                )
+-                raise InstallHistoryCorruptError(
+-                    f"non-monotonic install history at line {line_number}"
+-                )
++                self._skip_or_raise(line_number, reason="non_monotonic")
++                continue
+             record["append_sequence"] = append_sequence
+             previous_sequence = append_sequence
+             records.append(record)
+         return records
+ 
++    def _skip_or_raise(
++        self,
++        line_number: int,
++        *,
++        reason: str,
++        error_type: str | None = None,
++    ) -> None:
++        """跳过少量坏行。不把行内容写进日志。超限仍 fail-loud。"""
++        self._skipped_bad_lines += 1
++        logger.warning(
++            "skipping install history line path=%s line=%d reason=%s%s",
++            self.path,
++            line_number,
++            reason,
++            f" error_type={error_type}" if error_type else "",
++        )
++        if self._skipped_bad_lines > _SKIP_BAD_HISTORY_LINES:
++            raise InstallHistoryCorruptError(
++                f"too many unreadable install history lines at line {line_number}"
++            )
++
+     def _parse_records_snapshot_locked(
+         self,
+     ) -> tuple[list[dict], Optional[InstallHistoryFileSignature]]:
+@@ -1005,6 +1020,13 @@ class InstallHistory:
+                 )
+ 
+     def _next_sequence_locked(self, minimum: int) -> int:
++        size_now = self.path.stat().st_size if self.path.is_file() else 0
++        if (
++            self._seq_file_size is not None
++            and size_now != self._seq_file_size
++        ):
++            # 别的进程用旧格式追加过，sidecar 可能已经落后于行号。
++            self._sequence_validated = False
+         stored: int | None = None
+         sequence_present = self._sequence_path.is_file()
+         if sequence_present:
+@@ -1038,8 +1060,13 @@ class InstallHistory:
+                 ),
+                 default=0,
+             )
+-            stored = max(stored or 0, history_maximum)
++            stored = max(
++                stored or 0,
++                history_maximum,
++                self._last_read_physical_line_count,
++            )
+             self._sequence_validated = True
++        self._seq_file_size = size_now
+         return max(stored or 0, minimum, self._sequence_floor) + 1
+ 
+     def _append_records(
+@@ -1088,6 +1115,10 @@ class InstallHistory:
+                 ) from exc
+             if not history_existed:
+                 fsync_directory(self.path.parent)
++            try:
++                self._seq_file_size = self.path.stat().st_size
++            except OSError:
++                self._seq_file_size = None
+         return tuple(drafts)
+ 
+     def _read_recovery(self, skill: str, target: str) -> Optional[dict]:
+diff --git a/src/xskill/team/client/import_follow.py b/src/xskill/team/client/import_follow.py
+index dda060d..34fce12 100644
+--- a/src/xskill/team/client/import_follow.py
++++ b/src/xskill/team/client/import_follow.py
+@@ -4,7 +4,10 @@ from __future__ import annotations
+ import logging
+ from pathlib import Path
+ 
+-from xskill.ecosystems._history import InstallHistory
++from xskill.ecosystems._history import (
++    InstallHistory,
++    InstallHistoryCorruptError,
++)
+ from xskill.team.client.daemon import install_skill_to_ecosystems
+ from xskill.team.shared.git_bundle import apply_repo_bundle
+ from xskill.team.shared.reconcile import reconcile_skill_side
+@@ -22,7 +25,11 @@ def follow_imported_skill(
+     home_root: Path,
+     history_path: Path,
+ ) -> None:
+-    """拉 bundle，把本机 ``_active`` 切到这次导入的主干，并装到编程代理目录。"""
++    """拉 bundle，把本机 ``_active`` 切到这次导入的主干，并装到编程代理目录。
++
++    安装历史只用于灰度归因。账本坏了也要把技能装进 harness，不能让用户
++    看见「纳入失败」。
++    """
+     if not sha:
+         raise RuntimeError(f"import follow missing sha for {name}")
+     response = http.get(f"/api/v1/team/skill/{name}/bundle", headers=headers)
+@@ -33,16 +40,25 @@ def follow_imported_skill(
+         )
+     dest = Path(skill_dir) / name
+     apply_repo_bundle(response.content, dest)
+-    history = InstallHistory(history_path)
+-    result = reconcile_skill_side(
+-        repo_dir=dest,
+-        target_side="main",
+-        target_sha=sha,
+-        history=history,
+-        on_changed=lambda repo: install_skill_to_ecosystems(
+-            repo, home_root=home_root,
+-        ),
+-    )
+-    if result == "already_aligned":
++    result = "bundle_applied"
++    try:
++        history = InstallHistory(history_path)
++        result = reconcile_skill_side(
++            repo_dir=dest,
++            target_side="main",
++            target_sha=sha,
++            history=history,
++            on_changed=lambda repo: install_skill_to_ecosystems(
++                repo, home_root=home_root,
++            ),
++        )
++    except (InstallHistoryCorruptError, OSError) as history_error:
++        logger.warning(
++            "import follow history skipped for %s: %s",
++            name,
++            history_error,
++        )
++        result = "history_skipped"
++    if result != "checked_out" and result != "skipped_user_edit":
+         install_skill_to_ecosystems(dest, home_root=home_root)
+     logger.info("import follow %s -> main %s (%s)", name, sha[:8], result)

--- a/src/xskill/ecosystems/_history.py
+++ b/src/xskill/ecosystems/_history.py
@@ -38,6 +38,10 @@ from typing import Any, Callable, Iterable, Optional
 
 logger = logging.getLogger("xskill.ecosystems.install_history")
 
+# 旧账本没有 append_sequence，升级后 sidecar 可能落后于行号。
+# 中间几条序号倒退或一行坏 JSON 不应把整台机器的安装停掉。
+_SKIP_BAD_HISTORY_LINES = 64
+
 
 def fsync_directory(directory: Path) -> None:
     """在 POSIX 上持久化 rename/unlink 元数据；Windows 不支持目录 fsync。"""
@@ -463,6 +467,8 @@ class InstallHistory:
         self._index_cache_initialized = False
         self._sequence_validated = False
         self._sequence_floor = 0
+        self._seq_file_size: int | None = None
+        self._skipped_bad_lines = 0
 
     @property
     def _history_lock_path(self) -> Path:
@@ -614,6 +620,8 @@ class InstallHistory:
                 f"install history cannot be decoded: {self.path}"
             ) from exc
         records: list[dict] = []
+        if starting_line_number == 1 and previous_sequence == 0:
+            self._skipped_bad_lines = 0
         for line_number, raw_line in enumerate(
             lines,
             start=starting_line_number,
@@ -625,41 +633,48 @@ class InstallHistory:
             try:
                 record = json.loads(line)
             except json.JSONDecodeError as exc:
-                logger.error(
-                    "invalid install history JSON path=%s line=%d error_type=%s",
-                    self.path,
+                self._skip_or_raise(
                     line_number,
-                    type(exc).__name__,
+                    reason="invalid_json",
+                    error_type=type(exc).__name__,
                 )
-                raise InstallHistoryCorruptError(
-                    f"invalid install history JSON at line {line_number}"
-                ) from exc
+                continue
             if not isinstance(record, dict):
-                logger.error(
-                    "invalid install history schema path=%s line=%d",
-                    self.path,
-                    line_number,
-                )
-                raise InstallHistoryCorruptError(
-                    f"install history line {line_number} is not an object"
-                )
+                self._skip_or_raise(line_number, reason="not_object")
+                continue
             append_sequence = record.get("append_sequence", line_number)
             if (
-                not isinstance(append_sequence, int)
+                isinstance(append_sequence, bool)
+                or not isinstance(append_sequence, int)
                 or append_sequence <= previous_sequence
             ):
-                logger.error(
-                    "non-monotonic install history sequence path=%s line=%d",
-                    self.path,
-                    line_number,
-                )
-                raise InstallHistoryCorruptError(
-                    f"non-monotonic install history at line {line_number}"
-                )
+                self._skip_or_raise(line_number, reason="non_monotonic")
+                continue
             record["append_sequence"] = append_sequence
             previous_sequence = append_sequence
             records.append(record)
         return records
+
+    def _skip_or_raise(
+        self,
+        line_number: int,
+        *,
+        reason: str,
+        error_type: str | None = None,
+    ) -> None:
+        """跳过少量坏行。不把行内容写进日志。超限仍 fail-loud。"""
+        self._skipped_bad_lines += 1
+        logger.warning(
+            "skipping install history line path=%s line=%d reason=%s%s",
+            self.path,
+            line_number,
+            reason,
+            f" error_type={error_type}" if error_type else "",
+        )
+        if self._skipped_bad_lines > _SKIP_BAD_HISTORY_LINES:
+            raise InstallHistoryCorruptError(
+                f"too many unreadable install history lines at line {line_number}"
+            )
 
     def _parse_records_snapshot_locked(
         self,
@@ -1005,6 +1020,13 @@ class InstallHistory:
                 )
 
     def _next_sequence_locked(self, minimum: int) -> int:
+        size_now = self.path.stat().st_size if self.path.is_file() else 0
+        if (
+            self._seq_file_size is not None
+            and size_now != self._seq_file_size
+        ):
+            # 别的进程用旧格式追加过，sidecar 可能已经落后于行号。
+            self._sequence_validated = False
         stored: int | None = None
         sequence_present = self._sequence_path.is_file()
         if sequence_present:
@@ -1038,8 +1060,13 @@ class InstallHistory:
                 ),
                 default=0,
             )
-            stored = max(stored or 0, history_maximum)
+            stored = max(
+                stored or 0,
+                history_maximum,
+                self._last_read_physical_line_count,
+            )
             self._sequence_validated = True
+        self._seq_file_size = size_now
         return max(stored or 0, minimum, self._sequence_floor) + 1
 
     def _append_records(
@@ -1088,6 +1115,10 @@ class InstallHistory:
                 ) from exc
             if not history_existed:
                 fsync_directory(self.path.parent)
+            try:
+                self._seq_file_size = self.path.stat().st_size
+            except OSError:
+                self._seq_file_size = None
         return tuple(drafts)
 
     def _read_recovery(self, skill: str, target: str) -> Optional[dict]:

--- a/src/xskill/team/client/import_follow.py
+++ b/src/xskill/team/client/import_follow.py
@@ -4,7 +4,10 @@ from __future__ import annotations
 import logging
 from pathlib import Path
 
-from xskill.ecosystems._history import InstallHistory
+from xskill.ecosystems._history import (
+    InstallHistory,
+    InstallHistoryCorruptError,
+)
 from xskill.team.client.daemon import install_skill_to_ecosystems
 from xskill.team.shared.git_bundle import apply_repo_bundle
 from xskill.team.shared.reconcile import reconcile_skill_side
@@ -22,7 +25,11 @@ def follow_imported_skill(
     home_root: Path,
     history_path: Path,
 ) -> None:
-    """拉 bundle，把本机 ``_active`` 切到这次导入的主干，并装到编程代理目录。"""
+    """拉 bundle，把本机 ``_active`` 切到这次导入的主干，并装到编程代理目录。
+
+    安装历史只用于灰度归因。账本坏了也要把技能装进 harness，不能让用户
+    看见「纳入失败」。
+    """
     if not sha:
         raise RuntimeError(f"import follow missing sha for {name}")
     response = http.get(f"/api/v1/team/skill/{name}/bundle", headers=headers)
@@ -33,16 +40,25 @@ def follow_imported_skill(
         )
     dest = Path(skill_dir) / name
     apply_repo_bundle(response.content, dest)
-    history = InstallHistory(history_path)
-    result = reconcile_skill_side(
-        repo_dir=dest,
-        target_side="main",
-        target_sha=sha,
-        history=history,
-        on_changed=lambda repo: install_skill_to_ecosystems(
-            repo, home_root=home_root,
-        ),
-    )
-    if result == "already_aligned":
+    result = "bundle_applied"
+    try:
+        history = InstallHistory(history_path)
+        result = reconcile_skill_side(
+            repo_dir=dest,
+            target_side="main",
+            target_sha=sha,
+            history=history,
+            on_changed=lambda repo: install_skill_to_ecosystems(
+                repo, home_root=home_root,
+            ),
+        )
+    except (InstallHistoryCorruptError, OSError) as history_error:
+        logger.warning(
+            "import follow history skipped for %s: %s",
+            name,
+            history_error,
+        )
+        result = "history_skipped"
+    if result != "checked_out" and result != "skipped_user_edit":
         install_skill_to_ecosystems(dest, home_root=home_root)
     logger.info("import follow %s -> main %s (%s)", name, sha[:8], result)

--- a/tests/test_canary_install_atomic.py
+++ b/tests/test_canary_install_atomic.py
@@ -18,6 +18,7 @@ from xskill.ecosystems._history import (
     InstallHistoryCorruptError,
     InstallPlan,
     InstallTransactionRequest,
+    _SKIP_BAD_HISTORY_LINES,
 )
 from xskill.ecosystems.claude_code import (
     CCSessionIngester,
@@ -3080,16 +3081,16 @@ def test_transact_many_parses_history_once_for_twenty_five_skills(tmp_path):
     assert len(history.all_records()) == 25
 
 
-def test_bad_history_line_fails_loud_without_logging_content(tmp_path, caplog):
+def test_bad_history_line_is_skipped_without_logging_content(tmp_path, caplog):
     history_path = tmp_path / "history.jsonl"
     history_path.write_text(
-        '{"skill":"safe"}\nSECRET-BROKEN-CONTENT\n',
+        '{"skill":"safe"}\nSECRET-BROKEN-CONTENT\n{"skill":"after"}\n',
         encoding="utf-8",
     )
 
-    with pytest.raises(InstallHistoryCorruptError):
-        InstallHistory(history_path).all_records()
+    records = InstallHistory(history_path).all_records()
 
+    assert [record.get("skill") for record in records] == ["safe", "after"]
     assert "line=2" in caplog.text
     assert "SECRET-BROKEN-CONTENT" not in caplog.text
 
@@ -3178,3 +3179,49 @@ def test_terminal_and_rotation_share_generation_fence(tmp_path):
 
     assert state == {"generation": "main-v2:", "target": "main"}
     assert history.index().latest("race-skill", "claude_code")["sha"] == "main-v2"
+
+
+def _legacy_line(skill: str) -> str:
+    return json.dumps({
+        "t": 1.0,
+        "action": "install",
+        "skill": skill,
+        "side": "main",
+        "sha": "abc",
+    })
+
+
+def test_mixed_legacy_and_stale_sidecar_sequences_do_not_block(tmp_path):
+    """旧行无序号 + 新行 sidecar 落后于行号时，仍可读、仍可追加。"""
+    history_path = tmp_path / "history.jsonl"
+    lines = [_legacy_line(f"old-{index}") for index in range(1, 11)]
+    lines.append(json.dumps({
+        "t": 2.0,
+        "action": "install",
+        "skill": "atlas-dependency-analysis",
+        "side": "main",
+        "sha": "abc",
+        "append_sequence": 8,
+    }))
+    lines.append(_legacy_line("after-mix"))
+    history_path.write_text("\n".join(lines) + "\n", encoding="utf-8")
+    (tmp_path / "history.jsonl.sequence").write_text("9\n", encoding="ascii")
+
+    history = InstallHistory(history_path)
+    records = history.all_records()
+    skills = [record["skill"] for record in records]
+    assert "old-1" in skills
+    assert "after-mix" in skills
+    assert "atlas-dependency-analysis" not in skills
+
+    written = history.record(skill="new-skill", side="main", sha="def")
+    assert written["append_sequence"] > 11
+
+
+def test_too_many_bad_history_lines_still_fail_loud(tmp_path):
+    history_path = tmp_path / "history.jsonl"
+    payload = "\n".join(["not-json"] * (_SKIP_BAD_HISTORY_LINES + 1)) + "\n"
+    history_path.write_text(payload, encoding="utf-8")
+    with pytest.raises(InstallHistoryCorruptError, match="too many"):
+        InstallHistory(history_path).all_records()
+

--- a/tests/test_import_follow.py
+++ b/tests/test_import_follow.py
@@ -1,0 +1,65 @@
+"""import 收尾：账本坏了也要把技能装进 harness。"""
+from __future__ import annotations
+
+import json
+from pathlib import Path
+
+from xskill.team.client import import_follow
+
+
+class _FakeResponse:
+    def __init__(self, status_code: int = 200, content: bytes = b"bundle"):
+        self.status_code = status_code
+        self.content = content
+        self.text = "ok"
+
+
+class _FakeHttp:
+    def get(self, url, headers=None):
+        del url, headers
+        return _FakeResponse()
+
+
+def test_follow_installs_harness_when_history_is_corrupt(tmp_path, monkeypatch):
+    skill_dir = tmp_path / "skill"
+    dest = skill_dir / "xskill-install-server"
+    dest.mkdir(parents=True)
+    (dest / "SKILL.md").write_text("# imported\n", encoding="utf-8")
+    home = tmp_path / "home"
+    home.mkdir()
+    history_path = tmp_path / "history.jsonl"
+    history_path.write_text(
+        "\n".join(
+            json.dumps({"skill": f"old-{index}"}) for index in range(5)
+        )
+        + "\n"
+        + json.dumps({
+            "skill": "atlas-dependency-analysis",
+            "append_sequence": 2,
+        })
+        + "\n",
+        encoding="utf-8",
+    )
+    installed: list[Path] = []
+
+    monkeypatch.setattr(import_follow, "apply_repo_bundle", lambda *_a, **_k: None)
+
+    def fake_install(repo, *, home_root):
+        del home_root
+        installed.append(Path(repo))
+        return []
+
+    monkeypatch.setattr(
+        import_follow, "install_skill_to_ecosystems", fake_install,
+    )
+
+    import_follow.follow_imported_skill(
+        http=_FakeHttp(),
+        headers={},
+        skill_dir=skill_dir,
+        name="xskill-install-server",
+        sha="deadbeef",
+        home_root=home,
+        history_path=history_path,
+    )
+    assert installed == [dest]


### PR DESCRIPTION
## Summary
- 旧 `install_history.jsonl` 没有 `append_sequence`，升级后 sidecar 可能写出比行号更小的序号；解析不再因此把整份账本判坏，少量倒退序号和坏 JSON 会跳过。
- `xskill import` 收尾即使账本仍不整齐，也会把技能装进 harness，不再报「本机跟上这次主干失败」。
- 对应 #219。PyPI 已有 `0.6.30a2`，本 PR 把同一份修复合进 GitHub main。

## Test plan
- [x] `test_mixed_legacy_and_stale_sidecar_sequences_do_not_block`
- [x] `test_bad_history_line_is_skipped_without_logging_content`
- [x] `test_too_many_bad_history_lines_still_fail_loud`
- [x] `test_follow_installs_harness_when_history_is_corrupt`
- [x] `tests/test_canary_install_atomic.py` 与 reconcile 相关共 70 passed

Closes #219

Made with [Cursor](https://cursor.com)