### PR TITLE
fix(generate): 对本趟生成的文件按段 edit，不再只能整篇覆盖

### DIFF
--- a/src/xskill/agents/agent_tools.py
+++ b/src/xskill/agents/agent_tools.py
@@ -396,8 +396,7 @@ class AgentToolConfig:
 
     @property
     def writable_skill_dir(self) -> Path | None:
-        current = _AGENT_TOOL_CONTEXT.get()
-        return current.atom_skill_dir or current.skill_dir
+        return _writable_skill_root()
 
 
 agent_tool_config = AgentToolConfig()
@@ -754,6 +753,12 @@ def read_file(path: str, offset: int = 1, limit: int = 200) -> str:
         return f"error: limit must be >= 1 (got {line_limit})"
 
     p = Path(path)
+    if not p.is_absolute():
+        skill_root = _writable_skill_root()
+        if skill_root is not None:
+            in_skill = (skill_root / p).resolve()
+            if in_skill.is_file():
+                p = in_skill
     roots = _allowed_read_roots()
     resolved = p.resolve()
     try:
@@ -974,6 +979,17 @@ def list_candidates(skill_name: str) -> str:
     return "\n".join(lines)
 
 
+def _pin_skill_write_target(skill_name: str) -> None:
+    """把后续 write_file / edit 的相对路径根钉到这个 skill 仓。"""
+    slug = _slugify(skill_name)
+    if not slug:
+        return
+    current = current_agent_tool_context()
+    if current.skill_edit_skill_name == slug:
+        return
+    _AGENT_TOOL_CONTEXT.set(replace(current, skill_edit_skill_name=slug))
+
+
 def _writable_skill_root() -> Path | None:
     current = current_agent_tool_context()
     lib = current.atom_skill_dir or current.skill_dir
@@ -1081,11 +1097,12 @@ def write_file(path: str, content: str) -> str:
 
 @tool(name="edit")
 def edit_file(path: str, old_string: str, new_string: str) -> str:
-    """Replace one exact substring in a skill file the agent already read.
+    """改已经读过的 skill 文件里的一处原文。生成出来的文件同样用它改。
 
-    The file must have been read in this run via read_file or skill_read
-    (write_file also counts).  New files that do not exist yet should use
-    write_file instead.
+    已有文件（包括 new_skill_folder 放下的 stub SKILL.md、本趟 write_file
+    刚写的脚本）一律先 read_file 或 skill_read，再调用本工具。old_string
+    必须在文件里恰好出现一次。文件还不存在时用 write_file，不要用本工具
+    创建。相对路径按当前 skill 仓解析：SKILL.md、scripts/foo.py。
     """
     resolved, err = _resolve_skill_write_path(path)
     if err:
@@ -1349,7 +1366,10 @@ def new_skill_folder(skill_name: str, description: str) -> str:
         init_skill_repo_on_baby(str(target), name=slug, description=desc)
         return f"created on baby branch: {target}  desc={desc[:60]!r}"
 
-    return _run_cluster_mutation(mutate)
+    result = _run_cluster_mutation(mutate)
+    if not str(result).startswith("error:"):
+        _pin_skill_write_target(slug)
+    return result
 
 
 @tool(name="skill_read")
@@ -1360,6 +1380,8 @@ def skill_read(skill_name: str) -> str:
         return "error: atom task tool context not initialized"
     slug = _slugify(skill_name)
     skill_path = (skill_dir / slug).resolve()
+    if current_agent_tool_context().generate_user_id and skill_path.is_dir():
+        _pin_skill_write_target(slug)
     header = f"skill_dir: {skill_path}"
     try:
         from xskill.skill.git import current_branch

--- a/src/xskill/agents/generate_agent.py
+++ b/src/xskill/agents/generate_agent.py
@@ -42,12 +42,35 @@ scripts/ 下放可执行脚本、在 references/ 下放长参考材料。价值�
 用 list_files 摸清结构，用 grep_files 按关键词搜索，用 read_file 按行精读。
 看某个已有 skill 的现状用 skill_read。
 
+# 怎么改文件
+
+THINK 里一旦想到要改某个已有文件，下一手不要整文件 write_file。本趟
+new_skill_folder 刚建出来的 stub SKILL.md、刚 write_file 过的脚本、磁盘上
+已有的 skill，都算已有文件。按这个顺序做：
+
+1. 用 list_files 或 skill_read 看目录里有哪些文件
+2. 用 read_file 或 skill_read 读到要改的原文（辅助文件必须单独 read_file；
+   skill_read 只算读过 SKILL.md）
+3. 用 edit(path, old_string, new_string) 只替换那一处；old_string 必须在
+   文件里唯一
+
+write_file 只用于：文件还不存在、SKILL.md 仍是 init stub、或现有正文必须
+整篇改写。已经有正式正文之后只 edit 有差异的段落，禁止无故全篇覆盖。
+edit 前必须先读过该文件，否则工具会报错。
+
+相对路径按当前 skill 仓解析：SKILL.md、scripts/foo.py。不要加 ./skill/
+或技能文件夹名当第一段。
+
 # 怎么写
 
-- 新建：先 new_skill_folder(name, description)，再用 write_file 写出完整
-  SKILL.md 和脚本。
-- 改已有文件：必须先 read_file 或 skill_read，再 edit(path, old_string, new_string)。
-  没读过会报错。新建尚不存在的文件用 write_file。
+- 新建：先 new_skill_folder(name, description)，它会建目录并放下 stub
+  SKILL.md。填正文用 edit（stub 可一次 write_file 换成正式稿）。新脚本
+  还不存在时才 write_file。
+- 本趟已经 new_skill_folder 过的名字就是你自己的半成品，不是别人的 skill。
+  压缩上下文之后仍以「本趟已执行动作」为准：那个目录的 stub SKILL.md
+  只说明你还没写完，继续 edit，最后 commit_generate_main。
+  不要再调一次 new_skill_folder，也不要另开一个近义名字的新目录。
+- 改已有 skill：先 skill_read，再 edit。不要整篇 write_file 覆盖丢掉已有内容。
 - 写完必须调用 commit_generate_main(skill_name, message)。它会把结果提交到
   main：没有 main 就创建，目录几乎是空的也允许提交。不要调用任何灰度
   （staging）提交工具。
@@ -61,8 +84,8 @@ scripts/ 下放可执行脚本、在 references/ 下放长参考材料。价值�
 - grep_files(pattern, path="", glob="", max_results=100)
 - read_file(path, offset=1, limit=200)
 - skill_read(skill_name)
-- write_file(path, content)
-- edit(path, old_string, new_string)
+- write_file(path, content) — 仅新文件或 stub 整篇重写
+- edit(path, old_string, new_string) — 改已读过的已有文件（含本趟刚生成的）
 - new_skill_folder(skill_name, description)
 - commit_generate_main(skill_name, message)
 """

--- a/tests/test_generate_command.py
+++ b/tests/test_generate_command.py
@@ -90,6 +90,92 @@ def test_edit_requires_prior_read(tmp_path: Path):
     assert "new line" in skill_md.read_text(encoding="utf-8")
 
 
+def test_generate_prompt_teaches_edit_not_full_rewrite():
+    from xskill.agents.generate_agent import SYSTEM_PROMPT
+
+    assert "怎么改文件" in SYSTEM_PROMPT
+    assert "edit(path, old_string, new_string)" in SYSTEM_PROMPT
+    assert "不要整文件 write_file" in SYSTEM_PROMPT
+    assert "刚 write_file 过的脚本" in SYSTEM_PROMPT
+    assert "write_file 只用于" in SYSTEM_PROMPT
+
+
+def test_generate_agent_registers_edit_tool(tmp_path: Path):
+    from xskill.agents.generate_agent import GenerateAgent
+
+    captured: dict[str, list[str]] = {}
+
+    def factory(*, instructions, tools):
+        captured["tools"] = [
+            getattr(tool, "name", None) or getattr(tool, "__name__", "")
+            for tool in tools
+        ]
+
+        class _Agent:
+            def run(self, *_args, **_kwargs):
+                class _Result:
+                    content = "ok"
+
+                return _Result()
+
+        return _Agent()
+
+    skill_dir, ctx = _bind_skill_ctx(tmp_path)
+    agent = GenerateAgent(
+        skill_dir=skill_dir,
+        agno_agent_factory=factory,
+        llm_cfg={},
+        logs_dir=None,
+    )
+    with agent_tools.use_agent_tool_context(ctx):
+        agent.run(instruction="改一下发票 skill", user_id="alice", job_id="j1")
+    assert "edit" in captured["tools"]
+    assert "write_file" in captured["tools"]
+
+
+def test_generate_new_folder_then_edit_relative_skill_md(tmp_path: Path):
+    skill_dir, ctx = _bind_skill_ctx(tmp_path)
+    with agent_tools.use_agent_tool_context(ctx):
+        created = _call_tool(
+            agent_tools.new_skill_folder, "demo", "发票核对流程",
+        )
+        assert not str(created).startswith("error:"), created
+        stub_path = skill_dir / "demo" / "SKILL.md"
+        assert stub_path.is_file()
+        _call_tool(agent_tools.read_file, "SKILL.md")
+        ok = _call_tool(
+            agent_tools.edit_file,
+            "SKILL.md",
+            "(placeholder — SkillEditAgent 在 candidates 攒满阈值后会用真实 atom 内容填充正文)",
+            "用 edit 填进去的正文",
+        )
+        assert str(ok).startswith("edited:"), ok
+        text = stub_path.read_text(encoding="utf-8")
+        assert "用 edit 填进去的正文" in text
+        assert not (skill_dir / "SKILL.md").exists()
+
+
+def test_generate_skill_read_then_edit_existing(tmp_path: Path):
+    skill_dir, ctx = _bind_skill_ctx(tmp_path)
+    target = skill_dir / "invoice"
+    target.mkdir()
+    (target / "SKILL.md").write_text(
+        "---\nname: invoice\ndescription: hello world\n---\n\n# Invoice\n\nold line\n",
+        encoding="utf-8",
+    )
+    with agent_tools.use_agent_tool_context(ctx):
+        _call_tool(agent_tools.skill_read, "invoice")
+        ok = _call_tool(
+            agent_tools.edit_file,
+            "SKILL.md",
+            "old line",
+            "new line",
+        )
+        assert str(ok).startswith("edited:"), ok
+    assert "new line" in (target / "SKILL.md").read_text(encoding="utf-8")
+    assert not (skill_dir / "SKILL.md").exists()
+
+
 def test_generate_read_roots_include_traj_not_parent_secrets(tmp_path: Path):
     skill_dir, ctx = _bind_skill_ctx(tmp_path)
     traj = tmp_path / "team_trajectories" / "clients" / "alice" / "sessions"


### PR DESCRIPTION
Fixes #284

叠在 #278 上：需要当前 skill 仓才是 write/edit 根。临时包 `0.6.32a2` 已含同一批行为。

## Summary
- Generate 提示词与 SkillEdit 同一套改文件纪律：已有文件（含本趟 stub）先读再 edit。
- `new_skill_folder` / `skill_read` 把后续相对路径钉到这个 skill 仓。
- `read_file("SKILL.md")` 若当前仓里有这个文件，按仓解析，不再落到进程 cwd。

## Test plan
- [x] `tests/test_generate_command.py`：new_skill_folder 后相对路径 edit；skill_read 后 edit 已有 skill
- [x] Generate 工具箱含 edit；提示词含怎么改文件

Made with [Cursor](https://cursor.com)