### PR TITLE
perf(atom-store): 建立可重建的 Atom 定位投影

### DIFF
--- a/src/xskill/agents/task_agent.py
+++ b/src/xskill/agents/task_agent.py
@@ -425,10 +425,9 @@ class TaskAgent:
         if prior_atom is not None:
             new_atoms[0].pre_atom_id = prior_atom.atom_id
             prior_atom.post_atom_id = new_atoms[0].atom_id
-            self.store.save(prior_atom)
-
-        for a in new_atoms:
-            self.store.save(a)
+        self.store.save_many(
+            ([prior_atom] if prior_atom is not None else []) + new_atoms
+        )
 
         self._assert_eof_coverage(traj_id, resume_line=resume_line,
                                   total_lines=total_lines)

--- a/src/xskill/pipeline/atom.py
+++ b/src/xskill/pipeline/atom.py
@@ -2,8 +2,9 @@
 ==========================================================
 
 每个 ``AtomTask`` 是一段 multi-chat-turn（1-10 轮），由 ``TaskAgent`` 从
-轨迹按"用户意图切换"切出来。落盘到 ``<root>/<traj_id>/tasks/atom_*.json``，
-不入 SQLite——保持简单文件方案，``watcher`` 用 ``last_offset`` 决定增量起点。
+轨迹按"用户意图切换"切出来。内容落盘到
+``<root>/<traj_id>/tasks/atom_*.json``，``watcher`` 用 ``last_offset`` 决定
+增量起点；隐藏 SQLite 只保存可重建的 Atom→路径定位投影，不保存业务内容。
 
 向量索引（基于 atom 的 ``summary or intent`` 嵌入）持久化在 ``<root>/index.pkl``。
 ``HybridSearch`` (在 ``xskill.utils.search``) 把本模块的 ``vector_search`` 跟
@@ -20,6 +21,8 @@ import json
 import logging
 import pickle
 import re
+import sqlite3
+import threading
 import uuid
 from dataclasses import asdict, dataclass, field
 from pathlib import Path
@@ -27,7 +30,18 @@ from typing import Iterator
 
 import numpy as np
 
+from xskill._sqlite_connect import connect_with_lock
+
 logger = logging.getLogger("xskill.ux_score")
+
+_LOCATION_LOCKS_GUARD = threading.Lock()
+_LOCATION_LOCKS: dict[str, threading.RLock] = {}
+
+
+def _location_lock_for(root: Path) -> threading.RLock:
+    key = str(root.resolve(strict=False))
+    with _LOCATION_LOCKS_GUARD:
+        return _LOCATION_LOCKS.setdefault(key, threading.RLock())
 
 
 @dataclass
@@ -77,7 +91,7 @@ class AtomTaskStore:
     """文件系统存储：``<root>/<traj_id>/tasks/atom_*.json`` + ``<root>/index.pkl``。
 
     设计取舍：
-    - **不用 SQLite**: traj 数量级 < 数千；文件读写直接、调试方便、跨平台兼容。
+    - **JSON 是事实源**: 文件读写直接、调试方便；SQLite 仅作可重建定位投影。
     - **每 traj 一个子目录**: 让 watcher 按 traj 粒度做增量处理，``list_by_traj``
       不需要全表扫。
     - **向量索引增量重建**: TaskAgent 每给一条 traj 拆出新 atom 后由 watcher
@@ -87,9 +101,29 @@ class AtomTaskStore:
     """
 
     INDEX_FILE = "index.pkl"
+    LOCATION_INDEX_FILE = ".atom_locations.sqlite3"
+    _LOCATION_SCHEMA = """
+    CREATE TABLE IF NOT EXISTS atom_locations (
+        atom_id       TEXT NOT NULL,
+        traj_id       TEXT NOT NULL,
+        relative_path TEXT NOT NULL,
+        mtime_ns      INTEGER NOT NULL,
+        size_bytes    INTEGER NOT NULL,
+        PRIMARY KEY (atom_id, relative_path)
+    );
+    CREATE INDEX IF NOT EXISTS idx_atom_locations_traj
+        ON atom_locations(traj_id);
+    CREATE TABLE IF NOT EXISTS atom_location_meta (
+        key   TEXT PRIMARY KEY,
+        value TEXT NOT NULL
+    );
+    """
 
     def __init__(self, root: Path):
         self.root = Path(root)
+        self._location_lock = _location_lock_for(self.root)
+        self._location_schema_ready = False
+        self._location_index_complete: bool | None = None
 
     # ── paths ─────────────────────────────────────────────────────
 
@@ -102,43 +136,377 @@ class AtomTaskStore:
     def _index_path(self) -> Path:
         return self.root / self.INDEX_FILE
 
+    def _location_index_path(self) -> Path:
+        return self.root / self.LOCATION_INDEX_FILE
+
+    def _location_connection(self, path: Path | None = None):
+        index_path = path or self._location_index_path()
+        connection = connect_with_lock(
+            sqlite3.connect,
+            str(index_path),
+            timeout=5.0,
+        )
+        connection.row_factory = sqlite3.Row
+        if path is None and self._location_schema_ready:
+            return connection
+        try:
+            connection.executescript(self._LOCATION_SCHEMA)
+        except Exception:
+            connection.close()
+            raise
+        if path is None:
+            self._location_schema_ready = True
+        return connection
+
+    def _location_values(self, path: Path, traj_id: str) -> tuple:
+        stat_result = path.stat()
+        relative_path = path.relative_to(self.root).as_posix()
+        return (
+            path.stem,
+            traj_id,
+            relative_path,
+            int(stat_result.st_mtime_ns),
+            int(stat_result.st_size),
+        )
+
+    def _has_complete_location_index(self) -> bool:
+        """返回投影是否来自一次完整事实源扫描；每个 store 实例只查库一次。"""
+        if self._location_index_complete is not None:
+            return self._location_index_complete
+        if not self._location_index_path().is_file():
+            self._location_index_complete = False
+            return False
+        connection = self._location_connection()
+        try:
+            row = connection.execute(
+                "SELECT value FROM atom_location_meta WHERE key='complete'",
+            ).fetchone()
+        finally:
+            connection.close()
+        self._location_index_complete = bool(row and row["value"] == "1")
+        return self._location_index_complete
+
+    def ensure_location_index(self) -> None:
+        """旧 store 首次使用时从 JSON 一次性建立完整、可增量维护的投影。"""
+        with self._location_lock:
+            try:
+                if self._has_complete_location_index():
+                    return
+            except (OSError, sqlite3.DatabaseError):
+                pass
+            self.rebuild_location_index()
+
+    @staticmethod
+    def _upsert_location_row(connection, values: tuple) -> None:
+        connection.execute(
+            """
+            INSERT INTO atom_locations(
+                atom_id, traj_id, relative_path, mtime_ns, size_bytes
+            ) VALUES (?, ?, ?, ?, ?)
+            ON CONFLICT(atom_id, relative_path) DO UPDATE SET
+                traj_id=excluded.traj_id,
+                mtime_ns=excluded.mtime_ns,
+                size_bytes=excluded.size_bytes
+            """,
+            values,
+        )
+
+    def _upsert_atom_location(self, path: Path, traj_id: str) -> None:
+        self._upsert_atom_locations([(path, traj_id)])
+
+    def _upsert_atom_locations(self, locations: list[tuple[Path, str]]) -> None:
+        """用单个事务更新一批 Atom 定位，避免拆分结果逐条提交。"""
+        if not locations:
+            return
+        connection = self._location_connection()
+        try:
+            for path, traj_id in locations:
+                self._upsert_location_row(
+                    connection,
+                    self._location_values(path, traj_id),
+                )
+            connection.commit()
+        finally:
+            connection.close()
+
+    def _scan_atom_paths(self, atom_id: str) -> list[tuple[Path, str]]:
+        hits: list[tuple[Path, str]] = []
+        for traj_dir in self.root.iterdir():
+            if not traj_dir.is_dir():
+                continue
+            candidate = traj_dir / "tasks" / f"{atom_id}.json"
+            if candidate.is_file():
+                hits.append((candidate, traj_dir.name))
+        return hits
+
+    def _replace_atom_locations(
+        self,
+        atom_id: str,
+        hits: list[tuple[Path, str]],
+    ) -> None:
+        connection = self._location_connection()
+        try:
+            connection.execute(
+                "DELETE FROM atom_locations WHERE atom_id=?",
+                (atom_id,),
+            )
+            for path, traj_id in hits:
+                self._upsert_location_row(
+                    connection,
+                    self._location_values(path, traj_id),
+                )
+            connection.commit()
+        finally:
+            connection.close()
+
+    def _path_from_location_row(self, atom_id: str, row) -> Path | None:
+        relative = str(row["relative_path"] or "")
+        relative_path = Path(relative)
+        if (
+            not relative
+            or relative_path.is_absolute()
+            or ".." in relative_path.parts
+            or relative_path.name != f"{atom_id}.json"
+            or len(relative_path.parts) != 3
+            or relative_path.parts[1] != "tasks"
+        ):
+            return None
+        return self.root / relative_path
+
+    def rebuild_location_index(self) -> int:
+        """从 Atom JSON 事实源原子重建定位投影，返回记录数。"""
+        with self._location_lock:
+            return self._rebuild_location_index()
+
+    def _rebuild_location_index(self) -> int:
+        if not self.root.is_dir():
+            return 0
+        temporary_path = self.root / (
+            f".{self.LOCATION_INDEX_FILE}.{uuid.uuid4().hex}.tmp"
+        )
+        connection = self._location_connection(temporary_path)
+        count = 0
+        try:
+            for traj_dir in sorted(self.root.iterdir()):
+                if not traj_dir.is_dir():
+                    continue
+                tasks_dir = traj_dir / "tasks"
+                if not tasks_dir.is_dir():
+                    continue
+                for atom_path in sorted(tasks_dir.glob("*.json")):
+                    try:
+                        values = self._location_values(atom_path, traj_dir.name)
+                    except (FileNotFoundError, OSError):
+                        continue
+                    self._upsert_location_row(connection, values)
+                    count += 1
+            connection.execute(
+                """
+                INSERT INTO atom_location_meta(key, value) VALUES ('complete', '1')
+                ON CONFLICT(key) DO UPDATE SET value=excluded.value
+                """
+            )
+            connection.commit()
+        except Exception:
+            connection.close()
+            if temporary_path.is_file():
+                temporary_path.unlink()
+            raise
+        connection.close()
+        temporary_path.replace(self._location_index_path())
+        self._location_schema_ready = True
+        self._location_index_complete = True
+        return count
+
+    def remove_locations_for_trajs(self, traj_ids) -> None:
+        """Atom 文件删除/reset 后同步清理对应轨迹的定位行。"""
+        ids = sorted({str(traj_id) for traj_id in traj_ids if traj_id})
+        if not ids or not self._location_index_path().is_file():
+            return
+        try:
+            connection = self._location_connection()
+            try:
+                connection.executemany(
+                    "DELETE FROM atom_locations WHERE traj_id=?",
+                    [(traj_id,) for traj_id in ids],
+                )
+                connection.commit()
+            finally:
+                connection.close()
+        except (OSError, sqlite3.DatabaseError):
+            # 投影损坏不影响事实删除；直接从剩余 JSON 重建。
+            try:
+                self.rebuild_location_index()
+            except (OSError, sqlite3.DatabaseError):
+                logger.warning(
+                    "atom location projection reset failed: %s",
+                    self._location_index_path(),
+                    exc_info=True,
+                )
+
     # ── IO ────────────────────────────────────────────────────────
 
     def save(self, atom: AtomTask) -> Path:
-        atom_path = self._path(atom)
-        atom_path.parent.mkdir(parents=True, exist_ok=True)
-        temporary_path = atom_path.with_name(f".{atom_path.name}.{uuid.uuid4().hex}.tmp")
-        temporary_path.write_text(atom.to_json(), encoding="utf-8")
-        temporary_path.replace(atom_path)
-        return atom_path
+        return self.save_many([atom])[0]
+
+    def save_many(self, atoms: list[AtomTask]) -> list[Path]:
+        """保存一批 Atom；JSON 逐个原子替换，定位投影只提交一次。"""
+        with self._location_lock:
+            return self._save_many(atoms)
+
+    def _save_many(self, atoms: list[AtomTask]) -> list[Path]:
+        if not atoms:
+            return []
+        try:
+            projection_complete = self._has_complete_location_index()
+        except (OSError, sqlite3.DatabaseError):
+            projection_complete = False
+        saved: list[tuple[Path, str]] = []
+        for atom in atoms:
+            atom_path = self._path(atom)
+            atom_path.parent.mkdir(parents=True, exist_ok=True)
+            temporary_path = atom_path.with_name(
+                f".{atom_path.name}.{uuid.uuid4().hex}.tmp"
+            )
+            temporary_path.write_text(atom.to_json(), encoding="utf-8")
+            temporary_path.replace(atom_path)
+            saved.append((atom_path, atom.traj_id))
+        try:
+            if projection_complete:
+                self._upsert_atom_locations(saved)
+            else:
+                # Upgrade/legacy store: one full scan prevents every old Atom
+                # from paying its own trajectory-directory fallback later.
+                self.rebuild_location_index()
+        except (OSError, sqlite3.DatabaseError):
+            logger.warning(
+                "atom location projection batch update failed: %s",
+                [str(path) for path, _traj_id in saved],
+                exc_info=True,
+            )
+        return [path for path, _traj_id in saved]
 
     def load(self, atom_id: str) -> AtomTask:
-        """跨 traj_id 子目录查找。命中第一条即返回；找不到抛 FileNotFoundError。
-
-        ``watcher`` 的常态调用是 ``list_by_traj``（O(子目录文件数)），``load``
-        给 agent 工具 ``atom_task_read(atom_id)`` 用，调用频率低，遍历所有
-        traj 子目录可以接受。
-        """
-        if not self.root.is_dir():
-            raise FileNotFoundError(f"atom store root missing: {self.root}")
-        for d in self.root.iterdir():
-            if not d.is_dir():
-                continue
-            cand = d / "tasks" / f"{atom_id}.json"
-            if cand.is_file():
-                return AtomTask.from_json(cand.read_text(encoding="utf-8"))
+        """通过定位投影跨 traj_id 读取；找不到抛 ``FileNotFoundError``。"""
+        path = self.path_for_atom(atom_id)
+        if path is not None:
+            return AtomTask.from_json(path.read_text(encoding="utf-8"))
         raise FileNotFoundError(f"atom not found: {atom_id}")
 
     def path_for_atom(self, atom_id: str) -> Path | None:
-        """返回 atom JSON 路径；找不到返回 None。"""
-        if not self.root.is_dir():
+        """通过持久定位投影返回 Atom JSON；失效或 miss 时回退事实源自愈。"""
+        if (
+            not atom_id
+            or atom_id in (".", "..")
+            or "/" in atom_id
+            or "\\" in atom_id
+            or not self.root.is_dir()
+        ):
             return None
-        for d in self.root.iterdir():
-            if not d.is_dir():
+        try:
+            self.ensure_location_index()
+        except (OSError, sqlite3.DatabaseError):
+            logger.warning(
+                "atom location projection initialization failed: %s",
+                self._location_index_path(),
+                exc_info=True,
+            )
+        projected = self.projected_path_for_atom(atom_id)
+        if projected is not None:
+            return projected
+
+        # Legacy/external writes may not have emitted a projection event.  A miss
+        # pays one fact-source scan, then subsequent lookups are indexed.
+        hits = self._scan_atom_paths(atom_id)
+        try:
+            self._replace_atom_locations(atom_id, hits)
+        except (OSError, sqlite3.DatabaseError):
+            try:
+                self.rebuild_location_index()
+            except (OSError, sqlite3.DatabaseError):
+                logger.warning(
+                    "atom location projection repair failed: %s",
+                    self._location_index_path(),
+                    exc_info=True,
+                )
+        available_hits = [hit for hit in hits if hit[0].is_file()]
+        if not available_hits:
+            return None
+        return max(
+            available_hits,
+            key=lambda hit: (hit[0].stat().st_mtime_ns, str(hit[0])),
+        )[0]
+
+    def projected_path_for_atom(self, atom_id: str) -> Path | None:
+        """只查定位投影，不在 miss 时遍历轨迹目录（Multi-store 热路径用）。"""
+        if (
+            not atom_id
+            or atom_id in (".", "..")
+            or "/" in atom_id
+            or "\\" in atom_id
+            or not self.root.is_dir()
+            or not self._location_index_path().is_file()
+        ):
+            return None
+        try:
+            connection = self._location_connection()
+            try:
+                rows = connection.execute(
+                    """
+                    SELECT traj_id, relative_path, mtime_ns, size_bytes
+                    FROM atom_locations
+                    WHERE atom_id=?
+                    ORDER BY mtime_ns DESC, relative_path ASC
+                    """,
+                    (atom_id,),
+                ).fetchall()
+            finally:
+                connection.close()
+        except sqlite3.DatabaseError:
+            logger.warning(
+                "atom location projection damaged; rebuilding: %s",
+                self._location_index_path(),
+            )
+            try:
+                self.rebuild_location_index()
+            except (OSError, sqlite3.DatabaseError):
+                logger.warning(
+                    "atom location projection rebuild failed: %s",
+                    self._location_index_path(),
+                    exc_info=True,
+                )
+                return None
+            return self.projected_path_for_atom(atom_id)
+        available: list[tuple[Path, int]] = []
+        for row in rows:
+            candidate = self._path_from_location_row(atom_id, row)
+            if candidate is None or not candidate.is_file():
                 continue
-            cand = d / "tasks" / f"{atom_id}.json"
-            if cand.is_file():
-                return cand
+            try:
+                stat_result = candidate.stat()
+                available.append((candidate, int(stat_result.st_mtime_ns)))
+                if (
+                    int(row["mtime_ns"]) != int(stat_result.st_mtime_ns)
+                    or int(row["size_bytes"]) != int(stat_result.st_size)
+                ):
+                    self._upsert_atom_location(candidate, str(row["traj_id"]))
+            except (OSError, sqlite3.DatabaseError):
+                pass
+        if available:
+            return max(available, key=lambda item: (item[1], str(item[0])))[0]
+        if rows:
+            # A projected path was moved/deleted externally.  Clean misses stay
+            # O(1); only stale rows pay a fact-source scan and repair.
+            hits = self._scan_atom_paths(atom_id)
+            try:
+                self._replace_atom_locations(atom_id, hits)
+            except (OSError, sqlite3.DatabaseError):
+                return None
+            if hits:
+                return max(
+                    hits,
+                    key=lambda hit: (hit[0].stat().st_mtime_ns, str(hit[0])),
+                )[0]
         return None
 
     def list_by_traj(self, traj_id: str) -> list[AtomTask]:
@@ -299,6 +667,15 @@ class MultiAtomTaskStore:
         if not stores:
             raise ValueError("MultiAtomTaskStore 需要至少一个底层 store")
         self.stores = list(stores)
+        for store in self.stores:
+            try:
+                store.ensure_location_index()
+            except (OSError, sqlite3.DatabaseError):
+                logger.warning(
+                    "atom location projection initialization failed: %s",
+                    store._location_index_path(),
+                    exc_info=True,
+                )
 
     @property
     def roots(self) -> list[Path]:
@@ -332,7 +709,15 @@ class MultiAtomTaskStore:
         return store, path
 
     def _atom_hits(self, atom_id: str) -> list[tuple[int, "AtomTaskStore", Path]]:
-        hits: list[tuple[int, "AtomTaskStore", Path]] = []
+        hits = []
+        for idx, store in enumerate(self.stores):
+            path = store.projected_path_for_atom(atom_id)
+            if path is not None:
+                hits.append((idx, store, path))
+        if hits:
+            return hits
+        # Legacy or external writes without a projection event: only a complete
+        # projected miss pays the old fact-source scan and repairs each store.
         for idx, s in enumerate(self.stores):
             path = s.path_for_atom(atom_id)
             if path is not None:

--- a/src/xskill/pipeline/registry.py
+++ b/src/xskill/pipeline/registry.py
@@ -2190,6 +2190,7 @@ def reset_not_fit_for_interest_change(
             ),
         ).fetchall()
         directories_seen: set[str] = set()
+        trajectories_by_directory: dict[str, set[str]] = {}
         for row in rows:
             conn.execute(
                 "UPDATE trajectories SET status=?, process_action=NULL, "
@@ -2209,7 +2210,15 @@ def reset_not_fit_for_interest_change(
                 for atom_file in tasks_directory.glob("atom_*.json"):
                     atom_file.unlink()
             directories_seen.add(row["path"])
+            trajectories_by_directory.setdefault(row["path"], set()).add(
+                trajectory_stem,
+            )
         conn.commit()
+        from xskill.pipeline.atom import AtomTaskStore
+        for directory_path, trajectory_ids in trajectories_by_directory.items():
+            AtomTaskStore(Path(directory_path)).remove_locations_for_trajs(
+                trajectory_ids,
+            )
         for directory_path in directories_seen:
             index_path = Path(directory_path) / "index.pkl"
             if index_path.is_file():
@@ -2259,6 +2268,7 @@ def reset_trajectories(
         trajectory_rows = conn.execute(query_text, query_parameters).fetchall()
 
         directories_seen: set[str] = set()
+        trajectories_by_directory: dict[str, set[str]] = {}
         for trajectory_row in trajectory_rows:
             conn.execute(
                 "UPDATE trajectories SET status='discovered', process_action=NULL, "
@@ -2284,7 +2294,16 @@ def reset_trajectories(
             conn.execute("DELETE FROM atom_adoption WHERE atom_id GLOB ?",
                          (f"atom_{trajectory_stem}_*",))
             directories_seen.add(trajectory_row["path"])
+            trajectories_by_directory.setdefault(
+                trajectory_row["path"],
+                set(),
+            ).add(trajectory_stem)
         conn.commit()
+        from xskill.pipeline.atom import AtomTaskStore
+        for directory_path, trajectory_ids in trajectories_by_directory.items():
+            AtomTaskStore(Path(directory_path)).remove_locations_for_trajs(
+                trajectory_ids,
+            )
         # 清各目录的陈旧向量索引（AtomTaskStore.INDEX_FILE = "index.pkl"）。
         for directory_path in directories_seen:
             index_path = Path(directory_path) / "index.pkl"

--- a/tests/test_atom_task_store.py
+++ b/tests/test_atom_task_store.py
@@ -128,6 +128,146 @@ class TestPaths:
                 "atom_y_0001.json").is_file()
 
 
+class TestAtomLocationProjection:
+    def test_save_many_updates_projection_in_one_batch(
+        self,
+        tmp_path,
+        monkeypatch,
+    ):
+        store = _store(tmp_path)
+        store.root.mkdir(parents=True)
+        store.ensure_location_index()
+        atoms = [
+            _atom(atom_id=f"atom_batch_{index:04d}", traj_id="batch")
+            for index in range(3)
+        ]
+        original = store._upsert_atom_locations
+        batches = []
+
+        def record_batch(locations):
+            batches.append(list(locations))
+            original(locations)
+
+        monkeypatch.setattr(store, "_upsert_atom_locations", record_batch)
+
+        paths = store.save_many(atoms)
+
+        assert len(batches) == 1
+        assert len(batches[0]) == 3
+        assert [store.load(atom.atom_id) for atom in atoms] == atoms
+        assert all(path.is_file() for path in paths)
+
+    def test_legacy_store_is_fully_projected_on_first_lookup(
+        self,
+        tmp_path,
+        monkeypatch,
+    ):
+        store = _store(tmp_path)
+        atoms = [
+            _atom(atom_id=f"atom_legacy_{index:04d}", traj_id=f"legacy-{index}")
+            for index in range(2)
+        ]
+        for atom in atoms:
+            atom_path = store._path(atom)
+            atom_path.parent.mkdir(parents=True)
+            atom_path.write_text(atom.to_json(), encoding="utf-8")
+
+        assert store.load(atoms[0].atom_id) == atoms[0]
+        restarted = AtomTaskStore(store.root)
+        original_iterdir = Path.iterdir
+
+        def reject_root_scan(path):
+            if path == store.root:
+                raise AssertionError("complete legacy projection rescanned root")
+            return original_iterdir(path)
+
+        monkeypatch.setattr(Path, "iterdir", reject_root_scan)
+        assert restarted.load(atoms[1].atom_id) == atoms[1]
+
+    def test_restart_lookup_uses_projection_without_scanning_traj_dirs(
+        self,
+        tmp_path,
+        monkeypatch,
+    ):
+        store = _store(tmp_path)
+        for index in range(50):
+            (store.root / f"empty-{index:02d}").mkdir(parents=True)
+        atom = _atom(atom_id="atom_last_0001", traj_id="zz-last")
+        expected = store.save(atom)
+        restarted = AtomTaskStore(store.root)
+        original_iterdir = Path.iterdir
+
+        def reject_root_scan(path):
+            if path == store.root:
+                raise AssertionError("location lookup scanned trajectory root")
+            return original_iterdir(path)
+
+        monkeypatch.setattr(Path, "iterdir", reject_root_scan)
+
+        assert restarted.path_for_atom(atom.atom_id) == expected
+        assert restarted.load(atom.atom_id) == atom
+
+    def test_legacy_miss_scans_once_then_repairs_projection(
+        self,
+        tmp_path,
+        monkeypatch,
+    ):
+        store = _store(tmp_path)
+        atom = _atom(atom_id="atom_legacy_0001", traj_id="legacy")
+        atom_path = store._path(atom)
+        atom_path.parent.mkdir(parents=True)
+        atom_path.write_text(atom.to_json(), encoding="utf-8")
+
+        assert store.path_for_atom(atom.atom_id) == atom_path
+        original_iterdir = Path.iterdir
+
+        def reject_root_scan(path):
+            if path == store.root:
+                raise AssertionError("repaired lookup rescanned trajectory root")
+            return original_iterdir(path)
+
+        monkeypatch.setattr(Path, "iterdir", reject_root_scan)
+        assert store.path_for_atom(atom.atom_id) == atom_path
+
+    def test_stale_path_falls_back_and_repairs_external_move(self, tmp_path):
+        store = _store(tmp_path)
+        atom = _atom(atom_id="atom_move_0001", traj_id="before")
+        old_path = store.save(atom)
+        new_path = store.root / "after" / "tasks" / old_path.name
+        new_path.parent.mkdir(parents=True)
+        old_path.replace(new_path)
+
+        assert store.path_for_atom(atom.atom_id) == new_path
+        restarted = AtomTaskStore(store.root)
+        assert restarted.path_for_atom(atom.atom_id) == new_path
+
+    def test_corrupt_projection_is_rebuilt_from_atom_json(self, tmp_path):
+        store = _store(tmp_path)
+        atom = _atom(atom_id="atom_rebuild_0001", traj_id="rebuild")
+        atom_path = store.save(atom)
+        store._location_index_path().write_bytes(b"not sqlite")
+        restarted = AtomTaskStore(store.root)
+
+        assert restarted.path_for_atom(atom.atom_id) == atom_path
+        assert restarted.rebuild_location_index() == 1
+
+    def test_missing_atom_clears_stale_projection_row(self, tmp_path):
+        store = _store(tmp_path)
+        atom = _atom(atom_id="atom_deleted_0001", traj_id="deleted")
+        store.save(atom).unlink()
+
+        assert store.path_for_atom(atom.atom_id) is None
+        connection = store._location_connection()
+        try:
+            count = connection.execute(
+                "SELECT COUNT(*) FROM atom_locations WHERE atom_id=?",
+                (atom.atom_id,),
+            ).fetchone()[0]
+        finally:
+            connection.close()
+        assert count == 0
+
+
 class TestVectorIndex:
     def test_build_then_query_returns_top_k(self, tmp_path):
         store = _store(tmp_path)

--- a/tests/test_multi_atom_store.py
+++ b/tests/test_multi_atom_store.py
@@ -48,6 +48,26 @@ def _set_mtime(path: Path, ts: int) -> None:
 
 
 class TestMultiStoreRouting:
+    def test_load_does_not_scan_any_store_trajectory_directories(
+        self,
+        tmp_path,
+        monkeypatch,
+    ):
+        store_a, store_b = _two_client_stores(tmp_path)
+        multi = MultiAtomTaskStore([store_a, store_b])
+        roots = {store_a.root, store_b.root}
+        original_iterdir = Path.iterdir
+
+        def reject_store_scan(path):
+            if path in roots:
+                raise AssertionError("multi-store atom lookup scanned trajectory root")
+            return original_iterdir(path)
+
+        monkeypatch.setattr(Path, "iterdir", reject_store_scan)
+
+        atom = multi.load("atom_traj_cc_b_0042")
+        assert atom.summary == "client B merged cells"
+
     def test_load_finds_atom_in_non_first_store(self, tmp_path):
         store_a, store_b = _two_client_stores(tmp_path)
         multi = MultiAtomTaskStore([store_a, store_b])

--- a/tests/test_rebuild.py
+++ b/tests/test_rebuild.py
@@ -110,6 +110,34 @@ def test_reset_deletes_stale_index_pkl(tmp_path, db_path):
     assert not idx.exists(), "reset 应删陈旧 index.pkl"
 
 
+def test_reset_deletes_atom_location_projection_rows(tmp_path, db_path):
+    from xskill.pipeline.atom import AtomTask, AtomTaskStore
+
+    directory, _wid = _seed_done_traj(tmp_path, db_path)
+    store = AtomTaskStore(directory)
+    atom = AtomTask(
+        atom_id="atom_traj_ng_x_0001",
+        traj_id="traj_ng_x",
+        offset_start=1,
+        offset_end=2,
+        intent="intent",
+        summary="summary",
+    )
+    store.save(atom)
+
+    reset_trajectories(eco="ngagent", db_path=db_path)
+
+    connection = store._location_connection()
+    try:
+        count = connection.execute(
+            "SELECT COUNT(*) FROM atom_locations WHERE traj_id=?",
+            ("traj_ng_x",),
+        ).fetchone()[0]
+    finally:
+        connection.close()
+    assert count == 0
+
+
 def test_reset_requeues_not_fit_and_clears_interest_fields(tmp_path, db_path):
     directory_path, watch_dir_id = _seed_done_traj(tmp_path, db_path)
     mark_not_fit(


### PR DESCRIPTION
## Summary

- 为每个 Atom store 增加可从 JSON 事实源重建的 SQLite 定位投影
- 将跨客户端 Atom 读取从逐轨迹目录扫描改为按 store 的索引查询
- 保留重复 atom_id 取最新、旧数据回填、移动/删除自愈和 reset 清理语义
- 批量保存 Atom 时只提交一次投影事务，避免放大写入成本

## Changes

- 增加完整投影标记、首次使用重建和损坏投影回退
- 为同一 store 的初始化与写入增加进程内串行化，并复用项目 SQLite 生命周期保护
- TaskAgent 改用批量保存接口
- reset 路径同步清理对应轨迹的投影记录
- 覆盖重启、旧数据、移动、删除、损坏、跨 store 和 reset 场景

## Test plan

- [x] 相关单测：119 passed
- [x] 全量测试：2296 passed, 10 skipped
- [x] Ruff：通过
- [x] Docker E2E：runtime_ecosystem_detect、runtime_openclaw_detect 通过

## Linked issues

Closes #296