### PR TITLE
feat: 为 DeepSeek Harness 增加可安装的 dsh-xskill 插件

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -54,6 +54,10 @@ src/*.egg-info/
 .venv/
 venv/
 
+# dsh 插件本地安装残留
+node_modules/
+plugins/dsh-xskill/node_modules/
+
 # IDE
 .idea/
 .vscode/

--- a/README.en.md
+++ b/README.en.md
@@ -49,7 +49,7 @@ The moment one teammate works something out in their own session, that solution 
 
 ## 🧩 Across every agent &amp; device — one library
 
-Use Claude Code on your laptop, Codex on a server, Cursor in the IDE. xskill ingests redacted trajectories from all of them, evolves a single shared library, and syncs the result back to every agent you use.
+Use Claude Code on your laptop, Codex on a server, Cursor in the IDE, DeepSeek Harness (`dsh`) in the browser. xskill ingests redacted trajectories from all of them, evolves a single shared library, and syncs the result back to every agent you use.
 
 <div align="center">
 <img src="docs/assets/xs_crosscontext.svg" width="860" alt="Multiple agents and devices feed one trajectory watcher and one evolving skill library, which syncs back to all agents">
@@ -183,8 +183,22 @@ xskill upload ./my-skill       # package & upload a skill folder (with SKILL.md)
 | **OpenClaw** | 🟡 implemented | `~/.openclaw/agents/` | copy → `~/.agents/skills/<name>/` |
 | **Cursor** | 🟡 implemented | `~/.cursor/projects/*/agent-transcripts/` | symlink → `~/.cursor/skills/<name>/` |
 | **Trae** | 🟡 implemented | IDE `state.vscdb` / CLI `trajectory_*.json` | symlink → `~/.trae-cn/skills/`, `~/.trae/skills/` |
-| **DeepSeek Harness (dsh)** | 🟡 implemented | `~/.dsh/sessions/` (plaintext and default zstd sessions) | symlink → `~/.dsh/skills/<name>/` |
+| **DeepSeek Harness (dsh)** | 🟡 implemented | `~/.dsh/sessions/` (plaintext and default zstd sessions) | symlink → `~/.dsh/skills/<name>/`; or `dsh plugin add` the `dsh-xskill` bundle |
 | **Any other agent** | manual | SDK `xskill.adapters.submit_trajectory` | copy/symlink the `SKILL.md` dir |
+
+### Run inside DeepSeek Harness (dsh plugin)
+
+xskill already detects dsh, ingests its sessions, and symlinks evolved skills into `~/.dsh/skills/`. That is xskill pushing into dsh.
+
+dsh extensions are plugins: an npm package that declares `dsh.bundle`, installed into a profile (a bootable composition such as `web`) with `dsh plugin add`. This repo ships `dsh-xskill`. After install and a restart, dsh reads the local xskill library (default `~/.xskill/skill`) and gains `xskill_status`, `xskill_list`, and `xskill_search`.
+
+```bash
+dsh plugin --profile web add github:SkillNerds/xskill
+# local checkout:
+# dsh plugin --profile web add ./plugins/dsh-xskill
+```
+
+Restart `dsh web` (or `dsh --profile headless`). Keep `xskill serve` or `xskill connect` running so new dsh sessions become new skills. Details: [`plugins/dsh-xskill/README.md`](plugins/dsh-xskill/README.md).
 
 ## 📖 Concepts
 
@@ -208,6 +222,7 @@ xskill upload ./my-skill       # package & upload a skill folder (with SKILL.md)
 
 ## 📰 News
 
+- **2026-08-20**: DeepSeek Harness can `dsh plugin add github:SkillNerds/xskill` to load the `dsh-xskill` bundle and list or search locally evolved skills inside dsh.
 - **2026-08-14** `v0.6.31`: `xskill rebuild --force` no longer dies on a non-empty `.git/objects` directory; a full rebuild keeps skills brought in with `xskill import` and only wipes distilled ones.
 - **2026-08-14** `v0.6.30`: Team `xskill import` pins the skill onto the initiator's recommendation list; the skills library shows a hollow star to pin into your feed, plus whether a skill is already pushed or pinned; imported skills appear in the library list immediately.
 - **2026-08-14** `v0.6.30a3`: Team `xskill generate` prints queue/running status on the CLI instead of a blank wait; mixed legacy install history no longer blocks import from installing into harnesses.

--- a/README.md
+++ b/README.md
@@ -36,7 +36,7 @@
 xskill是企业级的团队skill演进方案，支持轨迹自动蒸馏Skill，基于轨迹画像推送Skill，支持导入团队skillhub进行推荐，支持skill评价。
 
 - **高手经验自动传递**： 一个人的解法自动到达全组，让最短路径不再壮志难酬。
-- **跨Harness和设备共享进化**： Codex、Claude Code、Cursor IDE都会加入光荣的进化,齐心,协力。
+- **跨Harness和设备共享进化**： Codex、Claude Code、Cursor IDE、DeepSeek Harness（dsh）都会加入光荣的进化,齐心,协力。
 - **支持专家修改Skill**： 觉得skill不完美？直接修改本地的skill，改动会被云端自动学习。
 - **轨迹保持私有**： 会话在上传前已脱敏，秘钥密码和相关隐私不会被别人看到。
 - **不让skill烂掉**： 自动评价skill，支持分析用户实际使用轨迹给出评价分并绘制不同**skill版本的得分趋势折线图**，大数据显微镜。
@@ -278,8 +278,24 @@ skillhub:
 | **OpenClaw** | 🟡 已实现 | `~/.openclaw/agents/` | 拷贝 → `~/.agents/skills/<name>/` |
 | **Cursor** | 🟡 已实现 | `~/.cursor/projects/*/agent-transcripts/` | 软链 → `~/.cursor/skills/<name>/` |
 | **Trae** | 🟡 已实现 | IDE `state.vscdb` / CLI `trajectory_*.json` | 软链 → `~/.trae-cn/skills/`、`~/.trae/skills/` |
-| **DeepSeek Harness (dsh)** | 🟡 已实现 | `~/.dsh/sessions/`（明文与默认 zstd 会话均可） | 软链 → `~/.dsh/skills/<name>/` |
+| **DeepSeek Harness (dsh)** | 🟡 已实现 | `~/.dsh/sessions/`（明文与默认 zstd 会话均可） | 软链 → `~/.dsh/skills/<name>/`；也可 `dsh plugin add` 装 `dsh-xskill` |
 | **任何其他 agent** | 手动 | SDK `xskill.adapters.submit_trajectory` | 拷贝/软链 `SKILL.md` 目录 |
+
+### 在 DeepSeek Harness 上跑（dsh 插件）
+
+xskill 已经能发现本机的 dsh、把会话收成轨迹、再把进化后的 skill 软链到 `~/.dsh/skills/`。那是 xskill 推给 dsh。
+
+dsh 自己的扩展方式是插件：一个带 `dsh.bundle` 声明的 npm 包，用 `dsh plugin add` 装进某个 profile（一份可启动的组合，例如 web）。本仓库带了一份这样的包 `dsh-xskill`。装上并重启后，dsh 会直接读本地 xskill 技能库（默认 `~/.xskill/skill`），不必只靠那条软链；同时多三个工具：`xskill_status`、`xskill_list`、`xskill_search`。
+
+```bash
+# 从本仓库安装（根目录 package.json 已声明 dsh.bundle，无需再写子目录路径）
+dsh plugin --profile web add github:SkillNerds/xskill
+
+# 本地 checkout
+dsh plugin --profile web add ./plugins/dsh-xskill
+```
+
+然后重启 `dsh web`（或 `dsh --profile headless`）。xskill 侧照常跑 `xskill serve` 或 `xskill connect`，负责蒸馏和把 dsh 会话收进来。安装说明见 [`plugins/dsh-xskill/README.md`](plugins/dsh-xskill/README.md)。
 
 ## 📖 概念
 
@@ -303,6 +319,7 @@ skillhub:
 
 
 ## 📰 动态
+- **2026-08-20**：DeepSeek Harness 可用 `dsh plugin add github:SkillNerds/xskill` 装上 `dsh-xskill` 插件，在 dsh 里直接列出、检索本地进化出的 skill。
 - **2026-08-14** `v0.6.31`：`xskill rebuild --force` 不再因 `.git/objects` 非空中断；全量 rebuild 会留下 `xskill import` 纳入的技能，只清蒸馏产物。
 - **2026-08-14** `v0.6.30`：team `xskill import` 后钉到发起人推荐列表；技能库登录后可点空心星 pin 进自己的推荐流，并标出推给我、已钉状态；import 后技能立即出现在技能库清单。
 - **2026-08-14** `v0.6.30a3`：`xskill generate` 排队和执行时 CLI 及时打出状态，不再干等；旧安装账本混入倒退序号时仍能 import 并装回 harness。

--- a/README.zh-CN.md
+++ b/README.zh-CN.md
@@ -21,6 +21,7 @@
 
 ## 动态
 
+- **2026-08-20** — DeepSeek Harness 可用 `dsh plugin add github:SkillNerds/xskill` 装上 `dsh-xskill`，在 dsh 里列出、检索本地进化出的 skill。
 - **2026-08-14** — `v0.6.31`：`xskill rebuild --force` 不再因 `.git/objects` 非空中断；全量 rebuild 会留下 `xskill import` 纳入的技能。详见 [Release notes](https://github.com/SkillNerds/xskill/releases/tag/v0.6.31)。
 - **2026-08-14** — `v0.6.30`：team `xskill import` 后钉到发起人推荐列表；技能库登录后可点空心星 pin 进自己的推荐流，并标出推给我、已钉状态。详见 [Release notes](https://github.com/SkillNerds/xskill/releases/tag/v0.6.30)。
 - **2026-08-03** — `v0.6.29a6`：`pymilvus` 改为可选（`xskill[milvus]`），修复 client 自动更新；「我的」页支持推给我 N 个 SKILL / 上传使用去向 / skill commit 状态。详见 [Release notes](https://github.com/SkillNerds/xskill/releases/tag/v0.6.29a6)。
@@ -66,7 +67,7 @@ embedding:
   dim:      0
 ```
 
-再跑一次 `xskill serve`，它会自动扫机器上装好的所有 agent（Claude Code、Codex、OpenCode、OpenClaw、Cursor、Trae）开始监听。如果还有一份历史轨迹归档想一起吃进来：
+再跑一次 `xskill serve`，它会自动扫机器上装好的所有 agent（Claude Code、Codex、OpenCode、OpenClaw、Cursor、Trae、DeepSeek Harness）开始监听。如果还有一份历史轨迹归档想一起吃进来：
 
 ```bash
 xskill registry add /path/to/trajectories
@@ -82,7 +83,7 @@ xskill connect <host:port> --token <token>
 ```
 
 - **无感蒸馏大佬员工** 一个人在自己工作里跑通的解法，自动可以让全团队复用，不需要任何人做任何事。（能力民主化）
-- **兼容各种 coding 方式** 用 codex、clade 还是 cursor IDE？ 都能加入，多端同步。
+- **兼容各种 coding 方式** 用 Codex、Claude Code、Cursor IDE 还是 DeepSeek Harness？ 都能加入，多端同步。
 - **轨迹隐私** 轨迹上传前先脱敏，agent 隐私功能。
 - **灰度测试驱动的进化** 一个 Skill 的改动会先在每个人身上分别衡量，赢了再扩散，人越多进化越准越快。
 - **专家指导的手动进化** 专家本地直接修改 skill，会被学习进服务器远程 `user-staging/<client_id>` 分支，作为下一步进化参考。
@@ -134,8 +135,22 @@ xskill upload ./my-skill            # 打包上传一个 skill 目录(含 SKILL.
 | **OpenClaw** | 🟡 已对接，not well tested | 扫 `~/.openclaw/agents/` | 拷贝 → `~/.agents/skills/<name>/` |
 | **Cursor** | 🟡 已对接，not well tested | 扫 `~/.cursor/projects/*/agent-transcripts/` | symlink → `~/.cursor/skills/<name>/` |
 | **Trae** | 🟡 已对接，not well tested | IDE：读 `%APPDATA%/Trae*/User/workspaceStorage/*/state.vscdb`；CLI：扫 `~/trajectories/trajectory_*.json` | symlink → `~/.trae-cn/skills/` 与/或 `~/.trae/skills/` |
-| **DeepSeek Harness (dsh)** | 🟡 已对接，not well tested | 扫 `~/.dsh/sessions/*/*/session.jsonl[.zstd]`（明文与默认 zstd 会话均可） | symlink → `~/.dsh/skills/<name>/` |
+| **DeepSeek Harness (dsh)** | 🟡 已对接，not well tested | 扫 `~/.dsh/sessions/*/*/session.jsonl[.zstd]`（明文与默认 zstd 会话均可） | symlink → `~/.dsh/skills/<name>/`；也可 `dsh plugin add` 装 `dsh-xskill` |
 | **其他 agent** | 手动 | SDK：`xskill.adapters.submit_trajectory` | 自己拷贝 / symlink `SKILL.md` 目录 |
+
+### 在 DeepSeek Harness 上跑（dsh 插件）
+
+xskill 已经能发现 dsh、收会话、把 skill 软链到 `~/.dsh/skills/`。那是 xskill 推给 dsh。
+
+dsh 的扩展方式是插件：带 `dsh.bundle` 的 npm 包，用 `dsh plugin add` 装进某个 profile。本仓库的 `dsh-xskill` 装上并重启后，dsh 会直接读本地 xskill 技能库，并提供 `xskill_status`、`xskill_list`、`xskill_search`。
+
+```bash
+dsh plugin --profile web add github:SkillNerds/xskill
+# 本地 checkout：
+# dsh plugin --profile web add ./plugins/dsh-xskill
+```
+
+重启 `dsh web`。xskill 侧照常 `xskill serve` 或 `xskill connect`。说明见 [`plugins/dsh-xskill/README.md`](plugins/dsh-xskill/README.md)。
 
 ## 几个名词
 

--- a/package.json
+++ b/package.json
@@ -1,0 +1,42 @@
+{
+  "name": "dsh-xskill",
+  "version": "0.1.0",
+  "description": "DeepSeek Harness bundle that mounts the local xskill skill library and adds xskill_status / xskill_list / xskill_search tools.",
+  "type": "module",
+  "main": "plugins/dsh-xskill/index.js",
+  "files": [
+    "plugins/dsh-xskill/index.js",
+    "plugins/dsh-xskill/lib.js",
+    "plugins/dsh-xskill/cordis.patch.yml",
+    "plugins/dsh-xskill/using-xskill.md",
+    "plugins/dsh-xskill/README.md"
+  ],
+  "exports": {
+    ".": "./plugins/dsh-xskill/index.js",
+    "./lib": "./plugins/dsh-xskill/lib.js",
+    "./package.json": "./package.json"
+  },
+  "license": "MIT",
+  "homepage": "https://github.com/SkillNerds/xskill",
+  "repository": {
+    "type": "git",
+    "url": "git+https://github.com/SkillNerds/xskill.git"
+  },
+  "keywords": [
+    "dsh-plugin",
+    "deepseek-harness",
+    "cordis",
+    "xskill",
+    "skills"
+  ],
+  "peerDependencies": {
+    "@deepseek-ai/dsh-skill": ">=0.1.0",
+    "@deepseek-ai/dsh-tools": ">=0.1.0",
+    "@deepseek-ai/schemastery": ">=1.0.0"
+  },
+  "dsh": {
+    "bundle": {
+      "patch": "./plugins/dsh-xskill/cordis.patch.yml"
+    }
+  }
+}

--- a/plugins/dsh-xskill/README.md
+++ b/plugins/dsh-xskill/README.md
@@ -1,0 +1,66 @@
+# dsh-xskill
+
+DeepSeek Harness (`dsh`) bundle for [xskill](https://github.com/SkillNerds/xskill). Install it with `dsh plugin add`; after a restart, dsh can see skills from the local xskill library and the agent gets three tools.
+
+This is the plugin-ecosystem path. It sits next to the filesystem adapter that already ships in xskill (`~/.dsh/sessions` ingest and `~/.dsh/skills` install). The adapter is xskill pushing into dsh. This bundle is dsh pulling from xskill.
+
+## Install
+
+Needs `dsh` and `pnpm` on PATH. The package is plain JavaScript, so a git install does not need a `prepare` script or `allowBuilds`.
+
+```bash
+# from this repository (root package.json declares dsh.bundle)
+dsh plugin --profile web add github:SkillNerds/xskill
+
+# from a local checkout of this folder
+dsh plugin --profile web add ./plugins/dsh-xskill
+```
+
+`web` is the usual profile. `headless` works the same way: `dsh plugin --profile headless add …`. Restart the profile after add (`dsh web`, or `dsh --profile headless "…"`).
+
+Check the layer without booting:
+
+```bash
+dsh --profile web --dump-config
+```
+
+You should see a `# == dsh-xskill` layer and a row `id: dsh-xskill`.
+
+## What runs after install
+
+- A skill provider named `xskill` lists `<skillRoot>/<name>/SKILL.md`. Default `skillRoot` is `~/.xskill/skill`. If `~/.xskill/config.yaml` has `skill_dir`, that path wins. `XSKILL_SKILL_DIR` or `XSKILL_HOME` can override.
+- Rank is 350: project / custom skills still win; this library beats a stale copy that only exists under `~/.dsh/skills` (rank 400).
+- Tools: `xskill_status`, `xskill_list`, `xskill_search` (on-disk substring search, not the team HTTP API).
+- A bundled `using-xskill` guide skill.
+
+The plugin does not start `xskill serve`, does not join a team server, and does not read dsh credential files.
+
+## Pair it with the xskill daemon
+
+```bash
+pip install xskill
+# fill ~/.xskill/config.yaml
+xskill serve          # or: xskill connect <host:port> --token <token> --name <id>
+```
+
+Then work in dsh as usual. New sessions land under `~/.dsh/sessions/`; the daemon turns them into skills; this plugin shows those skills inside dsh.
+
+## Override in the profile patch
+
+`$DSH_HOME/profiles/<name>/cordis.patch.yml` can restated the whole row (dsh replaces config, it does not deep-merge):
+
+```yaml
+- id: dsh-xskill
+  name: dsh-xskill
+  config:
+    skillRoot: ~/alt-skill-lib
+    rank: 350
+    registerGuide: true
+```
+
+## Out of scope for this package
+
+- Talking to a team server over HTTP
+- Writing into `~/.dsh/skills` (the Python installer already does that)
+- Project-scoped `<repo>/.dsh/skills` two-way sync
+- Managing API keys

--- a/plugins/dsh-xskill/cordis.patch.yml
+++ b/plugins/dsh-xskill/cordis.patch.yml
@@ -1,0 +1,10 @@
+# dsh-xskill bundle layer.
+# Inserts one plugin row. skillRoot empty means: XSKILL_SKILL_DIR, then
+# skill_dir in ~/.xskill/config.yaml, then ~/.xskill/skill.
+- insert:
+    - id: dsh-xskill
+      name: dsh-xskill
+      config:
+        skillRoot: ""
+        rank: 350
+        registerGuide: true

--- a/plugins/dsh-xskill/index.js
+++ b/plugins/dsh-xskill/index.js
@@ -1,0 +1,287 @@
+// dsh-xskill — DeepSeek Harness bundle for the xskill skill library.
+//
+// Ships as plain ESM so `dsh plugin add github:SkillNerds/xskill` needs no
+// prepare / allowBuilds step. peer services (skills, tools, schemastery)
+// come from the harness install.
+
+import { readFileSync } from "node:fs";
+import { readFile } from "node:fs/promises";
+import { dirname, join } from "node:path";
+import { fileURLToPath } from "node:url";
+import { homedir } from "node:os";
+import { spawnSync } from "node:child_process";
+import z from "@deepseek-ai/schemastery";
+import {
+  DEFAULT_RANK,
+  PROVIDER_NAME,
+  discoverSkills,
+  parseSkillDirFromConfig,
+  resolveSkillRoot,
+  searchSkills,
+  skillFromFrontmatter,
+  summarizeSkill,
+} from "./lib.js";
+
+export const name = "dsh-xskill";
+export const inject = ["skills", "tools"];
+
+export const Config = z.object({
+  skillRoot: z
+    .string()
+    .default("")
+    .description(
+      "Absolute or ~ path of the xskill skill library. Empty: XSKILL_SKILL_DIR, then skill_dir in ~/.xskill/config.yaml, then ~/.xskill/skill.",
+    ),
+  rank: z
+    .number()
+    .default(DEFAULT_RANK)
+    .description(
+      "Provider rank. Lower wins a duplicate name. 350 sits between dsh custom (300) and user-dsh (400).",
+    ),
+  registerGuide: z
+    .boolean()
+    .default(true)
+    .description("Register the bundled using-xskill guide skill."),
+});
+
+const GUIDE_PATH = join(dirname(fileURLToPath(import.meta.url)), "using-xskill.md");
+
+export function apply(ctx, config) {
+  const skillRootPromise = resolveConfiguredSkillRoot(config.skillRoot);
+
+  ctx.skills.registerProvider((control) => {
+    return new XskillSkillProvider(ctx, control, {
+      skillRootPromise,
+      rank: Number.isFinite(config.rank) ? config.rank : DEFAULT_RANK,
+    });
+  });
+
+  if (config.registerGuide !== false) {
+    registerGuideSkill(ctx);
+  }
+
+  registerTools(ctx, skillRootPromise);
+}
+
+async function resolveConfiguredSkillRoot(configured) {
+  const explicit = String(configured || "").trim();
+  if (explicit) return resolveSkillRoot(explicit);
+  try {
+    const text = await readFile(join(homedir(), ".xskill", "config.yaml"), "utf8");
+    const fromConfig = parseSkillDirFromConfig(text);
+    if (fromConfig) return resolveSkillRoot(fromConfig);
+  } catch {
+    // Missing or unreadable config is fine: fall through to defaults.
+  }
+  return resolveSkillRoot("");
+}
+
+function registerGuideSkill(ctx) {
+  // Cordis services are only safe to touch synchronously inside apply().
+  let raw;
+  try {
+    raw = readFileSync(GUIDE_PATH, "utf8");
+  } catch (error) {
+    ctx.logger?.warn?.(`dsh-xskill: bundled using-xskill.md missing: ${error}`);
+    return;
+  }
+  const parsed = skillFromFrontmatter(raw);
+  if (!parsed) {
+    ctx.logger?.warn?.("dsh-xskill: bundled using-xskill.md is invalid");
+    return;
+  }
+  ctx.skills.register({
+    name: parsed.name,
+    description: parsed.description,
+    ...(parsed.whenToUse ? { whenToUse: parsed.whenToUse } : {}),
+    source: "bundled",
+    content: parsed.content,
+    path: GUIDE_PATH,
+    resourceBase: {
+      kind: "directory",
+      path: dirname(GUIDE_PATH),
+    },
+  });
+}
+
+class XskillSkillProvider {
+  constructor(ctx, control, options) {
+    this.ctx = ctx;
+    this.name = PROVIDER_NAME;
+    this.skillRootPromise = options.skillRootPromise;
+    this.rank = options.rank;
+    this.control = control;
+  }
+
+  async list(options) {
+    options?.signal?.throwIfAborted?.();
+    const skillRoot = await this.skillRootPromise;
+    const found = await discoverSkills(skillRoot);
+    options?.signal?.throwIfAborted?.();
+    return found.map((skill) => ({
+      name: skill.name,
+      description: skill.description,
+      ...(skill.whenToUse ? { whenToUse: skill.whenToUse } : {}),
+      invocation: { modelInvocable: true, userInvocable: true },
+      provider: this.name,
+      source: "xskill",
+      rank: this.rank,
+      locator: { path: skill.path, directory: skill.directory },
+      resourceBase: { kind: "directory", path: skill.directory },
+      path: skill.path,
+    }));
+  }
+
+  async get(candidate, options) {
+    options?.signal?.throwIfAborted?.();
+    const path = candidate?.locator?.path || candidate?.path;
+    if (!path) return undefined;
+    let raw;
+    try {
+      raw = await readFile(path, "utf8");
+    } catch {
+      return undefined;
+    }
+    const parsed = skillFromFrontmatter(raw);
+    if (!parsed) return undefined;
+    return {
+      name: parsed.name,
+      description: parsed.description,
+      ...(parsed.whenToUse ? { whenToUse: parsed.whenToUse } : {}),
+      invocation: candidate.invocation || { modelInvocable: true, userInvocable: true },
+      provider: this.name,
+      source: candidate.source || "xskill",
+      content: parsed.content,
+      path,
+      resourceBase: {
+        kind: "directory",
+        path: candidate?.locator?.directory || dirname(path),
+      },
+    };
+  }
+}
+
+function registerTools(ctx, skillRootPromise) {
+  const register = (def) => ctx.tools.register(def);
+  const text = (s) => [{ type: "text", text: s }];
+
+  register({
+    name: "xskill_status",
+    description:
+      "Report the local xskill skill library this plugin is reading: root path, skill count, and whether the xskill CLI is on PATH. Does not start the daemon.",
+    parameters: { type: "object", properties: {}, required: [] },
+    output: {
+      schema: { type: "object" },
+      render: (_a, v) => {
+        const lines = [
+          `[xskill] root: ${v.skillRoot}`,
+          `[xskill] exists: ${v.exists}`,
+          `[xskill] skills: ${v.skillCount}`,
+          `[xskill] cli: ${v.cliOnPath ? v.cliPath : "not on PATH"}`,
+        ];
+        if (v.note) lines.push(`[xskill] ${v.note}`);
+        return text(lines.join("\n"));
+      },
+    },
+    async execute() {
+      const skillRoot = await skillRootPromise;
+      let exists = false;
+      let skillCount = 0;
+      try {
+        const skills = await discoverSkills(skillRoot);
+        exists = true;
+        skillCount = skills.length;
+      } catch (error) {
+        if (error && (error.code === "ENOENT" || error.code === "ENOTDIR")) {
+          exists = false;
+        } else {
+          throw error;
+        }
+      }
+      const cli = detectXskillCli();
+      return {
+        skillRoot,
+        exists,
+        skillCount,
+        cliOnPath: Boolean(cli),
+        cliPath: cli || "",
+        note: exists
+          ? "Plugin reads this directory. Run `xskill serve` or `xskill connect` to distill new skills."
+          : "Skill root is missing. Install xskill (`pip install xskill`) and run `xskill serve` once to create ~/.xskill.",
+      };
+    },
+  });
+
+  register({
+    name: "xskill_list",
+    description:
+      "List skills in the local xskill library (default ~/.xskill/skill). Returns name, description, and path. Use dsh's skill tool to load a body.",
+    parameters: {
+      type: "object",
+      properties: {
+        limit: { type: "number", description: "Max rows to return (default 100)." },
+      },
+      required: [],
+    },
+    output: {
+      schema: { type: "array" },
+      render: (_a, v) => {
+        if (!v.length) return text("[xskill] no skills in the local library.");
+        const lines = [`[xskill] ${v.length} skill(s):`];
+        for (const skill of v) {
+          lines.push(` - ${skill.name}: ${skill.description}`);
+        }
+        return text(lines.join("\n"));
+      },
+    },
+    async execute(args) {
+      const skillRoot = await skillRootPromise;
+      const skills = await discoverSkills(skillRoot);
+      const limit = Number.isInteger(args.limit) && args.limit > 0 ? args.limit : 100;
+      return skills.slice(0, limit).map(summarizeSkill);
+    },
+  });
+
+  register({
+    name: "xskill_search",
+    description:
+      "Search the local xskill library by case-insensitive substring over name, description, and skill body. This is on-disk search, not the team-server HTTP API.",
+    parameters: {
+      type: "object",
+      properties: {
+        query: { type: "string", description: "Substring to match. Required." },
+        limit: { type: "number", description: "Max matches (default 20)." },
+      },
+      required: ["query"],
+    },
+    output: {
+      schema: { type: "array" },
+      render: (_a, v) => {
+        if (!v.length) return text("[xskill] no matches.");
+        const lines = ["[xskill] matches:"];
+        for (const skill of v) {
+          lines.push(` - ${skill.name}: ${skill.description}`);
+        }
+        return text(lines.join("\n"));
+      },
+    },
+    async execute(args) {
+      const query = String(args.query || "").trim();
+      if (!query) throw new Error("dsh-xskill: query is required");
+      const skillRoot = await skillRootPromise;
+      const skills = await discoverSkills(skillRoot);
+      return searchSkills(skills, query, args.limit).map(summarizeSkill);
+    },
+  });
+}
+
+function detectXskillCli() {
+  const which = spawnSync(process.platform === "win32" ? "where" : "which", ["xskill"], {
+    encoding: "utf8",
+    timeout: 4000,
+    stdio: ["ignore", "pipe", "pipe"],
+  });
+  if (which.error && which.error.code === "ENOENT") return "";
+  if (which.status !== 0) return "";
+  return (which.stdout || "").split(/\r?\n/).find(Boolean) || "";
+}

--- a/plugins/dsh-xskill/lib.js
+++ b/plugins/dsh-xskill/lib.js
@@ -1,0 +1,240 @@
+// Pure helpers for the dsh-xskill bundle. No Cordis / schemastery imports so
+// Node's built-in test runner can exercise them without a harness install.
+
+import { homedir } from "node:os";
+import { join, resolve } from "node:path";
+import { readdir, readFile, stat } from "node:fs/promises";
+
+export const SKILL_NAME = /^[a-z0-9]+(?:-[a-z0-9]+)*$/;
+export const DEFAULT_RANK = 350;
+export const PROVIDER_NAME = "xskill";
+export const SKIP_DIR_NAMES = new Set([".canary", ".git", "node_modules"]);
+
+export function isSkillName(name) {
+  return typeof name === "string" && SKILL_NAME.test(name);
+}
+
+export function expandUserPath(raw, home = homedir()) {
+  const value = String(raw ?? "").trim();
+  if (!value) return "";
+  if (value === "~") return home;
+  if (value.startsWith("~/") || value.startsWith("~\\")) {
+    return join(home, value.slice(2));
+  }
+  return value;
+}
+
+export function parseSkillDirFromConfig(text) {
+  if (typeof text !== "string" || !text) return "";
+  for (const line of text.split(/\r?\n/)) {
+    const trimmed = line.trim();
+    if (!trimmed || trimmed.startsWith("#")) continue;
+    const match = /^skill_dir:\s*(.+?)\s*$/.exec(trimmed);
+    if (!match) continue;
+    let value = match[1];
+    if (
+      (value.startsWith('"') && value.endsWith('"')) ||
+      (value.startsWith("'") && value.endsWith("'"))
+    ) {
+      value = value.slice(1, -1);
+    }
+    if (!value || value.endsWith(":") || value === "|" || value === ">") {
+      return "";
+    }
+    return value;
+  }
+  return "";
+}
+
+export function resolveSkillRoot(configured, env = process.env, home = homedir()) {
+  const explicit = expandUserPath(configured, home);
+  if (explicit) return resolve(explicit);
+  const fromEnv = String(env.XSKILL_SKILL_DIR || "").trim();
+  if (fromEnv) return resolve(expandUserPath(fromEnv, home));
+  const xskillHome = String(env.XSKILL_HOME || "").trim();
+  if (xskillHome) return resolve(join(expandUserPath(xskillHome, home), "skill"));
+  return resolve(join(home, ".xskill", "skill"));
+}
+
+export function parseFrontmatter(raw) {
+  if (typeof raw !== "string") return undefined;
+  const normalized = raw.replace(/^\uFEFF/, "");
+  const firstLineEnd = normalized.indexOf("\n");
+  if (firstLineEnd < 0) return undefined;
+  if (normalized.slice(0, firstLineEnd).replace(/\r$/, "") !== "---") {
+    return undefined;
+  }
+  const start = firstLineEnd + 1;
+  const closing = findClosingFrontmatter(normalized, start);
+  if (closing === undefined) return undefined;
+  const data = parseSimpleYamlMap(normalized.slice(start, closing.start));
+  if (data === undefined) return undefined;
+  return {
+    data,
+    body: normalized.slice(closing.bodyStart),
+  };
+}
+
+function findClosingFrontmatter(raw, start) {
+  let lineStart = start;
+  while (lineStart <= raw.length) {
+    const nextNewline = raw.indexOf("\n", lineStart);
+    const lineEnd = nextNewline < 0 ? raw.length : nextNewline;
+    if (raw.slice(lineStart, lineEnd).replace(/\r$/, "") === "---") {
+      return {
+        start: lineStart,
+        bodyStart: nextNewline < 0 ? raw.length : nextNewline + 1,
+      };
+    }
+    if (nextNewline < 0) return undefined;
+    lineStart = nextNewline + 1;
+  }
+  return undefined;
+}
+
+function parseSimpleYamlMap(text) {
+  const data = {};
+  const lines = text.split(/\r?\n/);
+  let i = 0;
+  while (i < lines.length) {
+    const line = lines[i];
+    if (!line.trim() || line.trimStart().startsWith("#")) {
+      i += 1;
+      continue;
+    }
+    if (/^\s/.test(line)) return undefined;
+    const match = /^([A-Za-z0-9_-]+):\s*(.*)$/.exec(line);
+    if (!match) return undefined;
+    const key = match[1];
+    const rest = match[2];
+    if (rest === "|" || rest === ">") {
+      const folded = rest === ">";
+      const block = [];
+      i += 1;
+      while (i < lines.length) {
+        const next = lines[i];
+        if (next === "" || /^\s/.test(next)) {
+          block.push(next.replace(/^\s{2}/, ""));
+          i += 1;
+          continue;
+        }
+        break;
+      }
+      data[key] = folded
+        ? block.join(" ").replace(/\s+/g, " ").trim()
+        : block.join("\n").replace(/\s+$/, "");
+      continue;
+    }
+    data[key] = unquoteScalar(rest);
+    i += 1;
+  }
+  return data;
+}
+
+function unquoteScalar(value) {
+  const trimmed = value.trim();
+  if (
+    (trimmed.startsWith('"') && trimmed.endsWith('"')) ||
+    (trimmed.startsWith("'") && trimmed.endsWith("'"))
+  ) {
+    return trimmed.slice(1, -1);
+  }
+  if (trimmed === "true") return true;
+  if (trimmed === "false") return false;
+  return trimmed;
+}
+
+export function skillFromFrontmatter(raw) {
+  const parsed = parseFrontmatter(raw);
+  if (!parsed) return undefined;
+  const name = stringField(parsed.data, "name");
+  const description = stringField(parsed.data, "description");
+  if (!name || !description || !isSkillName(name)) return undefined;
+  const whenToUse = stringField(parsed.data, "whenToUse");
+  return {
+    name,
+    description,
+    ...(whenToUse ? { whenToUse } : {}),
+    content: parsed.body.trim(),
+  };
+}
+
+function stringField(data, key) {
+  const value = data[key];
+  return typeof value === "string" && value.length > 0 ? value : undefined;
+}
+
+export async function discoverSkills(skillRoot) {
+  let entries;
+  try {
+    entries = await readdir(skillRoot, { withFileTypes: true });
+  } catch (error) {
+    if (error && (error.code === "ENOENT" || error.code === "ENOTDIR")) {
+      return [];
+    }
+    throw error;
+  }
+  const skills = [];
+  for (const entry of entries.sort((a, b) => a.name.localeCompare(b.name))) {
+    if (entry.name.startsWith(".") || SKIP_DIR_NAMES.has(entry.name)) continue;
+    const directory = join(skillRoot, entry.name);
+    let kind = entry.isDirectory()
+      ? "directory"
+      : entry.isFile()
+        ? "file"
+        : "other";
+    if (entry.isSymbolicLink()) {
+      try {
+        const info = await stat(directory);
+        kind = info.isDirectory() ? "directory" : info.isFile() ? "file" : "other";
+      } catch {
+        continue;
+      }
+    }
+    if (kind !== "directory") continue;
+    const skillFile = join(directory, "SKILL.md");
+    let raw;
+    try {
+      raw = await readFile(skillFile, "utf8");
+    } catch {
+      continue;
+    }
+    const parsed = skillFromFrontmatter(raw);
+    if (!parsed) continue;
+    skills.push({
+      ...parsed,
+      directory,
+      path: skillFile,
+    });
+  }
+  return skills;
+}
+
+export function searchSkills(skills, query, limit = 20) {
+  const needle = String(query || "").trim().toLowerCase();
+  const cap = Number.isInteger(limit) && limit > 0 ? limit : 20;
+  if (!needle) return skills.slice(0, cap);
+  const hits = [];
+  for (const skill of skills) {
+    const hay = [
+      skill.name,
+      skill.description,
+      skill.whenToUse || "",
+      skill.content || "",
+    ]
+      .join("\n")
+      .toLowerCase();
+    if (hay.includes(needle)) hits.push(skill);
+    if (hits.length >= cap) break;
+  }
+  return hits;
+}
+
+export function summarizeSkill(skill) {
+  return {
+    name: skill.name,
+    description: skill.description,
+    ...(skill.whenToUse ? { whenToUse: skill.whenToUse } : {}),
+    path: skill.path,
+  };
+}

--- a/plugins/dsh-xskill/lib.test.js
+++ b/plugins/dsh-xskill/lib.test.js
@@ -1,0 +1,95 @@
+import { mkdtemp, mkdir, writeFile } from "node:fs/promises";
+import { tmpdir } from "node:os";
+import { join, resolve } from "node:path";
+import { test } from "node:test";
+import assert from "node:assert/strict";
+import {
+  discoverSkills,
+  isSkillName,
+  parseFrontmatter,
+  parseSkillDirFromConfig,
+  resolveSkillRoot,
+  searchSkills,
+  skillFromFrontmatter,
+} from "./lib.js";
+
+test("isSkillName accepts kebab-case only", () => {
+  assert.equal(isSkillName("using-xskill"), true);
+  assert.equal(isSkillName("invoice-check"), true);
+  assert.equal(isSkillName("UsingXskill"), false);
+  assert.equal(isSkillName("has_underscore"), false);
+  assert.equal(isSkillName(""), false);
+});
+
+test("parseFrontmatter reads name, description, and body", () => {
+  const parsed = parseFrontmatter(
+    "---\nname: invoice-check\ndescription: Check invoices\n---\n\n# Hello\n",
+  );
+  assert.deepEqual(parsed.data, {
+    name: "invoice-check",
+    description: "Check invoices",
+  });
+  assert.match(parsed.body, /# Hello/);
+});
+
+test("parseFrontmatter keeps a literal block description", () => {
+  const parsed = parseFrontmatter(
+    "---\nname: invoice-check\ndescription: |\n  line one\n  line two\n---\nbody\n",
+  );
+  assert.equal(parsed.data.description, "line one\nline two");
+});
+
+test("skillFromFrontmatter rejects invalid names", () => {
+  const parsed = skillFromFrontmatter(
+    "---\nname: NotKebab\ndescription: x\n---\nbody\n",
+  );
+  assert.equal(parsed, undefined);
+});
+
+test("parseSkillDirFromConfig reads a scalar skill_dir", () => {
+  const text = "# comment\nskill_dir: ~/.xskill/alt\nllm:\n  model: x\n";
+  assert.equal(parseSkillDirFromConfig(text), "~/.xskill/alt");
+});
+
+test("resolveSkillRoot prefers explicit, then env, then home", () => {
+  assert.equal(
+    resolveSkillRoot("/tmp/lib", {}, "/home/u"),
+    resolve("/tmp/lib"),
+  );
+  assert.equal(
+    resolveSkillRoot("", { XSKILL_HOME: "/tmp/xs" }, "/home/u"),
+    resolve(join("/tmp/xs", "skill")),
+  );
+  assert.equal(
+    resolveSkillRoot("", {}, "/home/u"),
+    resolve(join("/home/u", ".xskill", "skill")),
+  );
+});
+
+test("discoverSkills lists directory packages and skips junk", async () => {
+  const root = await mkdtemp(join(tmpdir(), "dsh-xskill-"));
+  await mkdir(join(root, "invoice-check"));
+  await writeFile(
+    join(root, "invoice-check", "SKILL.md"),
+    "---\nname: invoice-check\ndescription: Check invoices\n---\n\nUse the checker.\n",
+  );
+  await mkdir(join(root, ".canary"));
+  await mkdir(join(root, "NotValid"));
+  await writeFile(join(root, "NotValid", "SKILL.md"), "---\nname: NotValid\ndescription: x\n---\n");
+  await writeFile(join(root, "README.md"), "ignore me\n");
+
+  const skills = await discoverSkills(root);
+  assert.equal(skills.length, 1);
+  assert.equal(skills[0].name, "invoice-check");
+  assert.match(skills[0].content, /Use the checker/);
+});
+
+test("searchSkills matches name and body", async () => {
+  const skills = [
+    { name: "invoice-check", description: "AP invoices", content: "VAT rules" },
+    { name: "git-rebase", description: "history rewrite", content: "onto main" },
+  ];
+  const hits = searchSkills(skills, "vat", 10);
+  assert.equal(hits.length, 1);
+  assert.equal(hits[0].name, "invoice-check");
+});

--- a/plugins/dsh-xskill/package.json
+++ b/plugins/dsh-xskill/package.json
@@ -1,0 +1,43 @@
+{
+  "name": "dsh-xskill",
+  "version": "0.1.0",
+  "description": "DeepSeek Harness bundle that mounts the local xskill skill library and adds xskill_status / xskill_list / xskill_search tools.",
+  "type": "module",
+  "main": "index.js",
+  "files": [
+    "index.js",
+    "lib.js",
+    "cordis.patch.yml",
+    "using-xskill.md",
+    "README.md"
+  ],
+  "exports": {
+    ".": "./index.js",
+    "./lib": "./lib.js",
+    "./package.json": "./package.json"
+  },
+  "license": "MIT",
+  "homepage": "https://github.com/SkillNerds/xskill/tree/main/plugins/dsh-xskill",
+  "repository": {
+    "type": "git",
+    "url": "git+https://github.com/SkillNerds/xskill.git",
+    "directory": "plugins/dsh-xskill"
+  },
+  "keywords": [
+    "dsh-plugin",
+    "deepseek-harness",
+    "cordis",
+    "xskill",
+    "skills"
+  ],
+  "peerDependencies": {
+    "@deepseek-ai/dsh-skill": ">=0.1.0",
+    "@deepseek-ai/dsh-tools": ">=0.1.0",
+    "@deepseek-ai/schemastery": ">=1.0.0"
+  },
+  "dsh": {
+    "bundle": {
+      "patch": "./cordis.patch.yml"
+    }
+  }
+}

--- a/plugins/dsh-xskill/using-xskill.md
+++ b/plugins/dsh-xskill/using-xskill.md
@@ -1,0 +1,37 @@
+---
+name: using-xskill
+description: Use when installing or operating xskill from DeepSeek Harness (dsh) — listing evolved skills, searching the local skill library, checking whether xskill is running, or connecting a team server.
+---
+
+# Using xskill from DeepSeek Harness
+
+xskill distills reusable Skills (`SKILL.md` folders) from real coding-agent sessions. This dsh plugin (`dsh-xskill`) reads the local xskill skill library and exposes three tools. It does not start the Python daemon by itself.
+
+## Two layers (do not mix them up)
+
+1. xskill daemon (`xskill serve` or `xskill connect`) watches dsh sessions under `~/.dsh/sessions/`, distills skills, and may also symlink them into `~/.dsh/skills/`.
+2. This plugin mounts `~/.xskill/skill` (or `skill_dir` in `~/.xskill/config.yaml`) as a dsh skill source, and adds `xskill_status`, `xskill_list`, and `xskill_search`.
+
+Install the plugin once per profile:
+
+```bash
+dsh plugin --profile web add github:SkillNerds/xskill
+# local checkout:
+# dsh plugin --profile web add ./plugins/dsh-xskill
+```
+
+Then restart `dsh web` (or the headless profile). Keep `xskill serve` / `xskill connect` running if you want new sessions to become new skills.
+
+## Tools
+
+- `xskill_status` — skill root, how many skills are visible, whether the `xskill` CLI is on PATH.
+- `xskill_list` — name + description of every skill this plugin can load.
+- `xskill_search` — case-insensitive substring search over name, description, and body.
+
+To load a skill body, use dsh's normal `skill` tool with the listed name.
+
+## Common mistakes
+
+- Installing the plugin but never running `xskill serve` / `xskill connect`. The plugin only reads what is already on disk.
+- Expecting this plugin to log into the team server or ship API keys. Credentials stay in xskill / dsh; this bundle does not touch them.
+- Looking only in `~/.dsh/skills`. The plugin reads the xskill library first (`~/.xskill/skill` by default).

--- a/tests/test_dsh_plugin.py
+++ b/tests/test_dsh_plugin.py
@@ -1,0 +1,88 @@
+"""dsh-xskill bundle: manifest contract + Node helper tests.
+
+The bundle lives in ``plugins/dsh-xskill`` so ``dsh plugin add`` can install
+it (root ``package.json`` also declares ``dsh.bundle`` for
+``github:SkillNerds/xskill``). These tests do not boot dsh; they pin the
+files dsh will read and the scanner the plugin uses.
+"""
+
+from __future__ import annotations
+
+import json
+import shutil
+import subprocess
+from pathlib import Path
+
+import pytest
+import yaml
+
+REPO_ROOT = Path(__file__).resolve().parents[1]
+PLUGIN_DIR = REPO_ROOT / "plugins" / "dsh-xskill"
+ROOT_PACKAGE = REPO_ROOT / "package.json"
+PLUGIN_PACKAGE = PLUGIN_DIR / "package.json"
+
+
+def _load_json(path: Path) -> dict:
+    return json.loads(path.read_text(encoding="utf-8"))
+
+
+def test_root_and_plugin_package_declare_dsh_bundle():
+    root = _load_json(ROOT_PACKAGE)
+    plugin = _load_json(PLUGIN_PACKAGE)
+    assert root["name"] == "dsh-xskill"
+    assert plugin["name"] == "dsh-xskill"
+    assert root["dsh"]["bundle"]["patch"] == "./plugins/dsh-xskill/cordis.patch.yml"
+    assert plugin["dsh"]["bundle"]["patch"] == "./cordis.patch.yml"
+    assert (REPO_ROOT / root["dsh"]["bundle"]["patch"].lstrip("./")).is_file()
+    assert (PLUGIN_DIR / "cordis.patch.yml").is_file()
+    assert root["main"] == "plugins/dsh-xskill/index.js"
+    assert plugin["main"] == "index.js"
+
+
+def test_cordis_patch_inserts_dsh_xskill_row():
+    patch = yaml.safe_load((PLUGIN_DIR / "cordis.patch.yml").read_text(encoding="utf-8"))
+    assert isinstance(patch, list)
+    insert = next(item["insert"] for item in patch if "insert" in item)
+    row = next(item for item in insert if item.get("id") == "dsh-xskill")
+    assert row["name"] == "dsh-xskill"
+    assert row["config"]["rank"] == 350
+    assert row["config"]["registerGuide"] is True
+
+
+def test_plugin_entry_exports_cordis_contract():
+    text = (PLUGIN_DIR / "index.js").read_text(encoding="utf-8")
+    assert "export const name = 'dsh-xskill'" in text or 'export const name = "dsh-xskill"' in text
+    assert "export const inject" in text
+    assert "export function apply" in text
+    assert "xskill_status" in text
+    assert "xskill_list" in text
+    assert "xskill_search" in text
+    assert "registerProvider" in text
+
+
+def test_bundled_guide_skill_is_valid_kebab_name():
+    raw = (PLUGIN_DIR / "using-xskill.md").read_text(encoding="utf-8")
+    assert raw.startswith("---\n")
+    assert "name: using-xskill" in raw
+    assert "description:" in raw
+    assert "\n---\n" in raw
+
+
+def test_readme_documents_dsh_plugin_add():
+    readme = (REPO_ROOT / "README.md").read_text(encoding="utf-8")
+    assert "dsh plugin --profile web add github:SkillNerds/xskill" in readme
+    plugin_readme = (PLUGIN_DIR / "README.md").read_text(encoding="utf-8")
+    assert "dsh plugin" in plugin_readme
+    assert "xskill_search" in plugin_readme
+
+
+@pytest.mark.skipif(shutil.which("node") is None, reason="node is required for plugin helper tests")
+def test_plugin_lib_node_tests():
+    result = subprocess.run(
+        ["node", "--test", "lib.test.js"],
+        cwd=PLUGIN_DIR,
+        capture_output=True,
+        text=True,
+        timeout=30,
+    )
+    assert result.returncode == 0, result.stdout + result.stderr


### PR DESCRIPTION
## 这是什么

DeepSeek Harness（命令行工具 `dsh`）把几乎所有能力都做成插件：模型、工具、技能目录、会话存储都是同一套 Cordis 插件行。用户用 `dsh plugin add` 把一个 npm 包装进某个 profile（一份可启动的组合，例如 web），重启后即可用。社区靠仓库 topic `dsh-plugin` 和包内的 `dsh.bundle` 声明来发现、安装这些包。

#214 和 #243 已经让 xskill 能发现本机 dsh、把 `~/.dsh/sessions` 里的会话收成轨迹、再把进化后的 skill 软链到 `~/.dsh/skills/`。那是 xskill 推给 dsh，走的是文件系统适配，和 Claude Code / Codex 同构。#214 当时写明「不为 dsh 写插件包」，所以装上 dsh 的人仍然不能 `dsh plugin add` 这个仓库——仓库虽然挂了 `dsh-plugin` topic，根目录却没有 `dsh.bundle`，在插件生态里点进去装不上。

本 PR 补上那条被搁置的路径：给出一套 dsh 上能跑的方案。仓库带一份名为 `dsh-xskill` 的 bundle（可安装的配置层 + 一段 plain JavaScript）。装进 profile 并重启后，dsh 会直接读本地 xskill 技能库，agent 多三个工具。Python 蒸馏管线、team 客户端、#243 的采集与软链安装都不改。

下面每个词第一次出现都会说明它是什么。实现时不必先读完整份 xskill 或 dsh 源码。

## 用户怎么用

本机已有 `dsh` 和 `pnpm`。在想用的 profile 上执行：

```bash
dsh plugin --profile web add github:SkillNerds/xskill
```

本地 checkout 也可以：

```bash
dsh plugin --profile web add ./plugins/dsh-xskill
```

包是现成的 ESM，没有 `prepare` 构建脚本，git 安装不必再改 `allowBuilds`。`dsh plugin` 会把依赖写进该 profile 的 `package.json`，并因为包声明了 `dsh.bundle` 而把它追加到 `dsh.profile.bundles`。用 `dsh --profile web --dump-config` 应能看到 `# == dsh-xskill` 这一层。

然后重启 `dsh web`（或 `dsh --profile headless`）。xskill 侧照常：

```bash
xskill serve
# 或团队模式
xskill connect <host:port> --token <token> --name <工号>
```

daemon 负责把 dsh 会话蒸馏成 skill；插件负责让这些 skill 出现在 dsh 的技能目录里，并提供 `xskill_status`、`xskill_list`、`xskill_search`。两层不要混：插件不会自己启动 Python daemon，也不会代替 #243 去写 `~/.dsh/skills`。

## 它在哪运行

插件跑在 dsh 进程里，和 `@deepseek-ai/dsh-base` 同一套 Loader。它向 `ctx.skills`（技能注册表）登记一个名为 `xskill` 的 skill provider（技能来源），向 `ctx.tools` 登记三个工具。依赖的 `skills`、`tools`、`schemastery` 都来自 harness 自己的安装，本包不捆绑它们。

技能根目录的解析顺序：

1. 插件配置里的 `skillRoot`（profile 的 `cordis.patch.yml` 可改）
2. 环境变量 `XSKILL_SKILL_DIR`
3. `~/.xskill/config.yaml` 里的 `skill_dir`
4. `XSKILL_HOME/skill`
5. 默认 `~/.xskill/skill`

每个子目录若有合法 kebab-case `name` 和 `description` 的 `SKILL.md`，就会出现在 dsh 目录里。隐藏目录和 `.canary`（灰度物化目录）跳过。优先级 rank 为 350：低于项目级 / custom（300），高于 dsh 默认扫描的 `~/.dsh/skills`（400），同名时以 xskill 技能库为准，而不是一份可能过期的软链拷贝。

另外注册一份捆绑的指南技能 `using-xskill`，告诉模型这两层怎么配合。

## Changes

- 新增 `plugins/dsh-xskill/`：`package.json`（`dsh.bundle`）、`cordis.patch.yml`、`index.js`、无第三方依赖的 `lib.js`、指南 `using-xskill.md`、插件自己的 README。
- 仓库根目录增加一份同名 `package.json`，让 `dsh plugin add github:SkillNerds/xskill` 不必再写 `#path:`。两份清单都指向同一套 JS。
- 三个工具：`xskill_status`（根路径、数量、CLI 是否在 PATH）、`xskill_list`、`xskill_search`（本地子串，不是 team HTTP 检索）。
- 三份 README 的支持表、动态，以及「在 dsh 上跑」小节。
- `tests/test_dsh_plugin.py` 钉住清单契约；`plugins/dsh-xskill/lib.test.js` 覆盖清洗与扫描。

## 第一期边界

- 不调 team server 的 HTTP 检索 / 下载接口。
- 不写 `~/.dsh/skills`（#243 的 Python 安装器继续做这件事）。
- 不做项目级 `<repo>/.dsh/skills` 双向同步。
- 不碰 dsh 或 xskill 的凭据文件。
- 不改 dsh 上游，不覆盖 `skill-filesystem` 那一行的完整 config（dsh 的 patch 是整行替换，覆盖容易把默认根扫丢）。

## Test plan

- [x] `node --test plugins/dsh-xskill/lib.test.js`（8 例）
- [x] `pytest tests/test_dsh_plugin.py`（6 例：根/子包 `dsh.bundle`、patch 行、入口导出、指南 frontmatter、README 安装命令、转发 Node 单测）
- [x] 隔离 `DSH_HOME`：`dsh plugin --profile web add ./plugins/dsh-xskill` 与 `add <repo-root>` 都会把 `dsh-xskill` 写进 bundles；`--dump-config` 出现 `# == dsh-xskill` 层
- [x] 用 mock 的 `ctx.skills` / `ctx.tools` 调用 `apply()`：provider 能列出并加载临时技能库里的 `invoice-check`；三个工具名称正确；`xskill_search VAT` 命中；指南技能 `using-xskill` 已注册
- [ ] `make e2e`（未跑：未改 ingestion / install / daemon；CI 既有矩阵覆盖）

## Linked issues

接续 #214 里明确不做的「dsh 插件包」；#243 的发现、采集、软链安装保持不动。


Made with [Cursor](https://cursor.com)