### PR TITLE
fix(agents): make tool annotations evaluable on Python 3.9 (unbreaks main CI)

### DIFF
--- a/src/xskill/agents/agent_tools.py
+++ b/src/xskill/agents/agent_tools.py
@@ -26,7 +26,7 @@ from dataclasses import dataclass, replace
 from datetime import date, datetime
 from pathlib import Path
 from types import MappingProxyType
-from typing import Any
+from typing import Any, Optional
 
 from agno.tools import tool
 from pydantic import BaseModel, ConfigDict, Field, StrictInt
@@ -1003,7 +1003,7 @@ point. No preamble. Output the 2 sentences only.
 
 
 @tool(name="update_frontmatter_metadata")
-def update_frontmatter_metadata(skill_name: str, source_trajs: list[str] | None = None) -> str:
+def update_frontmatter_metadata(skill_name: str, source_trajs: Optional[list] = None) -> str:
     """
     Update frontmatter.metadata on a skill's SKILL.md:
       - bump version if source_trajs changed
@@ -1398,7 +1398,7 @@ def score_task(atom_id: str, score: int) -> str:
 def add_task(
     atom_id: str, *, traj_id: str, offset_start: int, offset_end: int,
     intent: str, summary: str, tags: list, used_skills: list,
-    ux_score: int | None = None,
+    ux_score: Optional[int] = None,
 ) -> str:
     """手动创建一个 AtomTask（offline 脚本 / agent 合成 atom 用）。
 
@@ -1437,8 +1437,8 @@ def make_task_agent_tools(
 
     @tool(name="submit_atom")
     def submit_atom(start_line: int, intent: str, summary: str,
-                    tags: list | None = None,
-                    used_skills: list | None = None,
+                    tags: Optional[list] = None,
+                    used_skills: Optional[list] = None,
                     *, ux_score: StrictInt) -> str:
         """提交一个新 AtomTask（提交即校验,不合法返 error 让你自改）。
 

--- a/tests/test_agent_tools_py39_schema.py
+++ b/tests/test_agent_tools_py39_schema.py
@@ -1,0 +1,42 @@
+"""agent 工具的参数注解必须在 Python 3.9 上可求值。
+
+agno 从函数签名生成 JSON schema；``list | None`` 这类 PEP 604 写法在 3.9 上
+无法在运行时求值，agno 会放弃解析**整个函数**的参数（日志
+``Could not parse args for <tool>``），生成的 schema 里 ``required`` 为空、
+``properties`` 缺失——模型看到的工具定义就是残缺的。#246 给 ``submit_atom``
+加了「ux_score 必填」的断言，恰好把这个既有隐患在 3.9 CI 上照了出来。
+
+本测试对每个 ``@tool`` 装饰的函数做一次不依赖 agno 的求值检查，让这类回归
+在任何 Python 版本上都能被本地 pytest 抓到，而不只是等 3.9 的 CI。
+"""
+from __future__ import annotations
+
+import inspect
+import typing
+
+import pytest
+
+from xskill.agents import agent_tools
+
+
+def _tool_functions():
+    for name, obj in vars(agent_tools).items():
+        entrypoint = getattr(obj, "entrypoint", None)
+        if callable(entrypoint):          # agno Function wrapper
+            yield name, entrypoint
+        elif inspect.isfunction(obj) and getattr(obj, "__wrapped__", None):
+            yield name, obj.__wrapped__
+
+
+@pytest.mark.parametrize("tool_name,fn", list(_tool_functions()))
+def test_tool_annotations_evaluate_on_this_python(tool_name, fn):
+    """``typing.get_type_hints`` 会像 3.9 上的 agno 一样求值注解；PEP 604 写法在
+    3.9 上会在这里抛 TypeError。3.10+ 上恒通过，本测试的价值在 3.9 CI job。"""
+    try:
+        typing.get_type_hints(fn)
+    except TypeError as exc:
+        pytest.fail(
+            f"tool {tool_name!r} has an annotation that cannot be evaluated on "
+            f"this Python: {exc}. Use typing.Optional[...] instead of 'X | None' "
+            f"so agno can build the tool schema on 3.9."
+        )


### PR DESCRIPTION
## Summary

上游 main 当前在 Python 3.9 的三个平台（ubuntu / macOS / Windows）CI 均为红：#246 给 `submit_atom` 增加了「`ux_score` 必填」的断言，恰好照出一个既有隐患——三个 agent 工具的可选参数用了 `list | None` / `int | None` 这类 3.10 才支持的写法，3.9 上无法求值，agno 放弃解析整个函数的参数，生成的工具 schema 里 `required` 为空、`properties` 缺失。本 PR 把这三处改为 `typing.Optional[...]`，并加一条跨版本回归测试。基于最新 main（`319cb6e`）。

## Changes

- `src/xskill/agents/agent_tools.py`：`submit_atom` 的 `tags` / `used_skills`、`add_task` 的 `ux_score`、`update_frontmatter_metadata` 的 `source_trajs`，注解由 PEP 604 联合改为 `Optional[...]`。3.10+ 行为不变；3.9 上 agno 恢复正常解析，导入时不再出现 `Could not parse args for ...` 警告。
- 新增 `tests/test_agent_tools_py39_schema.py`：对每个 `@tool` 函数用 `typing.get_type_hints` 求值注解（与 3.9 上 agno 的行为一致），失败时点名工具并提示改法。这样这类回归在**任何** Python 版本上都能被本地 pytest 抓到，不必等 3.9 的 CI。

## Test plan

- [x] `make test` passes：**py3.9 与 py3.11 各 2177 通过**（本地仅 `test_windows_script_encoding` 2 例因扫到本机 `.venv/bin/activate.ps1` 的环境原因失败，与本改动无关）
- [x] Added/updated unit tests for the change：新增参数化测试；红绿反证——撤掉修复后 3.9 上 `submit_atom`、`update_frontmatter_metadata` 两个工具被点名失败，恢复后全绿；`test_task_agent.py` 在 3.9 上 44/44（修复前 44 错）
- [ ] `make e2e` passes（未跑：仅注解改动，未触及 ingestion / install / daemon）
- [x] Manually verified：3.9 下 `import xskill.agents.agent_tools` 的三条 `Could not parse args` 警告清零

## Linked issues

Follow-up to #246（该 PR 的断言正确，本 PR 修复它暴露的 3.9 兼容问题）。同时解除 #243 等所有基于当前 main 的 PR 在 py3.9 job 上的失败。
