### PR TITLE
fix(skill-edit): AtomTaskRead 不回原文，ReadTraj 每次最多 200 行

### DIFF
--- a/src/xskill/agents/agent_tools.py
+++ b/src/xskill/agents/agent_tools.py
@@ -1236,30 +1236,101 @@ def update_frontmatter_metadata(skill_name: str, source_trajs: Optional[list] = 
 # AtomTask-era tools (v2) — consumed by TaskClusterAgent / SkillEditAgent
 # ═══════════════════════════════════════════════════════════════════
 
+READ_TRAJ_MAX_LINES = 200
+# AtomTaskRead 原样留给模型的字段。raw_segment 不在这里——原文走 read_traj。
+_ATOM_READ_KEEP_KEYS = (
+    "atom_id",
+    "traj_id",
+    "intent",
+    "summary",
+    "tags",
+    "used_skills",
+    "offset_start",
+    "offset_end",
+    "ux_score",
+    "pre_atom_id",
+    "post_atom_id",
+    "context_prefix",
+    "source_model",
+    "clustered",
+)
+
+
+def _atom_read_payload(atom) -> dict:
+    """intent / summary / 行号等元数据；不含 raw_segment。"""
+    full = json.loads(atom.to_json())
+    raw = full.get("raw_segment") or ""
+    start = int(full.get("offset_start") or 0)
+    end = int(full.get("offset_end") or 0)
+    line_span = max(0, end - start) if end > start else 0
+    first_end = start + min(line_span, READ_TRAJ_MAX_LINES) if line_span else start
+    if line_span > READ_TRAJ_MAX_LINES:
+        page_hint = (
+            f"本 atom 共 {line_span} 行，超过单次上限。先读 "
+            f"[{start}, {first_end})，再从 {first_end} 继续。"
+        )
+    elif line_span:
+        page_hint = f"本 atom 共 {line_span} 行，一次可读完。"
+    else:
+        page_hint = "本 atom 没有有效行区间。"
+    data = {key: full.get(key) for key in _ATOM_READ_KEEP_KEYS}
+    data["raw_segment_chars"] = len(raw)
+    data["raw_segment_lines"] = line_span
+    data["how_to_read"] = (
+        f'原文请用 read_traj(traj_id="{atom.traj_id}", '
+        f"offset_start={start}, offset_end=...)。"
+        f"行号是 1-based 半开区间 [{start}, {end})。"
+        f"每次最多 {READ_TRAJ_MAX_LINES} 行。{page_hint}"
+    )
+    return data
+
+
 @tool(name="atom_task_read")
 def atom_task_read(atom_id: str) -> str:
-    """读一个 AtomTask 的完整 JSON。
+    """读 AtomTask 的 intent / summary / 行号等，不含原文。
 
-    用于 cluster / edit agent 在决定归类前查看 atom 的 intent / summary /
-    raw_segment / used_skills。
+    返回 intent、summary、tags、used_skills、ux_score、前后 atom、
+    行号区间，以及 how_to_read。原文必须用 read_traj 按行分页取。
     """
     store = agent_tool_config.atom_store
     if store is None:
         return "error: atom task tool context not initialized"
     try:
-        return store.load(atom_id).to_json()
+        atom = store.load(atom_id)
     except FileNotFoundError as e:
         return f"error: {e}"
+    return json.dumps(_atom_read_payload(atom), ensure_ascii=False, indent=2)
 
 
 @tool(name="read_traj")
 def read_traj(traj_id: str, offset_start: int, offset_end: int) -> str:
-    """按**行号**读 traj.md 片段。
+    f"""按行号读取一条轨迹的原文。这是读 traj 正文的专用工具。
 
-    用法：agent 看了 atom 摘要后想确认细节时，传 atom 的 offset_start /
-    offset_end（都是 1-based 行号，半开区间 ``[start, end)``）回来取原文。
-    校验区间合法（``offset_end > offset_start`` 且区间在文件行数内），
-    违反直接返回 error。
+    先调用 atom_task_read，拿到 traj_id、offset_start、offset_end 和
+    how_to_read。本工具只读你指定的那一段行，不会返回 atom 的 intent 或
+    summary。整段 atom 往往远超一页，必须分页，不要一次把 atom 的
+    起止行原样塞进来指望拿全文。
+
+    行号规则：1-based 半开区间 [offset_start, offset_end)，含起始行、
+    不含结束行。第一行是 1，禁止传 0。对的例子：前 200 行是
+    offset_start=1, offset_end=201。错的例子：offset_start=0。
+
+    每次最多 {READ_TRAJ_MAX_LINES} 行（offset_end - offset_start）。超过则只
+    返回前 {READ_TRAJ_MAX_LINES} 行，并在正文开头给出 continue，下一页用
+    那个 offset_start 接着读。不要因为被截断就改用 grep_files 或
+    read_file 去倒整份 traj.md。
+
+    traj_id 必须与 atom_task_read 返回的字符串完全一致，包括下划线。
+    不要把 traj_oc_xskill-debug_ses_1da2 改成带连字符的近形名字。
+
+    不要用 grep_files(pattern='.' 或 '^')、也不要用 read_file 去整包
+    读取 traj.md。grep 只适合搜关键词定位行号；定位之后仍用本工具
+    按行号精读。
+
+    Args:
+        traj_id: atom 里的轨迹 id，原样复制。
+        offset_start: 起始行号，从 1 起。
+        offset_end: 结束行号（不含），必须大于 offset_start。
     """
     traj_root = agent_tool_config.default_traj_root
     if traj_root is None:
@@ -1279,17 +1350,42 @@ def read_traj(traj_id: str, offset_start: int, offset_end: int) -> str:
     p = traj_root / f"{traj_id}.md"
     if not p.is_file():
         return f"error: traj file not found: {p}"
-    if offset_end <= offset_start:
-        return f"error: offset_end ({offset_end}) must be > offset_start ({offset_start})"
+    try:
+        start = int(offset_start)
+        end = int(offset_end)
+    except (TypeError, ValueError):
+        return f"error: offset_start/offset_end must be int (got {offset_start!r}, {offset_end!r})"
+    if end <= start:
+        return f"error: offset_end ({end}) must be > offset_start ({start})"
+    if start < 1:
+        return (
+            f"error: line range [{start}..{end}) outside file "
+            f"(offset_start must be >= 1)"
+        )
     lines = p.read_text(encoding="utf-8").splitlines(keepends=True)
     total = len(lines)
-    # offset_end 是半开上界（行号），末 atom 可达 total + 1
-    if offset_start < 1 or offset_end > total + 1:
+    if start > total:
         return (
-            f"error: line range [{offset_start}..{offset_end}) outside file "
+            f"error: line range [{start}..{end}) outside file "
             f"line count {total}"
         )
-    return "".join(lines[offset_start - 1:offset_end - 1])
+    file_end = min(end, total + 1)
+    page_end = min(file_end, start + READ_TRAJ_MAX_LINES)
+    body = "".join(lines[start - 1:page_end - 1])
+    if page_end == end:
+        return body
+    next_hint = (
+        f"continue: read_traj(traj_id=\"{traj_id}\", "
+        f"offset_start={page_end}, offset_end=...)"
+        if page_end < file_end
+        else "no further lines in this file"
+    )
+    header = (
+        f"[read_traj] traj={traj_id} returned [{start}, {page_end}) "
+        f"requested [{start}, {end}); file_lines={total}; "
+        f"max_lines={READ_TRAJ_MAX_LINES}. {next_hint}\n"
+    )
+    return header + body
 
 
 @tool(name="new_skill_folder")

--- a/src/xskill/agents/skill_edit_agent.py
+++ b/src/xskill/agents/skill_edit_agent.py
@@ -193,10 +193,12 @@ weightscore ≥ 10，需要你产出/更新它的 SKILL.md。
 
 # 你的目标
 
-读 atom 内容（AtomTaskRead），必要时读 traj 原文（ReadTraj），从轨迹里
-**提炼可泛化的知识**，写成 skill。skill 的价值 = 读它的人少踩多少坑、
-少试多少次错，而不是把一次执行过程复述一遍。SKILL.md 是必产物，但你
-**不限于**只写 SKILL.md——可以补充任何辅助文件，只要在 skill 目录范围内：
+先 AtomTaskRead 看 atom 的 intent、summary、tags、used_skills 和行号，
+不要指望它带回原文。需要证据时用 ReadTraj 按行分页取 traj 原文（每次最多
+200 行），从轨迹里 **提炼可泛化的知识**，写成 skill。skill 的价值 = 读它
+的人少踩多少坑、少试多少次错，而不是把一次执行过程复述一遍。SKILL.md 是
+必产物，但你 **不限于** 只写 SKILL.md——可以补充任何辅助文件，只要在
+skill 目录范围内：
 
 - ``<skill_dir>/SKILL.md`` — 必产物，frontmatter + body
 - ``<skill_dir>/scripts/*.py`` / ``*.sh`` — 可机械执行、参数化的脚本
@@ -292,8 +294,10 @@ commit message 写明本次基于哪些 atom_id 整理，以及**行为级**变�
 若本轮判定「仅印证、无行为变化」：不要为凑 commit 改正文；按更新场景跳过无意义版本。
 
 # 可用工具
-- AtomTaskRead(atom_id) — 读 atom JSON
-- ReadTraj(traj_id, offset_start, offset_end) — 按行号取轨迹原文（offset 即 1-based 行号）
+- AtomTaskRead(atom_id) — 读 intent / summary / tags / used_skills / 行号等元数据，
+  不含 raw_segment。原文用 ReadTraj
+- ReadTraj(traj_id, offset_start, offset_end) — 按行号取 traj 原文（1-based 半开
+  区间）；每次最多 200 行，超了只返回前 200 行并告诉下一页从哪起
 - SkillRead(skill_name) — 读现有 SKILL.md + 该 skill 目录其余文件树（更新场景先看这个）
 - read_file(path, offset=1, limit=200) — 按 1-based 行号窗口读取 skill 仓 /
   ~/.xskill / /tmp spill 下的文件；trim 后的 ``spill_path`` 也用它分页回读

--- a/src/xskill/agents/task_cluster_agent.py
+++ b/src/xskill/agents/task_cluster_agent.py
@@ -147,8 +147,10 @@ NewSkillFolder 再添加）。一个 AtomTask 可以同时支撑多个语义不�
 通过添加工具至少落盘一次，一个都不能漏。**
 
 # 可用工具
-- AtomTaskRead(atom_id) — 读 atom 完整 JSON（intent / summary / raw_segment 全字段）
-- ReadTraj(traj_id, offset_start, offset_end) — 按行号读 traj.md 原文片段（offset 即 1-based 行号）
+- AtomTaskRead(atom_id) — 读 intent / summary / tags / used_skills / 行号等，
+  不含 raw_segment。原文用 ReadTraj 按需分页
+- ReadTraj(traj_id, offset_start, offset_end) — 按行号读 traj.md 原文（1-based
+  半开区间）；每次最多 200 行
 - SkillRead(skill_name) — 读 skill 的 SKILL.md（baby 返回 stub，main/staging 返回正版）
 - ReadSkillTasks(skill_name) — **看某 skill 的 candidates buffer 内已有哪些 atom**
   （和 SkillRead 不同——SkillRead 看 SKILL.md，ReadSkillTasks 看正在攒分的 atom

--- a/tests/test_skill_edit_agent.py
+++ b/tests/test_skill_edit_agent.py
@@ -538,6 +538,11 @@ class TestWritingDisciplineInPrompt:
         assert "隐私守护" in SYSTEM_PROMPT_TEMPLATE
         assert "AtomTaskRead" in SYSTEM_PROMPT_TEMPLATE
 
+    def test_atom_read_is_metadata_traj_is_paged(self):
+        assert "intent、summary" in SYSTEM_PROMPT_TEMPLATE
+        assert "不含 raw_segment" in SYSTEM_PROMPT_TEMPLATE
+        assert "每次最多 200 行" in SYSTEM_PROMPT_TEMPLATE
+
 
 # ────────────────────────────────────────────────────────────────────
 # jam-merge 场景：候选累计 ws ≥ jam_threshold 且 staging 存在 → 越过灰度强砍

--- a/tests/test_skill_tools_atom.py
+++ b/tests/test_skill_tools_atom.py
@@ -43,6 +43,22 @@ class TestAtomTaskRead:
         assert "atom_x_0001" in out
         assert "makemigrations" in out
 
+    def test_keeps_intent_summary_drops_raw_segment(self, tmp_path):
+        import json
+
+        _setup(tmp_path)
+        out = agent_tools.atom_task_read.entrypoint("atom_x_0001")
+        data = json.loads(out)
+        assert data["intent"] == "修 django migration"
+        assert data["summary"] == "跑了 makemigrations 找冲突"
+        assert data["tags"] == ["django"]
+        assert data["offset_start"] == 1
+        assert data["offset_end"] == 3
+        assert "raw_segment" not in data
+        assert "MIGRATIONS!" not in out
+        assert data["raw_segment_chars"] == len("MIGRATIONS!")
+        assert "read_traj" in data["how_to_read"]
+
     def test_not_found_returns_error(self, tmp_path):
         _setup(tmp_path)
         out = agent_tools.atom_task_read.entrypoint("atom_nonexistent")
@@ -73,10 +89,26 @@ class TestReadTraj:
         out = agent_tools.read_traj.entrypoint("x", offset_start=0, offset_end=2)
         assert out.startswith("error")
 
-    def test_out_of_bounds_returns_error(self, tmp_path):
+    def test_out_of_bounds_clamps_to_file_and_page(self, tmp_path):
+        """要的行超过文件或超过单页上限时，截断并说明下一页，不整包返回。"""
         _setup(tmp_path)
         out = agent_tools.read_traj.entrypoint("x", offset_start=1, offset_end=999999)
-        assert out.startswith("error")
+        assert not out.startswith("error")
+        assert "[read_traj]" in out
+        assert "L1\n" in out
+        assert "L5\n" in out
+
+    def test_caps_each_call_to_max_lines(self, tmp_path):
+        skill_dir, store = _setup(tmp_path)
+        long = "\n".join(f"R{i}" for i in range(1, 251)) + "\n"
+        (store.root / "x.md").write_text(long, encoding="utf-8")
+        out = agent_tools.read_traj.entrypoint("x", offset_start=1, offset_end=251)
+        assert out.startswith("[read_traj]")
+        assert "max_lines=200" in out
+        assert "offset_start=201" in out
+        assert "R1\n" in out
+        assert "R200\n" in out
+        assert "R201\n" not in out
 
     def test_nonexistent_traj_returns_error(self, tmp_path):
         _setup(tmp_path)


### PR DESCRIPTION
Fixes #282

临时包 `0.6.32a2` 已含同一批行为，本 PR 把主干对齐过去。

## Summary
- `atom_task_read` 只返回 intent、summary、行号和 `how_to_read`，不再把 `raw_segment` 塞回模型。
- `read_traj` 每次最多 200 行；超出截断并在开头写下一页从哪继续。
- SkillEdit / Cluster 提示词与工具 docstring 写清分页用法。

## Test plan
- [x] `tests/test_skill_tools_atom.py`：不含 raw_segment；超长区间截断
- [x] SkillEdit 提示词断言每次最多 200 行

Made with [Cursor](https://cursor.com)