### PR TITLE
perf(watcher): reuse atom snapshots within a poll

### DIFF
--- a/src/xskill/pipeline/runner.py
+++ b/src/xskill/pipeline/runner.py
@@ -93,7 +93,7 @@ class DirectoryWatcher:
     - indexed 阶段以 AtomTask 为单位整批重建 ``<traj_root>/index.pkl``
     - cluster 阶段**跨轨迹池化**：把所有 indexed 轨迹里尚未落地的 atom 汇成一池，
       按 ``cluster.batch_size`` 分批，提交给全局 cluster pool。
-    - indexed → done 由 ``_finalize_completed_trajs`` 标：一条轨迹的 atom 全部落进某个
+    - indexed → done 由 ``_reconcile_indexed_atoms`` 标：一条轨迹的 atom 全部落进某个
       skill 的 ``.candidates.yml`` 时才 done（文件系统即队列，天然去重+断点续传）。
     """
 
@@ -427,21 +427,15 @@ class DirectoryWatcher:
         # 避免 1 万 skill 下每轮白扫 1 万个 .candidates.yml。本轮内快照一致有效。
         from xskill.skill.candidates import LazyConsumedIndex
         consumed_index = LazyConsumedIndex(self.skill_dir)
-        # 同一轮内 collection / finalization / scoring 共享同一份 Atom 视图。
-        # key 带 wd_id，避免多个 watch directory 中同名 traj 相互污染；缓存不
-        # 跨 poll 存活，下一轮仍会重新读取文件系统上的 durable 状态。
-        atom_snapshots: dict[tuple[int, str], tuple] = {}
 
         # ── Step 1-4: 对每个目录扫描 + 提交 split/embed + 收集 cluster atom ──
         watch_dirs = list_watch_dirs(**kw)
-        active_watch_dirs = []
         for wd in watch_dirs:
             if self._stop.is_set():
                 break
             if not wd.get("auto_index"):
                 continue
-            active_watch_dirs.append(wd)
-            self._scan_dir(wd, consumed_index, atom_snapshots, **kw)
+            self._scan_dir(wd, consumed_index, **kw)
 
         if self._round_new_atoms:
             self.pending_atoms.extendleft(reversed(self._round_new_atoms))
@@ -449,17 +443,6 @@ class DirectoryWatcher:
         # 全部 watch_dir 共用一个 pending/claimed 队列；持续提交到 cluster 池满。
         # 最后不足 batch_size 的尾批也立即提交。
         self._submit_cluster_batches()
-
-        # 已完成归类的轨迹在下一次 durable atom 检查中进入 done。
-        if self.skill_dir:
-            for wd in active_watch_dirs:
-                dir_path = Path(wd["path"])
-                if dir_path.is_dir():
-                    self._finalize_completed_trajs(
-                        wd["id"], dir_path, consumed_index, atom_snapshots, **kw,
-                    )
-        # 后续 SkillEdit / canary 步骤不再使用 Atom 视图，尽早释放长轨迹内容。
-        atom_snapshots.clear()
 
         # ── Step 5a: 用户点名的 generate 入队到 SkillEdit 同一线程池 ──
         # 先于自动 SkillEdit 提交，避免后台整理把用户任务挤到池外。
@@ -2337,7 +2320,7 @@ class DirectoryWatcher:
 
         cluster batch 与 split/embed 不同：一个 batch future 覆盖一批跨轨迹的
         atom，没有单一 fname。它只负责"把 atom 写进 candidates"（agent 用工具
-        完成）+ 记日志；轨迹 done 由 ``_finalize_completed_trajs`` 独立核对落地情况后标。
+        完成）+ 记日志；轨迹 done 由 ``_reconcile_indexed_atoms`` 独立核对落地情况后标。
         batch 整体抛异常（如 LLM 余额耗尽）时，atom 留在未落地池，下一轮 scan
         重新进池重试——无单独重试计数，靠重池化自愈（cluster prompt 要求每个
         atom 必落地，永久失败不会发生，失败都是瞬时的）。
@@ -2415,7 +2398,7 @@ class DirectoryWatcher:
     # 扫描单个目录：发现 + 提交任务
     # ───────────────────────────────────────────────────────────
 
-    def _scan_dir(self, wd, consumed_index, atom_snapshots, **kw):
+    def _scan_dir(self, wd, consumed_index, **kw):
         wd_id = wd["id"]
         dir_path = Path(wd["path"])
         if not dir_path.is_dir():
@@ -2436,7 +2419,7 @@ class DirectoryWatcher:
                 update_traj_status(wd_id, fname, "discovered", **kw)
 
         # 跨轨迹批处理下 watcher 不再把轨迹置 "clustering"（done 由
-        # _finalize_completed_trajs 按 atom 落地情况标）。任何遗留的 "clustering"
+        # _reconcile_indexed_atoms 按 atom 落地情况标）。任何遗留的 "clustering"
         # （旧 daemon 升级残留 / 历史数据）一律回退 "indexed" 让其重新进池——
         # 已落地的 atom 会在 _collect_cluster_batch 被去重跳过，不会重复消费。
         for fname in get_trajs_by_status(wd_id, "clustering", **kw):
@@ -2514,10 +2497,10 @@ class DirectoryWatcher:
                         "stage": "embed",
                     }
 
-        # ── Cluster：只收集到全局 pending，不在目录循环内等待或串行 ──
+        # ── Cluster：逐轨迹收集 pending 并判断完成，不在目录循环内等待 ──
         if self.skill_dir:
-            self._collect_cluster_atoms(
-                dir_path, wd_id, consumed_index, atom_snapshots, **kw,
+            self._reconcile_indexed_atoms(
+                dir_path, wd_id, consumed_index, **kw,
             )
 
     # ───────────────────────────────────────────────────────────
@@ -2645,18 +2628,8 @@ class DirectoryWatcher:
         store.rebuild_vector_index(self.embed_client)
         return (wd_id, filenames)
 
-    @staticmethod
-    def _poll_atoms(store, wd_id, traj_id, atom_snapshots):
-        """Return one immutable Atom list snapshot per trajectory and poll."""
-        key = (wd_id, traj_id)
-        if key not in atom_snapshots:
-            atom_snapshots[key] = tuple(store.list_by_traj(traj_id))
-        return atom_snapshots[key]
-
-    def _collect_cluster_atoms(
-        self, dir_path, wd_id, consumed_index, atom_snapshots, **kw,
-    ):
-        """Collect every new unclustered atom into the global pending queue.
+    def _reconcile_indexed_atoms(self, dir_path, wd_id, consumed_index, **kw):
+        """Read each indexed trajectory once, then release its full Atom view.
 
         过滤靠 atom 的耐久 ``clustered`` 标记——已消费 atom（含上一批刚写入的、
         以及进程被 kill 前已消费的）一律跳过。这从机制上同时实现了**去重**与
@@ -2666,20 +2639,45 @@ class DirectoryWatcher:
         atom 看起来又"未消费"而被重复送 LLM。
 
         ``claimed_atoms`` covers both pending and running batches, so repeated
-        scans never enqueue the same atom twice.
+        scans never enqueue the same atom twice.  Collection, completion, and
+        scoring share one stable tuple for the current trajectory; the helper
+        returns before the next trajectory is loaded, bounding retained full
+        Atom content to one trajectory instead of the entire indexed backlog.
         """
         store = self._store_for(dir_path)
         for fname in get_trajs_by_status(wd_id, "indexed", **kw):
-            traj_id = (dir_path / fname).stem
-            for atom in self._poll_atoms(
-                store, wd_id, traj_id, atom_snapshots,
-            ):
-                if self._atom_consumed(atom, consumed_index):
-                    continue  # 已消费 → 跳过（去重 + 断点续传）
-                if atom.atom_id in self.claimed_atoms:
-                    continue
-                self.claimed_atoms.add(atom.atom_id)
-                self._round_new_atoms.append(atom.atom_id)
+            self._reconcile_indexed_traj(
+                store, dir_path, wd_id, fname, consumed_index, **kw,
+            )
+
+    def _reconcile_indexed_traj(
+        self, store, dir_path, wd_id, fname, consumed_index, **kw,
+    ):
+        """Reconcile one trajectory against a single durable Atom snapshot."""
+        traj_id = (dir_path / fname).stem
+        atoms = tuple(store.list_by_traj(traj_id))
+        all_consumed = True
+        for atom in atoms:
+            if self._atom_consumed(atom, consumed_index):
+                continue  # 已消费 → 跳过（去重 + 断点续传）
+            all_consumed = False
+            if atom.atom_id in self.claimed_atoms:
+                continue
+            self.claimed_atoms.add(atom.atom_id)
+            self._round_new_atoms.append(atom.atom_id)
+
+        if not all_consumed:
+            return
+        update_traj_status(
+            wd_id, fname, "done", process_action="clustered", **kw,
+        )
+        # 该轨迹所有 atom 已落盘——ux_score 使用同一份快照，避免再次读 JSON。
+        if self.server_mode:
+            self._score_atoms_for_traj_server(
+                wd_id, fname, atoms=atoms, **kw,
+            )
+        else:
+            self._score_atoms_for_traj(wd_id, fname, atoms=atoms, **kw)
 
     def _submit_cluster_batches(self) -> None:
         """Fill the cluster pool without ever waiting in the watcher thread."""
@@ -2805,7 +2803,7 @@ class DirectoryWatcher:
         轨迹状态。
 
         轨迹 done 与具体 batch 解耦——一个 batch 跨多条轨迹，done 由
-        ``_finalize_completed_trajs`` 按"该轨迹 atom 是否全落地"独立判定。
+        ``_reconcile_indexed_atoms`` 按"该轨迹 atom 是否全落地"独立判定。
         """
         n_total = len(results)
         in_skills = [r for r in results if _result_skill_assignments(r)]
@@ -2840,38 +2838,6 @@ class DirectoryWatcher:
                 len(dropped), [r.get("atom_id") for r in dropped],
             )
         self._stats["atoms_clustered"] += len(in_skills)
-
-    def _finalize_completed_trajs(
-        self, wd_id, dir_path, consumed_index, atom_snapshots, **kw,
-    ):
-        """把"所有 atom 都已落进某个 skill .candidates.yml"的 indexed 轨迹标
-        done，并触发该轨迹的 ux 打分。
-
-        这是跨轨迹批处理下 done 的唯一判据：cluster batch 不再 1:1 对应一条
-        轨迹，所以每轮 scan 重新核对每条 indexed 轨迹是否已被完全消费。0-atom
-        轨迹（无可拆 User 回合）视为已消费 → 直接 done。标 done 后该轨迹离开
-        indexed，下一轮不再重复处理 → 打分每条只触发一次。
-
-        判据用 atom 的耐久 ``clustered`` 标记（非 .candidates.yml 成员）——
-        SkillEdit 晋升会清空 .candidates.yml，用它判 done 会让已消费 atom 看起来
-        又未消费、轨迹永不 done。
-        """
-        store = self._store_for(dir_path)
-        for fname in get_trajs_by_status(wd_id, "indexed", **kw):
-            traj_id = (dir_path / fname).stem
-            atoms = self._poll_atoms(store, wd_id, traj_id, atom_snapshots)
-            if any(not self._atom_consumed(a, consumed_index) for a in atoms):
-                continue  # 还有未消费 atom → 等后续 batch 消费
-            update_traj_status(
-                wd_id, fname, "done", process_action="clustered", **kw,
-            )
-            # 该轨迹所有 atom 已落盘——ux_score 应当跑的时机。
-            if self.server_mode:
-                self._score_atoms_for_traj_server(
-                    wd_id, fname, atoms=atoms, **kw,
-                )
-            else:
-                self._score_atoms_for_traj(wd_id, fname, atoms=atoms, **kw)
 
     # ───────────────────────────────────────────────────────────
     # ux_score

--- a/src/xskill/pipeline/runner.py
+++ b/src/xskill/pipeline/runner.py
@@ -427,6 +427,10 @@ class DirectoryWatcher:
         # 避免 1 万 skill 下每轮白扫 1 万个 .candidates.yml。本轮内快照一致有效。
         from xskill.skill.candidates import LazyConsumedIndex
         consumed_index = LazyConsumedIndex(self.skill_dir)
+        # 同一轮内 collection / finalization / scoring 共享同一份 Atom 视图。
+        # key 带 wd_id，避免多个 watch directory 中同名 traj 相互污染；缓存不
+        # 跨 poll 存活，下一轮仍会重新读取文件系统上的 durable 状态。
+        atom_snapshots: dict[tuple[int, str], tuple] = {}
 
         # ── Step 1-4: 对每个目录扫描 + 提交 split/embed + 收集 cluster atom ──
         watch_dirs = list_watch_dirs(**kw)
@@ -437,7 +441,7 @@ class DirectoryWatcher:
             if not wd.get("auto_index"):
                 continue
             active_watch_dirs.append(wd)
-            self._scan_dir(wd, consumed_index, **kw)
+            self._scan_dir(wd, consumed_index, atom_snapshots, **kw)
 
         if self._round_new_atoms:
             self.pending_atoms.extendleft(reversed(self._round_new_atoms))
@@ -452,8 +456,10 @@ class DirectoryWatcher:
                 dir_path = Path(wd["path"])
                 if dir_path.is_dir():
                     self._finalize_completed_trajs(
-                        wd["id"], dir_path, consumed_index, **kw,
+                        wd["id"], dir_path, consumed_index, atom_snapshots, **kw,
                     )
+        # 后续 SkillEdit / canary 步骤不再使用 Atom 视图，尽早释放长轨迹内容。
+        atom_snapshots.clear()
 
         # ── Step 5a: 用户点名的 generate 入队到 SkillEdit 同一线程池 ──
         # 先于自动 SkillEdit 提交，避免后台整理把用户任务挤到池外。
@@ -2409,7 +2415,7 @@ class DirectoryWatcher:
     # 扫描单个目录：发现 + 提交任务
     # ───────────────────────────────────────────────────────────
 
-    def _scan_dir(self, wd, consumed_index, **kw):
+    def _scan_dir(self, wd, consumed_index, atom_snapshots, **kw):
         wd_id = wd["id"]
         dir_path = Path(wd["path"])
         if not dir_path.is_dir():
@@ -2511,7 +2517,7 @@ class DirectoryWatcher:
         # ── Cluster：只收集到全局 pending，不在目录循环内等待或串行 ──
         if self.skill_dir:
             self._collect_cluster_atoms(
-                dir_path, wd_id, consumed_index, **kw,
+                dir_path, wd_id, consumed_index, atom_snapshots, **kw,
             )
 
     # ───────────────────────────────────────────────────────────
@@ -2639,7 +2645,17 @@ class DirectoryWatcher:
         store.rebuild_vector_index(self.embed_client)
         return (wd_id, filenames)
 
-    def _collect_cluster_atoms(self, dir_path, wd_id, consumed_index, **kw):
+    @staticmethod
+    def _poll_atoms(store, wd_id, traj_id, atom_snapshots):
+        """Return one immutable Atom list snapshot per trajectory and poll."""
+        key = (wd_id, traj_id)
+        if key not in atom_snapshots:
+            atom_snapshots[key] = tuple(store.list_by_traj(traj_id))
+        return atom_snapshots[key]
+
+    def _collect_cluster_atoms(
+        self, dir_path, wd_id, consumed_index, atom_snapshots, **kw,
+    ):
         """Collect every new unclustered atom into the global pending queue.
 
         过滤靠 atom 的耐久 ``clustered`` 标记——已消费 atom（含上一批刚写入的、
@@ -2655,7 +2671,9 @@ class DirectoryWatcher:
         store = self._store_for(dir_path)
         for fname in get_trajs_by_status(wd_id, "indexed", **kw):
             traj_id = (dir_path / fname).stem
-            for atom in store.list_by_traj(traj_id):
+            for atom in self._poll_atoms(
+                store, wd_id, traj_id, atom_snapshots,
+            ):
                 if self._atom_consumed(atom, consumed_index):
                     continue  # 已消费 → 跳过（去重 + 断点续传）
                 if atom.atom_id in self.claimed_atoms:
@@ -2823,7 +2841,9 @@ class DirectoryWatcher:
             )
         self._stats["atoms_clustered"] += len(in_skills)
 
-    def _finalize_completed_trajs(self, wd_id, dir_path, consumed_index, **kw):
+    def _finalize_completed_trajs(
+        self, wd_id, dir_path, consumed_index, atom_snapshots, **kw,
+    ):
         """把"所有 atom 都已落进某个 skill .candidates.yml"的 indexed 轨迹标
         done，并触发该轨迹的 ux 打分。
 
@@ -2839,7 +2859,7 @@ class DirectoryWatcher:
         store = self._store_for(dir_path)
         for fname in get_trajs_by_status(wd_id, "indexed", **kw):
             traj_id = (dir_path / fname).stem
-            atoms = store.list_by_traj(traj_id)
+            atoms = self._poll_atoms(store, wd_id, traj_id, atom_snapshots)
             if any(not self._atom_consumed(a, consumed_index) for a in atoms):
                 continue  # 还有未消费 atom → 等后续 batch 消费
             update_traj_status(
@@ -2847,15 +2867,17 @@ class DirectoryWatcher:
             )
             # 该轨迹所有 atom 已落盘——ux_score 应当跑的时机。
             if self.server_mode:
-                self._score_atoms_for_traj_server(wd_id, fname, **kw)
+                self._score_atoms_for_traj_server(
+                    wd_id, fname, atoms=atoms, **kw,
+                )
             else:
-                self._score_atoms_for_traj(wd_id, fname, **kw)
+                self._score_atoms_for_traj(wd_id, fname, atoms=atoms, **kw)
 
     # ───────────────────────────────────────────────────────────
     # ux_score
     # ───────────────────────────────────────────────────────────
 
-    def _score_atoms_for_traj(self, wd_id, fname, **kw):
+    def _score_atoms_for_traj(self, wd_id, fname, atoms=None, **kw):
         """对一条已跑完 cluster 的 traj 扫所有 atom 打 ux_score。
 
         前置：
@@ -2892,8 +2914,8 @@ class DirectoryWatcher:
             return
         skill_name = header["skill"]
         traj_id = md_path.stem
-        store = self._store_for(dir_path)
-        atoms = store.list_by_traj(traj_id)
+        if atoms is None:
+            atoms = self._store_for(dir_path).list_by_traj(traj_id)
         if not atoms:
             return
         skill_sub, side, commit_sha = self._resolve_skill_for_scoring(
@@ -2950,7 +2972,7 @@ class DirectoryWatcher:
             return None, "", ""
         return hub_sub, "main", hub.content_sha(skill_name) or ""
 
-    def _score_atoms_for_traj_server(self, wd_id, fname, **kw):
+    def _score_atoms_for_traj_server(self, wd_id, fname, atoms=None, **kw):
         """CS 模式打分：遍历每个 atom 的 used_skills，对每个用到的 team skill
         用 pick_side(client_id, ...) 现算 side，逐个 score + AtomCanary.append。
 
@@ -2984,8 +3006,8 @@ class DirectoryWatcher:
         if not md_path.is_file():
             return
         traj_id = md_path.stem
-        store = self._store_for(dir_path)
-        atoms = store.list_by_traj(traj_id)
+        if atoms is None:
+            atoms = self._store_for(dir_path).list_by_traj(traj_id)
         if not atoms:
             return
         canary_cfg = CanaryConfig.from_dict(self.config.get("canary", {}))

--- a/tests/test_cluster_batch.py
+++ b/tests/test_cluster_batch.py
@@ -7,7 +7,7 @@ ClusterAgent 由"每次消费 1 个 atom"改为"每次消费 cluster batch_size 
 1. **批量生效**：构造 N 条 indexed 轨迹（N > batch_size），观察 ClusterAgent
    调用次数 == ceil(总未归类 atom 数 / batch_size)，而**非** == 总 atom 数。
 2. **已落地过滤**：构造已在某 skill ``.candidates.yml`` 的 atom，确认被
-   ``_collect_cluster_atoms`` 过滤、永不进入任何 batch、不送 LLM。
+   ``_reconcile_indexed_atoms`` 过滤、永不进入任何 batch、不送 LLM。
 3. **断点续传**：消费中途"kill 进程"（丢弃 watcher + 线程池），重启（新 watcher
    同一 wd/db/skill_dir/store）后从断点继续，已落地 atom 不重复消费。
 

--- a/tests/test_watcher_atom.py
+++ b/tests/test_watcher_atom.py
@@ -2,9 +2,11 @@
 from __future__ import annotations
 
 from concurrent.futures import Future
+import gc
 import threading
 import time
 from unittest.mock import Mock
+import weakref
 
 from xskill.pipeline.atom import AtomTaskStore
 from xskill.pipeline.registry import (
@@ -247,7 +249,7 @@ def _seed_indexed_with_atoms(wd, store, db, n_trajs, atoms_per_traj):
 
 
 class TestPollAtomSnapshot:
-    """同一轮共享 Atom 视图；下一轮重新观察 durable JSON。"""
+    """每条轨迹共享 Atom 视图；下一条前释放，下一轮重读 durable JSON。"""
 
     def test_indexed_traj_is_loaded_once_per_poll(self, tmp_path, monkeypatch):
         db = tmp_path / "test.db"
@@ -345,6 +347,50 @@ class TestPollAtomSnapshot:
 
         assert loaded == ["traj_0"]
         assert get_trajs_by_status(wd_id, "done", db_path=db) == ["traj_0.md"]
+        watcher.stop()
+
+    def test_full_atom_snapshot_is_released_before_loading_next_traj(
+        self, tmp_path, monkeypatch,
+    ):
+        db = tmp_path / "test.db"
+        wd = tmp_path / "wd"
+        wd.mkdir()
+        skill_dir = tmp_path / "skill"
+        skill_dir.mkdir()
+        store = AtomTaskStore(root=wd)
+        _seed_indexed_with_atoms(
+            wd, store, db, n_trajs=3, atoms_per_traj=1,
+        )
+        watcher = DirectoryWatcher(
+            llm=None,
+            embed_client=None,
+            config={},
+            skill_dir=skill_dir,
+            poll_interval=0.0,
+            pool_config=pool_config(workers=1),
+            db_path=db,
+            store=store,
+            home_root=tmp_path,
+        )
+        monkeypatch.setattr(watcher, "_submit_cluster_batches", lambda: None)
+
+        previous_atom = None
+        original_list_by_traj = store.list_by_traj
+
+        def tracked_list_by_traj(traj_id):
+            nonlocal previous_atom
+            if previous_atom is not None:
+                gc.collect()
+                assert previous_atom() is None
+            atoms = original_list_by_traj(traj_id)
+            previous_atom = weakref.ref(atoms[0])
+            return atoms
+
+        monkeypatch.setattr(store, "list_by_traj", tracked_list_by_traj)
+
+        watcher._scan_once()
+
+        assert watcher._stats["polls"] == 1
         watcher.stop()
 
 

--- a/tests/test_watcher_atom.py
+++ b/tests/test_watcher_atom.py
@@ -246,6 +246,108 @@ def _seed_indexed_with_atoms(wd, store, db, n_trajs, atoms_per_traj):
     return wd_id
 
 
+class TestPollAtomSnapshot:
+    """同一轮共享 Atom 视图；下一轮重新观察 durable JSON。"""
+
+    def test_indexed_traj_is_loaded_once_per_poll(self, tmp_path, monkeypatch):
+        db = tmp_path / "test.db"
+        wd = tmp_path / "wd"
+        wd.mkdir()
+        skill_dir = tmp_path / "skill"
+        skill_dir.mkdir()
+        store = AtomTaskStore(root=wd)
+        wd_id = _seed_indexed_with_atoms(
+            wd, store, db, n_trajs=1, atoms_per_traj=1,
+        )
+        watcher = DirectoryWatcher(
+            llm=None,
+            embed_client=None,
+            config={},
+            skill_dir=skill_dir,
+            poll_interval=0.0,
+            pool_config=pool_config(workers=1),
+            db_path=db,
+            store=store,
+            home_root=tmp_path,
+        )
+        monkeypatch.setattr(watcher, "_submit_cluster_batches", lambda: None)
+        scored = []
+        monkeypatch.setattr(
+            watcher,
+            "_score_atoms_for_traj",
+            lambda _wd_id, _fname, atoms=None, **_kw: scored.append(atoms),
+        )
+
+        loaded = []
+        original_list_by_traj = store.list_by_traj
+
+        def counted_list_by_traj(traj_id):
+            loaded.append(traj_id)
+            return original_list_by_traj(traj_id)
+
+        monkeypatch.setattr(store, "list_by_traj", counted_list_by_traj)
+
+        watcher._scan_once()
+
+        assert loaded == ["traj_0"]
+        assert get_trajs_by_status(wd_id, "indexed", db_path=db) == [
+            "traj_0.md"
+        ]
+
+        # 本轮之后落盘的 cluster 结果不改写旧快照；下一轮重新读取并完成轨迹。
+        atom = original_list_by_traj("traj_0")[0]
+        atom.clustered = True
+        store.save(atom)
+
+        watcher._scan_once()
+
+        assert loaded == ["traj_0", "traj_0"]
+        assert get_trajs_by_status(wd_id, "done", db_path=db) == ["traj_0.md"]
+        assert len(scored) == 1
+        assert isinstance(scored[0], tuple)
+        assert scored[0][0].clustered is True
+        watcher.stop()
+
+    def test_empty_traj_snapshot_is_reused_for_finalization(
+        self, tmp_path, monkeypatch,
+    ):
+        db = tmp_path / "test.db"
+        wd = tmp_path / "wd"
+        wd.mkdir()
+        skill_dir = tmp_path / "skill"
+        skill_dir.mkdir()
+        store = AtomTaskStore(root=wd)
+        wd_id = _seed_indexed_with_atoms(
+            wd, store, db, n_trajs=1, atoms_per_traj=0,
+        )
+        watcher = DirectoryWatcher(
+            llm=None,
+            embed_client=None,
+            config={},
+            skill_dir=skill_dir,
+            poll_interval=0.0,
+            pool_config=pool_config(workers=1),
+            db_path=db,
+            store=store,
+            home_root=tmp_path,
+        )
+
+        loaded = []
+        original_list_by_traj = store.list_by_traj
+
+        def counted_list_by_traj(traj_id):
+            loaded.append(traj_id)
+            return original_list_by_traj(traj_id)
+
+        monkeypatch.setattr(store, "list_by_traj", counted_list_by_traj)
+
+        watcher._scan_once()
+
+        assert loaded == ["traj_0"]
+        assert get_trajs_by_status(wd_id, "done", db_path=db) == ["traj_0.md"]
+        watcher.stop()
+
+
 class TestClusterParallel:
     """Cluster batch 填满独立池，同一 Atom 在重复扫描中只认领一次。"""
 


### PR DESCRIPTION
## Summary

Reuse one durable Atom snapshot per indexed trajectory across collection, completion checks, and scoring, then release the full Atom content before loading the next trajectory.

## Changes

- Reconcile each indexed trajectory in one helper so `list_by_traj()` runs at most once per trajectory and poll.
- Share the same stable tuple across cluster collection, completion checks, and UX scoring.
- Avoid a poll-wide full-Atom cache, bounding retained `raw_segment` and `context_prefix` content to one trajectory at a time.
- Reload durable Atom JSON on the next poll, preserving cluster retry, restart recovery, and zero-Atom completion semantics.
- Cover one-load-per-poll, next-poll refresh, zero-Atom completion, and release-before-next-trajectory behavior.

## Test plan

- [ ] `make test` passes
- [x] Added/updated unit tests for the change
- [ ] `make e2e` passes (if the change touches ingestion / install / daemon)
- [ ] Manually verified the affected user flow

Focused verification:

- `.venv/bin/python -m pytest -q tests/test_watcher_atom.py tests/test_cluster_batch.py` — 20 passed
- Watcher/Atom/Cluster/Canary focused suite — 239 passed
- `.venv/bin/python -m ruff check src/xskill/pipeline/runner.py tests/test_watcher_atom.py tests/test_cluster_batch.py --ignore E701,E702` — passed
- `make test PY=.venv/bin/python` on this branch — 2275 passed, 10 skipped; the six failures are the existing main-branch failures covered by #274/#275/#279
- Combined integration of #276, #277, #280, #267, this PR, and #290 — 2290 passed, 11 skipped
- `make e2e` could not run in the hardened verifier because its system Python lacks the `build` module and the verifier does not expose a Docker daemon

## Linked issues

Closes #288
