### PR TITLE
test: fix five Windows-flaky tests (three root-caused, two retried)

### DIFF
--- a/tests/test_dashboard_console_p2.py
+++ b/tests/test_dashboard_console_p2.py
@@ -692,6 +692,13 @@ def test_reco_trigger_matrix_computed_once_across_requests(
     _write_ux_score(console_env["skills"] / "alpha", "alpha",
                     "atom_traj0_0001", "2026-07-01T00:00:00")
     _clear_console_caches()
+    # 断言「5 次请求只算一次」依赖 5 次请求都落在缓存 TTL（5 s）内。Windows
+    # runner 比 Linux 慢约 6 倍，5 个 TestClient 请求 + 首次全量构建偶发跨过
+    # 5 s，缓存到期后重建第二次（CI 见 assert 2 == 1）。测试关心的是「同一
+    # 波次复用」，不是 TTL 长度——把 TTL 拉大，去掉对机器速度的隐含依赖。
+    import xskill.dashboard.console as console_module
+    monkeypatch.setattr(console_module._reco_trigger_cache, "ttl_seconds", 300.0)
+    monkeypatch.setattr(dashboard_metrics._usage_records_cache, "ttl_seconds", 300.0)
 
     builds: list[int] = []
     real_load = dashboard_metrics.load_usage_records

--- a/tests/test_dashboard_metrics.py
+++ b/tests/test_dashboard_metrics.py
@@ -559,7 +559,11 @@ def test_skills_catalog_concurrent_failure_is_shared(
     with ThreadPoolExecutor(max_workers=16) as pool:
         futures = [pool.submit(load_error) for _ in range(16)]
         assert entered.wait(timeout=5)
-        time.sleep(0.05)
+        # 给其余 15 个线程赶到共享等待点的余量。它们在被测代码内部等待，
+        # 测试无法直接观测，只能留时间：0.05 s 在慢 runner（Windows）上偶发
+        # 不够（表现为部分线程在放行后才进入、被判为第二次扫描）。放大到
+        # 0.3 s，并保留 flaky 重试作为兜底。
+        time.sleep(0.3)
         release.set()
         errors = [future.result(timeout=5) for future in futures]
 

--- a/tests/test_dashboard_metrics.py
+++ b/tests/test_dashboard_metrics.py
@@ -529,6 +529,7 @@ def test_skills_catalog_failed_backfill_does_not_poison_meta(tmp_path):
         ("vendor", "skillhub")]
 
 
+@pytest.mark.flaky(reruns=3, reruns_delay=1)
 def test_skills_catalog_concurrent_failure_is_shared(
         tmp_path, monkeypatch):
     root = tmp_path / "skills"; root.mkdir()

--- a/tests/test_pooled_connection.py
+++ b/tests/test_pooled_connection.py
@@ -112,6 +112,7 @@ def test_pool_capacity_evicts_oldest(tmp_path):
     assert paths[-1].resolve() in kept_keys
 
 
+@pytest.mark.flaky(reruns=3, reruns_delay=2, only_rerun=["OperationalError"])
 def test_concurrent_record_usage_from_pool_threads(tmp_path):
     db = tmp_path / "r.db"
     def write(_i):

--- a/tests/test_scatter_materialize.py
+++ b/tests/test_scatter_materialize.py
@@ -199,6 +199,7 @@ class _FakeEngine:
         return SimpleNamespace(changed=True, cancelled=False, embed_items=1)
 
 
+@pytest.mark.flaky(reruns=3, reruns_delay=1)
 def test_service_event_trigger_submits_both_methods(tmp_path):
     engine = _FakeEngine(tmp_path / "team_profile.db")
     service = ProfileRefreshService(engine, workers=1, queue_size=4)

--- a/tests/test_scatter_materialize.py
+++ b/tests/test_scatter_materialize.py
@@ -199,7 +199,6 @@ class _FakeEngine:
         return SimpleNamespace(changed=True, cancelled=False, embed_items=1)
 
 
-@pytest.mark.flaky(reruns=3, reruns_delay=1)
 def test_service_event_trigger_submits_both_methods(tmp_path):
     engine = _FakeEngine(tmp_path / "team_profile.db")
     service = ProfileRefreshService(engine, workers=1, queue_size=4)
@@ -208,7 +207,11 @@ def test_service_event_trigger_submits_both_methods(tmp_path):
     try:
         assert service.request("client-x")
         assert service.wait_idle(timeout=3)
-        time.sleep(0.05)  # 事件触发在 finalize 前,给投递一点点余量
+        # 事件触发在 finalize 前，投递由另一线程完成：用条件等待而不是固定
+        # sleep(0.05)——慢 runner（Windows）上固定睡眠偶发不够，CI 偶发失败。
+        deadline = time.monotonic() + 3.0
+        while len(recorder.enqueued) < 2 and time.monotonic() < deadline:
+            time.sleep(0.01)
         assert recorder.enqueued == [("client-x", "tsne"), ("client-x", "umap")]
     finally:
         assert service.stop(timeout=3)

--- a/tests/test_skillhub_hybrid_search.py
+++ b/tests/test_skillhub_hybrid_search.py
@@ -503,7 +503,11 @@ def test_embed_failure_cooldown_skips_repeated_backend_calls(tmp_path, monkeypat
     hub = SkillHub(enabled=True, hub_dir=hub_dir, embed_client=client,
                    search_max_embed=1)
     _prime_corpus_cache(hub)
-    monkeypatch.setattr(skillhub_module, "QUERY_EMBED_FAILURE_COOLDOWN_SECONDS", 0.02)
+    # 冷却窗与等待时长必须远大于 Windows 上 time.monotonic() 的分辨率
+    # （Python ≤3.12 约 15.6 ms）：原先 cooldown=0.02 / sleep(0.03) 只跨一到
+    # 两个时钟 tick，起点相位不巧时 sleep 后 monotonic() 只前进 15.6 ms，
+    # 冷却「仍未过期」→ 第二次 embed 被跳过，断言看到 ['alpha']（CI 偶发）。
+    monkeypatch.setattr(skillhub_module, "QUERY_EMBED_FAILURE_COOLDOWN_SECONDS", 0.1)
 
     client.fail = True
     first = hub.search("alpha", limit=5)
@@ -512,7 +516,7 @@ def test_embed_failure_cooldown_skips_repeated_backend_calls(tmp_path, monkeypat
     assert first and all(result["semantic_rank"] is None for result in first)
     assert second == []
 
-    time.sleep(0.03)
+    time.sleep(0.25)
     client.fail = False
     hub.search("beta", limit=5)
     assert client.encode_calls == ["alpha", "beta"]


### PR DESCRIPTION
## Summary

五个测试在 Windows runner 上偶发失败（一天内先后命中 #243 与本 PR 自身），均与被测代码无关。逐个查了根因：**三个可以确定性修复，两个属环境时序需重试兜底**。系统性背景与套件级策略建议见 #251。

## Changes

**根治（不靠重试）**
- `tests/test_skillhub_hybrid_search.py::test_embed_failure_cooldown_skips_repeated_backend_calls`：冷却窗设 0.02 s、睡 0.03 s。Windows 上 Python ≤3.12 的 `time.monotonic()` 分辨率约 15.6 ms，睡眠只让时钟前进一到两个 tick，起点相位不巧时冷却「仍未过期」，第二次 embed 被跳过，断言看到 `['alpha']`。按 tick 建模约 8% 的相位会失败。改为冷却 0.1 s / 睡 0.25 s，同一模型下 0/1000。
- `tests/test_scatter_materialize.py::test_service_event_trigger_submits_both_methods`：用固定 `sleep(0.05)` 等另一线程投递，改为有上限的条件等待；之前加的重试标记随之去掉。

- `tests/test_dashboard_console_p2.py::test_reco_trigger_matrix_computed_once_across_requests`：断言 5 次请求只算一次矩阵，隐含前提是 5 次请求都落在 5 s 缓存 TTL 内。Windows runner 比 Linux 慢约 6 倍（整套 17.7 分钟 vs 约 3 分钟），5 个 TestClient 请求 + 首次全量构建偶发跨过 5 s，缓存到期重建第二次（`assert 2 == 1`）。用真实的 `SingleFlightTtlCache` 按间隔跨过 TTL 可确定性复现。测试关心的是「同一波次复用」而不是 TTL 长度，改为在测试期间把两个缓存的 TTL 设为 300 s。

**重试兜底（环境属性）**
- `tests/test_pooled_connection.py::test_concurrent_record_usage_from_pool_threads`：SQLite `database is locked`，只对 `OperationalError` 重试。
- `tests/test_dashboard_metrics.py::test_skills_catalog_concurrent_failure_is_shared`：等其余 15 个线程到达共享等待点的余量测试无法观测，只能留时间；余量从 0.05 s 放大到 0.3 s，并保留重试。

## Test plan

- [x] `make test` passes
- [x] 五个文件本地 126 例通过；冷却测试的修法用时钟分辨率模型验证（修前 8/100 相位失败，修后 0/1000）
- [ ] `make e2e`（不涉及）

## Linked issues

补 #249 未赶上合入的提交；减少 #243 等 PR 在 Windows 上被偶发误伤；系统性讨论在 #251。