### PR TITLE
fix(recommend): fuse results from all profile centers

### DIFF
--- a/src/xskill/recommend/heavy_worker.py
+++ b/src/xskill/recommend/heavy_worker.py
@@ -73,21 +73,41 @@ def compute_recommend_for_user(
     if not profile_centers:
         save_recommend_slots(user_key, [], fingerprint="no_profile", db_path=db_path)
         return []
+
+    # 每个中心独立召回，再按中心轮询取一个未出现过的技能。直接把第一个
+    # 中心的结果填满 top_k 会让后续兴趣永远没有机会进入推荐槽位。
+    center_hits = [
+        vector_index.search(center, top_k=top_k)
+        for center in profile_centers
+    ]
+    positions = [0] * len(center_hits)
     names: list[str] = []
     seen: set[str] = set()
-    for center in profile_centers:
-        for catalog_key, _score in vector_index.search(center, top_k=top_k):
-            name = _skill_name_from_index(vector_index, catalog_key)
-            if name in seen:
-                continue
-            seen.add(name)
-            names.append(name)
+    source_centers: list[int] = []
+    while len(names) < top_k:
+        progress = False
+        for center_index, hits in enumerate(center_hits):
+            while positions[center_index] < len(hits):
+                catalog_key, _score = hits[positions[center_index]]
+                positions[center_index] += 1
+                name = _skill_name_from_index(vector_index, catalog_key)
+                if name in seen:
+                    continue
+                seen.add(name)
+                names.append(name)
+                source_centers.append(center_index)
+                progress = True
+                break
             if len(names) >= top_k:
                 break
-        if len(names) >= top_k:
+        if not progress:
             break
+    fingerprint = (
+        f"centers={len(profile_centers)};fusion=round_robin_v1;"
+        f"sources={','.join(map(str, source_centers))}"
+    )
     save_recommend_slots(
-        user_key, names, fingerprint=f"centers={len(profile_centers)}", db_path=db_path,
+        user_key, names, fingerprint=fingerprint, db_path=db_path,
     )
     return names
 

--- a/tests/test_skill_vector_consistency.py
+++ b/tests/test_skill_vector_consistency.py
@@ -289,3 +289,90 @@ def test_heavy_compute_recommend_from_centers(registry_db, index):
     )
     assert names
     assert load_recommend_slots("bob", db_path=registry_db) == names
+
+
+class _ScriptedSearchIndex:
+    def __init__(self, results):
+        self.results = results
+        self.search_calls = []
+
+    def search(self, vector, *, top_k=10):
+        key = tuple(vector)
+        self.search_calls.append((key, top_k))
+        return self.results[key][:top_k]
+
+    def get(self, catalog_key):
+        return {"name": catalog_key.split(":", 1)[-1], "source": "native"}
+
+
+def test_heavy_compute_recommend_interleaves_all_profile_centers(registry_db):
+    from xskill.recommend.heavy_worker import compute_recommend_for_user
+
+    first = (1.0, 0.0)
+    second = (0.0, 1.0)
+    index = _ScriptedSearchIndex({
+        first: [("native:first-a", 1.0), ("native:first-b", 0.9)],
+        second: [("native:second-a", 1.0), ("native:second-b", 0.9)],
+    })
+
+    names = compute_recommend_for_user(
+        "multi",
+        db_path=registry_db,
+        vector_index=index,
+        profile_centers=[list(first), list(second)],
+        top_k=4,
+    )
+
+    assert names == ["first-a", "second-a", "first-b", "second-b"]
+    assert index.search_calls == [(first, 4), (second, 4)]
+    with pooled_connection(registry_db) as conn:
+        fingerprint = conn.execute(
+            "SELECT fingerprint FROM client_recommend_slots WHERE user_key=?",
+            ("multi",),
+        ).fetchone()["fingerprint"]
+    assert fingerprint == "centers=2;fusion=round_robin_v1;sources=0,1,0,1"
+
+
+def test_heavy_compute_recommend_deduplicates_across_centers(registry_db):
+    from xskill.recommend.heavy_worker import compute_recommend_for_user
+
+    first = (1.0, 0.0)
+    second = (0.0, 1.0)
+    index = _ScriptedSearchIndex({
+        first: [("native:shared", 1.0), ("native:first", 0.9)],
+        second: [("native:shared", 1.0), ("native:second", 0.9)],
+    })
+
+    names = compute_recommend_for_user(
+        "deduplicated",
+        db_path=registry_db,
+        vector_index=index,
+        profile_centers=[list(first), list(second)],
+        top_k=3,
+    )
+
+    assert names == ["shared", "second", "first"]
+    assert len(names) == len(set(names))
+
+
+def test_heavy_compute_recommend_center_order_keeps_each_center_represented(
+    registry_db,
+):
+    from xskill.recommend.heavy_worker import compute_recommend_for_user
+
+    first = (1.0, 0.0)
+    second = (0.0, 1.0)
+    index = _ScriptedSearchIndex({
+        first: [("native:first-a", 1.0), ("native:first-b", 0.9)],
+        second: [("native:second-a", 1.0), ("native:second-b", 0.9)],
+    })
+
+    names = compute_recommend_for_user(
+        "reordered",
+        db_path=registry_db,
+        vector_index=index,
+        profile_centers=[list(second), list(first)],
+        top_k=4,
+    )
+
+    assert names == ["second-a", "first-a", "second-b", "first-b"]


### PR DESCRIPTION
## Summary

修复多兴趣画像推荐被首个中心独占的问题。每个画像中心先独立召回，再按中心轮询、跨中心去重生成最终 Top-K，使后续兴趣中心也能稳定贡献结果。

## Changes

- 将推荐融合改为确定性的 round-robin，并保持单中心排序与 Top-K 上限不变
- 在推荐 fingerprint 中记录融合版本和每个槽位的来源中心索引
- 增加多中心覆盖、中心换序、跨中心去重及调用次数回归测试

## Test plan

- [x] `make test` passes（2290 passed, 10 skipped）
- [x] Added/updated unit tests for the change
- [ ] `make e2e` passes (not applicable: no ingestion / install / daemon changes)
- [x] Manually verified the affected user flow with deterministic scripted search results

## Linked issues

Closes #300
