### PR TITLE
fix: rebuild --force 不误删 import 技能，并修 objects Directory not empty

### DIFF
--- a/README.en.md
+++ b/README.en.md
@@ -185,6 +185,7 @@ xskill upload ./my-skill       # package & upload a skill folder (with SKILL.md)
 
 ## 📰 News
 
+- **2026-08-14** `v0.6.31`: `xskill rebuild --force` no longer dies on a non-empty `.git/objects` directory; a full rebuild keeps skills brought in with `xskill import` and only wipes distilled ones.
 - **2026-08-14** `v0.6.30`: Team `xskill import` pins the skill onto the initiator's recommendation list; the skills library shows a hollow star to pin into your feed, plus whether a skill is already pushed or pinned; imported skills appear in the library list immediately.
 - **2026-08-14** `v0.6.30a3`: Team `xskill generate` prints queue/running status on the CLI instead of a blank wait; mixed legacy install history no longer blocks import from installing into harnesses.
 - **2026-08-14** `v0.6.30a2`: After context compaction, team `xskill generate` keeps executed tool work instead of emptying the agent memory.

--- a/README.md
+++ b/README.md
@@ -281,6 +281,7 @@ skillhub:
 
 
 ## 📰 动态
+- **2026-08-14** `v0.6.31`：`xskill rebuild --force` 不再因 `.git/objects` 非空中断；全量 rebuild 会留下 `xskill import` 纳入的技能，只清蒸馏产物。
 - **2026-08-14** `v0.6.30`：team `xskill import` 后钉到发起人推荐列表；技能库登录后可点空心星 pin 进自己的推荐流，并标出推给我、已钉状态；import 后技能立即出现在技能库清单。
 - **2026-08-14** `v0.6.30a3`：`xskill generate` 排队和执行时 CLI 及时打出状态，不再干等；旧安装账本混入倒退序号时仍能 import 并装回 harness。
 - **2026-08-14** `v0.6.30a2`：修复 team `xskill generate` 上下文压缩后代理忘掉已执行工作。

--- a/README.zh-CN.md
+++ b/README.zh-CN.md
@@ -21,6 +21,7 @@
 
 ## 动态
 
+- **2026-08-14** — `v0.6.31`：`xskill rebuild --force` 不再因 `.git/objects` 非空中断；全量 rebuild 会留下 `xskill import` 纳入的技能。详见 [Release notes](https://github.com/SkillNerds/xskill/releases/tag/v0.6.31)。
 - **2026-08-14** — `v0.6.30`：team `xskill import` 后钉到发起人推荐列表；技能库登录后可点空心星 pin 进自己的推荐流，并标出推给我、已钉状态。详见 [Release notes](https://github.com/SkillNerds/xskill/releases/tag/v0.6.30)。
 - **2026-08-03** — `v0.6.29a6`：`pymilvus` 改为可选（`xskill[milvus]`），修复 client 自动更新；「我的」页支持推给我 N 个 SKILL / 上传使用去向 / skill commit 状态。详见 [Release notes](https://github.com/SkillNerds/xskill/releases/tag/v0.6.29a6)。
 - **2026-07-07** — `v0.6.2a2`：修复 Windows Group Policy 环境下 `schtasks` 拒绝访问的问题，自动降级到开机启动文件夹，`connect` 无需管理员权限即可后台常驻。

--- a/src/xskill/cli.py
+++ b/src/xskill/cli.py
@@ -1864,7 +1864,8 @@ def cmd_rebuild(args, _xskill) -> int:
 
     默认：删除已拆 atom + index.pkl、轨迹状态翻回 discovered，让运行中的 watcher
     从头重拆重聚（删 atom 是真正触发重拆的动作——splitter 续接点取自 atom 文件，
-    不读 DB offset）。``--force``：额外先清空 skill 仓、看板派生埋点和安装历史。
+    不读 DB offset）。``--force``：额外先清空蒸馏所得 skill（``xskill import``
+    纳入的留下）、看板派生埋点和安装历史。
 
     换模型护栏：rebuild 的重跑是交给**正在运行的 daemon**，而 daemon 的模型是
     启动时缓存的（改 config 不重启不生效）。若 daemon 在跑且其模型 ≠ 当前 config
@@ -1899,10 +1900,15 @@ def cmd_rebuild(args, _xskill) -> int:
         from xskill.config import get_registry_db_path, get_skill_dir
         from xskill.pipeline.registry import clear_rebuild_derived_state
         from xskill.skill.repo import SkillRepo
-        skill_count = SkillRepo(get_skill_dir()).wipe_all_skills(
+        skill_count, kept_names = SkillRepo(get_skill_dir()).wipe_all_skills(
             db_path=get_registry_db_path(),
         )
-        print(f"--force: 清空 skill 仓（删 {skill_count} 个 skill）")
+        print(f"--force: 清空蒸馏 skill（删 {skill_count} 个）")
+        if kept_names:
+            print(
+                "--force: 保留 "
+                f"{len(kept_names)} 个 import 纳入的技能"
+            )
         deleted_counts = clear_rebuild_derived_state()
         print(
             "--force: 清空看板派生数据（"
@@ -2161,7 +2167,7 @@ def build_parser() -> argparse.ArgumentParser:
     )
     p_rebuild.add_argument(
         "--force", action="store_true",
-        help="先清空 skill 仓 + 已拆原子再全量重跑（删除重建）",
+        help="先清空蒸馏所得 skill（import 纳入的留下）和已拆原子再全量重跑",
     )
     p_rebuild.add_argument("--eco", default=None,
                            help="只重跑某生态的轨迹（默认全部）")

--- a/src/xskill/skill/git.py
+++ b/src/xskill/skill/git.py
@@ -477,6 +477,51 @@ def _commit_subject(repo: Repo, commit_sha: bytes) -> str:
     return msg.split("\n", 1)[0]
 
 
+def commit_history_has_subject_prefix(
+    skill_dir: str | Path, prefixes: tuple[str, ...],
+) -> bool:
+    """任一分支历史上出现过给定前缀的 commit subject。"""
+    if not prefixes:
+        return False
+    cwd = str(skill_dir)
+    try:
+        with skill_repo_lock(cwd, use_git_write_limit=False):
+            with _open_repo(cwd) as repo:
+                starts: list[bytes] = []
+                for ref in repo.refs.keys():
+                    if ref != b"HEAD" and not ref.startswith(b"refs/heads/"):
+                        continue
+                    try:
+                        sha = repo.refs[ref] if ref != b"HEAD" else _resolve_rev(
+                            repo, "HEAD")
+                    except KeyError:
+                        continue
+                    if sha:
+                        starts.append(sha)
+                seen: set[bytes] = set()
+                stack = list(starts)
+                while stack:
+                    sha = stack.pop()
+                    if sha in seen:
+                        continue
+                    seen.add(sha)
+                    try:
+                        commit = repo[sha]
+                    except KeyError:
+                        continue
+                    if not isinstance(commit, Commit):
+                        continue
+                    subject = _commit_subject(repo, sha)
+                    if any(subject.startswith(prefix) for prefix in prefixes):
+                        return True
+                    stack.extend(commit.parents)
+                    if len(seen) > 2000:
+                        break
+    except (NotGitRepository, OSError, KeyError):
+        return False
+    return False
+
+
 def _is_ancestor(repo: Repo, ancestor: bytes, descendant: bytes) -> bool:
     """check ancestor is reachable from descendant via parent chain."""
     if ancestor == descendant:

--- a/src/xskill/skill/importer.py
+++ b/src/xskill/skill/importer.py
@@ -24,6 +24,11 @@ from xskill.skill.git import (
 
 logger = logging.getLogger("xskill.skill.importer")
 
+# rebuild --force 认这个文件和 ``import:`` 提交，避免清掉用户纳入的技能。
+ORIGIN_FILENAME = ".xskill-origin"
+ORIGIN_IMPORT = "import"
+_KEEP_COMMIT_PREFIXES = ("import:",)
+
 RUNTIME_SIDECARS = frozenset({
     ".candidates.yml",
     ".ux_scores.jsonl",
@@ -200,6 +205,30 @@ def _target_has_git(target: Path) -> bool:
     return (target / ".git").is_dir()
 
 
+def mark_skill_imported(target: Path) -> None:
+    """写入纳入标记。须在 ``_replace_skill_files`` 之后，随 import 那次提交进仓。"""
+    (Path(target) / ORIGIN_FILENAME).write_text(
+        f"{ORIGIN_IMPORT}\n", encoding="utf-8",
+    )
+
+
+def skill_kept_on_rebuild(path: Path) -> bool:
+    """用户 ``xskill import`` 纳入的技能，全量 rebuild --force 不得删。"""
+    path = Path(path)
+    marker = path / ORIGIN_FILENAME
+    if marker.is_file():
+        try:
+            line = marker.read_text(encoding="utf-8").strip().splitlines()
+        except OSError:
+            line = []
+        if line and line[0].strip() == ORIGIN_IMPORT:
+            return True
+    if not (path / ".git").is_dir():
+        return False
+    from xskill.skill.git import commit_history_has_subject_prefix
+    return commit_history_has_subject_prefix(path, _KEEP_COMMIT_PREFIXES)
+
+
 def _notify_imported_catalog(
     target: Path,
     catalog_db_path: Path | str | None,
@@ -263,8 +292,10 @@ def import_one_skill(
             if not gi.is_file():
                 gi.write_text(SKILL_GITIGNORE, encoding="utf-8")
             _replace_skill_files(source, target)
+            mark_skill_imported(target)
             commit_update_main_branch(str(target), message)
         else:
+            mark_skill_imported(target)
             init_imported_repo_on_main(target, message)
         code, sha, _ = run_git(["rev-parse", "HEAD"], cwd=str(target))
         result.sha = sha.strip() if code == 0 else ""
@@ -288,6 +319,7 @@ def import_one_skill(
 
         ensure_head_on_main(target)
         _replace_skill_files(source, target)
+        mark_skill_imported(target)
         committed = commit_update_main_branch(str(target), message)
         if not committed:
             logger.info("import %s: worktree already matched, nothing to commit", name)

--- a/src/xskill/skill/repo.py
+++ b/src/xskill/skill/repo.py
@@ -13,13 +13,12 @@ from __future__ import annotations
 import logging
 import operator
 import pickle
-import shutil
 from pathlib import Path
 from typing import TYPE_CHECKING, Iterator, Optional
 
 import numpy
 
-from xskill.skill.skill import Skill, _load_skill
+from xskill.skill.skill import Skill, _load_skill, _remove_tree
 from xskill.skill.git import commit_changes
 
 if TYPE_CHECKING:
@@ -118,7 +117,7 @@ class SkillRepo:
             # 一个 skill 目录的判据：有 SKILL.md 或 .git 子仓（baby 态可能
             # 只有 .git 还没写 SKILL.md）。
             if (sub / "SKILL.md").is_file() or (sub / ".git").is_dir():
-                shutil.rmtree(sub)
+                _remove_tree(sub)
                 n += 1
         # 索引已失效，删掉避免指向不存在的 skill
         idx = self.root / ".skill_index.pkl"

--- a/src/xskill/skill/repo.py
+++ b/src/xskill/skill/repo.py
@@ -98,17 +98,23 @@ class SkillRepo:
         )
 
     # ─── 清空（rebuild --force 用）──────────────────────────────
-    def wipe_all_skills(self, *, db_path: Path | None = None) -> int:
-        """删除仓里所有 skill 子目录（含各自 ``.git`` 子仓），返回删除个数。
+    def wipe_all_skills(self, *, db_path: Path | None = None) -> tuple[int, list[str]]:
+        """删除仓里蒸馏所得 skill 子目录（含各自 ``.git`` 子仓）。
 
-        ``xskill rebuild --force`` 用：换强模型从零重建前先清空旧 skill。
-        只删 skill 子目录（每个有 ``SKILL.md`` 或 ``.git`` 的子目录），保留
+        ``xskill rebuild --force`` 用：换强模型从零重建前先清空旧蒸馏产物。
+        用户 ``xskill import`` 纳入的技能留下。``xskill upload`` 落在 skillhub
+        目录，本来就不在这个仓里。
+        只扫 skill 子目录（每个有 ``SKILL.md`` 或 ``.git`` 的子目录），保留
         仓根与 ``references`` / ``.skill_index.pkl`` 等非 skill 工件由 watcher
-        后续自行重建。删完一并清掉过期索引。
+        后续自行重建。删完清掉过期索引，并只删被去掉的那些 catalog 行。
+        返回 ``(删除个数, 留下的名字)``。
         """
         n = 0
+        kept: list[str] = []
+        removed: list[str] = []
         if not self.root.is_dir():
-            return 0
+            return 0, kept
+        from xskill.skill.importer import skill_kept_on_rebuild
         for sub in sorted(self.root.iterdir()):
             if not sub.is_dir():
                 continue
@@ -116,20 +122,27 @@ class SkillRepo:
                 continue
             # 一个 skill 目录的判据：有 SKILL.md 或 .git 子仓（baby 态可能
             # 只有 .git 还没写 SKILL.md）。
-            if (sub / "SKILL.md").is_file() or (sub / ".git").is_dir():
-                _remove_tree(sub)
-                n += 1
+            if not ((sub / "SKILL.md").is_file() or (sub / ".git").is_dir()):
+                continue
+            if skill_kept_on_rebuild(sub):
+                kept.append(sub.name)
+                continue
+            _remove_tree(sub)
+            removed.append(sub.name)
+            n += 1
         # 索引已失效，删掉避免指向不存在的 skill
         idx = self.root / ".skill_index.pkl"
         if idx.is_file():
             idx.unlink()
-        logger.info("wipe_all_skills: removed %d skill(s) under %s", n, self.root)
-        if n:
-            from xskill.skill.catalog_store import catalog_root_key, notify_native_wipe
-            notify_native_wipe(
-                root_key=catalog_root_key(self.root), db_path=db_path,
-            )
-        return n
+        logger.info(
+            "wipe_all_skills: removed %d skill(s), kept %d under %s",
+            n, len(kept), self.root,
+        )
+        if removed:
+            from xskill.skill.catalog_store import notify_native_delete
+            for name in removed:
+                notify_native_delete(name, db_path=db_path)
+        return n, kept
 
     def __repr__(self) -> str:
         return f"SkillRepo({self.root}, n={len(self)})"

--- a/src/xskill/skill/skill.py
+++ b/src/xskill/skill/skill.py
@@ -13,11 +13,13 @@ YAML frontmatter；legacy（skill.md + .abstract）目录读时惰性合成，�
 
 from __future__ import annotations
 
+import errno
 import json
 import logging
 import os
 import shutil
 import stat
+import time
 from datetime import datetime, date
 from pathlib import Path
 from typing import TYPE_CHECKING, Literal, Optional
@@ -36,17 +38,94 @@ if TYPE_CHECKING:
 logger = logging.getLogger("xskill.skill_manager")
 
 
-def _remove_readonly_file(function, path: str, error_info) -> None:
-    """让 Windows 上只读的 Git 对象可由 shutil.rmtree 删除。"""
+_RMTREE_RETRY_ERRNOS = {errno.ENOTEMPTY, errno.EBUSY, errno.EAGAIN}
+if hasattr(errno, "ESTALE"):
+    _RMTREE_RETRY_ERRNOS.add(errno.ESTALE)
+_RMTREE_ATTEMPTS = 8
+
+
+def _chmod_writable(path: str) -> None:
+    try:
+        mode = os.stat(path).st_mode
+        os.chmod(path, mode | stat.S_IRUSR | stat.S_IWUSR | stat.S_IXUSR)
+    except OSError:
+        pass
+
+
+def _make_tree_writable(path: Path) -> None:
+    """Git 对象常是 0444；overlay/NFS 上还要目录可写才能 rmdir。"""
+    for root, dirs, files in os.walk(path, topdown=False):
+        for name in files:
+            _chmod_writable(os.path.join(root, name))
+        for name in dirs:
+            _chmod_writable(os.path.join(root, name))
+    _chmod_writable(str(path))
+
+
+def _rmtree_onerror(function, path: str, error_info) -> None:
+    """只读 git 对象、以及偶发 PermissionError：chmod 后再删一次。"""
     error = error_info[1]
-    if os.name != "nt" or not isinstance(error, PermissionError):
+    _chmod_writable(path)
+    try:
+        function(path)
+    except OSError:
         raise error
-    os.chmod(path, stat.S_IWRITE)
-    function(path)
+
+
+def _park_for_delete(path: Path) -> Path:
+    """先改名再删，避免 serve/git 还往原路径写 objects 导致 ENOTEMPTY。"""
+    parent = path.parent
+    for index in range(16):
+        parked = parent / (
+            f".wipe-{path.name}-{os.getpid()}-{time.time_ns()}-{index}"
+        )
+        try:
+            path.rename(parked)
+            return parked
+        except OSError:
+            continue
+    return path
+
+
+def _rmtree_with_retry(path: Path) -> None:
+    delay = 0.05
+    last: OSError | None = None
+    for attempt in range(_RMTREE_ATTEMPTS):
+        try:
+            shutil.rmtree(path, onerror=_rmtree_onerror)
+            return
+        except OSError as error:
+            if not path.exists():
+                return
+            if error.errno not in _RMTREE_RETRY_ERRNOS:
+                raise
+            last = error
+            if attempt >= 1:
+                _make_tree_writable(path)
+            time.sleep(delay)
+            delay = min(delay * 2, 0.8)
+    assert last is not None
+    raise last
 
 
 def _remove_tree(path: Path) -> None:
-    shutil.rmtree(path, onerror=_remove_readonly_file)
+    """删 skill 目录（含 ``.git/objects``）。ENOTEMPTY 时重试。"""
+    path = Path(path)
+    if path.is_symlink() or path.is_file():
+        path.unlink()
+        return
+    if not path.is_dir():
+        return
+    parked = _park_for_delete(path)
+    try:
+        _rmtree_with_retry(parked)
+    except OSError as error:
+        raise OSError(
+            error.errno,
+            f"failed to delete {path}: {error.strerror}. "
+            "If xskill serve is still running, stop it and retry.",
+            str(parked),
+        ) from error
 
 
 # ═════════════════════════════════════════════════════════════════

--- a/tests/test_rebuild.py
+++ b/tests/test_rebuild.py
@@ -235,6 +235,74 @@ def test_wipe_all_skills_removes_skill_dirs_keeps_references(tmp_path):
     assert not (skill_root / ".skill_index.pkl").exists()
 
 
+def test_wipe_all_skills_retries_enotempty_on_git_objects(tmp_path, monkeypatch):
+    """serve/git 还在写 .git/objects 时 rmtree 会 ENOTEMPTY；应重试删干净。"""
+    import errno
+    import shutil
+    import xskill.skill.skill as skill_mod
+
+    skill_root = tmp_path / "skill"
+    skill_path = skill_root / "foo"
+    objects = skill_path / ".git" / "objects" / "ab"
+    objects.mkdir(parents=True)
+    blob = objects / ("c" * 38)
+    blob.write_bytes(b"git-obj")
+    blob.chmod(0o444)
+    (skill_path / "SKILL.md").write_text(
+        "---\nname: foo\ndescription: d\n---\n",
+        encoding="utf-8",
+    )
+
+    real_rmtree = shutil.rmtree
+    calls = {"n": 0}
+
+    def flaky(path, *args, **kwargs):
+        calls["n"] += 1
+        if calls["n"] == 1:
+            raise OSError(errno.ENOTEMPTY, "Directory not empty", "objects")
+        return real_rmtree(path, *args, **kwargs)
+
+    monkeypatch.setattr(skill_mod.shutil, "rmtree", flaky)
+    monkeypatch.setattr(skill_mod.time, "sleep", lambda _s: None)
+
+    removed_count = SkillRepo(skill_root).wipe_all_skills()
+
+    assert removed_count == 1
+    assert not skill_path.exists()
+    leftovers = [p for p in skill_root.iterdir() if p.name.startswith(".wipe-")]
+    assert leftovers == []
+    assert calls["n"] >= 2
+
+
+def test_wipe_all_skills_cleans_leftover_wipe_dir(tmp_path):
+    skill_root = tmp_path / "skill"
+    leftover = skill_root / ".wipe-foo-1"
+    (leftover / ".git").mkdir(parents=True)
+    (leftover / "SKILL.md").write_text("# leftover\n", encoding="utf-8")
+
+    removed_count = SkillRepo(skill_root).wipe_all_skills()
+
+    assert removed_count == 1
+    assert not leftover.exists()
+
+
+def test_wipe_all_skills_deletes_readonly_git_objects(tmp_path):
+    skill_root = tmp_path / "skill"
+    skill_path = skill_root / "packed"
+    objects = skill_path / ".git" / "objects" / "de"
+    objects.mkdir(parents=True)
+    blob = objects / ("f" * 38)
+    blob.write_bytes(b"packed")
+    blob.chmod(0o444)
+    (skill_path / "SKILL.md").write_text(
+        "---\nname: packed\ndescription: d\n---\n",
+        encoding="utf-8",
+    )
+
+    assert SkillRepo(skill_root).wipe_all_skills() == 1
+    assert not skill_path.exists()
+
+
 def test_rebuild_force_clears_derived_state_and_install_history(
     monkeypatch, tmp_path,
 ):

--- a/tests/test_rebuild.py
+++ b/tests/test_rebuild.py
@@ -227,9 +227,10 @@ def test_wipe_all_skills_removes_skill_dirs_keeps_references(tmp_path):
     (references_directory / "x.md").write_text("keep me", encoding="utf-8")
     (skill_root / ".skill_index.pkl").write_bytes(b"stale-skill-index")
 
-    removed_count = SkillRepo(skill_root).wipe_all_skills()
+    removed_count, kept_names = SkillRepo(skill_root).wipe_all_skills()
 
     assert removed_count == 2
+    assert kept_names == []
     assert not first_skill_path.exists() and not second_skill_path.exists()
     assert references_directory.exists(), "references 不应被删"
     assert not (skill_root / ".skill_index.pkl").exists()
@@ -265,9 +266,10 @@ def test_wipe_all_skills_retries_enotempty_on_git_objects(tmp_path, monkeypatch)
     monkeypatch.setattr(skill_mod.shutil, "rmtree", flaky)
     monkeypatch.setattr(skill_mod.time, "sleep", lambda _s: None)
 
-    removed_count = SkillRepo(skill_root).wipe_all_skills()
+    removed_count, kept_names = SkillRepo(skill_root).wipe_all_skills()
 
     assert removed_count == 1
+    assert kept_names == []
     assert not skill_path.exists()
     leftovers = [p for p in skill_root.iterdir() if p.name.startswith(".wipe-")]
     assert leftovers == []
@@ -280,9 +282,10 @@ def test_wipe_all_skills_cleans_leftover_wipe_dir(tmp_path):
     (leftover / ".git").mkdir(parents=True)
     (leftover / "SKILL.md").write_text("# leftover\n", encoding="utf-8")
 
-    removed_count = SkillRepo(skill_root).wipe_all_skills()
+    removed_count, kept_names = SkillRepo(skill_root).wipe_all_skills()
 
     assert removed_count == 1
+    assert kept_names == []
     assert not leftover.exists()
 
 
@@ -299,8 +302,71 @@ def test_wipe_all_skills_deletes_readonly_git_objects(tmp_path):
         encoding="utf-8",
     )
 
-    assert SkillRepo(skill_root).wipe_all_skills() == 1
+    assert SkillRepo(skill_root).wipe_all_skills() == (1, [])
     assert not skill_path.exists()
+
+
+def test_wipe_all_skills_keeps_imported_skill(tmp_path, monkeypatch):
+    from xskill.skill.importer import import_one_skill
+
+    monkeypatch.setattr(
+        "xskill.config.get_registry_db_path", lambda: tmp_path / "r.db")
+    skill_root = tmp_path / "skill"
+    distilled = skill_root / "distilled"
+    distilled.mkdir(parents=True)
+    (distilled / "SKILL.md").write_text(
+        "---\nname: distilled\ndescription: d\n---\n",
+        encoding="utf-8",
+    )
+    incoming = tmp_path / "incoming" / "kept-import"
+    incoming.mkdir(parents=True)
+    (incoming / "SKILL.md").write_text(
+        "---\nname: kept-import\ndescription: user brought this\n---\nbody\n",
+        encoding="utf-8",
+    )
+    imported = import_one_skill(skill_root, incoming)
+    assert imported.name == "kept-import"
+
+    removed_count, kept_names = SkillRepo(skill_root).wipe_all_skills(
+        db_path=tmp_path / "r.db",
+    )
+
+    assert removed_count == 1
+    assert kept_names == ["kept-import"]
+    assert not distilled.exists()
+    assert (skill_root / "kept-import" / "SKILL.md").is_file()
+    assert (skill_root / "kept-import" / ".xskill-origin").read_text(
+        encoding="utf-8",
+    ).strip() == "import"
+
+
+def test_wipe_all_skills_keeps_legacy_import_commit_without_marker(tmp_path, monkeypatch):
+    """0.6.30a1 纳入时还没有 .xskill-origin，靠 import: 提交认出来。"""
+    from xskill.skill.git import init_imported_repo_on_main
+
+    monkeypatch.setattr(
+        "xskill.config.get_registry_db_path", lambda: tmp_path / "r.db")
+    skill_root = tmp_path / "skill"
+    legacy = skill_root / "legacy-import"
+    legacy.mkdir(parents=True)
+    (legacy / "SKILL.md").write_text(
+        "---\nname: legacy-import\ndescription: old import\n---\n",
+        encoding="utf-8",
+    )
+    init_imported_repo_on_main(legacy, "import: legacy-import from /tmp/old")
+    distilled = skill_root / "baby-only"
+    distilled.mkdir(parents=True)
+    (distilled / ".git").mkdir()
+    (distilled / "SKILL.md").write_text("# baby\n", encoding="utf-8")
+
+    removed_count, kept_names = SkillRepo(skill_root).wipe_all_skills(
+        db_path=tmp_path / "r.db",
+    )
+
+    assert removed_count == 1
+    assert kept_names == ["legacy-import"]
+    assert (legacy / "SKILL.md").is_file()
+    assert not distilled.exists()
 
 
 def test_rebuild_force_clears_derived_state_and_install_history(


### PR DESCRIPTION
## Summary
- `xskill rebuild --force` 清空 skill 仓时，先把目录改名再删，并对 `.git/objects` 的 ENOTEMPTY / EBUSY 重试；只读 git 对象 chmod 后再删（#231）。
- 全量 rebuild 只删轨迹蒸馏出来的技能。`xskill import` 纳入自有仓的留下（新纳入写 `.xskill-origin`，旧的靠 `import:` 提交认出来）。`xskill upload` 本来就在 skillhub 目录，不在这次清仓范围。
- 不发版。合入后进下一版。

Closes #231

## Test plan
- [ ] `PYTHONPATH=src pytest tests/test_rebuild.py tests/test_import_skill.py tests/test_skill_repo.py`
- [ ] 仓里有带 `.git/objects` 的蒸馏技能时 `xskill rebuild --force` 能删完（可先停 serve）
- [ ] 仓里同时有 import 纳入的技能时，rebuild --force 后这些目录还在，蒸馏的被删掉