### PR TITLE
perf(registry): Watcher 状态查询走组合索引

### DIFF
--- a/src/xskill/pipeline/registry.py
+++ b/src/xskill/pipeline/registry.py
@@ -152,6 +152,14 @@ CREATE TABLE IF NOT EXISTS trajectories (
     updated_at    TEXT DEFAULT (datetime('now')),
     UNIQUE(watch_dir_id, filename)
 );
+CREATE INDEX IF NOT EXISTS idx_trajectories_watch_status_newest
+    ON trajectories(
+        watch_dir_id,
+        status,
+        discovered_at DESC,
+        file_mtime DESC,
+        id DESC
+    );
 
 CREATE TABLE IF NOT EXISTS llm_usage (
     id           INTEGER PRIMARY KEY AUTOINCREMENT,

--- a/tests/test_registry.py
+++ b/tests/test_registry.py
@@ -24,6 +24,7 @@ from xskill.pipeline.registry import (
     find_traj_file,
     update_traj_status,
     get_trajs_by_status,
+    increment_retry,
     mark_not_fit,
     reset_not_fit_for_interest_change,
 )
@@ -465,4 +466,110 @@ def test_get_trajs_by_status_newest_first(tmp_path, db_path):
     assert get_trajs_by_status(
         wid, "discovered", limit=1, db_path=db_path,
     ) == ["traj_zzz.md"]
+
+
+_WATCH_STATUS_INDEX = "idx_trajectories_watch_status_newest"
+
+
+def _watch_status_index_columns(conn):
+    return [
+        (row["name"], int(row["desc"]))
+        for row in conn.execute(f"PRAGMA index_xinfo({_WATCH_STATUS_INDEX})")
+        if row["key"]
+    ]
+
+
+def test_watch_status_index_on_new_and_existing_db(tmp_path, db_path):
+    """新库有索引；旧库下次 schema 检查用 CREATE INDEX IF NOT EXISTS 补上。"""
+    traj_dir = tmp_path / "dataset"
+    traj_dir.mkdir()
+    (traj_dir / "traj_keep.md").write_text("# keep\n")
+    wid = register_dir(traj_dir, db_path=db_path)
+    discover_trajectories(wid, traj_dir, db_path=db_path)
+
+    conn = get_connection(db_path)
+    assert _watch_status_index_columns(conn) == [
+        ("watch_dir_id", 0),
+        ("status", 0),
+        ("discovered_at", 1),
+        ("file_mtime", 1),
+        ("id", 1),
+    ]
+    before = [
+        dict(row)
+        for row in conn.execute(
+            "SELECT filename, status FROM trajectories ORDER BY id"
+        )
+    ]
+    conn.execute(f"DROP INDEX {_WATCH_STATUS_INDEX}")
+    conn.execute("PRAGMA user_version=0")
+    conn.commit()
+    conn.close()
+
+    conn = get_connection(db_path)
+    assert _watch_status_index_columns(conn) == [
+        ("watch_dir_id", 0),
+        ("status", 0),
+        ("discovered_at", 1),
+        ("file_mtime", 1),
+        ("id", 1),
+    ]
+    after = [
+        dict(row)
+        for row in conn.execute(
+            "SELECT filename, status FROM trajectories ORDER BY id"
+        )
+    ]
+    conn.close()
+    assert after == before
+    assert after == [{"filename": "traj_keep.md", "status": "discovered"}]
+
+
+def test_watch_status_query_plan_uses_index(db_path):
+    """状态查询按 watch_dir_id + status 走新索引，排序不再建临时 B-tree。"""
+    conn = get_connection(db_path)
+    conn.execute(
+        "INSERT INTO watch_dirs (id, path, label) VALUES (1, '/tmp/wd', 'wd')"
+    )
+    conn.executemany(
+        "INSERT INTO trajectories"
+        " (watch_dir_id, filename, status, discovered_at, file_mtime)"
+        " VALUES (1, ?, ?, ?, ?)",
+        [
+            ("traj_old.md", "indexed", "2024-01-01 00:00:00", 1.0),
+            ("traj_new.md", "indexed", "2026-08-20 00:00:00", 9.0),
+            ("traj_done.md", "done", "2026-08-19 00:00:00", 8.0),
+        ],
+    )
+    conn.commit()
+    plan = " ".join(
+        row["detail"]
+        for row in conn.execute(
+            "EXPLAIN QUERY PLAN "
+            "SELECT filename FROM trajectories "
+            "WHERE watch_dir_id=? AND status=? "
+            "ORDER BY discovered_at DESC, file_mtime DESC, id DESC",
+            (1, "indexed"),
+        )
+    )
+    conn.close()
+    assert _WATCH_STATUS_INDEX in plan
+    assert "TEMP B-TREE" not in plan
+
+
+def test_get_trajs_by_status_error_retry_filter(tmp_path, db_path):
+    traj_dir = tmp_path / "dataset"
+    traj_dir.mkdir()
+    (traj_dir / "traj_err.md").write_text("# err\n")
+    wid = register_dir(traj_dir, db_path=db_path)
+    discover_trajectories(wid, traj_dir, db_path=db_path)
+    update_traj_status(wid, "traj_err.md", "error", db_path=db_path)
+    assert get_trajs_by_status(wid, "error", db_path=db_path) == ["traj_err.md"]
+    increment_retry(wid, "traj_err.md", db_path=db_path)
+    increment_retry(wid, "traj_err.md", db_path=db_path)
+    increment_retry(wid, "traj_err.md", db_path=db_path)
+    assert get_trajs_by_status(wid, "error", db_path=db_path) == []
+    assert get_trajs_by_status(
+        wid, "error", max_retries=4, db_path=db_path,
+    ) == ["traj_err.md"]
 


### PR DESCRIPTION
## 背景

`trajectories` 的业务主键是目录加文件名，唯一索引也建在这两列上。Watcher 每几秒一轮的热查询却不是按文件名点查，而是按目录加状态捞一批待处理轨迹。#237 合入后，同一条查询还要按进库时间把新轨迹排在前面。现有唯一索引只能用上目录前缀，状态仍要在整个目录的历史行上逐行过滤，排序还要另造临时树。历史轨迹越多，轮询越贵，结果不错，只是越来越慢。

这条 PR 补一条跟热查询从左对齐的组合索引。过滤和 #237 的新排序走同一棵树。已有库下次打开会 `CREATE INDEX IF NOT EXISTS`，不重建表、不改轨迹行。

热查询（#237 之后的 `get_trajs_by_status`）：

```sql
SELECT filename
FROM trajectories
WHERE watch_dir_id = ? AND status = ?
ORDER BY discovered_at DESC, file_mtime DESC, id DESC
```

新索引字段：`watch_dir_id`，`status`，`discovered_at`，`file_mtime`，`id`。

| 业务 | 查询字段 |
| --- | --- |
| Watcher 按状态捞待处理轨迹 | watch_dir_id，status |
| #237 新轨迹优先 | 按 discovered_at、file_mtime、id 倒序排 |

两条是同一条 SQL 的过滤和排序。新索引按这个顺序建，两边都能用上。

这张表上还有别的查询。现有唯一索引对「点名这一条再改它」是对的；看板聚合、按人、按文件名反查对不上，但那些是打开页面才跑，不是 5 秒一轮。

| 业务 | 组件 | 频率 | 重要程度 | 查询字段 | 索引 |
| --- | --- | --- | --- | --- | --- |
| Watcher 按状态捞本轮要处理的轨迹 | 服务器端常驻业务 | ★★★★★ | ★★★★★ | watch_dir_id, status | watch_dir_id ✓  status ✗ |
| 发现目录里新出现或被改写的轨迹 | 服务器端常驻业务 | ★★★★★ | ★★★★★ | watch_dir_id, filename | watch_dir_id ✓  filename ✓ |
| 更新单条轨迹的处理状态和日志 | 服务器端常驻业务 | ★★★★ | ★★★★★ | watch_dir_id, filename | watch_dir_id ✓  filename ✓ |
| 看板看整体处理进度和生态分布 | 前端 | ★★ | ★★★★ | status, source_harness, source_model | status ✗  source_harness ✗  source_model ✗ |
| 列出某个目录下的全部轨迹 | 前端 | ★★ | ★★★ | watch_dir_id, discovered_at | watch_dir_id ✓  discovered_at ✗ |
| 按用户看贡献了多少轨迹 | 前端 | ★ | ★★★ | user_key | user_key ✗ |
| 按目录统计各状态有多少条 | 前端 | ★★ | ★★ | watch_dir_id, status | watch_dir_id ✓  status ✗ |
| 打开某条轨迹看详情 | 前端 | ★ | ★★ | filename | filename ✗ |
| 从技能反查哪些轨迹用过它 | 前端 | ★ | ★★ | skill_used | skill_used ✗ |

本 PR 只补第一行缺的那半截：让 `watch_dir_id` 加 `status` 也能直接走索引，并把 #237 的倒序嵌进同一棵树。

## Test plan

- [x] 新库索引列顺序与最终查询一致
- [x] 已有库下次 schema 检查补上索引，轨迹数据不变
- [x] 代表性查询计划走新索引，排序不再出现 TEMP B-TREE
- [x] `get_trajs_by_status` 最新优先、参数化 limit、error 重试过滤仍正确
- [x] `tests/test_registry.py` 36 passed
- [ ] `make e2e` 未跑（只动 Registry schema，发版前再跑）

Closes #261
