### PR TITLE
test(platform): isolate checks from generated files and WSL hosts

### DIFF
--- a/tests/e2e/test_connect_lifecycle_e2e.py
+++ b/tests/e2e/test_connect_lifecycle_e2e.py
@@ -11,6 +11,8 @@ import site
 
 import pytest
 
+from xskill.team.client.service import _is_wsl
+
 
 class _LocalTeamAndPypiHandler(BaseHTTPRequestHandler):
     def _json(self, payload: dict, status: int = 200) -> None:
@@ -58,7 +60,10 @@ def _json_output(result: subprocess.CompletedProcess) -> dict:
     return json.loads(result.stdout)
 
 
-@pytest.mark.skipif(not sys.platform.startswith("linux"), reason="Linux service E2E")
+@pytest.mark.skipif(
+    not sys.platform.startswith("linux") or _is_wsl(),
+    reason="non-WSL Linux service E2E",
+)
 def test_linux_connect_update_status_start_stop_lifecycle(tmp_path):
     """
     AC: 普通 Linux 用户关闭终端后 connect 常驻，且 start/stop/status/update 可用。

--- a/tests/test_connect_service.py
+++ b/tests/test_connect_service.py
@@ -127,6 +127,7 @@ def test_systemd_install_writes_unit_and_starts(tmp_path, monkeypatch):
 
 
 def test_linux_selects_detached_when_systemd_unavailable(monkeypatch):
+    monkeypatch.setattr(svc, "_is_wsl", lambda: False)
     monkeypatch.setattr(svc, "_systemd_user_available", lambda: False)
     monkeypatch.setattr(
         svc.DetachedProcessBackend, "install_and_start",

--- a/tests/test_windows_script_encoding.py
+++ b/tests/test_windows_script_encoding.py
@@ -11,16 +11,27 @@
 """
 from __future__ import annotations
 
+import os
 from pathlib import Path
 
 import pytest
 
 REPO_ROOT = Path(__file__).resolve().parent.parent
+# Virtual environments and build trees may contain third-party activation scripts.
+GENERATED_DIRS = {".git", ".venv", "venv", "node_modules", "build", "dist"}
 
-PS1_FILES = sorted(
-    p for p in REPO_ROOT.rglob("*.ps1")
-    if ".git" not in p.parts and "node_modules" not in p.parts
-)
+
+def _project_ps1_files(root: Path) -> list[Path]:
+    files = []
+    for directory, dirnames, filenames in os.walk(root):
+        dirnames[:] = [name for name in dirnames if name not in GENERATED_DIRS]
+        files.extend(
+            Path(directory, name) for name in filenames if name.endswith(".ps1")
+        )
+    return sorted(files)
+
+
+PS1_FILES = _project_ps1_files(REPO_ROOT)
 
 UTF8_BOM = b"\xef\xbb\xbf"
 
@@ -28,6 +39,17 @@ UTF8_BOM = b"\xef\xbb\xbf"
 def test_found_ps1_scripts():
     """守护自身有效性：仓库确实有 .ps1，glob 没有悄悄失效。"""
     assert PS1_FILES, "仓库里应存在 .ps1 脚本；若已全部删除请同步删除本测试"
+
+
+def test_generated_ps1_scripts_are_not_collected(tmp_path):
+    source = tmp_path / "scripts" / "source.ps1"
+    generated = tmp_path / ".venv" / "bin" / "activate.ps1"
+    source.parent.mkdir()
+    generated.parent.mkdir(parents=True)
+    source.touch()
+    generated.touch()
+
+    assert _project_ps1_files(tmp_path) == [source]
 
 
 @pytest.mark.parametrize("ps1", PS1_FILES, ids=lambda p: str(p.relative_to(REPO_ROOT)))


### PR DESCRIPTION
## Summary

Keep local verification deterministic across WSL hosts and generated workspaces.

## Changes

- Prune generated directories before scanning PowerShell scripts, pin the plain-Linux unit path, and skip its Linux-only lifecycle E2E on WSL.

## Test plan

- [ ] `make test` passes
- [x] Added/updated unit tests for the change
- [ ] `make e2e` passes (if the change touches ingestion / install / daemon)
- [x] Manually verified the affected user flow

Focused verification:

- `.venv/bin/python -m pytest tests/test_connect_service.py tests/test_wsl_persistence_policy.py tests/test_windows_script_encoding.py tests/e2e/test_connect_lifecycle_e2e.py -q` — 31 passed, 1 skipped (the non-WSL Linux lifecycle test)
- `.venv/bin/python -m ruff check tests/e2e/test_connect_lifecycle_e2e.py tests/test_connect_service.py tests/test_windows_script_encoding.py` — passed

## CI baseline note

The current `main` has two independent full-suite regressions fixed by #276 and #277. On the isolated #280 branch, `make test` reports 2273 passed and 11 skipped; its only two failures are the Dashboard route contract covered by #277 and the legacy Registry migration covered by #276. A combined #276 + #277 + #280 checkout passes `make test` with 2277 passed and 11 skipped. After #276 and #277 merge, #280 should be updated and rerun against the new `main`.

## Linked issues

Closes #279
