### PR TITLE
perf(watcher): skip unchanged trajectory discovery scans

### DIFF
--- a/config.yaml.server.example
+++ b/config.yaml.server.example
@@ -46,6 +46,7 @@ canary:
 watcher:
   poll_interval: 30      # 每隔 30 秒扫描一次所有 watch_dir，检测新轨迹
                          # 调小加快入库，但会增加 LLM 调用频率
+  full_reconcile_interval: 60 # 目录无变化时跳过全量扫描；原地覆盖最迟在此周期发现
 
 agent_worker:
   pools:

--- a/src/xskill/config.py
+++ b/src/xskill/config.py
@@ -202,6 +202,8 @@ server:
 # ===== Watcher (scan scheduling only) =====
 watcher:
   poll_interval: 5              # seconds between scans of every watch_dir
+  full_reconcile_interval: 60   # idle polls only stat the directory; this
+                                # periodic full scan catches in-place rewrites
 
 # ===== Persistent agent worker =====
 # Every pool has an automatic waiting capacity of workers * 2. Running plus

--- a/src/xskill/pipeline/registry.py
+++ b/src/xskill/pipeline/registry.py
@@ -1718,6 +1718,21 @@ def list_watch_dirs(
         return [dict(r) for r in rows]
 
 
+def list_watcher_dirs(*, db_path: Optional[Path] = None) -> list[dict]:
+    """返回 watcher 调度所需目录，不计算 dashboard 统计。
+
+    ``list_watch_dirs`` 会为每个目录统计历史轨迹数和已索引数，适合 CLI 与
+    dashboard，但不适合每几秒调用一次的 watcher 热路径。这里仅返回
+    ``watch_dirs`` 行；是否暂停仍由 watcher 在内存中判断，使查询不依赖旧库
+    可能缺少的 ``auto_index`` 列，并让空闲成本不随历史轨迹数量增长。
+    """
+    with pooled_connection(db_path) as conn:
+        rows = conn.execute(
+            "SELECT * FROM watch_dirs ORDER BY id",
+        ).fetchall()
+        return [dict(row) for row in rows]
+
+
 def get_watch_dir(dir_path: str | Path, *, db_path: Optional[Path] = None) -> dict | None:
     """查询单个目录记录。"""
     dir_path = str(Path(dir_path).resolve())

--- a/src/xskill/pipeline/runner.py
+++ b/src/xskill/pipeline/runner.py
@@ -44,6 +44,7 @@ from xskill.pipeline.registry import (
     ProcessAction,
     TrajectoryStatus,
     list_watch_dirs,
+    list_watcher_dirs,
     discover_trajectories,
     get_pending_traj_ids,
     get_trajs_by_status,
@@ -152,6 +153,22 @@ class DirectoryWatcher:
             else xskill_state_root / "tmp" / "spill"
         ).expanduser().resolve()
         self.poll_interval = poll_interval
+        watcher_config = self.config.get("watcher") or {}
+        configured_reconcile_interval = watcher_config.get(
+            "full_reconcile_interval",
+        )
+        # Production defaults to a low-frequency correctness sweep.  Tests and
+        # direct callers traditionally use poll_interval=0 to request an eager
+        # scan on every call, so preserve that behavior unless configured.
+        if configured_reconcile_interval is None:
+            configured_reconcile_interval = 60.0 if poll_interval > 0 else 0.0
+        self.full_reconcile_interval = max(
+            0.0,
+            float(configured_reconcile_interval),
+        )
+        # watch_dir_id -> ((device, inode, directory mtime ns), last full scan)
+        # Only the watcher thread reads/writes this map.
+        self._discovery_snapshots: dict[int, tuple[tuple[int, int, int], float]] = {}
         self.max_retries = max_retries
         self.db_path = db_path
         # 每轮 _loop 在 _scan_once 之前调一次的钩子，用来让 server 端的"生态
@@ -429,7 +446,7 @@ class DirectoryWatcher:
         consumed_index = LazyConsumedIndex(self.skill_dir)
 
         # ── Step 1-4: 对每个目录扫描 + 提交 split/embed + 收集 cluster atom ──
-        watch_dirs = list_watch_dirs(**kw)
+        watch_dirs = list_watcher_dirs(**kw)
         active_watch_dirs = []
         for wd in watch_dirs:
             if self._stop.is_set():
@@ -2442,8 +2459,9 @@ class DirectoryWatcher:
             increment_retry(wd_id, fname, **kw)
             self._stats["retries"] += 1
 
-        # 发现新文件
-        new = discover_trajectories(wd_id, dir_path, **kw)
+        # 发现新文件。稳态轮询只 stat 目录本身；目录项变化时立即协调，已有
+        # 文件被原地覆盖（目录 mtime 可能不变）则由低频全量扫描兜底。
+        new = self._discover_if_needed(wd_id, dir_path, **kw)
         if new:
             self._stats["new_trajs"] += len(new)
             logger.info("[%s] discovered %d new", dir_path.name, len(new))
@@ -2513,6 +2531,46 @@ class DirectoryWatcher:
             self._collect_cluster_atoms(
                 dir_path, wd_id, consumed_index, **kw,
             )
+
+    def _discover_if_needed(self, watch_dir_id, dir_path, **kw):
+        """按目录变化增量触发发现，并周期性执行全量 correctness sweep。
+
+        新建、删除、rename/atomic replace 会改变目录身份或 mtime，因此下一轮
+        poll 立即执行 ``discover_trajectories``。普通的原地覆盖不一定改变目录
+        mtime，最迟会在 ``full_reconcile_interval`` 内由全量扫描发现。首次
+        poll、目录被替换和进程重启都无快照，必定全量扫描。
+        """
+        if not kw:
+            kw = self._db_kw()
+        try:
+            directory_stat = dir_path.stat()
+        except OSError:
+            return []
+        directory_token = (
+            directory_stat.st_dev,
+            directory_stat.st_ino,
+            directory_stat.st_mtime_ns,
+        )
+        now = time.monotonic()
+        previous = self._discovery_snapshots.get(watch_dir_id)
+        full_reconcile_due = (
+            previous is None
+            or self.full_reconcile_interval == 0
+            or now - previous[1] >= self.full_reconcile_interval
+        )
+        if (
+            previous is not None
+            and previous[0] == directory_token
+            and not full_reconcile_due
+        ):
+            return []
+
+        discovered = discover_trajectories(watch_dir_id, dir_path, **kw)
+        # Record the token observed before scanning.  If a writer changes the
+        # directory while discovery is running, the next poll sees a mismatch
+        # instead of hiding that race until the periodic sweep.
+        self._discovery_snapshots[watch_dir_id] = (directory_token, now)
+        return discovered
 
     # ───────────────────────────────────────────────────────────
     # Helpers: store / agno factory 按需获取

--- a/tests/test_watcher_incremental_discovery.py
+++ b/tests/test_watcher_incremental_discovery.py
@@ -1,0 +1,165 @@
+from __future__ import annotations
+
+import os
+from pathlib import Path
+
+from tests.pool_helpers import pool_config
+from xskill.pipeline.registry import (
+    get_trajs_by_status,
+    list_watch_dirs,
+    list_watcher_dirs,
+    register_dir,
+    update_traj_status,
+)
+from xskill.pipeline.runner import DirectoryWatcher
+
+
+def _watcher(tmp_path: Path, db_path: Path, *, reconcile_interval: float):
+    return DirectoryWatcher(
+        config={
+            "watcher": {"full_reconcile_interval": reconcile_interval},
+        },
+        poll_interval=5,
+        pool_config=pool_config(workers=1),
+        db_path=db_path,
+        home_root=tmp_path,
+        xskill_home=tmp_path,
+    )
+
+
+def test_watcher_dirs_omit_dashboard_history_counts(tmp_path):
+    db_path = tmp_path / "registry.db"
+    active = tmp_path / "active"
+    paused = tmp_path / "paused"
+    active.mkdir()
+    paused.mkdir()
+    register_dir(active, auto_index=True, db_path=db_path)
+    register_dir(paused, auto_index=False, db_path=db_path)
+
+    rows = list_watcher_dirs(db_path=db_path)
+
+    assert [row["path"] for row in rows] == [
+        str(active.resolve()),
+        str(paused.resolve()),
+    ]
+    assert "traj_count" not in rows[0]
+    assert "indexed_count" not in rows[0]
+    assert "traj_count" in list_watch_dirs(db_path=db_path)[0]
+
+
+def test_idle_poll_does_not_rescan_registry_or_trajectory_files(
+    tmp_path,
+    monkeypatch,
+):
+    db_path = tmp_path / "registry.db"
+    watch_dir = tmp_path / "sessions"
+    watch_dir.mkdir()
+    for index in range(40):
+        (watch_dir / f"traj_{index:04d}.md").write_text(
+            "# trajectory\n",
+            encoding="utf-8",
+        )
+    watch_dir_id = register_dir(watch_dir, db_path=db_path)
+    watcher = _watcher(tmp_path, db_path, reconcile_interval=60)
+    clock = [100.0]
+    monkeypatch.setattr("xskill.pipeline.runner.time.monotonic", lambda: clock[0])
+    original_stat = Path.stat
+    trajectory_stats = 0
+
+    def counting_stat(path, *args, **kwargs):
+        nonlocal trajectory_stats
+        if path.parent == watch_dir and path.name.startswith("traj_"):
+            trajectory_stats += 1
+        return original_stat(path, *args, **kwargs)
+
+    monkeypatch.setattr(Path, "stat", counting_stat)
+    try:
+        assert len(watcher._discover_if_needed(watch_dir_id, watch_dir)) == 40
+        assert trajectory_stats == 40
+
+        clock[0] += 5
+        assert watcher._discover_if_needed(watch_dir_id, watch_dir) == []
+        assert trajectory_stats == 40
+    finally:
+        watcher.stop()
+
+
+def test_directory_change_is_discovered_on_next_poll(tmp_path, monkeypatch):
+    db_path = tmp_path / "registry.db"
+    watch_dir = tmp_path / "sessions"
+    watch_dir.mkdir()
+    watch_dir_id = register_dir(watch_dir, db_path=db_path)
+    watcher = _watcher(tmp_path, db_path, reconcile_interval=60)
+    clock = [100.0]
+    monkeypatch.setattr("xskill.pipeline.runner.time.monotonic", lambda: clock[0])
+    try:
+        assert watcher._discover_if_needed(watch_dir_id, watch_dir) == []
+        before = watch_dir.stat()
+        (watch_dir / "traj_new.md").write_text("# new\n", encoding="utf-8")
+        os.utime(
+            watch_dir,
+            ns=(before.st_atime_ns, before.st_mtime_ns + 1_000_000),
+        )
+
+        clock[0] += 5
+        assert watcher._discover_if_needed(watch_dir_id, watch_dir) == [
+            "traj_new.md",
+        ]
+    finally:
+        watcher.stop()
+
+
+def test_periodic_reconcile_catches_in_place_rewrite(tmp_path, monkeypatch):
+    db_path = tmp_path / "registry.db"
+    watch_dir = tmp_path / "sessions"
+    watch_dir.mkdir()
+    trajectory = watch_dir / "traj_existing.md"
+    trajectory.write_text("# original\n", encoding="utf-8")
+    watch_dir_id = register_dir(watch_dir, db_path=db_path)
+    watcher = _watcher(tmp_path, db_path, reconcile_interval=60)
+    clock = [100.0]
+    monkeypatch.setattr("xskill.pipeline.runner.time.monotonic", lambda: clock[0])
+    try:
+        assert watcher._discover_if_needed(watch_dir_id, watch_dir) == [
+            trajectory.name,
+        ]
+        update_traj_status(
+            watch_dir_id,
+            trajectory.name,
+            "done",
+            db_path=db_path,
+        )
+        directory_stat = watch_dir.stat()
+        trajectory_stat = trajectory.stat()
+        trajectory.write_text("# rewritten in place\n", encoding="utf-8")
+        os.utime(
+            trajectory,
+            ns=(
+                trajectory_stat.st_atime_ns,
+                trajectory_stat.st_mtime_ns + 1_000_000,
+            ),
+        )
+        # Model a filesystem where overwriting an existing entry does not
+        # update the directory mtime.
+        os.utime(
+            watch_dir,
+            ns=(directory_stat.st_atime_ns, directory_stat.st_mtime_ns),
+        )
+
+        clock[0] += 5
+        assert watcher._discover_if_needed(watch_dir_id, watch_dir) == []
+        assert get_trajs_by_status(
+            watch_dir_id,
+            "done",
+            db_path=db_path,
+        ) == [trajectory.name]
+
+        clock[0] += 55
+        assert watcher._discover_if_needed(watch_dir_id, watch_dir) == []
+        assert get_trajs_by_status(
+            watch_dir_id,
+            "updated",
+            db_path=db_path,
+        ) == [trajectory.name]
+    finally:
+        watcher.stop()


### PR DESCRIPTION
## Summary

Skip unchanged trajectory discovery scans while retaining periodic correctness reconciliation.

## Changes

- Query watch directories without materializing per-directory trajectory counts on every poll.
- Cache directory identity and mtime in the watcher so unchanged polls skip the full Registry read, file glob, and per-trajectory `stat()` calls.
- Reconcile immediately after directory-entry changes and run a configurable 60-second full sweep for in-place rewrites, missed signals, and restart recovery.
- Add complexity and correctness regressions for idle polls, new files, and in-place rewrites.

## Test plan

- [ ] `make test` passes
- [x] Added/updated unit tests for the change
- [ ] `make e2e` passes (if the change touches ingestion / install / daemon)
- [ ] Manually verified the affected user flow

Focused verification:

- `.venv/bin/python -m pytest -q tests/test_watcher_incremental_discovery.py tests/test_registry.py tests/test_watcher_atom.py` — 53 passed
- `.venv/bin/python -m ruff check src/xskill/pipeline/registry.py src/xskill/pipeline/runner.py src/xskill/config.py tests/test_watcher_incremental_discovery.py` — passed
- Full suite on the PR commit — 2276 passed, 10 skipped, with only the six existing failures covered by #274/#275/#279
- Combined integration of #276, #277, #280, #267, #289, and this PR — 2289 passed, 11 skipped

## Linked issues

Closes #263
