### PR TITLE
perf(recommend): sync catalog vectors from a dirty queue

### DIFF
--- a/src/xskill/pipeline/registry.py
+++ b/src/xskill/pipeline/registry.py
@@ -280,6 +280,26 @@ CREATE TABLE IF NOT EXISTS recommend_dirty (
     marked_at  TEXT NOT NULL
 );
 
+-- skills_catalog → vector index 增量同步队列。generation 是消费 fence：
+-- worker 只能清理自己实际处理的版本，并发晚到写入会保留到下一轮。
+CREATE TABLE IF NOT EXISTS catalog_vector_dirty (
+    catalog_key TEXT PRIMARY KEY,
+    generation  INTEGER NOT NULL DEFAULT 1,
+    dirty       INTEGER NOT NULL DEFAULT 1 CHECK(dirty IN (0,1)),
+    operation   TEXT NOT NULL CHECK(operation IN ('upsert','delete')),
+    content_sha TEXT NOT NULL DEFAULT '',
+    marked_at   REAL NOT NULL
+);
+CREATE INDEX IF NOT EXISTS idx_catalog_vector_dirty_marked
+    ON catalog_vector_dirty(dirty, marked_at, catalog_key);
+
+-- 全量向量对账水位：首次升级、模型/算法变化和低频修复时更新。
+CREATE TABLE IF NOT EXISTS catalog_vector_sync_meta (
+    singleton          INTEGER PRIMARY KEY CHECK(singleton=1),
+    model_fingerprint  TEXT NOT NULL DEFAULT '',
+    reconciled_at      REAL NOT NULL DEFAULT 0
+);
+
 -- P3-3.1 events:四类既有事实源的消费者(D7),通知+世界消息共用。
 -- kind: feedback(他人触发+ux打分) / push_edit(修改分支) / canary(裁决) / pin。
 -- targets 单独成表:一条事件可通知多个贡献者;世界消息 feed 直接读 events。
@@ -1189,12 +1209,28 @@ def retire_skill(*, skill_name: str, set_by: str,
                  db_path: Optional[Path] = None) -> None:
     """下线:停止分发与推荐,数据与 git 历史保留。幂等。"""
     with pooled_connection(db_path) as conn:
+        already_retired = conn.execute(
+            "SELECT 1 FROM skill_lifecycle WHERE skill_name=? AND state='retired'",
+            (skill_name,),
+        ).fetchone() is not None
         conn.execute(
             "INSERT INTO skill_lifecycle(skill_name,state,set_by) VALUES(?,?,?)"
             " ON CONFLICT(skill_name) DO UPDATE SET state='retired',"
             " set_by=excluded.set_by, ts=datetime('now')",
             (skill_name, "retired", set_by),
         )
+        if not already_retired:
+            rows = conn.execute(
+                "SELECT catalog_key FROM skills_catalog WHERE name=?",
+                (skill_name,),
+            ).fetchall()
+            from xskill.recommend.vector_dirty import (
+                mark_catalog_vector_dirty_on_connection,
+            )
+            for row in rows:
+                mark_catalog_vector_dirty_on_connection(
+                    conn, row["catalog_key"], operation="delete",
+                )
         conn.commit()
 
 
@@ -1203,6 +1239,30 @@ def unretire_skill(*, skill_name: str, db_path: Optional[Path] = None) -> bool:
     with pooled_connection(db_path) as conn:
         cur = conn.execute(
             "DELETE FROM skill_lifecycle WHERE skill_name=?", (skill_name,))
+        if cur.rowcount > 0:
+            from xskill.recommend.skill_vector_store import (
+                catalog_row_is_indexable,
+            )
+            from xskill.recommend.vector_dirty import (
+                mark_catalog_vector_dirty_on_connection,
+            )
+            rows = conn.execute(
+                """
+                SELECT catalog_key, name, source, description, content_sha,
+                       distributable
+                FROM skills_catalog WHERE name=?
+                """,
+                (skill_name,),
+            ).fetchall()
+            for row in rows:
+                stored = dict(row)
+                if catalog_row_is_indexable(stored):
+                    mark_catalog_vector_dirty_on_connection(
+                        conn,
+                        row["catalog_key"],
+                        operation="upsert",
+                        content_sha=row["content_sha"] or "",
+                    )
         conn.commit()
         return cur.rowcount > 0
 

--- a/src/xskill/recommend/heavy_worker.py
+++ b/src/xskill/recommend/heavy_worker.py
@@ -2,23 +2,69 @@
 from __future__ import annotations
 
 import logging
+import time
 from pathlib import Path
 from typing import Optional
 
 logger = logging.getLogger("xskill.recommend.heavy_worker")
 
 
-def _load_catalog_rows(db_path: Path) -> list[dict]:
+VECTOR_RECONCILE_INTERVAL_SECONDS = 24 * 60 * 60
+VECTOR_SYNC_ALGORITHM = "catalog-vector-dirty-v1"
+
+
+def _load_catalog_rows(
+    db_path: Path,
+    *,
+    catalog_keys: Optional[list[str]] = None,
+) -> list[dict]:
     from xskill.pipeline.registry import pooled_connection
 
     with pooled_connection(db_path) as conn:
+        where = ""
+        params: list = []
+        if catalog_keys is not None:
+            if not catalog_keys:
+                return []
+            placeholders = ",".join("?" for _ in catalog_keys)
+            where = f"WHERE c.catalog_key IN ({placeholders})"
+            params.extend(catalog_keys)
         rows = conn.execute(
-            """
-            SELECT catalog_key, name, source, description, content_sha, skill_id
-            FROM skills_catalog
-            """
+            f"""
+            SELECT c.catalog_key, c.name, c.source, c.description,
+                   c.content_sha, c.skill_id, c.distributable,
+                   CASE WHEN l.state='retired' THEN 1 ELSE 0 END AS retired
+            FROM skills_catalog AS c
+            LEFT JOIN skill_lifecycle AS l ON l.skill_name=c.name
+            {where}
+            """,  # noqa: S608 -- placeholders carry all external values
+            params,
         ).fetchall()
     return [dict(r) for r in rows]
+
+
+def _row_target(row: dict | None):
+    if row is None:
+        return None
+    from xskill.recommend.skill_vector_store import (
+        catalog_row_is_indexable,
+        content_sha_for_text,
+    )
+
+    if not catalog_row_is_indexable(row):
+        return None
+    description = (row.get("description") or "").strip()
+    return (
+        row.get("content_sha") or content_sha_for_text(description),
+        row.get("source") or "",
+        row.get("name") or "",
+        description,
+    )
+
+
+def _load_catalog_row(db_path: Path, catalog_key: str) -> dict | None:
+    rows = _load_catalog_rows(db_path, catalog_keys=[catalog_key])
+    return rows[0] if rows else None
 
 
 def run_vector_reconcile(
@@ -27,6 +73,8 @@ def run_vector_reconcile(
     vector_db_path: Path,
     embed=None,
     memory_index=None,
+    force_upsert: bool = False,
+    should_apply=None,
 ) -> dict:
     from xskill.recommend.skill_vector_store import (
         DEFAULT_DIM,
@@ -38,12 +86,153 @@ def run_vector_reconcile(
     rows = _load_catalog_rows(db_path)
     embed_fn = embed or (lambda text: fake_embed(text, DEFAULT_DIM))
     index = memory_index or open_skill_vector_index(vector_db_path, dim=DEFAULT_DIM)
-    stats = reconcile_catalog_to_index(index, rows, embed=embed_fn)
+    stats = reconcile_catalog_to_index(
+        index,
+        rows,
+        embed=embed_fn,
+        force_upsert=force_upsert,
+        should_apply=should_apply,
+    )
     logger.info(
         "vector reconcile: upserted=%s deleted=%s skipped=%s",
         stats["upserted"], stats["deleted"], stats["skipped"],
     )
     return stats
+
+
+def _full_apply_fence(
+    *,
+    db_path: Path,
+    snapshot_generations: dict[str, int],
+):
+    """构造低频全量对账的逐 key fence，避免写回扫描后的旧快照。"""
+    from xskill.pipeline.registry import pooled_connection
+    from xskill.recommend.vector_dirty import (
+        mark_catalog_vector_dirty_on_connection,
+    )
+
+    def _should_apply(catalog_key: str, snapshot_row: dict | None) -> bool:
+        with pooled_connection(db_path) as conn:
+            event = conn.execute(
+                """
+                SELECT generation FROM catalog_vector_dirty
+                WHERE catalog_key=? AND dirty=1
+                """,
+                (catalog_key,),
+            ).fetchone()
+            current_generation = int(event["generation"]) if event else None
+            expected_generation = snapshot_generations.get(catalog_key)
+            if current_generation != expected_generation:
+                return False
+        current_row = _load_catalog_row(db_path, catalog_key)
+        if _row_target(current_row) == _row_target(snapshot_row):
+            return True
+        # 非标准写入没有产生事件时也不写旧快照，并补一个可恢复的脏项。
+        target = _row_target(current_row)
+        with pooled_connection(db_path) as conn:
+            mark_catalog_vector_dirty_on_connection(
+                conn,
+                catalog_key,
+                operation="upsert" if target is not None else "delete",
+                content_sha=target[0] if target is not None else "",
+            )
+            conn.commit()
+        return False
+
+    return _should_apply
+
+
+def run_vector_sync(
+    *,
+    db_path: Path,
+    vector_db_path: Path,
+    index,
+    embed,
+    model_fingerprint: str,
+    force_full: bool = False,
+    now: float | None = None,
+    limit: int = 256,
+) -> dict:
+    """优先消费增量队列；首次/模型变化/低频周期执行全量修复。"""
+    from xskill.recommend.skill_vector_store import indexable_catalog_rows
+    from xskill.recommend.vector_dirty import (
+        catalog_vector_event_is_current,
+        catalog_vector_reconcile_reason,
+        clear_catalog_vector_dirty,
+        finish_catalog_vector_reconcile,
+        list_all_catalog_vector_generations,
+        list_catalog_vector_dirty,
+    )
+
+    reason = "ephemeral" if force_full else catalog_vector_reconcile_reason(
+        model_fingerprint,
+        db_path=db_path,
+        now=now,
+        interval_seconds=VECTOR_RECONCILE_INTERVAL_SECONDS,
+    )
+    if reason:
+        generations = list_all_catalog_vector_generations(db_path=db_path)
+        stats = run_vector_reconcile(
+            db_path=db_path,
+            vector_db_path=vector_db_path,
+            embed=embed,
+            memory_index=index,
+            # 升级 bootstrap 先复用旧索引中 content/source/name 一致的向量，
+            # 避免部署本 PR 就为整个 catalog 重付 embedding 成本。模型水位建立后，
+            # 真正的模型切换会强制全量重算；空/临时索引自然逐条 miss。
+            force_upsert=reason in {"model_changed", "ephemeral"},
+            should_apply=_full_apply_fence(
+                db_path=db_path,
+                snapshot_generations=generations,
+            ),
+        )
+        finish_catalog_vector_reconcile(
+            generations,
+            model_fingerprint=model_fingerprint,
+            reconciled_at=time.time() if now is None else now,
+            db_path=db_path,
+        )
+        return {**stats, "mode": "full", "reason": reason}
+
+    events = list_catalog_vector_dirty(db_path=db_path, limit=limit)
+    rows = _load_catalog_rows(
+        db_path,
+        catalog_keys=[event["catalog_key"] for event in events],
+    )
+    rows_by_key = {row["catalog_key"]: row for row in rows}
+    stats = {"upserted": 0, "deleted": 0, "skipped": 0, "deferred": 0}
+    for event in events:
+        key = event["catalog_key"]
+        generation = int(event["generation"])
+        row = rows_by_key.get(key)
+        wanted = indexable_catalog_rows([row]) if row is not None else []
+        if wanted:
+            target = wanted[0]
+            vector = embed(target["description"])
+            if not catalog_vector_event_is_current(
+                key, generation, db_path=db_path,
+            ):
+                stats["deferred"] += 1
+                continue
+            index.upsert(
+                key,
+                vector,
+                content_sha=target["content_sha"],
+                source=target.get("source") or "",
+                name=target.get("name") or "",
+            )
+            stats["upserted"] += 1
+        else:
+            if not catalog_vector_event_is_current(
+                key, generation, db_path=db_path,
+            ):
+                stats["deferred"] += 1
+                continue
+            index.delete(key)
+            stats["deleted"] += 1
+        if not clear_catalog_vector_dirty(key, generation, db_path=db_path):
+            stats["deferred"] += 1
+    return {**stats, "mode": "incremental", "reason": ""}
 
 
 def _skill_name_from_index(vector_index, catalog_key: str) -> str:
@@ -184,6 +373,23 @@ def _embed_fn_from_engine(engine):
     return _embed
 
 
+def _vector_index_identity(index, vector_db_path: Path) -> str:
+    """廉价识别持久索引实例；同路径数据库被重建后强制 bootstrap。"""
+    stored_path = getattr(index, "db_path", None)
+    if stored_path is not None:
+        path = Path(stored_path).expanduser().resolve()
+        try:
+            stat = path.stat()
+            return f"file:{path}:{stat.st_dev}:{stat.st_ino}"
+        except OSError:
+            return f"file:{path}:missing"
+    # 显式注入的内存/测试索引只在当前进程实例内可复用。
+    return (
+        f"object:{type(index).__module__}.{type(index).__qualname__}:"
+        f"{id(index)}:{Path(vector_db_path).expanduser().resolve()}"
+    )
+
+
 def run_recommend_heavy_once(
     *,
     engine,
@@ -197,6 +403,7 @@ def run_recommend_heavy_once(
     from xskill.recommend.recommend_store import mark_all_recommend_dirty
     from xskill.recommend.skill_vector_store import (
         DEFAULT_DIM,
+        MemorySkillVectorIndex,
         default_vector_db_path,
         fake_embed,
         open_skill_vector_index,
@@ -208,15 +415,32 @@ def run_recommend_heavy_once(
     if embed_fn is None:
         embed_fn = lambda text: fake_embed(text, DEFAULT_DIM)  # noqa: E731
         dim = DEFAULT_DIM
+        model_fingerprint = f"{VECTOR_SYNC_ALGORITHM}:fake:{dim}"
     else:
-        dim = len(embed_fn("dimension probe"))
+        client = engine.embed_client
+        dim = int(getattr(client, "dim", 0) or 0)
+        if dim <= 0:
+            # 正常 EmbedClient 在 engine 构造时已 probe；仅兼容自定义 client。
+            dim = len(embed_fn("dimension probe"))
+        model = str(getattr(client, "model", "") or "unknown")
+        model_fingerprint = f"{VECTOR_SYNC_ALGORITHM}:{model}:{dim}"
     # open_skill_vector_index：无 pymilvus 时退回内存索引并 hourly warn
     index = memory_index or open_skill_vector_index(vdb, dim=dim)
-    vec_stats = run_vector_reconcile(
+    model_fingerprint = (
+        f"{model_fingerprint}:{_vector_index_identity(index, vdb)}"
+    )
+    # 生产 fallback 每次都会创建空的内存索引，必须全量填充；调用方显式传入的
+    # memory_index 可跨 tick 复用，仍走增量路径（用于测试/嵌入式调用）。
+    ephemeral_index = memory_index is None and isinstance(
+        index, MemorySkillVectorIndex,
+    )
+    vec_stats = run_vector_sync(
         db_path=registry,
         vector_db_path=vdb,
         embed=embed_fn,
-        memory_index=index,
+        index=index,
+        model_fingerprint=model_fingerprint,
+        force_full=ephemeral_index,
     )
     if mark_catalog_dirty and (
         vec_stats.get("upserted", 0) or vec_stats.get("deleted", 0)

--- a/src/xskill/recommend/skill_vector_store.py
+++ b/src/xskill/recommend/skill_vector_store.py
@@ -131,7 +131,7 @@ class MilvusLiteSkillVectorIndex:
     """``~/.xskill/skill_vectors.db`` 嵌入式 Milvus Lite。"""
 
     def __init__(self, db_path: Path | str, *, dim: int = DEFAULT_DIM) -> None:
-        from pymilvus import DataType, MilvusClient
+        from pymilvus import MilvusClient
 
         self.db_path = Path(db_path)
         self.db_path.parent.mkdir(parents=True, exist_ok=True)
@@ -143,7 +143,26 @@ class MilvusLiteSkillVectorIndex:
         from pymilvus import DataType
 
         if self._client.has_collection(COLLECTION):
-            return
+            try:
+                described = self._client.describe_collection(COLLECTION)
+                current_dim = self._described_vector_dim(described)
+            except Exception:  # pylint: disable=broad-exception-caught
+                logger.warning(
+                    "cannot inspect existing Milvus collection dimension; "
+                    "keeping collection",
+                    exc_info=True,
+                )
+                return
+            if current_dim is None or current_dim == self.dim:
+                return
+            # 向量索引是 skills_catalog 的可重建投影。维度变化时 Milvus 不能原地
+            # 修改 schema，只能删 collection 后由本轮 model_changed 全量重灌。
+            logger.info(
+                "Milvus skill vector dimension changed: %s -> %s; rebuilding",
+                current_dim,
+                self.dim,
+            )
+            self._client.drop_collection(COLLECTION)
         schema = self._client.create_schema(auto_id=False, enable_dynamic_field=True)
         schema.add_field("id", DataType.INT64, is_primary=True)
         schema.add_field("catalog_key", DataType.VARCHAR, max_length=512)
@@ -156,6 +175,19 @@ class MilvusLiteSkillVectorIndex:
         self._client.create_collection(
             collection_name=COLLECTION, schema=schema, index_params=index_params,
         )
+
+    @staticmethod
+    def _described_vector_dim(description: dict) -> int | None:
+        """兼容 pymilvus 2.4+ describe_collection 的字段形状。"""
+        for field in description.get("fields", []) or []:
+            if field.get("name") != "vector":
+                continue
+            value = (field.get("params") or {}).get("dim", field.get("dim"))
+            try:
+                return int(value)
+            except (TypeError, ValueError):
+                return None
+        return None
 
     def upsert(
         self,
@@ -247,13 +279,24 @@ class MilvusLiteSkillVectorIndex:
 EmbedFn = Callable[[str], list[float]]
 
 
+def catalog_row_is_indexable(row: dict) -> bool:
+    """该 catalog 行当前是否可进入推荐向量索引。"""
+    if row.get("retired"):
+        return False
+    if not (row.get("description") or "").strip():
+        return False
+    # SkillHub 条目没有 native Git 分支，历史上 distributable 固定为 0，
+    # 但仍是可检索第三方技能；native 则只索引 main/staging 成品。
+    return row.get("source") == "skillhub" or bool(row.get("distributable", 1))
+
+
 def indexable_catalog_rows(rows: Iterable[dict]) -> list[dict]:
-    """过滤应写入向量索引的投影行（需非空 description）。"""
+    """过滤应写入向量索引的投影行。"""
     out = []
     for row in rows:
-        desc = (row.get("description") or "").strip()
-        if not desc:
+        if not catalog_row_is_indexable(row):
             continue
+        desc = (row.get("description") or "").strip()
         sha = row.get("content_sha") or content_sha_for_text(desc)
         out.append({**row, "content_sha": sha, "description": desc})
     return out
@@ -269,7 +312,12 @@ def sync_row_to_index(
     sha = row["content_sha"]
     key = row["catalog_key"]
     existing = index.get(key)
-    if existing and existing.get("content_sha") == sha:
+    if (
+        existing
+        and existing.get("content_sha") == sha
+        and (existing.get("source") or "") == (row.get("source") or "")
+        and (existing.get("name") or "") == (row.get("name") or "")
+    ):
         return
     index.upsert(
         key,
@@ -289,24 +337,60 @@ def reconcile_catalog_to_index(
     catalog_rows: Sequence[dict],
     *,
     embed: EmbedFn,
+    force_upsert: bool = False,
+    should_apply: Optional[Callable[[str, Optional[dict]], bool]] = None,
 ) -> dict:
-    """对账：投影表 → Milvus。返回 {upserted, deleted, skipped}。"""
+    """对账：投影表 → Milvus。``should_apply`` 用于并发 generation fence。"""
     wanted = {
         r["catalog_key"]: r for r in indexable_catalog_rows(catalog_rows)
     }
     existing_keys = index.list_keys()
-    upserted = deleted = skipped = 0
+    upserted = deleted = skipped = deferred = 0
     for key, row in wanted.items():
         cur = index.get(key)
-        if cur and cur.get("content_sha") == row["content_sha"]:
+        if (
+            not force_upsert
+            and cur
+            and cur.get("content_sha") == row["content_sha"]
+            and (cur.get("source") or "") == (row.get("source") or "")
+            and (cur.get("name") or "") == (row.get("name") or "")
+        ):
             skipped += 1
             continue
-        sync_row_to_index(index, row, embed=embed)
+        # content 未变、仅 source/name 元数据变化时复用旧向量，避免一次无意义的
+        # embedding；模型切换的 force_upsert 仍强制重算。
+        if (
+            not force_upsert
+            and cur
+            and cur.get("content_sha") == row["content_sha"]
+            and cur.get("vector") is not None
+        ):
+            vector = cur["vector"]
+        else:
+            vector = embed(row["description"])
+        if should_apply is not None and not should_apply(key, row):
+            deferred += 1
+            continue
+        index.upsert(
+            key,
+            vector,
+            content_sha=row["content_sha"],
+            source=row.get("source") or "",
+            name=row.get("name") or "",
+        )
         upserted += 1
     for key in existing_keys - set(wanted):
+        if should_apply is not None and not should_apply(key, None):
+            deferred += 1
+            continue
         index.delete(key)
         deleted += 1
-    return {"upserted": upserted, "deleted": deleted, "skipped": skipped}
+    return {
+        "upserted": upserted,
+        "deleted": deleted,
+        "skipped": skipped,
+        "deferred": deferred,
+    }
 
 
 def default_vector_db_path(xskill_home: Path | None = None) -> Path:

--- a/src/xskill/recommend/vector_dirty.py
+++ b/src/xskill/recommend/vector_dirty.py
@@ -1,0 +1,160 @@
+"""skills_catalog → 向量索引的持久化增量队列。"""
+from __future__ import annotations
+
+import time
+from pathlib import Path
+from typing import Optional
+
+from xskill.pipeline.registry import pooled_connection
+
+
+def mark_catalog_vector_dirty_on_connection(
+    conn,
+    catalog_key: str,
+    *,
+    operation: str,
+    content_sha: str = "",
+    marked_at: float | None = None,
+) -> None:
+    """在调用方事务中合并一个目标状态，并递增 generation。"""
+    if operation not in {"upsert", "delete"}:
+        raise ValueError(f"invalid catalog vector operation: {operation!r}")
+    conn.execute(
+        """
+        INSERT INTO catalog_vector_dirty(
+            catalog_key, generation, dirty, operation, content_sha, marked_at
+        ) VALUES (?, 1, 1, ?, ?, ?)
+        ON CONFLICT(catalog_key) DO UPDATE SET
+            generation=catalog_vector_dirty.generation + 1,
+            dirty=1,
+            operation=excluded.operation,
+            content_sha=excluded.content_sha,
+            marked_at=excluded.marked_at
+        """,
+        (catalog_key, operation, content_sha, time.time() if marked_at is None else marked_at),
+    )
+
+
+def list_catalog_vector_dirty(
+    *,
+    db_path: Optional[Path] = None,
+    limit: int = 256,
+) -> list[dict]:
+    with pooled_connection(db_path) as conn:
+        rows = conn.execute(
+            """
+            SELECT catalog_key, generation, operation, content_sha, marked_at
+            FROM catalog_vector_dirty
+            WHERE dirty=1
+            ORDER BY marked_at, catalog_key
+            LIMIT ?
+            """,
+            (max(1, int(limit)),),
+        ).fetchall()
+    return [dict(row) for row in rows]
+
+
+def list_all_catalog_vector_generations(
+    *, db_path: Optional[Path] = None,
+) -> dict[str, int]:
+    with pooled_connection(db_path) as conn:
+        rows = conn.execute(
+            """
+            SELECT catalog_key, generation FROM catalog_vector_dirty
+            WHERE dirty=1
+            """
+        ).fetchall()
+    return {row["catalog_key"]: int(row["generation"]) for row in rows}
+
+
+def catalog_vector_event_is_current(
+    catalog_key: str,
+    generation: int,
+    *,
+    db_path: Optional[Path] = None,
+) -> bool:
+    with pooled_connection(db_path) as conn:
+        row = conn.execute(
+            """
+            SELECT generation FROM catalog_vector_dirty
+            WHERE catalog_key=? AND dirty=1
+            """,
+            (catalog_key,),
+        ).fetchone()
+    return row is not None and int(row["generation"]) == int(generation)
+
+
+def clear_catalog_vector_dirty(
+    catalog_key: str,
+    generation: int,
+    *,
+    db_path: Optional[Path] = None,
+) -> bool:
+    """只确认观察到的 generation；晚到更新不会被旧 worker 删除。"""
+    with pooled_connection(db_path) as conn:
+        cursor = conn.execute(
+            """
+            UPDATE catalog_vector_dirty SET dirty=0
+            WHERE catalog_key=? AND generation=? AND dirty=1
+            """,
+            (catalog_key, int(generation)),
+        )
+        conn.commit()
+        return cursor.rowcount > 0
+
+
+def finish_catalog_vector_reconcile(
+    generations: dict[str, int],
+    *,
+    model_fingerprint: str,
+    reconciled_at: float | None = None,
+    db_path: Optional[Path] = None,
+) -> None:
+    """提交全量对账水位，并按 generation 清理开始时观察到的事件。"""
+    with pooled_connection(db_path) as conn:
+        for catalog_key, generation in generations.items():
+            conn.execute(
+                "UPDATE catalog_vector_dirty SET dirty=0 "
+                "WHERE catalog_key=? AND generation=? AND dirty=1",
+                (catalog_key, int(generation)),
+            )
+        conn.execute(
+            """
+            INSERT INTO catalog_vector_sync_meta(
+                singleton, model_fingerprint, reconciled_at
+            ) VALUES (1, ?, ?)
+            ON CONFLICT(singleton) DO UPDATE SET
+                model_fingerprint=excluded.model_fingerprint,
+                reconciled_at=excluded.reconciled_at
+            """,
+            (
+                model_fingerprint,
+                time.time() if reconciled_at is None else reconciled_at,
+            ),
+        )
+        conn.commit()
+
+
+def catalog_vector_reconcile_reason(
+    model_fingerprint: str,
+    *,
+    db_path: Optional[Path] = None,
+    now: float | None = None,
+    interval_seconds: float = 24 * 60 * 60,
+) -> str:
+    """返回 bootstrap/model/periodic；空串表示本轮走增量。"""
+    with pooled_connection(db_path) as conn:
+        row = conn.execute(
+            """
+            SELECT model_fingerprint, reconciled_at
+            FROM catalog_vector_sync_meta WHERE singleton=1
+            """
+        ).fetchone()
+    if row is None:
+        return "bootstrap"
+    if (row["model_fingerprint"] or "") != model_fingerprint:
+        return "model_changed"
+    current = time.time() if now is None else float(now)
+    if current - float(row["reconciled_at"] or 0) >= interval_seconds:
+        return "periodic"
+    return ""

--- a/src/xskill/skill/catalog_store.py
+++ b/src/xskill/skill/catalog_store.py
@@ -281,13 +281,72 @@ def catalog_api_row(stored: dict) -> dict:
     return row
 
 
-def _upsert_row(conn, row: dict) -> None:
+def _vector_target(row: dict | None, *, retired: bool = False):
+    if row is None:
+        return None
+    from xskill.recommend.skill_vector_store import (
+        catalog_row_is_indexable,
+        content_sha_for_text,
+    )
+
+    candidate = {**row, "retired": retired}
+    if not catalog_row_is_indexable(candidate):
+        return None
+    description = (candidate.get("description") or "").strip()
+    content_sha = candidate.get("content_sha") or content_sha_for_text(description)
+    return (
+        content_sha,
+        candidate.get("source") or "",
+        candidate.get("name") or "",
+        description,
+    )
+
+
+def _stored_vector_row(conn, catalog_key: str) -> tuple[dict | None, bool]:
+    row = conn.execute(
+        """
+        SELECT catalog_key, name, source, description, content_sha, distributable
+        FROM skills_catalog WHERE catalog_key=?
+        """,
+        (catalog_key,),
+    ).fetchone()
+    if row is None:
+        return None, False
+    retired = conn.execute(
+        "SELECT 1 FROM skill_lifecycle WHERE skill_name=? AND state='retired'",
+        (row["name"],),
+    ).fetchone() is not None
+    return dict(row), retired
+
+
+def _mark_vector_transition(
+    conn,
+    catalog_key: str,
+    old_target,
+    new_target,
+) -> None:
+    if old_target == new_target:
+        return
+    from xskill.recommend.vector_dirty import mark_catalog_vector_dirty_on_connection
+
+    mark_catalog_vector_dirty_on_connection(
+        conn,
+        catalog_key,
+        operation="upsert" if new_target is not None else "delete",
+        content_sha=new_target[0] if new_target is not None else "",
+    )
+
+
+def _upsert_row(conn, row: dict, *, mark_vector: bool = True) -> None:
     from xskill.recommend.skill_vector_store import content_sha_for_text
 
     description = row["description"]
     content_sha = row.get("content_sha") or (
         content_sha_for_text(description) if description else ""
     )
+    old_row = old_retired = None
+    if mark_vector:
+        old_row, old_retired = _stored_vector_row(conn, row["catalog_key"])
     conn.execute(
         """
         INSERT INTO skills_catalog(
@@ -335,6 +394,18 @@ def _upsert_row(conn, row: dict) -> None:
             content_sha,
         ),
     )
+    if mark_vector:
+        retired = conn.execute(
+            "SELECT 1 FROM skill_lifecycle WHERE skill_name=? AND state='retired'",
+            (row["name"],),
+        ).fetchone() is not None
+        new_row = {**row, "content_sha": content_sha}
+        _mark_vector_transition(
+            conn,
+            row["catalog_key"],
+            _vector_target(old_row, retired=bool(old_retired)),
+            _vector_target(new_row, retired=retired),
+        )
 
 
 _BACKFILL_WAIT_TIMEOUT_SECONDS = 120.0
@@ -381,10 +452,19 @@ def delete_native_skill(name: str, *, db_path: Path) -> None:
     if db_path is None:
         raise TypeError("skills_catalog delete requires explicit db_path")
     with pooled_connection(Path(db_path)) as conn:
+        catalog_key = _native_catalog_key(name)
+        old_row, old_retired = _stored_vector_row(conn, catalog_key)
         conn.execute(
             "DELETE FROM skills_catalog WHERE catalog_key=?",
-            (_native_catalog_key(name),),
+            (catalog_key,),
         )
+        if old_row is not None:
+            _mark_vector_transition(
+                conn,
+                catalog_key,
+                _vector_target(old_row, retired=old_retired),
+                None,
+            )
         conn.commit()
 
 
@@ -393,6 +473,12 @@ def delete_all_native(*, root_key: str = "", db_path: Path) -> int:
     if db_path is None:
         raise TypeError("skills_catalog wipe requires explicit db_path")
     with pooled_connection(Path(db_path)) as conn:
+        where = "source=? AND root_key=?" if root_key else "source=?"
+        params = (_SOURCE_NATIVE, root_key) if root_key else (_SOURCE_NATIVE,)
+        old_rows = conn.execute(
+            f"SELECT catalog_key FROM skills_catalog WHERE {where}",  # noqa: S608
+            params,
+        ).fetchall()
         if root_key:
             cursor = conn.execute(
                 "DELETE FROM skills_catalog WHERE source=? AND root_key=?",
@@ -402,6 +488,11 @@ def delete_all_native(*, root_key: str = "", db_path: Path) -> int:
             cursor = conn.execute(
                 "DELETE FROM skills_catalog WHERE source=?",
                 (_SOURCE_NATIVE,),
+            )
+        from xskill.recommend.vector_dirty import mark_catalog_vector_dirty_on_connection
+        for row in old_rows:
+            mark_catalog_vector_dirty_on_connection(
+                conn, row["catalog_key"], operation="delete",
             )
         conn.commit()
         return int(cursor.rowcount or 0)
@@ -421,10 +512,19 @@ def rename_native_skill(
         raise FileNotFoundError(f"skill path not found for catalog rename: {path}")
     row = _read_native_row(path)
     with pooled_connection(Path(db_path)) as conn:
+        old_key = _native_catalog_key(old_name)
+        old_row, old_retired = _stored_vector_row(conn, old_key)
         conn.execute(
             "DELETE FROM skills_catalog WHERE catalog_key=?",
-            (_native_catalog_key(old_name),),
+            (old_key,),
         )
+        if old_row is not None:
+            _mark_vector_transition(
+                conn,
+                old_key,
+                _vector_target(old_row, retired=old_retired),
+                None,
+            )
         _upsert_row(conn, row)
         conn.commit()
 
@@ -574,13 +674,44 @@ def backfill_skills_catalog(
     skillhub_key = _skillhub_fingerprint(skillhub)
     rows = scan_skills_catalog(skill_dir, skillhub=skillhub)
     with pooled_connection(db_path) as conn:
+        old_rows = conn.execute(
+            """
+            SELECT catalog_key, name, source, description, content_sha, distributable
+            FROM skills_catalog WHERE root_key=?
+            """,
+            (root,),
+        ).fetchall()
+        retired = {
+            row["skill_name"] for row in conn.execute(
+                "SELECT skill_name FROM skill_lifecycle WHERE state='retired'"
+            ).fetchall()
+        }
+        old_targets = {
+            row["catalog_key"]: _vector_target(
+                dict(row), retired=row["name"] in retired,
+            )
+            for row in old_rows
+        }
         conn.execute(
             "DELETE FROM skills_catalog WHERE root_key=?",
             (root,),
         )
         for row in rows:
             row["root_key"] = root
-            _upsert_row(conn, row)
+            _upsert_row(conn, row, mark_vector=False)
+        new_targets = {
+            row["catalog_key"]: _vector_target(
+                row, retired=row["name"] in retired,
+            )
+            for row in rows
+        }
+        for catalog_key in old_targets.keys() | new_targets.keys():
+            _mark_vector_transition(
+                conn,
+                catalog_key,
+                old_targets.get(catalog_key),
+                new_targets.get(catalog_key),
+            )
         conn.execute(
             """
             INSERT INTO skills_catalog_meta(root_key, backfilled_at, skillhub_key)

--- a/tests/test_skill_vector_incremental.py
+++ b/tests/test_skill_vector_incremental.py
@@ -1,0 +1,418 @@
+"""catalog_vector_dirty 增量同步、generation fence 与低频修复。"""
+from __future__ import annotations
+
+import sys
+from pathlib import Path
+from types import SimpleNamespace
+
+import pytest
+
+from xskill.pipeline import registry as registry_mod
+from xskill.pipeline.registry import get_connection, pooled_connection
+from xskill.recommend.heavy_worker import (
+    VECTOR_RECONCILE_INTERVAL_SECONDS,
+    run_vector_sync,
+)
+from xskill.recommend.skill_vector_store import (
+    DEFAULT_DIM,
+    MemorySkillVectorIndex,
+    MilvusLiteSkillVectorIndex,
+    content_sha_for_text,
+    fake_embed,
+)
+from xskill.recommend.vector_dirty import (
+    clear_catalog_vector_dirty,
+    list_catalog_vector_dirty,
+    mark_catalog_vector_dirty_on_connection,
+)
+from xskill.skill.catalog_store import (
+    delete_native_skill,
+    rename_native_skill,
+    upsert_native_skill,
+)
+
+
+class CountingIndex(MemorySkillVectorIndex):
+    def __init__(self) -> None:
+        super().__init__(dim=DEFAULT_DIM)
+        self.calls = {"upsert": 0, "delete": 0, "get": 0, "list_keys": 0}
+
+    def reset_calls(self) -> None:
+        for key in self.calls:
+            self.calls[key] = 0
+
+    def upsert(self, *args, **kwargs) -> None:
+        self.calls["upsert"] += 1
+        super().upsert(*args, **kwargs)
+
+    def delete(self, *args, **kwargs) -> None:
+        self.calls["delete"] += 1
+        super().delete(*args, **kwargs)
+
+    def get(self, *args, **kwargs):
+        self.calls["get"] += 1
+        return super().get(*args, **kwargs)
+
+    def list_keys(self) -> set[str]:
+        self.calls["list_keys"] += 1
+        return super().list_keys()
+
+
+@pytest.fixture()
+def registry_db(tmp_path: Path) -> Path:
+    db = tmp_path / "registry.db"
+    get_connection(db).close()
+    return db
+
+
+def _catalog_row(key: str, description: str, *, name: str | None = None) -> dict:
+    return {
+        "catalog_key": key,
+        "name": name or key.split(":", 1)[-1],
+        "source": "native",
+        "description": description,
+        "content_sha": content_sha_for_text(description),
+        "distributable": 1,
+    }
+
+
+def _store_catalog(db: Path, row: dict, *, mark: bool = True) -> None:
+    with pooled_connection(db) as conn:
+        conn.execute(
+            """
+            INSERT INTO skills_catalog(
+                catalog_key, name, source, state, description, distributable,
+                content_sha
+            ) VALUES (?, ?, ?, 'main', ?, ?, ?)
+            ON CONFLICT(catalog_key) DO UPDATE SET
+                name=excluded.name,
+                source=excluded.source,
+                description=excluded.description,
+                distributable=excluded.distributable,
+                content_sha=excluded.content_sha
+            """,
+            (
+                row["catalog_key"], row["name"], row["source"],
+                row["description"], row["distributable"], row["content_sha"],
+            ),
+        )
+        if mark:
+            mark_catalog_vector_dirty_on_connection(
+                conn,
+                row["catalog_key"],
+                operation="upsert",
+                content_sha=row["content_sha"],
+            )
+        conn.commit()
+
+
+def _sync(db: Path, index, *, model: str = "model-a", now: float = 100.0, embed=None):
+    return run_vector_sync(
+        db_path=db,
+        vector_db_path=db.parent / "vectors.db",
+        index=index,
+        embed=embed or (lambda text: fake_embed(text, DEFAULT_DIM)),
+        model_fingerprint=f"test:{model}:{DEFAULT_DIM}",
+        now=now,
+    )
+
+
+def _write_native_skill(root: Path, name: str, description: str) -> Path:
+    skill = root / name
+    skill.mkdir(parents=True, exist_ok=True)
+    (skill / "SKILL.md").write_text(
+        f"---\nname: {name}\ndescription: {description}\n---\n",
+        encoding="utf-8",
+    )
+    ref = skill / ".git" / "refs" / "heads" / "main"
+    ref.parent.mkdir(parents=True)
+    ref.write_text("a" * 40, encoding="utf-8")
+    return skill
+
+
+def test_idle_tick_does_not_scan_vector_index(registry_db):
+    index = CountingIndex()
+    _store_catalog(registry_db, _catalog_row("native:alpha", "alpha"))
+    first = _sync(registry_db, index)
+    assert first["mode"] == "full"
+    assert index.get("native:alpha") is not None
+
+    index.reset_calls()
+    embeds = []
+    second = _sync(
+        registry_db,
+        index,
+        now=101,
+        embed=lambda text: embeds.append(text) or fake_embed(text, DEFAULT_DIM),
+    )
+    assert second == {
+        "upserted": 0, "deleted": 0, "skipped": 0, "deferred": 0,
+        "mode": "incremental", "reason": "",
+    }
+    assert index.calls == {"upsert": 0, "delete": 0, "get": 0, "list_keys": 0}
+    assert embeds == []
+
+
+def test_upgrade_bootstrap_reuses_matching_legacy_vectors(registry_db):
+    index = CountingIndex()
+    row = _catalog_row("native:alpha", "alpha")
+    _store_catalog(registry_db, row, mark=False)
+    index.upsert(
+        row["catalog_key"],
+        fake_embed(row["description"]),
+        content_sha=row["content_sha"],
+        source=row["source"],
+        name=row["name"],
+    )
+    index.reset_calls()
+    embeds = []
+    stats = _sync(
+        registry_db,
+        index,
+        embed=lambda text: embeds.append(text) or fake_embed(text, DEFAULT_DIM),
+    )
+    assert stats["reason"] == "bootstrap"
+    assert stats["skipped"] == 1
+    assert index.calls["upsert"] == 0
+    assert embeds == []
+
+
+def test_one_dirty_skill_only_updates_that_key(registry_db):
+    index = CountingIndex()
+    _store_catalog(registry_db, _catalog_row("native:alpha", "alpha"))
+    _store_catalog(registry_db, _catalog_row("native:beta", "beta"))
+    _sync(registry_db, index)
+    index.reset_calls()
+
+    _store_catalog(registry_db, _catalog_row("native:beta", "beta v2"))
+    stats = _sync(registry_db, index, now=101)
+    assert stats["mode"] == "incremental"
+    assert stats["upserted"] == 1
+    assert index.calls == {"upsert": 1, "delete": 0, "get": 0, "list_keys": 0}
+    assert index._rows["native:alpha"]["content_sha"] == content_sha_for_text("alpha")
+    assert index._rows["native:beta"]["content_sha"] == content_sha_for_text("beta v2")
+
+
+def test_generation_cas_keeps_late_update_and_prevents_stale_write(registry_db):
+    index = CountingIndex()
+    _store_catalog(registry_db, _catalog_row("native:alpha", "v1"))
+    _sync(registry_db, index)
+    _store_catalog(registry_db, _catalog_row("native:alpha", "v2"))
+
+    def racing_embed(text: str):
+        assert text == "v2"
+        _store_catalog(registry_db, _catalog_row("native:alpha", "v3"))
+        return fake_embed(text, DEFAULT_DIM)
+
+    stats = _sync(registry_db, index, now=101, embed=racing_embed)
+    assert stats["upserted"] == 0
+    assert stats["deferred"] == 1
+    assert index._rows["native:alpha"]["content_sha"] == content_sha_for_text("v1")
+    assert list_catalog_vector_dirty(db_path=registry_db)[0]["generation"] == 3
+
+    stats = _sync(registry_db, index, now=102)
+    assert stats["upserted"] == 1
+    assert index._rows["native:alpha"]["content_sha"] == content_sha_for_text("v3")
+    assert list_catalog_vector_dirty(db_path=registry_db) == []
+
+
+def test_generation_watermark_prevents_aba_clear(registry_db):
+    row = _catalog_row("native:alpha", "v1")
+    _store_catalog(registry_db, row)
+    first = list_catalog_vector_dirty(db_path=registry_db)[0]
+    assert clear_catalog_vector_dirty(
+        first["catalog_key"], first["generation"], db_path=registry_db,
+    )
+
+    _store_catalog(registry_db, _catalog_row("native:alpha", "v2"))
+    second = list_catalog_vector_dirty(db_path=registry_db)[0]
+    assert second["generation"] > first["generation"]
+    assert not clear_catalog_vector_dirty(
+        first["catalog_key"], first["generation"], db_path=registry_db,
+    )
+    assert list_catalog_vector_dirty(db_path=registry_db)[0]["generation"] == second[
+        "generation"
+    ]
+
+
+def test_model_switch_forces_reembedding_and_periodic_repairs_ghost(registry_db):
+    index = CountingIndex()
+    _store_catalog(registry_db, _catalog_row("native:alpha", "alpha"))
+    _sync(registry_db, index, model="model-a")
+    index.reset_calls()
+
+    changed = _sync(registry_db, index, model="model-b", now=101)
+    assert changed["mode"] == "full"
+    assert changed["reason"] == "model_changed"
+    assert changed["upserted"] == 1
+    assert index.calls["list_keys"] == 1
+    assert index.calls["upsert"] == 1
+
+    index.upsert(
+        "native:ghost", fake_embed("ghost"), content_sha="ghost",
+        source="native", name="ghost",
+    )
+    repaired = _sync(
+        registry_db,
+        index,
+        model="model-b",
+        now=101 + VECTOR_RECONCILE_INTERVAL_SECONDS,
+    )
+    assert repaired["reason"] == "periodic"
+    assert repaired["deleted"] == 1
+    assert index.get("native:ghost") is None
+
+
+def test_full_reconcile_updates_metadata_when_content_sha_is_unchanged(registry_db):
+    index = CountingIndex()
+    row = _catalog_row("native:alpha", "same text", name="old-name")
+    _store_catalog(registry_db, row)
+    _sync(registry_db, index)
+
+    renamed = {**row, "name": "new-name", "source": "skillhub"}
+    _store_catalog(registry_db, renamed)
+    embeds = []
+    stats = _sync(
+        registry_db,
+        index,
+        now=100 + VECTOR_RECONCILE_INTERVAL_SECONDS,
+        embed=lambda text: embeds.append(text) or fake_embed(text, DEFAULT_DIM),
+    )
+    assert stats["mode"] == "full"
+    assert stats["upserted"] == 1
+    assert index._rows["native:alpha"]["name"] == "new-name"
+    assert index._rows["native:alpha"]["source"] == "skillhub"
+    assert embeds == []
+
+
+def test_catalog_writes_coalesce_and_emit_rename_tombstone(registry_db, tmp_path):
+    root = tmp_path / "skills"
+    old = _write_native_skill(root, "old-name", "first description")
+    upsert_native_skill(old, db_path=registry_db)
+    event = list_catalog_vector_dirty(db_path=registry_db)[0]
+    assert event["catalog_key"] == "native:old-name"
+    assert event["operation"] == "upsert"
+
+    upsert_native_skill(old, db_path=registry_db)
+    unchanged = list_catalog_vector_dirty(db_path=registry_db)[0]
+    assert unchanged["generation"] == event["generation"]
+
+    assert clear_catalog_vector_dirty(
+        unchanged["catalog_key"], unchanged["generation"], db_path=registry_db,
+    )
+    new = _write_native_skill(root, "new-name", "renamed description")
+    rename_native_skill("old-name", new, db_path=registry_db)
+    events = {row["catalog_key"]: row for row in list_catalog_vector_dirty(
+        db_path=registry_db,
+    )}
+    assert events["native:old-name"]["operation"] == "delete"
+    assert events["native:new-name"]["operation"] == "upsert"
+
+    delete_native_skill("new-name", db_path=registry_db)
+    events = {row["catalog_key"]: row for row in list_catalog_vector_dirty(
+        db_path=registry_db,
+    )}
+    assert events["native:new-name"]["operation"] == "delete"
+
+
+def test_retire_and_unretire_emit_delete_and_upsert(registry_db):
+    row = _catalog_row("native:alpha", "alpha")
+    _store_catalog(registry_db, row, mark=False)
+    registry_mod.retire_skill(skill_name="alpha", set_by="test", db_path=registry_db)
+    event = list_catalog_vector_dirty(db_path=registry_db)[0]
+    assert event["operation"] == "delete"
+    assert registry_mod.unretire_skill(skill_name="alpha", db_path=registry_db)
+    event = list_catalog_vector_dirty(db_path=registry_db)[0]
+    assert event["operation"] == "upsert"
+    assert event["generation"] == 2
+
+
+def test_heavy_tick_reuses_known_embedding_dimension(registry_db, tmp_path):
+    from xskill.recommend.heavy_worker import run_recommend_heavy_once
+
+    class EmbedClient:
+        dim = DEFAULT_DIM
+        model = "known-dim"
+
+        def __init__(self):
+            self.calls = []
+
+        def encode(self, text):
+            self.calls.append(text)
+            return fake_embed(text, DEFAULT_DIM)
+
+    class Engine:
+        embed_client = EmbedClient()
+
+    stats = run_recommend_heavy_once(
+        engine=Engine(),
+        db_path=registry_db,
+        vector_db_path=tmp_path / "vectors.db",
+        memory_index=MemorySkillVectorIndex(),
+    )
+    assert stats["vector"]["mode"] == "full"
+    assert Engine.embed_client.calls == []
+
+
+@pytest.mark.parametrize(
+    ("description", "expected"),
+    [
+        ({"fields": [{"name": "vector", "params": {"dim": 1536}}]}, 1536),
+        ({"fields": [{"name": "vector", "dim": "1024"}]}, 1024),
+        ({"fields": [{"name": "catalog_key", "params": {}}]}, None),
+    ],
+)
+def test_milvus_description_dimension_parsing(description, expected):
+    assert MilvusLiteSkillVectorIndex._described_vector_dim(description) == expected
+
+
+def test_milvus_dimension_change_recreates_projection(monkeypatch):
+    class Schema:
+        def __init__(self):
+            self.fields = []
+
+        def add_field(self, *args, **kwargs):
+            self.fields.append((args, kwargs))
+
+    class Client:
+        def __init__(self):
+            self.dropped = []
+            self.schema = Schema()
+            self.created = []
+
+        def has_collection(self, _name):
+            return True
+
+        def describe_collection(self, _name):
+            return {"fields": [{"name": "vector", "params": {"dim": 4}}]}
+
+        def drop_collection(self, name):
+            self.dropped.append(name)
+
+        def create_schema(self, **_kwargs):
+            return self.schema
+
+        def prepare_index_params(self):
+            return SimpleNamespace(add_index=lambda **_kwargs: None)
+
+        def create_collection(self, **kwargs):
+            self.created.append(kwargs)
+
+    monkeypatch.setitem(
+        sys.modules,
+        "pymilvus",
+        SimpleNamespace(
+            DataType=SimpleNamespace(INT64=1, VARCHAR=2, FLOAT_VECTOR=3),
+        ),
+    )
+    index = object.__new__(MilvusLiteSkillVectorIndex)
+    index.dim = DEFAULT_DIM
+    index._client = Client()
+    index._ensure_collection()
+    assert index._client.dropped == ["skill_vectors"]
+    assert index._client.created
+    vector_fields = [
+        kwargs for _args, kwargs in index._client.schema.fields
+        if _args and _args[0] == "vector"
+    ]
+    assert vector_fields[0]["dim"] == DEFAULT_DIM


### PR DESCRIPTION
## Summary

将技能向量重任务从每轮扫描全部 catalog 和向量 key 改为消费持久化脏技能队列；无变化周期只做有索引的 SQLite 空队列查询，不再调用 `list_keys()`、逐条 `get()` 或 embedding。

## Changes

- 在 `skills_catalog` 写入事务内维护 `catalog_vector_dirty`，覆盖新增、描述/来源/名称变化、删除、重命名、wipe、SkillHub backfill、下线与恢复
- 使用单调 generation 水位和 CAS 确认消费，避免晚到更新及 generation ABA 被旧 worker 误清；失败事件保留重试
- worker 批量读取脏 key 的 catalog 当前状态，单技能变化只更新单技能；启动、模型/索引身份变化及每 24 小时保留全量 reconciliation 修复遗漏
- 升级 bootstrap 复用 `content_sha/source/name` 一致的旧向量，模型变化强制重算；向量维度变化时重建可恢复的 Milvus collection
- native baby/unknown、空描述及已下线技能写 tombstone，SkillHub 条目保持可索引
- 复用 `EmbedClient.dim`，取消每轮额外的 `dimension probe` 请求；同内容仅元数据变化的全量修复复用已有向量
- 内存 fallback 为短命索引时仍每轮全量填充，避免增量模式导致推荐索引为空

## Performance / correctness checks

- 空闲增量 tick：0 次 `list_keys`、0 次 `get`、0 次 upsert/delete、0 次 embedding
- 单个脏技能：只执行 1 次对应向量 upsert，不扫描其他向量 key
- 覆盖 generation 晚到更新、ABA、重复无变化写入、删除/重命名、下线/恢复、来源元数据变化、模型切换、维度切换、周期 ghost 修复和 legacy bootstrap

## Test plan

- [x] 聚焦回归：66 passed
- [x] 全量测试：2301 passed, 10 skipped
- [x] Changed-file Ruff 与 `git diff --check`：通过
- [x] 当前提交 wheel Docker E2E：`runtime_ecosystem_detect`、`runtime_openclaw_detect` 通过

## Linked issues

Closes #298
