### PR TITLE
fix(registry): preserve multi-skill pending projections

### DIFF
--- a/src/xskill/pipeline/registry.py
+++ b/src/xskill/pipeline/registry.py
@@ -361,10 +361,11 @@ CREATE TABLE IF NOT EXISTS ux_scores_meta (
 -- atom 在途 pending 投影：真相仍是各 skill 的 .candidates.yml；
 -- 写出口（candidates 落盘闸）同步；dashboard 读路径只查本表，禁止 per-atom 扫盘。
 CREATE TABLE IF NOT EXISTS atom_candidate_pending (
-    atom_id     TEXT PRIMARY KEY,
+    atom_id     TEXT NOT NULL,
     skill       TEXT NOT NULL,
     weightscore INTEGER NOT NULL DEFAULT 0,
-    updated_at  TEXT DEFAULT (datetime('now'))
+    updated_at  TEXT DEFAULT (datetime('now')),
+    PRIMARY KEY (atom_id, skill)
 );
 CREATE INDEX IF NOT EXISTS idx_acp_skill ON atom_candidate_pending(skill);
 
@@ -515,6 +516,68 @@ def pooled_connection(db_path: Optional[Path] = None) -> Iterator[sqlite3.Connec
         slot.busy = False
 
 
+def _migrate_atom_candidate_pending(conn: sqlite3.Connection) -> None:
+    """Replace the legacy key and invalidate stale projection readiness."""
+    table_info = conn.execute(
+        "PRAGMA table_info(atom_candidate_pending)",
+    ).fetchall()
+    primary_key = [
+        row[1]
+        for row in sorted(table_info, key=lambda row: row[5])
+        if row[5]
+    ]
+    if primary_key == ["atom_id", "skill"]:
+        return
+
+    required_columns = {"atom_id", "skill", "weightscore", "updated_at"}
+    actual_columns = {row[1] for row in table_info}
+    if not required_columns.issubset(actual_columns):
+        raise sqlite3.DatabaseError(
+            "cannot migrate atom_candidate_pending with columns "
+            f"{sorted(actual_columns)!r}",
+        )
+
+    conn.execute("SAVEPOINT migrate_atom_candidate_pending")
+    try:
+        conn.execute(
+            """
+            CREATE TABLE atom_candidate_pending_v2 (
+                atom_id     TEXT NOT NULL,
+                skill       TEXT NOT NULL,
+                weightscore INTEGER NOT NULL DEFAULT 0,
+                updated_at  TEXT DEFAULT (datetime('now')),
+                PRIMARY KEY (atom_id, skill)
+            )
+            """,
+        )
+        conn.execute(
+            """
+            INSERT INTO atom_candidate_pending_v2(
+                atom_id, skill, weightscore, updated_at
+            )
+            SELECT atom_id, skill, weightscore, updated_at
+            FROM atom_candidate_pending
+            """,
+        )
+        conn.execute("DROP TABLE atom_candidate_pending")
+        conn.execute(
+            "ALTER TABLE atom_candidate_pending_v2 "
+            "RENAME TO atom_candidate_pending",
+        )
+        conn.execute(
+            "CREATE INDEX idx_acp_skill ON atom_candidate_pending(skill)",
+        )
+        # The legacy table retained at most one skill for each Atom.  Force a
+        # reconcile from the authoritative .candidates.yml files so cached
+        # root/mtime markers cannot hide associations lost before migration.
+        conn.execute("DELETE FROM atom_candidate_pending_meta")
+    except Exception:
+        conn.execute("ROLLBACK TO SAVEPOINT migrate_atom_candidate_pending")
+        conn.execute("RELEASE SAVEPOINT migrate_atom_candidate_pending")
+        raise
+    conn.execute("RELEASE SAVEPOINT migrate_atom_candidate_pending")
+
+
 def _migrate(conn: sqlite3.Connection) -> None:
     """Add columns missing from older schema versions."""
     # ── trajectories ──
@@ -604,6 +667,8 @@ def _migrate(conn: sqlite3.Connection) -> None:
         conn.execute(
             "ALTER TABLE skill_prefs ADD COLUMN side TEXT NOT NULL DEFAULT ''"
         )
+
+    _migrate_atom_candidate_pending(conn)
 
     # Backfill status from has_meta/has_embedding —— **只在首次补 status 列时跑一次**。
     # 以前每次 get_connection 都跑这条,会把任何 status='discovered' 的**活行**
@@ -1195,7 +1260,7 @@ def sync_atom_candidate_pending_for_skill(
 ) -> None:
     """按某 skill 当前 candidates 快照替换其 pending 投影行。
 
-    ``atom_id`` 为主键：同 atom 若改挂到其他 skill，ON CONFLICT 覆盖 skill 列。
+    ``(atom_id, skill)`` 为关联主键；同 atom 可独立挂到多个 skill。
     """
     rows: list[tuple[str, str, int]] = []
     for candidate in candidates or []:
@@ -1214,8 +1279,7 @@ def sync_atom_candidate_pending_for_skill(
                 """
                 INSERT INTO atom_candidate_pending(atom_id, skill, weightscore)
                 VALUES (?, ?, ?)
-                ON CONFLICT(atom_id) DO UPDATE SET
-                    skill=excluded.skill,
+                ON CONFLICT(atom_id, skill) DO UPDATE SET
                     weightscore=excluded.weightscore,
                     updated_at=datetime('now')
                 """,
@@ -1326,8 +1390,7 @@ def backfill_atom_candidate_pending(
                 """
                 INSERT INTO atom_candidate_pending(atom_id, skill, weightscore)
                 VALUES (?, ?, ?)
-                ON CONFLICT(atom_id) DO UPDATE SET
-                    skill=excluded.skill,
+                ON CONFLICT(atom_id, skill) DO UPDATE SET
                     weightscore=excluded.weightscore,
                     updated_at=datetime('now')
                 """,

--- a/tests/test_atom_candidate_pending.py
+++ b/tests/test_atom_candidate_pending.py
@@ -2,10 +2,11 @@
 
 from __future__ import annotations
 
+import sqlite3
 from pathlib import Path
 from unittest import mock
 
-from xskill.dashboard.explore import TrajExplorer
+from xskill.dashboard.explore import TrajExplorer, skill_lineage
 from xskill.pipeline import registry as reg
 from xskill.skill.candidates import (
     CANDIDATES_FILENAME,
@@ -24,6 +25,154 @@ def _write_skill(skill_dir: Path, name: str) -> Path:
     return path
 
 
+def _pending_primary_key(conn: sqlite3.Connection) -> list[str]:
+    rows = conn.execute("PRAGMA table_info(atom_candidate_pending)").fetchall()
+    return [
+        row["name"]
+        for row in sorted(rows, key=lambda row: row["pk"])
+        if row["pk"]
+    ]
+
+
+def test_pending_projection_uses_composite_primary_key(tmp_path: Path) -> None:
+    conn = reg.get_connection(tmp_path / "registry.db")
+    try:
+        assert _pending_primary_key(conn) == ["atom_id", "skill"]
+        indexes = {
+            row["name"]
+            for row in conn.execute("PRAGMA index_list(atom_candidate_pending)")
+        }
+        assert "idx_acp_skill" in indexes
+    finally:
+        conn.close()
+
+
+def test_legacy_pending_projection_migrates_without_data_loss(
+    tmp_path: Path,
+) -> None:
+    db = tmp_path / "registry.db"
+    legacy = sqlite3.connect(db)
+    try:
+        legacy.executescript(
+            """
+            CREATE TABLE atom_candidate_pending (
+                atom_id     TEXT PRIMARY KEY,
+                skill       TEXT NOT NULL,
+                weightscore INTEGER NOT NULL DEFAULT 0,
+                updated_at  TEXT DEFAULT (datetime('now'))
+            );
+            CREATE INDEX idx_acp_skill ON atom_candidate_pending(skill);
+            INSERT INTO atom_candidate_pending(
+                atom_id, skill, weightscore, updated_at
+            ) VALUES
+                ('atom_t1_0001', 'foo', 4, '2026-08-17 01:02:03'),
+                ('atom_t1_0002', 'bar', 8, '2026-08-17 04:05:06');
+            """,
+        )
+        legacy.commit()
+    finally:
+        legacy.close()
+
+    conn = reg.get_connection(db)
+    try:
+        assert _pending_primary_key(conn) == ["atom_id", "skill"]
+        rows = [
+            tuple(row)
+            for row in conn.execute(
+                "SELECT atom_id, skill, weightscore, updated_at "
+                "FROM atom_candidate_pending ORDER BY atom_id",
+            )
+        ]
+        assert rows == [
+            ("atom_t1_0001", "foo", 4, "2026-08-17 01:02:03"),
+            ("atom_t1_0002", "bar", 8, "2026-08-17 04:05:06"),
+        ]
+        conn.execute("PRAGMA user_version=0")
+        conn.commit()
+    finally:
+        conn.close()
+
+    reopened = reg.get_connection(db)
+    try:
+        assert _pending_primary_key(reopened) == ["atom_id", "skill"]
+        assert reopened.execute(
+            "SELECT COUNT(*) FROM atom_candidate_pending",
+        ).fetchone()[0] == 2
+    finally:
+        reopened.close()
+
+
+def test_legacy_migration_rebuilds_multi_skill_projection_despite_stale_meta(
+    tmp_path: Path,
+) -> None:
+    db = tmp_path / "registry.db"
+    skill_dir = tmp_path / "skill"
+    skill_dir.mkdir()
+    skills = (("foo", 4), ("bar", 6), ("baz", 8))
+    for name, score in skills:
+        skill_path = _write_skill(skill_dir, name)
+        (skill_path / CANDIDATES_FILENAME).write_text(
+            "candidates:\n"
+            "  - atom_id: atom_t1_0001\n"
+            f"    weightscore: {score}\n",
+            encoding="utf-8",
+        )
+
+    legacy = sqlite3.connect(db)
+    try:
+        legacy.executescript(
+            """
+            CREATE TABLE atom_candidate_pending (
+                atom_id     TEXT PRIMARY KEY,
+                skill       TEXT NOT NULL,
+                weightscore INTEGER NOT NULL DEFAULT 0,
+                updated_at  TEXT DEFAULT (datetime('now'))
+            );
+            CREATE INDEX idx_acp_skill ON atom_candidate_pending(skill);
+            CREATE TABLE atom_candidate_pending_meta (
+                root_key      TEXT PRIMARY KEY,
+                backfilled_at TEXT NOT NULL
+            );
+            INSERT INTO atom_candidate_pending(atom_id, skill, weightscore)
+            VALUES ('atom_t1_0001', 'foo', 4);
+            """,
+        )
+        legacy.executemany(
+            "INSERT INTO atom_candidate_pending_meta(root_key, backfilled_at) "
+            "VALUES (?, '9999999999')",
+            [
+                (reg._atom_pending_root_key(skill_dir),),
+                *((f"pending_mtime:{name}",) for name, _score in skills),
+            ],
+        )
+        legacy.commit()
+    finally:
+        legacy.close()
+
+    migrated = reg.get_connection(db)
+    try:
+        assert migrated.execute(
+            "SELECT COUNT(*) FROM atom_candidate_pending_meta",
+        ).fetchone()[0] == 0
+    finally:
+        migrated.close()
+
+    reg.ensure_atom_pending_backfilled(skill_dir, db_path=db)
+    with reg.pooled_connection(db) as conn:
+        rows = [
+            tuple(row)
+            for row in conn.execute(
+                "SELECT atom_id, skill, weightscore "
+                "FROM atom_candidate_pending ORDER BY skill",
+            )
+        ]
+    assert rows == [
+        ("atom_t1_0001", "bar", 6),
+        ("atom_t1_0001", "baz", 8),
+        ("atom_t1_0001", "foo", 4),
+    ]
+
+
 def test_candidates_save_syncs_pending_projection(tmp_path: Path) -> None:
     db = tmp_path / "registry.db"
     skill_dir = tmp_path / "skill"
@@ -36,17 +185,21 @@ def test_candidates_save_syncs_pending_projection(tmp_path: Path) -> None:
         return_value=db,
     ):
         add_atom_contributions(foo, [("atom_t1_0001", 7, "")])
-        add_atom_contributions(bar, [("atom_t1_0002", 3, "")])
+        add_atom_contributions(bar, [("atom_t1_0001", 3, "")])
+        add_atom_contributions(foo, [("atom_t1_0001", 9, "")])
 
     with reg.pooled_connection(db) as conn:
-        rows = {
-            r["atom_id"]: (r["skill"], r["weightscore"])
-            for r in conn.execute(
-                "SELECT atom_id, skill, weightscore FROM atom_candidate_pending",
+        rows = [
+            tuple(row)
+            for row in conn.execute(
+                "SELECT atom_id, skill, weightscore "
+                "FROM atom_candidate_pending ORDER BY skill",
             )
-        }
-    assert rows["atom_t1_0001"] == ("foo", 7)
-    assert rows["atom_t1_0002"] == ("bar", 3)
+        ]
+    assert rows == [
+        ("atom_t1_0001", "bar", 3),
+        ("atom_t1_0001", "foo", 9),
+    ]
 
     with mock.patch(
         "xskill.skill.catalog_store.resolve_catalog_db_path",
@@ -56,43 +209,53 @@ def test_candidates_save_syncs_pending_projection(tmp_path: Path) -> None:
 
     with reg.pooled_connection(db) as conn:
         left = [
-            r["atom_id"]
-            for r in conn.execute(
-                "SELECT atom_id FROM atom_candidate_pending",
+            tuple(row)
+            for row in conn.execute(
+                "SELECT atom_id, skill, weightscore FROM atom_candidate_pending",
             )
         ]
-    assert left == ["atom_t1_0002"]
+    assert left == [("atom_t1_0001", "bar", 3)]
 
 
-def test_atom_destinations_reads_pending_from_db_without_iterdir(
+def test_backfill_and_dashboard_keep_multi_skill_pending_associations(
     tmp_path: Path,
 ) -> None:
     db = tmp_path / "registry.db"
     skill_dir = tmp_path / "skill"
     skill_dir.mkdir()
-    _write_skill(skill_dir, "foo")
-    reg.sync_atom_candidate_pending_for_skill(
-        "foo",
-        [{"atom_id": "atom_t9_0001", "weightscore": 5}],
-        db_path=db,
-    )
-    # 标记已 backfill，避免读路径再扫盘
-    with reg.pooled_connection(db) as conn:
-        conn.execute(
-            "INSERT INTO atom_candidate_pending_meta(root_key, backfilled_at)"
-            " VALUES (?, datetime('now'))",
-            (reg._atom_pending_root_key(skill_dir),),
+    foo = _write_skill(skill_dir, "foo")
+    bar = _write_skill(skill_dir, "bar")
+    for skill_path, score in ((foo, 5), (bar, 8)):
+        (skill_path / CANDIDATES_FILENAME).write_text(
+            "candidates:\n"
+            "  - atom_id: atom_t9_0001\n"
+            f"    weightscore: {score}\n",
+            encoding="utf-8",
         )
-        conn.commit()
+    assert reg.backfill_atom_candidate_pending(skill_dir, db_path=db) == 2
 
     explorer = TrajExplorer(db_path=db, skill_dir=skill_dir)
     with mock.patch.object(Path, "iterdir", side_effect=AssertionError("扫盘")):
         dests = explorer._atom_destinations("atom_t9_0001")
-    assert dests == [{
-        "skill": "foo",
-        "weightscore": 5,
-        "state": "pending",
-        "ts": "",
-    }]
-    # 磁盘上甚至可以没有 candidates 文件
-    assert not (skill_dir / "foo" / CANDIDATES_FILENAME).exists()
+    assert sorted(dests, key=lambda row: row["skill"]) == [
+        {
+            "skill": "bar",
+            "weightscore": 8,
+            "state": "pending",
+            "ts": "",
+        },
+        {
+            "skill": "foo",
+            "weightscore": 5,
+            "state": "pending",
+            "ts": "",
+        },
+    ]
+    assert [
+        row["atom_id"]
+        for row in skill_lineage(skill_dir, "foo", db_path=db)["atoms"]
+    ] == ["atom_t9_0001"]
+    assert [
+        row["atom_id"]
+        for row in skill_lineage(skill_dir, "bar", db_path=db)["atoms"]
+    ] == ["atom_t9_0001"]


### PR DESCRIPTION
## Summary

Preserve every pending Atom-to-skill association in the registry projection.
This is a follow-up to #248 and keeps `.candidates.yml` as the authoritative source.

## Changes

- Use `(atom_id, skill)` as the pending projection key and conflict target.
- Migrate legacy rows transactionally and invalidate stale readiness metadata so the projection is rebuilt from candidate files.
- Cover legacy migration, multi-skill sync and deletion, backfill, and dashboard lineage reads.

## Test plan

- [ ] `make test` passes
- [x] Added/updated unit tests for the change
- [ ] `make e2e` passes (if the change touches ingestion / install / daemon)
- [ ] Manually verified the affected user flow

Focused verification:

- `.venv/bin/python -m pytest tests/test_atom_candidate_pending.py tests/test_skill_dir_sync.py tests/test_dashboard_explore.py tests/test_dashboard_skill_detail.py -q` — 30 passed
- `.venv/bin/python -m pytest tests/ --ignore=tests/docker_e2e --ignore=tests/live --ignore=tests/e2e --ignore=tests/test_windows_script_encoding.py -m 'not nightly' --deselect=tests/test_connect_service.py::test_linux_selects_detached_when_systemd_unavailable -q` — 2171 passed, 9 skipped, 4 deselected
- `.venv/bin/python -m ruff check src/xskill/pipeline/registry.py tests/test_atom_candidate_pending.py --select F401,F841,ARG,E722,S110,S112 --per-file-ignores 'tests/*:ARG'` — passed

The broad suite excludes two unrelated environment-sensitive baseline areas: WSL systemd service selection and the repository-wide PowerShell glob that collects the verifier-generated `.venv/activate.ps1`.

## Linked issues

Follow-up to #248.

Closes #252
