### PR TITLE
feat(generate): hide on-hold trajectories from explore tools

### DIFF
--- a/src/xskill/agents/agent_tools.py
+++ b/src/xskill/agents/agent_tools.py
@@ -15,13 +15,13 @@ from __future__ import annotations
 import contextlib
 import contextvars
 import copy
+import hashlib
 import json
 import logging
 import os
 import re
 import shutil
 import subprocess
-import uuid
 from collections.abc import Iterator, Mapping
 from dataclasses import dataclass, replace
 from datetime import date, datetime
@@ -518,7 +518,10 @@ def _onhold_block_message(path: Path | str) -> str:
 
 
 def _maybe_spill_list_files(body: str, listed_path: Path) -> str:
-    """If a directory listing is too large, write it to spill_root and tell the model to page it."""
+    """超长列表写入 spill 文件，文件名由目录路径哈希决定，同一目录覆盖同一文件。
+
+    没有 spill_root 时保持整份列表，不截断——否则模型没有翻页入口。
+    """
     lines = body.splitlines()
     too_long = (
         len(lines) > _LIST_FILES_INLINE_MAX_LINES
@@ -527,19 +530,13 @@ def _maybe_spill_list_files(body: str, listed_path: Path) -> str:
     if not too_long:
         return body
     ctx = current_agent_tool_context()
-    spill_root = ctx.spill_root
-    if spill_root is None:
-        kept = "\n".join(lines[:_LIST_FILES_INLINE_MAX_LINES])
-        omitted = max(0, len(lines) - _LIST_FILES_INLINE_MAX_LINES)
-        return (
-            f"{kept}\n"
-            f"... (truncated {omitted} entries — 目录过长。"
-            "请收窄 path，或对具体文件用 read_file 按行读取)"
-        )
-    spill_dir = Path(spill_root)
+    if ctx.spill_root is None:
+        return body
+    spill_dir = Path(ctx.spill_root) / "list_files"
     spill_dir.mkdir(parents=True, exist_ok=True)
-    spill_path = spill_dir / f"{uuid.uuid4().hex}_list_files.txt"
-    spill_path.write_text(body, encoding="utf-8")
+    digest = hashlib.sha256(str(listed_path).encode("utf-8")).hexdigest()[:16]
+    spill_path = spill_dir / f"{digest}.txt"
+    spill_path.write_text(body + "\n", encoding="utf-8")
     return "\n".join((
         "[list_files_spilled]",
         f"listed_path: {listed_path}",

--- a/src/xskill/agents/agent_tools.py
+++ b/src/xskill/agents/agent_tools.py
@@ -21,6 +21,7 @@ import os
 import re
 import shutil
 import subprocess
+import uuid
 from collections.abc import Iterator, Mapping
 from dataclasses import dataclass, replace
 from datetime import date, datetime
@@ -87,6 +88,7 @@ class AgentToolContext:
     registry_db_path: Path | None = None
     extra_read_roots: tuple[Path, ...] = ()
     generate_user_id: str | None = None
+    blocked_read_roots: tuple[Path, ...] = ()
 
     def __post_init__(self) -> None:
         object.__setattr__(
@@ -102,6 +104,8 @@ class AgentToolContext:
             )
         extra = tuple(Path(p) for p in (self.extra_read_roots or ()))
         object.__setattr__(self, "extra_read_roots", extra)
+        blocked = tuple(Path(p) for p in (self.blocked_read_roots or ()))
+        object.__setattr__(self, "blocked_read_roots", blocked)
 
 
 _EMPTY_AGENT_TOOL_CONTEXT = AgentToolContext()
@@ -131,6 +135,7 @@ def create_agent_tool_context(
     registry_db_path=None,
     extra_read_roots=(),
     generate_user_id=None,
+    blocked_read_roots=(),
 ) -> AgentToolContext:
     """Create an immutable context without changing the current task."""
     return AgentToolContext(
@@ -168,6 +173,9 @@ def create_agent_tool_context(
         extra_read_roots=tuple(Path(p) for p in (extra_read_roots or ())),
         generate_user_id=(
             str(generate_user_id) if generate_user_id else None
+        ),
+        blocked_read_roots=tuple(
+            Path(p) for p in (blocked_read_roots or ())
         ),
     )
 
@@ -293,6 +301,7 @@ class AgentToolConfig:
             "registry_db_path": current.registry_db_path,
             "extra_read_roots": current.extra_read_roots,
             "generate_user_id": current.generate_user_id,
+            "blocked_read_roots": current.blocked_read_roots,
         }
 
     def restore(self, snapshot: dict) -> None:
@@ -313,6 +322,7 @@ class AgentToolConfig:
             registry_db_path=snapshot.get("registry_db_path"),
             extra_read_roots=snapshot.get("extra_read_roots") or (),
             generate_user_id=snapshot.get("generate_user_id"),
+            blocked_read_roots=snapshot.get("blocked_read_roots") or (),
         ))
         if not snapshot.get("configured", True):
             current = _AGENT_TOOL_CONTEXT.get()
@@ -467,6 +477,77 @@ def _is_relative_to(path: Path, root: Path) -> bool:
         return True
     except ValueError:
         return False
+
+
+_LIST_FILES_INLINE_MAX_LINES = 200
+_LIST_FILES_INLINE_MAX_CHARS = 10000
+_ONHOLD_BLOCK_ERROR = "error: on hold 轨迹，不要参考"
+
+
+def _blocked_read_roots() -> list[Path]:
+    ctx = current_agent_tool_context()
+    roots: list[Path] = []
+    seen: set[str] = set()
+    for raw in ctx.blocked_read_roots or ():
+        path = Path(raw)
+        try:
+            resolved = path.resolve()
+        except OSError:
+            resolved = path
+        key = str(resolved)
+        if key in seen:
+            continue
+        seen.add(key)
+        roots.append(resolved)
+    return roots
+
+
+def _is_blocked_read_path(path: Path) -> bool:
+    try:
+        resolved = path.resolve()
+    except OSError:
+        resolved = path
+    for root in _blocked_read_roots():
+        if resolved == root or _is_relative_to(resolved, root):
+            return True
+    return False
+
+
+def _onhold_block_message(path: Path | str) -> str:
+    return f"{_ONHOLD_BLOCK_ERROR} ({path})"
+
+
+def _maybe_spill_list_files(body: str, listed_path: Path) -> str:
+    """If a directory listing is too large, write it to spill_root and tell the model to page it."""
+    lines = body.splitlines()
+    too_long = (
+        len(lines) > _LIST_FILES_INLINE_MAX_LINES
+        or len(body) > _LIST_FILES_INLINE_MAX_CHARS
+    )
+    if not too_long:
+        return body
+    ctx = current_agent_tool_context()
+    spill_root = ctx.spill_root
+    if spill_root is None:
+        kept = "\n".join(lines[:_LIST_FILES_INLINE_MAX_LINES])
+        omitted = max(0, len(lines) - _LIST_FILES_INLINE_MAX_LINES)
+        return (
+            f"{kept}\n"
+            f"... (truncated {omitted} entries — 目录过长。"
+            "请收窄 path，或对具体文件用 read_file 按行读取)"
+        )
+    spill_dir = Path(spill_root)
+    spill_dir.mkdir(parents=True, exist_ok=True)
+    spill_path = spill_dir / f"{uuid.uuid4().hex}_list_files.txt"
+    spill_path.write_text(body, encoding="utf-8")
+    return "\n".join((
+        "[list_files_spilled]",
+        f"listed_path: {listed_path}",
+        f"entries: {len(lines)}",
+        f"spill_path: {spill_path}",
+        f"chars: {len(body)}",
+        "reload: 用 read_file(spill_path, offset=1, limit=200) 按行读取，需要时增大 offset 翻页。",
+    ))
 
 
 SENSITIVE_FILENAMES = frozenset({
@@ -681,6 +762,8 @@ def read_file(path: str, offset: int = 1, limit: int = 200) -> str:
             f"resolved_path: {resolved}\n"
             f"allowed_roots:\n{allowed_block}"
         )
+    if _is_blocked_read_path(resolved):
+        return _onhold_block_message(resolved)
     if _is_sensitive_file(resolved):
         return f"error: sensitive file, not readable by agent ({path})"
 
@@ -1614,21 +1697,29 @@ def list_files(path: str) -> str:
 
     可列 skill 仓、~/.xskill、/tmp spill 三个只读根内的任意目录——摸清 skill
     已有文件、轨迹 / atom 数据布局都用它。越界返回 error。
+    on hold 轨迹目录会被拦截，不出现在列表里。
+    目录条目过多时完整列表写入 spill 文件，请用 read_file 按行翻页。
     """
     target_directory = Path(path).resolve()
     roots = _allowed_read_roots()
     if not any(_is_relative_to(target_directory, root) for root in roots):
         allowed_block = ", ".join(str(root) for root in roots)
         return f"error: list_files restricted to {allowed_block} (tried: {path})"
+    if _is_blocked_read_path(target_directory):
+        return _onhold_block_message(target_directory)
     if not target_directory.is_dir():
         return f"error: not a directory: {path}"
     entries = sorted(target_directory.iterdir())
     if not entries:
         return "(empty)"
-    return "\n".join(
+    visible = [e for e in entries if not _is_blocked_read_path(e)]
+    if not visible:
+        return "(empty)"
+    body = "\n".join(
         f"{'[dir] ' if e.is_dir() else '[file] '}{e.resolve()}{'/' if e.is_dir() else ''}"
-        for e in entries
+        for e in visible
     )
+    return _maybe_spill_list_files(body, target_directory)
 
 
 @tool(name="grep_files")
@@ -1648,6 +1739,8 @@ def grep_files(pattern: str, path: str = "", glob: str = "",
     if not any(_is_relative_to(search_root, root) for root in roots):
         allowed_block = ", ".join(str(root) for root in roots)
         return f"error: grep_files restricted to {allowed_block} (tried: {path})"
+    if _is_blocked_read_path(search_root):
+        return _onhold_block_message(search_root)
     if not search_root.exists():
         return f"error: path not found ({path})"
 
@@ -1716,6 +1809,8 @@ def grep_files(pattern: str, path: str = "", glob: str = "",
         hit_match = hit_line_pattern.match(output_line)
         # resolve() 后再判敏感：防符号链接用无害文件名包装密钥文件绕过过滤。
         if hit_match and _is_sensitive_file(Path(hit_match.group(1)).resolve()):
+            continue
+        if hit_match and _is_blocked_read_path(Path(hit_match.group(1))):
             continue
         filtered_lines.append(output_line)
         if len(filtered_lines) >= max_results:

--- a/src/xskill/agents/generate_agent.py
+++ b/src/xskill/agents/generate_agent.py
@@ -13,6 +13,8 @@ from typing import Any, Callable
 
 logger = logging.getLogger("xskill.generate_agent")
 
+ONHOLD_PROMPT_LINE = "不要参考 on hold 轨迹。"
+
 SYSTEM_PROMPT = """你是 XSkill 的 GenerateAgent。用户通过 `xskill generate` 发来一条指令，
 要你立刻新建或改写一个 skill，并且提交到主干分支 main。
 
@@ -30,6 +32,8 @@ scripts/ 下放可执行脚本、在 references/ 下放长参考材料。价值�
 优先阅读范围：{name_hint}
 这不是禁读名单。磁盘上你能读到的轨迹目录都可以搜；上面列出的人只是
 用户希望你先看的范围。
+
+不要参考 on hold 轨迹。
 
 # 你可以读的目录
 
@@ -53,7 +57,7 @@ scripts/ 下放可执行脚本、在 references/ 下放长参考材料。价值�
 
 # 可用工具
 
-- list_files(path)
+- list_files(path)：目录条目过多时完整列表写入 spill 文件，用 read_file 按行翻页。
 - grep_files(pattern, path="", glob="", max_results=100)
 - read_file(path, offset=1, limit=200)
 - skill_read(skill_name)

--- a/src/xskill/team/server/client_registry.py
+++ b/src/xskill/team/server/client_registry.py
@@ -60,6 +60,85 @@ def client_id_from_name(name: str) -> str:
 _SAFE_DIR_RE = re.compile(r"[^A-Za-z0-9._-]")
 
 
+def list_paused_client_dir_names(db_path: Path | str | None) -> list[str]:
+    """Return filesystem dir names for clients with ingest_paused=1.
+
+    Lightweight read: does not construct ClientRegistry (no touch timer).
+    Missing db / missing table / missing column → empty list.
+    """
+    if not db_path:
+        return []
+    path = Path(db_path)
+    if not path.is_file():
+        return []
+    try:
+        conn = sqlite3.connect(str(path), timeout=5)
+        conn.row_factory = sqlite3.Row
+        try:
+            tables = {
+                row[0]
+                for row in conn.execute(
+                    "SELECT name FROM sqlite_master WHERE type='table'"
+                )
+            }
+            if "clients" not in tables:
+                return []
+            cols = {
+                row["name"] for row in conn.execute("PRAGMA table_info(clients)")
+            }
+            if "client_id" not in cols:
+                return []
+            if "ingest_paused" not in cols:
+                return []
+            user_col = "user_name" if "user_name" in cols else None
+            select = "client_id" + (", user_name" if user_col else "")
+            rows = conn.execute(
+                f"SELECT {select} FROM clients WHERE ingest_paused=1"
+            ).fetchall()
+        finally:
+            conn.close()
+    except sqlite3.Error:
+        logger.debug("list_paused_client_dir_names failed on %s", path, exc_info=True)
+        return []
+    names: list[str] = []
+    seen: set[str] = set()
+    for row in rows:
+        client_id = str(row["client_id"] or "").strip()
+        if not client_id:
+            continue
+        raw_name = ""
+        if user_col:
+            raw_name = str(row["user_name"] or "").strip()
+        try:
+            dir_name = safe_dir_name(raw_name or None, client_id)
+        except ValueError:
+            dir_name = client_id
+        if dir_name in seen:
+            continue
+        seen.add(dir_name)
+        names.append(dir_name)
+    return names
+
+
+def paused_trajectory_roots(
+    traj_root: Path | str | None,
+    clients_db_path: Path | str | None,
+) -> tuple[Path, ...]:
+    """Absolute client trajectory trees that generate must not read."""
+    if traj_root is None:
+        return ()
+    root = Path(traj_root)
+    names = list_paused_client_dir_names(clients_db_path)
+    blocked: list[Path] = []
+    for name in names:
+        client_dir = root / "clients" / name
+        try:
+            blocked.append(client_dir.resolve())
+        except OSError:
+            blocked.append(client_dir)
+    return tuple(blocked)
+
+
 def safe_dir_name(user_name: str | None, client_id: str) -> str:
     """文件系统目录名：优先用 user_name 明文（安全转义），匿名用 client_id。
 

--- a/src/xskill/team/server/generate_jobs.py
+++ b/src/xskill/team/server/generate_jobs.py
@@ -329,6 +329,54 @@ def collect_read_roots(
     return unique
 
 
+def exclude_blocked_read_roots(
+    roots: list[Path],
+    blocked: tuple[Path, ...] | list[Path],
+) -> list[Path]:
+    """Drop roots that are an on-hold client tree or sit inside one."""
+    if not blocked:
+        return list(roots)
+    blocked_resolved: list[Path] = []
+    for raw in blocked:
+        path = Path(raw)
+        try:
+            blocked_resolved.append(path.resolve())
+        except OSError:
+            blocked_resolved.append(path)
+
+    def _is_blocked(path: Path) -> bool:
+        try:
+            resolved = path.resolve() if path.exists() else path
+        except OSError:
+            resolved = path
+        for root in blocked_resolved:
+            if resolved == root:
+                return True
+            try:
+                resolved.relative_to(root)
+                return True
+            except ValueError:
+                continue
+        return False
+
+    return [path for path in roots if not _is_blocked(path)]
+
+
+def collect_blocked_traj_roots(
+    traj_root: Path | None,
+    clients_db_path: Path | None = None,
+) -> tuple[Path, ...]:
+    from xskill.config import get_team_clients_db_path
+    from xskill.team.server.client_registry import paused_trajectory_roots
+
+    if traj_root is None:
+        return ()
+    db_path = clients_db_path
+    if db_path is None:
+        db_path = get_team_clients_db_path()
+    return paused_trajectory_roots(traj_root, db_path)
+
+
 def pin_generated_skills(
     *,
     user_id: str,
@@ -438,6 +486,7 @@ def _run_generate_job_body(
     config: dict,
     db_path: Path | None = None,
     logs_dir: Path | None = None,
+    clients_db_path: Path | None = None,
 ) -> None:
     from xskill.agents import agent_tools
     from xskill.agents.agno_factory import make_default_factory
@@ -446,6 +495,10 @@ def _run_generate_job_body(
 
     skill_dir = Path(skill_dir)
     extra_roots = collect_read_roots(skill_dir, traj_root, db_path=db_path)
+    blocked_roots = collect_blocked_traj_roots(
+        traj_root, clients_db_path=clients_db_path,
+    )
+    extra_roots = exclude_blocked_read_roots(extra_roots, blocked_roots)
     logs_dir = Path(logs_dir) if logs_dir is not None else get_logs_dir()
     spill_root = (
         logs_dir / "agents" / "generate_agents" / job["user_id"] / "spill" / job["job_id"]
@@ -463,6 +516,7 @@ def _run_generate_job_body(
         extra_read_roots=tuple(extra_roots),
         generate_user_id=job["user_id"],
         registry_db_path=resolved_db,
+        blocked_read_roots=blocked_roots,
     )
     llm_cfg = {**(config.get("llm") or {}), **(config.get("llm_skill") or {})}
     factory = make_default_factory(

--- a/tests/test_generate_onhold.py
+++ b/tests/test_generate_onhold.py
@@ -1,0 +1,141 @@
+"""on hold 轨迹：generate 提示词单列一行；list/grep/read 拦截；list 超长 spill。"""
+from __future__ import annotations
+
+from pathlib import Path
+
+from xskill.agents import agent_tools
+from xskill.agents.generate_agent import ONHOLD_PROMPT_LINE, SYSTEM_PROMPT
+from xskill.team.server.client_registry import (
+    ClientRegistry,
+    list_paused_client_dir_names,
+    paused_trajectory_roots,
+)
+from xskill.team.server.generate_jobs import exclude_blocked_read_roots
+
+
+def test_onhold_prompt_is_its_own_line():
+    lines = SYSTEM_PROMPT.splitlines()
+    assert ONHOLD_PROMPT_LINE in lines
+    assert lines.count(ONHOLD_PROMPT_LINE) == 1
+    assert ONHOLD_PROMPT_LINE.strip() == ONHOLD_PROMPT_LINE
+
+
+def _traj_ctx(tmp_path: Path, blocked: tuple[Path, ...], spill: bool = True):
+    skill_dir = tmp_path / "skill"
+    skill_dir.mkdir()
+    traj_root = tmp_path / "team_trajectories"
+    live = traj_root / "clients" / "alice" / "sessions"
+    held = traj_root / "clients" / "bob" / "sessions"
+    live.mkdir(parents=True)
+    held.mkdir(parents=True)
+    (live / "traj_ok.md").write_text("live evidence\n", encoding="utf-8")
+    (held / "traj_secret.md").write_text("secret evidence\n", encoding="utf-8")
+    spill_root = tmp_path / "spill" if spill else None
+    if spill_root is not None:
+        spill_root.mkdir()
+    ctx = agent_tools.create_agent_tool_context(
+        skill_dir=skill_dir,
+        extra_read_roots=(traj_root,),
+        blocked_read_roots=blocked or (traj_root / "clients" / "bob",),
+        spill_root=spill_root,
+    )
+    return traj_root, live, held, ctx
+
+
+def test_list_files_omits_onhold_client_dir(tmp_path):
+    traj_root, live, held, ctx = _traj_ctx(tmp_path, ())
+    with agent_tools.use_agent_tool_context(ctx):
+        listing = agent_tools.list_files.entrypoint(str(traj_root / "clients"))
+    assert "alice" in listing
+    assert "bob" not in listing
+    with agent_tools.use_agent_tool_context(ctx):
+        blocked = agent_tools.list_files.entrypoint(str(held.parent))
+    assert blocked.startswith("error: on hold 轨迹，不要参考")
+
+
+def test_read_and_grep_block_onhold_trajs(tmp_path):
+    traj_root, live, held, ctx = _traj_ctx(tmp_path, ())
+    secret = held / "traj_secret.md"
+    live_file = live / "traj_ok.md"
+    with agent_tools.use_agent_tool_context(ctx):
+        denied = agent_tools.read_file.entrypoint(str(secret))
+        allowed = agent_tools.read_file.entrypoint(str(live_file))
+        grep_all = agent_tools.grep_files.entrypoint("evidence", path=str(traj_root))
+        grep_held = agent_tools.grep_files.entrypoint(
+            "secret", path=str(held),
+        )
+    assert denied.startswith("error: on hold 轨迹，不要参考")
+    assert "secret evidence" not in denied
+    assert "live evidence" in allowed
+    assert "traj_ok.md" in grep_all
+    assert "traj_secret.md" not in grep_all
+    assert grep_held.startswith("error: on hold 轨迹，不要参考")
+
+
+def test_list_files_spills_long_listing(tmp_path):
+    skill_dir = tmp_path / "skill"
+    skill_dir.mkdir()
+    fat = tmp_path / "fat"
+    fat.mkdir()
+    for index in range(220):
+        (fat / f"file_{index:03d}.txt").write_text("x\n", encoding="utf-8")
+    spill_root = tmp_path / "spill"
+    spill_root.mkdir()
+    ctx = agent_tools.create_agent_tool_context(
+        skill_dir=skill_dir,
+        extra_read_roots=(fat,),
+        spill_root=spill_root,
+    )
+    with agent_tools.use_agent_tool_context(ctx):
+        out = agent_tools.list_files.entrypoint(str(fat))
+    assert "[list_files_spilled]" in out
+    assert "read_file(spill_path, offset=1, limit=200)" in out
+    assert "file_000.txt" not in out
+    spill_line = [
+        line for line in out.splitlines() if line.startswith("spill_path:")
+    ][0]
+    spill_path = Path(spill_line.split(":", 1)[1].strip())
+    spilled = spill_path.read_text(encoding="utf-8")
+    assert "file_000.txt" in spilled
+    assert spilled.count("\n") + 1 >= 220
+    with agent_tools.use_agent_tool_context(ctx):
+        page = agent_tools.read_file.entrypoint(str(spill_path), offset=1, limit=20)
+    assert "file_000.txt" in page
+
+
+def test_paused_client_dirs_become_blocked_roots(tmp_path):
+    db_path = tmp_path / "team_clients.db"
+    registry = ClientRegistry(db_path)
+    try:
+        live_id = registry.register(user_name="alice")
+        held_id = registry.register(user_name="bob")
+        registry.set_ingest_paused(held_id, True, actor="boss")
+        assert registry.is_ingest_paused(live_id) is False
+    finally:
+        registry.close()
+    traj_root = tmp_path / "team_trajectories"
+    (traj_root / "clients" / "alice").mkdir(parents=True)
+    (traj_root / "clients" / "bob").mkdir(parents=True)
+    names = list_paused_client_dir_names(db_path)
+    assert names == ["bob"]
+    blocked = paused_trajectory_roots(traj_root, db_path)
+    assert any(path.name == "bob" for path in blocked)
+    assert all(path.name != "alice" for path in blocked)
+    roots = [
+        traj_root,
+        traj_root / "clients",
+        traj_root / "clients" / "alice" / "sessions",
+        traj_root / "clients" / "bob" / "sessions",
+    ]
+    kept = exclude_blocked_read_roots(roots, blocked)
+    kept_names = {path.name for path in kept}
+    assert "alice" in {path.parent.name for path in kept if path.name == "sessions"}
+    assert "bob" not in {path.parent.name for path in kept if path.name == "sessions"}
+    assert traj_root in kept
+    assert (traj_root / "clients") in kept
+    assert "sessions" in kept_names
+
+
+def test_missing_clients_db_blocks_nothing(tmp_path):
+    assert list_paused_client_dir_names(tmp_path / "nope.db") == []
+    assert paused_trajectory_roots(tmp_path / "traj", tmp_path / "nope.db") == ()

--- a/tests/test_generate_onhold.py
+++ b/tests/test_generate_onhold.py
@@ -18,6 +18,11 @@ def test_onhold_prompt_is_its_own_line():
     assert ONHOLD_PROMPT_LINE in lines
     assert lines.count(ONHOLD_PROMPT_LINE) == 1
     assert ONHOLD_PROMPT_LINE.strip() == ONHOLD_PROMPT_LINE
+    assert (
+        SYSTEM_PROMPT.index("优先阅读范围")
+        < SYSTEM_PROMPT.index(ONHOLD_PROMPT_LINE)
+        < SYSTEM_PROMPT.index("# 你可以读的目录")
+    )
 
 
 def _traj_ctx(tmp_path: Path, blocked: tuple[Path, ...], spill: bool = True):
@@ -29,7 +34,7 @@ def _traj_ctx(tmp_path: Path, blocked: tuple[Path, ...], spill: bool = True):
     live.mkdir(parents=True)
     held.mkdir(parents=True)
     (live / "traj_ok.md").write_text("live evidence\n", encoding="utf-8")
-    (held / "traj_secret.md").write_text("secret evidence\n", encoding="utf-8")
+    (held / "traj_held.md").write_text("secret evidence\n", encoding="utf-8")
     spill_root = tmp_path / "spill" if spill else None
     if spill_root is not None:
         spill_root.mkdir()
@@ -55,7 +60,7 @@ def test_list_files_omits_onhold_client_dir(tmp_path):
 
 def test_read_and_grep_block_onhold_trajs(tmp_path):
     traj_root, live, held, ctx = _traj_ctx(tmp_path, ())
-    secret = held / "traj_secret.md"
+    secret = held / "traj_held.md"
     live_file = live / "traj_ok.md"
     with agent_tools.use_agent_tool_context(ctx):
         denied = agent_tools.read_file.entrypoint(str(secret))
@@ -68,8 +73,15 @@ def test_read_and_grep_block_onhold_trajs(tmp_path):
     assert "secret evidence" not in denied
     assert "live evidence" in allowed
     assert "traj_ok.md" in grep_all
-    assert "traj_secret.md" not in grep_all
+    assert "traj_held.md" not in grep_all
     assert grep_held.startswith("error: on hold 轨迹，不要参考")
+
+
+def _spill_path_from_listing(out: str) -> Path:
+    spill_line = [
+        line for line in out.splitlines() if line.startswith("spill_path:")
+    ][0]
+    return Path(spill_line.split(":", 1)[1].strip())
 
 
 def test_list_files_spills_long_listing(tmp_path):
@@ -88,19 +100,71 @@ def test_list_files_spills_long_listing(tmp_path):
     )
     with agent_tools.use_agent_tool_context(ctx):
         out = agent_tools.list_files.entrypoint(str(fat))
+        again = agent_tools.list_files.entrypoint(str(fat))
     assert "[list_files_spilled]" in out
     assert "read_file(spill_path, offset=1, limit=200)" in out
     assert "file_000.txt" not in out
-    spill_line = [
-        line for line in out.splitlines() if line.startswith("spill_path:")
-    ][0]
-    spill_path = Path(spill_line.split(":", 1)[1].strip())
+    spill_path = _spill_path_from_listing(out)
+    assert _spill_path_from_listing(again) == spill_path
+    assert spill_path.parent.name == "list_files"
     spilled = spill_path.read_text(encoding="utf-8")
     assert "file_000.txt" in spilled
-    assert spilled.count("\n") + 1 >= 220
+    assert "file_219.txt" in spilled
+    assert spilled.count("\n") >= 220
     with agent_tools.use_agent_tool_context(ctx):
         page = agent_tools.read_file.entrypoint(str(spill_path), offset=1, limit=20)
+        last = agent_tools.read_file.entrypoint(str(spill_path), offset=201, limit=30)
     assert "file_000.txt" in page
+    assert "file_219.txt" in last
+
+
+def test_list_files_short_listing_stays_inline(tmp_path):
+    skill_dir = tmp_path / "skill"
+    skill_dir.mkdir()
+    small = tmp_path / "small"
+    small.mkdir()
+    (small / "traj_0001.md").write_text("x\n", encoding="utf-8")
+    spill_root = tmp_path / "spill"
+    spill_root.mkdir()
+    ctx = agent_tools.create_agent_tool_context(
+        skill_dir=skill_dir,
+        extra_read_roots=(small,),
+        spill_root=spill_root,
+    )
+    with agent_tools.use_agent_tool_context(ctx):
+        out = agent_tools.list_files.entrypoint(str(small))
+    assert "[list_files_spilled]" not in out
+    assert "traj_0001.md" in out
+
+
+def test_list_files_without_spill_root_keeps_full_listing(tmp_path):
+    skill_dir = tmp_path / "skill"
+    skill_dir.mkdir()
+    fat = tmp_path / "fat"
+    fat.mkdir()
+    for index in range(220):
+        (fat / f"file_{index:03d}.txt").write_text("x\n", encoding="utf-8")
+    ctx = agent_tools.create_agent_tool_context(
+        skill_dir=skill_dir,
+        extra_read_roots=(fat,),
+    )
+    with agent_tools.use_agent_tool_context(ctx):
+        out = agent_tools.list_files.entrypoint(str(fat))
+    assert "[list_files_spilled]" not in out
+    assert "file_000.txt" in out
+    assert "file_219.txt" in out
+
+
+def test_read_onhold_without_blocked_roots_is_noop(tmp_path):
+    traj_root, _live, held, _ctx = _traj_ctx(tmp_path, ())
+    ctx = agent_tools.create_agent_tool_context(
+        skill_dir=tmp_path / "skill",
+        extra_read_roots=(traj_root,),
+        blocked_read_roots=(),
+    )
+    with agent_tools.use_agent_tool_context(ctx):
+        out = agent_tools.read_file.entrypoint(str(held / "traj_held.md"))
+    assert "secret evidence" in out
 
 
 def test_paused_client_dirs_become_blocked_roots(tmp_path):
@@ -139,3 +203,17 @@ def test_paused_client_dirs_become_blocked_roots(tmp_path):
 def test_missing_clients_db_blocks_nothing(tmp_path):
     assert list_paused_client_dir_names(tmp_path / "nope.db") == []
     assert paused_trajectory_roots(tmp_path / "traj", tmp_path / "nope.db") == ()
+
+
+def test_unpausing_removes_blocked_root(tmp_path):
+    db_path = tmp_path / "team_clients.db"
+    registry = ClientRegistry(db_path)
+    try:
+        held_id = registry.register(user_name="bob")
+        registry.set_ingest_paused(held_id, True, actor="boss")
+        assert list_paused_client_dir_names(db_path) == ["bob"]
+        registry.set_ingest_paused(held_id, False, actor="boss")
+    finally:
+        registry.close()
+    assert list_paused_client_dir_names(db_path) == []
+    assert paused_trajectory_roots(tmp_path / "traj", db_path) == ()


### PR DESCRIPTION
## Summary

Stop GenerateAgent from using paused (on hold) member trajectories, and page overlong `list_files` results through `read_file` instead of dumping them into the model context.

This is #265 rebased onto current main, plus the stable path-hash spill from #268: the same directory overwrites one spill file, and a missing `spill_root` keeps the full listing instead of truncating it. The generate hot path still reads `team_clients.db` directly and does not construct `ClientRegistry`.

## Changes

- Add a standalone GenerateAgent prompt line: `不要参考 on hold 轨迹。`
- Intercept `list_files`, `grep_files`, and `read_file` for `ingest_paused` client trees under `team_trajectories/clients/<dir>/`.
- Drop those watch roots from the generate readable-directory list.
- When a listing exceeds ~200 lines or ~10k chars, write the full listing to the job spill directory using a hash of the listed path, and tell the model to page it with `read_file(spill_path, offset=1, limit=200)`. This does not turn global context spill (`enable_spill`) back on.

## Test plan

- [x] Focused unit tests: `tests/test_generate_onhold.py tests/test_agent_tools_explore.py tests/test_generate_command.py tests/test_team_client_registry.py` — 55 passed
- [ ] `make test` / CI

## Linked issues

Closes #264
Supersedes #265 and #268


Made with [Cursor](https://cursor.com)