### PR TITLE
ci: Windows ut+it 失败用例重试两次 (#251)

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -52,10 +52,16 @@ jobs:
       - name: Install package with dev extras
         run: pip install -e .[dev]
       - name: Run UT + IT
+        if: runner.os != 'Windows'
         # Excludes tests under tests/e2e/ (covered by smoke-e2e job in P4).
         # ``nightly`` 标记的负载/平台时序敏感测试移出 PR 矩阵，
         # 由 nightly-control-plane-stress.yml 的 nightly-flaky _job 按平台跑。
         run: pytest tests/ --ignore=tests/e2e -q -m "not nightly"
+      - name: Run UT + IT
+        if: runner.os == 'Windows'
+        # Windows runner 的时钟分辨率和线程调度会把短睡眠、SQLite 锁变成
+        # 偶发失败（#251）。只对失败用例重试，Linux / macOS 保持一次即红。
+        run: pytest tests/ --ignore=tests/e2e -q -m "not nightly" --reruns 2 --reruns-delay 1
 
   skill-edit-bdd:
     name: skill-edit BDD (aimock)


### PR DESCRIPTION
## Summary

Implement the suite-level Windows retry from #251. Failed `ut+it` cases on `windows-latest` rerun twice with a 1s delay. Linux and macOS stay fail-fast.

`pytest-rerunfailures` is already in the `dev` extra. This does not mark more tests `@pytest.mark.flaky`, and it does not grant fork authors a `/retest` button (that is the separate permission track in #251).

## Test plan

- [x] Workflow change is Windows-gated (`runner.os == 'Windows'`)
- [ ] PR CI: Linux / macOS `ut+it` still run once
- [ ] PR CI: Windows `ut+it` command includes `--reruns 2 --reruns-delay 1`

Closes #251


Made with [Cursor](https://cursor.com)