### PR TITLE
test(dashboard): include pipeline pool route in builtin contract

### DIFF
--- a/tests/test_dashboard_standalone.py
+++ b/tests/test_dashboard_standalone.py
@@ -82,6 +82,7 @@ _BUILTIN_ONLY_OPERATIONS = {
     ("post", "/api/v1/dashboard/admin/skill/{name}/retire"),
     ("post", "/api/v1/dashboard/admin/skill/{name}/unretire"),
     ("delete", "/api/v1/dashboard/admin/skill/{name}"),
+    ("patch", "/api/v1/dashboard/admin/pipeline/pools"),
     ("get", "/api/v1/dashboard/admin/config"),
     ("post", "/api/v1/dashboard/admin/config/validate"),
     ("post", "/api/v1/dashboard/admin/config/reload"),


### PR DESCRIPTION
## Summary

Keep the built-in Dashboard route contract in sync with the pipeline pool admin endpoint.

## Changes

- Adds the existing authenticated PATCH endpoint to the explicit built-in-only allowlist while preserving the standalone read-only set.

## Test plan

- [ ] `make test` passes
- [x] Added/updated unit tests for the change
- [ ] `make e2e` passes (if the change touches ingestion / install / daemon)
- [x] Manually verified the affected user flow

Focused verification:

- `.venv/bin/python -m pytest tests/test_dashboard_standalone.py tests/test_dashboard_console_p2.py -q` — passed
- `.venv/bin/python -m ruff check tests/test_dashboard_standalone.py` — passed

## CI baseline note

Completed Linux and macOS matrix jobs fail only at `tests/test_rebuild_resplit_repro.py::test_legacy_migration_backfills_status_once`, the independent main-branch migration regression fixed by #276. The combined #276 + #277 checkout passes the affected suites. After either PR merges, the remaining branch should be updated and rerun against the new `main`.

## Linked issues

Closes #275
