### PR TITLE
fix(kernel): 已注册 watch_dir 平铺扫描，避免 OE 重复枚举轨迹 (#236)

### DIFF
--- a/src/xskill/kernels/context.py
+++ b/src/xskill/kernels/context.py
@@ -285,14 +285,38 @@ def _trajectory_resource_from_path(
     )
 
 
+def _scan_watch_dir_trajectories(
+    watch_dir: TrajectoryDirectoryResource,
+) -> list[Path]:
+    """List ``traj_*.md`` visible from one watch directory.
+
+    A registered Registry root is a flat bucket: only direct children.
+    The synthetic no-Registry manual root (``id=root``,
+    ``ecosystem=kernel-input``) may recurse, matching ``--trajectory-dir``.
+    """
+    root = watch_dir.path
+    if not root.is_dir():
+        return []
+    recursive = (
+        watch_dir.id == "root" and watch_dir.ecosystem == "kernel-input"
+    )
+    scanner = root.rglob if recursive else root.glob
+    return sorted(
+        path
+        for path in scanner("traj_*.md")
+        if path.is_file() and not path.is_symlink()
+    )
+
+
 class TrajectoryReader:
     """Filesystem-capable facade over this invocation's trajectory input.
 
     ``root`` is the absolute input root exposed to the kernel for its own batch
     readers and filesystem tools.  Registered watch directories remain the
-    preferred source of attribution and status metadata.  When no watch
-    directory is registered, the reader falls back to recursively discovering
-    ``traj_*.md`` below ``root`` so manually supplied trajectory trees still work.
+    preferred source of attribution and status metadata, and are scanned as
+    flat trajectory buckets.  When no watch directory is registered, the
+    reader falls back to recursively discovering ``traj_*.md`` below ``root``
+    so manually supplied trajectory trees still work.
     """
 
     def __init__(
@@ -364,14 +388,17 @@ class TrajectoryReader:
 
         accepted = set(statuses) if statuses is not None else None
         registry = Registry(self._db_path)
+        seen_canonical: set[Path] = set()
         for watch_dir in self.directories():
             if directory_id is not None and str(watch_dir.id) != str(directory_id):
                 continue
             if not watch_dir.path.is_dir():
                 continue
-            for path in sorted(watch_dir.path.rglob("traj_*.md")):
-                if path.is_symlink() or not path.is_file():
+            for path in _scan_watch_dir_trajectories(watch_dir):
+                canonical = path.resolve()
+                if canonical in seen_canonical:
                     continue
+                seen_canonical.add(canonical)
                 trajectory = Trajectory.load(path, registry=registry)
                 status = trajectory.status
                 if accepted is not None and status not in accepted:

--- a/tests/test_kernel_registry_overlap.py
+++ b/tests/test_kernel_registry_overlap.py
@@ -1,0 +1,99 @@
+"""Issue #236: registered watch dirs are flat; Kernel must not rglob through children."""
+
+from __future__ import annotations
+
+from pathlib import Path
+
+from xskill.kernels.context import TrajectoryReader
+from xskill.pipeline.registry import register_dir
+
+
+def _write_traj(path: Path, body: str) -> Path:
+    path.parent.mkdir(parents=True, exist_ok=True)
+    path.write_text(f"## User\n\n{body}\n", encoding="utf-8")
+    return path
+
+
+def test_registered_parent_does_not_see_nested_sessions(tmp_path):
+    registry_db = tmp_path / "registry.db"
+    parent = tmp_path / "team_trajectories"
+    nested = parent / "clients" / "user-a" / "sessions" / "traj_example.md"
+    _write_traj(parent / "traj_parent.md", "parent only")
+    _write_traj(nested, "nested session")
+
+    register_dir(parent, label="all-trajectories", db_path=registry_db)
+    resources = list(TrajectoryReader(registry_db).iter())
+
+    assert [item.trajectory_id for item in resources] == ["traj_parent"]
+    assert all(item.path.parent == parent.resolve() for item in resources)
+
+
+def test_registered_sessions_dir_sees_its_direct_files(tmp_path):
+    registry_db = tmp_path / "registry.db"
+    sessions = tmp_path / "team_trajectories" / "clients" / "user-a" / "sessions"
+    _write_traj(sessions / "traj_example.md", "session")
+
+    child_id = register_dir(sessions, label="user-a", ecosystem="team_client", db_path=registry_db)
+    resources = list(TrajectoryReader(registry_db).iter())
+
+    assert len(resources) == 1
+    assert resources[0].id == f"{child_id}:traj_example.md"
+    assert resources[0].label == "user-a"
+    assert resources[0].ecosystem == "team_client"
+
+
+def test_parent_and_child_expose_same_physical_file_once(tmp_path):
+    registry_db = tmp_path / "registry.db"
+    parent = tmp_path / "team_trajectories"
+    sessions = parent / "clients" / "user-a" / "sessions"
+    parent_file = _write_traj(parent / "traj_parent.md", "parent")
+    nested_file = _write_traj(sessions / "traj_example.md", "nested")
+
+    register_dir(parent, label="all-trajectories", db_path=registry_db)
+    child_id = register_dir(
+        sessions, label="user-a", ecosystem="team_client", db_path=registry_db,
+    )
+
+    resources = list(TrajectoryReader(registry_db).iter())
+    paths = [item.path.resolve() for item in resources]
+    ids = [item.id for item in resources]
+
+    assert parent_file.resolve() in paths
+    assert nested_file.resolve() in paths
+    assert len(paths) == 2
+    assert len(set(paths)) == 2
+    assert f"{child_id}:traj_example.md" in ids
+    assert not any("clients/user-a/sessions/traj_example.md" in item_id for item_id in ids)
+
+
+def test_distinct_directories_keep_same_traj_name(tmp_path):
+    registry_db = tmp_path / "registry.db"
+    dir_a = tmp_path / "client_a" / "sessions"
+    dir_b = tmp_path / "client_b" / "sessions"
+    file_a = _write_traj(dir_a / "traj_0001.md", "user a")
+    file_b = _write_traj(dir_b / "traj_0001.md", "user b")
+
+    register_dir(dir_a, label="user_a", db_path=registry_db)
+    register_dir(dir_b, label="user_b", db_path=registry_db)
+
+    resources = list(TrajectoryReader(registry_db).iter())
+    paths = {item.path.resolve() for item in resources}
+
+    assert paths == {file_a.resolve(), file_b.resolve()}
+    assert [item.trajectory_id for item in resources] == ["traj_0001", "traj_0001"]
+
+
+def test_symlink_watch_dir_alias_dedups_to_one_resource(tmp_path):
+    registry_db = tmp_path / "registry.db"
+    real_dir = tmp_path / "real_store"
+    link_dir = tmp_path / "link_store"
+    _write_traj(real_dir / "traj_0001.md", "real")
+    link_dir.symlink_to(real_dir)
+
+    register_dir(real_dir, label="real", db_path=registry_db)
+    register_dir(link_dir, label="alias", db_path=registry_db)
+
+    resources = list(TrajectoryReader(registry_db).iter())
+
+    assert len(resources) == 1
+    assert resources[0].path.resolve() == (real_dir / "traj_0001.md").resolve()


### PR DESCRIPTION
## Summary
- 把 `TrajectoryReader` 对已注册 Registry 目录的扫描从 `rglob` 改成平铺 `glob`，和 Watcher 一致。父子目录同时注册时，同一份 `traj_*.md` 只暴露一次。
- 没有 Registry、只给了手动 `--trajectory-dir` 根的情况，仍走递归，现有 `test_trajectory_reader_falls_back_to_recursive_manual_root` 保持不变。
- 枚举时再按 `path.resolve()` 去重一层，软链别名指向同一物理文件时也只出一条。不去重文件名，不同用户的同名轨迹都会留着。

Closes #236

这条对着 `feat/algorithm-kernel-demo`，因为 `src/xskill/kernels/context.py` 只在内核分支上。不是 267 那条打到 main 的 Registry 警告。

## Test plan
- [x] `pytest tests/test_kernel_registry_overlap.py tests/test_kernel_abstraction.py tests/test_kernel_atom_view.py`（29 passed）
- [x] 父子目录同时注册后，同一物理文件只出一条（`test_parent_and_child_expose_same_physical_file_once`）
- [x] 仅注册父目录时，看不到 `clients/.../sessions` 里的嵌套轨迹（`test_registered_parent_does_not_see_nested_sessions`）
- [x] 仅注册 sessions 子目录时，仍能看到其中轨迹，label / ecosystem 还在（`test_registered_sessions_dir_sees_its_direct_files`）
- [x] 两个不同目录的同名轨迹都保留（`test_distinct_directories_keep_same_traj_name`）
- [x] 软链别名指向同一目录时只出一条（`test_symlink_watch_dir_alias_dedups_to_one_resource`）
