### PR TITLE
fix(team): 本机既是 server 又 connect 时不再清空自有仓

### DIFF
--- a/src/xskill/cli.py
+++ b/src/xskill/cli.py
@@ -318,6 +318,17 @@ def cmd_connect(args) -> int:
             print(f"error: {e}", file=sys.stderr)
             return 1
 
+    from xskill.config import (
+        XSKILL_HOME, get_team_server_state_path, resolve_team_client_skill_dir,
+    )
+    client_skill = resolve_team_client_skill_dir(XSKILL_HOME / "skill")
+    if get_team_server_state_path().is_file() and client_skill != XSKILL_HOME / "skill":
+        print(
+            "warning: 本机已是 team server。client 工作副本放到 "
+            f"{client_skill}，不会清理 server 自有仓 {XSKILL_HOME / 'skill'}",
+            file=sys.stderr,
+        )
+
     from xskill.team.client.service import ServiceError, get_backend
     backend = get_backend()
 
@@ -405,7 +416,10 @@ def _run_team_client_forever(state, *, use_proxy: bool,
     """构造 TeamClient 并阻塞跑守护循环。"""
     import httpx
     from xskill.config import (
-        XSKILL_HOME, get_team_client_cursor_path, get_team_client_history_path,
+        XSKILL_HOME,
+        get_team_client_cursor_path,
+        get_team_client_history_path,
+        resolve_team_client_skill_dir,
     )
     from xskill.team.client.daemon import TeamClient
 
@@ -413,7 +427,7 @@ def _run_team_client_forever(state, *, use_proxy: bool,
                         trust_env=use_proxy)
     client = TeamClient(
         state=state, http=http,
-        skill_dir=XSKILL_HOME / "skill",
+        skill_dir=resolve_team_client_skill_dir(XSKILL_HOME / "skill"),
         cursor_path=get_team_client_cursor_path(state.server_url),
         history_path=get_team_client_history_path(state.server_url),
         auto_update=auto_update,

--- a/src/xskill/config.py
+++ b/src/xskill/config.py
@@ -951,6 +951,44 @@ def get_team_server_state_path() -> Path:
     return XSKILL_HOME / "team_server.json"
 
 
+def _canonical_server_skill_dir() -> Path:
+    try:
+        return get_skill_dir()
+    except Exception:  # pylint: disable=broad-exception-caught
+        return XSKILL_HOME / "skill"
+
+
+def is_team_server_canonical_skill_dir(skill_dir: Path | str) -> bool:
+    """这条目录是不是本机 team server 的自有仓。
+
+    本机既 ``serve --server`` 又 ``connect`` 时，client 默认也会指向
+    ``~/.xskill/skill/``。cleanup 会按派发清单删仓，把自有仓收成只剩
+    分给这个 client 的那几十上百个。
+    """
+    if not get_team_server_state_path().is_file():
+        return False
+    try:
+        return (
+            Path(skill_dir).expanduser().resolve()
+            == _canonical_server_skill_dir().expanduser().resolve()
+        )
+    except (OSError, RuntimeError):
+        return False
+
+
+def resolve_team_client_skill_dir(skill_dir: Path | str) -> Path:
+    """client 工作副本目录。与 server 自有仓撞车时改放到 ``client_skill/``。"""
+    requested = Path(skill_dir)
+    if not is_team_server_canonical_skill_dir(requested):
+        return requested
+    relocated = XSKILL_HOME / "client_skill"
+    logger.warning(
+        "team client colocated with team server; using %s instead of %s",
+        relocated, requested,
+    )
+    return relocated
+
+
 def get_team_clients_db_path() -> Path:
     """server 端 client 注册表 SQLite。"""
     return XSKILL_HOME / "team_clients.db"

--- a/src/xskill/team/client/daemon.py
+++ b/src/xskill/team/client/daemon.py
@@ -117,10 +117,16 @@ class TeamClient:
     ):
         self.state = state
         self.http = http
-        # skill working copies 落标准 skill_dir（= ~/.xskill/skill/）——与
-        # standalone 模式同一个位置，不另开 team_skills/。一台机器要么
-        # standalone 要么 client，这个目录谁来管取决于模式。
-        self.skill_dir = Path(skill_dir)
+        # 普通 client：工作副本落 ~/.xskill/skill/，与 standalone 同一位置。
+        # 本机已是 team server 时不能再用自有仓——cleanup 会按派发清单删目录。
+        from xskill.config import resolve_team_client_skill_dir
+        requested = Path(skill_dir)
+        self.skill_dir = resolve_team_client_skill_dir(requested)
+        if self.skill_dir != requested:
+            logger.warning(
+                "colocated team client skill_dir=%s (server canonical preserved)",
+                self.skill_dir,
+            )
         self.skill_dir.mkdir(parents=True, exist_ok=True)
         self.home_root = Path(home_root) if home_root else Path.home()
         self.poll_interval = poll_interval
@@ -191,6 +197,17 @@ class TeamClient:
         manifest.slots = list(manifest.slots[:n])
         return manifest
 
+    def _refuse_canonical_skill_dir(self, action: str) -> bool:
+        """本机 team server 自有仓禁止当 client working copy 来改、删。"""
+        from xskill.config import is_team_server_canonical_skill_dir
+        if not is_team_server_canonical_skill_dir(self.skill_dir):
+            return False
+        logger.error(
+            "refusing client %s of team server skill repo",
+            action,
+        )
+        return True
+
     # ── ③ reconcile ─────────────────────────────────────────────
     def reconcile_skill_sides(self, manifest: SyncResponse) -> None:
         """对 manifest 每个 slot：拉 bundle → 对齐 side → 装到本机生态。
@@ -199,6 +216,8 @@ class TeamClient:
         就是读 manifest slot 的 side/sha；步骤 2/3/4 走共享
         reconcile_skill_side。
         """
+        if self._refuse_canonical_skill_dir("reconcile"):
+            return
         for slot in manifest.slots:
             repo_dir = self.skill_dir / slot.skill_name
             # 拉 bundle 落地/刷新本地 working copy
@@ -361,6 +380,8 @@ class TeamClient:
         自动到 working copy。每个 skill 先跑 reverse_sync_openclaw_dest 把
         dest 改灌回 working copy，下面 git status 才能看到。
         """
+        if self._refuse_canonical_skill_dir("push-edit"):
+            return 0
         from xskill.agents.user_edit_absorb_agent import (
             ReverseSyncStatus,
             reverse_sync_openclaw_dest,
@@ -483,6 +504,8 @@ class TeamClient:
         get_default_ledger().migrate_from_sidecars(
             _ecosystem_skill_roots(self.home_root),
         )
+        if self._refuse_canonical_skill_dir("cleanup"):
+            return
         keep = {s.skill_name for s in manifest.slots}
         for repo_dir in sorted(self.skill_dir.iterdir()):
             if (

--- a/tests/test_team_client.py
+++ b/tests/test_team_client.py
@@ -253,6 +253,44 @@ def test_cleanup_removes_skill_not_in_manifest(server_app, tmp_path):
     assert (tmp_path / "client_home" / ".xskill" / "skill" / "fix-foo").is_dir()   # manifest 里的保留
 
 
+def test_colocated_client_does_not_delete_server_skills(tmp_path, monkeypatch):
+    """本机既是 server 又 connect 时，不得按派发清单清空自有仓。"""
+    from xskill.team.shared.protocol import SyncResponse
+
+    xhome = tmp_path / ".xskill"
+    canonical = xhome / "skill"
+    keep = canonical / "unassigned"
+    keep.mkdir(parents=True)
+    (keep / "SKILL.md").write_text("# keep\n", encoding="utf-8")
+    (xhome / "team_server.json").write_text('{"join_token": "t"}', encoding="utf-8")
+    monkeypatch.setattr("xskill.config.XSKILL_HOME", xhome)
+    monkeypatch.setattr(
+        "xskill.config.get_team_server_state_path",
+        lambda: xhome / "team_server.json",
+    )
+    monkeypatch.setattr("xskill.config.get_skill_dir", lambda: canonical)
+
+    tc = TeamClient(
+        state=ClientState(
+            server_url="http://testserver", client_id="c", join_token="t",
+        ),
+        http=SimpleNamespace(),
+        skill_dir=canonical,
+        cursor_path=tmp_path / "cursor.json",
+        history_path=tmp_path / "history.jsonl",
+        home_root=tmp_path / "home",
+        min_change_interval=0,
+    )
+    assert tc.skill_dir == xhome / "client_skill"
+    empty = SyncResponse(slots=[], server_time=1.0)
+    tc.cleanup(empty)
+    assert keep.is_dir()
+
+    tc.skill_dir = canonical
+    tc.cleanup(empty)
+    assert keep.is_dir()
+
+
 def test_cleanup_reaps_orphaned_ecosystem_links(server_app, tmp_path):
     """cleanup 按生态目录反向收孤儿 link:工作副本被 out-of-band 删除后残留、
     指向 xskill 工作副本根、且不在 manifest 的 dangling link 要收掉;第三方 link /

--- a/tests/test_team_config.py
+++ b/tests/test_team_config.py
@@ -71,3 +71,27 @@ def test_team_server_section_malformed_raises_valueerror_not_attributeerror():
     # allow_anonymous_user 走同一个 section 解析,行为一致
     with pytest.raises(ValueError, match="team 必须是 mapping"):
         C.allow_anonymous_user({"team": "foo"})
+
+
+def test_resolve_team_client_skill_dir_relocates_when_colocated(tmp_path, monkeypatch):
+    xhome = tmp_path / ".xskill"
+    canonical = xhome / "skill"
+    canonical.mkdir(parents=True)
+    (xhome / "team_server.json").write_text("{}", encoding="utf-8")
+    monkeypatch.setattr(C, "XSKILL_HOME", xhome)
+    monkeypatch.setattr(C, "get_team_server_state_path", lambda: xhome / "team_server.json")
+    monkeypatch.setattr(C, "get_skill_dir", lambda: canonical)
+    assert C.resolve_team_client_skill_dir(canonical) == xhome / "client_skill"
+    other = tmp_path / "elsewhere" / "skill"
+    other.mkdir(parents=True)
+    assert C.resolve_team_client_skill_dir(other) == other
+
+
+def test_resolve_team_client_skill_dir_unchanged_without_server(tmp_path, monkeypatch):
+    xhome = tmp_path / ".xskill"
+    canonical = xhome / "skill"
+    canonical.mkdir(parents=True)
+    monkeypatch.setattr(C, "XSKILL_HOME", xhome)
+    monkeypatch.setattr(C, "get_team_server_state_path", lambda: xhome / "missing.json")
+    monkeypatch.setattr(C, "get_skill_dir", lambda: canonical)
+    assert C.resolve_team_client_skill_dir(canonical) == canonical


### PR DESCRIPTION
## Summary

- team client 默认把工作副本放在 `~/.xskill/skill/`，cleanup 会删掉不在派发清单里的技能。server 本机再 connect 自己时，删的就是全量自有仓。
- 检测到本机已有 `team_server.json` 且目录就是 server 自有仓时，工作副本改放到 `~/.xskill/client_skill/`。
- reconcile、push-edit、cleanup 若仍指向自有仓则直接拒绝。connect 时打出警告。

## Test plan

- [x] `pytest tests/test_team_config.py tests/test_team_client.py`
- [ ] 未跑完整 `make test` / `make e2e`
- [ ] 合入后：现网 server 上若仍有本机 connect，先停掉那个 client 守护；已被删的技能目录需要从备份恢复（Agent 进不了格力内网）

## Linked issues

Closes #227


Made with [Cursor](https://cursor.com)