### PR TITLE
fix(import): 纳入技能后写入 skills_catalog 投影表

### DIFF
--- a/src/xskill/skill/importer.py
+++ b/src/xskill/skill/importer.py
@@ -199,11 +199,31 @@ def _target_has_git(target: Path) -> bool:
     return (target / ".git").is_dir()
 
 
+def _notify_imported_catalog(
+    target: Path,
+    catalog_db_path: Path | str | None,
+) -> None:
+    """import 不跑 Agent 工具上下文，git 写出口的 upsert 会被跳过。
+
+    看板技能库读的是 ``skills_catalog`` 投影表，冷启动灌过表之后不再扫盘。
+    这里显式把纳入结果写进 registry，CLI 报成功后面板才能看见。
+    """
+    from xskill.config import get_registry_db_path
+    from xskill.skill.catalog_store import notify_native_upsert
+
+    resolved = (
+        Path(catalog_db_path) if catalog_db_path is not None
+        else get_registry_db_path()
+    )
+    notify_native_upsert(target, db_path=resolved)
+
+
 def import_one_skill(
     skill_dir: Path,
     source: Path,
     *,
     commit_message: str | None = None,
+    catalog_db_path: Path | str | None = None,
 ) -> ImportResult:
     """把一个源技能目录落入 ``skill_dir / source.name``。"""
     source = Path(source).resolve()
@@ -222,6 +242,7 @@ def import_one_skill(
             shutil.copytree(source, copied, symlinks=True)
             return import_one_skill(
                 skill_dir, copied, commit_message=message,
+                catalog_db_path=catalog_db_path,
             )
         finally:
             shutil.rmtree(tmp, ignore_errors=True)
@@ -246,6 +267,7 @@ def import_one_skill(
             init_imported_repo_on_main(target, message)
         code, sha, _ = run_git(["rev-parse", "HEAD"], cwd=str(target))
         result.sha = sha.strip() if code == 0 else ""
+        _notify_imported_catalog(target, catalog_db_path)
         logger.info("imported new skill %s sha=%s", name, result.sha[:8])
         return result
 
@@ -271,6 +293,7 @@ def import_one_skill(
 
     code, sha, _ = run_git(["rev-parse", "HEAD"], cwd=str(target))
     result.sha = sha.strip() if code == 0 else ""
+    _notify_imported_catalog(target, catalog_db_path)
     logger.info("imported existing skill %s sha=%s staging=%s",
                 name, result.sha[:8], result.staging_kept)
     return result

--- a/tests/test_import_skill.py
+++ b/tests/test_import_skill.py
@@ -20,6 +20,7 @@ from xskill.skill.git import (
     init_skill_repo_on_baby,
     run_git,
 )
+from xskill.skill import catalog_store
 from xskill.skill.importer import (
     HARNESS_IMPORT_WARNING,
     discover_import_sources,
@@ -41,6 +42,24 @@ from xskill.team.server.client_registry import ClientRegistry
 
 
 TOKEN = "secret-token"
+
+
+@pytest.fixture(autouse=True)
+def _isolate_import_registry(tmp_path, monkeypatch):
+    """import 会按 get_registry_db_path() 写投影表，测试不得碰到本机 registry。"""
+    registry = tmp_path / "registry.db"
+    monkeypatch.setattr(
+        "xskill.config.get_registry_db_path",
+        lambda: registry,
+    )
+    return registry
+
+
+def _catalog_names(skill_dir: Path, registry: Path) -> list[str]:
+    return [
+        row["name"]
+        for row in catalog_store.list_skills_catalog(skill_dir, db_path=registry)
+    ]
 
 
 def _skill_md(name: str, body: str) -> str:
@@ -114,6 +133,52 @@ def test_standalone_new_skill_without_git_starts_on_main(tmp_path):
     assert current_branch(str(dest)) == "main"
     assert (dest / "scripts" / "run.sh").is_file()
     assert (dest / ".git").is_dir()
+
+
+def test_import_new_skill_appears_in_catalog_after_backfill(
+    tmp_path, _isolate_import_registry,
+):
+    """灌过投影表之后再 import：磁盘已有，看板列表仍应出现新名字。"""
+    registry = _isolate_import_registry
+    skill_dir = tmp_path / "skill"
+    old = _write_skill(skill_dir / "old", "old", "# already there")
+    init_imported_repo_on_main(old, "seed")
+    catalog_store.ensure_skills_catalog(skill_dir, db_path=registry)
+    assert _catalog_names(skill_dir, registry) == ["old"]
+
+    source = _write_skill(tmp_path / "src" / "fresh", "fresh", "# brand new")
+    imported = import_one_skill(skill_dir, source)
+    assert imported.existed is False
+    page = catalog_store.page_skills_catalog(
+        skill_dir, db_path=registry, name="fresh",
+    )
+    assert page["total"] == 1
+    assert page["skills"][0]["name"] == "fresh"
+    assert page["skills"][0]["state"] == "main"
+    assert "fresh helper" in page["skills"][0]["description"]
+    assert _catalog_names(skill_dir, registry) == ["fresh", "old"]
+
+
+def test_import_nothing_to_commit_still_upserts_catalog(
+    tmp_path, _isolate_import_registry,
+):
+    """同名同内容、git 无新提交时，漏掉的投影行也要补上。"""
+    registry = _isolate_import_registry
+    skill_dir = tmp_path / "skill"
+    dest = _write_skill(skill_dir / "foo", "foo", "# same")
+    init_imported_repo_on_main(dest, "already")
+    catalog_store.ensure_skills_catalog(skill_dir, db_path=registry)
+    catalog_store.delete_native_skill("foo", db_path=registry)
+    assert _catalog_names(skill_dir, registry) == []
+
+    source = _write_skill(tmp_path / "incoming" / "foo", "foo", "# same")
+    imported = import_one_skill(skill_dir, source)
+    assert imported.existed is True
+    page = catalog_store.page_skills_catalog(
+        skill_dir, db_path=registry, name="foo",
+    )
+    assert page["total"] == 1
+    assert page["skills"][0]["name"] == "foo"
 
 
 def test_standalone_existing_replaces_files_keeps_history_and_sidecars(tmp_path):
@@ -295,7 +360,9 @@ def _register(client: TestClient) -> dict:
     return {"X-Xskill-Token": TOKEN, "X-Xskill-Client": r.json()["client_id"]}
 
 
-def test_team_import_new_skill_keeps_history_not_skillhub(tmp_path):
+def test_team_import_new_skill_keeps_history_not_skillhub(
+    tmp_path, _isolate_import_registry,
+):
     client = _team_client(tmp_path)
     hdr = _register(client)
     source = _write_skill(tmp_path / "incoming" / "foo", "foo", "# v1")
@@ -316,6 +383,7 @@ def test_team_import_new_skill_keeps_history_not_skillhub(tmp_path):
     assert (dest / "SKILL.md").is_file()
     subjects = _log_subjects(dest)
     assert "source first" in subjects
+    assert "foo" in _catalog_names(tmp_path / "skill", _isolate_import_registry)
     upload = client.post(
         "/api/v1/team/skill_hub/upload",
         files={"file": ("foo.zip", payload, "application/zip")},


### PR DESCRIPTION
## Summary

- import 落仓成功后命令行报 OK，但看板技能库只读 `skills_catalog`。git 写出口没有 Agent 工具上下文，投影 UPSERT 被跳过。
- 纳入完成后显式按 `get_registry_db_path()` 写一行投影，灌过表的现网列表也能立刻看到新技能。
- 单测覆盖：已经 backfill 后再 import、git 无新提交时补投影、team `/skills/import` 同样入表。

## Test plan

- [x] `pytest tests/test_import_skill.py tests/test_skills_catalog_store.py::test_notify_upsert_without_db_path_skips_global`
- [ ] 未跑完整 `make test` / `make e2e`（改动只在 import 落仓后的 catalog 钩子）
- [ ] 合入后在现网用 `xskill import` 纳入一个新名字，看板技能库按名字能搜到（Agent 进不了格力内网）

## Linked issues

Closes #225


Made with [Cursor](https://cursor.com)