### PR TITLE
fix(skill-edit): write_file 按技能仓解析，并补上进程路径位置

### DIFF
--- a/src/xskill/agents/agent_tools.py
+++ b/src/xskill/agents/agent_tools.py
@@ -965,38 +965,73 @@ def list_candidates(skill_name: str) -> str:
     return "\n".join(lines)
 
 
+def _writable_skill_root() -> Path | None:
+    root = agent_tool_config.writable_skill_dir
+    if root is None:
+        return None
+    return Path(root).resolve()
+
+
+def _skill_write_error(path: str, skill_dir: Path | None, detail: str) -> str:
+    lines = [f"error: {detail} (tried: {path})"]
+    if skill_dir is not None:
+        lines.append(f"skill_dir: {skill_dir}")
+        lines.append(f"example: SKILL.md  or  {skill_dir / 'SKILL.md'}")
+    return "\n".join(lines)
+
+
+def _resolve_skill_write_path(path: str) -> tuple[Path | None, str | None]:
+    """把 write_file / edit 的 path 收到当前 skill_dir 下。
+
+    相对路径按 skill_dir 拼接，不按进程 cwd。``skill/`` 或 ``./skill/``
+    前缀会写成仓内套一层 skill/，直接拒掉并给出可写示例。
+    """
+    skill_dir = _writable_skill_root()
+    if skill_dir is None:
+        return None, "error: skill directory is not configured"
+    raw = Path(path)
+    if not raw.is_absolute() and raw.parts and raw.parts[0] == "skill":
+        return None, _skill_write_error(
+            path,
+            skill_dir,
+            "path is relative to skill_dir; do not prefix skill/",
+        )
+    candidate = raw if raw.is_absolute() else (skill_dir / raw)
+    try:
+        resolved = candidate.resolve()
+        if not _is_relative_to(resolved, skill_dir):
+            raise ValueError("outside skill_dir")
+    except (OSError, ValueError):
+        return None, _skill_write_error(
+            path, skill_dir, "writes restricted to skill_dir"
+        )
+    if ".git" in resolved.parts:
+        return None, f"error: writes into .git/ are forbidden (tried: {path})"
+    return resolved, None
+
+
 @tool(name="write_file")
 def write_file(path: str, content: str) -> str:
-    """Write or overwrite a file under ./skill/ only.
+    """Write or overwrite a file under the current skill_dir.
+
+    Relative paths resolve against skill_dir, not the process working
+    directory. Use ``SKILL.md`` or ``scripts/foo.py``. Do not prefix
+    ``./skill/``. Absolute paths must stay inside skill_dir.
 
     v2 行为：只做路径安全 + frontmatter 日期消毒。旧 v1 ``source_trajs ≥ 3``
     gate 和 ``N/M 条轨迹`` warning 消毒已删——v2 用 ``source_atoms`` 引用 atom
     而非 traj，且质量保障靠 candidates buffer 累计 weightscore ≥ 10 的硬门槛，
     不需要 SKILL.md 写入端再卡一道。
     """
-    p = Path(path)
-    if agent_tool_config.atom_skill_dir is not None:
-        skill_dir = agent_tool_config.atom_skill_dir
-    else:
-        skill_dir = agent_tool_config.skill_dir
-
-    try:
-        resolved = p.resolve()
-        resolved.relative_to(skill_dir.resolve())
-    except ValueError:
-        return f"error: writes restricted to ./skill/ (tried: {path})"
-
-    # 拒写 .git/ —— agent LLM 撞到 git 错误时会试图"自己修 git"，把可恢复
-    # 的 index race 变成永久 repo 损坏（实跑遇到 3 个 skill 仓被 LLM 写进
-    # .git/HEAD / .git/refs / .git/config 而毁掉）。.git 严格归 git 自己管。
-    if ".git" in resolved.parts:
-        return f"error: writes into .git/ are forbidden (tried: {path})"
+    resolved, err = _resolve_skill_write_path(path)
+    if err:
+        return err
 
     # 写 SKILL.md：先做 frontmatter 写后校验（漏拦=静默放行坏 skill），
     # 非法**不写盘**，把富误差返回给 agent 让它当场改重写；合法再消毒日期 +
     # 重序列化写入。校验逻辑见 frontmatter.parse_strict（必填 name/description、
     # description 必须非空字符串、body 非空）。
-    if p.name == "SKILL.md":
+    if resolved.name == "SKILL.md":
         try:
             fm, body = fm_parse_strict(content)
         except FrontmatterError as e:
@@ -1009,11 +1044,11 @@ def write_file(path: str, content: str) -> str:
         _sanitize_frontmatter_dates(fm)
         content = fm_serialize(fm, body)
 
-    p.parent.mkdir(parents=True, exist_ok=True)
-    p.write_text(content, encoding="utf-8")
-    logger.info(f"✏️  wrote: {p} ({len(content)} bytes)")
+    resolved.parent.mkdir(parents=True, exist_ok=True)
+    resolved.write_text(content, encoding="utf-8")
+    logger.info(f"✏️  wrote: {resolved} ({len(content)} bytes)")
     _mark_file_read(resolved)
-    return f"wrote: {p} ({len(content)} chars)"
+    return f"wrote: {resolved} ({len(content)} chars)"
 
 
 @tool(name="edit")
@@ -1024,19 +1059,9 @@ def edit_file(path: str, old_string: str, new_string: str) -> str:
     (write_file also counts).  New files that do not exist yet should use
     write_file instead.
     """
-    if agent_tool_config.atom_skill_dir is not None:
-        skill_dir = agent_tool_config.atom_skill_dir
-    else:
-        skill_dir = agent_tool_config.skill_dir
-    if skill_dir is None:
-        return "error: skill directory is not configured"
-    try:
-        resolved = Path(path).resolve()
-        resolved.relative_to(Path(skill_dir).resolve())
-    except (OSError, ValueError):
-        return f"error: writes restricted to the skill repository (tried: {path})"
-    if ".git" in resolved.parts:
-        return f"error: writes into .git/ are forbidden (tried: {path})"
+    resolved, err = _resolve_skill_write_path(path)
+    if err:
+        return err
     if not resolved.is_file():
         return (
             f"error: file not found ({path}). "

--- a/src/xskill/agents/skill_edit_agent.py
+++ b/src/xskill/agents/skill_edit_agent.py
@@ -300,7 +300,8 @@ commit message 写明本次基于哪些 atom_id 整理，以及**行为级**变�
 - list_files(path) — 列目录文件，返回可直接传给 read_file 的完整路径
 - grep_files(pattern, path="", glob="", max_results=100) — 全文检索（ripgrep），
   返回「文件:行号:内容」；先检索定位、再 read_file 精读，别逐个翻文件
-- write_file(path, content) — 写任意文件到 skill_dir 下
+- write_file(path, content) — 写到 skill_dir 下；相对路径如 SKILL.md、
+  scripts/foo.py，不要加 ./skill/ 前缀
 - commit_baby(skill_name, message) — 仅 baby 分支可用；checkpoint 当前批次
 - commit_to_staging(skill_name, message) — 仅 main 分支可用
 
@@ -402,9 +403,13 @@ class SkillEditAgent:
 
     def _skill_tree_context_lines(self, max_entries: int = 80) -> list[str]:
         """返回当前 skill 根目录与文件树，供 agent 决定是否 read_file。"""
+        cwd = Path.cwd().resolve()
         lines = [
             "",
+            f"process_cwd: {cwd}",
             f"skill_base_path: {self.skill_dir}",
+            "write_file / edit 相对路径按 skill_base_path 解析（SKILL.md、scripts/foo.py）。不要加 ./skill/ 前缀。",
+            "read_file / list_files / grep_files 相对路径按 process_cwd 解析；list_files 返回的完整路径可直接给 read_file。",
             "# 当前 skill 文件树（相对 skill_base_path；需要内容时用 read_file 读取）",
         ]
         entries: list[str] = []

--- a/tests/test_skill_edit_agent.py
+++ b/tests/test_skill_edit_agent.py
@@ -343,6 +343,10 @@ class TestMainNeedsUxScoreBeforeStaging:
         assert agent.maybe_run() is True
         assert "read_file" in _InspectingStagingStubAgno.tool_names
         assert f"skill_base_path: {skill_dir}" in _InspectingStagingStubAgno.user_msg
+        assert f"process_cwd: {Path.cwd().resolve()}" in _InspectingStagingStubAgno.user_msg
+        assert "write_file / edit 相对路径按 skill_base_path 解析" in (
+            _InspectingStagingStubAgno.user_msg
+        )
         assert "scripts/helper.py" in _InspectingStagingStubAgno.user_msg
 
 

--- a/tests/test_write_file_skill_dir_paths.py
+++ b/tests/test_write_file_skill_dir_paths.py
@@ -1,0 +1,78 @@
+"""write_file 相对路径按 skill_dir 解析，不按进程 cwd。"""
+from __future__ import annotations
+
+from pathlib import Path
+
+import pytest
+
+from xskill.agents import agent_tools
+
+
+SKILL_MD = "---\nname: demo-skill\ndescription: x\n---\n# demo\n"
+
+
+@pytest.fixture
+def skill_repo(tmp_path):
+    parent = tmp_path / "workspace" / "skill"
+    repo = parent / "demo-skill"
+    repo.mkdir(parents=True)
+    (repo / "scripts").mkdir()
+    snap = agent_tools.agent_tool_config.snapshot()
+    agent_tools.init_skill_authoring_tool_context(parent, parent, {})
+    agent_tools.init_atom_task_tool_context(
+        skill_dir=repo,
+        atom_store=None,
+        default_traj_root=repo,
+    )
+    yield repo
+    agent_tools.agent_tool_config.restore(snap)
+
+
+def test_relative_skill_md_writes_inside_repo_from_other_cwd(skill_repo, tmp_path, monkeypatch):
+    monkeypatch.chdir(tmp_path)
+    out = agent_tools.write_file.entrypoint("SKILL.md", SKILL_MD)
+    assert not out.startswith("error"), out
+    assert (skill_repo / "SKILL.md").is_file()
+    assert not (tmp_path / "SKILL.md").exists()
+    assert "name: demo-skill" in (skill_repo / "SKILL.md").read_text(encoding="utf-8")
+
+
+def test_relative_script_writes_inside_repo_from_other_cwd(skill_repo, tmp_path, monkeypatch):
+    monkeypatch.chdir(tmp_path)
+    out = agent_tools.write_file.entrypoint("scripts/check.py", "print(1)\n")
+    assert not out.startswith("error"), out
+    assert (skill_repo / "scripts" / "check.py").read_text(encoding="utf-8") == "print(1)\n"
+
+
+def test_skill_prefix_is_rejected_with_location(skill_repo, tmp_path, monkeypatch):
+    monkeypatch.chdir(tmp_path)
+    for path in (
+        "skill/SKILL.md",
+        "./skill/SKILL.md",
+        "skill/scripts/check.py",
+    ):
+        out = agent_tools.write_file.entrypoint(path, SKILL_MD)
+        assert out.startswith("error:"), path
+        assert "do not prefix skill/" in out
+        assert f"skill_dir: {skill_repo.resolve()}" in out
+        assert "example: SKILL.md" in out
+        assert not (skill_repo / "skill").exists()
+
+
+def test_outside_absolute_path_names_skill_dir(skill_repo, tmp_path):
+    outsider = tmp_path / "other" / "SKILL.md"
+    outsider.parent.mkdir()
+    out = agent_tools.write_file.entrypoint(str(outsider), SKILL_MD)
+    assert "writes restricted to skill_dir" in out
+    assert f"skill_dir: {skill_repo.resolve()}" in out
+    assert not outsider.exists()
+
+
+def test_edit_relative_path_from_other_cwd(skill_repo, tmp_path, monkeypatch):
+    target = skill_repo / "notes.md"
+    target.write_text("hello\n", encoding="utf-8")
+    agent_tools.write_file.entrypoint("notes.md", "hello\n")
+    monkeypatch.chdir(tmp_path)
+    out = agent_tools.edit_file.entrypoint("notes.md", "hello", "world")
+    assert not out.startswith("error"), out
+    assert target.read_text(encoding="utf-8") == "world\n"


### PR DESCRIPTION
Fixes #272

## Summary
- SkillEdit 每轮 scenario 补上 process_cwd，并写明读工具按进程目录解析、write_file / edit 按 skill_dir 解析。
- write_file 相对路径改为相对 skill_dir（SKILL.md、scripts/foo.py 即可），不再按进程 cwd 解析。
- 去掉「restricted to ./skill/」这种会诱使模型加前缀的回执；误写 skill/ 或 ./skill/ 时直接拒掉并给出可写示例。

## Test plan
- [x] tests/test_write_file_skill_dir_paths.py：换 cwd 后相对路径写入技能仓；skill/ 前缀被拒
- [x] 现有 write_file / SkillEdit 单测仍过


Made with [Cursor](https://cursor.com)