### PR TITLE
fix(dashboard): separate current push from exposure history

### DIFF
--- a/src/xskill/dashboard/console.py
+++ b/src/xskill/dashboard/console.py
@@ -13,7 +13,7 @@ import operator
 from pathlib import Path
 from typing import Literal, Optional
 
-from fastapi import APIRouter, Depends, HTTPException
+from fastapi import APIRouter, Depends, HTTPException, Query
 from pydantic import BaseModel, Field
 
 from xskill.dashboard.auth import require_admin, require_user
@@ -103,6 +103,66 @@ def _client_to_user(registry) -> dict[str, str]:
     for row in registry.list():
         out[row["client_id"]] = row.get("user_name") or row["client_id"]
     return out
+
+
+def _recommendation_history_for_user(
+    *,
+    user: str,
+    registry,
+    db_path: Optional[Path],
+    offset: int,
+    limit: int,
+) -> dict:
+    """Return one user's first-exposure records, newest first.
+
+    ``recommendation_log`` and ``ClientRegistry`` live in separate databases,
+    so resolve all client ids for the user before querying the log.  Anonymous
+    clients keep their client id as the user key, matching ``_client_to_user``.
+    """
+    client_ids = sorted({
+        row["client_id"]
+        for row in registry.list()
+        if (row.get("user_name") or row["client_id"]) == user
+    })
+    if not client_ids:
+        return {
+            "user": user,
+            "total": 0,
+            "offset": offset,
+            "limit": limit,
+            "has_more": False,
+            "exposures": [],
+        }
+
+    placeholders = ",".join("?" for _ in client_ids)
+    with pooled_connection(db_path) as conn:
+        total = int(conn.execute(
+            f"SELECT COUNT(*) FROM recommendation_log "
+            f"WHERE client_id IN ({placeholders})",
+            client_ids,
+        ).fetchone()[0])
+        rows = conn.execute(
+            "SELECT ts,skill,side,bucket,sha FROM recommendation_log "
+            f"WHERE client_id IN ({placeholders}) "
+            "ORDER BY ts DESC,id DESC LIMIT ? OFFSET ?",
+            [*client_ids, limit, offset],
+        ).fetchall()
+
+    exposures = [{
+        "ts": row["ts"] or "",
+        "skill": row["skill"] or "",
+        "side": row["side"] or "main",
+        "bucket": row["bucket"] or "recommended",
+        "sha": row["sha"] or "",
+    } for row in rows]
+    return {
+        "user": user,
+        "total": total,
+        "offset": offset,
+        "limit": limit,
+        "has_more": offset + len(exposures) < total,
+        "exposures": exposures,
+    }
 
 
 # ---------------------------------------------------------------------------
@@ -1263,6 +1323,23 @@ def build_console_router(db_path: Optional[Path] = None) -> APIRouter:
             raise HTTPException(status_code=400, detail="user_key required")
         slots = _manifest_slots_for_user(ctx, user=user_key, db_path=db_path)
         return {"user": user_key, "slots": slots}
+
+    @router.get("/admin/user/{user_key}/recommendations")
+    def admin_user_recommendations(
+        user_key: str,
+        offset: int = Query(0, ge=0),
+        limit: int = Query(20, ge=1, le=100),
+        _=Depends(require_admin),
+    ):
+        """管理抽屉：某用户历史推荐曝光，与当前 manifest 分开分页。"""
+        ctx = _require_team_ctx()
+        return _recommendation_history_for_user(
+            user=user_key,
+            registry=ctx.client_registry,
+            db_path=db_path,
+            offset=offset,
+            limit=limit,
+        )
 
     @router.put("/admin/client/{client_id}/ingest")
     def admin_client_ingest(

--- a/src/xskill/dashboard/static/app.js
+++ b/src/xskill/dashboard/static/app.js
@@ -2473,7 +2473,7 @@ async function loadAdmin() {
     const ingestState = u.ingest_paused
       ? `<span class="text-[10px] px-1.5 py-0.5 rounded bg-amber-100 text-amber-700" title="${esc(pauseDetail)}">已暂停</span>`
       : '<span class="text-[10px] px-1.5 py-0.5 rounded bg-emerald-100 text-emerald-700">处理中</span>';
-    const cur = u.current_slots != null ? u.current_slots : u.exposures;
+    const cur = u.current_slots != null ? u.current_slots : '—';
     const stg = u.staging_slots != null ? u.staging_slots : '—';
     return `<tr>
       <td class="py-2 font-medium">${esc(u.user)}</td>
@@ -2530,8 +2530,12 @@ async function openAdminDrawer(user) {
   d.classList.remove('hidden');
   d.innerHTML = `<div class="flex items-baseline justify-between">
       <h3 class="font-medium text-[12.5px]">${esc(user)} 的当前推送 <span class="text-[10.5px] text-slate-400 font-normal ml-1">${(assign.slots || []).length} 槽 · pinned=${p.effective.pinned.length} blocked=${p.effective.blocked.length}</span></h3>
-      <button id="adm-drawer-x" class="text-[11px] text-slate-400 hover:bg-slate-100 px-1.5 rounded">收起</button></div>
+      <div class="flex items-center gap-2">
+        <button class="adm-history-toggle text-[11px] text-teal-700 hover:bg-teal-50 px-1.5 rounded" data-user="${esc(user)}" aria-expanded="false">历史曝光</button>
+        <button id="adm-drawer-x" class="text-[11px] text-slate-400 hover:bg-slate-100 px-1.5 rounded">收起</button>
+      </div></div>
     <div class="mt-2 space-y-1.5 max-h-72 overflow-y-auto">${slotRows}</div>
+    <div id="adm-history-panel" data-user="${esc(user)}" class="hidden mt-3 pt-3 border-t border-slate-200"></div>
     <div class="mt-3 pt-3 border-t border-slate-200">
       <div class="text-[11px] text-slate-400 mb-1.5">偏好（pin / 屏蔽）</div>
       <div class="flex flex-wrap gap-1.5">${p.prefs.map(r => `
@@ -2544,6 +2548,42 @@ async function openAdminDrawer(user) {
         <button class="adm-pref px-2 py-1 rounded-lg ring-1 ring-rose-200 text-rose-700 hover:bg-rose-50 text-[11px]" data-user="${esc(user)}" data-act="block">代屏蔽</button>
       </div>
     </div>`;
+}
+
+async function loadAdminRecommendationHistory(user, offset = 0) {
+  const panel = document.getElementById('adm-history-panel');
+  if (!panel || panel.dataset.user !== user) return;
+  const limit = 20;
+  panel.classList.remove('hidden');
+  panel.innerHTML = '<span class="text-[11px] text-slate-400">历史曝光加载中…</span>';
+  const history = await j(
+    '/api/v1/dashboard/admin/user/' + encodeURIComponent(user)
+      + '/recommendations?offset=' + offset + '&limit=' + limit,
+  );
+  if (!panel.isConnected || panel.dataset.user !== user) return;
+  const exposureRows = (history.exposures || []).map(row => `
+    <div class="flex items-center gap-2 px-2.5 py-2 rounded-lg ring-1 ring-slate-100 bg-white">
+      <div class="min-w-0 flex-1">
+        <div class="flex items-center gap-1.5 flex-wrap">
+          <span class="skill-jump cursor-pointer font-medium text-teal-700 text-[12px]" data-skill="${esc(row.skill)}">${esc(row.skill)}</span>
+          <span class="text-[10px] px-1.5 py-0.5 rounded ${BUCKET_CHIP[row.bucket] || 'bg-slate-100 text-slate-500'}">${esc(row.bucket)}</span>
+          <span class="text-[10px] px-1.5 py-0.5 rounded ${row.side === 'staging' ? 'bg-amber-50 text-amber-700 ring-1 ring-amber-100' : 'bg-slate-100 text-slate-500'}">${esc(row.side || 'main')}</span>
+          ${row.sha ? `<code class="text-[10px] text-slate-400">${esc(String(row.sha).slice(0, 7))}</code>` : ''}
+        </div>
+      </div>
+      <time class="shrink-0 text-[10px] text-slate-400" title="${esc(row.ts)} UTC">${fdate(row.ts)}</time>
+    </div>`).join('') || '<span class="text-[11px] text-slate-400">暂无历史曝光</span>';
+  const exposureCount = (history.exposures || []).length;
+  const start = exposureCount ? history.offset + 1 : 0;
+  const end = exposureCount ? history.offset + exposureCount : 0;
+  panel.innerHTML = `<div class="flex items-baseline justify-between gap-2">
+      <div><span class="text-[11px] text-slate-500">历史曝光</span><span class="text-[10px] text-slate-400 ml-1">按首次曝光时间倒序 · ${start}-${end}/${history.total}</span></div>
+      <div class="flex gap-1">
+        <button class="adm-history-page text-[10px] px-1.5 py-0.5 rounded ring-1 ring-slate-200 ${history.offset > 0 ? 'hover:bg-slate-50' : 'text-slate-300 cursor-not-allowed'}" data-user="${esc(user)}" data-offset="${Math.max(0, history.offset - history.limit)}" ${history.offset > 0 ? '' : 'disabled'}>上一页</button>
+        <button class="adm-history-page text-[10px] px-1.5 py-0.5 rounded ring-1 ring-slate-200 ${history.has_more ? 'hover:bg-slate-50' : 'text-slate-300 cursor-not-allowed'}" data-user="${esc(user)}" data-offset="${history.offset + history.limit}" ${history.has_more ? '' : 'disabled'}>下一页</button>
+      </div>
+    </div>
+    <div class="mt-2 space-y-1.5 max-h-72 overflow-y-auto">${exposureRows}</div>`;
 }
 document.addEventListener('click', async e => {
   const ingest = e.target.closest('.adm-ingest');
@@ -2571,6 +2611,25 @@ document.addEventListener('click', async e => {
   const cfg = e.target.closest('.adm-cfg');
   if (cfg) { openAdminDrawer(cfg.dataset.user).catch(err => alert(err.message)); return; }
   if (e.target.id === 'adm-drawer-x') { document.getElementById('admin-drawer').classList.add('hidden'); return; }
+  const historyToggle = e.target.closest('.adm-history-toggle');
+  if (historyToggle) {
+    const panel = document.getElementById('adm-history-panel');
+    if (!panel) return;
+    const opening = panel.classList.contains('hidden');
+    historyToggle.setAttribute('aria-expanded', opening ? 'true' : 'false');
+    historyToggle.textContent = opening ? '收起历史' : '历史曝光';
+    if (opening) loadAdminRecommendationHistory(historyToggle.dataset.user).catch(err => alert(err.message));
+    else panel.classList.add('hidden');
+    return;
+  }
+  const historyPage = e.target.closest('.adm-history-page');
+  if (historyPage && !historyPage.disabled) {
+    loadAdminRecommendationHistory(
+      historyPage.dataset.user,
+      Number(historyPage.dataset.offset || 0),
+    ).catch(err => alert(err.message));
+    return;
+  }
   const ap = e.target.closest('.adm-pref');
   if (ap) {
     const skill = ap.dataset.skill || (document.getElementById('adm-skill-in') || {}).value;

--- a/tests/test_dashboard_console_p2.py
+++ b/tests/test_dashboard_console_p2.py
@@ -119,6 +119,9 @@ def test_wrong_credentials_401(console_env):
 def test_user_hitting_admin_endpoint_403(console_env):
     alice = console_env["alice"]
     assert alice.get("/api/v1/dashboard/admin/skills").status_code == 403
+    assert alice.get(
+        "/api/v1/dashboard/admin/user/alice/recommendations"
+    ).status_code == 403
     assert alice.post(
         "/api/v1/dashboard/admin/skill/alpha/retire").status_code == 403
     assert alice.get("/api/v1/dashboard/admin/config").status_code == 403
@@ -421,6 +424,61 @@ def test_users_matrix_lists_clients_with_version(console_env):
     assert row["client_version"] == "0.9.9"
     assert row["client_id"] == cid
     assert row["ingest_paused"] is False
+
+
+def test_admin_recommendation_history_is_separate_and_paginated(console_env):
+    db = console_env["db"]
+    client_id = console_env["registry"].find_by_user_name("alice")
+    with R.get_connection(db) as conn:
+        conn.executemany(
+            "INSERT INTO recommendation_log("
+            "ts,client_id,skill,side,bucket,sha) VALUES(?,?,?,?,?,?)",
+            [
+                ("2026-07-01 00:00:00", client_id, "alpha", "main",
+                 "recommended", "sha-alpha"),
+                ("2026-07-02 00:00:00", client_id, "beta", "staging",
+                 "ranked", "sha-beta"),
+                ("2026-07-03 00:00:00", client_id, "gamma", "main",
+                 "recommended", "sha-gamma"),
+                ("2026-07-04 00:00:00", "another-client", "other", "main",
+                 "recommended", "sha-other"),
+            ],
+        )
+        conn.commit()
+
+    boss = console_env["boss"]
+    first = boss.get(
+        "/api/v1/dashboard/admin/user/alice/recommendations",
+        params={"offset": 0, "limit": 2},
+    )
+    assert first.status_code == 200
+    payload = first.json()
+    assert payload == {
+        "user": "alice",
+        "total": 3,
+        "offset": 0,
+        "limit": 2,
+        "has_more": True,
+        "exposures": [
+            {"ts": "2026-07-03 00:00:00", "skill": "gamma",
+             "side": "main", "bucket": "recommended", "sha": "sha-gamma"},
+            {"ts": "2026-07-02 00:00:00", "skill": "beta",
+             "side": "staging", "bucket": "ranked", "sha": "sha-beta"},
+        ],
+    }
+    assert all("client_id" not in row for row in payload["exposures"])
+
+    second = boss.get(
+        "/api/v1/dashboard/admin/user/alice/recommendations",
+        params={"offset": 2, "limit": 2},
+    ).json()
+    assert second["total"] == 3
+    assert second["has_more"] is False
+    assert [row["skill"] for row in second["exposures"]] == ["alpha"]
+    assert boss.get(
+        "/api/v1/dashboard/admin/user/alice/recommendations",
+        params={"limit": 0},
+    ).status_code == 422
 
 
 def test_admin_ingest_control_is_authorized_idempotent_and_syncs_watch_dir(

--- a/tests/test_dashboard_frontend_smoke.py
+++ b/tests/test_dashboard_frontend_smoke.py
@@ -157,6 +157,19 @@ def test_appjs_routes_skillhub_detail_by_source():
     assert "/ux/atoms?days=" in js
 
 
+def test_admin_drawer_separates_current_push_from_history():
+    """当前推送不回退成历史总数；历史曝光独立按需分页。"""
+    js = (STATIC / "app.js").read_text(encoding="utf-8")
+
+    assert "u.current_slots != null ? u.current_slots : '—'" in js
+    assert "u.current_slots != null ? u.current_slots : u.exposures" not in js
+    assert "adm-history-toggle" in js
+    assert "async function loadAdminRecommendationHistory(" in js
+    assert "/recommendations?offset=" in js
+    assert "按首次曝光时间倒序" in js
+    assert "adm-history-page" in js
+
+
 def test_pipeline_log_scroll_is_sticky_not_forced():
     """#178: 流水线日志仅在贴底时跟随；pmStartLog 用 kind/name 比较，避免抽屉重渲染重启轮询。"""
     js = (STATIC / "app.js").read_text(encoding="utf-8")

--- a/tests/test_dashboard_standalone.py
+++ b/tests/test_dashboard_standalone.py
@@ -76,6 +76,7 @@ _BUILTIN_ONLY_OPERATIONS = {
     ("put", "/api/v1/dashboard/admin/client/{client_id}/ingest"),
     ("get", "/api/v1/dashboard/admin/user/{user_key}/prefs"),
     ("get", "/api/v1/dashboard/admin/user/{user_key}/assignment"),
+    ("get", "/api/v1/dashboard/admin/user/{user_key}/recommendations"),
     ("post", "/api/v1/dashboard/admin/prefs"),
     ("get", "/api/v1/dashboard/admin/cluster-graph"),
     ("get", "/api/v1/dashboard/admin/skills"),


### PR DESCRIPTION
## Summary

Separate current manifest assignments from paginated historical recommendation exposure.

## Changes

- Add an admin-only lazy history endpoint and drawer pagination while keeping current push as the primary view.

## Test plan

- [ ] `make test` passes
- [x] Added/updated unit tests for the change
- [ ] `make e2e` passes (if the change touches ingestion / install / daemon)
- [ ] Manually verified the affected user flow

Focused verification:

- `.venv/bin/python -m pytest tests/test_dashboard_console_p2.py tests/test_dashboard_frontend_smoke.py tests/test_dashboard_standalone.py -q` — passed
- `.venv/bin/python -m pytest tests/ --ignore=tests/docker_e2e --ignore=tests/live --ignore=tests/e2e --ignore=tests/test_windows_script_encoding.py -m "not nightly" --deselect=tests/test_connect_service.py::test_linux_selects_detached_when_systemd_unavailable -q` — passed
- `.venv/bin/python -m ruff check src/xskill/dashboard/console.py tests/test_dashboard_console_p2.py tests/test_dashboard_frontend_smoke.py tests/test_dashboard_standalone.py` — passed

## Linked issues

Closes #167
