### PR TITLE
fix(cluster-agent): enforce candidate write invariants

### DIFF
--- a/src/xskill/agents/agent_tools.py
+++ b/src/xskill/agents/agent_tools.py
@@ -79,6 +79,7 @@ class AgentToolContext:
     usage_ledger: Any = None
     cluster_write_queue: Any = None
     cluster_result_recorder: Any = None
+    cluster_batch_ids: frozenset[str] = frozenset()
     skill_edit_skill_name: str | None = None
     skill_edit_batch_ids: tuple[str, ...] = ()
     grep_fallback_warned: bool = False
@@ -124,6 +125,7 @@ def create_agent_tool_context(
     usage_ledger=None,
     cluster_write_queue=None,
     cluster_result_recorder=None,
+    cluster_batch_ids=(),
     skill_edit_skill_name=None,
     skill_edit_batch_ids=(),
     registry_db_path=None,
@@ -149,6 +151,9 @@ def create_agent_tool_context(
         usage_ledger=usage_ledger,
         cluster_write_queue=cluster_write_queue,
         cluster_result_recorder=cluster_result_recorder,
+        cluster_batch_ids=frozenset(
+            str(atom_id) for atom_id in (cluster_batch_ids or ())
+        ),
         skill_edit_skill_name=(
             str(skill_edit_skill_name)
             if skill_edit_skill_name is not None
@@ -196,6 +201,18 @@ def use_agent_tool_context(
         yield context
     finally:
         reset_agent_tool_context(token)
+
+
+@contextlib.contextmanager
+def use_cluster_batch(atom_ids) -> Iterator[AgentToolContext]:
+    """Limit candidate writes to atom IDs supplied for one cluster turn."""
+    current = current_agent_tool_context()
+    bound = replace(
+        current,
+        cluster_batch_ids=frozenset(str(atom_id) for atom_id in atom_ids),
+    )
+    with use_agent_tool_context(bound):
+        yield bound
 
 
 @contextlib.contextmanager
@@ -269,6 +286,7 @@ class AgentToolConfig:
             "usage_ledger": current.usage_ledger,
             "cluster_write_queue": current.cluster_write_queue,
             "cluster_result_recorder": current.cluster_result_recorder,
+            "cluster_batch_ids": current.cluster_batch_ids,
             "skill_edit_skill_name": current.skill_edit_skill_name,
             "skill_edit_batch_ids": current.skill_edit_batch_ids,
             "grep_fallback_warned": current.grep_fallback_warned,
@@ -289,6 +307,7 @@ class AgentToolConfig:
             usage_ledger=snapshot.get("usage_ledger"),
             cluster_write_queue=snapshot.get("cluster_write_queue"),
             cluster_result_recorder=snapshot.get("cluster_result_recorder"),
+            cluster_batch_ids=snapshot.get("cluster_batch_ids") or (),
             skill_edit_skill_name=snapshot.get("skill_edit_skill_name"),
             skill_edit_batch_ids=snapshot.get("skill_edit_batch_ids") or (),
             registry_db_path=snapshot.get("registry_db_path"),
@@ -369,13 +388,13 @@ def _run_cluster_mutation(operation):
     """Run one ClusterAgent filesystem mutation in queue order."""
     context = current_agent_tool_context()
     queue = context.cluster_write_queue
-    if queue is None:
-        return operation()
 
     def run_bound():
         with use_agent_tool_context(context):
             return operation()
 
+    if queue is None:
+        return run_bound()
     return queue.call(run_bound)
 
 
@@ -383,6 +402,26 @@ def _record_cluster_result(atom_id: str, skill_name: str, weightscore: int) -> N
     recorder = current_agent_tool_context().cluster_result_recorder
     if recorder is not None:
         recorder.record(atom_id, skill_name, weightscore)
+
+
+def _move_cluster_result(
+    atom_id: str,
+    skill_from: str,
+    skill_to: str,
+    weightscore: int,
+) -> None:
+    recorder = current_agent_tool_context().cluster_result_recorder
+    if recorder is not None:
+        recorder.move(atom_id, skill_from, skill_to, weightscore)
+
+
+def _cluster_batch_membership_error(atom_id: str) -> str | None:
+    allowed_ids = current_agent_tool_context().cluster_batch_ids
+    if atom_id not in allowed_ids:
+        return (
+            f"error: atom_id {atom_id!r} is not in the current cluster batch"
+        )
+    return None
 
 
 def init_atom_task_tool_context(
@@ -1232,11 +1271,17 @@ def skill_read(skill_name: str) -> str:
 
 
 @tool(name="add_task_to_skill")
-def add_task_to_skill(skill_name: str, atom_id: str, weightscore: int) -> str:
+def add_task_to_skill(
+    skill_name: str,
+    atom_id: str,
+    weightscore: StrictInt,
+) -> str:
     """v2.1: 把 atom 加进 skill 的 candidates buffer。
 
-    同 atom 重复 add 时**覆盖**（不累加，cluster 可改主意）。返回末尾附该
-    atom 的 weightscore + buffer 总分 / 10，让 agent 看到"还差多少到阈值"。
+    同 atom + 同 skill 重复 add 时**覆盖**（不累加，cluster 可改分）。同一
+    atom 可以独立支撑多个不同 skill，每个 skill 保留自己的 weightscore。
+    返回末尾附该 atom 的 weightscore + buffer 总分 / 10，让 agent 看到
+    "还差多少到阈值"。
     """
     from xskill.skill import candidates as C
     skill_dir = agent_tool_config.atom_skill_dir
@@ -1246,10 +1291,12 @@ def add_task_to_skill(skill_name: str, atom_id: str, weightscore: int) -> str:
     target = skill_dir / slug
     if not target.is_dir():
         return f"error: skill {slug} not found; call new_skill_folder first"
-    try:
-        weightscore_value = int(weightscore)
-    except (TypeError, ValueError):
+    batch_error = _cluster_batch_membership_error(atom_id)
+    if batch_error is not None:
+        return batch_error
+    if type(weightscore) is not int:
         return f"error: weightscore must be int 1..10 (got {weightscore!r})"
+    weightscore_value = weightscore
     if not (1 <= weightscore_value <= 10):
         return (
             "error: weightscore must be 1..10 "
@@ -1281,7 +1328,7 @@ class CandidateTaskInput(BaseModel):
         min_length=1,
         description="Existing AtomTask identifier from the current batch.",
     )
-    weightscore: int = Field(
+    weightscore: StrictInt = Field(
         ge=1,
         le=10,
         description="Candidate relevance score from 1 through 10.",
@@ -1301,7 +1348,8 @@ def add_tasks_to_skill(
 
     Each item requires ``atom_id`` and ``weightscore``; ``note`` is optional.
     Use this instead of repeated ``add_task_to_skill`` calls when several atoms
-    in the current cluster batch belong to the same skill.
+    in the current cluster batch belong to the same skill. An atom may appear
+    in separate calls for different skills when it materially supports each.
     """
     from xskill.skill import candidates as C
 
@@ -1330,14 +1378,16 @@ def add_tasks_to_skill(
         if atom_id in seen_atom_ids:
             return f"error: duplicate atom_id in tasks ({atom_id})"
         seen_atom_ids.add(atom_id)
+        batch_error = _cluster_batch_membership_error(atom_id)
+        if batch_error is not None:
+            return batch_error
         weightscore = task_data.get("weightscore")
-        try:
-            weightscore_value = int(weightscore)
-        except (TypeError, ValueError):
+        if type(weightscore) is not int:
             return (
                 "error: each task.weightscore must be int 1..10 "
                 f"(got {weightscore!r})"
             )
+        weightscore_value = weightscore
         if not (1 <= weightscore_value <= 10):
             return (
                 "error: each task.weightscore must be 1..10 "
@@ -2130,7 +2180,7 @@ def move_task_to(skill_from: str, skill_to: str, atom_id: str) -> str:
         )
         if weightscore is None:
             return f"error: atom_id {atom_id} 不在 {from_slug} buffer 中"
-        _record_cluster_result(atom_id, to_slug, weightscore)
+        _move_cluster_result(atom_id, from_slug, to_slug, weightscore)
         logger.info(f"moved task: atom={atom_id} {from_slug} → {to_slug}")
         return (f"moved: atom={atom_id} from {from_slug} to {to_slug} "
                 f"(weightscore={weightscore})")

--- a/src/xskill/agents/task_cluster_agent.py
+++ b/src/xskill/agents/task_cluster_agent.py
@@ -1,8 +1,8 @@
 """TaskClusterAgent —— AtomTask → skill 归类
 ============================================
 
-输入：单个 AtomTask（由 watcher / process 喂进来）
-副作用：往一个或多个 skill 的 .candidates.yml 写 atom 贡献（含 weightscore 0-10）；
+输入：单个或一批 AtomTask（由 watcher / process 喂进来）
+副作用：把 atom 贡献写入一个或多个 skill 的 .candidates.yml（含 weightscore 1-10）；
        如有必要先 new_skill_folder 建空 skill 目录。
 
 sysprompt 设计
@@ -140,9 +140,11 @@ def build_skill_catalog_block(skill_dir: Path, max_chars: int) -> str:
 
 SYSTEM_PROMPT_TEMPLATE = """你是 TaskClusterAgent。我会给你一个或多个 AtomTask（每个是
 用户的一段完整意图 + agent 的执行复盘）；当给你多个时**逐个独立处理**，互不影响。
-对每个 AtomTask 你决定它是否值得被某个 skill 收录，应该归到哪个已有 skill（用
+对每个 AtomTask 你决定它值得被哪些 skill 收录，应该归到哪些已有 skill（用
 add_task_to_skill / add_tasks_to_skill），或者应该新建一个 skill 容纳它（用
-NewSkillFolder 再添加）。**每个 AtomTask 都必须通过添加工具落盘，一个都不能漏。**
+NewSkillFolder 再添加）。一个 AtomTask 可以同时支撑多个语义不同的 skill，每个
+关联独立评分；不要为了多归类而写入近义、重叠的 skill。**每个 AtomTask 都必须
+通过添加工具至少落盘一次，一个都不能漏。**
 
 # 可用工具
 - AtomTaskRead(atom_id) — 读 atom 完整 JSON（intent / summary / raw_segment 全字段）
@@ -154,12 +156,14 @@ NewSkillFolder 再添加）。**每个 AtomTask 都必须通过添加工具落�
 - NewSkillFolder(skill_name, description) — 新建 baby 分支 skill。description
   必填（2-3 句中文）。**最后才考虑**——能复用就别开新的。
 - add_task_to_skill(skill_name, atom_id, weightscore) — 把 atom 加进 buffer。
-  weightscore 1-10 整数。累计满 10 触发 SkillEditAgent 写 SKILL.md。
+  weightscore 1-10 整数。累计满 10 触发 SkillEditAgent 写 SKILL.md。同一个 atom
+  如果独立支撑多个 skill，可以分别调用并为每个关联单独评分。
 - add_tasks_to_skill(skill_name, tasks) — 同一批有多个 atom 归入同一个 skill
   时优先使用；tasks 每项含 atom_id、weightscore，可选 note。整批只读写一次
   candidates 文件，不能把不同目标 skill 混进同一次调用。
 - MoveTaskTo(skill_from, skill_to, atom_id) — 把 atom 从一个 buffer 移到另一个。
-  合并近义 baby 时用 MoveTaskTo 把 atom 全搬到主 slug。
+  仅在已有某个关联放错位置，或合并近义 baby 时用 MoveTaskTo 搬到主 slug；
+  给 atom 新增另一个有效 skill 关联时不需要先 move。
   之后 from baby 空 buffer 但仍存在（保留以防后续 cluster 又往里写）。
 - score_task(atom_id, score) — 修改 atom 自身的 ux_score
 
@@ -205,8 +209,9 @@ NewSkillFolder 再添加）。**每个 AtomTask 都必须通过添加工具落�
 - 路由表里所有 baby/main/staging skill 全看一遍，重点找 desc 同类的
 
 ## Step 2: 复用判断
-- 找到 1 个 desc 精准匹配的 → 直接 add_task_to_skill（流程结束）
-- 找到 ≥2 个 desc 同类的 baby（近义 slug 泛滥）→ 进入"整合"步骤
+- 找到一个或多个语义不同且都精准匹配的 → 分别 add，每个关联独立评分
+- 找到 ≥2 个同义或高度重叠的 baby（近义 slug 泛滥）→ 进入"整合"步骤，
+  不要把它们误当成多标签目标
 - 没找到合适候选 → 跳到 Step 4
 
 ## Step 3: 整合近义 baby（用 MoveTaskTo）
@@ -223,7 +228,8 @@ NewSkillFolder 再添加）。**每个 AtomTask 都必须通过添加工具落�
 
 ## Step 5: 边缘 atom 兜底（**绝不允许直接 return 不调工具**）
 - weightscore 2-3：仍要 add_task_to_skill 把 atom 灌进 desc 最贴近的 skill；
-  ws=2/3 不会单独触发 SkillEdit（buffer 阈值 10），但 atom→skill 归属必须留底
+  ws=2/3 不会单独触发 SkillEdit（buffer 阈值 10），但至少一个 atom→skill
+  关联必须留底
 - weightscore 1：跟路由表所有 skill 都没明显交叉时，挑 desc 最不远的那个 add，
   weightscore=1；**不要**为 ws=1 atom 新开 skill（守住"≥7 才新建"门槛）
 - 任何分数都不允许"什么都不调，直接说明理由结束"——atom 不能静默蒸发
@@ -232,11 +238,12 @@ NewSkillFolder 再添加）。**每个 AtomTask 都必须通过添加工具落�
 
 多个 ClusterAgent 可以并行推理；所有目录修改会进入单线程写入队列。相同 slug 的
 并发创建会按顺序处理，后续请求复用已经创建的目录。同一批里如给了多个 atom，
-仍要逐个判断、彼此独立；判断完成后，将归入同一个 skill 的 atom 合并成一次
-add_tasks_to_skill 调用。
+仍要逐个判断、彼此独立；判断完成后，按目标 skill 分组调用 add_tasks_to_skill。
+同一 atom 可以出现在多个不同目标 skill 的调用中。
 
 # 硬禁止
-- 不要为了"做点事"乱打高分。低质 atom 就别加，会污染 candidates 触发劣质 skill。
+- 不要为了"做点事"乱打高分。低质 atom 应按分档打低分，避免污染 candidates
+  触发劣质 skill。
 - 不要伪造 atom_id；只用我给的真实 id。
 - 不要直接写 SKILL.md——那是 SkillEditAgent 的职责。
 - 使用 MoveTaskTo 整合已有 baby；ClusterAgent 暂不提供 rename_skill。
@@ -285,6 +292,7 @@ class TaskClusterAgent:
             tools=self.tools,
         )
         # 逐轮 CoT/工具调用 → logs/agents/task_cluster_agents/<traj_id>/<atom_id>.log
+        from xskill.agents import agent_tools
         from xskill.agents.agent_trace import trace_to
         sink = (
             self.logs_dir / "agents" / "task_cluster_agents"
@@ -292,7 +300,7 @@ class TaskClusterAgent:
             if self.logs_dir is not None
             else None
         )
-        with trace_to(sink):
+        with agent_tools.use_cluster_batch([atom.atom_id]), trace_to(sink):
             result = agent.run(user_msg)
         return getattr(result, "content", "") or ""
 
@@ -318,7 +326,8 @@ class TaskClusterAgent:
             + "\n\n# 本次批量调用限制\n"
             "本次只提供 add_tasks_to_skill，不提供逐条 add_task_to_skill。"
             "先逐个判断，再按目标 skill 分组；每组只调用一次 "
-            "add_tasks_to_skill，确保每个 atom_id 恰好出现一次。"
+            "add_tasks_to_skill，确保每个 atom_id 至少出现一次；如果一个 atom "
+            "独立支撑多个不同 skill，可以出现在多个分组中。"
         )
 
         blocks: list[str] = []
@@ -336,7 +345,7 @@ class TaskClusterAgent:
             )
         user_msg = (
             f"待分类 AtomTask 共 {len(atoms)} 个，请**逐个**按系统指令处理，每个都必须"
-            " 出现在某次 add_tasks_to_skill 调用中（任何分数都不允许跳过、"
+            " 至少出现在一次 add_tasks_to_skill 调用中（任何分数都不允许跳过、"
             "不能静默漏掉任何一个）：\n\n"
             + "\n\n".join(blocks)
         )
@@ -345,6 +354,7 @@ class TaskClusterAgent:
             instructions=[sysprompt],
             tools=self.tools,
         )
+        from xskill.agents import agent_tools
         from xskill.agents.agent_trace import trace_to
         # 批量可能跨轨迹——按首 atom 的 traj_id 归档，文件名带 batch 标识与规模。
         first = atoms[0]
@@ -354,6 +364,8 @@ class TaskClusterAgent:
             if self.logs_dir is not None
             else None
         )
-        with trace_to(sink):
+        with agent_tools.use_cluster_batch(
+            atom.atom_id for atom in atoms
+        ), trace_to(sink):
             result = agent.run(user_msg)
         return getattr(result, "content", "") or ""

--- a/src/xskill/pipeline/runner.py
+++ b/src/xskill/pipeline/runner.py
@@ -2710,10 +2710,13 @@ class DirectoryWatcher:
         ``_finalize_completed_trajs`` 按"该轨迹 atom 是否全落地"独立判定。
         """
         n_total = len(results)
-        in_skills = [r for r in results if r.get("skill_name")]
+        in_skills = [r for r in results if _result_skill_assignments(r)]
         dropped = [
             r for r in results
-            if r.get("action") == "clustered" and not r.get("skill_name")
+            if (
+                r.get("action") == "clustered"
+                and not _result_skill_assignments(r)
+            )
         ]
 
         _emit = logger.info if n_total > 0 else logger.debug
@@ -2721,12 +2724,15 @@ class DirectoryWatcher:
             "cluster batch → %d total, %d in skills, %d dropped",
             n_total, len(in_skills), len(dropped),
         )
-        # 落到 skill 的每个 atom 一行 info（per-atom 审计链）
+        # 每个 atom→skill 关联一行 info（per-association 审计链）。
         for r in in_skills:
-            logger.info(
-                "  %s → %s @ ws=%s",
-                r.get("atom_id"), r.get("skill_name"), r.get("weightscore"),
-            )
+            for assignment in _result_skill_assignments(r):
+                logger.info(
+                    "  %s → %s @ ws=%s",
+                    r.get("atom_id"),
+                    assignment.get("skill_name"),
+                    assignment.get("weightscore"),
+                )
         # drop 的 atom 走 WARNING 让人 grep 得到。新 prompt 改完不应再出现，
         # 但作为 defensive 保留——cluster agent 真违反"任何分数都必须 add"
         # 这条硬约束时必须立刻被发现。
@@ -3030,6 +3036,29 @@ class DirectoryWatcher:
 _process_logger = logging.getLogger("xskill.process")
 
 
+def _result_skill_assignments(result: dict) -> list[dict]:
+    """Return the multi-skill view, with legacy result compatibility."""
+    assignments = result.get("skill_assignments")
+    if assignments:
+        return list(assignments)
+    skill_name = result.get("skill_name")
+    if not skill_name:
+        return []
+    return [{
+        "skill_name": skill_name,
+        "weightscore": result.get("weightscore"),
+    }]
+
+
+def _recorded_skill_assignments(recorder, atom_id: str) -> list[dict]:
+    if recorder is None:
+        return []
+    return [
+        {"skill_name": skill_name, "weightscore": weightscore}
+        for skill_name, weightscore in recorder.get_all(atom_id)
+    ]
+
+
 def process_atom_task(*, atom_id: str, config: dict, skill_dir: Path,
                       store, embed_client, agno_agent_factory,
                       db_path: Path | None = None,
@@ -3123,17 +3152,21 @@ def _process_atom_task_bound(*, atom_id: str, config: dict,
     except BaseException as error:  # preserve successful tool writes before failure
         cluster_error = (error, error.__traceback__)
 
-    hit = (
-        cluster_result_recorder.get(atom_id)
-        if cluster_result_recorder is not None
-        else None
+    skill_assignments = _recorded_skill_assignments(
+        cluster_result_recorder,
+        atom_id,
     )
-    skill_name = hit[0] if hit else None
-    weightscore = hit[1] if hit else None
+    latest_assignment = skill_assignments[-1] if skill_assignments else None
+    skill_name = (
+        latest_assignment["skill_name"] if latest_assignment else None
+    )
+    weightscore = (
+        latest_assignment["weightscore"] if latest_assignment else None
+    )
 
     # 落地即打耐久消费标记（与批量版 process_atom_batch 一致），让 watcher 的
     # 去重/done 判定不依赖会被 SkillEdit 晋升清空的 .candidates.yml。
-    if skill_name:
+    if skill_assignments:
         latest_atom = store.load(atom_id)
         if not latest_atom.clustered:
             latest_atom.clustered = True
@@ -3142,12 +3175,16 @@ def _process_atom_task_bound(*, atom_id: str, config: dict,
     # 埋点：atom 实际落到某 skill = 一次采纳(best-effort，失败不阻断)。
     # 在 cluster(大模型调用,按秒)之后,这条数据库写入(毫秒级)可忽略——和
     # record_usage 同样的代价位置,生产无影响。
-    if skill_name:
+    for assignment in skill_assignments:
         try:
             from xskill.pipeline.registry import record_atom_adoption
-            record_atom_adoption(atom_id=atom_id, skill=skill_name,
-                                 weightscore=weightscore or 0, was_new=True,
-                                 db_path=db_path)
+            record_atom_adoption(
+                atom_id=atom_id,
+                skill=assignment["skill_name"],
+                weightscore=assignment["weightscore"],
+                was_new=True,
+                db_path=db_path,
+            )
         except Exception:  # pylint: disable=broad-exception-caught
             logger.debug("atom adoption telemetry skipped", exc_info=True)
 
@@ -3160,6 +3197,7 @@ def _process_atom_task_bound(*, atom_id: str, config: dict,
         "atom_id": atom_id,
         "skill_name": skill_name,
         "weightscore": weightscore,
+        "skill_assignments": skill_assignments,
         "cluster_log": (cluster_content or "")[:500],
     }
 
@@ -3220,7 +3258,8 @@ def _process_atom_batch_bound(*, atom_ids: list[str], config: dict,
 
     Returns:
         list[dict]，每条含 keys: action / atom_id / skill_name / weightscore /
-        cluster_log。
+        skill_assignments / cluster_log。``skill_name`` 和 ``weightscore`` 保留
+        最近一次写入作为兼容视图；完整结果以 ``skill_assignments`` 为准。
     """
     from xskill.agents.task_cluster_agent import TaskClusterAgent
     from xskill.agents import agent_tools
@@ -3252,27 +3291,37 @@ def _process_atom_batch_bound(*, atom_ids: list[str], config: dict,
 
     results: list[dict] = []
     for aid in atom_ids:
-        hit = (
-            cluster_result_recorder.get(aid)
-            if cluster_result_recorder is not None
-            else None
+        skill_assignments = _recorded_skill_assignments(
+            cluster_result_recorder,
+            aid,
         )
-        skill_name = hit[0] if hit else None
-        weightscore = hit[1] if hit else None
+        latest_assignment = (
+            skill_assignments[-1] if skill_assignments else None
+        )
+        skill_name = (
+            latest_assignment["skill_name"] if latest_assignment else None
+        )
+        weightscore = (
+            latest_assignment["weightscore"] if latest_assignment else None
+        )
         # 落地即打耐久消费标记（在 SkillEdit 可能清空 .candidates.yml 之前完成
         # 这次回查），让 watcher 的去重/done 判定不受后续 skill 晋升影响。
-        if skill_name and aid in atom_by_id:
+        if skill_assignments and aid in atom_by_id:
             latest_atom = store.load(aid)
             if not latest_atom.clustered:
                 latest_atom.clustered = True
                 store.save(latest_atom)
         # 埋点：atom 落到某 skill = 一次采纳（best-effort，失败不阻断）。
-        if skill_name:
+        for assignment in skill_assignments:
             try:
                 from xskill.pipeline.registry import record_atom_adoption
-                record_atom_adoption(atom_id=aid, skill=skill_name,
-                                     weightscore=weightscore or 0, was_new=True,
-                                     db_path=db_path)
+                record_atom_adoption(
+                    atom_id=aid,
+                    skill=assignment["skill_name"],
+                    weightscore=assignment["weightscore"],
+                    was_new=True,
+                    db_path=db_path,
+                )
             except Exception:  # pylint: disable=broad-exception-caught
                 logger.debug("atom adoption telemetry skipped", exc_info=True)
         results.append({
@@ -3280,6 +3329,7 @@ def _process_atom_batch_bound(*, atom_ids: list[str], config: dict,
             "atom_id": aid,
             "skill_name": skill_name,
             "weightscore": weightscore,
+            "skill_assignments": skill_assignments,
             "cluster_log": (cluster_content or "")[:500],
         })
     if cluster_error is not None:

--- a/src/xskill/pipeline/worker_runtime.py
+++ b/src/xskill/pipeline/worker_runtime.py
@@ -213,23 +213,54 @@ class BoundedExecutor:
 
 
 class ClusterResultRecorder:
-    """Thread-safe record of successful writes made for one ClusterAgent call."""
+    """Thread-safe record of successful writes made for one ClusterAgent call.
+
+    Candidate files are authoritative and allow one atom to support multiple
+    skills, so the in-memory result must retain every per-skill association too.
+    """
 
     def __init__(self):
         self._lock = threading.Lock()
-        self._results: dict[str, tuple[str, int]] = {}
+        self._results: dict[str, dict[str, int]] = {}
 
     def record(self, atom_id: str, skill_name: str, weightscore: int) -> None:
         with self._lock:
-            self._results[atom_id] = (skill_name, int(weightscore))
+            assignments = self._results.setdefault(atom_id, {})
+            # Reinsert an overwrite so ``get`` keeps its historical meaning:
+            # the most recently written association is the compatibility view.
+            assignments.pop(skill_name, None)
+            assignments[skill_name] = int(weightscore)
 
     def get(self, atom_id: str) -> tuple[str, int] | None:
         with self._lock:
-            return self._results.get(atom_id)
+            assignments = self._results.get(atom_id)
+            if not assignments:
+                return None
+            return next(reversed(assignments.items()))
 
-    def snapshot(self) -> dict[str, tuple[str, int]]:
+    def move(
+        self,
+        atom_id: str,
+        skill_from: str,
+        skill_to: str,
+        weightscore: int,
+    ) -> None:
         with self._lock:
-            return dict(self._results)
+            assignments = self._results.setdefault(atom_id, {})
+            assignments.pop(skill_from, None)
+            assignments.pop(skill_to, None)
+            assignments[skill_to] = int(weightscore)
+
+    def get_all(self, atom_id: str) -> tuple[tuple[str, int], ...]:
+        with self._lock:
+            return tuple(self._results.get(atom_id, {}).items())
+
+    def snapshot(self) -> dict[str, tuple[tuple[str, int], ...]]:
+        with self._lock:
+            return {
+                atom_id: tuple(assignments.items())
+                for atom_id, assignments in self._results.items()
+            }
 
 
 class ClusterWriteQueue:

--- a/tests/test_agent_tool_context_isolation.py
+++ b/tests/test_agent_tool_context_isolation.py
@@ -315,12 +315,14 @@ class _ConcurrentSkillEdit:
                 },
             },
         )
-        result = _call_tool(
-            agent_tools.add_task_to_skill,
-            self._skill_dir.name,
-            f"edit-atom-{suffix}",
-            5,
-        )
+        atom_id = f"edit-atom-{suffix}"
+        with agent_tools.use_cluster_batch([atom_id]):
+            result = _call_tool(
+                agent_tools.add_task_to_skill,
+                self._skill_dir.name,
+                atom_id,
+                5,
+            )
         assert not result.startswith("error:")
         return False
 

--- a/tests/test_agent_worker_runtime.py
+++ b/tests/test_agent_worker_runtime.py
@@ -505,6 +505,7 @@ def test_candidate_writes_follow_cluster_queue_order(tmp_path):
     context = agent_tools.create_agent_tool_context(
         atom_skill_dir=skill_root,
         cluster_write_queue=queue,
+        cluster_batch_ids=["atom-a", "atom-b"],
     )
     release = threading.Event()
     executor = ThreadPoolExecutor(max_workers=3)
@@ -597,6 +598,96 @@ def test_clustered_marker_rereads_atom_and_preserves_queued_score(tmp_path):
     assert result[0]["weightscore"] == 7
     assert latest.clustered is True
     assert latest.ux_score == 9
+
+
+def test_cluster_result_preserves_every_skill_association(tmp_path):
+    from tests.test_cluster_batch import _call_tool, _tool_name
+    from xskill.pipeline.registry import pooled_connection
+    from xskill.skill.candidates import load_candidates
+
+    skill_root = tmp_path / "skills"
+    skill_root.mkdir()
+    for skill_name in ("skill-a", "skill-b", "skill-c"):
+        init_skill_repo_on_baby(
+            str(skill_root / skill_name),
+            name=skill_name,
+            description=f"{skill_name} description",
+        )
+    store = AtomTaskStore(root=tmp_path / "watch")
+    store.root.mkdir()
+    atom = AtomTask(
+        atom_id="atom_traj_multi_0000",
+        traj_id="traj_multi",
+        offset_start=1,
+        offset_end=2,
+        intent="intent",
+        summary="summary",
+        tags=[],
+        used_skills=[],
+        ux_score=7,
+    )
+    store.save(atom)
+
+    class Agent:
+        def __init__(self, *, instructions, tools):
+            del instructions
+            self.tools = {_tool_name(tool): tool for tool in tools}
+
+        def run(self, _message):
+            for skill_name, weightscore in (("skill-a", 6), ("skill-b", 7)):
+                _call_tool(
+                    self.tools["add_tasks_to_skill"],
+                    skill_name,
+                    [{
+                        "atom_id": atom.atom_id,
+                        "weightscore": weightscore,
+                    }],
+                )
+            _call_tool(
+                self.tools["move_task_to"],
+                "skill-a",
+                "skill-c",
+                atom.atom_id,
+            )
+            _call_tool(
+                self.tools["add_tasks_to_skill"],
+                "skill-c",
+                [{"atom_id": atom.atom_id, "weightscore": 9}],
+            )
+            return type("Result", (), {"content": "ok"})()
+
+    db_path = tmp_path / "registry.db"
+    result = process_atom_batch(
+        atom_ids=[atom.atom_id],
+        config={"llm": {}},
+        skill_dir=skill_root,
+        store=store,
+        embed_client=None,
+        agno_agent_factory=Agent,
+        db_path=db_path,
+    )[0]
+
+    assert result["skill_name"] == "skill-c"
+    assert result["weightscore"] == 9
+    assert {
+        item["skill_name"]: item["weightscore"]
+        for item in result["skill_assignments"]
+    } == {"skill-b": 7, "skill-c": 9}
+    assert load_candidates(skill_root / "skill-a")["candidates"] == []
+    assert load_candidates(skill_root / "skill-b")["candidates"][0][
+        "weightscore"
+    ] == 7
+    assert load_candidates(skill_root / "skill-c")["candidates"][0][
+        "weightscore"
+    ] == 9
+    with pooled_connection(db_path) as connection:
+        adoptions = [
+            (row["skill"], row["weightscore"])
+            for row in connection.execute(
+                "SELECT skill, weightscore FROM atom_adoption ORDER BY skill"
+            )
+        ]
+    assert adoptions == [("skill-b", 7), ("skill-c", 9)]
 
 
 def test_successful_cluster_write_is_marked_when_agent_fails_later(tmp_path):

--- a/tests/test_candidates_concurrency.py
+++ b/tests/test_candidates_concurrency.py
@@ -503,6 +503,10 @@ def test_thousand_item_batch_loads_and_saves_once(tmp_path, monkeypatch):
         atom_skill_dir=tmp_path,
         atom_store=None,
         default_traj_root=tmp_path,
+        cluster_batch_ids=[
+            f"atom-{index:04d}"
+            for index in range(1000)
+        ],
     )
     with agent_tools.use_agent_tool_context(tool_context):
         result = agent_tools.add_tasks_to_skill.entrypoint(

--- a/tests/test_skill_tools_atom.py
+++ b/tests/test_skill_tools_atom.py
@@ -3,6 +3,9 @@ from __future__ import annotations
 
 from pathlib import Path
 
+import pytest
+from pydantic import ValidationError
+
 from xskill.pipeline.atom import AtomTask, AtomTaskStore
 from xskill.agents import agent_tools
 
@@ -188,15 +191,29 @@ class TestAddTaskToSkill:
     def test_first_add_creates_entry(self, tmp_path):
         skill_dir, _ = _setup(tmp_path)
         agent_tools.new_skill_folder.entrypoint("auto-skill", "stub desc")
-        msg = agent_tools.add_task_to_skill.entrypoint("auto-skill", "atom_x_0001", 6)
+        with agent_tools.use_cluster_batch(["atom_x_0001"]):
+            msg = agent_tools.add_task_to_skill.entrypoint(
+                "auto-skill",
+                "atom_x_0001",
+                6,
+            )
         assert "buffer_total=6" in msg
 
     def test_repeated_add_overwrites(self, tmp_path):
         """v2.1: 同 atom 重复 add → 覆盖 weightscore（不累加）。"""
         _setup(tmp_path)
         agent_tools.new_skill_folder.entrypoint("auto-skill", "stub desc")
-        agent_tools.add_task_to_skill.entrypoint("auto-skill", "atom_x_0001", 4)
-        msg = agent_tools.add_task_to_skill.entrypoint("auto-skill", "atom_x_0001", 5)
+        with agent_tools.use_cluster_batch(["atom_x_0001"]):
+            agent_tools.add_task_to_skill.entrypoint(
+                "auto-skill",
+                "atom_x_0001",
+                4,
+            )
+            msg = agent_tools.add_task_to_skill.entrypoint(
+                "auto-skill",
+                "atom_x_0001",
+                5,
+            )
         assert "weightscore=5" in msg
         # buffer 仍是单条 atom，total 是覆盖后的 5（不是 4+5=9）
         assert "buffer_total=5" in msg
@@ -210,24 +227,108 @@ class TestAddTaskToSkill:
     def test_weightscore_out_of_range_returns_error(self, tmp_path):
         _setup(tmp_path)
         agent_tools.new_skill_folder.entrypoint("auto-skill", "stub desc")
-        for bad in [0, 11, -1, 100]:
-            msg = agent_tools.add_task_to_skill.entrypoint("auto-skill", "atom_x_0001", bad)
-            assert msg.startswith("error")
+        with agent_tools.use_cluster_batch(["atom_x_0001"]):
+            for bad in [0, 11, -1, 100]:
+                msg = agent_tools.add_task_to_skill.entrypoint(
+                    "auto-skill",
+                    "atom_x_0001",
+                    bad,
+                )
+                assert msg.startswith("error")
+
+    @pytest.mark.parametrize("invalid_score", [True, "8", 8.0])
+    def test_weightscore_requires_strict_integer(self, tmp_path, invalid_score):
+        _setup(tmp_path)
+        agent_tools.new_skill_folder.entrypoint("auto-skill", "stub desc")
+
+        with agent_tools.use_cluster_batch(["atom_x_0001"]):
+            with pytest.raises(ValidationError):
+                agent_tools.add_task_to_skill.entrypoint(
+                    "auto-skill",
+                    "atom_x_0001",
+                    invalid_score,
+                )
+
+    def test_rejects_write_without_current_cluster_batch(self, tmp_path):
+        skill_dir, _ = _setup(tmp_path)
+        agent_tools.new_skill_folder.entrypoint("auto-skill", "stub desc")
+
+        with agent_tools.use_cluster_batch([]):
+            message = agent_tools.add_task_to_skill.entrypoint(
+                "auto-skill",
+                "atom_x_0001",
+                7,
+            )
+
+        assert message.startswith("error:")
+        assert "current cluster batch" in message
+        from xskill.skill import candidates as C
+        assert C.load_candidates(
+            skill_dir / "auto-skill",
+        )["candidates"] == []
+
+    def test_rejects_atom_outside_current_cluster_batch(self, tmp_path):
+        skill_dir, _ = _setup(tmp_path)
+        agent_tools.new_skill_folder.entrypoint("auto-skill", "stub desc")
+
+        with agent_tools.use_cluster_batch(["atom_x_0001"]):
+            message = agent_tools.add_task_to_skill.entrypoint(
+                "auto-skill",
+                "atom_outside_batch",
+                7,
+            )
+
+        assert message.startswith("error:")
+        assert "current cluster batch" in message
+        from xskill.skill import candidates as C
+        assert C.load_candidates(
+            skill_dir / "auto-skill",
+        )["candidates"] == []
+
+    def test_allows_independent_cross_skill_associations(self, tmp_path):
+        skill_dir, _ = _setup(tmp_path)
+        agent_tools.new_skill_folder.entrypoint("skill-a", "first target")
+        agent_tools.new_skill_folder.entrypoint("skill-b", "second target")
+
+        with agent_tools.use_cluster_batch(["atom_x_0001"]):
+            first = agent_tools.add_task_to_skill.entrypoint(
+                "skill-a",
+                "atom_x_0001",
+                6,
+            )
+            second = agent_tools.add_task_to_skill.entrypoint(
+                "skill-b",
+                "atom_x_0001",
+                7,
+            )
+
+        assert first.startswith("new:")
+        assert second.startswith("new:")
+        from xskill.skill import candidates as C
+        assert C.load_candidates(skill_dir / "skill-a")["candidates"] == [{
+            "atom_id": "atom_x_0001",
+            "weightscore": 6,
+        }]
+        assert C.load_candidates(skill_dir / "skill-b")["candidates"] == [{
+            "atom_id": "atom_x_0001",
+            "weightscore": 7,
+        }]
 
     def test_batch_add_writes_every_atom(self, tmp_path):
         skill_dir, _ = _setup(tmp_path)
         agent_tools.new_skill_folder.entrypoint("auto-skill", "stub desc")
-        message = agent_tools.add_tasks_to_skill.entrypoint(
-            "auto-skill",
-            [
-                {"atom_id": "atom-a", "weightscore": 3},
-                {
-                    "atom_id": "atom-b",
-                    "weightscore": 7,
-                    "note": "strong",
-                },
-            ],
-        )
+        with agent_tools.use_cluster_batch(["atom-a", "atom-b"]):
+            message = agent_tools.add_tasks_to_skill.entrypoint(
+                "auto-skill",
+                [
+                    {"atom_id": "atom-a", "weightscore": 3},
+                    {
+                        "atom_id": "atom-b",
+                        "weightscore": 7,
+                        "note": "strong",
+                    },
+                ],
+            )
 
         assert "atoms=2" in message
         assert "new=2" in message
@@ -242,15 +343,107 @@ class TestAddTaskToSkill:
     def test_batch_add_rejects_duplicate_without_writing(self, tmp_path):
         skill_dir, _ = _setup(tmp_path)
         agent_tools.new_skill_folder.entrypoint("auto-skill", "stub desc")
-        message = agent_tools.add_tasks_to_skill.entrypoint(
-            "auto-skill",
-            [
-                {"atom_id": "atom-a", "weightscore": 3},
-                {"atom_id": "atom-a", "weightscore": 7},
-            ],
-        )
+        with agent_tools.use_cluster_batch(["atom-a"]):
+            message = agent_tools.add_tasks_to_skill.entrypoint(
+                "auto-skill",
+                [
+                    {"atom_id": "atom-a", "weightscore": 3},
+                    {"atom_id": "atom-a", "weightscore": 7},
+                ],
+            )
 
         assert message.startswith("error")
+        from xskill.skill import candidates as C
+        assert C.load_candidates(
+            skill_dir / "auto-skill",
+        )["candidates"] == []
+
+    @pytest.mark.parametrize("invalid_score", [True, "8", 8.0])
+    def test_batch_weightscore_requires_strict_integer(
+        self,
+        tmp_path,
+        invalid_score,
+    ):
+        _setup(tmp_path)
+        agent_tools.new_skill_folder.entrypoint("auto-skill", "stub desc")
+
+        with agent_tools.use_cluster_batch(["atom_x_0001"]):
+            with pytest.raises(ValidationError):
+                agent_tools.add_tasks_to_skill.entrypoint(
+                    "auto-skill",
+                    [{
+                        "atom_id": "atom_x_0001",
+                        "weightscore": invalid_score,
+                    }],
+                )
+
+    def test_batch_rejects_write_without_current_cluster_batch(self, tmp_path):
+        skill_dir, _ = _setup(tmp_path)
+        agent_tools.new_skill_folder.entrypoint("auto-skill", "stub desc")
+
+        with agent_tools.use_cluster_batch([]):
+            message = agent_tools.add_tasks_to_skill.entrypoint(
+                "auto-skill",
+                [{"atom_id": "atom_x_0001", "weightscore": 7}],
+            )
+
+        assert message.startswith("error:")
+        assert "current cluster batch" in message
+        from xskill.skill import candidates as C
+        assert C.load_candidates(
+            skill_dir / "auto-skill",
+        )["candidates"] == []
+
+    def test_batch_preserves_existing_cross_skill_association(self, tmp_path):
+        skill_dir, _ = _setup(tmp_path)
+        agent_tools.new_skill_folder.entrypoint("skill-a", "first target")
+        agent_tools.new_skill_folder.entrypoint("skill-b", "second target")
+
+        with agent_tools.use_cluster_batch(["atom_x_0001", "atom_x_0002"]):
+            agent_tools.add_task_to_skill.entrypoint(
+                "skill-a",
+                "atom_x_0001",
+                6,
+            )
+            message = agent_tools.add_tasks_to_skill.entrypoint(
+                "skill-b",
+                [
+                    {"atom_id": "atom_x_0002", "weightscore": 5},
+                    {"atom_id": "atom_x_0001", "weightscore": 7},
+                ],
+            )
+
+        assert message.startswith("batched:")
+        from xskill.skill import candidates as C
+        assert C.load_candidates(skill_dir / "skill-a")["candidates"] == [{
+            "atom_id": "atom_x_0001",
+            "weightscore": 6,
+        }]
+        assert {
+            candidate["atom_id"]: candidate["weightscore"]
+            for candidate in C.load_candidates(skill_dir / "skill-b")[
+                "candidates"
+            ]
+        } == {
+            "atom_x_0001": 7,
+            "atom_x_0002": 5,
+        }
+
+    def test_batch_membership_validation_is_all_or_nothing(self, tmp_path):
+        skill_dir, _ = _setup(tmp_path)
+        agent_tools.new_skill_folder.entrypoint("auto-skill", "stub desc")
+
+        with agent_tools.use_cluster_batch(["atom_x_0001"]):
+            message = agent_tools.add_tasks_to_skill.entrypoint(
+                "auto-skill",
+                [
+                    {"atom_id": "atom_x_0001", "weightscore": 5},
+                    {"atom_id": "atom_outside_batch", "weightscore": 7},
+                ],
+            )
+
+        assert message.startswith("error:")
+        assert "current cluster batch" in message
         from xskill.skill import candidates as C
         assert C.load_candidates(
             skill_dir / "auto-skill",
@@ -353,8 +546,9 @@ class TestReadSkillTasks:
     def test_reads_candidates_with_weightscore(self, tmp_path):
         _setup(tmp_path)
         agent_tools.new_skill_folder.entrypoint("buf", "stub")
-        agent_tools.add_task_to_skill.entrypoint("buf", "atom_a", 6)
-        agent_tools.add_task_to_skill.entrypoint("buf", "atom_b", 8)
+        with agent_tools.use_cluster_batch(["atom_a", "atom_b"]):
+            agent_tools.add_task_to_skill.entrypoint("buf", "atom_a", 6)
+            agent_tools.add_task_to_skill.entrypoint("buf", "atom_b", 8)
         result = agent_tools.read_skill_tasks.entrypoint("buf")
         assert "atom_a" in result
         assert "atom_b" in result
@@ -379,8 +573,18 @@ class TestMoveTaskTo:
         skill_dir, _ = _setup(tmp_path)
         agent_tools.new_skill_folder.entrypoint("from-skill", "stub")
         agent_tools.new_skill_folder.entrypoint("to-skill", "stub")
-        agent_tools.add_task_to_skill.entrypoint("from-skill", "atom_x", 8)
-        result = agent_tools.move_task_to.entrypoint("from-skill", "to-skill", "atom_x")
+        with agent_tools.use_cluster_batch(["atom_x"]):
+            agent_tools.add_task_to_skill.entrypoint(
+                "from-skill",
+                "atom_x",
+                8,
+            )
+        with agent_tools.use_cluster_batch(["atom_current"]):
+            result = agent_tools.move_task_to.entrypoint(
+                "from-skill",
+                "to-skill",
+                "atom_x",
+            )
         assert "moved" in result
         # source 空
         from xskill.skill import candidates as C
@@ -396,8 +600,17 @@ class TestMoveTaskTo:
         skill_dir, _ = _setup(tmp_path)
         agent_tools.new_skill_folder.entrypoint("from", "stub")
         agent_tools.new_skill_folder.entrypoint("to", "stub")
-        agent_tools.add_task_to_skill.entrypoint("from", "atom_dup", 3)
-        agent_tools.add_task_to_skill.entrypoint("to", "atom_dup", 9)
+        with agent_tools.use_cluster_batch(["atom_dup"]):
+            agent_tools.add_task_to_skill.entrypoint(
+                "from",
+                "atom_dup",
+                3,
+            )
+            agent_tools.add_task_to_skill.entrypoint(
+                "to",
+                "atom_dup",
+                9,
+            )
         agent_tools.move_task_to.entrypoint("from", "to", "atom_dup")
         # target 的 atom_dup 被覆盖为 from 的 weightscore=3
         from xskill.skill import candidates as C
@@ -407,7 +620,8 @@ class TestMoveTaskTo:
     def test_move_same_skill_noop(self, tmp_path):
         _setup(tmp_path)
         agent_tools.new_skill_folder.entrypoint("solo", "stub")
-        agent_tools.add_task_to_skill.entrypoint("solo", "atom_a", 5)
+        with agent_tools.use_cluster_batch(["atom_a"]):
+            agent_tools.add_task_to_skill.entrypoint("solo", "atom_a", 5)
         result = agent_tools.move_task_to.entrypoint("solo", "solo", "atom_a")
         assert "noop" in result
 


### PR DESCRIPTION
## Summary

Enforce ClusterAgent candidate-write validation without treating an Atom as single-owner. Candidate files remain authoritative, so one Atom may contribute to several distinct skills with an independent score for each association.

## Changes

- bind framework-provided Atom IDs to each ClusterAgent turn and reject writes outside the current batch
- require strict integer `weightscore` values from 1 through 10 for single and batch candidate tools
- keep the same Atom in multiple skill candidate buffers while preserving same-skill score overwrites
- retain every final Atom-to-skill association in the result recorder, adoption telemetry, and batch logs
- add `skill_assignments` to process results while keeping `skill_name` and `weightscore` as the latest-write compatibility view
- make `move_task_to` replace the recorded source association instead of leaving a stale second result
- update the ClusterAgent prompt and regression coverage for multi-skill routing
- remove the ownership scan and root-wide candidate lock; existing per-skill and move locks still protect file writes

The SQLite `atom_candidate_pending` projection is unchanged. Migrating it to represent several skill associations requires separate schema-migration coverage; candidate files remain the authoritative pending state.

## Test plan

- [ ] `make test` passes
- [x] Added/updated unit tests for the change
- [ ] `make e2e` passes (if the change touches ingestion / install / daemon)
- [ ] Manually verified the affected user flow

Focused verification:

- `.venv/bin/python -m pytest tests/test_skill_tools_atom.py tests/test_agent_worker_runtime.py tests/test_candidates_concurrency.py tests/test_agent_tool_context_isolation.py tests/test_task_cluster_agent.py tests/test_process_atom.py tests/test_cluster_batch.py -q`: 110 passed
- `.venv/bin/python -m ruff check src/xskill/agents/agent_tools.py src/xskill/agents/task_cluster_agent.py src/xskill/pipeline/runner.py src/xskill/pipeline/worker_runtime.py tests/test_agent_tool_context_isolation.py tests/test_agent_worker_runtime.py tests/test_candidates_concurrency.py tests/test_skill_tools_atom.py --select F401,F841,ARG,E722,S110,S112 --per-file-ignores 'tests/*:ARG'`: passed

Full non-E2E verification:

- `.venv/bin/python -m pytest tests/ --ignore=tests/e2e --ignore=tests/test_windows_script_encoding.py -q -m 'not nightly' --deselect=tests/test_connect_service.py::test_linux_selects_detached_when_systemd_unavailable`: 2182 passed, 9 skipped, 4 deselected
- the WSL service test remains an upstream/container mismatch
- `tests/test_windows_script_encoding.py` was excluded because it recursively includes Starfix's generated `.venv/bin/activate.ps1`, not a repository PowerShell source file

GitHub Actions verification:

- [CI run 32149107228](https://github.com/SkillNerds/xskill/actions/runs/32149107228) passed build verification, BDD, Python 3.9 through 3.12 UT/IT on Linux, macOS, and Windows, connect lifecycle E2E, smoke E2E, and live-agent E2E
- `real-llm-e2e` was skipped by the pull-request workflow as configured

## Linked issues

Closes #247
