### PR TITLE
perf(canary): poll only active staging skills

### DIFF
--- a/src/xskill/ecosystems/_history.py
+++ b/src/xskill/ecosystems/_history.py
@@ -504,6 +504,51 @@ class InstallHistory:
         """目标是否有尚未确认追加完成的事务日志。"""
         return self._recovery_path(skill, target).is_file()
 
+    def pending_recovery_skills(self, target: str) -> set[str]:
+        """列出指定目标仍有事务日志的 skill，供恢复调度重建活跃集。"""
+        transaction_dir = self.path.parent / ".install_transactions"
+        if not transaction_dir.is_dir():
+            return set()
+        pending: set[str] = set()
+        for recovery_path in sorted(transaction_dir.glob("*.json")):
+            try:
+                candidate = json.loads(recovery_path.read_text(encoding="utf-8"))
+            except (OSError, UnicodeError, json.JSONDecodeError) as exc:
+                logger.error(
+                    "install recovery discovery failed path=%s error_type=%s",
+                    recovery_path,
+                    type(exc).__name__,
+                )
+                raise InstallHistoryCorruptError(
+                    f"invalid install recovery: {recovery_path}"
+                ) from exc
+            if not isinstance(candidate, dict):
+                raise InstallHistoryCorruptError(
+                    f"install recovery is not an object: {recovery_path}"
+                )
+            skill = candidate.get("skill")
+            candidate_target = candidate.get("target")
+            if (
+                not isinstance(skill, str)
+                or not skill
+                or skill in (".", "..")
+                or "/" in skill
+                or "\\" in skill
+                or not isinstance(candidate_target, str)
+            ):
+                raise InstallHistoryCorruptError(
+                    f"invalid install recovery identity: {recovery_path}"
+                )
+            if self._recovery_path(skill, candidate_target) != recovery_path:
+                raise InstallHistoryCorruptError(
+                    f"install recovery path does not match identity: {recovery_path}"
+                )
+            # Reuse the strict schema validation used by transaction recovery.
+            self._read_recovery(skill, candidate_target)
+            if candidate_target == target:
+                pending.add(skill)
+        return pending
+
     @staticmethod
     def _file_signature(
         stat_result: os.stat_result,

--- a/src/xskill/pipeline/runner.py
+++ b/src/xskill/pipeline/runner.py
@@ -228,6 +228,8 @@ class DirectoryWatcher:
         # 单机 canary 轮转节流：上次真跑 _reconcile_skill_sides 的时间戳。
         # None = 从未跑过（首轮 scan 必跑一次）。
         self._last_rotate_ts: float | None = None
+        # Canary 正常轮询读 catalog 活跃集；该时间戳控制低频磁盘事实源对账。
+        self._last_canary_catalog_reconcile_ts: float | None = None
         self._stats = {
             "polls": 0, "new_trajs": 0,
             "atoms_extracted": 0,    # v2: 累计 atom 数（替代 meta_extracted）
@@ -1312,6 +1314,83 @@ class DirectoryWatcher:
             except Exception:
                 logger.exception("user edit absorb failed: %s", d.name)
 
+    def _active_canary_skill_paths(self, *, history, target: str) -> list[Path]:
+        """返回 staging 或待恢复事务对应的 skill 路径。
+
+        正常轮询只查 ``skills_catalog``；启动和低频周期从 Git refs 修复投影。
+        没有显式 registry DB 的测试/嵌入调用保持旧的全目录扫描语义。
+        """
+        if self.skill_dir is None or not self.skill_dir.is_dir():
+            return []
+        if self.db_path is None:
+            return [
+                path
+                for path in sorted(self.skill_dir.iterdir())
+                if path.is_dir() and not path.name.startswith(".")
+            ]
+        from xskill.skill.catalog_store import (
+            list_active_native_canaries,
+            reconcile_native_canary_catalog,
+        )
+
+        now = time.monotonic()
+        reconcile_due = (
+            self._last_canary_catalog_reconcile_ts is None
+            or self.full_reconcile_interval == 0
+            or now - self._last_canary_catalog_reconcile_ts
+            >= self.full_reconcile_interval
+        )
+        try:
+            if reconcile_due:
+                reconcile_native_canary_catalog(
+                    self.skill_dir,
+                    db_path=Path(self.db_path),
+                )
+                self._last_canary_catalog_reconcile_ts = now
+            names = set(list_active_native_canaries(
+                self.skill_dir,
+                db_path=Path(self.db_path),
+            ))
+        except Exception:  # pylint: disable=broad-exception-caught
+            # 投影只是可重建加速层；损坏或暂时不可用时回退磁盘事实源。
+            logger.exception("canary catalog unavailable; falling back to disk scan")
+            names = {
+                path.name
+                for path in self.skill_dir.iterdir()
+                if path.is_dir() and not path.name.startswith(".")
+            }
+        names.update(history.pending_recovery_skills(target))
+        unsafe_names = {
+            name
+            for name in names
+            if (
+                not name
+                or name in (".", "..")
+                or "/" in name
+                or "\\" in name
+            )
+        }
+        if unsafe_names:
+            logger.error(
+                "canary catalog contains %d unsafe skill identities",
+                len(unsafe_names),
+            )
+            names.difference_update(unsafe_names)
+        return [self.skill_dir / name for name in sorted(names)]
+
+    def _refresh_canary_catalog_skill(self, skill_path: Path) -> None:
+        """事务成功后立刻按磁盘真相更新单条 Canary 投影。"""
+        if self.db_path is None:
+            return
+        from xskill.skill.catalog_store import (
+            notify_native_delete,
+            notify_native_upsert,
+        )
+        if skill_path.is_dir():
+            notify_native_upsert(skill_path, db_path=Path(self.db_path))
+        else:
+            notify_native_delete(skill_path.name, db_path=Path(self.db_path))
+
     def _check_canary_decisions(self):
         """灰度判定独立轮询：对每个有 staging 分支的 skill 调 check_and_decide。
 
@@ -1334,12 +1413,6 @@ class DirectoryWatcher:
         )
         from xskill.pipeline.registry import model_share
         from xskill.skill.git import run_git
-        canary_cfg = CanaryConfig.from_dict(self.config.get("canary", {}))
-        # 模型分桶权重:使用量 top-N 模型的人口占比(unknown 等已被排除)。
-        # 有合格模型 → 按模型加权裁决;一个都没有(全 unknown)→ None = 单桶均分,
-        # 不让纯 unknown 部署的灰度永远卡住。
-        weights = eligible_models(model_share(**self._db_kw()),
-                                  canary_cfg.scope_top_n) or None
         history = self._install_history()
         target_root = self._resolve_target_root()
         claude_code_detected = (
@@ -1353,10 +1426,24 @@ class DirectoryWatcher:
             if claude_code_detected
             else "canary_state" if self.server_mode else "working_tree"
         )
-        for d in sorted(self.skill_dir.iterdir()):
-            if not d.is_dir() or d.name.startswith("."):
+        active_paths = self._active_canary_skill_paths(
+            history=history,
+            target=target,
+        )
+        if not active_paths:
+            return
+        canary_cfg = CanaryConfig.from_dict(self.config.get("canary", {}))
+        # 模型分桶权重:使用量 top-N 模型的人口占比(unknown 等已被排除)。
+        # 有合格模型 → 按模型加权裁决;一个都没有(全 unknown)→ None = 单桶均分,
+        # 不让纯 unknown 部署的灰度永远卡住。
+        weights = eligible_models(model_share(**self._db_kw()),
+                                  canary_cfg.scope_top_n) or None
+        for d in active_paths:
+            if not d.is_dir():
+                self._refresh_canary_catalog_skill(d)
                 continue
             if not (d / ".git").is_dir():
+                self._refresh_canary_catalog_skill(d)
                 continue
             code, _, _ = run_git(["rev-parse", "--verify", "staging"], cwd=str(d))
             if code != 0:
@@ -1373,6 +1460,8 @@ class DirectoryWatcher:
                             "terminal transaction recovery failed: %s",
                             d.name,
                         )
+                        continue
+                self._refresh_canary_catalog_skill(d)
                 continue  # 无 staging，跳过
             try:
                 expected_generation = canary_generation(d)
@@ -1553,6 +1642,7 @@ class DirectoryWatcher:
                     recovery_candidate=recovery_telemetry,
                 )
                 if action in ("promoted", "rejected", "timeout_discarded"):
+                    self._refresh_canary_catalog_skill(d)
                     logger.info("canary decision %s: %s — %s",
                                 d.name, action, decision)
             except Exception:

--- a/src/xskill/skill/catalog_store.py
+++ b/src/xskill/skill/catalog_store.py
@@ -407,6 +407,129 @@ def delete_all_native(*, root_key: str = "", db_path: Path) -> int:
         return int(cursor.rowcount or 0)
 
 
+def reconcile_native_canary_catalog(
+    skill_dir: Path | str,
+    *,
+    db_path: Path,
+) -> int:
+    """低频从 Git refs 修复自产 skill 的 Canary 状态投影。
+
+    已有行只刷新分支状态与 SHA，避免为了 Canary 对账重复解析全部
+    ``SKILL.md`` 和 ``.candidates.yml``。新目录仍完整建行，消失的目录从
+    投影删除；SkillHub 行不受影响。
+    """
+    root_path = Path(skill_dir)
+    root = _root_key(root_path)
+    paths = []
+    if root_path.is_dir():
+        paths = [
+            path
+            for path in sorted(root_path.iterdir())
+            if path.is_dir() and not path.name.startswith(".")
+        ]
+    names = {path.name for path in paths}
+    active = 0
+    with pooled_connection(Path(db_path)) as conn:
+        existing = {
+            row["name"]: dict(row)
+            for row in conn.execute(
+                """
+                SELECT name, state, main_sha, staging_sha, distributable
+                FROM skills_catalog
+                WHERE source=? AND root_key=?
+                """,
+                (_SOURCE_NATIVE, root),
+            ).fetchall()
+        }
+        for path in paths:
+            branches = _branch_names(path)
+            state = (
+                "staging" if "staging" in branches
+                else "main" if "main" in branches
+                else "baby" if "baby" in branches
+                else "unknown"
+            )
+            if state == "staging":
+                active += 1
+            if path.name not in existing:
+                row = _read_native_row(path)
+                row["root_key"] = root
+                _upsert_row(conn, row)
+                continue
+            current_main_sha = _ref_sha(path, "main")
+            current_staging_sha = _ref_sha(path, "staging")
+            distributable = int(
+                state in ("main", "staging")
+                and (path / "SKILL.md").is_file()
+            )
+            stored = existing[path.name]
+            if (
+                stored["state"] == state
+                and stored["main_sha"] == current_main_sha
+                and stored["staging_sha"] == current_staging_sha
+                and int(stored["distributable"]) == distributable
+            ):
+                continue
+            conn.execute(
+                """
+                UPDATE skills_catalog
+                SET state=?, main_sha=?, staging_sha=?, distributable=?,
+                    updated_at=datetime('now')
+                WHERE catalog_key=? AND source=? AND root_key=?
+                """,
+                (
+                    state,
+                    current_main_sha,
+                    current_staging_sha,
+                    distributable,
+                    _native_catalog_key(path.name),
+                    _SOURCE_NATIVE,
+                    root,
+                ),
+            )
+        removed = set(existing) - names
+        if removed:
+            conn.executemany(
+                """
+                DELETE FROM skills_catalog
+                WHERE catalog_key=? AND source=? AND root_key=?
+                """,
+                [
+                    (_native_catalog_key(name), _SOURCE_NATIVE, root)
+                    for name in sorted(removed)
+                ],
+            )
+        conn.execute(
+            """
+            INSERT INTO skills_catalog_meta(root_key, backfilled_at, skillhub_key)
+            VALUES (?, datetime('now'), ?)
+            ON CONFLICT(root_key) DO UPDATE SET backfilled_at=datetime('now')
+            """,
+            (root, _skillhub_fingerprint(None)),
+        )
+        conn.commit()
+    return active
+
+
+def list_active_native_canaries(
+    skill_dir: Path | str,
+    *,
+    db_path: Path,
+) -> list[str]:
+    """从可重建 catalog 投影返回当前有 staging 的自产 skill 名。"""
+    root = _root_key(skill_dir)
+    with pooled_connection(Path(db_path)) as conn:
+        rows = conn.execute(
+            """
+            SELECT name FROM skills_catalog
+            WHERE source=? AND root_key=? AND state='staging'
+            ORDER BY name
+            """,
+            (_SOURCE_NATIVE, root),
+        ).fetchall()
+    return [row["name"] for row in rows]
+
+
 def rename_native_skill(
     old_name: str,
     new_skill_path: Path | str,

--- a/tests/test_canary_rotation.py
+++ b/tests/test_canary_rotation.py
@@ -176,6 +176,111 @@ def _make_watcher(skill_dir: Path, tmp_path: Path, *, probability: float):
 
 
 class TestRotateCanarySide:
+    def test_canary_decisions_probe_only_projected_active_skills(
+        self,
+        tmp_path,
+        monkeypatch,
+    ):
+        """稳态 Git 探测随 staging 数增长，低频对账修复外部建分支。"""
+        from xskill import canary as canary_module
+        from xskill.skill import git as skill_git
+
+        skill_dir = tmp_path / "skill"
+        skill_dir.mkdir()
+        active = _init_repo(skill_dir / "active")
+        _make_staging(active)
+        late = _init_repo(skill_dir / "late")
+        for index in range(20):
+            path = skill_dir / f"inactive-{index:02d}"
+            (path / ".git" / "refs" / "heads").mkdir(parents=True)
+            (path / ".git" / "refs" / "heads" / "main").write_text(
+                "a" * 40 + "\n",
+                encoding="ascii",
+            )
+            (path / "SKILL.md").write_text("main", encoding="utf-8")
+        watcher = DirectoryWatcher(
+            skill_dir=skill_dir,
+            config={
+                "canary": {},
+                "watcher": {"full_reconcile_interval": 60},
+            },
+            install_history_path=tmp_path / "install_history.jsonl",
+            home_root=tmp_path,
+            db_path=tmp_path / "registry.db",
+        )
+        clock = [100.0]
+        monkeypatch.setattr(
+            "xskill.pipeline.runner.time.monotonic",
+            lambda: clock[0],
+        )
+        monkeypatch.setattr(
+            "xskill.pipeline.registry.model_share",
+            lambda **_kwargs: [],
+        )
+        monkeypatch.setattr(
+            canary_module.AtomCanary,
+            "plan_decision",
+            lambda *_args, **_kwargs: {"action": "waiting"},
+        )
+        probes = []
+        original_run_git = skill_git.run_git
+
+        def count_staging_probe(args, cwd):
+            if args == ["rev-parse", "--verify", "staging"]:
+                probes.append(Path(cwd).name)
+            return original_run_git(args, cwd=cwd)
+
+        monkeypatch.setattr(skill_git, "run_git", count_staging_probe)
+
+        watcher._check_canary_decisions()
+        _make_staging(late)
+        clock[0] = 101.0
+        watcher._check_canary_decisions()
+        clock[0] = 161.0
+        watcher._check_canary_decisions()
+
+        assert probes == ["active", "active", "active", "late"]
+
+    def test_pending_recovery_is_scheduled_outside_staging_projection(
+        self,
+        tmp_path,
+    ):
+        from xskill.ecosystems._history import InstallHistory
+
+        skill_dir = tmp_path / "skill"
+        skill_dir.mkdir()
+        skill_path = _init_repo(skill_dir / "recover-me")
+        history = InstallHistory(tmp_path / "install_history.jsonl")
+        history._write_recovery(
+            skill=skill_path.name,
+            target="working_tree",
+            transaction_id="transaction-1",
+            records=[{"record_id": "record-1", "action": "install"}],
+            decision_ids=("decision-1",),
+            side="main",
+            sha="a" * 40,
+            generation=f"{'a' * 40}:",
+            source_generation=f"{'a' * 40}:{'b' * 40}",
+            state="applying",
+        )
+        watcher = DirectoryWatcher(
+            skill_dir=skill_dir,
+            config={"watcher": {"full_reconcile_interval": 60}},
+            install_history_path=history.path,
+            home_root=tmp_path,
+            db_path=tmp_path / "registry.db",
+        )
+
+        paths = watcher._active_canary_skill_paths(
+            history=history,
+            target="working_tree",
+        )
+
+        assert paths == [skill_path]
+        assert history.pending_recovery_skills("working_tree") == {
+            "recover-me",
+        }
+
     def test_twenty_five_skills_share_one_history_parse(
         self,
         tmp_path,
@@ -515,6 +620,11 @@ class TestRotateCanarySide:
         assert latest["side"] == "main"
         assert latest["generation"] == canary_generation(skill_path)
         assert latest["generation"].endswith(":")
+        from xskill.skill.catalog_store import list_active_native_canaries
+        assert list_active_native_canaries(
+            skill_dir,
+            db_path=tmp_path / "registry.db",
+        ) == []
 
     def test_terminal_receipts_recover_after_staging_is_gone(
         self,

--- a/tests/test_skills_catalog_store.py
+++ b/tests/test_skills_catalog_store.py
@@ -4,7 +4,11 @@ from __future__ import annotations
 import pytest
 
 from xskill.skill import catalog_store
-from xskill.skill.git import commit_baby_to_main_branch, init_skill_repo_on_baby
+from xskill.skill.git import (
+    commit_baby_to_main_branch,
+    commit_to_staging_branch,
+    init_skill_repo_on_baby,
+)
 
 
 @pytest.fixture(autouse=True)
@@ -18,6 +22,16 @@ def _isolate_registry(tmp_path, monkeypatch):
         "xskill.pipeline.registry.get_registry_db_path",
         lambda: registry,
     )
+
+
+def _init_repo_for_catalog(path):
+    init_skill_repo_on_baby(
+        str(path),
+        name=path.name,
+        description=f"{path.name} description",
+    )
+    assert commit_baby_to_main_branch(str(path), "graduate")
+    return path
 
 
 def test_init_and_graduate_upsert_native_row(tmp_path):
@@ -80,6 +94,68 @@ def test_backfill_replaces_stale_native_and_hub(tmp_path):
     )
     assert [row["name"] for row in rows] == ["keep", "hub-skill"]
     assert rows[1]["use_count"] == 2
+
+
+def test_canary_reconcile_preserves_skillhub_and_lists_only_staging(tmp_path):
+    root = tmp_path / "skills"
+    root.mkdir()
+    registry = tmp_path / "registry.db"
+    main = _init_repo_for_catalog(root / "main-only")
+    staged = _init_repo_for_catalog(root / "active")
+    (staged / ".git" / "refs" / "heads" / "staging").write_text(
+        "b" * 40 + "\n",
+        encoding="ascii",
+    )
+    hub = [{
+        "display_name": "hub-skill",
+        "source_path": "team/x",
+        "skill_id": "hub-skill@1",
+        "description": "from hub",
+    }]
+    catalog_store.backfill_skills_catalog(root, skillhub=hub, db_path=registry)
+
+    assert catalog_store.reconcile_native_canary_catalog(
+        root,
+        db_path=registry,
+    ) == 1
+    assert catalog_store.list_active_native_canaries(
+        root,
+        db_path=registry,
+    ) == ["active"]
+    rows = catalog_store.list_skills_catalog(
+        root,
+        skillhub=hub,
+        db_path=registry,
+    )
+    assert {row["name"] for row in rows} == {
+        main.name,
+        staged.name,
+        "hub-skill",
+    }
+
+
+def test_staging_write_hook_immediately_enters_active_projection(tmp_path):
+    from xskill.agents import agent_tools
+
+    root = tmp_path / "skills"
+    root.mkdir()
+    registry = tmp_path / "registry.db"
+    skill = _init_repo_for_catalog(root / "new-canary")
+    context = agent_tools.create_agent_tool_context(
+        skill_dir=root,
+        atom_skill_dir=root,
+        registry_db_path=registry,
+    )
+    catalog_store.reconcile_native_canary_catalog(root, db_path=registry)
+    (skill / "SKILL.md").write_text("staging body", encoding="utf-8")
+
+    with agent_tools.use_agent_tool_context(context):
+        assert commit_to_staging_branch(str(skill), "create staging")
+
+    assert catalog_store.list_active_native_canaries(
+        root,
+        db_path=registry,
+    ) == ["new-canary"]
 
 
 def test_candidates_notify_uses_count_not_reread(tmp_path, monkeypatch):


### PR DESCRIPTION
## Summary

将 Canary 正常轮询范围从全部技能缩小到存在 staging 或终态恢复事务的活跃技能，避免每轮对所有 Git 仓执行 `rev-parse`。磁盘 Git refs 和事务 journal 仍是事实源，启动及低频周期会重建投影。

## Changes

- 复用 `skills_catalog` 的 `(root_key, state)` 索引读取活跃 Canary 技能
- 增加低频 Git refs reconciliation；只更新变化行，并保留 SkillHub 投影
- 将未完成的安装事务 journal 加入活跃集，保证 staging 已删除后仍可恢复
- staging 创建、终态完成后立即刷新单条投影；投影故障时回退全目录扫描
- 增加活跃 Git 探测次数、外部分支变化、事务恢复、SkillHub 保留和写路径同步测试

## Test plan

- [x] `make test` passes（2291 passed, 10 skipped）
- [x] Added/updated unit tests for the change
- [x] `make e2e` passes（2 scenarios）
- [x] Manually verified the affected user flow with deterministic Git probe counting

## Linked issues

Closes #295
