### PR TITLE
perf(cluster): reuse generation-keyed catalog snapshots

### DIFF
--- a/src/xskill/agents/task_cluster_agent.py
+++ b/src/xskill/agents/task_cluster_agent.py
@@ -19,6 +19,8 @@ budget 控制（``build_skill_catalog_block``）：
 from __future__ import annotations
 
 import logging
+import threading
+from collections import OrderedDict
 from dataclasses import dataclass
 from pathlib import Path
 from typing import Any, Callable
@@ -31,6 +33,25 @@ logger = logging.getLogger("xskill.task_cluster_agent")
 
 _DESC_MIN_CHARS = 75   # 约 25 token；低于这个值就只留 name
 _DESC_HARD_CAP = 300   # 单条 desc 上限（即使预算够也别全塞）
+_CATALOG_CACHE_MAX_ENTRIES = 32
+_CATALOG_CACHE_MAX_CHARS = 1_000_000
+
+
+class _CatalogFlight:
+    def __init__(self) -> None:
+        self.done = threading.Event()
+        self.value = ""
+        self.error: BaseException | None = None
+
+
+_CATALOG_CACHE_LOCK = threading.Lock()
+_CATALOG_CACHE: OrderedDict[
+    tuple[str, int, int, str, int, int], str
+] = OrderedDict()
+_CATALOG_CACHE_CHARS = 0
+_CATALOG_FLIGHTS: dict[
+    tuple[str, int, int, str, int, int], _CatalogFlight
+] = {}
 
 
 def _scan_skill_state(skill_dir: Path) -> list[tuple[str, str, str]]:
@@ -103,18 +124,11 @@ def _scan_skill_state(skill_dir: Path) -> list[tuple[str, str, str]]:
     return out
 
 
-def build_skill_catalog_block(skill_dir: Path, max_chars: int) -> str:
-    """构造 sysprompt 中的 skill 路由表块。
-
-    展示**所有** skill 目录（含 wip 空骨架），让 cluster agent 看到完整画
-    像——避免对近义场景反复 ``new_skill_folder`` 创建近义 slug。
-
-    每行格式：``- <name>[<state>]: <desc>``
-    state 有 main / staging / main+staging / wip 四种。
-
-    无 skill 时返回 ``(no skills yet)``。
-    """
-    entries = _scan_skill_state(skill_dir)
+def _format_skill_catalog_block(
+    entries: list[tuple[str, str, str]],
+    max_chars: int,
+) -> str:
+    """把稳定目录快照格式化为 sysprompt 路由表。"""
     if not entries:
         return "(no skills yet)"
 
@@ -136,6 +150,137 @@ def build_skill_catalog_block(skill_dir: Path, max_chars: int) -> str:
             truncated = d[:cap] + ("…" if len(d) > cap else "")
             out_lines.append(f"- {n}[{s}]: {truncated}")
     return "\n".join(out_lines)
+
+
+def _projected_catalog_entries(rows: list[dict]) -> list[tuple[str, str, str]]:
+    entries: list[tuple[str, str, str]] = []
+    for row in rows:
+        name = str(row["name"])
+        state = str(row["state"])
+        if state == "unknown":
+            desc = "(skill 无 git 仓库)"
+        else:
+            desc = str(row.get("description") or "")
+        if state == "baby":
+            count = int(row.get("candidates_count") or 0)
+            suffix = f"({count} cand in buffer)" if desc else f"({count} cand)"
+            desc = f"{desc} {suffix}" if desc else suffix
+        entries.append((name, state, desc))
+    return entries
+
+
+def _cache_catalog_block(
+    key: tuple[str, int, int, str, int, int],
+    builder: Callable[[], str],
+) -> str:
+    """同 generation 单飞构建；LRU 条目数和总字符数双重有界。"""
+    global _CATALOG_CACHE_CHARS  # pylint: disable=global-statement
+    with _CATALOG_CACHE_LOCK:
+        cached = _CATALOG_CACHE.get(key)
+        if cached is not None:
+            _CATALOG_CACHE.move_to_end(key)
+            return cached
+        flight = _CATALOG_FLIGHTS.get(key)
+        if flight is None:
+            flight = _CatalogFlight()
+            _CATALOG_FLIGHTS[key] = flight
+            owner = True
+        else:
+            owner = False
+
+    if not owner:
+        flight.done.wait()
+        if flight.error is not None:
+            raise flight.error
+        return flight.value
+
+    try:
+        value = builder()
+    except BaseException as error:
+        flight.error = error
+        raise
+    else:
+        flight.value = value
+        with _CATALOG_CACHE_LOCK:
+            if len(value) <= _CATALOG_CACHE_MAX_CHARS:
+                _CATALOG_CACHE[key] = value
+                _CATALOG_CACHE.move_to_end(key)
+                _CATALOG_CACHE_CHARS += len(value)
+                while (
+                    len(_CATALOG_CACHE) > _CATALOG_CACHE_MAX_ENTRIES
+                    or _CATALOG_CACHE_CHARS > _CATALOG_CACHE_MAX_CHARS
+                ):
+                    _, evicted = _CATALOG_CACHE.popitem(last=False)
+                    _CATALOG_CACHE_CHARS -= len(evicted)
+        return value
+    finally:
+        with _CATALOG_CACHE_LOCK:
+            if _CATALOG_FLIGHTS.get(key) is flight:
+                _CATALOG_FLIGHTS.pop(key, None)
+            flight.done.set()
+
+
+def _clear_catalog_block_cache() -> None:
+    """测试和显式进程内重置用；generation 仍是生产失效机制。"""
+    global _CATALOG_CACHE_CHARS  # pylint: disable=global-statement
+    with _CATALOG_CACHE_LOCK:
+        _CATALOG_CACHE.clear()
+        _CATALOG_CACHE_CHARS = 0
+
+
+def _catalog_db_identity(db_path: Path) -> tuple[int, int]:
+    stat = db_path.stat()
+    return stat.st_dev, stat.st_ino
+
+
+def _projected_catalog_block(skill_dir: Path, max_chars: int, db_path: Path) -> str:
+    from xskill.skill.catalog_store import (
+        catalog_root_key,
+        list_native_cluster_catalog,
+        native_catalog_generation,
+    )
+
+    root = catalog_root_key(skill_dir)
+    resolved_path = Path(db_path).expanduser().resolve(strict=False)
+    generation = native_catalog_generation(skill_dir, db_path=Path(db_path))
+    db_device, db_inode = _catalog_db_identity(resolved_path)
+    key = (
+        str(resolved_path), db_device, db_inode,
+        root, int(max_chars), generation,
+    )
+
+    def build() -> str:
+        rows = list_native_cluster_catalog(skill_dir, db_path=Path(db_path))
+        return _format_skill_catalog_block(_projected_catalog_entries(rows), max_chars)
+
+    return _cache_catalog_block(key, build)
+
+
+def build_skill_catalog_block(
+    skill_dir: Path,
+    max_chars: int,
+    *,
+    db_path: Path | None = None,
+) -> str:
+    """构造 sysprompt 中的 skill 路由表块。
+
+    展示**所有** skill 目录（含 wip 空骨架），让 cluster agent 看到完整画
+    像——避免对近义场景反复 ``new_skill_folder`` 创建近义 slug。
+
+    每行格式：``- <name>[<state>]: <desc>``
+    state 有 main / staging / main+staging / wip 四种。
+
+    无 skill 时返回 ``(no skills yet)``。
+    """
+    if db_path is not None:
+        try:
+            return _projected_catalog_block(Path(skill_dir), max_chars, Path(db_path))
+        except Exception:  # pylint: disable=broad-exception-caught
+            logger.warning(
+                "cluster catalog projection unavailable; falling back to disk scan",
+                exc_info=True,
+            )
+    return _format_skill_catalog_block(_scan_skill_state(skill_dir), max_chars)
 
 
 SYSTEM_PROMPT_TEMPLATE = """你是 TaskClusterAgent。我会给你一个或多个 AtomTask（每个是
@@ -261,16 +406,19 @@ class TaskClusterAgent:
     # 更大，按 plan 用 20% 作为软门槛）
     sysprompt_budget_chars: int = 25000
     logs_dir: Path | None = None
+    db_path: Path | None = None
 
     def __post_init__(self) -> None:
         self.skill_dir = Path(self.skill_dir)
         if self.logs_dir is not None:
             self.logs_dir = Path(self.logs_dir)
+        if self.db_path is not None:
+            self.db_path = Path(self.db_path)
 
     def process(self, atom: AtomTask) -> str:
         """跑一次 cluster 决策，返回 agent 的 final content（日志用）。"""
         catalog = build_skill_catalog_block(
-            self.skill_dir, self.sysprompt_budget_chars,
+            self.skill_dir, self.sysprompt_budget_chars, db_path=self.db_path,
         )
         sysprompt = SYSTEM_PROMPT_TEMPLATE.format(skill_catalog=catalog)
 
@@ -319,7 +467,7 @@ class TaskClusterAgent:
         if not atoms:
             return ""
         catalog = build_skill_catalog_block(
-            self.skill_dir, self.sysprompt_budget_chars,
+            self.skill_dir, self.sysprompt_budget_chars, db_path=self.db_path,
         )
         sysprompt = (
             SYSTEM_PROMPT_TEMPLATE.format(skill_catalog=catalog)

--- a/src/xskill/pipeline/registry.py
+++ b/src/xskill/pipeline/registry.py
@@ -261,7 +261,8 @@ CREATE INDEX IF NOT EXISTS idx_skills_catalog_root_state
 CREATE TABLE IF NOT EXISTS skills_catalog_meta (
     root_key      TEXT PRIMARY KEY,
     backfilled_at TEXT NOT NULL,
-    skillhub_key  TEXT NOT NULL DEFAULT ''
+    skillhub_key  TEXT NOT NULL DEFAULT '',
+    generation    INTEGER NOT NULL DEFAULT 0
 );
 
 -- 预计算推荐结果：/sync 只读；重活进程写入（脏算）。
@@ -680,6 +681,17 @@ def _migrate(conn: sqlite3.Connection) -> None:
     if "content_sha" not in sc_cols:
         conn.execute(
             "ALTER TABLE skills_catalog ADD COLUMN content_sha TEXT NOT NULL DEFAULT ''"
+        )
+
+    # skills_catalog_meta.generation：Cluster 路由表的跨进程失效键。必须先补列，
+    # 后续 catalog 写出口才能在同一事务内 bump；旧库从 0 起步，下一次目录
+    # 语义变化会推进版本。
+    cur = conn.execute("PRAGMA table_info(skills_catalog_meta)")
+    scm_cols = {row[1] for row in cur.fetchall()}
+    if "generation" not in scm_cols:
+        conn.execute(
+            "ALTER TABLE skills_catalog_meta"
+            " ADD COLUMN generation INTEGER NOT NULL DEFAULT 0"
         )
 
     # skill_prefs.side：pin 时可钉灰度侧（空=自动分流）

--- a/src/xskill/pipeline/runner.py
+++ b/src/xskill/pipeline/runner.py
@@ -169,6 +169,7 @@ class DirectoryWatcher:
         # watch_dir_id -> ((device, inode, directory mtime ns), last full scan)
         # Only the watcher thread reads/writes this map.
         self._discovery_snapshots: dict[int, tuple[tuple[int, int, int], float]] = {}
+        self._last_cluster_catalog_reconcile: float | None = None
         self.max_retries = max_retries
         self.db_path = db_path
         # 每轮 _loop 在 _scan_once 之前调一次的钩子，用来让 server 端的"生态
@@ -2739,6 +2740,9 @@ class DirectoryWatcher:
 
     def _submit_cluster_batches(self) -> None:
         """Fill the cluster pool without ever waiting in the watcher thread."""
+        if not self.pending_atoms or self._pools["cluster"].available_capacity <= 0:
+            return
+        self._reconcile_cluster_catalog_if_due()
         while self.pending_atoms:
             batch_size = min(self.cluster_batch_size, len(self.pending_atoms))
             atom_ids = list(self.pending_atoms)[:batch_size]
@@ -2756,6 +2760,34 @@ class DirectoryWatcher:
                 "atom_ids": atom_ids,
             }
             self.cluster_futures.add(future)
+
+    def _reconcile_cluster_catalog_if_due(self) -> None:
+        """低频修复磁盘→catalog 投影漂移；正常 batch 只读 generation 快照。"""
+        if self.db_path is None or self.skill_dir is None:
+            return
+        now = time.monotonic()
+        due = (
+            self._last_cluster_catalog_reconcile is None
+            or self.full_reconcile_interval == 0
+            or now - self._last_cluster_catalog_reconcile
+            >= self.full_reconcile_interval
+        )
+        if not due:
+            return
+        try:
+            from xskill.skill.catalog_store import reconcile_native_skills_catalog
+
+            stats = reconcile_native_skills_catalog(
+                self.skill_dir,
+                db_path=self.db_path,
+            )
+            if stats["changed"]:
+                logger.info("cluster catalog reconciled: %s", stats)
+        except Exception:  # pylint: disable=broad-exception-caught
+            logger.warning("cluster catalog reconciliation failed", exc_info=True)
+        finally:
+            # Avoid hammering a broken filesystem/DB on every fast watcher poll.
+            self._last_cluster_catalog_reconcile = now
 
     def _atom_consumed(self, atom, consumed_index) -> bool:
         """atom 是否已被 cluster 消费。耐久标记 ``clustered`` 为主（O(1)，扛得住
@@ -3263,6 +3295,7 @@ def _process_atom_task_bound(*, atom_id: str, config: dict,
         agno_agent_factory=agno_agent_factory,
         llm_cfg=config.get("llm", {}),
         logs_dir=logs_dir,
+        db_path=db_path,
         tools=[
             agent_tools.atom_task_read, agent_tools.read_traj,
             agent_tools.skill_read, agent_tools.read_skill_tasks,
@@ -3400,6 +3433,7 @@ def _process_atom_batch_bound(*, atom_ids: list[str], config: dict,
         agno_agent_factory=agno_agent_factory,
         llm_cfg=config.get("llm", {}),
         logs_dir=logs_dir,
+        db_path=db_path,
         tools=[
             agent_tools.atom_task_read, agent_tools.read_traj,
             agent_tools.skill_read, agent_tools.read_skill_tasks,

--- a/src/xskill/skill/catalog_store.py
+++ b/src/xskill/skill/catalog_store.py
@@ -17,6 +17,15 @@ logger = logging.getLogger(__name__)
 
 _SOURCE_NATIVE = "native"
 _SOURCE_SKILLHUB = "skillhub"
+_CATALOG_COMPARE_COLUMNS = (
+    "root_key", "name", "repo_name", "source", "state", "description",
+    "version", "candidates_count", "main_sha", "staging_sha",
+    "distributable", "search_id", "hub", "skill_id", "use_count",
+    "content_sha",
+)
+_CATALOG_INTEGER_COLUMNS = frozenset({
+    "version", "candidates_count", "distributable", "use_count",
+})
 
 _STATE_ORDER_SQL = """
 CASE state
@@ -337,6 +346,31 @@ def _upsert_row(conn, row: dict) -> None:
     )
 
 
+def _bump_catalog_generation(conn, root_key: str) -> None:
+    """推进已初始化 root 的目录版本；未 backfill 的 root 留给 ensure 初始化。"""
+    if not root_key:
+        return
+    conn.execute(
+        """
+        UPDATE skills_catalog_meta
+        SET generation=generation + 1
+        WHERE root_key=?
+        """,
+        (root_key,),
+    )
+
+
+def _catalog_row_matches(stored, row: dict) -> bool:
+    """比较会影响 Cluster 路由的稳定字段，忽略 ``updated_at``。"""
+    for column in _CATALOG_COMPARE_COLUMNS:
+        expected = row[column]
+        if column in _CATALOG_INTEGER_COLUMNS:
+            expected = int(expected or 0)
+        if stored[column] != expected:
+            return False
+    return True
+
+
 _BACKFILL_WAIT_TIMEOUT_SECONDS = 120.0
 
 
@@ -373,7 +407,18 @@ def upsert_native_skill(
         raise FileNotFoundError(f"skill path not found for catalog upsert: {path}")
     row = _read_native_row(path, candidates_count=candidates_count)
     with pooled_connection(Path(db_path)) as conn:
+        existing = conn.execute(
+            "SELECT * FROM skills_catalog WHERE catalog_key=?",
+            (row["catalog_key"],),
+        ).fetchone()
+        if existing is not None and _catalog_row_matches(existing, row):
+            return
         _upsert_row(conn, row)
+        affected_roots = {row["root_key"]}
+        if existing is not None:
+            affected_roots.add(existing["root_key"])
+        for affected_root in affected_roots:
+            _bump_catalog_generation(conn, affected_root)
         conn.commit()
 
 
@@ -381,10 +426,16 @@ def delete_native_skill(name: str, *, db_path: Path) -> None:
     if db_path is None:
         raise TypeError("skills_catalog delete requires explicit db_path")
     with pooled_connection(Path(db_path)) as conn:
-        conn.execute(
+        existing = conn.execute(
+            "SELECT root_key FROM skills_catalog WHERE catalog_key=?",
+            (_native_catalog_key(name),),
+        ).fetchone()
+        cursor = conn.execute(
             "DELETE FROM skills_catalog WHERE catalog_key=?",
             (_native_catalog_key(name),),
         )
+        if cursor.rowcount > 0 and existing is not None:
+            _bump_catalog_generation(conn, existing["root_key"])
         conn.commit()
 
 
@@ -394,15 +445,26 @@ def delete_all_native(*, root_key: str = "", db_path: Path) -> int:
         raise TypeError("skills_catalog wipe requires explicit db_path")
     with pooled_connection(Path(db_path)) as conn:
         if root_key:
+            affected_roots = [root_key]
             cursor = conn.execute(
                 "DELETE FROM skills_catalog WHERE source=? AND root_key=?",
                 (_SOURCE_NATIVE, root_key),
             )
         else:
+            affected_roots = [
+                row["root_key"] for row in conn.execute(
+                    "SELECT DISTINCT root_key FROM skills_catalog WHERE source=?",
+                    (_SOURCE_NATIVE,),
+                ).fetchall()
+                if row["root_key"]
+            ]
             cursor = conn.execute(
                 "DELETE FROM skills_catalog WHERE source=?",
                 (_SOURCE_NATIVE,),
             )
+        if cursor.rowcount > 0:
+            for affected_root in affected_roots:
+                _bump_catalog_generation(conn, affected_root)
         conn.commit()
         return int(cursor.rowcount or 0)
 
@@ -421,11 +483,20 @@ def rename_native_skill(
         raise FileNotFoundError(f"skill path not found for catalog rename: {path}")
     row = _read_native_row(path)
     with pooled_connection(Path(db_path)) as conn:
+        existing = conn.execute(
+            "SELECT root_key FROM skills_catalog WHERE catalog_key=?",
+            (_native_catalog_key(old_name),),
+        ).fetchone()
         conn.execute(
             "DELETE FROM skills_catalog WHERE catalog_key=?",
             (_native_catalog_key(old_name),),
         )
         _upsert_row(conn, row)
+        affected_roots = {row["root_key"]}
+        if existing is not None:
+            affected_roots.add(existing["root_key"])
+        for affected_root in affected_roots:
+            _bump_catalog_generation(conn, affected_root)
         conn.commit()
 
 
@@ -438,16 +509,24 @@ def update_native_candidates_count(
     """热路径：只改 ``candidates_count``，不重读 SKILL.md / yaml / refs。"""
     if db_path is None:
         raise TypeError("skills_catalog candidates update requires explicit db_path")
-    name = Path(skill_path).name
+    path = Path(skill_path)
+    name = path.name
     with pooled_connection(Path(db_path)) as conn:
-        conn.execute(
+        existing = conn.execute(
+            "SELECT root_key FROM skills_catalog WHERE catalog_key=?",
+            (_native_catalog_key(name),),
+        ).fetchone()
+        count = int(candidates_count)
+        cursor = conn.execute(
             """
             UPDATE skills_catalog
             SET candidates_count=?, updated_at=datetime('now')
-            WHERE catalog_key=?
+            WHERE catalog_key=? AND candidates_count<>?
             """,
-            (int(candidates_count), _native_catalog_key(name)),
+            (count, _native_catalog_key(name), count),
         )
+        if cursor.rowcount > 0 and existing is not None:
+            _bump_catalog_generation(conn, existing["root_key"])
         conn.commit()
 
 
@@ -583,11 +662,14 @@ def backfill_skills_catalog(
             _upsert_row(conn, row)
         conn.execute(
             """
-            INSERT INTO skills_catalog_meta(root_key, backfilled_at, skillhub_key)
-            VALUES (?, datetime('now'), ?)
+            INSERT INTO skills_catalog_meta(
+                root_key, backfilled_at, skillhub_key, generation
+            )
+            VALUES (?, datetime('now'), ?, 1)
             ON CONFLICT(root_key) DO UPDATE SET
                 backfilled_at=datetime('now'),
-                skillhub_key=excluded.skillhub_key
+                skillhub_key=excluded.skillhub_key,
+                generation=skills_catalog_meta.generation + 1
             """,
             (root, skillhub_key),
         )
@@ -596,6 +678,142 @@ def backfill_skills_catalog(
         "skills_catalog backfill: root=%s rows=%d", root, len(rows),
     )
     return len(rows)
+
+
+def reconcile_native_skills_catalog(
+    skill_dir: Path | str,
+    *,
+    db_path: Path,
+) -> dict[str, int]:
+    """低频磁盘→投影对账；generation fence 防止旧扫描覆盖并发写入。"""
+    if db_path is None:
+        raise TypeError("skills_catalog reconcile requires explicit db_path")
+    skill_dir = Path(skill_dir)
+    root = _root_key(skill_dir)
+
+    # 先确保 generation 存在。这里只补 meta，不碰 catalog 行，因而不会误删同
+    # root 的 SkillHub 投影。之后所有正常写出口都会 bump，供扫描后的 fence 检查。
+    with pooled_connection(Path(db_path)) as conn:
+        cursor = conn.execute(
+            """
+            INSERT INTO skills_catalog_meta(
+                root_key, backfilled_at, skillhub_key, generation
+            ) VALUES (?, datetime('now'), 'none', 1)
+            ON CONFLICT(root_key) DO NOTHING
+            """,
+            (root,),
+        )
+        meta_created = cursor.rowcount > 0
+        start_generation = int(conn.execute(
+            "SELECT generation FROM skills_catalog_meta WHERE root_key=?",
+            (root,),
+        ).fetchone()["generation"])
+        conn.commit()
+
+    rows = scan_skills_catalog(skill_dir)
+    wanted = {row["catalog_key"]: row for row in rows}
+    with pooled_connection(Path(db_path)) as conn:
+        # 锁内先验 generation 必须仍等于扫描前版本。若期间有写出口推进版本，
+        # 本轮旧快照直接放弃；写出口已经把新行写入，低频对账下轮再补外部漂移。
+        conn.execute("BEGIN IMMEDIATE")
+        current_generation = int(conn.execute(
+            "SELECT generation FROM skills_catalog_meta WHERE root_key=?",
+            (root,),
+        ).fetchone()["generation"])
+        if current_generation != start_generation:
+            conn.rollback()
+            return {"upserted": 0, "deleted": 0, "changed": 0, "skipped": 1}
+
+        existing_rows = conn.execute(
+            f"""
+            SELECT catalog_key, {', '.join(_CATALOG_COMPARE_COLUMNS)}
+            FROM skills_catalog
+            WHERE root_key=? AND source=?
+            """,
+            (root, _SOURCE_NATIVE),
+        ).fetchall()
+        existing = {row["catalog_key"]: dict(row) for row in existing_rows}
+        upserted = 0
+        for key, row in wanted.items():
+            current = existing.get(key)
+            if current is not None and _catalog_row_matches(current, row):
+                continue
+            _upsert_row(conn, row)
+            upserted += 1
+
+        stale = set(existing) - set(wanted)
+        if stale:
+            placeholders = ",".join("?" for _ in stale)
+            conn.execute(
+                f"DELETE FROM skills_catalog WHERE catalog_key IN ({placeholders})",
+                tuple(sorted(stale)),
+            )
+
+        changed = bool(upserted or stale)
+        if changed:
+            _bump_catalog_generation(conn, root)
+        conn.commit()
+    return {
+        "upserted": upserted,
+        "deleted": len(stale),
+        "changed": int(changed or meta_created),
+        "skipped": 0,
+    }
+
+
+def _ensure_native_catalog_ready(skill_dir: Path | str, *, db_path: Path) -> None:
+    """只要该 root 已有任意 catalog backfill 即可读 native 投影。"""
+    root = _root_key(skill_dir)
+    with pooled_connection(Path(db_path)) as conn:
+        ready = conn.execute(
+            "SELECT 1 FROM skills_catalog_meta WHERE root_key=?",
+            (root,),
+        ).fetchone()
+    if ready is None:
+        ensure_skills_catalog(skill_dir, db_path=Path(db_path))
+
+
+def native_catalog_generation(skill_dir: Path | str, *, db_path: Path) -> int:
+    """返回 native 路由目录的跨进程失效版本。"""
+    if db_path is None:
+        raise TypeError("skills_catalog generation requires explicit db_path")
+    root = _root_key(skill_dir)
+    with pooled_connection(Path(db_path)) as conn:
+        row = conn.execute(
+            "SELECT generation FROM skills_catalog_meta WHERE root_key=?",
+            (root,),
+        ).fetchone()
+    if row is None:
+        ensure_skills_catalog(skill_dir, db_path=Path(db_path))
+        with pooled_connection(Path(db_path)) as conn:
+            row = conn.execute(
+                "SELECT generation FROM skills_catalog_meta WHERE root_key=?",
+                (root,),
+            ).fetchone()
+    return int(row["generation"] if row is not None else 0)
+
+
+def list_native_cluster_catalog(
+    skill_dir: Path | str,
+    *,
+    db_path: Path,
+) -> list[dict]:
+    """按旧 Cluster 路由顺序读取 native 投影；不改写 SkillHub fingerprint。"""
+    if db_path is None:
+        raise TypeError("native cluster catalog requires explicit db_path")
+    _ensure_native_catalog_ready(skill_dir, db_path=Path(db_path))
+    root = _root_key(skill_dir)
+    with pooled_connection(Path(db_path)) as conn:
+        rows = conn.execute(
+            """
+            SELECT name, state, description, candidates_count
+            FROM skills_catalog
+            WHERE root_key=? AND source=?
+            ORDER BY name
+            """,
+            (root, _SOURCE_NATIVE),
+        ).fetchall()
+    return [dict(row) for row in rows]
 
 
 def ensure_skills_catalog(

--- a/tests/test_cluster_batch.py
+++ b/tests/test_cluster_batch.py
@@ -162,6 +162,43 @@ def _drive(watcher: DirectoryWatcher, wd_id: int, db: Path, max_rounds: int = 30
             return
 
 
+def test_cluster_catalog_reconciliation_is_low_frequency(tmp_path, monkeypatch):
+    from xskill.pipeline import runner as runner_module
+    from xskill.skill import catalog_store
+
+    skill_dir = tmp_path / "skill"
+    skill_dir.mkdir()
+    watcher = DirectoryWatcher(
+        config={"watcher": {"full_reconcile_interval": 60}},
+        skill_dir=skill_dir,
+        poll_interval=1,
+        db_path=tmp_path / "registry.db",
+        home_root=tmp_path,
+        xskill_home=tmp_path / "xskill-home",
+    )
+    calls: list[Path] = []
+
+    def reconcile(path, *, db_path):
+        calls.append(Path(path))
+        return {"changed": 0}
+
+    monkeypatch.setattr(
+        catalog_store,
+        "reconcile_native_skills_catalog",
+        reconcile,
+    )
+    times = iter((100.0, 120.0, 161.0))
+    monkeypatch.setattr(runner_module.time, "monotonic", lambda: next(times))
+    try:
+        watcher._reconcile_cluster_catalog_if_due()
+        watcher._reconcile_cluster_catalog_if_due()
+        watcher._reconcile_cluster_catalog_if_due()
+    finally:
+        watcher.stop()
+
+    assert calls == [skill_dir, skill_dir]
+
+
 # ─────────────────────────────────────────────────────────────────────
 # 验收 1：批量生效 —— 调用次数 == ceil(总 atom / batch_size) 而非 == 总 atom
 # ─────────────────────────────────────────────────────────────────────

--- a/tests/test_skills_catalog_store.py
+++ b/tests/test_skills_catalog_store.py
@@ -1,6 +1,8 @@
 """skills_catalog 投影表：UPSERT / DELETE / backfill / page。"""
 from __future__ import annotations
 
+import sqlite3
+
 import pytest
 
 from xskill.skill import catalog_store
@@ -38,10 +40,14 @@ def test_init_and_graduate_upsert_native_row(tmp_path):
         assert page["total"] == 1
         assert page["skills"][0]["state"] == "baby"
         assert "baby desc" in page["skills"][0]["description"]
+        before = catalog_store.native_catalog_generation(root, db_path=registry)
+        catalog_store.upsert_native_skill(root / "demo", db_path=registry)
+        assert catalog_store.native_catalog_generation(root, db_path=registry) == before
 
         assert commit_baby_to_main_branch(str(root / "demo"), "graduate")
         page = catalog_store.page_skills_catalog(root, limit=10, db_path=registry)
         assert page["skills"][0]["state"] == "main"
+        assert catalog_store.native_catalog_generation(root, db_path=registry) > before
 
 
 def test_delete_native_removes_row(tmp_path):
@@ -52,8 +58,10 @@ def test_delete_native_removes_row(tmp_path):
         str(root / "gone"), name="gone", description="x",
     )
     catalog_store.ensure_skills_catalog(root, db_path=registry)
+    before = catalog_store.native_catalog_generation(root, db_path=registry)
     catalog_store.delete_native_skill("gone", db_path=registry)
     assert catalog_store.list_skills_catalog(root, db_path=registry) == []
+    assert catalog_store.native_catalog_generation(root, db_path=registry) > before
 
 
 def test_backfill_replaces_stale_native_and_hub(tmp_path):
@@ -94,9 +102,15 @@ def test_candidates_notify_uses_count_not_reread(tmp_path, monkeypatch):
         encoding="utf-8",
     )
     catalog_store.ensure_skills_catalog(root, db_path=registry)
+    before = catalog_store.native_catalog_generation(root, db_path=registry)
     catalog_store.notify_native_candidates_count(skill, 3, db_path=registry)
     page = catalog_store.page_skills_catalog(root, db_path=registry)
     assert page["skills"][0]["candidates"] == 3
+    after = catalog_store.native_catalog_generation(root, db_path=registry)
+    assert after > before
+
+    catalog_store.notify_native_candidates_count(skill, 3, db_path=registry)
+    assert catalog_store.native_catalog_generation(root, db_path=registry) == after
 
 
 def test_notify_upsert_without_db_path_skips_global(tmp_path, monkeypatch):
@@ -120,6 +134,7 @@ def test_notify_upsert_without_db_path_skips_global(tmp_path, monkeypatch):
     catalog_store.notify_native_upsert(skill)
     assert not global_db.exists()
 
+
 def test_rename_is_single_transaction(tmp_path):
     registry = tmp_path / "registry.db"
     root = tmp_path / "skills"
@@ -132,6 +147,8 @@ def test_rename_is_single_transaction(tmp_path):
         "---\nname: old\ndescription: d\n---\n", encoding="utf-8",
     )
     catalog_store.upsert_native_skill(old_path, db_path=registry)
+    catalog_store.ensure_skills_catalog(root, db_path=registry)
+    before = catalog_store.native_catalog_generation(root, db_path=registry)
     old_path.rename(new_path)
     (new_path / "SKILL.md").write_text(
         "---\nname: new\ndescription: d\n---\n", encoding="utf-8",
@@ -139,3 +156,93 @@ def test_rename_is_single_transaction(tmp_path):
     catalog_store.rename_native_skill("old", new_path, db_path=registry)
     rows = catalog_store.list_skills_catalog(root, db_path=registry)
     assert [row["name"] for row in rows] == ["new"]
+    assert catalog_store.native_catalog_generation(root, db_path=registry) > before
+
+
+def test_native_reconcile_preserves_skillhub_rows(tmp_path):
+    registry = tmp_path / "registry.db"
+    root = tmp_path / "skills"
+    root.mkdir()
+    init_skill_repo_on_baby(
+        str(root / "alpha"), name="alpha", description="native alpha",
+    )
+    hub = [{
+        "display_name": "hub-skill",
+        "source_path": "team/x",
+        "skill_id": "hub-skill@1",
+        "description": "from hub",
+        "use_count": 2,
+    }]
+    catalog_store.backfill_skills_catalog(root, skillhub=hub, db_path=registry)
+
+    init_skill_repo_on_baby(
+        str(root / "beta"), name="beta", description="native beta",
+    )
+    stats = catalog_store.reconcile_native_skills_catalog(root, db_path=registry)
+
+    assert stats == {
+        "upserted": 1, "deleted": 0, "changed": 1, "skipped": 0,
+    }
+    rows = catalog_store.list_skills_catalog(root, skillhub=hub, db_path=registry)
+    assert [row["name"] for row in rows] == ["alpha", "beta", "hub-skill"]
+
+
+def test_native_reconcile_does_not_overwrite_concurrent_upsert(tmp_path, monkeypatch):
+    registry = tmp_path / "registry.db"
+    root = tmp_path / "skills"
+    root.mkdir()
+    skill = root / "alpha"
+    init_skill_repo_on_baby(
+        str(skill), name="alpha", description="old description",
+    )
+    catalog_store.ensure_skills_catalog(root, db_path=registry)
+    original_scan = catalog_store.scan_skills_catalog
+
+    def scan_then_write(skill_dir, skillhub=None):
+        stale = original_scan(skill_dir, skillhub=skillhub)
+        (skill / "SKILL.md").write_text(
+            "---\nname: alpha\ndescription: concurrent description\n---\n",
+            encoding="utf-8",
+        )
+        catalog_store.upsert_native_skill(skill, db_path=registry)
+        return stale
+
+    monkeypatch.setattr(catalog_store, "scan_skills_catalog", scan_then_write)
+    stats = catalog_store.reconcile_native_skills_catalog(root, db_path=registry)
+
+    assert stats == {"upserted": 0, "deleted": 0, "changed": 0, "skipped": 1}
+    rows = catalog_store.list_native_cluster_catalog(root, db_path=registry)
+    assert rows[0]["description"] == "concurrent description"
+
+
+def test_legacy_catalog_meta_adds_generation_column(tmp_path):
+    registry = tmp_path / "registry.db"
+    with sqlite3.connect(registry) as conn:
+        conn.execute(
+            """
+            CREATE TABLE skills_catalog_meta (
+                root_key TEXT PRIMARY KEY,
+                backfilled_at TEXT NOT NULL,
+                skillhub_key TEXT NOT NULL DEFAULT ''
+            )
+            """
+        )
+        conn.execute(
+            "INSERT INTO skills_catalog_meta VALUES ('legacy', 'now', 'none')"
+        )
+
+    from xskill.pipeline.registry import get_connection
+
+    conn = get_connection(registry)
+    columns = {
+        row[1] for row in conn.execute(
+            "PRAGMA table_info(skills_catalog_meta)"
+        ).fetchall()
+    }
+    generation = conn.execute(
+        "SELECT generation FROM skills_catalog_meta WHERE root_key='legacy'"
+    ).fetchone()[0]
+    conn.close()
+
+    assert "generation" in columns
+    assert generation == 0

--- a/tests/test_task_cluster_agent.py
+++ b/tests/test_task_cluster_agent.py
@@ -1,10 +1,25 @@
 """TaskClusterAgent + build_skill_catalog_block 单测"""
 from __future__ import annotations
 
+from concurrent.futures import ThreadPoolExecutor
 from pathlib import Path
 
+import pytest
+
+from xskill.agents import task_cluster_agent as task_cluster_module
 from xskill.pipeline.atom import AtomTask, AtomTaskStore
-from xskill.agents.task_cluster_agent import TaskClusterAgent, build_skill_catalog_block
+from xskill.agents.task_cluster_agent import (
+    TaskClusterAgent,
+    _clear_catalog_block_cache,
+    build_skill_catalog_block,
+)
+
+
+@pytest.fixture(autouse=True)
+def _clear_cluster_catalog_cache():
+    _clear_catalog_block_cache()
+    yield
+    _clear_catalog_block_cache()
 
 
 def _make_skill_on_main(skill_dir: Path, name: str, desc: str):
@@ -130,6 +145,144 @@ class TestSkillCatalogBudget:
         skill_dir.mkdir()
         block = build_skill_catalog_block(skill_dir, max_chars=10000)
         assert "no skills" in block.lower()
+
+    def test_projection_snapshot_singleflights_until_generation_changes(
+        self, tmp_path, monkeypatch,
+    ):
+        """同 generation 并发 batch 只读一次目录行；写入后下一批立即刷新。"""
+        from xskill.skill import catalog_store
+
+        skill_dir = tmp_path / "skill"
+        registry = tmp_path / "registry.db"
+        _make_skill(skill_dir, "alpha", "first description")
+
+        calls: list[None] = []
+        disk_reads: list[None] = []
+        original = catalog_store.list_native_cluster_catalog
+        original_read = catalog_store._read_native_row
+
+        def counted(*args, **kwargs):
+            calls.append(None)
+            return original(*args, **kwargs)
+
+        def counted_disk_read(*args, **kwargs):
+            disk_reads.append(None)
+            return original_read(*args, **kwargs)
+
+        monkeypatch.setattr(catalog_store, "list_native_cluster_catalog", counted)
+        monkeypatch.setattr(catalog_store, "_read_native_row", counted_disk_read)
+        monkeypatch.setattr(
+            task_cluster_module,
+            "_scan_skill_state",
+            lambda _path: pytest.fail("projection path must not run legacy Git scan"),
+        )
+        with ThreadPoolExecutor(max_workers=8) as executor:
+            blocks = list(executor.map(
+                lambda _: build_skill_catalog_block(
+                    skill_dir, max_chars=20000, db_path=registry,
+                ),
+                range(16),
+            ))
+
+        assert len(calls) == 1
+        assert len(disk_reads) == 1
+        assert all("alpha[main]: first description" in block for block in blocks)
+
+        _make_skill_on_baby(skill_dir, "beta", "new baby description")
+        catalog_store.upsert_native_skill(skill_dir / "beta", db_path=registry)
+        refreshed = build_skill_catalog_block(
+            skill_dir, max_chars=20000, db_path=registry,
+        )
+        assert len(calls) == 2
+        assert len(disk_reads) == 2
+        assert "beta[baby]: new baby description (0 cand in buffer)" in refreshed
+
+    def test_projection_failure_falls_back_to_disk_scan(self, tmp_path, monkeypatch):
+        from xskill.skill import catalog_store
+
+        skill_dir = tmp_path / "skill"
+        skill_dir.mkdir()
+
+        def unavailable(*_args, **_kwargs):
+            raise OSError("registry unavailable")
+
+        monkeypatch.setattr(catalog_store, "native_catalog_generation", unavailable)
+        monkeypatch.setattr(
+            task_cluster_module,
+            "_scan_skill_state",
+            lambda _path: [("fallback", "main", "disk truth")],
+        )
+
+        block = build_skill_catalog_block(
+            skill_dir, max_chars=10000, db_path=tmp_path / "registry.db",
+        )
+        assert block == "- fallback[main]: disk truth"
+
+    def test_replaced_registry_file_cannot_reuse_old_generation(self, tmp_path, monkeypatch):
+        from xskill.skill import catalog_store
+
+        skill_dir = tmp_path / "skill"
+        registry = tmp_path / "registry.db"
+        rows = [{
+            "name": "alpha", "state": "main", "description": "first",
+            "candidates_count": 0,
+        }]
+        calls: list[None] = []
+        identity = {"value": (1, 1)}
+
+        monkeypatch.setattr(
+            catalog_store, "native_catalog_generation", lambda *_args, **_kwargs: 1,
+        )
+        monkeypatch.setattr(
+            catalog_store,
+            "list_native_cluster_catalog",
+            lambda *_args, **_kwargs: calls.append(None) or list(rows),
+        )
+        monkeypatch.setattr(
+            task_cluster_module,
+            "_catalog_db_identity",
+            lambda _path: identity["value"],
+        )
+
+        first = build_skill_catalog_block(
+            skill_dir, max_chars=10000, db_path=registry,
+        )
+        assert build_skill_catalog_block(
+            skill_dir, max_chars=10000, db_path=registry,
+        ) == first
+        assert len(calls) == 1
+
+        rows[0] = {
+            "name": "beta", "state": "main", "description": "replacement",
+            "candidates_count": 0,
+        }
+        identity["value"] = (1, 2)
+        replaced = build_skill_catalog_block(
+            skill_dir, max_chars=10000, db_path=registry,
+        )
+        assert "beta[main]: replacement" in replaced
+        assert len(calls) == 2
+
+    def test_projection_cache_has_hard_entry_and_size_bounds(self):
+        value = "x" * 100
+        for generation in range(40):
+            key = ("db", 1, 1, "root", 1000, generation)
+            task_cluster_module._cache_catalog_block(key, lambda: value)
+
+        assert len(task_cluster_module._CATALOG_CACHE) == 32
+        assert sum(
+            len(block) for block in task_cluster_module._CATALOG_CACHE.values()
+        ) <= task_cluster_module._CATALOG_CACHE_MAX_CHARS
+
+        _clear_catalog_block_cache()
+        large_value = "x" * 600_000
+        for generation in range(2):
+            key = ("db", 1, 1, "root", 1000, generation)
+            task_cluster_module._cache_catalog_block(key, lambda: large_value)
+        assert len(task_cluster_module._CATALOG_CACHE) == 1
+        assert sum(
+            len(block) for block in task_cluster_module._CATALOG_CACHE.values()
+        ) <= task_cluster_module._CATALOG_CACHE_MAX_CHARS
 
 
 class TestClusterAgentPrompt:


### PR DESCRIPTION
## Summary

Cluster 路由目录改为读取 generation-keyed 的 `skills_catalog` 不可变快照，避免每个 batch 重复扫描全部技能仓、读取 `SKILL.md` 和探测 Git 分支。磁盘/Git 仍是事实源；投影异常时回退原有扫盘路径，低频 reconciliation 负责修复漂移。

## Changes

- 为 `skills_catalog_meta` 增加安全迁移的 generation，并在 create/edit/promote/reject/rename/delete/candidates 写出口中与投影变更同事务失效；完全相同的重复写入不产生无效 generation。
- 为 Cluster prompt 增加按 DB identity、root、预算和 generation 隔离的进程内 singleflight LRU，限制为最多 32 项且总计不超过 1,000,000 字符。
- Watcher 在有待处理 Cluster batch 时执行启动及低频 native-only reconciliation；generation fence 防止旧扫描覆盖并发写入，且保留同 root 的 SkillHub 行。
- 覆盖并发批次复用、写后刷新、数据库同路径重建、缓存上限、投影故障回退、旧库迁移、并发对账及节流行为。

## Test plan

- [x] `make test` passes（2295 passed, 10 skipped）
- [x] Added/updated unit tests for the change（affected suite: 165 passed）
- [x] `make e2e` passes (if the change touches ingestion / install / daemon)（2/2 scenarios；最终 wheel，验证副本仅将当前环境不可达的阿里云内网镜像源切回公共源）
- [ ] Manually verified the affected user flow
- [x] Changed-file Ruff passes；全仓 Ruff 的 27 条告警与当前 `main` 基线一致

## Linked issues

Closes #293

Related to #301