### PR TITLE
docs: document xskill generate

### DIFF
--- a/README.en.md
+++ b/README.en.md
@@ -123,6 +123,28 @@ xskill connect <host:port> --token <token>     # on each teammate's machine
 - **A/B-driven evolution** — a change is measured per person before it spreads. More people → faster, sharper evolution.
 - **Experts can teach manually** — edit a Skill locally and it is pulled in as `user-staging/<client_id>` to feed the next round.
 
+#### Generate or rewrite a Skill on demand
+
+`generate` does not create a Skill from scratch. It distills or rewrites one from existing trajectories the team server allows it to access; the natural-language instruction only describes the desired result. Once connected to a team server that supports `generate`, create a Skill like this:
+
+```bash
+xskill generate "Create a Skill for diagnosing Python memory leaks, including common diagnostic commands"
+```
+
+The same command can rewrite an existing Skill from trajectory evidence. Name the Skill and describe the change in the instruction:
+
+```bash
+xskill generate "Rewrite the existing python-memory-debug Skill to add Windows troubleshooting steps"
+```
+
+Use `--name` when the agent should prioritize specific users' trajectories. Separate multiple employee or user IDs with commas. Without this option, the agent can search all trajectories the server allows it to access:
+
+```bash
+xskill generate --name alice,bob "Build a database migration Skill from these users' successful sessions"
+```
+
+The job may wait for a free seat in the SkillEdit pool. The CLI streams queue and execution logs; when it finishes, the generated or rewritten Skill is committed directly to its main branch and pinned to the initiator's recommendation list. If the CLI reports that the server is too old, ask the administrator to upgrade the team server.
+
 #### Run it persistently
 
 `xskill connect` connects **directly** by default, bypassing corporate proxies (e.g. Huawei SWG) — teammates on an internal network no longer need to set `NO_PROXY` by hand. Add `--use-proxy` only when the machine's sole route out is a proxy that can actually reach the server.

--- a/README.md
+++ b/README.md
@@ -192,7 +192,6 @@ xskill serve --server  # 会打印connect join命令，复制给组内同事便�
 xskill connect <host:port> --token <token>  --name <工号/姓名>   # 在每个同事的机器上运行
 ```
 
-
 #### 额外功能：管控面板
 
 在config.yaml中可以填写管理员身份:
@@ -222,6 +221,28 @@ xskill dashboard
 - 下线某个自己不喜欢的skill
 - 查看自己的轨迹贡献给了哪些用户，谁用了自己的skill
 - 查看skill的版本血缘，得分趋势
+
+#### 额外功能：即时生成或改写 Skill
+
+`generate` 不是凭空创作 Skill：它会从 team server 上已有且有权访问的轨迹中提取经验，自然语言指令只用来描述想生成或改写什么。连接到支持 `generate` 的 team server 后，可以这样创建 Skill：
+
+```bash
+xskill generate "创建一个排查 Python 内存泄漏的 Skill，包含常用诊断命令"
+```
+
+同一个命令也能基于轨迹改写已有 Skill；在指令中写明 Skill 名称和修改目标即可：
+
+```bash
+xskill generate "改写现有的 python-memory-debug Skill，补充 Windows 排查步骤"
+```
+
+需要代理优先参考指定用户的历史轨迹时，使用 `--name`；多个工号或用户 ID 以逗号分隔。省略该参数时，代理可以在 server 授权的全部轨迹范围内检索：
+
+```bash
+xskill generate --name alice,bob "根据这些用户的成功案例生成数据库迁移 Skill"
+```
+
+任务可能会先等待 SkillEdit 池的空闲席位。CLI 会持续输出排队和运行日志；完成后，生成或改写的 Skill 会直接提交到主干，并 pin 到发起人的推荐列表。如果 CLI 提示 server 版本过旧，请联系管理员升级 team server。
 
 #### 额外功能：按需搜索
 


### PR DESCRIPTION
## Summary

Documents the team-mode `xskill generate` command in the Chinese and English tutorials, covering how to create or rewrite a Skill from a natural-language instruction.

## Changes

- Added examples for creating and rewriting Skills with `xskill generate`.
- Documented the optional `--name` trajectory filter.
- Explained queue and execution logs, main-branch commits, automatic pinning, and the old-server upgrade requirement.
- Kept the Chinese and English documentation aligned.

## Test plan

- [ ] `make test` passes
- [ ] Added/updated unit tests for the change
- [ ] `make e2e` passes (if the change touches ingestion / install / daemon)
- [x] Manually verified the affected user flow
  - Parsed all six Chinese and English examples with the current `xskill.cli.build_parser()`.
  - Ran `git diff --check`.
  - Confirmed the diff only contains `README.md` and `README.en.md`.
  - Full pytest collection was unavailable because the existing environment lacks required runtime dependencies such as `dulwich`.

## Linked issues

N/A