### PR TITLE
fix(skill-edit): write_file 补对错例子，写偏了直接报错

### DIFF
--- a/src/xskill/agents/agent_tools.py
+++ b/src/xskill/agents/agent_tools.py
@@ -243,6 +243,15 @@ def use_skill_edit_batch(
         yield bound
 
 
+@contextlib.contextmanager
+def use_skill_write_target(skill_name: str) -> Iterator[AgentToolContext]:
+    """把 write_file / edit 的相对路径根钉到这个 skill 仓，不改 commit 批次。"""
+    current = current_agent_tool_context()
+    bound = replace(current, skill_edit_skill_name=_slugify(skill_name))
+    with use_agent_tool_context(bound):
+        yield bound
+
+
 class AgentToolConfig:
     """Stateless compatibility facade over the current task's context."""
 
@@ -966,35 +975,53 @@ def list_candidates(skill_name: str) -> str:
 
 
 def _writable_skill_root() -> Path | None:
-    root = agent_tool_config.writable_skill_dir
-    if root is None:
+    current = current_agent_tool_context()
+    lib = current.atom_skill_dir or current.skill_dir
+    if lib is None:
         return None
-    return Path(root).resolve()
+    lib = Path(lib).resolve()
+    name = current.skill_edit_skill_name
+    if name:
+        if lib.name == name:
+            return lib
+        return (lib / name).resolve()
+    return lib
+
+
+def _skill_write_hint_lines(skill_dir: Path) -> list[str]:
+    name = skill_dir.name
+    return [
+        f"skill_dir: {skill_dir}",
+        f"ok: SKILL.md  ->  {skill_dir / 'SKILL.md'}",
+        f"ok: scripts/foo.py  ->  {skill_dir / 'scripts' / 'foo.py'}",
+        "not: ./skill/SKILL.md",
+        f"not: {name}/SKILL.md",
+    ]
 
 
 def _skill_write_error(path: str, skill_dir: Path | None, detail: str) -> str:
     lines = [f"error: {detail} (tried: {path})"]
     if skill_dir is not None:
-        lines.append(f"skill_dir: {skill_dir}")
-        lines.append(f"example: SKILL.md  or  {skill_dir / 'SKILL.md'}")
+        lines.extend(_skill_write_hint_lines(skill_dir))
     return "\n".join(lines)
 
 
 def _resolve_skill_write_path(path: str) -> tuple[Path | None, str | None]:
     """把 write_file / edit 的 path 收到当前 skill_dir 下。
 
-    相对路径按 skill_dir 拼接，不按进程 cwd。``skill/`` 或 ``./skill/``
-    前缀会写成仓内套一层 skill/，直接拒掉并给出可写示例。
+    相对路径按 skill_dir 拼接，不按进程 cwd。``skill/``、``./skill/``
+    或技能文件夹名当第一段，会写成仓内再套一层，直接拒掉并给出对错例子。
     """
     skill_dir = _writable_skill_root()
     if skill_dir is None:
         return None, "error: skill directory is not configured"
     raw = Path(path)
-    if not raw.is_absolute() and raw.parts and raw.parts[0] == "skill":
+    first = raw.parts[0] if raw.parts else ""
+    if not raw.is_absolute() and first in {"skill", skill_dir.name}:
         return None, _skill_write_error(
             path,
             skill_dir,
-            "path is relative to skill_dir; do not prefix skill/",
+            f"path is relative to skill_dir; do not prefix {first}/",
         )
     candidate = raw if raw.is_absolute() else (skill_dir / raw)
     try:
@@ -1016,7 +1043,8 @@ def write_file(path: str, content: str) -> str:
 
     Relative paths resolve against skill_dir, not the process working
     directory. Use ``SKILL.md`` or ``scripts/foo.py``. Do not prefix
-    ``./skill/``. Absolute paths must stay inside skill_dir.
+    ``./skill/`` or the skill folder name. Wrong paths return error
+    with ok or not examples. Absolute paths must stay inside skill_dir.
 
     v2 行为：只做路径安全 + frontmatter 日期消毒。旧 v1 ``source_trajs ≥ 3``
     gate 和 ``N/M 条轨迹`` warning 消毒已删——v2 用 ``source_atoms`` 引用 atom

--- a/src/xskill/agents/skill_edit_agent.py
+++ b/src/xskill/agents/skill_edit_agent.py
@@ -404,11 +404,17 @@ class SkillEditAgent:
     def _skill_tree_context_lines(self, max_entries: int = 80) -> list[str]:
         """返回当前 skill 根目录与文件树，供 agent 决定是否 read_file。"""
         cwd = Path.cwd().resolve()
+        skill = Path(self.skill_dir)
+        name = skill.name
         lines = [
             "",
             f"process_cwd: {cwd}",
-            f"skill_base_path: {self.skill_dir}",
-            "write_file / edit 相对路径按 skill_base_path 解析（SKILL.md、scripts/foo.py）。不要加 ./skill/ 前缀。",
+            f"skill_base_path: {skill}",
+            "write_file / edit 相对路径按 skill_base_path 解析。写错会返回 error，并带上对错例子。",
+            f"对：write_file(path=\"SKILL.md\")  写成  {skill / 'SKILL.md'}",
+            f"对：write_file(path=\"scripts/foo.py\")  写成  {skill / 'scripts' / 'foo.py'}",
+            "错：write_file(path=\"./skill/SKILL.md\")",
+            f"错：write_file(path=\"{name}/SKILL.md\")",
             "read_file / list_files / grep_files 相对路径按 process_cwd 解析；list_files 返回的完整路径可直接给 read_file。",
             "# 当前 skill 文件树（相对 skill_base_path；需要内容时用 read_file 读取）",
         ]
@@ -1037,16 +1043,18 @@ class SkillEditAgent:
 
     def _trace_run(self, agent: Any, user_msg: str) -> None:
         """Append one agent.run() to the skill's single human-readable trace."""
+        from xskill.agents import agent_tools
         from xskill.agents.agent_trace import trace_to
 
         spill_limit, compact_limit = self._trace_limits()
-        with trace_to(
-            self._trace_path(),
-            append=True,
-            spill_token_limit=spill_limit,
-            compact_token_limit=compact_limit,
-        ):
-            agent.run(user_msg)
+        with agent_tools.use_skill_write_target(self.skill_dir.name):
+            with trace_to(
+                self._trace_path(),
+                append=True,
+                spill_token_limit=spill_limit,
+                compact_token_limit=compact_limit,
+            ):
+                agent.run(user_msg)
 
     # ───────────────────────────────────────────────────────────────
     # 多轮消化主循环

--- a/tests/test_skill_edit_agent.py
+++ b/tests/test_skill_edit_agent.py
@@ -347,6 +347,10 @@ class TestMainNeedsUxScoreBeforeStaging:
         assert "write_file / edit 相对路径按 skill_base_path 解析" in (
             _InspectingStagingStubAgno.user_msg
         )
+        assert '对：write_file(path="SKILL.md")' in _InspectingStagingStubAgno.user_msg
+        assert f'错：write_file(path="{skill_dir.name}/SKILL.md")' in (
+            _InspectingStagingStubAgno.user_msg
+        )
         assert "scripts/helper.py" in _InspectingStagingStubAgno.user_msg
 
 

--- a/tests/test_write_file_skill_dir_paths.py
+++ b/tests/test_write_file_skill_dir_paths.py
@@ -55,7 +55,8 @@ def test_skill_prefix_is_rejected_with_location(skill_repo, tmp_path, monkeypatc
         assert out.startswith("error:"), path
         assert "do not prefix skill/" in out
         assert f"skill_dir: {skill_repo.resolve()}" in out
-        assert "example: SKILL.md" in out
+        assert "ok: SKILL.md" in out
+        assert f"not: {skill_repo.name}/SKILL.md" in out
         assert not (skill_repo / "skill").exists()
 
 
@@ -66,6 +67,41 @@ def test_outside_absolute_path_names_skill_dir(skill_repo, tmp_path):
     assert "writes restricted to skill_dir" in out
     assert f"skill_dir: {skill_repo.resolve()}" in out
     assert not outsider.exists()
+
+
+def test_skill_folder_prefix_is_rejected(skill_repo, tmp_path, monkeypatch):
+    monkeypatch.chdir(tmp_path)
+    out = agent_tools.write_file.entrypoint(
+        f"{skill_repo.name}/SKILL.md",
+        SKILL_MD,
+    )
+    assert out.startswith("error:")
+    assert f"do not prefix {skill_repo.name}/" in out
+    assert "ok: SKILL.md" in out
+    assert not (skill_repo / skill_repo.name).exists()
+
+
+def test_skill_edit_name_writes_into_repo_not_library(tmp_path, monkeypatch):
+    parent = tmp_path / "workspace" / "skill"
+    repo = parent / "demo-skill"
+    repo.mkdir(parents=True)
+    (repo / "scripts").mkdir()
+    snap = agent_tools.agent_tool_config.snapshot()
+    agent_tools.init_skill_authoring_tool_context(parent, parent, {})
+    agent_tools.init_atom_task_tool_context(
+        skill_dir=parent,
+        atom_store=None,
+        default_traj_root=parent,
+    )
+    monkeypatch.chdir(tmp_path)
+    try:
+        with agent_tools.use_skill_write_target("demo-skill"):
+            out = agent_tools.write_file.entrypoint("SKILL.md", SKILL_MD)
+        assert not out.startswith("error"), out
+        assert (repo / "SKILL.md").is_file()
+        assert not (parent / "SKILL.md").exists()
+    finally:
+        agent_tools.agent_tool_config.restore(snap)
 
 
 def test_edit_relative_path_from_other_cwd(skill_repo, tmp_path, monkeypatch):


### PR DESCRIPTION
Fixes #281

Follow-up to #272 / #273

## Summary
- SkillEdit 每轮 scenario 写上对、错例子：SKILL.md、scripts/foo.py 是对的，./skill/SKILL.md 和 <技能文件夹>/SKILL.md 是错的。
- 写错不再静默落到 skill 父目录。当前编辑的技能仓才是 write_file 根；加错前缀或写到仓外会返回 error，并带上 skill_dir 和对错例子。

## Test plan
- [x] tests/test_write_file_skill_dir_paths.py：库目录下绑 skill 名后 SKILL.md 进仓；文件夹名前缀被拒
- [x] SkillEdit scenario 含对、错例子


Made with [Cursor](https://cursor.com)