### PR TITLE
feat: import 钉到发起人，技能库空心星 pin 进推荐流

### DIFF
--- a/README.en.md
+++ b/README.en.md
@@ -185,6 +185,7 @@ xskill upload ./my-skill       # package & upload a skill folder (with SKILL.md)
 
 ## 📰 News
 
+- **2026-08-14** `v0.6.30`: Team `xskill import` pins the skill onto the initiator's recommendation list; the skills library shows a hollow star to pin into your feed, plus whether a skill is already pushed or pinned; imported skills appear in the library list immediately.
 - **2026-08-14** `v0.6.30a3`: Team `xskill generate` prints queue/running status on the CLI instead of a blank wait; mixed legacy install history no longer blocks import from installing into harnesses.
 - **2026-08-14** `v0.6.30a2`: After context compaction, team `xskill generate` keeps executed tool work instead of emptying the agent memory.
 - **2026-08-14** `v0.6.30a1`: Team mode adds `xskill generate` to write skills onto main from a user instruction, and `xskill import` to bring existing skills into the native repo.

--- a/README.md
+++ b/README.md
@@ -281,6 +281,7 @@ skillhub:
 
 
 ## 📰 动态
+- **2026-08-14** `v0.6.30`：team `xskill import` 后钉到发起人推荐列表；技能库登录后可点空心星 pin 进自己的推荐流，并标出推给我、已钉状态；import 后技能立即出现在技能库清单。
 - **2026-08-14** `v0.6.30a3`：`xskill generate` 排队和执行时 CLI 及时打出状态，不再干等；旧安装账本混入倒退序号时仍能 import 并装回 harness。
 - **2026-08-14** `v0.6.30a2`：修复 team `xskill generate` 上下文压缩后代理忘掉已执行工作。
 - **2026-08-14** `v0.6.30a1`：team 模式新增 `xskill generate` 按指令写技能到主干；新增 `xskill import` 纳入已有技能。

--- a/README.zh-CN.md
+++ b/README.zh-CN.md
@@ -21,6 +21,7 @@
 
 ## 动态
 
+- **2026-08-14** — `v0.6.30`：team `xskill import` 后钉到发起人推荐列表；技能库登录后可点空心星 pin 进自己的推荐流，并标出推给我、已钉状态。详见 [Release notes](https://github.com/SkillNerds/xskill/releases/tag/v0.6.30)。
 - **2026-08-03** — `v0.6.29a6`：`pymilvus` 改为可选（`xskill[milvus]`），修复 client 自动更新；「我的」页支持推给我 N 个 SKILL / 上传使用去向 / skill commit 状态。详见 [Release notes](https://github.com/SkillNerds/xskill/releases/tag/v0.6.29a6)。
 - **2026-07-07** — `v0.6.2a2`：修复 Windows Group Policy 环境下 `schtasks` 拒绝访问的问题，自动降级到开机启动文件夹，`connect` 无需管理员权限即可后台常驻。
 - **2026-07-07** — `v0.6.2`：用户画像 + skill 推荐引擎（`--name` 稳定身份、多兴趣聚类、80/20 质量+相关性混合推荐、staging 优先达量灰度）；三方 skillhub 纳入检索池；ux 得分 RESTful 查询；Windows 计划任务后台常驻。详见 [Release notes](https://github.com/SkillNerds/xskill/releases/tag/v0.6.2)。

--- a/src/xskill/cli.py
+++ b/src/xskill/cli.py
@@ -1688,10 +1688,13 @@ def _print_import_result(imported, *, json_mode: bool) -> None:
             "main_round_scores_cleared": imported.main_round_scores_cleared,
             "stash_path": imported.stash_path,
             "warnings": imported.warnings,
+            "pinned": imported.pinned,
         }, ensure_ascii=False, indent=2))
         return
     verb = "更新" if imported.existed else "纳入"
     print(f"imported: {imported.name}  ({verb} 主干 {imported.sha[:8]})")
+    if imported.pinned:
+        print("已钉到发起人推荐列表: " + "、".join(imported.pinned))
     if imported.baby_overwritten:
         print("  原来停在预备分支 baby 的草稿已被这次导入覆盖")
     if imported.staging_kept:
@@ -1812,6 +1815,7 @@ def _cmd_import_team(args, sources, *, http=None, headers=None) -> int:
                 body.get("main_round_scores_cleared") or 0
             ),
             stash_path=str(stash) if stash else "",
+            pinned=list(body.get("pinned") or []),
         )
         if is_harness_skill_path(source, home_root=home):
             imported.warnings.append(HARNESS_IMPORT_WARNING)

--- a/src/xskill/dashboard/console.py
+++ b/src/xskill/dashboard/console.py
@@ -337,6 +337,47 @@ def _pack_manifest_slots(resp_slots, *, user: str, prefs: dict,
     return slots
 
 
+def annotate_library_skills(page: dict, *, user: str,
+                            db_path: Optional[Path]) -> None:
+    """给技能库当前页补 pinned / in_push。无 team 上下文则不动。"""
+    ctx = _team_ctx()
+    if getattr(ctx, "client_registry", None) is None or not user:
+        return
+    prefs = effective_prefs(user, db_path=db_path)
+    pinned_set = set(prefs.get("pinned") or [])
+    pin_meta = prefs.get("pin_meta") or {}
+    push_bucket: dict[str, str] = {}
+    try:
+        from xskill.team.server.api import live_manifest_tuning
+        from xskill.team.server.skill_manifest import build_manifest
+        client_id = ctx.client_registry.find_by_user_name(user) or user
+        total_slots, ranked_slots, probability = live_manifest_tuning()
+        resp = build_manifest(
+            client_id=client_id,
+            skill_dir=ctx.skill_dir,
+            probability=probability,
+            ranked_slots=ranked_slots,
+            total_slots=total_slots,
+            traj_root=ctx.traj_root,
+            prefs=prefs,
+            retired=retired_skills(db_path=db_path),
+        )
+        push_bucket = {slot.skill_name: slot.bucket for slot in resp.slots}
+    except Exception:  # pylint: disable=broad-exception-caught
+        logger.debug("skills library in_push annotate skipped", exc_info=True)
+    for row in page.get("skills") or []:
+        name = row.get("name") or ""
+        meta = pin_meta.get(name) or {}
+        is_pinned = name in pinned_set
+        bucket = push_bucket.get(name) or ("pinned" if is_pinned else "")
+        row["pinned"] = is_pinned
+        row["in_push"] = name in push_bucket
+        row["bucket"] = bucket
+        row["pin_scope"] = meta.get("scope") or ""
+        row["user_removable"] = (not is_pinned) or meta.get("set_by") == user
+    page["viewer"] = {"can_pin": True}
+
+
 def _manifest_slots_for_user(ctx, *, user: str,
                              db_path: Optional[Path]) -> list[dict]:
     """为任意 user 现算并打包当前推送槽位（与 /my/manifest 同源）。"""

--- a/src/xskill/dashboard/router.py
+++ b/src/xskill/dashboard/router.py
@@ -9,11 +9,11 @@ import json
 from pathlib import Path
 from typing import Optional
 
-from fastapi import APIRouter, Depends, HTTPException
+from fastapi import APIRouter, Depends, HTTPException, Request
 from fastapi.responses import HTMLResponse, Response
 
 from xskill.dashboard.metrics import DashboardMetrics, skills_catalog_page
-from xskill.dashboard.auth import require_admin
+from xskill.dashboard.auth import _identity_from_request, require_admin
 from xskill.pipeline.registry import (
     harness_share,
     list_watch_dirs,
@@ -143,7 +143,7 @@ def build_dashboard_router(db_path: Optional[Path] = None, *,
         return {"tags": tag_rows}
 
     @router.get("/api/v1/dashboard/skills")
-    def skills(limit: int = 0, offset: int = 0, name: str = "",
+    def skills(request: Request, limit: int = 0, offset: int = 0, name: str = "",
                q: str = "") -> dict:
         """skill 库存清单(分析式：读 skill 目录,不依赖埋点)。
 
@@ -157,11 +157,17 @@ def build_dashboard_router(db_path: Optional[Path] = None, *,
         ``total`` 为过滤后条数，``skills`` 只含当前页。
         列表读 ``skills_catalog`` 投影表（写出口 UPSERT；冷启动对该 root 一次性
         backfill），翻页不再扫盘。
+        登录用户（team）会带上 pinned / in_push，供技能库空心星 pin。
         """
         page = skills_catalog_page(
             skill_dir, skillhub=_build_skillhub(),
             limit=limit, offset=offset, name=name, q=q, db_path=db_path)
         if expose_sensitive:
+            ident = _identity_from_request(request)
+            if ident and ident.get("user"):
+                from xskill.dashboard.console import annotate_library_skills
+                annotate_library_skills(
+                    page, user=ident["user"], db_path=db_path)
             return page
         for index, row in enumerate(page["skills"]):
             source = row["source"]

--- a/src/xskill/dashboard/static/app.js
+++ b/src/xskill/dashboard/static/app.js
@@ -189,6 +189,31 @@ let skillsQ = '';
 let _skillsQTimer = null;
 const SKILLS_PAGE_SIZE = 10;
 
+function libRelationHtml(s) {
+  if (s.pinned) {
+    return `<span class="text-[10px] px-1.5 py-0.5 rounded ${BUCKET_CHIP.pinned}">${esc(bucketLabel({
+      bucket: 'pinned', pin_scope: s.pin_scope, user_removable: s.user_removable,
+    }))}</span>`;
+  }
+  if (s.in_push) {
+    const cls = BUCKET_CHIP[s.bucket] || 'bg-slate-100 text-slate-500';
+    return `<span class="text-[10px] px-1.5 py-0.5 rounded ${cls}">推给我</span>`;
+  }
+  return '';
+}
+
+function libStarHtml(s) {
+  if (s.pinned && !s.user_removable) {
+    return `<span class="inline-flex items-center justify-center w-7 h-7 text-amber-400 opacity-70" title="admin/全局 pin，不可取消">${_myStarSvg(true)}</span>`;
+  }
+  if (s.pinned) {
+    return `<button type="button" class="lib-star inline-flex items-center justify-center w-7 h-7 rounded-md text-amber-400 hover:text-amber-500 hover:bg-slate-50"
+      data-skill="${esc(s.name)}" data-act="clear" title="已 pin · 点击取消" aria-label="取消 pin">${_myStarSvg(true)}</button>`;
+  }
+  return `<button type="button" class="lib-star inline-flex items-center justify-center w-7 h-7 rounded-md text-slate-300 hover:text-amber-300 hover:bg-slate-50"
+    data-skill="${esc(s.name)}" data-act="pin" title="未 pin · 点击加入推荐流" aria-label="pin">${_myStarSvg(false)}</button>`;
+}
+
 async function loadSkills() {
   const off = skillsPage * SKILLS_PAGE_SIZE;
   const qEl = document.getElementById('skills-q');
@@ -199,13 +224,15 @@ async function loadSkills() {
     offset: String(off),
   });
   if (q) sp.set('q', q);
-  const d = await jc(`api/v1/dashboard/skills?${sp}`);
+  const d = await j(`api/v1/dashboard/skills?${sp}`);
   const bs = d.by_state || {};
   const parts = Object.keys(bs).sort().map(k => `${k} ${bs[k]}`).join(' · ');
   put('skills.summary', `${q ? '匹配' : '共'} ${d.total} 个${parts ? ' · ' + parts : ''}`);
+  const canPin = !!(d.viewer && d.viewer.can_pin);
   rows('skills-body', (d.skills || []).map(s =>
     `<tr class="hover:bg-slate-50 cursor-pointer" data-skill-row="${esc(s.name)}">`
-    + `<td class="py-2.5 font-medium text-teal-700">${esc(s.name)}${sourceBadge(s)}</td>`
+    + (canPin ? `<td class="py-2.5 w-8">${libStarHtml(s)}</td>` : '<td class="py-2.5 w-8"></td>')
+    + `<td class="py-2.5 font-medium text-teal-700"><span class="inline-flex items-center gap-1.5 flex-wrap">${esc(s.name)}${sourceBadge(s)}${libRelationHtml(s)}</span></td>`
     + `<td>${stateBadge(s.state)}</td>`
     + `<td class="text-slate-500 max-w-[480px] truncate" title="${esc(s.description)}">${esc(s.description) || '—'}</td>`
     + `<td class="text-right tabular-nums">v${esc(s.version)}</td>`
@@ -1572,6 +1599,18 @@ document.addEventListener('click', async e => {
     if (aidx > 0) { location.hash = '#traj/' + abody.slice(0, aidx) + '/' + ajump.dataset.atom; }
     return;
   }
+  const libStar = e.target.closest('.lib-star');
+  if (libStar) {
+    const name = libStar.dataset.skill;
+    const act = libStar.dataset.act;
+    if (!name || (act !== 'pin' && act !== 'clear')) return;
+    try {
+      await jpost('/api/v1/dashboard/my/prefs', { skill_name: name, action: act });
+      await loadSkills();
+      if (IDENT) loadMy().catch(console.error);
+    } catch (err) { alert(err.message); }
+    return;
+  }
   const row = e.target.closest('[data-skill-row]');
   if (row) { _skillBackHash = null; location.hash = 'skill/' + encodeURIComponent(row.dataset.skillRow); return; }
   const sj = e.target.closest('.skill-jump');
@@ -1713,6 +1752,7 @@ async function initIdent() {
     const h = (location.hash || '').replace(/^#/, '');
     if (!h) location.hash = '#my';
   }
+  loadSkills().catch(console.error);
 }
 
 // 登录弹窗
@@ -1729,6 +1769,7 @@ document.getElementById('login-submit').addEventListener('click', async () => {
     _lm.classList.add('hidden');
     applyIdent();
     loadMy().catch(console.error);
+    loadSkills().catch(console.error);
     initEvents();
     if (IDENT.role === 'admin') { loadAdmin().catch(console.error); loadSettings().catch(console.error); }
     else location.hash = '#my';
@@ -1738,6 +1779,7 @@ document.getElementById('login-secret').addEventListener('keydown', e => { if (e
 document.getElementById('btn-logout').addEventListener('click', async () => {
   await jpost('/api/v1/dashboard/logout').catch(() => {});
   IDENT = null; applyIdent(); location.hash = '#overview';
+  loadSkills().catch(console.error);
 });
 
 // ── 我的 ────────────────────────────────────────────────────────

--- a/src/xskill/dashboard/static/index.html
+++ b/src/xskill/dashboard/static/index.html
@@ -240,10 +240,11 @@
         <div class="overflow-x-auto">
         <table class="w-full mt-2 text-[12.5px]">
           <thead><tr class="text-[11px] text-slate-400 border-b border-slate-100">
+            <th class="text-left font-medium py-2 w-8"></th>
             <th class="text-left font-medium py-2">技能</th><th class="text-left font-medium">状态 <span class="hint" title="baby=cluster 刚建的草稿；main=已正式产出；staging=灰度候选并存。">ⓘ</span></th>
             <th class="text-left font-medium">描述</th><th class="text-right font-medium">版本</th>
             <th class="text-right font-medium">候选 <span class="hint" title=".candidates.yml 里待攒分的 atom 数。">ⓘ</span></th></tr></thead>
-          <tbody id="skills-body" class="divide-y divide-slate-50"><tr><td colspan="5" class="py-2 text-slate-400">加载中…</td></tr></tbody></table>
+          <tbody id="skills-body" class="divide-y divide-slate-50"><tr><td colspan="6" class="py-2 text-slate-400">加载中…</td></tr></tbody></table>
           <div id="skills-pager" class="flex items-center justify-end gap-2 mt-2 text-[11px] text-slate-500"></div>
         </div>
       </div>

--- a/src/xskill/skill/importer.py
+++ b/src/xskill/skill/importer.py
@@ -199,11 +199,31 @@ def _target_has_git(target: Path) -> bool:
     return (target / ".git").is_dir()
 
 
+def _notify_imported_catalog(
+    target: Path,
+    catalog_db_path: Path | str | None,
+) -> None:
+    """import 不跑 Agent 工具上下文，git 写出口的 upsert 会被跳过。
+
+    看板技能库读的是 ``skills_catalog`` 投影表，冷启动灌过表之后不再扫盘。
+    这里显式把纳入结果写进 registry，CLI 报成功后面板才能看见。
+    """
+    from xskill.config import get_registry_db_path
+    from xskill.skill.catalog_store import notify_native_upsert
+
+    resolved = (
+        Path(catalog_db_path) if catalog_db_path is not None
+        else get_registry_db_path()
+    )
+    notify_native_upsert(target, db_path=resolved)
+
+
 def import_one_skill(
     skill_dir: Path,
     source: Path,
     *,
     commit_message: str | None = None,
+    catalog_db_path: Path | str | None = None,
 ) -> ImportResult:
     """把一个源技能目录落入 ``skill_dir / source.name``。"""
     source = Path(source).resolve()
@@ -222,6 +242,7 @@ def import_one_skill(
             shutil.copytree(source, copied, symlinks=True)
             return import_one_skill(
                 skill_dir, copied, commit_message=message,
+                catalog_db_path=catalog_db_path,
             )
         finally:
             shutil.rmtree(tmp, ignore_errors=True)
@@ -246,6 +267,7 @@ def import_one_skill(
             init_imported_repo_on_main(target, message)
         code, sha, _ = run_git(["rev-parse", "HEAD"], cwd=str(target))
         result.sha = sha.strip() if code == 0 else ""
+        _notify_imported_catalog(target, catalog_db_path)
         logger.info("imported new skill %s sha=%s", name, result.sha[:8])
         return result
 
@@ -271,6 +293,7 @@ def import_one_skill(
 
     code, sha, _ = run_git(["rev-parse", "HEAD"], cwd=str(target))
     result.sha = sha.strip() if code == 0 else ""
+    _notify_imported_catalog(target, catalog_db_path)
     logger.info("imported existing skill %s sha=%s staging=%s",
                 name, result.sha[:8], result.staging_kept)
     return result

--- a/src/xskill/skill/importer.py
+++ b/src/xskill/skill/importer.py
@@ -65,6 +65,7 @@ class ImportResult:
     main_round_scores_cleared: int = 0
     warnings: list[str] = field(default_factory=list)
     stash_path: str = ""
+    pinned: list[str] = field(default_factory=list)
 
 
 def is_skill_source_dir(path: Path) -> bool:

--- a/src/xskill/team/server/api.py
+++ b/src/xskill/team/server/api.py
@@ -1259,13 +1259,43 @@ async def team_skills_import(
     if len(payload) > 50 * 1024 * 1024:
         raise HTTPException(status_code=413, detail="import archive exceeds 50MB")
     result = await run_in_threadpool(_import_skill_archive, payload, skill_name)
-    logger.info("native import from %s: %s sha=%s existed=%s",
+    result["pinned"] = _pin_imported_skill(client_id, result["name"])
+    logger.info("native import from %s: %s sha=%s existed=%s pinned=%s",
                 client_id, result["name"], result.get("sha", "")[:8],
-                result.get("existed"))
+                result.get("existed"), result["pinned"])
     return result
 
 
 _IMPORT_ARCHIVE_MAX_FILES = 20000
+
+
+def _pin_imported_skill(client_id: str, skill_name: str) -> list[str]:
+    """纳入后钉到发起人，和 generate 一样只钉 user_name，不钉全员。"""
+    row = (_ctx.client_registry.get(client_id) or {}) if _ctx.client_registry else {}
+    user_id = (row.get("user_name") or "").strip()
+    if not user_id:
+        return []
+    from xskill.api import app as app_mod
+    from xskill.config import get_registry_db_path, team_server_slots_config
+    from xskill.team.server.generate_jobs import pin_generated_skills
+
+    max_pinned = None
+    try:
+        max_pinned = team_server_slots_config(app_mod._config or {})["skill_slots"]
+    except Exception:  # pylint: disable=broad-exception-caught
+        logger.debug("skill_slots unavailable for import pin quota", exc_info=True)
+    pinned = pin_generated_skills(
+        user_id=user_id,
+        skill_names=[skill_name],
+        db_path=get_registry_db_path(),
+        max_pinned=max_pinned,
+    )
+    try:
+        from xskill.dashboard.console import _bump_routing_epoch
+        _bump_routing_epoch()
+    except Exception:  # pylint: disable=broad-exception-caught
+        logger.debug("routing epoch bump after import pin skipped", exc_info=True)
+    return pinned
 
 
 def _import_skill_archive(payload: bytes, skill_name: str) -> dict:

--- a/tests/test_dashboard_console_p2.py
+++ b/tests/test_dashboard_console_p2.py
@@ -177,6 +177,45 @@ def test_retired_not_distributed_even_if_pinned(console_env):
     assert all(s.skill_name != "gamma" for s in resp.slots)
 
 
+def test_annotate_library_skills_pin_and_push(console_env):
+    from xskill.dashboard.console import annotate_library_skills
+
+    db = console_env["db"]
+    R.set_skill_pref(user_key="alice", skill_name="gamma", pref="pinned",
+                     set_by="alice", db_path=db)
+    R.set_skill_pref(user_key="alice", skill_name="alpha", pref="blocked",
+                     set_by="alice", db_path=db)
+    page = {"skills": [
+        {"name": "alpha"}, {"name": "beta"}, {"name": "gamma"},
+    ]}
+    annotate_library_skills(page, user="alice", db_path=db)
+    assert page["viewer"]["can_pin"] is True
+    by_name = {row["name"]: row for row in page["skills"]}
+    assert by_name["gamma"]["pinned"] is True
+    assert by_name["gamma"]["in_push"] is True
+    assert by_name["gamma"]["bucket"] == "pinned"
+    assert by_name["gamma"]["user_removable"] is True
+    assert by_name["alpha"]["pinned"] is False
+    assert by_name["alpha"]["in_push"] is False
+    assert by_name["beta"]["pinned"] is False
+    assert by_name["beta"]["in_push"] is True
+    assert by_name["beta"]["bucket"] in ("ranked", "recommended")
+
+
+def test_annotate_library_skills_admin_pin_not_user_removable(console_env):
+    from xskill.dashboard.console import annotate_library_skills
+
+    db = console_env["db"]
+    R.set_skill_pref(user_key=R.GLOBAL_PREF_KEY, skill_name="gamma",
+                     pref="pinned", set_by="boss", db_path=db)
+    page = {"skills": [{"name": "gamma"}]}
+    annotate_library_skills(page, user="alice", db_path=db)
+    row = page["skills"][0]
+    assert row["pinned"] is True
+    assert row["pin_scope"] == "global"
+    assert row["user_removable"] is False
+
+
 # ── 2.4d 写入侧超量拒绝 ───────────────────────────────────────────────
 
 def test_pin_quota_rejected_at_write_side(console_env):

--- a/tests/test_dashboard_skills_pagination.py
+++ b/tests/test_dashboard_skills_pagination.py
@@ -16,6 +16,10 @@ from xskill.dashboard.router import build_dashboard_router
 from xskill.pipeline.registry import get_connection
 
 
+class _AnonRequest:
+    cookies = {}
+
+
 def _fake_catalog_rows(skill_dir, n):
     root_key = catalog_store.catalog_root_key(skill_dir)
     rows = []
@@ -125,20 +129,20 @@ def test_standalone_projects_10000_skills_for_all_page_and_name(
         if route.path == "/api/v1/dashboard/skills"
     )
 
-    all_skills = skills_endpoint()
+    all_skills = skills_endpoint(request=_AnonRequest())
     assert all_skills["total"] == 10000
     assert len(all_skills["skills"]) == 10000
     assert set(all_skills["skills"][0]) == {
         "name", "state", "source", "version", "candidates",
     }
 
-    page = skills_endpoint(limit=100, offset=4200)
+    page = skills_endpoint(request=_AnonRequest(), limit=100, offset=4200)
     assert len(page["skills"]) == 100
     assert page["skills"][0]["name"] == "s4200"
     assert page["offset"] == 4200
     assert page["limit"] == 100
 
-    named = skills_endpoint(name="s4242")
+    named = skills_endpoint(request=_AnonRequest(), name="s4242")
     assert named["total"] == 1  # name 过滤时 total 为命中条数
     assert named["skills"] == [{
         "name": "s4242",
@@ -191,7 +195,7 @@ def test_standalone_projection_reuses_catalog_page_list(tmp_path, monkeypatch):
         for route in router.routes
         if route.path == "/api/v1/dashboard/skills"
     )
-    body = skills_endpoint()
+    body = skills_endpoint(request=_AnonRequest())
     assert body is page
     assert body["skills"] is original_list
     assert body["skills"][0] is not original_first_row

--- a/tests/test_import_skill.py
+++ b/tests/test_import_skill.py
@@ -20,6 +20,7 @@ from xskill.skill.git import (
     init_skill_repo_on_baby,
     run_git,
 )
+from xskill.skill import catalog_store
 from xskill.skill.importer import (
     HARNESS_IMPORT_WARNING,
     discover_import_sources,
@@ -41,6 +42,24 @@ from xskill.team.server.client_registry import ClientRegistry
 
 
 TOKEN = "secret-token"
+
+
+@pytest.fixture(autouse=True)
+def _isolate_import_registry(tmp_path, monkeypatch):
+    """import 会按 get_registry_db_path() 写投影表，测试不得碰到本机 registry。"""
+    registry = tmp_path / "registry.db"
+    monkeypatch.setattr(
+        "xskill.config.get_registry_db_path",
+        lambda: registry,
+    )
+    return registry
+
+
+def _catalog_names(skill_dir: Path, registry: Path) -> list[str]:
+    return [
+        row["name"]
+        for row in catalog_store.list_skills_catalog(skill_dir, db_path=registry)
+    ]
 
 
 def _skill_md(name: str, body: str) -> str:
@@ -114,6 +133,52 @@ def test_standalone_new_skill_without_git_starts_on_main(tmp_path):
     assert current_branch(str(dest)) == "main"
     assert (dest / "scripts" / "run.sh").is_file()
     assert (dest / ".git").is_dir()
+
+
+def test_import_new_skill_appears_in_catalog_after_backfill(
+    tmp_path, _isolate_import_registry,
+):
+    """灌过投影表之后再 import：磁盘已有，看板列表仍应出现新名字。"""
+    registry = _isolate_import_registry
+    skill_dir = tmp_path / "skill"
+    old = _write_skill(skill_dir / "old", "old", "# already there")
+    init_imported_repo_on_main(old, "seed")
+    catalog_store.ensure_skills_catalog(skill_dir, db_path=registry)
+    assert _catalog_names(skill_dir, registry) == ["old"]
+
+    source = _write_skill(tmp_path / "src" / "fresh", "fresh", "# brand new")
+    imported = import_one_skill(skill_dir, source)
+    assert imported.existed is False
+    page = catalog_store.page_skills_catalog(
+        skill_dir, db_path=registry, name="fresh",
+    )
+    assert page["total"] == 1
+    assert page["skills"][0]["name"] == "fresh"
+    assert page["skills"][0]["state"] == "main"
+    assert "fresh helper" in page["skills"][0]["description"]
+    assert _catalog_names(skill_dir, registry) == ["fresh", "old"]
+
+
+def test_import_nothing_to_commit_still_upserts_catalog(
+    tmp_path, _isolate_import_registry,
+):
+    """同名同内容、git 无新提交时，漏掉的投影行也要补上。"""
+    registry = _isolate_import_registry
+    skill_dir = tmp_path / "skill"
+    dest = _write_skill(skill_dir / "foo", "foo", "# same")
+    init_imported_repo_on_main(dest, "already")
+    catalog_store.ensure_skills_catalog(skill_dir, db_path=registry)
+    catalog_store.delete_native_skill("foo", db_path=registry)
+    assert _catalog_names(skill_dir, registry) == []
+
+    source = _write_skill(tmp_path / "incoming" / "foo", "foo", "# same")
+    imported = import_one_skill(skill_dir, source)
+    assert imported.existed is True
+    page = catalog_store.page_skills_catalog(
+        skill_dir, db_path=registry, name="foo",
+    )
+    assert page["total"] == 1
+    assert page["skills"][0]["name"] == "foo"
 
 
 def test_standalone_existing_replaces_files_keeps_history_and_sidecars(tmp_path):
@@ -295,7 +360,9 @@ def _register(client: TestClient) -> dict:
     return {"X-Xskill-Token": TOKEN, "X-Xskill-Client": r.json()["client_id"]}
 
 
-def test_team_import_new_skill_keeps_history_not_skillhub(tmp_path):
+def test_team_import_new_skill_keeps_history_not_skillhub(
+    tmp_path, _isolate_import_registry,
+):
     client = _team_client(tmp_path)
     hdr = _register(client)
     source = _write_skill(tmp_path / "incoming" / "foo", "foo", "# v1")
@@ -316,6 +383,7 @@ def test_team_import_new_skill_keeps_history_not_skillhub(tmp_path):
     assert (dest / "SKILL.md").is_file()
     subjects = _log_subjects(dest)
     assert "source first" in subjects
+    assert "foo" in _catalog_names(tmp_path / "skill", _isolate_import_registry)
     upload = client.post(
         "/api/v1/team/skill_hub/upload",
         files={"file": ("foo.zip", payload, "application/zip")},

--- a/tests/test_import_skill.py
+++ b/tests/test_import_skill.py
@@ -384,6 +384,7 @@ def test_team_import_new_skill_keeps_history_not_skillhub(
     subjects = _log_subjects(dest)
     assert "source first" in subjects
     assert "foo" in _catalog_names(tmp_path / "skill", _isolate_import_registry)
+    assert body.get("pinned") == []
     upload = client.post(
         "/api/v1/team/skill_hub/upload",
         files={"file": ("foo.zip", payload, "application/zip")},
@@ -471,3 +472,52 @@ def test_scripting_button_gates(tmp_path):
     (staged / "SKILL.md").write_text(_skill_md("stg", "# s"), encoding="utf-8")
     assert commit_to_staging_branch(str(staged), "cand")
     assert "灰度" in scripting_gate_reason(staged)
+
+
+def _register_named(client: TestClient, user_name: str) -> dict:
+    r = client.post("/api/v1/team/register", json={
+        "token": TOKEN, "client_label": "t", "hostname": "h",
+        "user_name": user_name,
+    })
+    assert r.status_code == 200, r.text
+    return {"X-Xskill-Token": TOKEN, "X-Xskill-Client": r.json()["client_id"]}
+
+
+def test_team_import_pins_named_initiator(
+    tmp_path, _isolate_import_registry, monkeypatch,
+):
+    from xskill.api import app as app_mod
+    from xskill.pipeline.registry import prefs_for
+
+    monkeypatch.setattr(
+        app_mod, "_config",
+        {"team": {"server": {"skill_slots": 10, "ranked_slots": 8}}},
+    )
+    client = _team_client(tmp_path)
+    hdr = _register_named(client, "alice")
+    source = _write_skill(tmp_path / "incoming" / "foo", "foo", "# v1")
+    r = client.post(
+        "/api/v1/team/skills/import",
+        files={"file": ("foo.zip", pack_import_zip(source), "application/zip")},
+        data={"name": "foo"},
+        headers=hdr,
+    )
+    assert r.status_code == 200, r.text
+    body = r.json()
+    assert body["pinned"] == ["foo"]
+    rows = prefs_for("alice", db_path=_isolate_import_registry)
+    assert any(p["skill_name"] == "foo" and p["pref"] == "pinned" for p in rows)
+
+
+def test_team_import_anonymous_does_not_pin(tmp_path, _isolate_import_registry):
+    client = _team_client(tmp_path)
+    hdr = _register(client)
+    source = _write_skill(tmp_path / "incoming" / "bar", "bar", "# v1")
+    r = client.post(
+        "/api/v1/team/skills/import",
+        files={"file": ("bar.zip", pack_import_zip(source), "application/zip")},
+        data={"name": "bar"},
+        headers=hdr,
+    )
+    assert r.status_code == 200, r.text
+    assert r.json()["pinned"] == []

--- a/tests/test_library_pin.py
+++ b/tests/test_library_pin.py
@@ -1,0 +1,106 @@
+"""技能库登录后带 pinned / in_push，供空心星 pin。"""
+from __future__ import annotations
+
+import subprocess
+from pathlib import Path
+
+from fastapi import FastAPI
+from fastapi.testclient import TestClient
+
+from xskill.dashboard.auth import (
+    build_auth_router, configure_auth, ensure_dashboard_secret,
+)
+from xskill.dashboard.console import build_console_router
+from xskill.dashboard.router import build_dashboard_router
+from xskill.pipeline import registry as R
+from xskill.team.server.api import init_team_context
+from xskill.team.server.client_registry import ClientRegistry
+
+
+def _git(args, cwd):
+    subprocess.run(["git"] + args, cwd=str(cwd),
+                   capture_output=True, text=True, check=True)
+
+
+def _make_skill(root: Path, name: str) -> Path:
+    d = root / name
+    d.mkdir(parents=True)
+    _git(["init", "-q"], d)
+    _git(["checkout", "-q", "-b", "main"], d)
+    _git(["config", "user.email", "t@t"], d)
+    _git(["config", "user.name", "t"], d)
+    (d / "SKILL.md").write_text(f"# {name}\n", encoding="utf-8")
+    _git(["add", "."], d)
+    _git(["commit", "-q", "-m", "v1"], d)
+    return d
+
+
+def _library_client(tmp_path, monkeypatch):
+    skills = tmp_path / "skill"
+    skills.mkdir()
+    for name in ("alpha", "beta"):
+        _make_skill(skills, name)
+    db = tmp_path / "r.db"
+    R.get_connection(db).close()
+    monkeypatch.setattr("xskill.config.get_registry_db_path", lambda: db)
+    monkeypatch.setattr(
+        "xskill.pipeline.registry.get_registry_db_path", lambda: db)
+    reg = ClientRegistry(tmp_path / "c.db")
+    cid = reg.register(user_name="alice")
+    token = reg.ensure_dashboard_token(cid)
+    init_team_context(
+        join_token="jt", client_registry=reg, skill_dir=skills,
+        traj_root=tmp_path / "traj",
+        register_dir=lambda path, label: None)
+    from xskill.api import app as app_mod
+    app_mod._config = {"team": {"server": {"skill_slots": 3, "ranked_slots": 2}}}
+    configure_auth(
+        secret=ensure_dashboard_secret(tmp_path / "sec.json"),
+        admins=["boss"], admin_password="pw",
+        registry_provider=lambda: reg)
+    app = FastAPI()
+    app.include_router(build_dashboard_router(db_path=db))
+    app.include_router(build_auth_router())
+    app.include_router(build_console_router(db_path=db))
+    anon = TestClient(app)
+    alice = TestClient(app)
+    assert alice.post("/api/v1/dashboard/login",
+                      json={"user_name": "alice", "secret": token}
+                      ).status_code == 200
+    return {"anon": anon, "alice": alice, "db": db}
+
+
+def test_anonymous_skills_have_no_pin_fields(tmp_path, monkeypatch):
+    env = _library_client(tmp_path, monkeypatch)
+    body = env["anon"].get("/api/v1/dashboard/skills").json()
+    assert body["total"] >= 2
+    assert "viewer" not in body
+    for row in body["skills"]:
+        assert "pinned" not in row
+        assert "in_push" not in row
+
+
+def test_logged_in_skills_include_pin_state(tmp_path, monkeypatch):
+    env = _library_client(tmp_path, monkeypatch)
+    alice, db = env["alice"], env["db"]
+    R.set_skill_pref(user_key="alice", skill_name="alpha", pref="pinned",
+                     set_by="alice", db_path=db)
+    body = alice.get("/api/v1/dashboard/skills").json()
+    assert body["viewer"]["can_pin"] is True
+    by_name = {row["name"]: row for row in body["skills"]}
+    assert by_name["alpha"]["pinned"] is True
+    assert by_name["alpha"]["in_push"] is True
+    assert by_name["alpha"]["user_removable"] is True
+    assert by_name["beta"]["pinned"] is False
+
+
+def test_library_pin_via_prefs_then_skills_list(tmp_path, monkeypatch):
+    env = _library_client(tmp_path, monkeypatch)
+    alice = env["alice"]
+    r = alice.post("/api/v1/dashboard/my/prefs",
+                   json={"skill_name": "beta", "action": "pin"})
+    assert r.status_code == 200, r.text
+    body = alice.get("/api/v1/dashboard/skills").json()
+    by_name = {row["name"]: row for row in body["skills"]}
+    assert by_name["beta"]["pinned"] is True
+    assert by_name["beta"]["in_push"] is True


### PR DESCRIPTION
## Summary
- team `xskill import` 成功后把技能钉到发起人（有 user_name）的推荐列表，和 generate 一样立即出现在「我的」；匿名注册不钉。
- 技能库登录后展示空心星，点击走已有 `POST /my/prefs` pin 进自己的推荐流；已推送、已钉状态用和「我的」相同的标签标出。点星星不打开详情。
- 一并带上 import 写入 `skills_catalog`（#225），否则技能库列表根本没有这一行。本 PR 取代 #226。

Closes #229
Closes #225

## Test plan
- [ ] `PYTHONPATH=src pytest tests/test_import_skill.py tests/test_library_pin.py tests/test_dashboard_console_p2.py tests/test_dashboard_skills_pagination.py tests/test_dashboard_standalone.py`
- [ ] 带 `--name` 的 client `xskill import` 后，发起人「我的」出现该技能（pinned）
- [ ] 看板技能库登录后能看到空心星；点击后变成实心星，标签为 pinned·自己；刷新「我的」也能看到
- [ ] 已被推荐但未钉的技能显示「推给我」；admin/全局钉显示实心星且不可点取消
- [ ] 未登录技能库列表不带个人 pin 字段


Made with [Cursor](https://cursor.com)