### PR TITLE
perf(recommend): 以脏用户增量刷新画像

### DIFF
--- a/src/xskill/_workers.py
+++ b/src/xskill/_workers.py
@@ -302,13 +302,19 @@ def run_ecosystem_ingest_loop(
 
 
 def run_profile_refresh_once(*, engine=None) -> int:
-    """遍历所有 client 重算画像落库即退,状态落 profile_refresh_status.json。
-
-    复用 ProfileRefreshService(短命形态:批量提交所有 client → wait_idle → stop),
-    含散点物化子系统,进程退出即销毁,不留常驻线程。``update_user_interest`` 自带
-    revision 未变早退,冷启动全量跑一遍也只对变化的 client 真算增量批量 embedding。
-    """
-    from xskill.config import XSKILL_HOME, load_config, profile_refresh_config
+    """只消费持久化脏用户；首次/版本变化/低频对账才批量标记全部 client。"""
+    from xskill.config import (
+        XSKILL_HOME,
+        load_config,
+        profile_refresh_config,
+    )
+    from xskill.pipeline.registry import get_registry_db_path
+    from xskill.recommend.profile_dirty import (
+        PROFILE_ALGORITHM_VERSION,
+        clear_profile_dirty,
+        list_dirty_profiles,
+        reconcile_profile_dirty,
+    )
     from xskill.team.server.engine_factory import build_recommend_engine
     from xskill.team.server.profile_refresh import ProfileRefreshService
     from xskill.utils.status_file import PROFILE_STATUS_FILE, write_status_file
@@ -320,17 +326,64 @@ def run_profile_refresh_once(*, engine=None) -> int:
     try:
         if engine is None:
             engine = build_recommend_engine(config)
-        client_ids = [row["client_id"] for row in engine.client_registry.list()]
+        client_rows = engine.client_registry.list()
+        key_to_client: dict[str, str] = {}
+        profile_keys: list[str] = []
+        for row in client_rows:
+            client_id = row["client_id"]
+            key_to_client[client_id] = client_id
+            try:
+                profile_key = engine.client_registry.dir_name_for(client_id)
+            except Exception:  # pylint: disable=broad-exception-caught
+                profile_key = client_id
+            key_to_client[profile_key] = client_id
+            profile_keys.append(profile_key)
+        registry_db = get_registry_db_path()
+        model = getattr(getattr(engine, "embed_client", None), "model", "") or ""
+        input_fingerprint = f"{PROFILE_ALGORITHM_VERSION}:{model}"
+        reconcile_reason = reconcile_profile_dirty(
+            profile_keys,
+            input_fingerprint=input_fingerprint,
+            db_path=registry_db,
+        )
+        dirty_rows = list_dirty_profiles(db_path=registry_db)
+        dirty_by_client: dict[str, list[dict]] = {}
+        stale_rows: list[dict] = []
+        for row in dirty_rows:
+            client_id = key_to_client.get(row["user_key"])
+            if client_id:
+                dirty_by_client.setdefault(client_id, []).append(row)
+            else:
+                stale_rows.append(row)
+        for row in stale_rows:
+            clear_profile_dirty(
+                row["user_key"], row["generation"], db_path=registry_db,
+            )
+
+        def _finish(client_id: str, succeeded: bool) -> None:
+            if not succeeded:
+                return
+            for dirty in dirty_by_client.get(client_id, []):
+                clear_profile_dirty(
+                    dirty["user_key"], dirty["generation"], db_path=registry_db,
+                )
+
         # 批量任务:settle_delay=0 立即算(settle 是给在线 sync 突发让路用的,批量无此需求)。
         service = ProfileRefreshService(
             engine, workers=pr_cfg["workers"], queue_size=pr_cfg["queue_size"],
-            settle_delay=0, autostart=True,
+            settle_delay=0, autostart=True, on_processed=_finish,
         )
-        for client_id in client_ids:
-            service.request(client_id)
+        requested = 0
+        for client_id in dirty_by_client:
+            if service.request(client_id):
+                requested += 1
         service.wait_idle()
         metrics = dict(service.metrics)
-        metrics["clients"] = len(client_ids)
+        metrics["clients"] = len(client_rows)
+        metrics["requested_clients"] = requested
+        metrics["dirty_rows"] = len(dirty_rows)
+        metrics["stale_rows"] = len(stale_rows)
+        metrics["reconcile_reason"] = reconcile_reason
         write_status_file(status_path, metrics, ok=True)
         return 0
     except Exception as exc:  # noqa: BLE001 — 顶层任务边界,落状态文件+日志后报错

--- a/src/xskill/agents/agent_tools.py
+++ b/src/xskill/agents/agent_tools.py
@@ -1525,6 +1525,19 @@ def add_tasks_to_skill(
     return _run_cluster_mutation(mutate)
 
 
+def _mark_atom_profile_dirty(atom_path: Path, reason: str) -> None:
+    """Team Atom 画像旁路事件；本地 store/投影故障不阻断工具主操作。"""
+    try:
+        from xskill.recommend.profile_dirty import mark_profile_dirty_for_store
+        mark_profile_dirty_for_store(
+            atom_path.parents[2],
+            reason=reason,
+            db_path=agent_tool_config.registry_db_path,
+        )
+    except Exception:  # pylint: disable=broad-exception-caught
+        logger.debug("profile dirty mark failed after %s", reason, exc_info=True)
+
+
 @tool(name="score_task")
 def score_task(atom_id: str, score: int) -> str:
     """覆盖 AtomTask 的 ux_score（手动修正 / 灰度链路使用）。"""
@@ -1543,7 +1556,8 @@ def score_task(atom_id: str, score: int) -> str:
         except FileNotFoundError as error:
             return f"error: {error}"
         atom.ux_score = sc
-        store.save(atom)
+        atom_path = store.save(atom)
+        _mark_atom_profile_dirty(atom_path, "atom_score_changed")
         return f"scored: {atom_id} → {sc}"
 
     return _run_cluster_mutation(mutate)
@@ -1572,7 +1586,8 @@ def add_task(
         pre_atom_id=None, post_atom_id=None,
         context_prefix="", raw_segment="",
     )
-    store.save(atom)
+    atom_path = store.save(atom)
+    _mark_atom_profile_dirty(atom_path, "atom_added")
     return f"added: {atom_id}"
 
 

--- a/src/xskill/dashboard/console.py
+++ b/src/xskill/dashboard/console.py
@@ -1398,6 +1398,7 @@ def build_console_router(db_path: Optional[Path] = None) -> APIRouter:
         """暂停或恢复指定 client 的后续轨迹处理；显式目标状态保证幂等。"""
         ctx = _require_team_ctx()
         try:
+            was_paused = ctx.client_registry.is_ingest_paused(client_id)
             row = ctx.client_registry.set_ingest_paused(
                 client_id,
                 req.paused,
@@ -1420,6 +1421,19 @@ def build_console_router(db_path: Optional[Path] = None) -> APIRouter:
                 status_code=503,
                 detail="暂停状态已保存，但 watch_dir 同步失败；可安全重试",
             ) from exc
+
+        if was_paused != bool(row.get("ingest_paused")):
+            try:
+                from xskill.recommend.profile_dirty import mark_profile_dirty
+                mark_profile_dirty(
+                    watch_state["dir_name"],
+                    reason="ingest_privacy_changed",
+                    db_path=db_path,
+                )
+            except Exception:  # pylint: disable=broad-exception-caught
+                logger.debug(
+                    "画像脏标记失败: client_id=%s", client_id, exc_info=True,
+                )
 
         logger.info(
             "admin %s set client %s ingest_paused=%s",

--- a/src/xskill/pipeline/registry.py
+++ b/src/xskill/pipeline/registry.py
@@ -301,6 +301,23 @@ CREATE TABLE IF NOT EXISTS catalog_vector_sync_meta (
     reconciled_at      REAL NOT NULL DEFAULT 0
 );
 
+-- 用户画像脏队列：generation 让“计算期间又发生变化”不会被旧任务误清。
+CREATE TABLE IF NOT EXISTS profile_dirty (
+    user_key    TEXT PRIMARY KEY,
+    generation  INTEGER NOT NULL DEFAULT 1,
+    reason      TEXT NOT NULL DEFAULT '',
+    marked_at   REAL NOT NULL
+);
+CREATE INDEX IF NOT EXISTS idx_profile_dirty_marked
+    ON profile_dirty(marked_at, user_key);
+
+-- 画像算法/embedding 输入版本与低频全量对账水位。
+CREATE TABLE IF NOT EXISTS profile_refresh_meta (
+    singleton          INTEGER PRIMARY KEY CHECK(singleton=1),
+    input_fingerprint  TEXT NOT NULL DEFAULT '',
+    reconciled_at      REAL NOT NULL DEFAULT 0
+);
+
 -- P3-3.1 events:四类既有事实源的消费者(D7),通知+世界消息共用。
 -- kind: feedback(他人触发+ux打分) / push_edit(修改分支) / canary(裁决) / pin。
 -- targets 单独成表:一条事件可通知多个贡献者;世界消息 feed 直接读 events。
@@ -2404,7 +2421,7 @@ def reset_not_fit_for_interest_change(
         return 0
     with pooled_connection(db_path) as conn:
         rows = conn.execute(
-            "SELECT t.id, t.filename, w.path FROM trajectories t "
+            "SELECT t.id, t.filename, t.user_key, w.path FROM trajectories t "
             "JOIN watch_dirs w ON t.watch_dir_id = w.id "
             "WHERE t.status=? AND t.process_action=? "
             "AND (t.interest_fingerprint IS NULL OR t.interest_fingerprint != ?)",
@@ -2415,6 +2432,7 @@ def reset_not_fit_for_interest_change(
             ),
         ).fetchall()
         directories_seen: set[str] = set()
+        profile_store_roots: set[str] = set()
         trajectories_by_directory: dict[str, set[str]] = {}
         for row in rows:
             conn.execute(
@@ -2435,9 +2453,22 @@ def reset_not_fit_for_interest_change(
                 for atom_file in tasks_directory.glob("atom_*.json"):
                     atom_file.unlink()
             directories_seen.add(row["path"])
+            if row["user_key"]:
+                profile_store_roots.add(row["path"])
             trajectories_by_directory.setdefault(row["path"], set()).add(
                 trajectory_stem,
             )
+        if profile_store_roots:
+            from xskill.recommend.profile_dirty import (
+                mark_profile_dirty_on_connection,
+                profile_user_key_for_store_root,
+            )
+            for store_root in profile_store_roots:
+                mark_profile_dirty_on_connection(
+                    conn,
+                    profile_user_key_for_store_root(store_root),
+                    reason="atom_reset",
+                )
         conn.commit()
         from xskill.pipeline.atom import AtomTaskStore
         for directory_path, trajectory_ids in trajectories_by_directory.items():
@@ -2480,7 +2511,7 @@ def reset_trajectories(
     """
     with pooled_connection(db_path) as conn:
         query_text = (
-            "SELECT t.id, t.filename, w.path FROM trajectories t "
+            "SELECT t.id, t.filename, t.user_key, w.path FROM trajectories t "
             "JOIN watch_dirs w ON t.watch_dir_id = w.id WHERE 1=1"
         )
         query_parameters: list = []
@@ -2493,6 +2524,7 @@ def reset_trajectories(
         trajectory_rows = conn.execute(query_text, query_parameters).fetchall()
 
         directories_seen: set[str] = set()
+        profile_store_roots: set[str] = set()
         trajectories_by_directory: dict[str, set[str]] = {}
         for trajectory_row in trajectory_rows:
             conn.execute(
@@ -2519,10 +2551,23 @@ def reset_trajectories(
             conn.execute("DELETE FROM atom_adoption WHERE atom_id GLOB ?",
                          (f"atom_{trajectory_stem}_*",))
             directories_seen.add(trajectory_row["path"])
+            if trajectory_row["user_key"]:
+                profile_store_roots.add(trajectory_row["path"])
             trajectories_by_directory.setdefault(
                 trajectory_row["path"],
                 set(),
             ).add(trajectory_stem)
+        if profile_store_roots:
+            from xskill.recommend.profile_dirty import (
+                mark_profile_dirty_on_connection,
+                profile_user_key_for_store_root,
+            )
+            for store_root in profile_store_roots:
+                mark_profile_dirty_on_connection(
+                    conn,
+                    profile_user_key_for_store_root(store_root),
+                    reason="atom_reset",
+                )
         conn.commit()
         from xskill.pipeline.atom import AtomTaskStore
         for directory_path, trajectory_ids in trajectories_by_directory.items():

--- a/src/xskill/pipeline/runner.py
+++ b/src/xskill/pipeline/runner.py
@@ -3073,6 +3073,18 @@ class DirectoryWatcher:
             tasks_extracted=total_atoms, **kw,
         )
         self._stats["atoms_extracted"] += n_atoms
+        if n_atoms:
+            try:
+                from xskill.recommend.profile_dirty import (
+                    mark_profile_dirty_for_store,
+                )
+                mark_profile_dirty_for_store(
+                    matched[0]["path"],
+                    reason="atom_split",
+                    db_path=kw.get("db_path"),
+                )
+            except Exception:  # pylint: disable=broad-exception-caught
+                logger.debug("profile dirty mark failed after split", exc_info=True)
 
     def _on_embed_done(self, wd_id, _filename, result, **kw):
         _wd_id, filenames = result

--- a/src/xskill/recommend/profile_dirty.py
+++ b/src/xskill/recommend/profile_dirty.py
@@ -1,0 +1,175 @@
+"""持久化用户画像脏队列；Atom JSON 是事实源，本表只保存待刷新事件。"""
+from __future__ import annotations
+
+import time
+from pathlib import Path
+from typing import Iterable, Optional
+
+from xskill.pipeline.registry import pooled_connection
+
+PROFILE_ALGORITHM_VERSION = "profile-v1"
+DEFAULT_RECONCILE_INTERVAL_SECONDS = 24 * 60 * 60
+
+
+def mark_profile_dirty_on_connection(
+    connection,
+    user_key: str,
+    *,
+    reason: str = "",
+    marked_at: float | None = None,
+) -> int:
+    """在调用方事务内合并事件；用于 Atom 删除与 registry 状态原子提交。"""
+    key = str(user_key or "").strip()
+    if not key:
+        return 0
+    timestamp = time.time() if marked_at is None else float(marked_at)
+    connection.execute(
+        """
+        INSERT INTO profile_dirty(user_key, generation, reason, marked_at)
+        VALUES (?, 1, ?, ?)
+        ON CONFLICT(user_key) DO UPDATE SET
+            generation=profile_dirty.generation + 1,
+            reason=excluded.reason,
+            marked_at=excluded.marked_at
+        """,
+        (key, str(reason or ""), timestamp),
+    )
+    row = connection.execute(
+        "SELECT generation FROM profile_dirty WHERE user_key=?",
+        (key,),
+    ).fetchone()
+    return int(row["generation"])
+
+
+def profile_user_key_for_store_root(root: Path | str) -> str:
+    """识别 ``clients/<user>/sessions`` team store；本地 watch dir 返回空。"""
+    path = Path(root)
+    if (
+        path.name != "sessions"
+        or path.parent.parent.name != "clients"
+        or not path.parent.name
+    ):
+        return ""
+    return path.parent.name
+
+
+def mark_profile_dirty(
+    user_key: str,
+    *,
+    reason: str = "",
+    db_path: Optional[Path] = None,
+    marked_at: float | None = None,
+) -> int:
+    """合并一次画像变化并返回新 generation。"""
+    key = str(user_key or "").strip()
+    if not key:
+        return 0
+    with pooled_connection(db_path) as conn:
+        generation = mark_profile_dirty_on_connection(
+            conn,
+            key,
+            reason=reason,
+            marked_at=marked_at,
+        )
+        conn.commit()
+    return generation
+
+
+def mark_profile_dirty_for_store(
+    root: Path | str,
+    *,
+    reason: str,
+    db_path: Optional[Path] = None,
+) -> int:
+    return mark_profile_dirty(
+        profile_user_key_for_store_root(root),
+        reason=reason,
+        db_path=db_path,
+    )
+
+
+def list_dirty_profiles(
+    *,
+    limit: int = 0,
+    db_path: Optional[Path] = None,
+) -> list[dict]:
+    sql = (
+        "SELECT user_key, generation, reason, marked_at FROM profile_dirty "
+        "ORDER BY marked_at ASC, user_key ASC"
+    )
+    params: tuple = ()
+    if limit > 0:
+        sql += " LIMIT ?"
+        params = (int(limit),)
+    with pooled_connection(db_path) as conn:
+        rows = conn.execute(sql, params).fetchall()
+    return [dict(row) for row in rows]
+
+
+def clear_profile_dirty(
+    user_key: str,
+    generation: int,
+    *,
+    db_path: Optional[Path] = None,
+) -> bool:
+    """仅清理已处理的 generation；晚到事件已递增时保留新任务。"""
+    with pooled_connection(db_path) as conn:
+        cursor = conn.execute(
+            "DELETE FROM profile_dirty WHERE user_key=? AND generation=?",
+            (user_key, int(generation)),
+        )
+        conn.commit()
+        return cursor.rowcount == 1
+
+
+def reconcile_profile_dirty(
+    user_keys: Iterable[str],
+    *,
+    input_fingerprint: str,
+    db_path: Optional[Path] = None,
+    now: float | None = None,
+    interval_seconds: float = DEFAULT_RECONCILE_INTERVAL_SECONDS,
+) -> str:
+    """首次运行、输入版本变化或低频水位到期时，把全部现存用户标脏。"""
+    timestamp = time.time() if now is None else float(now)
+    keys = sorted({str(key).strip() for key in user_keys if str(key).strip()})
+    with pooled_connection(db_path) as conn:
+        row = conn.execute(
+            """
+            SELECT input_fingerprint, reconciled_at
+            FROM profile_refresh_meta WHERE singleton=1
+            """
+        ).fetchone()
+        if row is None:
+            reason = "bootstrap"
+        elif row["input_fingerprint"] != input_fingerprint:
+            reason = "profile_input_changed"
+        elif timestamp - float(row["reconciled_at"] or 0) >= interval_seconds:
+            reason = "periodic_reconcile"
+        else:
+            return ""
+
+        conn.executemany(
+            """
+            INSERT INTO profile_dirty(user_key, generation, reason, marked_at)
+            VALUES (?, 1, ?, ?)
+            ON CONFLICT(user_key) DO UPDATE SET
+                generation=profile_dirty.generation + 1,
+                reason=excluded.reason,
+                marked_at=excluded.marked_at
+            """,
+            [(key, reason, timestamp) for key in keys],
+        )
+        conn.execute(
+            """
+            INSERT INTO profile_refresh_meta(
+                singleton, input_fingerprint, reconciled_at
+            ) VALUES (1, ?, ?)
+            ON CONFLICT(singleton) DO UPDATE SET
+                input_fingerprint=excluded.input_fingerprint,
+                reconciled_at=excluded.reconciled_at
+            """,
+            (input_fingerprint, timestamp),
+        )
+        conn.commit()
+    return reason

--- a/src/xskill/team/server/profile_refresh.py
+++ b/src/xskill/team/server/profile_refresh.py
@@ -51,6 +51,7 @@ class ProfileRefreshService:
         scatter_materialize: bool = True,
         scatter_pool_factory: Optional[Callable[[], object]] = None,
         scatter_registry_db: Optional[Path] = None,
+        on_processed: Optional[Callable[[str, bool], None]] = None,
     ):
         if workers < 1:
             raise ValueError("workers 必须 >= 1")
@@ -67,6 +68,7 @@ class ProfileRefreshService:
         self.worker_count = workers
         self.settle_delay = float(settle_delay)
         self.interest_factory = interest_factory
+        self.on_processed = on_processed
         self._queue: queue.Queue = queue.Queue(maxsize=queue_size)
         self._condition = threading.Condition()
         self._states: dict[str, dict[str, bool | str]] = {}
@@ -272,8 +274,9 @@ class ProfileRefreshService:
                 self._metrics["running"] += 1
 
             changed = False
+            succeeded = False
             if self._wait_for_settle():
-                changed = self._run_once(client_id)
+                changed, succeeded = self._run_once(client_id)
 
             run_again = False
             with self._condition:
@@ -285,7 +288,8 @@ class ProfileRefreshService:
                     self._metrics["rerun"] += 1
                     run_again = True
             if run_again:
-                changed = self._run_once(client_id) or changed
+                rerun_changed, succeeded = self._run_once(client_id)
+                changed = rerun_changed or changed
 
             # 事件触发（在 finalize 之前,保证 wait_idle 解除时投递已发生）:画像真的
             # 变了才投递该用户 tsne+umap 两个方法的散点重算,指纹未变的空转在重算侧跳过。
@@ -311,6 +315,15 @@ class ProfileRefreshService:
                         "mark recommend dirty failed for %s", client_id, exc_info=True,
                     )
 
+            if self.on_processed is not None:
+                try:
+                    self.on_processed(client_id, succeeded)
+                except Exception:  # pylint: disable=broad-exception-caught
+                    logger.exception(
+                        "profile refresh completion callback failed for %s",
+                        client_id,
+                    )
+
             with self._condition:
                 self._states.pop(client_id, None)
                 self._metrics["running"] -= 1
@@ -327,8 +340,8 @@ class ProfileRefreshService:
                 self._condition.wait(timeout=remaining)
             return False
 
-    def _run_once(self, client_id: str) -> bool:
-        """执行一次画像更新;返回是否产生了变更（供事件触发散点重算判定）。"""
+    def _run_once(self, client_id: str) -> tuple[bool, bool]:
+        """返回 ``(changed, succeeded)``，供派生事件与耐久队列分别判定。"""
         try:
             result = self.engine.update_user_interest(
                 self.interest_factory(client_id),
@@ -338,7 +351,7 @@ class ProfileRefreshService:
             with self._condition:
                 self._metrics["failed"] += 1
             logger.exception("profile refresh failed for client %s", client_id)
-            return False
+            return False, False
         cancelled = getattr(result, "cancelled", False)
         changed = getattr(result, "changed", True)
         with self._condition:
@@ -357,7 +370,7 @@ class ProfileRefreshService:
             self._metrics["reused_vector_items"] += int(
                 getattr(result, "reused_vector_items", 0),
             )
-        return bool(changed and not cancelled)
+        return bool(changed and not cancelled), not cancelled
 
     def _should_commit(self) -> bool:
         """供引擎在最终画像 upsert 前检查停机状态。"""

--- a/tests/test_dashboard_console_p2.py
+++ b/tests/test_dashboard_console_p2.py
@@ -547,6 +547,11 @@ def test_admin_ingest_control_is_authorized_idempotent_and_syncs_watch_dir(
     assert body["auto_index"] is False
     paused_at = body["ingest_paused_at"]
     assert R.get_watch_dir(sessions_dir, db_path=db)["auto_index"] == 0
+    from xskill.recommend.profile_dirty import list_dirty_profiles
+    dirty = list_dirty_profiles(db_path=db)
+    assert [(row["user_key"], row["generation"]) for row in dirty] == [
+        ("alice", 1),
+    ]
     paused_contributions = alice.get(
         "/api/v1/dashboard/my/contributions"
     ).json()["steps"]
@@ -559,6 +564,7 @@ def test_admin_ingest_control_is_authorized_idempotent_and_syncs_watch_dir(
     assert repeated.status_code == 200
     assert repeated.json()["ingest_paused_at"] == paused_at
     assert repeated.json()["ingest_pause_reason"] == "quality review"
+    assert list_dirty_profiles(db_path=db)[0]["generation"] == 1
 
     matrix = boss.get("/api/v1/dashboard/admin/users-matrix").json()
     user_row = next(row for row in matrix["users"] if row["client_id"] == client_id)
@@ -571,6 +577,7 @@ def test_admin_ingest_control_is_authorized_idempotent_and_syncs_watch_dir(
     assert resumed.json()["ingest_paused_at"] == ""
     assert resumed.json()["auto_index"] is True
     assert R.get_watch_dir(sessions_dir, db_path=db)["auto_index"] == 1
+    assert list_dirty_profiles(db_path=db)[0]["generation"] == 2
     assert (
         alice.get("/api/v1/dashboard/my/contributions").json()["steps"]["trajs"]
         == 2
@@ -966,4 +973,3 @@ def test_reload_pool_seats_only_is_hot_not_restart(console_env, tmp_path, monkey
     body = r.json()
     assert "agent_worker" not in body["needs_restart"]
     assert "agent_worker" in body["hot_reloaded"]
-

--- a/tests/test_profile_dirty.py
+++ b/tests/test_profile_dirty.py
@@ -1,0 +1,122 @@
+"""用户画像脏队列的合并、CAS 清理与低频对账。"""
+from __future__ import annotations
+
+import pytest
+
+from xskill.pipeline.registry import get_connection
+from xskill.pipeline.registry import discover_trajectories, register_dir
+from xskill.pipeline.atom import AtomTask, AtomTaskStore
+from xskill.pipeline.runner import DirectoryWatcher
+from xskill.recommend.profile_dirty import (
+    clear_profile_dirty,
+    list_dirty_profiles,
+    mark_profile_dirty,
+    profile_user_key_for_store_root,
+    reconcile_profile_dirty,
+)
+
+
+@pytest.fixture
+def registry_db(tmp_path):
+    path = tmp_path / "registry.db"
+    connection = get_connection(path)
+    connection.close()
+    return path
+
+
+def test_team_store_root_maps_to_profile_user(tmp_path):
+    root = tmp_path / "trajectories" / "clients" / "alice" / "sessions"
+    assert profile_user_key_for_store_root(root) == "alice"
+    assert profile_user_key_for_store_root(tmp_path / "local") == ""
+
+
+def test_split_completion_marks_only_owning_team_user_dirty(tmp_path, registry_db):
+    sessions = tmp_path / "trajectories" / "clients" / "alice" / "sessions"
+    sessions.mkdir(parents=True)
+    trajectory = sessions / "traj_team.md"
+    trajectory.write_text("# trajectory", encoding="utf-8")
+    watch_dir_id = register_dir(
+        sessions, label="alice", ecosystem="team_client", db_path=registry_db,
+    )
+    discover_trajectories(watch_dir_id, sessions, db_path=registry_db)
+    store = AtomTaskStore(sessions)
+    atom = AtomTask(
+        atom_id="atom_traj_team_0001",
+        traj_id="traj_team",
+        offset_start=1,
+        offset_end=2,
+        intent="intent",
+        summary="summary",
+    )
+    store.save(atom)
+    watcher = object.__new__(DirectoryWatcher)
+    watcher.store = store
+    watcher._stats = {"atoms_extracted": 0}
+
+    watcher._on_split_done(
+        watch_dir_id,
+        trajectory.name,
+        (trajectory.name, 1, 2, atom.atom_id, None),
+        db_path=registry_db,
+    )
+
+    dirty = list_dirty_profiles(db_path=registry_db)
+    assert [(row["user_key"], row["reason"]) for row in dirty] == [
+        ("alice", "atom_split"),
+    ]
+
+
+def test_mark_profile_dirty_avoids_returning_clause():
+    import inspect
+    from xskill.recommend import profile_dirty
+    source = inspect.getsource(profile_dirty.mark_profile_dirty_on_connection)
+    assert "RETURNING" not in source
+
+
+def test_multiple_changes_coalesce_and_late_change_survives_cas(registry_db):
+    assert mark_profile_dirty("alice", reason="first", db_path=registry_db) == 1
+    assert mark_profile_dirty("alice", reason="second", db_path=registry_db) == 2
+    row = list_dirty_profiles(db_path=registry_db)[0]
+    assert row["user_key"] == "alice"
+    assert row["generation"] == 2
+    assert row["reason"] == "second"
+
+    assert mark_profile_dirty("alice", reason="late", db_path=registry_db) == 3
+    assert clear_profile_dirty("alice", 2, db_path=registry_db) is False
+    assert list_dirty_profiles(db_path=registry_db)[0]["generation"] == 3
+    assert clear_profile_dirty("alice", 3, db_path=registry_db) is True
+    assert list_dirty_profiles(db_path=registry_db) == []
+
+
+def test_reconcile_only_marks_on_bootstrap_version_change_or_interval(registry_db):
+    assert reconcile_profile_dirty(
+        ["alice", "bob"], input_fingerprint="v1", db_path=registry_db,
+        now=100, interval_seconds=1000,
+    ) == "bootstrap"
+    initial = list_dirty_profiles(db_path=registry_db)
+    assert {row["user_key"] for row in initial} == {"alice", "bob"}
+    for row in initial:
+        assert clear_profile_dirty(
+            row["user_key"], row["generation"], db_path=registry_db,
+        )
+
+    assert reconcile_profile_dirty(
+        ["alice", "bob"], input_fingerprint="v1", db_path=registry_db,
+        now=200, interval_seconds=1000,
+    ) == ""
+    assert list_dirty_profiles(db_path=registry_db) == []
+
+    assert reconcile_profile_dirty(
+        ["alice", "bob"], input_fingerprint="v2", db_path=registry_db,
+        now=300, interval_seconds=1000,
+    ) == "profile_input_changed"
+    changed = list_dirty_profiles(db_path=registry_db)
+    for row in changed:
+        assert clear_profile_dirty(
+            row["user_key"], row["generation"], db_path=registry_db,
+        )
+
+    assert reconcile_profile_dirty(
+        ["alice", "bob"], input_fingerprint="v2", db_path=registry_db,
+        now=1400, interval_seconds=1000,
+    ) == "periodic_reconcile"

--- a/tests/test_profile_refresh_once.py
+++ b/tests/test_profile_refresh_once.py
@@ -12,6 +12,9 @@ class _FakeRegistry:
     def list(self):
         return [{"client_id": cid} for cid in self._ids]
 
+    def dir_name_for(self, client_id):
+        return client_id
+
 
 class _FakeEngine:
     def __init__(self, ids):
@@ -20,18 +23,28 @@ class _FakeEngine:
 
 class _FakeService:
     instances: list = []
+    succeed = True
+    before_complete = None
 
     def __init__(self, engine, **_kwargs):
         self.engine = engine
         self.requested: list[str] = []
         self.stopped = False
         self._metrics = {"completed": 2, "unchanged": 1, "failed": 0}
+        self._on_processed = _kwargs.get("on_processed")
         _FakeService.instances.append(self)
 
     def request(self, client_id):
         self.requested.append(client_id)
+        return True
 
     def wait_idle(self):
+        if self._on_processed is not None:
+            for client_id in self.requested:
+                before_complete = type(self).before_complete
+                if before_complete is not None:
+                    before_complete(client_id)
+                self._on_processed(client_id, self.succeed)
         return True
 
     @property
@@ -44,6 +57,8 @@ class _FakeService:
 
 def _patch(monkeypatch, tmp_path, engine_or_exc):
     _FakeService.instances = []
+    _FakeService.succeed = True
+    _FakeService.before_complete = None
     monkeypatch.setattr("xskill.config.XSKILL_HOME", tmp_path)
 
     def fake_load_config():
@@ -80,6 +95,52 @@ def test_empty_client_list_is_ok(tmp_path, monkeypatch):
     rc = _workers.run_profile_refresh_once()
     assert rc == 0
     assert read_status_file(tmp_path / PROFILE_STATUS_FILE)["stats"]["clients"] == 0
+
+
+def test_unchanged_second_tick_reads_no_client_profiles(tmp_path, monkeypatch):
+    from xskill.recommend.profile_dirty import mark_profile_dirty
+
+    engine = _FakeEngine(["c1", "c2", "c3"])
+    _patch(monkeypatch, tmp_path, engine)
+    assert _workers.run_profile_refresh_once(engine=engine) == 0
+    assert _FakeService.instances[-1].requested == ["c1", "c2", "c3"]
+
+    assert _workers.run_profile_refresh_once(engine=engine) == 0
+    assert _FakeService.instances[-1].requested == []
+
+    mark_profile_dirty("c2", reason="atom_split")
+    assert _workers.run_profile_refresh_once(engine=engine) == 0
+    assert _FakeService.instances[-1].requested == ["c2"]
+
+
+def test_failed_profile_refresh_keeps_dirty_generation(tmp_path, monkeypatch):
+    from xskill.recommend.profile_dirty import list_dirty_profiles
+
+    engine = _FakeEngine(["c1"])
+    _patch(monkeypatch, tmp_path, engine)
+    _FakeService.succeed = False
+
+    assert _workers.run_profile_refresh_once(engine=engine) == 0
+    assert [row["user_key"] for row in list_dirty_profiles()] == ["c1"]
+
+
+def test_change_during_refresh_survives_old_generation_callback(tmp_path, monkeypatch):
+    from xskill.recommend.profile_dirty import (
+        list_dirty_profiles,
+        mark_profile_dirty,
+    )
+
+    engine = _FakeEngine(["c1"])
+    _patch(monkeypatch, tmp_path, engine)
+    _FakeService.before_complete = lambda _client_id: mark_profile_dirty(
+        "c1", reason="late_atom",
+    )
+
+    assert _workers.run_profile_refresh_once(engine=engine) == 0
+    dirty = list_dirty_profiles()
+    assert [(row["user_key"], row["generation"], row["reason"]) for row in dirty] == [
+        ("c1", 2, "late_atom"),
+    ]
 
 
 def test_build_failure_writes_error_status_and_returns_1(tmp_path, monkeypatch):

--- a/tests/test_profile_refresh_service.py
+++ b/tests/test_profile_refresh_service.py
@@ -112,6 +112,35 @@ def test_failure_clears_state_and_later_request_retries():
     assert service.stop(timeout=_IDLE_TIMEOUT)
 
 
+def test_completion_callback_only_reports_successful_commits():
+    outcomes = []
+
+    class Engine:
+        def __init__(self):
+            self.calls = 0
+
+        def update_user_interest(self, _interest, *, should_commit=None):
+            self.calls += 1
+            if self.calls == 1:
+                raise RuntimeError("temporary failure")
+            return _Result(changed=False)
+
+    service = ProfileRefreshService(
+        Engine(),
+        workers=1,
+        queue_size=1,
+        on_processed=lambda client_id, succeeded: outcomes.append(
+            (client_id, succeeded),
+        ),
+    )
+    assert service.request("u1")
+    assert service.wait_idle(timeout=_IDLE_TIMEOUT)
+    assert service.request("u1")
+    assert service.wait_idle(timeout=_IDLE_TIMEOUT)
+    assert outcomes == [("u1", False), ("u1", True)]
+    assert service.stop(timeout=_IDLE_TIMEOUT)
+
+
 @pytest.mark.flaky(reruns=2, reruns_delay=1)
 def test_worker_concurrency_is_fixed_and_threads_are_daemon():
     all_workers_busy = threading.Event()

--- a/tests/test_rebuild.py
+++ b/tests/test_rebuild.py
@@ -165,6 +165,28 @@ def test_reset_deletes_atom_location_projection_rows(tmp_path, db_path):
     assert count == 0
 
 
+def test_reset_marks_only_team_profile_dirty(tmp_path, db_path):
+    from xskill.recommend.profile_dirty import list_dirty_profiles
+
+    sessions = tmp_path / "trajectories" / "clients" / "alice" / "sessions"
+    sessions.mkdir(parents=True)
+    (sessions / "traj_team.md").write_text("# team", encoding="utf-8")
+    watch_dir_id = register_dir(
+        sessions,
+        label="alice",
+        ecosystem="team_client",
+        db_path=db_path,
+    )
+    discover_trajectories(watch_dir_id, sessions, db_path=db_path)
+
+    reset_trajectories(traj_id="traj_team", db_path=db_path)
+
+    dirty = list_dirty_profiles(db_path=db_path)
+    assert [(row["user_key"], row["reason"]) for row in dirty] == [
+        ("alice", "atom_reset"),
+    ]
+
+
 def test_reset_requeues_not_fit_and_clears_interest_fields(tmp_path, db_path):
     directory_path, watch_dir_id = _seed_done_traj(tmp_path, db_path)
     mark_not_fit(


### PR DESCRIPTION
## Summary

- 将画像重任务从每轮遍历全部客户端改为只消费持久化脏用户
- 同一用户变化合并，处理期间的晚到变化不会被旧任务误清
- 保留首次升级、embedding/算法版本变化和低频全量对账兜底

## Changes

- 在 registry 增加 `profile_dirty` generation 队列与 `profile_refresh_meta` 水位
- Atom split、reset、手动 add/score 和轨迹隐私开关变化时标记对应用户
- 画像成功或 unchanged 后按 generation CAS 清理；失败、取消、队列满时保留
- reset 的 registry 状态与画像脏事件在同一 SQLite 事务提交
- 状态指标增加 requested/dirty/stale/reconcile 信息，保留原 `clients` 口径

## Test plan

- [x] 相关与推荐/team/SQLite 扩展测试：201 passed, 1 skipped
- [x] 全量测试：2295 passed, 10 skipped
- [x] 最终聚焦回归：89 passed
- [x] Ruff：通过
- [x] Docker E2E：runtime_ecosystem_detect、runtime_openclaw_detect 通过

## Linked issues

Closes #297