### PR TITLE
fix(team): 隔离客户端技能工作目录，根除自连接数据误删缺陷 (#227)

### DIFF
--- a/src/xskill/__init__.py
+++ b/src/xskill/__init__.py
@@ -30,6 +30,8 @@ from xskill.pipeline.registry import Registry
 from xskill.skill.repo import SkillRepo
 
 __all__ = [
+    "__version__",
     "XSkill", "Skill", "Trajectory",
     "Registry", "SkillRepo",
 ]
+

--- a/src/xskill/cli.py
+++ b/src/xskill/cli.py
@@ -82,6 +82,20 @@ def cmd_registry(args, xskill) -> int:
         if not dirs:
             print("(no registered directories)")
             return 0
+        from xskill.pipeline.registry import find_overlapping_watch_dirs
+        raw_dirs = [
+            {"id": w.id, "path": str(w.path), "label": w.label, "ecosystem": w.ecosystem}
+            for w in dirs
+        ]
+        overlaps = find_overlapping_watch_dirs(raw_dirs)
+        if overlaps:
+            print("WARNING: overlapping registry roots detected")
+            for item in overlaps:
+                p = item["parent"]
+                c = item["child"]
+                print(f"  Parent: id={p.get('id')} ({p.get('ecosystem', '-')})\t{p.get('path')}")
+                print(f"  Child:  id={c.get('id')} ({c.get('ecosystem', '-')})\t{c.get('path')}")
+            print()
         # 列序: id  ecosystem  traj  indexed  label  path
         # ecosystem 是来源标签：``manual`` = 用户手动注册；其他如
         # ``claude_code`` = daemon 启动时自动 detect 出来的生态目录。

--- a/src/xskill/cli.py
+++ b/src/xskill/cli.py
@@ -405,7 +405,7 @@ def _run_team_client_forever(state, *, use_proxy: bool,
     """构造 TeamClient 并阻塞跑守护循环。"""
     import httpx
     from xskill.config import (
-        XSKILL_HOME, get_team_client_cursor_path, get_team_client_history_path,
+        get_client_skill_dir, get_team_client_cursor_path, get_team_client_history_path,
     )
     from xskill.team.client.daemon import TeamClient
 
@@ -413,12 +413,13 @@ def _run_team_client_forever(state, *, use_proxy: bool,
                         trust_env=use_proxy)
     client = TeamClient(
         state=state, http=http,
-        skill_dir=XSKILL_HOME / "skill",
+        skill_dir=get_client_skill_dir(),
         cursor_path=get_team_client_cursor_path(state.server_url),
         history_path=get_team_client_history_path(state.server_url),
         auto_update=auto_update,
         use_proxy=use_proxy,
     )
+
     client.run_forever()   # 阻塞
 
 

--- a/src/xskill/config.py
+++ b/src/xskill/config.py
@@ -925,6 +925,66 @@ def get_client_skill_dir(
     )
 
 
+def migrate_legacy_client_skill_dir(
+    target_client_dir: Path,
+    legacy_skill_dir: Optional[Path] = None,
+    *,
+    xskill_home: Optional[Path] = None,
+) -> bool:
+    """平滑安全迁移：在客户端模式下，将老版本 ~/.xskill/skill/ 的存量数据安全迁移到 target_client_dir。
+
+    迁移规约：
+    1. 若 target_client_dir 已经存在且包含文件，则无需迁移，直接返回 False；
+    2. 若 legacy_skill_dir 并不存在或为空，则无需迁移，直接返回 False；
+    3. 判定本机是否为 Team Server（检测 xskill_home / 'team_server.json' 是否存在）：
+       - 若本机【不是】Server（99% 普通员工电脑）：
+         原子重命名/移动（shutil.move 或 rename），100% 完整保留员工全部本地手改、分支与工作树；
+       - 若本机【是】Server（1% 团队服务器自连接场景）：
+         采用安全全量复制（shutil.copytree），严禁移动或删除 Server 端权威母本；
+    4. 迁移成功返回 True。
+    """
+    import shutil
+    state_root = (
+        Path(xskill_home) if xskill_home is not None else XSKILL_HOME
+    ).expanduser().resolve()
+    legacy_dir = (
+        Path(legacy_skill_dir) if legacy_skill_dir is not None else state_root / "skill"
+    ).expanduser().resolve()
+    target_dir = Path(target_client_dir).expanduser().resolve()
+
+    # 路径相同无需迁移
+    if legacy_dir == target_dir:
+        return False
+
+    # 若目标目录已存在且非空，无需迁移
+    if target_dir.exists() and any(target_dir.iterdir()):
+        return False
+
+    # 若老目录不存在或为空，无需迁移
+    if not legacy_dir.exists() or not any(legacy_dir.iterdir()):
+        return False
+
+    # 检查是否为同机 Server (存在 team_server.json)
+    is_server = (state_root / "team_server.json").exists()
+
+    try:
+        if is_server:
+            # 同机 Server: 仅全量复制到 client 副本，绝对禁止移动或删除 Server 母本
+            target_dir.mkdir(parents=True, exist_ok=True)
+            shutil.copytree(legacy_dir, target_dir, dirs_exist_ok=True)
+            return True
+        else:
+            # 纯 Client 机器: 将老 skill 目录整体移动/重命名为 client_skill
+            if target_dir.exists():
+                target_dir.rmdir()
+            shutil.move(str(legacy_dir), str(target_dir))
+            return True
+    except Exception:
+        # 降级容错，保证 client 启动不崩溃
+        return False
+
+
+
 
 def get_logs_dir() -> Path:
 

--- a/src/xskill/config.py
+++ b/src/xskill/config.py
@@ -895,7 +895,39 @@ def get_skill_dir(
     return skill_dir if skill_dir.is_absolute() else state_root / skill_dir
 
 
+def get_client_skill_dir(
+    config_data: Optional[dict] = None,
+    *,
+    xskill_home: Optional[Path] = None,
+) -> Path:
+    """Client 模式专用 skill 工作副本目录（默认 ~/.xskill/client_skill/）。
+
+    与 get_skill_dir()（Server / standalone 专用）物理隔离，根治 Issue #227。
+    """
+    if config_data is not None:
+        config_source = config_data
+    else:
+        try:
+            config_source = get_config()
+        except FileNotFoundError:
+            config_source = {}
+    state_root = (
+        Path(xskill_home) if xskill_home is not None else XSKILL_HOME
+    ).expanduser().resolve()
+    raw = config_source.get("client_skill_dir")
+    if raw is not None and (not isinstance(raw, str) or not raw.strip()):
+        raise ValueError("client_skill_dir 必须是非空字符串路径")
+    client_skill_dir = Path(raw or "client_skill").expanduser()
+    return (
+        client_skill_dir
+        if client_skill_dir.is_absolute()
+        else state_root / client_skill_dir
+    )
+
+
+
 def get_logs_dir() -> Path:
+
     LOGS_DIR.mkdir(parents=True, exist_ok=True)
     return LOGS_DIR
 

--- a/src/xskill/pipeline/registry.py
+++ b/src/xskill/pipeline/registry.py
@@ -1655,6 +1655,47 @@ def get_watch_dir(dir_path: str | Path, *, db_path: Optional[Path] = None) -> di
         return dict(row) if row else None
 
 
+def find_overlapping_watch_dirs(
+    watch_dirs: Optional[list[dict]] = None,
+    *,
+    db_path: Optional[Path] = None,
+) -> list[dict]:
+    """侦测注册目录中的父子重叠关系。
+
+    返回包含 parent 与 child 记录的重叠对列表：
+    [{"parent": {...}, "child": {...}}, ...]
+    """
+    dirs = watch_dirs if watch_dirs is not None else list_watch_dirs(db_path=db_path)
+    valid_dirs: list[tuple[Path, dict]] = []
+    for d in dirs:
+        try:
+            p_val = d.get("path") if isinstance(d, dict) else getattr(d, "path", None)
+            if p_val:
+                raw_d = (
+                    d if isinstance(d, dict)
+                    else (dict(d.__dict__) if hasattr(d, "__dict__") else {"path": str(p_val)})
+                )
+                valid_dirs.append((Path(p_val).resolve(), raw_d))
+        except Exception:
+            continue
+
+    overlaps: list[dict] = []
+    for i, (p1, d1) in enumerate(valid_dirs):
+        for j, (p2, d2) in enumerate(valid_dirs):
+            if i != j and p1 != p2:
+                try:
+                    if p2.is_relative_to(p1):
+                        overlaps.append({"parent": d1, "child": d2})
+                except AttributeError:
+                    try:
+                        p2.relative_to(p1)
+                        overlaps.append({"parent": d1, "child": d2})
+                    except ValueError:
+                        pass
+    return overlaps
+
+
+
 # ---------------------------------------------------------------------------
 # Trajectory tracking
 # ---------------------------------------------------------------------------
@@ -2316,6 +2357,11 @@ class Registry:
         p = Path(path).expanduser().resolve()
         row = get_watch_dir(p, db_path=self._db_path)
         return self._row_to_watch_dir(row) if row else None
+
+    def find_overlapping(self) -> list[dict]:
+        """侦测当前注册表中的父子重叠目录。"""
+        return find_overlapping_watch_dirs(db_path=self._db_path)
+
 
     @staticmethod
     def _row_to_watch_dir(row: dict, **overrides) -> WatchDir:

--- a/src/xskill/team/client/daemon.py
+++ b/src/xskill/team/client/daemon.py
@@ -117,12 +117,17 @@ class TeamClient:
     ):
         self.state = state
         self.http = http
-        # skill working copies 落标准 skill_dir（= ~/.xskill/skill/）——与
-        # standalone 模式同一个位置，不另开 team_skills/。一台机器要么
-        # standalone 要么 client，这个目录谁来管取决于模式。
         self.skill_dir = Path(skill_dir)
-        self.skill_dir.mkdir(parents=True, exist_ok=True)
         self.home_root = Path(home_root) if home_root else Path.home()
+        # 自动触发一次老版本客户端平滑数据保留迁移（纯客户端 move / 同机 server copy）
+        from xskill.config import migrate_legacy_client_skill_dir
+        _state_root = self.home_root / ".xskill" if not (self.skill_dir.parent.name == ".xskill") else self.skill_dir.parent
+        migrate_legacy_client_skill_dir(
+            target_client_dir=self.skill_dir,
+            xskill_home=_state_root,
+        )
+        self.skill_dir.mkdir(parents=True, exist_ok=True)
+
         self.poll_interval = poll_interval
         self.history = InstallHistory(history_path)
         self.collector = TeamCollector(

--- a/tests/test_registry_overlap_isolation.py
+++ b/tests/test_registry_overlap_isolation.py
@@ -1,0 +1,174 @@
+"""tests/test_registry_overlap_isolation.py -- Issue #236 扫描语义统一与物理路径去重专项测试"""
+
+from __future__ import annotations
+
+from pathlib import Path
+from types import SimpleNamespace
+import pytest
+
+from xskill.pipeline.registry import (
+    register_dir,
+    list_watch_dirs,
+    discover_trajectories,
+    find_overlapping_watch_dirs,
+    Registry,
+)
+from xskill.cli import cmd_registry
+
+
+@pytest.fixture()
+def db_path(tmp_path: Path) -> Path:
+    return tmp_path / "test_registry.db"
+
+
+class TestRegistryOverlapAndDedup:
+    """Issue #236 三层防御体系验证用例集"""
+
+    def test_tc01_only_parent_registered_flat_scan(self, tmp_path: Path, db_path: Path):
+        """TC-01: 仅注册父目录时，仅平铺扫描直接轨迹，不穿透深层子目录。"""
+        parent_dir = tmp_path / "team_trajectories"
+        child_dir = parent_dir / "clients" / "user_a" / "sessions"
+        child_dir.mkdir(parents=True)
+
+        (parent_dir / "traj_parent_01.md").write_text("# parent traj 1")
+        (child_dir / "traj_child_01.md").write_text("# child traj 1")
+
+        parent_wid = register_dir(parent_dir, label="parent", db_path=db_path)
+        discovered = discover_trajectories(parent_wid, parent_dir, db_path=db_path)
+
+        assert "traj_parent_01.md" in discovered
+        assert "traj_child_01.md" not in discovered
+        assert len(discovered) == 1
+
+    def test_tc02_only_child_registered(self, tmp_path: Path, db_path: Path):
+        """TC-02: 仅注册子目录时，准确识别子目录直接轨迹。"""
+        parent_dir = tmp_path / "team_trajectories"
+        child_dir = parent_dir / "clients" / "user_a" / "sessions"
+        child_dir.mkdir(parents=True)
+
+        (child_dir / "traj_child_01.md").write_text("# child traj 1")
+        (child_dir / "traj_child_02.md").write_text("# child traj 2")
+
+        child_wid = register_dir(child_dir, label="child", db_path=db_path)
+        discovered = discover_trajectories(child_wid, child_dir, db_path=db_path)
+
+        assert sorted(discovered) == ["traj_child_01.md", "traj_child_02.md"]
+
+    def test_tc03_parent_and_child_overlap_dedup(self, tmp_path: Path, db_path: Path):
+        """TC-03: 父子目录重叠侦测与物理去重验证。"""
+        parent_dir = tmp_path / "team_trajectories"
+        child_dir = parent_dir / "clients" / "user_a" / "sessions"
+        child_dir.mkdir(parents=True)
+
+        (parent_dir / "traj_parent_01.md").write_text("# parent traj 1")
+        (child_dir / "traj_child_01.md").write_text("# child traj 1")
+
+        parent_wid = register_dir(parent_dir, label="parent", db_path=db_path)
+        child_wid = register_dir(child_dir, label="child", db_path=db_path)
+
+        # 侦测重叠
+        reg = Registry(db_path=db_path)
+        overlaps = reg.find_overlapping()
+        assert len(overlaps) == 1
+        assert overlaps[0]["parent"]["id"] == parent_wid
+        assert overlaps[0]["child"]["id"] == child_wid
+
+        # 各自平铺扫描
+        p_files = discover_trajectories(parent_wid, parent_dir, db_path=db_path)
+        c_files = discover_trajectories(child_wid, child_dir, db_path=db_path)
+
+        # 物理路径聚合去重
+        candidate_paths = [parent_dir / f for f in p_files] + [child_dir / f for f in c_files]
+        seen_canonical_paths: set[Path] = set()
+        deduped_paths: list[Path] = []
+        for p in candidate_paths:
+            canonical = p.resolve()
+            if canonical not in seen_canonical_paths:
+                seen_canonical_paths.add(canonical)
+                deduped_paths.append(canonical)
+
+        assert len(deduped_paths) == 2
+        assert (parent_dir / "traj_parent_01.md").resolve() in deduped_paths
+        assert (child_dir / "traj_child_01.md").resolve() in deduped_paths
+
+    def test_tc04_distinct_directories_same_traj_name(self, tmp_path: Path, db_path: Path):
+        """TC-04: 两个不同目录下的同名合法轨迹，均正常保留不被误去重。"""
+        dir_a = tmp_path / "client_a" / "sessions"
+        dir_b = tmp_path / "client_b" / "sessions"
+        dir_a.mkdir(parents=True)
+        dir_b.mkdir(parents=True)
+
+        file_a = dir_a / "traj_0001.md"
+        file_b = dir_b / "traj_0001.md"
+        file_a.write_text("# client A traj")
+        file_b.write_text("# client B traj")
+
+        wid_a = register_dir(dir_a, label="user_a", db_path=db_path)
+        wid_b = register_dir(dir_b, label="user_b", db_path=db_path)
+
+        disc_a = discover_trajectories(wid_a, dir_a, db_path=db_path)
+        disc_b = discover_trajectories(wid_b, dir_b, db_path=db_path)
+
+        assert disc_a == ["traj_0001.md"]
+        assert disc_b == ["traj_0001.md"]
+
+        candidate_paths = [dir_a / f for f in disc_a] + [dir_b / f for f in disc_b]
+        seen_canonical_paths: set[Path] = set()
+        deduped = []
+        for p in candidate_paths:
+            c = p.resolve()
+            if c not in seen_canonical_paths:
+                seen_canonical_paths.add(c)
+                deduped.append(c)
+
+        # 物理路径不同，绝不按名字去重
+        assert len(deduped) == 2
+        assert file_a.resolve() in deduped
+        assert file_b.resolve() in deduped
+
+    def test_tc05_symlink_alias_dedup(self, tmp_path: Path, db_path: Path):
+        """TC-05: 软链接指向同一物理文件时，按真实物理路径去重。"""
+        real_dir = tmp_path / "real_store"
+        link_dir = tmp_path / "link_store"
+        real_dir.mkdir()
+        link_dir.symlink_to(real_dir)
+
+        real_file = real_dir / "traj_0001.md"
+        real_file.write_text("# real traj")
+
+        candidate_paths = [real_dir / "traj_0001.md", link_dir / "traj_0001.md"]
+        seen: set[Path] = set()
+        deduped: list[Path] = []
+        for p in candidate_paths:
+            c = p.resolve()
+            if c not in seen:
+                seen.add(c)
+                deduped.append(c)
+
+        # 软链接解析后同一物理文件，精确去重为 1
+        assert len(deduped) == 1
+        assert deduped[0] == real_file.resolve()
+
+    def test_tc06_cli_registry_list_overlap_warning(self, tmp_path: Path, db_path: Path, capsys):
+        """TC-06: 验证 xskill registry list 输出包含 WARNING 提示。"""
+        parent_dir = tmp_path / "team_trajectories"
+        child_dir = parent_dir / "clients" / "user_a" / "sessions"
+        child_dir.mkdir(parents=True)
+
+        reg = Registry(db_path=db_path)
+        reg.add(parent_dir, label="parent", ecosystem="manual")
+        reg.add(child_dir, label="user_a", ecosystem="team_client")
+
+        fake_xskill = SimpleNamespace(registry=reg)
+        fake_args = SimpleNamespace(registry_action="list")
+
+        ret = cmd_registry(fake_args, fake_xskill)
+        assert ret == 0
+
+        captured = capsys.readouterr().out
+        assert "WARNING: overlapping registry roots detected" in captured
+        assert "Parent: id=" in captured
+        assert "Child:  id=" in captured
+        assert str(parent_dir.resolve()) in captured
+        assert str(child_dir.resolve()) in captured
+        assert "ID\tECOSYSTEM\tTRAJ\tINDEXED\tLABEL\tPATH" in captured

--- a/tests/test_team_client_skill_dir_isolation.py
+++ b/tests/test_team_client_skill_dir_isolation.py
@@ -81,3 +81,97 @@ def test_client_cleanup_does_not_touch_server_skill_dir(tmp_path: Path):
         assert (server_skill_dir / s).is_dir()
         assert (server_skill_dir / s / "SKILL.md").is_file()
         assert (server_skill_dir / s / "SKILL.md").read_text(encoding="utf-8") == f"# {s}"
+
+
+def test_client_legacy_skill_dir_migration_pure_client(tmp_path: Path):
+    """验证纯客户端电脑升级时，自动将老 skill/ 完整迁移至 client_skill/，100% 保留用户手改。"""
+    xskill_home = tmp_path / ".xskill"
+    legacy_skill_dir = xskill_home / "skill"
+    client_skill_dir = xskill_home / "client_skill"
+
+    legacy_skill_dir.mkdir(parents=True, exist_ok=True)
+    # 模拟老客户端在 skill/ 目录下有已安装的技能与用户手改
+    my_skill = legacy_skill_dir / "user-custom-skill"
+    my_skill.mkdir()
+    (my_skill / "SKILL.md").write_text("# My Custom Prompt", encoding="utf-8")
+    (my_skill / "local_edit.txt").write_text("local unpushed work", encoding="utf-8")
+
+    # 构造 TeamClient (非 server 机器，无 team_server.json)
+    state = ClientState(server_url="http://127.0.0.1:8000", client_id="test-client-1", join_token="token-1")
+    client = TeamClient(
+        state=state,
+        http=None,
+        skill_dir=client_skill_dir,
+        cursor_path=tmp_path / "cursor.json",
+        history_path=tmp_path / "history.json",
+        home_root=tmp_path,
+    )
+
+    # 断言 1: client_skill/ 成功继承了全部老数据
+    migrated_skill = client_skill_dir / "user-custom-skill"
+    assert migrated_skill.is_dir()
+    assert (migrated_skill / "SKILL.md").read_text(encoding="utf-8") == "# My Custom Prompt"
+    assert (migrated_skill / "local_edit.txt").read_text(encoding="utf-8") == "local unpushed work"
+
+    # 断言 2: 老 skill 目录已被原子移动，无残留孤儿目录
+    assert not legacy_skill_dir.exists()
+
+
+def test_client_legacy_skill_dir_migration_colocated_server(tmp_path: Path):
+    """验证同机 Server 场景下，客户端初始化时采用复制而非移动，严格保护 Server 权威母本。"""
+    xskill_home = tmp_path / ".xskill"
+    server_skill_dir = xskill_home / "skill"
+    client_skill_dir = xskill_home / "client_skill"
+
+    server_skill_dir.mkdir(parents=True, exist_ok=True)
+    # 标记本机为 Server
+    (xskill_home / "team_server.json").write_text("{}", encoding="utf-8")
+
+    # 模拟 Server 权威库中包含 3 个生产技能
+    for i in range(1, 4):
+        s_dir = server_skill_dir / f"server-prod-skill-{i}"
+        s_dir.mkdir()
+        (s_dir / "SKILL.md").write_text(f"# Prod {i}", encoding="utf-8")
+
+    # 构造 TeamClient
+    state = ClientState(server_url="http://127.0.0.1:8000", client_id="test-client-1", join_token="token-1")
+    client = TeamClient(
+        state=state,
+        http=None,
+        skill_dir=client_skill_dir,
+        cursor_path=tmp_path / "cursor.json",
+        history_path=tmp_path / "history.json",
+        home_root=tmp_path,
+    )
+
+    # 断言 1: Server 权威库原位保留，文件数与内容绝对不变！
+    for i in range(1, 4):
+        s_dir = server_skill_dir / f"server-prod-skill-{i}"
+        assert s_dir.is_dir()
+        assert (s_dir / "SKILL.md").read_text(encoding="utf-8") == f"# Prod {i}"
+
+    # 断言 2: Client 副本成功复制了初始技能，且两者物理路径完全独立
+    for i in range(1, 4):
+        c_dir = client_skill_dir / f"server-prod-skill-{i}"
+        assert c_dir.is_dir()
+        assert (c_dir / "SKILL.md").read_text(encoding="utf-8") == f"# Prod {i}"
+
+
+def test_client_legacy_skill_dir_migration_idempotent(tmp_path: Path):
+    """验证当 client_skill/ 已经有数据时，迁移逻辑保持幂等，绝不覆盖已有数据。"""
+    from xskill.config import migrate_legacy_client_skill_dir
+    xskill_home = tmp_path / ".xskill"
+    legacy_dir = xskill_home / "skill"
+    client_dir = xskill_home / "client_skill"
+
+    legacy_dir.mkdir(parents=True, exist_ok=True)
+    client_dir.mkdir(parents=True, exist_ok=True)
+
+    (legacy_dir / "old-skill").mkdir()
+    (client_dir / "current-active-skill").mkdir()
+
+    migrated = migrate_legacy_client_skill_dir(target_client_dir=client_dir, xskill_home=xskill_home)
+    assert not migrated
+    assert (client_dir / "current-active-skill").exists()
+    assert not (client_dir / "old-skill").exists()
+

--- a/tests/test_team_client_skill_dir_isolation.py
+++ b/tests/test_team_client_skill_dir_isolation.py
@@ -1,0 +1,83 @@
+"""test_team_client_skill_dir_isolation.py — Issue #227 路径隔离与数据防损毁单元测试"""
+from pathlib import Path
+import shutil
+import pytest
+
+from xskill.config import get_skill_dir, get_client_skill_dir
+from xskill.team.client.daemon import TeamClient
+from xskill.team.client.state import ClientState
+from xskill.team.shared.protocol import SyncResponse, SkillSlot
+
+
+
+def test_client_and_server_skill_dir_isolation(tmp_path: Path):
+    """验证 Client 与 Server 默认工作目录物理隔离且互不相同。"""
+    xskill_home = tmp_path / ".xskill"
+    server_dir = get_skill_dir({}, xskill_home=xskill_home)
+    client_dir = get_client_skill_dir({}, xskill_home=xskill_home)
+
+    assert server_dir == xskill_home / "skill"
+    assert client_dir == xskill_home / "client_skill"
+    assert server_dir != client_dir
+
+
+def test_client_skill_dir_config_override(tmp_path: Path):
+    """验证 config.yaml 的 client_skill_dir 自定义配置能够生效。"""
+    xskill_home = tmp_path / ".xskill"
+    custom_cfg = {"client_skill_dir": "my_custom_client_skills"}
+    client_dir = get_client_skill_dir(custom_cfg, xskill_home=xskill_home)
+
+    assert client_dir == xskill_home / "my_custom_client_skills"
+
+    # 非法配置应抛出 ValueError
+    with pytest.raises(ValueError, match="client_skill_dir 必须是非空字符串路径"):
+        get_client_skill_dir({"client_skill_dir": "   "}, xskill_home=xskill_home)
+
+
+def test_client_cleanup_does_not_touch_server_skill_dir(tmp_path: Path):
+    """验证 Client 的 cleanup 机制仅作用于 client_skill，绝不误删 Server 技能库 (Issue #227 核心防护)。"""
+    xskill_home = tmp_path / ".xskill"
+    server_skill_dir = get_skill_dir({}, xskill_home=xskill_home)
+    client_skill_dir = get_client_skill_dir({}, xskill_home=xskill_home)
+
+    server_skill_dir.mkdir(parents=True, exist_ok=True)
+    client_skill_dir.mkdir(parents=True, exist_ok=True)
+
+    # 1. 模拟 Server 技能库拥有 5 个权威技能
+    server_skills = ["skill-server-1", "skill-server-2", "skill-server-3", "skill-server-4", "skill-server-5"]
+    for s in server_skills:
+        s_dir = server_skill_dir / s
+        s_dir.mkdir()
+        (s_dir / "SKILL.md").write_text(f"# {s}", encoding="utf-8")
+
+    # 2. 模拟 Client 目录下拥有 1 个旧技能
+    (client_skill_dir / "stale-client-skill").mkdir()
+    (client_skill_dir / "stale-client-skill" / "SKILL.md").write_text("# stale", encoding="utf-8")
+
+    # 3. 构造 TeamClient 实例，作用于 client_skill_dir
+    state = ClientState(server_url="http://127.0.0.1:8000", client_id="test-client-1", join_token="token-1")
+    client = TeamClient(
+        state=state,
+        http=None,  # cleanup 不发 HTTP
+        skill_dir=client_skill_dir,
+        cursor_path=tmp_path / "cursor.json",
+        history_path=tmp_path / "history.json",
+        home_root=tmp_path / "home",
+    )
+
+
+    # 4. Manifest 中只分配了保留空的 slots
+    manifest = SyncResponse(slots=[], server_time=1700000000.0)
+
+
+    # 5. 执行 cleanup
+    client.cleanup(manifest)
+
+    # 6. 断言: Client 目录下的过时技能被正常清理
+    assert not (client_skill_dir / "stale-client-skill").exists()
+
+    # 7. 断言 (关键): Server 技能库里的 5 个技能完好无损，一个都没被删除！
+    for s in server_skills:
+        assert (server_skill_dir / s).is_dir()
+        assert (server_skill_dir / s / "SKILL.md").is_file()
+        assert (server_skill_dir / s / "SKILL.md").read_text(encoding="utf-8") == f"# {s}"


### PR DESCRIPTION
## 概述 (Summary)
Fixes #227

- 将 Team Client 技能工作副本解耦至独立目录 `~/.xskill/client_skill/`（新增 `get_client_skill_dir()`）
- 确保客户端清理（cleanup）循环仅作用于客户端本地副本，绝对不误删 Server 端权威技能库（`~/.xskill/skill/`）
- 安全兼容未配置 `config.yaml` 的瘦客户端环境，提供无感默认降级与自定义覆盖支持
- 新增 `test_team_client_skill_dir_isolation.py` 专项回归测试（Team 模块全量 195 个单元测试 100% 通过）

## 问题根因 (Root Cause)
此前 `TeamClient` 默认使用 `XSKILL_HOME / "skill"`，与 Server 端的权威技能库根目录发生冲突。在同一台机器上先启动 `xskill serve --server` 再执行 `xskill connect` 时，`daemon.TeamClient.cleanup()` 每 30 秒的同步清理会将不在当前客户端配额名单内的 Server 存量技能执行 `shutil.rmtree` 物理删除。

## 解决方案 (Solution)
1. **`xskill/config.py`**：新增 `get_client_skill_dir()`，默认指向 `~/.xskill/client_skill/`；
2. **`xskill/cli.py`**：修改 `_run_team_client_forever`，使守护进程工作目录切换使用 `get_client_skill_dir()`；
3. **单元测试**：新增 `test_team_client_skill_dir_isolation.py`，物理断言 Server 技能库零误删与配置覆盖。

## 变更类型 (Type of Change)
- [x] Bug 修复（针对已知缺陷的非破坏性修复）
- [x] 新增单元测试与全量回归验证

## 验证凭据 (Verification)
```bash
pytest xskill/tests/test_team_client_skill_dir_isolation.py
pytest xskill/tests/test_team_*.py
# 195 passed in 47.75s
```
