### PR TITLE
fix(context): generate 压缩后不再清空已执行工作

### DIFF
--- a/src/xskill/agents/agno_factory.py
+++ b/src/xskill/agents/agno_factory.py
@@ -71,7 +71,7 @@ def _wrap_with_context_mgmt(model, llm_cfg: dict, *, spill_root=None):
 
     - max_context 配置优先,缺省 200K + warning（``resolve_max_context``）。
     - 发请求前到 85% 主动剪裁旧 look/readfile 工具返回。
-    - 若 llm/llm_skill 配了 compact_token_limit，剪裁后仍超限时做一次摘要。
+    - 若 llm/llm_skill 配了 compact_token_limit，剪裁后仍超限时写一份续跑 handoff 摘要。
     - 唯一底层兜底：抓后端"上下文超长"报错 → 再剪 → 重发一次。
     - 记后端真实 prompt_tokens 供 ``context_budget()`` 工具读。
 

--- a/src/xskill/agents/context_budget.py
+++ b/src/xskill/agents/context_budget.py
@@ -15,8 +15,8 @@
    ``usage.prompt_tokens`` 与估算 raw 值做 EMA 方向校准。  
    从最旧的开始剪,剪到回落 85% 以下为止。
 3. **可选 compact**：先把可 spill 的结果尽量降到 85% 边界；仍超出
-   ``max(compact_token_limit, spill 边界)`` 才调用同一个 model 做一次工作
-   记忆摘要，然后保留 system、首轮 user、摘要和最近完整消息块。
+   ``max(compact_token_limit, spill 边界)`` 才调用同一个 model 写一份
+   可续跑的 handoff 摘要，然后保留 system、首轮 user、摘要和最近完整消息块。
 4. **最底层兜底（唯一）**：抓住后端抛的"上下文超长"报错 → 再剪一轮历史 →
    **重发一次**。就这一条,不做解析上限学分母、不做多触发统一。
 5. **真实已用 token**：每次请求拿到 ``usage.prompt_tokens`` 写进 thread-local,
@@ -67,32 +67,49 @@ _SPILLABLE_TOOLS = (
     "grep_files", "edit",
 )
 _TRIM_MARK = "[…look 旧结果已剪裁,需要可重新 look…]"
-_COMPACT_MARK = "[compacted_skill_edit_agent_memory]"
+_COMPACT_MARK = "[compacted_agent_memory]"
+_COMPACT_TOOL_ARGS_MAX_CHARS = 2000
 
-COMPACT_PROMPT_TEMPLATE = """You are compacting SkillEditAgent working memory.
+# Handoff prompt: Pi's structured checkpoint + Codex's "another LLM resumes"
+# framing. The old SkillEdit-only "Keep only …" wording made GenerateAgent
+# summaries collapse to empty sections, so the next turn forgot executed work.
+COMPACT_PROMPT_TEMPLATE = """You are performing a CONTEXT CHECKPOINT COMPACTION.
 
-Keep only information needed to continue editing the skill safely.
+The conversation below is working memory for an XSkill agent (GenerateAgent, SkillEditAgent, or similar). Another LLM will resume the SAME task from your summary, plus the original system prompt and a short recent-message tail. If you drop executed work, that next agent will not know what it already did.
 
-You must preserve:
-1. The original task scenario and target skill name.
-2. Candidate atom_ids, weightscore, intent, summary, and unresolved work.
-3. Evidence already read from atom_task_read/read_traj/read_file/skill_read.
-4. Any concrete rules, pitfalls, commands, or file edits already inferred.
-5. Files already read, files already written, and pending files to edit.
-6. All spill_path values needed to reload full evidence later.
+Do NOT continue the task. Do NOT call tools. Do NOT answer the user. ONLY output the handoff summary.
+
+Be dense, not empty. Prefer a longer accurate handoff over a short one that forgets progress. A good summary is usually hundreds to a few thousand words. Empty or near-empty sections are a failure when the history shows real tool calls, file edits, or findings.
+
+If the history already contains a compacted summary, carry every still-relevant fact forward. Newer messages update progress; they do not license deleting earlier decisions, findings, file paths, skill names, or unfinished work.
+
+Preserve, with exact names, paths, ids, commands, and error text whenever present:
+1. The original user request, constraints, and target skill.
+2. What was already executed: tools called, files/trajectories read, files written or edited, searches run, commits attempted, and each outcome.
+3. Concrete findings: rules, pitfalls, commands, errors, function names, line-level evidence, examples, and any skill text already drafted.
+4. SkillEdit candidates when present (atom_id, weightscore, intent, summary) and any still unresolved items. If this run has no candidates, do not invent a Candidate section — put the real work under Progress and Evidence.
+5. All spill_path values, with tool_name and how to reload them.
+6. Current file and skill state, and the next concrete actions.
 
 Do not invent evidence.
-Do not drop unresolved candidates.
-Do not copy long raw trajectory text; summarize it and keep spill_path.
+Do not omit unfinished work just to look concise.
+Do not paste huge raw trajectory dumps; extract the concrete facts listed above and keep every spill_path so full text can be reloaded.
 
-Output sections:
-## Current Goal
-## Candidate Status
-## Evidence Summary
-## Derived Rules
-## File State
-## Pending Actions
+Write in the same language as the conversation.
+
+Use this format:
+
+## Goal
+## Constraints
+## Progress
+### Done
+### In Progress
+### Blocked
+## Key Decisions
+## Evidence And Artifacts
 ## Reloadable Spill Paths
+## Next Steps
+## Critical Context
 
 Conversation history to compact:
 {history}
@@ -381,18 +398,93 @@ def _estimate_history_tokens(
     return int(total * calibration)
 
 
+def _truncate_for_compact(text: str, max_chars: int) -> str:
+    if len(text) <= max_chars:
+        return text
+    omitted = len(text) - max_chars
+    return f"{text[:max_chars]}\n... [{omitted} chars truncated]"
+
+
+def _format_tool_calls_for_compact(msg: Any) -> str:
+    """Serialize assistant tool_calls so the summarizer can see executed work."""
+    calls = getattr(msg, "tool_calls", None)
+    if calls is None and isinstance(msg, dict):
+        calls = msg.get("tool_calls")
+    lines: list[str] = []
+    for call in calls or []:
+        if isinstance(call, dict):
+            function_data = call.get("function") or {}
+            name = function_data.get("name") or call.get("name") or "unknown"
+            arguments = function_data.get("arguments")
+        else:
+            function_data = getattr(call, "function", None)
+            name = (
+                getattr(function_data, "name", None)
+                or getattr(call, "name", None)
+                or "unknown"
+            )
+            arguments = getattr(function_data, "arguments", None)
+        if arguments is None:
+            args_text = ""
+        elif isinstance(arguments, str):
+            args_text = arguments
+        else:
+            args_text = json.dumps(arguments, ensure_ascii=False)
+        args_text = _truncate_for_compact(args_text, _COMPACT_TOOL_ARGS_MAX_CHARS)
+        lines.append(f"[tool_call] {name}({args_text})")
+    return "\n".join(lines)
+
+
+def _format_message_for_compact(index: int, msg: Any) -> str:
+    role = _msg_role(msg) or "unknown"
+    tool = _tool_name(msg)
+    title = f"### message {index}: role={role}"
+    if tool:
+        title += f" tool={tool}"
+    body_parts: list[str] = []
+    content = _msg_content_str(msg)
+    if content:
+        body_parts.append(content)
+    tool_calls_text = _format_tool_calls_for_compact(msg)
+    if tool_calls_text:
+        body_parts.append(tool_calls_text)
+    body = "\n".join(body_parts) if body_parts else "(empty)"
+    return f"{title}\n{body}"
+
+
 def build_compact_prompt(messages: list) -> str:
-    """Build the LLM prompt used to compact SkillEditAgent working memory."""
-    parts: list[str] = []
-    for i, msg in enumerate(messages or [], 1):
-        role = _msg_role(msg) or "unknown"
-        tool = _tool_name(msg)
-        title = f"### message {i}: role={role}"
-        if tool:
-            title += f" tool={tool}"
-        parts.append(title)
-        parts.append(_msg_content_str(msg))
+    """Build the LLM prompt used to compact agent working memory."""
+    parts = [
+        _format_message_for_compact(i, msg)
+        for i, msg in enumerate(messages or [], 1)
+    ]
     return COMPACT_PROMPT_TEMPLATE.replace("{history}", "\n\n".join(parts))
+
+
+def _messages_for_compact_prompt(
+    messages: list,
+    *,
+    system_msg: Any,
+    first_user: Any,
+    tail: list,
+) -> list:
+    """History the summarizer must cover: first user + dropped middle.
+
+    System and the recent tail stay verbatim after compact, so they are
+    omitted here. Dumping the huge system prompt made the summarizer ignore
+    executed work.
+    """
+    kept_ids = {
+        id(msg)
+        for msg in (system_msg, first_user, *tail)
+        if msg is not None
+    }
+    dropped = [msg for msg in messages or [] if id(msg) not in kept_ids]
+    source: list = []
+    if first_user is not None:
+        source.append(first_user)
+    source.extend(dropped)
+    return source
 
 
 def _safe_recent_tail(messages: list, keep_recent_messages: int) -> list:
@@ -568,7 +660,16 @@ def _compact_history_in_place(
     system_msg = next((m for m in messages if _msg_role(m) == "system"), None)
     first_user = next((m for m in messages if _msg_role(m) == "user"), None)
     tail = _safe_recent_tail(messages, keep_recent_messages)
-    prompt = build_compact_prompt(messages)
+    compact_source = _messages_for_compact_prompt(
+        messages,
+        system_msg=system_msg,
+        first_user=first_user,
+        tail=tail,
+    )
+    dropped = [msg for msg in compact_source if msg is not first_user]
+    if not dropped:
+        return False
+    prompt = build_compact_prompt(compact_source)
     summary = (compact_fn(prompt) or "").strip()
     if not summary:
         return False

--- a/src/xskill/config.py
+++ b/src/xskill/config.py
@@ -81,10 +81,11 @@ llm:
                          # gpt-4o, 64000 for deepseek-chat).
   # compact_token_limit: 120000  # optional; after trimming/spilling old tool
                          # results, if the estimated history is still above this
-                         # limit, ask the same chat model to summarize old
-                         # SkillEditAgent memory. The effective limit is never
-                         # below spill@ (85% of max_context), so spill always
-                         # runs first. Leave commented to disable.
+                         # limit, ask the same chat model to write a handoff
+                         # summary of old agent memory (Generate / SkillEdit).
+                         # The effective limit is never below spill@ (85% of
+                         # max_context), so spill always runs first. Leave
+                         # commented to disable.
   # compact_keep_recent_messages: 6 # optional; recent complete message blocks
                          # kept verbatim after compact. Default 6.
   # temperature: 0.0     # optional; default 0 (deterministic)

--- a/tests/test_agno_factory_probe_smoke.py
+++ b/tests/test_agno_factory_probe_smoke.py
@@ -121,7 +121,8 @@ def test_context_management_reads_compact_config_and_calls_compactor(tmp_path):
             })
             if len(calls) == 1:
                 assert len(messages) == 1
-                assert "SkillEditAgent working memory" in messages[0].content
+                assert "CONTEXT CHECKPOINT COMPACTION" in messages[0].content
+                assert "Keep only information needed" not in messages[0].content
                 if assistant_message is not None:
                     assistant_message.role = "assistant"
                     assistant_message.content = "COMPACT SUMMARY"

--- a/tests/test_task_agent.py
+++ b/tests/test_task_agent.py
@@ -959,8 +959,12 @@ class TestContextManager:
         cm.wrap(fake_invoke)(messages)
 
         assert len(compact_calls) == 1
-        assert "SkillEditAgent working memory" in compact_calls[0]
+        assert "CONTEXT CHECKPOINT COMPACTION" in compact_calls[0]
+        assert "handoff summary" in compact_calls[0]
+        assert "Keep only information needed" not in compact_calls[0]
         assert "spill_path:" in compact_calls[0]
+        # system prompt is kept verbatim; do not dump it into the summarizer
+        assert compact_calls[0].count("SkillEditAgent system prompt") == 0
         compacted = seen["messages"]
         assert [m.role for m in compacted] == [
             "system", "user", "assistant", "assistant", "user",
@@ -1038,6 +1042,57 @@ class TestContextManager:
         )
 
         assert compact_calls == []
+
+    def test_compact_prompt_is_handoff_and_includes_tool_calls(self, tmp_path):
+        """压缩提示词应是续跑 handoff，并让摘要模型看见已执行的 tool_call。"""
+        from xskill.agents.context_budget import (
+            COMPACT_PROMPT_TEMPLATE,
+            build_compact_prompt,
+        )
+
+        assert "Keep only information needed" not in COMPACT_PROMPT_TEMPLATE
+        assert "Candidate Status" not in COMPACT_PROMPT_TEMPLATE
+        assert "CONTEXT CHECKPOINT COMPACTION" in COMPACT_PROMPT_TEMPLATE
+        assert "### Done" in COMPACT_PROMPT_TEMPLATE
+        assert "compacted summary" in COMPACT_PROMPT_TEMPLATE
+        assert "GenerateAgent" in COMPACT_PROMPT_TEMPLATE
+
+        class _Msg:
+            def __init__(self, role, content, tool_name=None, tool_calls=None):
+                self.role = role
+                self.content = content
+                self.tool_name = tool_name
+                self.tool_calls = tool_calls
+
+        prompt = build_compact_prompt([
+            _Msg("user", "根据 alice 的轨迹生成 docker-compose skill"),
+            _Msg(
+                "assistant",
+                "",
+                tool_calls=[{
+                    "id": "call_grep",
+                    "function": {
+                        "name": "grep_files",
+                        "arguments": '{"pattern": "compose", "path": "/data/traj"}',
+                    },
+                }],
+            ),
+            _Msg("tool", "hit: docker-compose.yml", "grep_files"),
+            _Msg(
+                "assistant",
+                "准备提交",
+                tool_calls=[{
+                    "id": "call_commit",
+                    "function": {
+                        "name": "commit_generate_main",
+                        "arguments": '{"skill_name": "docker-compose"}',
+                    },
+                }],
+            ),
+        ])
+        assert "[tool_call] grep_files(" in prompt
+        assert "commit_generate_main" in prompt
+        assert "根据 alice 的轨迹生成 docker-compose skill" in prompt
 
     def test_overlong_error_triggers_retrim_and_resend(self):
         from xskill.agents.context_budget import ContextManager, _TRIM_MARK


### PR DESCRIPTION
## Summary

Generate 和 SkillEdit 共用上下文压缩。旧提示词按 SkillEdit 来写，spill 之后又只把 message 正文塞进摘要请求，长任务的 generate 会忘掉已经调用过的工具和写过的文件。这次改成给下一个代理写交接备忘，并把 tool_call 参数带进压缩输入。

## Changes

- 压缩提示词改为 Pi / Codex 那种 handoff：记下已执行工作、结论、spill_path 和下一步；没有候选时不要硬套空的 Candidate 表
- 序列化 assistant 的 tool_call 参数，不再只丢正文
- 摘要请求不再塞进整份 system prompt（本来就会原样保留）
- 单测覆盖提示词文案和 tool_call 可见性

## Test plan

- [x] `pytest tests/test_task_agent.py::TestContextManager tests/test_agno_factory_probe_smoke.py::test_context_management_reads_compact_config_and_calls_compactor`
- [x] 本机用 `~/.aikey` 的 DeepSeek，对同一份 mock Generate 历史做旧提示词和新提示词对照：旧的丢掉命令和已写文件，新的保住
- [ ] 未跑完整 `make test` / `make e2e`（改动只在 compact 提示词与序列化）

## Linked issues

Closes #221


Made with [Cursor](https://cursor.com)