### PR TITLE
test(team): widen profile-refresh idle wait to remove Windows CI flake

### DIFF
--- a/tests/test_team_sync_profile.py
+++ b/tests/test_team_sync_profile.py
@@ -160,6 +160,16 @@ def _headers(client_id: str) -> dict[str, str]:
     return {"X-Xskill-Token": "tok", "X-Xskill-Client": client_id}
 
 
+# 等待后台画像刷新收尾的统一上限。这些断言验证的是「刷新最终会完成」，
+# 不是「须在多少秒内完成」——「sync 先返回、刷新在后台」的性质由响应先到
+# / 版本号未变等断言单独保障。上限从 2 秒放宽到 10 秒：Windows CI 运行器
+# 慢且负载波动大（约为 Linux 的六分之一速度），2 秒是压线值，2026-08-19
+# 同日在三个不同分支的矩阵上偶发超时（zero_slots 用例，禁用分发时 sync
+# 立即返回，后台刷新几乎没有提前量，窗口最紧）。快路径下等待立即返回，
+# 放宽上限不增加正常轮次的耗时。
+IDLE_WAIT_SECONDS = 10
+
+
 def test_sync_returns_before_uncached_embedding_finishes(team_runtime):
     engine, embed, service, client, client_id, _registry, _traj_root = team_runtime
     embed.block = True
@@ -174,7 +184,7 @@ def test_sync_returns_before_uncached_embedding_finishes(team_runtime):
     assert engine.profile_store.load(client_id) is None
     assert service.metrics["running"] == 1
     embed.release.set()
-    assert service.wait_idle(timeout=2)
+    assert service.wait_idle(timeout=IDLE_WAIT_SECONDS)
     assert engine.profile_store.load(client_id)["feature_tensor"] is not None
 
 
@@ -206,7 +216,7 @@ def test_zero_slots_skips_preference_reads_but_still_refreshes_profile(
     assert response.json()["slots"] == []
     assert preference_calls == []
     assert embed.started.wait(2)
-    assert service.wait_idle(timeout=2)
+    assert service.wait_idle(timeout=IDLE_WAIT_SECONDS)
     assert engine.profile_store.load(client_id) is not None
 
 
@@ -233,7 +243,7 @@ def test_sync_uses_old_profile_then_refreshes_in_background(team_runtime):
     assert embed.started.wait(2)
     assert engine.profile_store.get_revision(client_id)["source_revision"] == old_revision
     embed.release.set()
-    assert service.wait_idle(timeout=2)
+    assert service.wait_idle(timeout=IDLE_WAIT_SECONDS)
     assert engine.profile_store.get_revision(client_id)["source_revision"] != old_revision
 
 
@@ -292,7 +302,7 @@ def test_repeated_sync_for_same_client_is_coalesced(team_runtime):
     assert embed.calls == 1
     assert service.metrics["coalesced"] == 1
     embed.release.set()
-    assert service.wait_idle(timeout=2)
+    assert service.wait_idle(timeout=IDLE_WAIT_SECONDS)
 
 
 def test_thirty_clients_return_while_embedding_is_bounded(tmp_path, monkeypatch):
@@ -380,7 +390,7 @@ def test_thirty_clients_return_while_embedding_is_bounded(tmp_path, monkeypatch)
         assert service.metrics["queued"] + service.metrics["running"] == 30
 
         embed.release.set()
-        assert service.wait_idle(timeout=10)
+        assert service.wait_idle(timeout=IDLE_WAIT_SECONDS)
         assert embed.items == 30
         assert service.metrics["embed_items"] == 30
         assert service.metrics["failed"] == 0


### PR DESCRIPTION
## Summary

消除 `tests/test_team_sync_profile.py` 在 Windows CI 上的偶发超时。2026-08-19 同日在三个不同分支的 Windows 矩阵上失败三次（#243 py3.9、#260 py3.10 与 py3.11），均为同一用例 `test_zero_slots_skips_preference_reads_but_still_refreshes_profile` 的 `service.wait_idle(timeout=2)` 断言，重跑即通过。

## Changes

该文件四处 `wait_idle(timeout=2)` 统一放宽为常量 `IDLE_WAIT_SECONDS = 10`（同文件已有 10 秒的既有用例，一并统一为该常量）。理由：

- 这些断言验证的是「后台画像刷新最终会完成」，不含时限语义；「sync 先返回、刷新在后台」的性质由响应先到、版本号未变等断言单独保障，放宽上限不损失任何检验力。
- Windows 运行器约为 Linux 六分之一速度且负载波动大，2 秒是压线值；zero_slots 用例窗口最紧（禁用分发时 sync 立即返回，后台刷新几乎没有提前量），因此三次失败都落在它身上。
- 等待是条件变量快路径，刷新完成即返回——正常轮次耗时不变，只有真出问题时才会等满 10 秒后失败。

## Test plan

- [x] `pytest tests/test_team_sync_profile.py`（9 passed）
- [x] 与 #250 处理 Windows 时序偶发的既有做法一致（放宽边界 / 条件等待，不加重试标记）

## Linked issues

无独立 issue；失败记录见 #260 与 #243 的对应 CI 轮次。