### PR TITLE
feat: 给发起人和用量最多的用户按体验分补漏换侧

### DIFF
--- a/src/xskill/canary.py
+++ b/src/xskill/canary.py
@@ -517,6 +517,49 @@ def pick_side_scoped(traj_id: str, skill_name: str, probability: float,
     return pick_side(traj_id, skill_name, probability)
 
 
+def fill_deficit_side(
+    *,
+    staging_n: int,
+    main_n: int,
+    need: int,
+    fallback: str,
+) -> str:
+    """体验分补漏：staging 不够先喂 staging，够了 main 还不够就喂 main。
+
+    两侧都达到 ``need`` 后返回 ``fallback``（通常是 CanaryRouter / pick_side）。
+    只改路由，不虚补分数。
+    """
+    if need <= 0:
+        return fallback if fallback in ("main", "staging") else "main"
+    if staging_n < need:
+        return "staging"
+    if main_n < need:
+        return "main"
+    return fallback if fallback in ("main", "staging") else "main"
+
+
+def auto_canary_side(
+    skill_dir: Path,
+    *,
+    main_sha: str,
+    staging_sha: str,
+    need: int,
+    fallback: str,
+) -> str:
+    """按当前这对 sha 的体验分条数做补漏换侧。"""
+    s_sha = staging_sha or ""
+    m_sha = main_sha or ""
+    staging_n = len(recent_scores(
+        skill_dir, side="staging", commit_sha=s_sha, n=max(need, 1),
+    )) if s_sha else 0
+    main_n = len(recent_scores(
+        skill_dir, side="main", commit_sha=m_sha, n=max(need, 1),
+    )) if m_sha else 0
+    return fill_deficit_side(
+        staging_n=staging_n, main_n=main_n, need=need, fallback=fallback,
+    )
+
+
 # ═══════════════════════════════════════════════════════════════════
 # 有状态分流：CanaryRouter —— 在线偏差最小化 + pick_side hash 随机
 # ═══════════════════════════════════════════════════════════════════
@@ -573,6 +616,24 @@ class CanaryRouter:
                 probability, (staging_sha or "")[:12],
             )
             return side
+
+    def note(self, *, client_id: str, skill_name: str, side: str,
+             probability: float, staging_sha: str) -> None:
+        """把已决定的 side 记进账本（自动灰度补漏后同步人数）。"""
+        if side not in ("main", "staging"):
+            return
+        with self._lock:
+            st = self._skills.get(skill_name)
+            if (st is None
+                    or st["staging_sha"] != staging_sha
+                    or st["probability"] != probability):
+                st = {
+                    "staging_sha": staging_sha,
+                    "probability": probability,
+                    "sides": {},
+                }
+                self._skills[skill_name] = st
+            st["sides"][client_id] = side
 
     @staticmethod
     def _balanced_side(n_main: int, n_staging: int, probability: float,

--- a/src/xskill/dashboard/console.py
+++ b/src/xskill/dashboard/console.py
@@ -361,6 +361,8 @@ def annotate_library_skills(page: dict, *, user: str,
             traj_root=ctx.traj_root,
             prefs=prefs,
             retired=retired_skills(db_path=db_path),
+            user_key=user,
+            db_path=db_path,
         )
         push_bucket = {slot.skill_name: slot.bucket for slot in resp.slots}
     except Exception:  # pylint: disable=broad-exception-caught
@@ -395,6 +397,8 @@ def _manifest_slots_for_user(ctx, *, user: str,
         traj_root=ctx.traj_root,
         prefs=prefs,
         retired=retired_skills(db_path=db_path),
+        user_key=user,
+        db_path=db_path,
     )
     return _pack_manifest_slots(
         resp.slots, user=user, prefs=prefs, skill_dir=ctx.skill_dir,
@@ -637,7 +641,8 @@ def _normalize_pref_side(side: Optional[str]) -> Optional[str]:
 
 def _skill_routing_table(ctx, *, skill_name: str, db_path: Optional[Path]) -> dict:
     """现算某 skill 对所有已注册 client 的推送路由（与 /sync 同源 build_manifest）。"""
-    from xskill.canary import main_sha, pick_side, staging_sha
+    from xskill.canary import auto_canary_side, main_sha, pick_side, staging_sha
+    from xskill.pipeline.registry import is_auto_canary_user
     from xskill.team.server.api import live_manifest_tuning
     from xskill.team.server.skill_manifest import build_manifest
 
@@ -654,6 +659,7 @@ def _skill_routing_table(ctx, *, skill_name: str, db_path: Optional[Path]) -> di
         client_id = client["client_id"]
         user = (client.get("user_name") or "").strip() or client_id
         prefs = effective_prefs(user, db_path=db_path)
+        auto = is_auto_canary_user(user, skill_name, db_path=db_path)
         resp = build_manifest(
             client_id=client_id,
             skill_dir=ctx.skill_dir,
@@ -663,6 +669,8 @@ def _skill_routing_table(ctx, *, skill_name: str, db_path: Optional[Path]) -> di
             traj_root=ctx.traj_root,
             prefs=prefs,
             retired=retired,
+            user_key=user,
+            db_path=db_path,
         )
         hit = next(
             (s for s in resp.slots if s.skill_name == skill_name), None)
@@ -678,12 +686,23 @@ def _skill_routing_table(ctx, *, skill_name: str, db_path: Optional[Path]) -> di
                 "sha": hit.sha or "",
                 "overridden": bool(side_ov),
                 "pinned": pinned or hit.bucket == "pinned",
+                "auto_canary": auto and not bool(side_ov),
             })
             continue
         would = "main"
         if has_staging:
-            would = side_ov if side_ov in ("main", "staging") else pick_side(
-                client_id, skill_name, probability)
+            if side_ov in ("main", "staging"):
+                would = side_ov
+            elif auto:
+                would = auto_canary_side(
+                    skill_path,
+                    main_sha=m_sha,
+                    staging_sha=s_sha or "",
+                    need=5,
+                    fallback=pick_side(client_id, skill_name, probability),
+                )
+            else:
+                would = pick_side(client_id, skill_name, probability)
         sha = (s_sha if would == "staging" and s_sha else m_sha) or ""
         users.append({
             "user": user,
@@ -694,6 +713,7 @@ def _skill_routing_table(ctx, *, skill_name: str, db_path: Optional[Path]) -> di
             "sha": sha,
             "overridden": bool(side_ov),
             "pinned": pinned,
+            "auto_canary": auto and not bool(side_ov),
         })
     staging_n = sum(
         1 for u in users if u["in_manifest"] and u["side"] == "staging")
@@ -773,6 +793,8 @@ def build_console_router(db_path: Optional[Path] = None) -> APIRouter:
             traj_root=ctx.traj_root,
             prefs=prefs,
             retired=retired_skills(db_path=db_path),
+            user_key=user,
+            db_path=db_path,
         )
         server_push = _pack_manifest_slots(
             resp.slots, user=user, prefs=prefs, skill_dir=ctx.skill_dir,
@@ -817,6 +839,7 @@ def build_console_router(db_path: Optional[Path] = None) -> APIRouter:
             probability=probability, ranked_slots=ranked_slots,
             total_slots=total_slots, traj_root=ctx.traj_root,
             prefs=prefs, retired=retired_skills(db_path=db_path),
+            user_key=user, db_path=db_path,
         )
         return _settings_payload(
             user, server_slots=total_slots, server_pushed=len(resp.slots),

--- a/src/xskill/dashboard/static/app.js
+++ b/src/xskill/dashboard/static/app.js
@@ -657,6 +657,7 @@ function _routeUserRowHtml(u) {
         <span>${esc(u.user)}</span>
         ${_routePushPill(u)}
         ${u.overridden ? '<span class="text-[10px] px-1.5 py-0.5 rounded bg-violet-100 text-violet-700">pinned</span>' : ''}
+        ${u.auto_canary && !u.overridden ? '<span class="text-[10px] px-1.5 py-0.5 rounded bg-sky-50 text-sky-700 ring-1 ring-sky-100">自动灰度</span>' : ''}
       </div>
       <div class="text-[10.5px] text-slate-400 mt-0.5 flex items-center gap-1.5">
         ${u.sha ? `<code>${esc(String(u.sha).slice(0, 7))}</code>` : '<span>—</span>'}

--- a/src/xskill/pipeline/registry.py
+++ b/src/xskill/pipeline/registry.py
@@ -19,6 +19,7 @@ import json
 import logging
 import sqlite3
 import threading
+import time
 import zlib
 from contextlib import contextmanager
 from datetime import datetime, timezone
@@ -373,6 +374,15 @@ CREATE TABLE IF NOT EXISTS atom_candidate_pending_meta (
     root_key      TEXT PRIMARY KEY,
     backfilled_at TEXT NOT NULL
 );
+
+-- 纳入 / generate 发起人。首次写入生效，供自动灰度对象（与用量最多的用户取并）。
+CREATE TABLE IF NOT EXISTS skill_origin (
+    skill_name TEXT PRIMARY KEY,
+    user_key   TEXT NOT NULL,
+    source     TEXT NOT NULL,
+    ts         TEXT DEFAULT (datetime('now'))
+);
+CREATE INDEX IF NOT EXISTS idx_skill_origin_user ON skill_origin(user_key);
 """
 
 
@@ -810,6 +820,147 @@ def clear_skill_pref(*, user_key: str, skill_name: str,
         except Exception:  # pylint: disable=broad-exception-caught
             logger.debug("mark recommend dirty after clear pref failed", exc_info=True)
     return deleted
+
+
+_SKILL_ORIGIN_SOURCES = frozenset({"import", "generate"})
+_AUTO_CANARY_TTL_SEC = 5.0
+_auto_canary_cache_lock = threading.Lock()
+_auto_canary_cache: dict[str, tuple[float, dict[str, set[str]]]] = {}
+
+
+def _auto_canary_cache_key(db_path: Optional[Path]) -> str:
+    path = db_path if db_path is not None else get_registry_db_path()
+    return str(Path(path).expanduser().resolve())
+
+
+def clear_auto_canary_cache_for_tests() -> None:
+    with _auto_canary_cache_lock:
+        _auto_canary_cache.clear()
+
+
+def record_skill_origin(
+    *,
+    skill_name: str,
+    user_key: str,
+    source: str,
+    db_path: Optional[Path] = None,
+) -> bool:
+    """记录纳入或 generate 发起人。首次写入生效，后写忽略。"""
+    skill_name = (skill_name or "").strip()
+    user_key = (user_key or "").strip()
+    source = (source or "").strip()
+    if not skill_name or not user_key or source not in _SKILL_ORIGIN_SOURCES:
+        return False
+    with pooled_connection(db_path) as conn:
+        cur = conn.execute(
+            "INSERT OR IGNORE INTO skill_origin(skill_name, user_key, source)"
+            " VALUES(?,?,?)",
+            (skill_name, user_key, source),
+        )
+        conn.commit()
+        inserted = cur.rowcount > 0
+    if inserted:
+        clear_auto_canary_cache_for_tests()
+    return inserted
+
+
+def skill_origin_user(skill_name: str, *,
+                      db_path: Optional[Path] = None) -> Optional[str]:
+    skill_name = (skill_name or "").strip()
+    if not skill_name:
+        return None
+    with pooled_connection(db_path) as conn:
+        row = conn.execute(
+            "SELECT user_key FROM skill_origin WHERE skill_name=?",
+            (skill_name,),
+        ).fetchone()
+    user = (row["user_key"] or "").strip() if row else ""
+    return user or None
+
+
+def _traj_id_from_ux_row(traj_id: str, atom_id: str) -> str:
+    tid = (traj_id or "").strip()
+    if tid:
+        return tid
+    atom = atom_id or ""
+    if not atom.startswith("atom_"):
+        return ""
+    body = atom[5:]
+    idx = body.rfind("_")
+    return body[:idx] if idx > 0 else ""
+
+
+def _build_auto_canary_users(db_path: Optional[Path]) -> dict[str, set[str]]:
+    """skill_name → {纳入/生成发起人, 体验分用量最多的用户}。"""
+    with pooled_connection(db_path) as conn:
+        origin_rows = conn.execute(
+            "SELECT skill_name, user_key FROM skill_origin",
+        ).fetchall()
+        traj_rows = conn.execute(
+            "SELECT filename, user_key FROM trajectories WHERE user_key!=''",
+        ).fetchall()
+        ux_rows = conn.execute(
+            "SELECT skill_name, traj_id, atom_id FROM ux_scores",
+        ).fetchall()
+    out: dict[str, set[str]] = {}
+    for row in origin_rows:
+        skill = (row["skill_name"] or "").strip()
+        user = (row["user_key"] or "").strip()
+        if skill and user:
+            out.setdefault(skill, set()).add(user)
+    traj_user: dict[str, str] = {}
+    for row in traj_rows:
+        fn = row["filename"] or ""
+        stem = fn[:-3] if fn.endswith(".md") else fn
+        user = (row["user_key"] or "").strip()
+        if stem and user:
+            traj_user[stem] = user
+    usage: dict[str, dict[str, int]] = {}
+    for row in ux_rows:
+        skill = (row["skill_name"] or "").strip()
+        traj = _traj_id_from_ux_row(row["traj_id"] or "", row["atom_id"] or "")
+        user = traj_user.get(traj, "")
+        if not skill or not user:
+            continue
+        bucket = usage.setdefault(skill, {})
+        bucket[user] = bucket.get(user, 0) + 1
+    for skill, by_user in usage.items():
+        ranked = sorted(by_user.items(), key=lambda kv: (-kv[1], kv[0]))
+        if ranked:
+            out.setdefault(skill, set()).add(ranked[0][0])
+    return out
+
+
+def auto_canary_users_by_skill(
+    *, db_path: Optional[Path] = None,
+) -> dict[str, set[str]]:
+    """短 TTL 缓存：每个 skill 的自动灰度对象集合。"""
+    key = _auto_canary_cache_key(db_path)
+    now = time.monotonic()
+    with _auto_canary_cache_lock:
+        hit = _auto_canary_cache.get(key)
+        if hit is not None and now - hit[0] < _AUTO_CANARY_TTL_SEC:
+            return {name: set(users) for name, users in hit[1].items()}
+    built = _build_auto_canary_users(db_path)
+    with _auto_canary_cache_lock:
+        _auto_canary_cache[key] = (now, built)
+    return {name: set(users) for name, users in built.items()}
+
+
+def auto_canary_users(skill_name: str, *,
+                      db_path: Optional[Path] = None) -> set[str]:
+    skill_name = (skill_name or "").strip()
+    if not skill_name:
+        return set()
+    return auto_canary_users_by_skill(db_path=db_path).get(skill_name, set())
+
+
+def is_auto_canary_user(user_key: str, skill_name: str, *,
+                        db_path: Optional[Path] = None) -> bool:
+    user_key = (user_key or "").strip()
+    if not user_key:
+        return False
+    return user_key in auto_canary_users(skill_name, db_path=db_path)
 
 
 def prefs_for(user_key: str, *, db_path: Optional[Path] = None) -> list[dict]:

--- a/src/xskill/pipeline/runner.py
+++ b/src/xskill/pipeline/runner.py
@@ -2914,7 +2914,9 @@ class DirectoryWatcher:
                 skill_sub, side, sha = self._resolve_server_skill(
                     skill_name, hub=hub, client_id=client_id,
                     source_model=atom.source_model,
-                    canary_cfg=canary_cfg, eligible=eligible)
+                    canary_cfg=canary_cfg, eligible=eligible,
+                    user_key=client_id, db_path=kw.get("db_path"),
+                )
                 if skill_sub is None:
                     continue
                 try:
@@ -2947,6 +2949,8 @@ class DirectoryWatcher:
     def _resolve_server_skill(
         self, skill_name: str, *, hub, client_id: str,
         source_model: str, canary_cfg, eligible,
+        user_key: str = "",
+        db_path=None,
     ) -> tuple[Path | None, str, str]:
         """CS 模式两步定位打分目标 skill：先 ``skill_dir``（自有，走灰度路由），
         后 ``skillhub_dir``（三方，side 恒 ``main``）。
@@ -2956,13 +2960,29 @@ class DirectoryWatcher:
           无 staging → ``main`` + main_sha。
         - 三方 skill：无 git/staging → ``main`` + ``SkillHub.content_sha``。
         """
-        from xskill.canary import has_staging, main_sha, pick_side_scoped, staging_sha
+        from xskill.canary import (
+            auto_canary_side, has_staging, main_sha, pick_side_scoped,
+            staging_sha,
+        )
+        from xskill.pipeline.registry import is_auto_canary_user
         own = self.skill_dir / skill_name
         if (own / ".git").is_dir():
             if has_staging(own):
                 side = pick_side_scoped(
                     client_id, skill_name, canary_cfg.probability,
                     user_model=source_model, eligible=eligible)
+                model_ok = eligible is None or source_model in eligible
+                if model_ok and is_auto_canary_user(
+                        user_key, skill_name, db_path=db_path):
+                    m_sha = main_sha(own) or ""
+                    s_sha = staging_sha(own) or ""
+                    side = auto_canary_side(
+                        own,
+                        main_sha=m_sha,
+                        staging_sha=s_sha,
+                        need=max(int(canary_cfg.min_samples), 1),
+                        fallback=side,
+                    )
                 sha = staging_sha(own) if side == "staging" else main_sha(own)
             else:
                 side = "main"

--- a/src/xskill/recommend/engine.py
+++ b/src/xskill/recommend/engine.py
@@ -23,7 +23,7 @@ from typing import TYPE_CHECKING, Callable, Optional
 
 import numpy as np
 
-from xskill.canary import CanaryConfig, main_sha, pick_side, staging_sha
+from xskill.canary import CanaryConfig, fill_deficit_side, main_sha, pick_side, staging_sha
 from xskill.config import recommend_config
 from xskill.pipeline.atom import AtomTaskStore
 from xskill.recommend.profile_store import ProfileStore
@@ -682,12 +682,13 @@ class SkillRecommendEngine:
         if not s_sha:
             return "main"
         staging_n = self._side_count(skill.path, "staging", s_sha)
-        if staging_n < self.staging_need:
-            return "staging"
         main_n = self._side_count(skill.path, "main", m_sha)
-        if main_n < self.staging_need:
-            return "main"
-        return pick_side(client_user.user_id, skill.name, self.canary_cfg.probability)
+        fallback = pick_side(
+            client_user.user_id, skill.name, self.canary_cfg.probability)
+        return fill_deficit_side(
+            staging_n=staging_n, main_n=main_n,
+            need=self.staging_need, fallback=fallback,
+        )
 
     # ── 5.6 find_friend ──────────────────────────────────────────
     def relevance_search(self, query_vec, top_k: int = 5) -> list[tuple[str, bool]]:

--- a/src/xskill/team/server/api.py
+++ b/src/xskill/team/server/api.py
@@ -825,6 +825,7 @@ def team_sync(
             prefs=prefs,
             retired=retired,
             telemetry_submit=telemetry_submit,
+            user_key=user_key,
         )
         resp.server_slots = total_slots
         # client 截取安装数：默认=服务器 skill_slots；看板可改 user_client_settings
@@ -1289,6 +1290,7 @@ def _pin_imported_skill(client_id: str, skill_name: str) -> list[str]:
         skill_names=[skill_name],
         db_path=get_registry_db_path(),
         max_pinned=max_pinned,
+        origin_source="import",
     )
     try:
         from xskill.dashboard.console import _bump_routing_epoch

--- a/src/xskill/team/server/generate_jobs.py
+++ b/src/xskill/team/server/generate_jobs.py
@@ -335,8 +335,11 @@ def pin_generated_skills(
     skill_names: list[str],
     db_path: Path | None,
     max_pinned: int | None,
+    origin_source: str = "generate",
 ) -> list[str]:
-    from xskill.pipeline.registry import PinQuotaExceeded, set_skill_pref
+    from xskill.pipeline.registry import (
+        PinQuotaExceeded, record_skill_origin, set_skill_pref,
+    )
 
     pinned: list[str] = []
     for name in skill_names:
@@ -354,6 +357,15 @@ def pin_generated_skills(
             logger.warning("generate pin quota exceeded for %s: %s", name, error)
         except Exception:
             logger.exception("generate pin failed for %s", name)
+        try:
+            record_skill_origin(
+                skill_name=name,
+                user_key=user_id,
+                source=origin_source,
+                db_path=db_path,
+            )
+        except Exception:
+            logger.exception("skill origin record failed for %s", name)
     try:
         from xskill.team.server import api as server_api
         with server_api._MANIFEST_CONTROL_CACHE_LOCK:

--- a/src/xskill/team/server/skill_manifest.py
+++ b/src/xskill/team/server/skill_manifest.py
@@ -11,9 +11,9 @@ slot 结构 = 80 ranked + 20 recommended：
                  从候选里取 cosine 最近邻（``profile_reco.py``）。无画像
                  （冷启动）或非 team server 调用 → 退回 ux 排序往下取。
 
-灰度归因：某 skill 有 staging 分支 → side = CanaryRouter.assign(client_id,
-name, p, staging_sha)；同 client 同 staging 版本内 side 钉死。无 staging → main。
-种子/破平随机沿用 pick_side 的 hash（见 canary.CanaryRouter）。
+灰度归因：某 skill 有 staging 分支时，纳入/生成发起人与体验分用量最多的用户
+走体验分补漏换侧（自动灰度）；其余 client 仍由 ``CanaryRouter.assign`` sticky。
+无 staging → main。看板钉死的 side 覆盖自动灰度。
 """
 from __future__ import annotations
 
@@ -26,7 +26,14 @@ from functools import partial
 from pathlib import Path
 from typing import Callable
 
-from xskill.canary import CanaryRouter, main_sha, staging_sha
+from xskill.canary import (
+    CanaryConfig,
+    CanaryRouter,
+    auto_canary_side,
+    main_sha,
+    pick_side,
+    staging_sha,
+)
 from xskill.skill.skill import Skill
 from xskill.skill.repo import SkillRepo
 from xskill.team.shared.protocol import SkillSlot, SyncResponse
@@ -236,6 +243,10 @@ def get_recommend_engine():
 def _resolve_slot(
     skill: Skill | dict, client_id: str, probability: float, bucket: str,
     refs: dict[str, tuple[str, str | None]] | None = None,
+    *,
+    user_key: str = "",
+    fill_need: int = 5,
+    db_path: Path | str | None = None,
 ) -> SkillSlot | None:
     """对一个 skill 现算它对该 client 的 side + sha。"""
     if isinstance(skill, dict) and skill.get("source") == "skillhub":
@@ -259,15 +270,34 @@ def _resolve_slot(
         (main_sha(skill.path) or "", staging_sha(skill.path))
     )
     if cached_staging:
-        # team-CS：有状态 CanaryRouter（hash 种子/破平），避免小基数饿死 staging。
-        # SkillRecommendEngine.resolve_side 仍供推荐链路其它调用方使用；manifest
-        # 槽位 side 以 Router 账本为准（同 client / staging_sha / p sticky）。
-        side = _ROUTER.assign(
-            client_id=client_id,
-            skill_name=skill.name,
-            probability=probability,
-            staging_sha=cached_staging or "",
-        )
+        from xskill.pipeline.registry import is_auto_canary_user
+        origin_db = Path(db_path) if db_path else None
+        if user_key and is_auto_canary_user(
+                user_key, skill.name, db_path=origin_db):
+            # 纳入/生成发起人与用量最多的用户：按体验分补漏换侧。
+            fallback = pick_side(client_id, skill.name, probability)
+            side = auto_canary_side(
+                skill.path,
+                main_sha=cached_main or "",
+                staging_sha=cached_staging or "",
+                need=max(int(fill_need), 1),
+                fallback=fallback,
+            )
+            _ROUTER.note(
+                client_id=client_id,
+                skill_name=skill.name,
+                side=side,
+                probability=probability,
+                staging_sha=cached_staging or "",
+            )
+        else:
+            # team-CS：有状态 CanaryRouter（hash 种子/破平），避免小基数饿死 staging。
+            side = _ROUTER.assign(
+                client_id=client_id,
+                skill_name=skill.name,
+                probability=probability,
+                staging_sha=cached_staging or "",
+            )
         sha = cached_staging if side == "staging" else cached_main
     else:
         side = "main"
@@ -288,6 +318,9 @@ def build_manifest(
     prefs: dict | None = None,
     retired: set | None = None,
     telemetry_submit: Callable[[Callable[[], None]], bool] | None = None,
+    user_key: str = "",
+    fill_need: int | None = None,
+    db_path: Path | str | None = None,
 ) -> SyncResponse:
     """为 ``client_id`` 现算 manifest。skill 总数不足 total_slots 时全发。
 
@@ -355,6 +388,8 @@ def build_manifest(
     )
 
     side_overrides = prefs.get("side") or {}
+    need = CanaryConfig().min_samples if fill_need is None else max(int(fill_need), 1)
+    origin_db = Path(db_path) if db_path else None
     slots: list[SkillSlot] = []
     for idx, skill in enumerate(chosen):
         if idx < len(pinned):
@@ -365,6 +400,7 @@ def build_manifest(
             bucket = "recommended"
         slot = _resolve_slot(
             skill, client_id, probability, bucket, refs=catalog.refs,
+            user_key=user_key, fill_need=need, db_path=origin_db,
         )
         if slot is not None:
             ov = side_overrides.get(slot.skill_name)

--- a/tests/test_auto_canary.py
+++ b/tests/test_auto_canary.py
@@ -1,0 +1,195 @@
+"""自动灰度：纳入/生成发起人 ∪ 用量最多的用户，按体验分补漏换侧。"""
+from __future__ import annotations
+
+import subprocess
+from pathlib import Path
+
+from xskill.canary import append_ux_score, fill_deficit_side, staging_sha
+from xskill.pipeline.registry import (
+    auto_canary_users,
+    clear_auto_canary_cache_for_tests,
+    is_auto_canary_user,
+    pooled_connection,
+    record_skill_origin,
+    register_dir,
+    skill_origin_user,
+)
+from xskill.pipeline.ux_scores_store import insert_ux_score
+from xskill.team.server.skill_manifest import _ROUTER, build_manifest
+
+
+def _git(args, cwd):
+    subprocess.run(
+        ["git"] + args, cwd=str(cwd), capture_output=True, text=True, check=True,
+    )
+
+
+def _make_skill(root: Path, name: str, *, with_staging: bool = False) -> Path:
+    d = root / name
+    d.mkdir(parents=True)
+    _git(["init", "-q"], d)
+    _git(["checkout", "-q", "-b", "main"], d)
+    _git(["config", "user.email", "t@t"], d)
+    _git(["config", "user.name", "t"], d)
+    (d / "SKILL.md").write_text(f"# {name}\n", encoding="utf-8")
+    _git(["add", "."], d)
+    _git(["commit", "-q", "-m", "v1"], d)
+    if with_staging:
+        _git(["checkout", "-q", "-b", "staging"], d)
+        (d / "SKILL.md").write_text(f"# {name} staging\n", encoding="utf-8")
+        _git(["add", "."], d)
+        _git(["commit", "-q", "-m", "staging"], d)
+        _git(["checkout", "-q", "main"], d)
+    return d
+
+
+def _seed_usage(db: Path, *, skill: str, user: str, n: int, wd: Path) -> None:
+    register_dir(wd, label=user, db_path=db)
+    with pooled_connection(db) as conn:
+        wd_id = conn.execute(
+            "SELECT id FROM watch_dirs WHERE path=?",
+            (str(wd.resolve()),),
+        ).fetchone()[0]
+        for i in range(n):
+            conn.execute(
+                "INSERT INTO trajectories(watch_dir_id, filename, user_key)"
+                " VALUES (?,?,?)",
+                (wd_id, f"{user}-t{i}.md", user),
+            )
+        conn.commit()
+    for i in range(n):
+        insert_ux_score(
+            {
+                "skill_name": skill,
+                "side": "main",
+                "commit_sha": "abc",
+                "score": 8.0,
+                "scored_at": "2026-01-01T00:00:00+00:00",
+                "traj_id": f"{user}-t{i}",
+                "atom_id": "",
+            },
+            db_path=db,
+        )
+    clear_auto_canary_cache_for_tests()
+
+
+def test_fill_deficit_side_order():
+    assert fill_deficit_side(
+        staging_n=0, main_n=10, need=5, fallback="main") == "staging"
+    assert fill_deficit_side(
+        staging_n=5, main_n=1, need=5, fallback="staging") == "main"
+    assert fill_deficit_side(
+        staging_n=5, main_n=5, need=5, fallback="main") == "main"
+
+
+def test_origin_first_writer_wins(tmp_path):
+    db = tmp_path / "r.db"
+    register_dir(tmp_path / "wd", label="t", db_path=db)
+    assert record_skill_origin(
+        skill_name="s1", user_key="alice", source="import", db_path=db)
+    assert not record_skill_origin(
+        skill_name="s1", user_key="bob", source="generate", db_path=db)
+    assert skill_origin_user("s1", db_path=db) == "alice"
+
+
+def test_auto_canary_users_union_origin_and_top_usage(tmp_path):
+    db = tmp_path / "r.db"
+    record_skill_origin(
+        skill_name="s1", user_key="alice", source="import", db_path=db)
+    _seed_usage(
+        db, skill="s1", user="bob", n=3, wd=tmp_path / "bob-wd")
+    _seed_usage(
+        db, skill="s1", user="carol", n=1, wd=tmp_path / "carol-wd")
+    users = auto_canary_users("s1", db_path=db)
+    assert users == {"alice", "bob"}
+    assert is_auto_canary_user("alice", "s1", db_path=db)
+    assert is_auto_canary_user("bob", "s1", db_path=db)
+    assert not is_auto_canary_user("carol", "s1", db_path=db)
+
+
+def test_manifest_origin_user_fills_staging(tmp_path, monkeypatch):
+    db = tmp_path / "r.db"
+    monkeypatch.setattr("xskill.config.get_registry_db_path", lambda: db)
+    register_dir(tmp_path / "wd", label="t", db_path=db)
+    record_skill_origin(
+        skill_name="s1", user_key="alice", source="import", db_path=db)
+    skills = tmp_path / "skills"
+    skills.mkdir()
+    _make_skill(skills, "s1", with_staging=True)
+    _ROUTER.reset()
+    alice = build_manifest(
+        client_id="c-alice", skill_dir=skills, probability=0,
+        ranked_slots=80, total_slots=100, user_key="alice", db_path=db,
+    )
+    bob = build_manifest(
+        client_id="c-bob", skill_dir=skills, probability=0,
+        ranked_slots=80, total_slots=100, user_key="bob", db_path=db,
+    )
+    assert alice.slots[0].side == "staging"
+    assert bob.slots[0].side == "main"
+    _ROUTER.reset()
+
+
+def test_manifest_top_usage_user_fills_staging(tmp_path, monkeypatch):
+    db = tmp_path / "r.db"
+    monkeypatch.setattr("xskill.config.get_registry_db_path", lambda: db)
+    _seed_usage(db, skill="s1", user="bob", n=4, wd=tmp_path / "bob-wd")
+    skills = tmp_path / "skills"
+    skills.mkdir()
+    _make_skill(skills, "s1", with_staging=True)
+    _ROUTER.reset()
+    bob = build_manifest(
+        client_id="c-bob", skill_dir=skills, probability=0,
+        ranked_slots=80, total_slots=100, user_key="bob", db_path=db,
+    )
+    alice = build_manifest(
+        client_id="c-alice", skill_dir=skills, probability=0,
+        ranked_slots=80, total_slots=100, user_key="alice", db_path=db,
+    )
+    assert bob.slots[0].side == "staging"
+    assert alice.slots[0].side == "main"
+    _ROUTER.reset()
+
+
+def test_manifest_pin_side_overrides_auto_canary(tmp_path, monkeypatch):
+    db = tmp_path / "r.db"
+    monkeypatch.setattr("xskill.config.get_registry_db_path", lambda: db)
+    register_dir(tmp_path / "wd", label="t", db_path=db)
+    record_skill_origin(
+        skill_name="s1", user_key="alice", source="import", db_path=db)
+    skills = tmp_path / "skills"
+    skills.mkdir()
+    _make_skill(skills, "s1", with_staging=True)
+    _ROUTER.reset()
+    resp = build_manifest(
+        client_id="c-alice", skill_dir=skills, probability=0,
+        ranked_slots=80, total_slots=100, user_key="alice", db_path=db,
+        prefs={"pinned": ["s1"], "blocked": set(), "side": {"s1": "main"}},
+    )
+    assert resp.slots[0].side == "main"
+    _ROUTER.reset()
+
+
+def test_auto_canary_switches_to_main_when_staging_full(tmp_path, monkeypatch):
+    db = tmp_path / "r.db"
+    monkeypatch.setattr("xskill.config.get_registry_db_path", lambda: db)
+    register_dir(tmp_path / "wd", label="t", db_path=db)
+    record_skill_origin(
+        skill_name="s1", user_key="alice", source="import", db_path=db)
+    skills = tmp_path / "skills"
+    skills.mkdir()
+    dest = _make_skill(skills, "s1", with_staging=True)
+    s_sha = staging_sha(dest)
+    for i in range(2):
+        append_ux_score(
+            dest, traj_id=f"st{i}", skill_name="s1", side="staging",
+            commit_sha=s_sha or "", score=7, reasons="r",
+        )
+    _ROUTER.reset()
+    resp = build_manifest(
+        client_id="c-alice", skill_dir=skills, probability=0,
+        ranked_slots=80, total_slots=100, user_key="alice", db_path=db,
+        fill_need=2,
+    )
+    assert resp.slots[0].side == "main"
+    _ROUTER.reset()

--- a/tests/test_canary_router_hash.py
+++ b/tests/test_canary_router_hash.py
@@ -240,9 +240,9 @@ class TestManifestWiring(unittest.TestCase):
         src = Path(sm.__file__).read_text(encoding="utf-8")
         self.assertIn("_ROUTER.assign", src)
         self.assertIn("CanaryRouter", src)
-        # 有 staging 时不应再直接 pick_side(client_id, ...)
         resolve = src.split("def _resolve_slot", 1)[1].split("def build_manifest", 1)[0]
-        self.assertNotIn("pick_side(", resolve)
+        self.assertIn("_ROUTER.assign", resolve)
+        self.assertIn("auto_canary_side", resolve)
 
 
 class TestStarvationRateComparison(unittest.TestCase):

--- a/tests/test_generate_command.py
+++ b/tests/test_generate_command.py
@@ -140,6 +140,8 @@ def test_pin_generated_skills(tmp_path: Path):
     assert pinned == ["invoice-check"]
     rows = prefs_for("alice", db_path=db)
     assert any(r["skill_name"] == "invoice-check" and r["pref"] == "pinned" for r in rows)
+    from xskill.pipeline.registry import skill_origin_user
+    assert skill_origin_user("invoice-check", db_path=db) == "alice"
 
 
 def test_iter_job_events_pings_while_running(tmp_path: Path):

--- a/tests/test_import_skill.py
+++ b/tests/test_import_skill.py
@@ -507,6 +507,8 @@ def test_team_import_pins_named_initiator(
     assert body["pinned"] == ["foo"]
     rows = prefs_for("alice", db_path=_isolate_import_registry)
     assert any(p["skill_name"] == "foo" and p["pref"] == "pinned" for p in rows)
+    from xskill.pipeline.registry import skill_origin_user
+    assert skill_origin_user("foo", db_path=_isolate_import_registry) == "alice"
 
 
 def test_team_import_anonymous_does_not_pin(tmp_path, _isolate_import_registry):


### PR DESCRIPTION
## Summary
- 纳入或 generate 会记下发起人；每个技能再取体验分条数最多的用户。这两类人打开自动灰度：哪一侧体验分不够，下次同步就推缺的那侧。
- 其他人仍走原来的大约两成分流。看板上钉死的主干或灰度侧别覆盖自动灰度。推送名单标「自动灰度」。
- 打分和清单用同一套补漏，避免分记到错的一侧。

Closes #238

## Test plan
- [x] `pytest tests/test_auto_canary.py tests/test_canary_router_hash.py tests/test_generate_command.py::test_pin_generated_skills tests/test_import_skill.py tests/test_skill_routing.py tests/test_team_skill_manifest.py tests/test_recommend_engine.py::TestResolveSide tests/test_dashboard_console_p2.py`
- [ ] 有用户名的 `xskill import` 或 `xskill generate` 后，发起人在技能处于灰度观察且灰度侧还没分时，下次 sync 拿到 staging
- [ ] 看板上该人显示「自动灰度」；把侧别钉死成 main 后不再换侧
- [ ] 另一个几乎不用这份技能的人，在概率为 0 时仍拿主干版


Made with [Cursor](https://cursor.com)