### PR TITLE
perf(skill-edit): schedule edits from persistent dirty queue

### DIFF
--- a/src/xskill/pipeline/registry.py
+++ b/src/xskill/pipeline/registry.py
@@ -376,6 +376,17 @@ CREATE TABLE IF NOT EXISTS atom_candidate_pending_meta (
     backfilled_at TEXT NOT NULL
 );
 
+-- SkillEdit 持久脏队列：候选写入只合并同一 skill 的 generation；watcher
+-- 以 compare-and-delete 确认已观察版本，避免编辑期间的新写入被旧任务误清。
+CREATE TABLE IF NOT EXISTS skill_edit_dirty (
+    root_key   TEXT NOT NULL,
+    skill      TEXT NOT NULL,
+    generation INTEGER NOT NULL DEFAULT 1,
+    reason     TEXT NOT NULL DEFAULT '',
+    marked_at  TEXT NOT NULL DEFAULT (datetime('now')),
+    PRIMARY KEY (root_key, skill)
+);
+
 -- 纳入 / generate 发起人。首次写入生效，供自动灰度对象（与用量最多的用户取并）。
 CREATE TABLE IF NOT EXISTS skill_origin (
     skill_name TEXT PRIMARY KEY,
@@ -1282,6 +1293,7 @@ def sync_atom_candidate_pending_for_skill(
     candidates: list,
     *,
     db_path: Optional[Path] = None,
+    dirty_root_key: str | None = None,
 ) -> None:
     """按某 skill 当前 candidates 快照替换其 pending 投影行。
 
@@ -1310,6 +1322,13 @@ def sync_atom_candidate_pending_for_skill(
                 """,
                 rows,
             )
+        if dirty_root_key is not None:
+            _mark_skill_edit_dirty_conn(
+                conn,
+                root_key=dirty_root_key,
+                skill=skill,
+                reason="candidates",
+            )
         conn.commit()
 
 
@@ -1317,11 +1336,19 @@ def delete_atom_candidate_pending_for_skill(
     skill: str,
     *,
     db_path: Optional[Path] = None,
+    dirty_root_key: str | None = None,
 ) -> None:
     with pooled_connection(db_path) as conn:
         conn.execute(
             "DELETE FROM atom_candidate_pending WHERE skill=?", (skill,),
         )
+        if dirty_root_key is not None:
+            _mark_skill_edit_dirty_conn(
+                conn,
+                root_key=dirty_root_key,
+                skill=skill,
+                reason="candidates_missing",
+            )
         conn.commit()
 
 
@@ -1342,7 +1369,10 @@ def notify_atom_pending_sync(
             )
             return
         sync_atom_candidate_pending_for_skill(
-            Path(skill_path).name, candidates, db_path=resolved,
+            Path(skill_path).name,
+            candidates,
+            db_path=resolved,
+            dirty_root_key=_atom_pending_root_key(Path(skill_path).parent),
         )
     except Exception:  # pylint: disable=broad-exception-caught
         logger.exception(
@@ -1369,6 +1399,129 @@ def notify_atom_pending_delete(
         logger.exception(
             "atom_candidate_pending delete failed: %s", skill,
         )
+
+
+def _mark_skill_edit_dirty_conn(
+    conn: sqlite3.Connection,
+    *,
+    root_key: str,
+    skill: str,
+    reason: str,
+) -> None:
+    conn.execute(
+        """
+        INSERT INTO skill_edit_dirty(root_key, skill, generation, reason)
+        VALUES (?, ?, 1, ?)
+        ON CONFLICT(root_key, skill) DO UPDATE SET
+            generation=skill_edit_dirty.generation + 1,
+            reason=excluded.reason,
+            marked_at=datetime('now')
+        """,
+        (root_key, skill, reason),
+    )
+
+
+def mark_skill_edit_dirty(
+    skill_path: Path | str,
+    *,
+    reason: str = "candidates",
+    db_path: Optional[Path] = None,
+) -> None:
+    """持久标记一个 skill；重复标记只递增 generation，不增加队列行。"""
+    path = Path(skill_path)
+    with pooled_connection(db_path) as conn:
+        _mark_skill_edit_dirty_conn(
+            conn,
+            root_key=_atom_pending_root_key(path.parent),
+            skill=path.name,
+            reason=reason,
+        )
+        conn.commit()
+
+
+def list_skill_edit_dirty(
+    skill_dir: Path | str,
+    *,
+    db_path: Optional[Path] = None,
+) -> list[dict]:
+    """返回一个 skill root 当前待检查的持久脏项。"""
+    root_key = _atom_pending_root_key(skill_dir)
+    with pooled_connection(db_path) as conn:
+        return [
+            dict(row)
+            for row in conn.execute(
+                "SELECT skill, generation, reason, marked_at "
+                "FROM skill_edit_dirty WHERE root_key=? ORDER BY skill",
+                (root_key,),
+            ).fetchall()
+        ]
+
+
+def skill_edit_dirty_generation(
+    skill_path: Path | str,
+    *,
+    db_path: Optional[Path] = None,
+) -> int | None:
+    """读取一个 skill 当前 generation；无脏项返回 ``None``。"""
+    path = Path(skill_path)
+    with pooled_connection(db_path) as conn:
+        row = conn.execute(
+            "SELECT generation FROM skill_edit_dirty "
+            "WHERE root_key=? AND skill=?",
+            (_atom_pending_root_key(path.parent), path.name),
+        ).fetchone()
+    return None if row is None else int(row["generation"])
+
+
+def acknowledge_skill_edit_dirty(
+    skill_dir: Path | str,
+    skill: str,
+    generation: int,
+    *,
+    db_path: Optional[Path] = None,
+) -> bool:
+    """仅确认仍是所观察 generation 的脏项，避免吞掉并发候选写入。"""
+    root_key = _atom_pending_root_key(skill_dir)
+    with pooled_connection(db_path) as conn:
+        cursor = conn.execute(
+            "DELETE FROM skill_edit_dirty "
+            "WHERE root_key=? AND skill=? AND generation=?",
+            (root_key, skill, int(generation)),
+        )
+        conn.commit()
+        return cursor.rowcount > 0
+
+
+def reconcile_skill_edit_dirty(
+    skill_dir: Path | str,
+    *,
+    db_path: Optional[Path] = None,
+) -> int:
+    """低频扫一次 skill root，为缺失的脏项补行；已有行不改 generation。"""
+    root = Path(skill_dir)
+    if not root.is_dir():
+        return 0
+    skill_names = sorted(
+        path.name
+        for path in root.iterdir()
+        if path.is_dir() and not path.name.startswith(".")
+    )
+    if not skill_names:
+        return 0
+    root_key = _atom_pending_root_key(root)
+    with pooled_connection(db_path) as conn:
+        before = conn.total_changes
+        conn.executemany(
+            """
+            INSERT INTO skill_edit_dirty(root_key, skill, generation, reason)
+            VALUES (?, ?, 1, 'reconcile')
+            ON CONFLICT(root_key, skill) DO NOTHING
+            """,
+            ((root_key, skill) for skill in skill_names),
+        )
+        inserted = conn.total_changes - before
+        conn.commit()
+    return inserted
 
 
 _ATOM_PENDING_BACKFILL_LOCK = threading.Lock()

--- a/src/xskill/pipeline/runner.py
+++ b/src/xskill/pipeline/runner.py
@@ -169,6 +169,7 @@ class DirectoryWatcher:
         # watch_dir_id -> ((device, inode, directory mtime ns), last full scan)
         # Only the watcher thread reads/writes this map.
         self._discovery_snapshots: dict[int, tuple[tuple[int, int, int], float]] = {}
+        self._last_skill_edit_reconcile_ts: float | None = None
         self.max_retries = max_retries
         self.db_path = db_path
         # 每轮 _loop 在 _scan_once 之前调一次的钩子，用来让 server 端的"生态
@@ -427,7 +428,7 @@ class DirectoryWatcher:
             self._stop.wait(self.poll_interval)
 
     def _scan_once(self):
-        """一次扫描：收割 → 发现 → 提交任务 → 独立扫 pending skill edits。"""
+        """一次扫描：收割 → 发现 → 提交任务 → 调度 pending skill edits。"""
         self._last_poll = time.time()
         self._stats["polls"] += 1
         kw = self._db_kw()
@@ -465,9 +466,9 @@ class DirectoryWatcher:
         # 先于自动 SkillEdit 提交，避免后台整理把用户任务挤到池外。
         self._submit_generate_jobs()
 
-        # ── Step 5: 独立扫所有 skill 目录的 candidates buffer ──
-        # 这步与具体 atom 处理解耦：即便某些 atom cluster 失败，buffer
-        # 已满阈值的 skill 仍能在每轮 scan 中被检出 + 触发 SkillEdit。
+        # ── Step 5: 从持久脏队列调度 candidates buffer ──
+        # 这步与具体 atom 处理解耦：候选落盘会把所属 skill 标脏；低频全量
+        # reconciliation 兜住进程重启、外部写入和时间型 jam gate。
         # 不放在 _scan_dir 内是因为 skill_dir 不是 watch_dir，跟 wd 循环
         # 无关——每个 watcher 只有一个全局 skill_dir。
         self._run_skill_edit_step()
@@ -593,7 +594,7 @@ class DirectoryWatcher:
         cold_start_signal.consume()
 
     def _check_pending_skill_edits(self, threshold=None):
-        """遍历每个 skill 目录调 SkillEditAgent.maybe_run()。
+        """从持久脏队列选出 skill，调 ``SkillEditAgent.maybe_run()``。
 
         ``threshold``：None 时各 skill 用默认 ATOM_PROMOTION_THRESHOLD；cold
         start 显式传同一个常量，避免在配置里散落另一套数值。
@@ -608,8 +609,201 @@ class DirectoryWatcher:
         """
         if self.skill_dir is None or not self.skill_dir.is_dir():
             return
+        from xskill.pipeline.registry import (
+            acknowledge_skill_edit_dirty,
+            list_skill_edit_dirty,
+            reconcile_skill_edit_dirty,
+        )
+
+        now = time.monotonic()
+        reconcile_due = (
+            self._last_skill_edit_reconcile_ts is None
+            or self.full_reconcile_interval == 0
+            or now - self._last_skill_edit_reconcile_ts
+            >= self.full_reconcile_interval
+        )
+        if reconcile_due:
+            try:
+                reconcile_skill_edit_dirty(
+                    self.skill_dir,
+                    **self._db_kw(),
+                )
+                self._last_skill_edit_reconcile_ts = now
+            except Exception:
+                # YAML/skill 目录是真相源；队列投影失败不能阻断其余流水线。
+                logger.exception("skill_edit dirty reconciliation failed")
+        try:
+            dirty_rows = list_skill_edit_dirty(
+                self.skill_dir,
+                **self._db_kw(),
+            )
+        except Exception:
+            logger.exception("skill_edit dirty queue read failed")
+            return
+        if not dirty_rows:
+            return
+
+        def _acknowledge_dirty(skill: str, generation: int) -> bool:
+            try:
+                return acknowledge_skill_edit_dirty(
+                    self.skill_dir,
+                    skill,
+                    generation,
+                    **self._db_kw(),
+                )
+            except Exception:
+                logger.exception(
+                    "skill_edit dirty acknowledgement failed: %s",
+                    skill,
+                )
+                return False
+
+        dirty_skills: list[tuple[Path, int]] = []
+        for row in dirty_rows:
+            skill_path = self.skill_dir / str(row["skill"])
+            generation = int(row["generation"])
+            if (
+                not skill_path.is_dir()
+                or skill_path.name.startswith(".")
+            ):
+                _acknowledge_dirty(skill_path.name, generation)
+                continue
+            dirty_skills.append((skill_path, generation))
+        if not dirty_skills:
+            return
+
+        skill_edit_in_flight = {
+            info.get("skill_dir") for info in self._futures.values()
+            if info.get("stage") in ("skill_edit", "skill_scripting")
+        }
+        dirty_skills = [
+            item for item in dirty_skills if item[0] not in skill_edit_in_flight
+        ]
+        if not dirty_skills:
+            return
+
         from xskill.agents.skill_edit_agent import SkillEditAgent
         from xskill.canary import CanaryConfig
+        # ── 跨技能并行写正文，且不阻塞扫描循环 ──
+        # 每个 skill 文件夹是独立 git 仓（skill/git.py 各自 git init），仓锁
+        # _repo_lock_for(repo_dir) 是 per-skill 的 → 不同技能 = 不同锁 = 零冲突，
+        # 跨技能并发安全。每个 future 显式绑定自己的不可变 AgentToolContext；
+        # write_file / commit_baby_to_main / commit_to_staging / skill_read 都从
+        # 当前 task context 取根目录，不共享进程级可变路径。
+        #
+        # 不在这里 as_completed 等待：SkillEditAgent 现在支持多轮渐进式消化，
+        # 单个 skill 的 maybe_run() 可能跑到小时级（buffer 攒了几十上百批候选
+        # 时）。像 split/cluster 一样把每个 skill 的 maybe_run() 提交进
+        # self._futures（stage="skill_edit"），本方法立即返回；结果由
+        # ``_harvest``（每轮 scan 开头）收割 + 做 _stats 自增/即时 install。
+        # 同一个 skill 同时只允许一个 skill_edit future 在飞，避免同一 skill
+        # 被并发跑两个 maybe_run（第二个进来时前一个多半仍在改 candidates/git）。
+        from xskill.skill import candidates as candidate_buffer
+        from xskill.skill.git import current_branch, run_git
+        from xskill.canary import evaluate_jam_gates, load_ux_scores
+        from xskill.skill.importer import is_imported_skill
+
+        jam_cfg = CanaryConfig.from_dict(self.config.get("canary", {}))
+        edit_threshold = (
+            int(threshold)
+            if threshold is not None
+            else candidate_buffer.ATOM_PROMOTION_THRESHOLD
+        )
+
+        def _skill_edit_actionable(
+            skill_path: Path,
+        ) -> tuple[bool | None, int]:
+            """与 maybe_run 守门对齐：不会开 LLM 的 skill 不进 edit 池。
+
+            单目录异常只排除该 skill，禁止拖垮整轮 edit submit。
+            无 ``.git`` 的目录仍返回 True：交由 worker 侧 ``_run_one`` /
+            ``maybe_run`` 吞错（与过滤前提交语义一致），避免 listcomp 里
+            ``current_branch`` 抛穿扫描；也不把「脏目录」误当成可过滤的
+            伪 skill 状态机。
+            """
+            try:
+                data = candidate_buffer.load_candidates(skill_path)
+                candidates = list(data.get("candidates") or [])
+                pending_count = len(candidates)
+                if not (skill_path / ".git").exists():
+                    logger.warning(
+                        "SkillEdit schedule: %s has no .git; submit and let "
+                        "worker isolate failures",
+                        skill_path.name,
+                    )
+                    return True, pending_count
+                total_ws = 0
+                for item in candidates:
+                    try:
+                        total_ws += int(item.get("weightscore") or 0)
+                    except (TypeError, ValueError):
+                        pass
+                staging_exists = run_git(
+                    ["rev-parse", "--verify", "staging"],
+                    cwd=str(skill_path),
+                )[0] == 0
+                # jam：age ∧ plateau ∧ ws 三条件合取（见 evaluate_jam_gates）
+                jam = False
+                if staging_exists:
+                    gates = evaluate_jam_gates(
+                        skill_path, total_ws=total_ws, config=jam_cfg,
+                    )
+                    jam = bool(gates.get("ok"))
+                    if not jam:
+                        return False, pending_count
+                if jam:
+                    return True, pending_count
+                ready = bool(
+                    candidate_buffer.ready_for_promotion_v2(
+                        data, threshold=edit_threshold,
+                    )
+                )
+                baby_checkpoint = run_git(
+                    ["rev-parse", "baby~1"],
+                    cwd=str(skill_path),
+                )[0] == 0
+                branch = current_branch(str(skill_path)) or ""
+                if branch == "baby":
+                    return baby_checkpoint or ready, pending_count
+                if branch == "main":
+                    if not ready:
+                        return False, pending_count
+                    try:
+                        scores = load_ux_scores(skill_path)
+                    except Exception:
+                        logger.exception(
+                            "load_ux_scores failed during skill_edit "
+                            "filter: %s",
+                            skill_path.name,
+                        )
+                        return None, pending_count
+                    return (
+                        any(score.get("side") == "main" for score in scores),
+                        pending_count,
+                    )
+                if "_turn" in branch:
+                    return baby_checkpoint or ready, pending_count
+                return False, pending_count
+            except Exception:
+                logger.exception(
+                    "skill_edit actionable check failed: %s",
+                    skill_path.name,
+                )
+                return None, 0
+
+        actionable_skills: list[tuple[Path, int]] = []
+        for skill_path, generation in dirty_skills:
+            actionable, pending_count = _skill_edit_actionable(skill_path)
+            if actionable is None:
+                # 读取/门控异常保留脏项，下一轮沿用现有重试行为。
+                continue
+            if not actionable:
+                _acknowledge_dirty(skill_path.name, generation)
+                continue
+            actionable_skills.append((skill_path, pending_count))
+        if not actionable_skills:
+            return
+
         factory = self._factory()
         # store 选哪个：edit agent 工具 (atom_task_read/read_traj) 需要 store +
         # traj_root 才能读到 atom 原文。单机只有一个 watch_dir（cc_sessions）。
@@ -650,138 +844,12 @@ class DirectoryWatcher:
             usage_ledger=self.usage_ledger,
             registry_db_path=self.db_path,
         )
-        # ── 跨技能并行写正文，且不阻塞扫描循环 ──
-        # 每个 skill 文件夹是独立 git 仓（skill/git.py 各自 git init），仓锁
-        # _repo_lock_for(repo_dir) 是 per-skill 的 → 不同技能 = 不同锁 = 零冲突，
-        # 跨技能并发安全。每个 future 显式绑定自己的不可变 AgentToolContext；
-        # write_file / commit_baby_to_main / commit_to_staging / skill_read 都从
-        # 当前 task context 取根目录，不共享进程级可变路径。
-        #
-        # 不在这里 as_completed 等待：SkillEditAgent 现在支持多轮渐进式消化，
-        # 单个 skill 的 maybe_run() 可能跑到小时级（buffer 攒了几十上百批候选
-        # 时）。像 split/cluster 一样把每个 skill 的 maybe_run() 提交进
-        # self._futures（stage="skill_edit"），本方法立即返回；结果由
-        # ``_harvest``（每轮 scan 开头）收割 + 做 _stats 自增/即时 install。
-        # 同一个 skill 同时只允许一个 skill_edit future 在飞，避免同一 skill
-        # 被并发跑两个 maybe_run（第二个进来时前一个多半仍在改 candidates/git）。
-        from xskill.skill import candidates as candidate_buffer
-        from xskill.skill.git import current_branch, run_git
-        from xskill.canary import evaluate_jam_gates, load_ux_scores
-        from xskill.skill.importer import is_imported_skill
-
-        skill_dirs = [
-            d for d in self.skill_dir.iterdir()
-            if d.is_dir() and not d.name.startswith(".")
-        ]
-        if not skill_dirs:
-            return
-
-        jam_cfg = CanaryConfig.from_dict(self.config.get("canary", {}))
-        edit_threshold = (
-            int(threshold)
-            if threshold is not None
-            else candidate_buffer.ATOM_PROMOTION_THRESHOLD
-        )
-
-        def _pending_atom_count(skill_path: Path) -> int:
-            try:
-                data = candidate_buffer.load_candidates(skill_path)
-            except Exception:
-                logger.exception(
-                    "failed to load candidates for skill_edit sort: %s",
-                    skill_path.name,
-                )
-                raise
-            return len(data.get("candidates") or [])
-
-        def _skill_edit_actionable(skill_path: Path) -> bool:
-            """与 maybe_run 守门对齐：不会开 LLM 的 skill 不进 edit 池。
-
-            单目录异常只排除该 skill，禁止拖垮整轮 edit submit。
-            无 ``.git`` 的目录仍返回 True：交由 worker 侧 ``_run_one`` /
-            ``maybe_run`` 吞错（与过滤前提交语义一致），避免 listcomp 里
-            ``current_branch`` 抛穿扫描；也不把「脏目录」误当成可过滤的
-            伪 skill 状态机。
-            """
-            if not (skill_path / ".git").exists():
-                logger.warning(
-                    "SkillEdit schedule: %s has no .git; submit and let "
-                    "worker isolate failures",
-                    skill_path.name,
-                )
-                return True
-            try:
-                data = candidate_buffer.load_candidates(skill_path)
-                candidates = list(data.get("candidates") or [])
-                total_ws = 0
-                for item in candidates:
-                    try:
-                        total_ws += int(item.get("weightscore") or 0)
-                    except (TypeError, ValueError):
-                        pass
-                staging_exists = run_git(
-                    ["rev-parse", "--verify", "staging"],
-                    cwd=str(skill_path),
-                )[0] == 0
-                # jam：age ∧ plateau ∧ ws 三条件合取（见 evaluate_jam_gates）
-                jam = False
-                if staging_exists:
-                    gates = evaluate_jam_gates(
-                        skill_path, total_ws=total_ws, config=jam_cfg,
-                    )
-                    jam = bool(gates.get("ok"))
-                    if not jam:
-                        return False
-                if jam:
-                    return True
-                ready = bool(
-                    candidate_buffer.ready_for_promotion_v2(
-                        data, threshold=edit_threshold,
-                    )
-                )
-                baby_checkpoint = run_git(
-                    ["rev-parse", "baby~1"],
-                    cwd=str(skill_path),
-                )[0] == 0
-                branch = current_branch(str(skill_path)) or ""
-                if branch == "baby":
-                    return baby_checkpoint or ready
-                if branch == "main":
-                    if not ready:
-                        return False
-                    try:
-                        scores = load_ux_scores(skill_path)
-                    except Exception:
-                        logger.exception(
-                            "load_ux_scores failed during skill_edit "
-                            "filter: %s",
-                            skill_path.name,
-                        )
-                        return False
-                    return any(
-                        score.get("side") == "main" for score in scores
-                    )
-                if "_turn" in branch:
-                    return baby_checkpoint or ready
-                return False
-            except Exception:
-                logger.exception(
-                    "skill_edit actionable check failed: %s",
-                    skill_path.name,
-                )
-                return False
-
-        skill_dirs = [
-            path for path in skill_dirs if _skill_edit_actionable(path)
-        ]
-        if not skill_dirs:
-            return
 
         # 错误少优先；已纳入且已达触发条件的 skill 先于自动蒸馏；
         # 有候选优先于空 buffer；再 lean-first。
         # 无 .git 等「仍提交」的空目录靠 empty-last 避免抢窗。
-        def _skill_edit_sort_key(path: Path):
-            pending = _pending_atom_count(path)
+        def _skill_edit_sort_key(item: tuple[Path, int]):
+            path, pending = item
             return (
                 self._skill_edit_error_counts.get(path, 0),
                 0 if is_imported_skill(path) else 1,
@@ -790,7 +858,7 @@ class DirectoryWatcher:
                 path.name,
             )
 
-        skill_dirs.sort(key=_skill_edit_sort_key)
+        actionable_skills.sort(key=_skill_edit_sort_key)
 
         base_llm_cfg = self.config.get("llm", {}) or {}
         skill_llm_override = self.config.get("llm_skill", {}) or {}
@@ -835,13 +903,7 @@ class DirectoryWatcher:
                         self.skill_edit_batch_size,
                     )
 
-        skill_edit_in_flight = {
-            info.get("skill_dir") for info in self._futures.values()
-            if info.get("stage") in ("skill_edit", "skill_scripting")
-        }
-        for d in skill_dirs:
-            if d in skill_edit_in_flight:
-                continue
+        for d, _pending_count in actionable_skills:
             fut = self._pools["edit"].submit(
                 _run_one,
                 d,
@@ -922,6 +984,35 @@ class DirectoryWatcher:
                     self._skill_edit_n1_fail_counts[d] = fails
         if not ok:
             return
+        # 成功且 buffer 已空时立即确认观察到的脏版本。若此处与 cluster 并发写入，
+        # candidate 落盘钩子会递增 generation，compare-and-delete 自然失败，
+        # 新候选仍留给下一轮调度。
+        try:
+            from xskill.pipeline.registry import (
+                acknowledge_skill_edit_dirty,
+                skill_edit_dirty_generation,
+            )
+            from xskill.skill.candidates import load_candidates
+
+            dirty_generation = skill_edit_dirty_generation(
+                d,
+                **self._db_kw(),
+            )
+            if (
+                dirty_generation is not None
+                and not (load_candidates(d).get("candidates") or [])
+            ):
+                acknowledge_skill_edit_dirty(
+                    d.parent,
+                    d.name,
+                    dirty_generation,
+                    **self._db_kw(),
+                )
+        except Exception:
+            logger.exception(
+                "failed to acknowledge completed skill_edit: %s",
+                d.name,
+            )
         self._stats["skills_edited"] += 1
         logger.info("SkillEditAgent promoted: %s", d.name)
         # 即时 install 让 Claude Code 立刻看到新生成的 SKILL.md，不必等

--- a/src/xskill/pipeline/runner.py
+++ b/src/xskill/pipeline/runner.py
@@ -628,10 +628,13 @@ class DirectoryWatcher:
                     self.skill_dir,
                     **self._db_kw(),
                 )
-                self._last_skill_edit_reconcile_ts = now
             except Exception:
                 # YAML/skill 目录是真相源；队列投影失败不能阻断其余流水线。
                 logger.exception("skill_edit dirty reconciliation failed")
+            finally:
+                # 持续的文件系统/DB 故障不应让每个快速 poll 都退化成全量
+                # skill_dir 扫描；下一次周期对账仍会继续修复投影。
+                self._last_skill_edit_reconcile_ts = now
         try:
             dirty_rows = list_skill_edit_dirty(
                 self.skill_dir,
@@ -2992,6 +2995,32 @@ class DirectoryWatcher:
     # ux_score
     # ───────────────────────────────────────────────────────────
 
+    def _notify_skill_edit_ux_change(self, skill_path: Path, **kw) -> None:
+        """自有 skill 新增 UX 分数后立即重新检查 SkillEdit 门控。
+
+        SkillHub 目录不属于本 watcher 的 SkillEdit 状态机，不能写入自有
+        ``skill_edit_dirty`` root。通知失败只影响触发时效；低频盘→库对账仍会
+        从事实源修复。
+        """
+        if self.skill_dir is None or Path(skill_path).parent != self.skill_dir:
+            return
+        registry_db_path = kw.get("db_path") or self.db_path
+        if registry_db_path is None:
+            return
+        try:
+            from xskill.pipeline.registry import mark_skill_edit_dirty
+
+            mark_skill_edit_dirty(
+                skill_path,
+                reason="ux_score",
+                db_path=registry_db_path,
+            )
+        except Exception:
+            logger.exception(
+                "skill_edit dirty UX notification failed: %s",
+                Path(skill_path).name,
+            )
+
     def _score_atoms_for_traj(self, wd_id, fname, atoms=None, **kw):
         """对一条已跑完 cluster 的 traj 扫所有 atom 打 ux_score。
 
@@ -3059,6 +3088,8 @@ class DirectoryWatcher:
         # check_and_decide 不再绑在打分链路里——移到 watcher 周期性
         # _check_canary_decisions() 独立轮询，保证灰度系统自治不依赖
         # traj 触发。这里只负责打分落盘。
+        if new_scores:
+            self._notify_skill_edit_ux_change(skill_sub, **kw)
         mark_skill_used(wd_id, fname, skill_name, side, **kw)
         if new_scores:
             self._emit_feedback_event(
@@ -3154,7 +3185,13 @@ class DirectoryWatcher:
                     ):
                         entry = new_by_skill.setdefault(
                             skill_name,
-                            {"scores": [], "side": side, "sha": sha})
+                            {
+                                "scores": [],
+                                "side": side,
+                                "sha": sha,
+                                "skill_path": skill_sub,
+                            },
+                        )
                         entry["scores"].append(float(atom.ux_score))
                     self._stats["scores"] += 1
                     used_any = True
@@ -3162,6 +3199,7 @@ class DirectoryWatcher:
                     logger.exception("CS score_atom failed: %s/%s/%s",
                                      fname, atom.atom_id, skill_name)
         for skill_name, entry in new_by_skill.items():
+            self._notify_skill_edit_ux_change(entry["skill_path"], **kw)
             self._emit_feedback_event(
                 wd_id, fname, skill_name=skill_name, traj_id=traj_id,
                 scores=entry["scores"], side=entry["side"],

--- a/src/xskill/pipeline/skill_dir_sync.py
+++ b/src/xskill/pipeline/skill_dir_sync.py
@@ -130,7 +130,11 @@ def _sync_pending_for_skill(
         if prev == PENDING_MISSING:
             stats["skipped"] += 1
             return
-        delete_atom_candidate_pending_for_skill(skill, db_path=db_path)
+        delete_atom_candidate_pending_for_skill(
+            skill,
+            db_path=db_path,
+            dirty_root_key=_atom_pending_root_key(skill_path.parent),
+        )
         _pending_mtime_set(skill, PENDING_MISSING, db_path=db_path)
         stats["synced"] += 1
         return
@@ -156,7 +160,10 @@ def _sync_pending_for_skill(
         )
         return
     sync_atom_candidate_pending_for_skill(
-        skill, candidates, db_path=db_path,
+        skill,
+        candidates,
+        db_path=db_path,
+        dirty_root_key=_atom_pending_root_key(skill_path.parent),
     )
     _pending_mtime_set(skill, str(mtime), db_path=db_path)
     stats["synced"] += 1

--- a/tests/test_skill_edit_dirty_queue.py
+++ b/tests/test_skill_edit_dirty_queue.py
@@ -1,0 +1,345 @@
+"""SkillEdit 持久脏队列：增量调度、重启恢复与并发版本确认。"""
+
+from __future__ import annotations
+
+import sqlite3
+from concurrent.futures import Future
+from pathlib import Path
+from unittest import mock
+
+from xskill.pipeline import registry as reg
+from xskill.pipeline.atom import AtomTaskStore
+from xskill.pipeline.registry import register_dir
+from xskill.pipeline.runner import DirectoryWatcher
+from xskill.skill import candidates
+from xskill.skill.git import init_skill_repo_on_baby
+from tests.pool_helpers import pool_config
+
+
+def _unused_agent_factory(**_kwargs):
+    raise AssertionError("non-actionable skills must not construct an agent")
+
+
+def _make_watcher(tmp_path: Path, skill_root: Path) -> DirectoryWatcher:
+    db = tmp_path / "registry.db"
+    watch_dir = tmp_path / "watch"
+    watch_dir.mkdir(exist_ok=True)
+    register_dir(watch_dir, db_path=db)
+    return DirectoryWatcher(
+        config={
+            "llm": {"base_url": "x", "model": "y", "api_key": "z"},
+            "watcher": {"full_reconcile_interval": 3600},
+        },
+        skill_dir=skill_root,
+        poll_interval=1.0,
+        pool_config=pool_config(workers=1),
+        db_path=db,
+        store=AtomTaskStore(root=watch_dir),
+        agno_agent_factory=_unused_agent_factory,
+        home_root=tmp_path,
+        xskill_home=tmp_path,
+    )
+
+
+def _seed_baby(skill_root: Path, name: str, score: int = 1) -> Path:
+    skill_path = skill_root / name
+    init_skill_repo_on_baby(
+        str(skill_path),
+        name=name,
+        description="dirty queue test",
+    )
+    candidates.add_atom_contributions(
+        skill_path,
+        [(f"atom-{name}", score, "")],
+    )
+    return skill_path
+
+
+def test_candidate_writes_coalesce_per_skill_and_use_generation_fence(
+    tmp_path: Path,
+) -> None:
+    db = tmp_path / "registry.db"
+    skill_root = tmp_path / "skills"
+    foo = skill_root / "foo"
+    bar = skill_root / "bar"
+    foo.mkdir(parents=True)
+    bar.mkdir()
+
+    with mock.patch(
+        "xskill.skill.catalog_store.resolve_catalog_db_path",
+        return_value=db,
+    ):
+        candidates.add_atom_contributions(foo, [("shared-atom", 4, "")])
+        candidates.add_atom_contributions(bar, [("shared-atom", 6, "")])
+        candidates.add_atom_contributions(foo, [("shared-atom", 8, "")])
+
+    rows = reg.list_skill_edit_dirty(skill_root, db_path=db)
+    assert [(row["skill"], row["generation"]) for row in rows] == [
+        ("bar", 1),
+        ("foo", 2),
+    ]
+    with sqlite3.connect(db) as connection:
+        assert connection.execute(
+            "SELECT COUNT(*) FROM skill_edit_dirty",
+        ).fetchone()[0] == 2
+
+    assert not reg.acknowledge_skill_edit_dirty(
+        skill_root,
+        "foo",
+        1,
+        db_path=db,
+    )
+    assert reg.acknowledge_skill_edit_dirty(
+        skill_root,
+        "foo",
+        2,
+        db_path=db,
+    )
+    assert [
+        row["skill"]
+        for row in reg.list_skill_edit_dirty(skill_root, db_path=db)
+    ] == ["bar"]
+
+
+def test_idle_round_does_not_rescan_skill_directories_or_candidates(
+    tmp_path: Path,
+    monkeypatch,
+) -> None:
+    skill_root = tmp_path / "skills"
+    skill_root.mkdir()
+    _seed_baby(skill_root, "alpha")
+    _seed_baby(skill_root, "beta")
+    watcher = _make_watcher(tmp_path, skill_root)
+    try:
+        watcher._check_pending_skill_edits()
+        assert reg.list_skill_edit_dirty(
+            skill_root,
+            db_path=tmp_path / "registry.db",
+        ) == []
+
+        def reject_iterdir(_path):
+            raise AssertionError("idle SkillEdit round scanned the skill root")
+
+        def reject_candidate_read(_path):
+            raise AssertionError("idle SkillEdit round read candidates")
+
+        monkeypatch.setattr(Path, "iterdir", reject_iterdir)
+        monkeypatch.setattr(candidates, "load_candidates", reject_candidate_read)
+        watcher._check_pending_skill_edits()
+    finally:
+        watcher.stop()
+
+
+def test_candidate_change_only_checks_and_schedules_the_changed_skill(
+    tmp_path: Path,
+    monkeypatch,
+) -> None:
+    skill_root = tmp_path / "skills"
+    skill_root.mkdir()
+    alpha = _seed_baby(skill_root, "alpha")
+    _seed_baby(skill_root, "beta")
+    watcher = _make_watcher(tmp_path, skill_root)
+    try:
+        watcher._check_pending_skill_edits()
+        with mock.patch(
+            "xskill.skill.catalog_store.resolve_catalog_db_path",
+            return_value=tmp_path / "registry.db",
+        ):
+            candidates.add_atom_contributions(
+                alpha,
+                [("atom-alpha", 10, "updated")],
+            )
+
+        loaded: list[str] = []
+        original_load = candidates.load_candidates
+
+        def counted_load(path):
+            loaded.append(Path(path).name)
+            return original_load(path)
+
+        submitted: list[str] = []
+
+        def capture_submit(_callable, skill_path, **_kwargs):
+            submitted.append(Path(skill_path).name)
+            return Future()
+
+        monkeypatch.setattr(candidates, "load_candidates", counted_load)
+        monkeypatch.setattr(watcher._pools["edit"], "submit", capture_submit)
+        watcher._check_pending_skill_edits()
+
+        assert loaded == ["alpha"]
+        assert submitted == ["alpha"]
+    finally:
+        watcher.stop()
+
+
+def test_failed_skill_edit_remains_queued_for_retry(
+    tmp_path: Path,
+    monkeypatch,
+) -> None:
+    from xskill.agents import skill_edit_agent
+
+    class _FailingSkillEditAgent:
+        def __init__(self, **_kwargs):
+            self.next_batch_size = 5
+
+        def maybe_run(self):
+            return False
+
+    skill_root = tmp_path / "skills"
+    skill_root.mkdir()
+    _seed_baby(skill_root, "retry", score=10)
+    watcher = _make_watcher(tmp_path, skill_root)
+    monkeypatch.setattr(
+        skill_edit_agent,
+        "SkillEditAgent",
+        _FailingSkillEditAgent,
+    )
+    try:
+        watcher._check_pending_skill_edits()
+        watcher._drain_futures(stage="skill_edit")
+        first = reg.list_skill_edit_dirty(
+            skill_root,
+            db_path=tmp_path / "registry.db",
+        )
+        assert [row["skill"] for row in first] == ["retry"]
+
+        watcher._check_pending_skill_edits()
+        watcher._drain_futures(stage="skill_edit")
+        second = reg.list_skill_edit_dirty(
+            skill_root,
+            db_path=tmp_path / "registry.db",
+        )
+        assert [row["skill"] for row in second] == ["retry"]
+    finally:
+        watcher.stop()
+
+
+def test_cancelled_skill_edit_remains_queued(
+    tmp_path: Path,
+    monkeypatch,
+) -> None:
+    skill_root = tmp_path / "skills"
+    skill_root.mkdir()
+    _seed_baby(skill_root, "cancelled", score=10)
+    watcher = _make_watcher(tmp_path, skill_root)
+    cancelled = Future()
+    cancelled.cancel()
+    monkeypatch.setattr(
+        watcher._pools["edit"],
+        "submit",
+        lambda *_args, **_kwargs: cancelled,
+    )
+    try:
+        watcher._check_pending_skill_edits()
+        watcher._harvest()
+        assert [
+            row["skill"]
+            for row in reg.list_skill_edit_dirty(
+                skill_root,
+                db_path=tmp_path / "registry.db",
+            )
+        ] == ["cancelled"]
+    finally:
+        watcher.stop()
+
+
+def test_new_watcher_schedules_a_persisted_dirty_skill(
+    tmp_path: Path,
+    monkeypatch,
+) -> None:
+    skill_root = tmp_path / "skills"
+    skill_root.mkdir()
+    skill_path = _seed_baby(skill_root, "restart", score=10)
+    db = tmp_path / "registry.db"
+    reg.mark_skill_edit_dirty(skill_path, db_path=db)
+
+    watcher = _make_watcher(tmp_path, skill_root)
+    submitted: list[str] = []
+
+    def capture_submit(_callable, path, **_kwargs):
+        submitted.append(Path(path).name)
+        return Future()
+
+    monkeypatch.setattr(watcher._pools["edit"], "submit", capture_submit)
+    try:
+        watcher._check_pending_skill_edits()
+        assert submitted == ["restart"]
+    finally:
+        watcher.stop()
+
+
+def test_successful_skill_edit_acknowledges_an_empty_buffer(
+    tmp_path: Path,
+    monkeypatch,
+) -> None:
+    skill_root = tmp_path / "skills"
+    skill_root.mkdir()
+    skill_path = skill_root / "done"
+    skill_path.mkdir()
+    candidates.save_candidates(skill_path, {"candidates": []})
+    watcher = _make_watcher(tmp_path, skill_root)
+    reg.mark_skill_edit_dirty(
+        skill_path,
+        db_path=tmp_path / "registry.db",
+    )
+    monkeypatch.setattr(
+        watcher,
+        "_install_skill_to_all_detected",
+        lambda _path: None,
+    )
+    try:
+        watcher._on_skill_edit_done(
+            (skill_path, True, watcher.skill_edit_batch_size),
+        )
+        assert reg.list_skill_edit_dirty(
+            skill_root,
+            db_path=tmp_path / "registry.db",
+        ) == []
+    finally:
+        watcher.stop()
+
+
+def test_success_ack_does_not_consume_a_concurrent_dirty_generation(
+    tmp_path: Path,
+    monkeypatch,
+) -> None:
+    skill_root = tmp_path / "skills"
+    skill_root.mkdir()
+    skill_path = skill_root / "raced"
+    skill_path.mkdir()
+    candidates.save_candidates(skill_path, {"candidates": []})
+    watcher = _make_watcher(tmp_path, skill_root)
+    db = tmp_path / "registry.db"
+    reg.mark_skill_edit_dirty(skill_path, db_path=db)
+    original_generation = reg.skill_edit_dirty_generation
+
+    def generation_then_concurrent_mark(path, *, db_path=None):
+        generation = original_generation(path, db_path=db_path)
+        reg.mark_skill_edit_dirty(
+            skill_path,
+            reason="concurrent_candidate",
+            db_path=db,
+        )
+        return generation
+
+    monkeypatch.setattr(
+        reg,
+        "skill_edit_dirty_generation",
+        generation_then_concurrent_mark,
+    )
+    monkeypatch.setattr(
+        watcher,
+        "_install_skill_to_all_detected",
+        lambda _path: None,
+    )
+    try:
+        watcher._on_skill_edit_done(
+            (skill_path, True, watcher.skill_edit_batch_size),
+        )
+        rows = reg.list_skill_edit_dirty(skill_root, db_path=db)
+        assert [(row["skill"], row["generation"]) for row in rows] == [
+            ("raced", 2),
+        ]
+    finally:
+        watcher.stop()

--- a/tests/test_skill_edit_dirty_queue.py
+++ b/tests/test_skill_edit_dirty_queue.py
@@ -2,6 +2,7 @@
 
 from __future__ import annotations
 
+import json
 import sqlite3
 from concurrent.futures import Future
 from pathlib import Path
@@ -130,6 +131,36 @@ def test_idle_round_does_not_rescan_skill_directories_or_candidates(
         watcher.stop()
 
 
+def test_failed_reconciliation_is_throttled_until_next_interval(
+    tmp_path: Path,
+    monkeypatch,
+) -> None:
+    from xskill.pipeline import runner as runner_module
+
+    skill_root = tmp_path / "skills"
+    skill_root.mkdir()
+    watcher = _make_watcher(tmp_path, skill_root)
+    watcher.full_reconcile_interval = 60
+    calls: list[Path] = []
+
+    def fail_reconcile(path, *, db_path=None):
+        calls.append(Path(path))
+        raise sqlite3.OperationalError("registry unavailable")
+
+    monkeypatch.setattr(reg, "reconcile_skill_edit_dirty", fail_reconcile)
+    monkeypatch.setattr(reg, "list_skill_edit_dirty", lambda *_a, **_kw: [])
+    times = iter((100.0, 120.0, 161.0))
+    monkeypatch.setattr(runner_module.time, "monotonic", lambda: next(times))
+    try:
+        watcher._check_pending_skill_edits()
+        watcher._check_pending_skill_edits()
+        watcher._check_pending_skill_edits()
+    finally:
+        watcher.stop()
+
+    assert calls == [skill_root, skill_root]
+
+
 def test_candidate_change_only_checks_and_schedules_the_changed_skill(
     tmp_path: Path,
     monkeypatch,
@@ -169,6 +200,62 @@ def test_candidate_change_only_checks_and_schedules_the_changed_skill(
 
         assert loaded == ["alpha"]
         assert submitted == ["alpha"]
+    finally:
+        watcher.stop()
+
+
+def test_new_main_ux_score_requeues_a_waiting_skill(
+    tmp_path: Path,
+    monkeypatch,
+) -> None:
+    from xskill.skill.git import commit_baby_to_main_branch
+
+    skill_root = tmp_path / "skills"
+    skill_root.mkdir()
+    skill_path = _seed_baby(skill_root, "waiting-for-ux", score=10)
+    assert commit_baby_to_main_branch(str(skill_path), "graduate for UX gate")
+    watcher = _make_watcher(tmp_path, skill_root)
+    db = tmp_path / "registry.db"
+    try:
+        # 候选已达阈值但还没有 main UX 证据，本轮应确认脏项并等待评分事件。
+        watcher._check_pending_skill_edits()
+        assert reg.list_skill_edit_dirty(skill_root, db_path=db) == []
+
+        (skill_path / ".ux_scores.jsonl").write_text(
+            json.dumps({"side": "main", "score": 8}) + "\n",
+            encoding="utf-8",
+        )
+        watcher._notify_skill_edit_ux_change(skill_path, db_path=db)
+        rows = reg.list_skill_edit_dirty(skill_root, db_path=db)
+        assert [(row["skill"], row["reason"]) for row in rows] == [
+            ("waiting-for-ux", "ux_score"),
+        ]
+
+        submitted: list[str] = []
+
+        def capture_submit(_callable, path, **_kwargs):
+            submitted.append(Path(path).name)
+            return Future()
+
+        monkeypatch.setattr(watcher._pools["edit"], "submit", capture_submit)
+        watcher._check_pending_skill_edits()
+        assert submitted == ["waiting-for-ux"]
+    finally:
+        watcher.stop()
+
+
+def test_skillhub_ux_score_does_not_enter_the_native_dirty_queue(
+    tmp_path: Path,
+) -> None:
+    skill_root = tmp_path / "skills"
+    skill_root.mkdir()
+    hub_skill = tmp_path / "skillhub" / "external"
+    hub_skill.mkdir(parents=True)
+    watcher = _make_watcher(tmp_path, skill_root)
+    db = tmp_path / "registry.db"
+    try:
+        watcher._notify_skill_edit_ux_change(hub_skill, db_path=db)
+        assert reg.list_skill_edit_dirty(skill_root, db_path=db) == []
     finally:
         watcher.stop()
 


### PR DESCRIPTION
## Summary

将 SkillEdit 调度从每轮全量扫描技能目录改为持久化脏队列：空闲轮询只读取发生变化的技能，并保留低频全量 reconciliation 作为正确性兜底。候选 YAML 仍是事实源，generation fencing 防止编辑期间的新候选被旧任务误确认。

## Changes

- 在 Registry 中增加按 `(root_key, skill)` 合并的 `skill_edit_dirty` 队列，并在候选投影事务中递增 generation。
- Watcher 只检查脏技能；不可执行项按观察版本确认，失败、取消和并发写入继续保留，启动及低频周期补回遗漏项。
- 自有 Skill 新增 UX 分数后立即重新标脏，使等待 `side=main` 证据的候选在下一轮重新检查；第三方 SkillHub 不进入 SkillEdit 队列。
- reconciliation 失败同样按 `full_reconcile_interval` 限流，避免持续故障让快速轮询退化为重复全量扫盘。
- 复用一次候选快照完成可执行性判断和排序，避免原有的第二次 YAML 读取。
- 增加空闲轮询、单技能增量调度、多 Skill、重启、失败、取消、成功清理、并发 generation、UX 门控唤醒和异常限流测试。

## Test plan

- [x] `make test` passes（2298 passed，10 skipped）
- [x] Added/updated unit tests for the change
- [x] `make e2e` passes (if the change touches ingestion / install / daemon)（2 scenarios passed）
- [ ] Manually verified the affected user flow
- [x] Changed-file Ruff checks pass

## Linked issues

Closes #294
