### PR TITLE
fix(task-agent): reject missing or invalid ux_score

### DIFF
--- a/src/xskill/agents/agent_tools.py
+++ b/src/xskill/agents/agent_tools.py
@@ -29,7 +29,7 @@ from types import MappingProxyType
 from typing import Any
 
 from agno.tools import tool
-from pydantic import BaseModel, ConfigDict, Field
+from pydantic import BaseModel, ConfigDict, Field, StrictInt
 
 from xskill.skill.frontmatter import (
     parse as fm_parse,
@@ -1439,7 +1439,7 @@ def make_task_agent_tools(
     def submit_atom(start_line: int, intent: str, summary: str,
                     tags: list | None = None,
                     used_skills: list | None = None,
-                    ux_score: int | None = None) -> str:
+                    *, ux_score: StrictInt) -> str:
         """提交一个新 AtomTask（提交即校验,不合法返 error 让你自改）。
 
         Args:
@@ -1470,6 +1470,8 @@ def make_task_agent_tools(
                     f"({submitted[-1]['start_line']})，本次 {sl}")
         if not (intent or "").strip() or not (summary or "").strip():
             return "error: intent 和 summary 必填"
+        if not 1 <= ux_score <= 10:
+            return f"error: ux_score 必须是 1~10 的整数 (got {ux_score})"
         submitted.append({
             "start_line": sl,
             "intent": intent.strip(),
@@ -1477,8 +1479,7 @@ def make_task_agent_tools(
             "tags": [str(t).strip() for t in (tags or []) if str(t).strip()],
             "used_skills": [str(s).strip() for s in (used_skills or [])
                             if str(s).strip()],
-            "ux_score": ux_score if isinstance(ux_score, int)
-            and 1 <= ux_score <= 10 else None,
+            "ux_score": ux_score,
         })
         return f"ok: 已记录 atom #{len(submitted)} (start_line={sl})"
 

--- a/tests/test_task_agent.py
+++ b/tests/test_task_agent.py
@@ -15,6 +15,7 @@ import re
 from pathlib import Path
 
 import pytest
+from pydantic import ValidationError
 
 from xskill.pipeline.atom import AtomTaskStore
 from xskill.agents.task_agent import (
@@ -85,11 +86,12 @@ def _scripted_factory(submit_calls, *, status=None):
     名也记到 captured。``status`` 注入 run_response.status（测 error 兜底）。
     """
     captured: dict = {"results": [], "instructions": None, "user_msg": None,
-                      "tool_names": None}
+                      "submit_tool": None, "tool_names": None}
 
     def factory(*, instructions, tools):
         toolmap = {_tool_name(t): t for t in tools}
         captured["instructions"] = instructions
+        captured["submit_tool"] = toolmap["submit_atom"]
         captured["tool_names"] = sorted(toolmap)
 
         class _A:
@@ -305,7 +307,7 @@ class TestFirstRunSinglePass:
         traj_path.write_text(_TRAJ_MD, encoding="utf-8")
         store = AtomTaskStore(root=traj_dir)
         factory = _scripted_factory([
-            dict(start_line=5, intent="i", summary="s"),
+            dict(start_line=5, intent="i", summary="s", ux_score=7),
         ])
         TaskAgent(agno_agent_factory=factory, store=store).run(
             traj_id="traj_t", traj_path=traj_path)
@@ -461,7 +463,7 @@ class TestZeroSubmitRaises:
             value = "ERROR"
 
         factory = _scripted_factory([
-            dict(start_line=5, intent="i", summary="s"),
+            dict(start_line=5, intent="i", summary="s", ux_score=7),
         ], status=_Status())
         with pytest.raises(RuntimeError, match="ERROR"):
             TaskAgent(agno_agent_factory=factory, store=store).run(
@@ -485,8 +487,9 @@ class TestSubmitValidation:
         traj_path, store = self._setup(tmp_path)
         # 第 9 行是 ## Assistant,不是 ## User 回合
         factory = _scripted_factory([
-            dict(start_line=9, intent="i", summary="s"),
-            dict(start_line=5, intent="i2", summary="s2"),  # 补一个合法的
+            dict(start_line=9, intent="i", summary="s", ux_score=7),
+            dict(start_line=5, intent="i2", summary="s2",
+                 ux_score=7),  # 补一个合法的
         ])
         atoms = TaskAgent(agno_agent_factory=factory, store=store).run(
             traj_id="traj_e", traj_path=traj_path)
@@ -500,8 +503,9 @@ class TestSubmitValidation:
         """撤销/反悔不切：倒退的 start_line（回到上一意图）被拒,不另起 atom。"""
         traj_path, store = self._setup(tmp_path)
         factory = _scripted_factory([
-            dict(start_line=17, intent="i1", summary="s1"),
-            dict(start_line=5, intent="撤销回上一个", summary="s2"),  # 倒退 → reject
+            dict(start_line=17, intent="i1", summary="s1", ux_score=7),
+            dict(start_line=5, intent="撤销回上一个", summary="s2",
+                 ux_score=7),  # 倒退 → reject
         ])
         atoms = TaskAgent(agno_agent_factory=factory, store=store).run(
             traj_id="traj_e", traj_path=traj_path)
@@ -516,14 +520,58 @@ class TestSubmitValidation:
     def test_missing_required_field_then_valid(self, tmp_path):
         traj_path, store = self._setup(tmp_path)
         factory = _scripted_factory([
-            dict(start_line=5, intent="i", summary=""),   # 缺 summary → reject
-            dict(start_line=5, intent="i", summary="s"),  # 改对重提
+            dict(start_line=5, intent="i", summary="", ux_score=7),
+            dict(start_line=5, intent="i", summary="s", ux_score=7),
         ])
         atoms = TaskAgent(agno_agent_factory=factory, store=store).run(
             traj_id="traj_e", traj_path=traj_path)
         assert factory.captured["results"][0].startswith("error:")
         assert "必填" in factory.captured["results"][0]
         assert len(atoms) == 1
+
+    def test_ux_score_is_required_strict_integer(self, tmp_path):
+        traj_path, store = self._setup(tmp_path)
+        factory = _scripted_factory([
+            dict(start_line=5, intent="i", summary="s", ux_score=8),
+        ])
+        TaskAgent(agno_agent_factory=factory, store=store).run(
+            traj_id="traj_e", traj_path=traj_path)
+
+        submit_tool = factory.captured["submit_tool"]
+        assert "ux_score" in submit_tool.parameters["required"]
+        assert submit_tool.parameters["properties"]["ux_score"]["type"] == "integer"
+        with pytest.raises(ValidationError):
+            _call_tool(
+                submit_tool,
+                start_line=17,
+                intent="i2",
+                summary="s2",
+            )
+        for invalid_score in (None, True, "8"):
+            with pytest.raises(ValidationError):
+                _call_tool(
+                    submit_tool,
+                    start_line=17,
+                    intent="i2",
+                    summary="s2",
+                    ux_score=invalid_score,
+                )
+
+    @pytest.mark.parametrize("invalid_score", [0, 11])
+    def test_ux_score_out_of_range_rejected(self, tmp_path, invalid_score):
+        traj_path, store = self._setup(tmp_path)
+        factory = _scripted_factory([
+            dict(start_line=5, intent="i", summary="s",
+                 ux_score=invalid_score),
+            dict(start_line=5, intent="i", summary="s", ux_score=8),
+        ])
+        atoms = TaskAgent(agno_agent_factory=factory, store=store).run(
+            traj_id="traj_e", traj_path=traj_path)
+
+        assert factory.captured["results"][0].startswith("error:")
+        assert "ux_score" in factory.captured["results"][0]
+        assert len(atoms) == 1
+        assert atoms[0].ux_score == 8
 
 
 # ────────────────────────────────────────────────────────────────────
@@ -553,6 +601,7 @@ class TestLookTool:
                         start_line=5,
                         intent="i",
                         summary="s",
+                        ux_score=7,
                     )
                     return _RunResult()
 
@@ -584,12 +633,14 @@ class TestLookTool:
                         start_line=5,
                         intent="i",
                         summary="s",
+                        ux_score=7,
                     )
                     _call_tool(
                         toolmap["submit_atom"],
                         start_line=17,
                         intent="i2",
                         summary="s2",
+                        ux_score=7,
                     )
                     captured_my["out"] = _call_tool(toolmap["my_atoms"])
                     captured_my["budget"] = _call_tool(toolmap["context_budget"])
@@ -619,8 +670,8 @@ class TestSystemPrompt:
         traj_path.write_text(_TRAJ_MD, encoding="utf-8")
         store = AtomTaskStore(root=traj_dir)
         factory = _scripted_factory([
-            dict(start_line=5, intent="i", summary="s"),
-            dict(start_line=17, intent="i2", summary="s2"),
+            dict(start_line=5, intent="i", summary="s", ux_score=7),
+            dict(start_line=17, intent="i2", summary="s2", ux_score=7),
         ])
         TaskAgent(agno_agent_factory=factory, store=store).run(
             traj_id="traj_p", traj_path=traj_path)
@@ -649,7 +700,7 @@ class TestSystemPrompt:
         )
         store = AtomTaskStore(root=traj_dir)
         factory = _scripted_factory([
-            dict(start_line=1, intent="i", summary="s"),
+            dict(start_line=1, intent="i", summary="s", ux_score=7),
         ])
         atoms = TaskAgent(agno_agent_factory=factory, store=store).run(
             traj_id="traj_b", traj_path=traj_path)
@@ -666,8 +717,8 @@ class TestInterestFilter:
         traj_path.write_text(_TRAJ_MD, encoding="utf-8")
         store = AtomTaskStore(root=traj_dir)
         factory = _scripted_factory([
-            dict(start_line=5, intent="deploy", summary="done"),
-            dict(start_line=17, intent="frontend", summary="done"),
+            dict(start_line=5, intent="deploy", summary="done", ux_score=7),
+            dict(start_line=17, intent="frontend", summary="done", ux_score=7),
         ])
 
         TaskAgent(
@@ -685,8 +736,8 @@ class TestInterestFilter:
         traj_path.write_text(_TRAJ_MD, encoding="utf-8")
         store = AtomTaskStore(root=traj_dir)
         factory = _scripted_factory([
-            dict(start_line=5, intent="deploy", summary="done"),
-            dict(start_line=17, intent="frontend", summary="done"),
+            dict(start_line=5, intent="deploy", summary="done", ux_score=7),
+            dict(start_line=17, intent="frontend", summary="done", ux_score=7),
         ])
 
         TaskAgent(
@@ -752,6 +803,7 @@ class TestInterestFilter:
                             start_line=5,
                             intent="deploy",
                             summary="done",
+                            ux_score=7,
                         )
                     )
                     return _RunResult()
@@ -789,6 +841,7 @@ class TestInterestFilter:
                             start_line=5,
                             intent="deploy",
                             summary="done",
+                            ux_score=7,
                         )
                     )
                     captured["results"].append(


### PR DESCRIPTION
## Summary

`submit_atom` currently makes `ux_score` optional and silently records missing
or out-of-range values as `None`. Downstream Canary scoring skips those atoms,
hiding malformed TaskAgent output and losing scoring samples.

This change makes the TaskAgent tool contract fail closed: `ux_score` must be a
strict integer from 1 through 10 before an atom can be recorded.

## Changes

- expose `ux_score` as a required integer in the Agno tool schema
- reject missing, null, boolean, and string values instead of coercing them
- return a retryable error for scores outside 1-10 without recording an atom
- update TaskAgent test submissions to satisfy the stricter contract
- add regression coverage for missing, mistyped, and out-of-range scores

Out of scope: migrating historical atoms whose `ux_score` is already `None`, or
changing downstream Canary behavior.

## Test plan

- [x] `.venv/bin/python -m pytest tests/test_task_agent.py -q` — 44 passed
- [x] Ruff checks for the changed files
- [x] `git diff --check`
- [x] Broader `make test` run during preparation — 2152 passed, 9 skipped; the
      two WSL/systemd-only failures were reproduced unchanged on `origin/main`

## Linked issues

Closes #245

AI assistance: OpenAI Codex was used to investigate the issue, implement the
change, and draft tests. `tiammomo` reviewed the final diff, understands the
change, and takes responsibility for this contribution.
