### PR TITLE
perf(atom-index): 增量维护 Atom 向量索引

### DIFF
--- a/src/xskill/pipeline/atom.py
+++ b/src/xskill/pipeline/atom.py
@@ -4,9 +4,11 @@
 每个 ``AtomTask`` 是一段 multi-chat-turn（1-10 轮），由 ``TaskAgent`` 从
 轨迹按"用户意图切换"切出来。内容落盘到
 ``<root>/<traj_id>/tasks/atom_*.json``，``watcher`` 用 ``last_offset`` 决定
-增量起点；隐藏 SQLite 只保存可重建的 Atom→路径定位投影，不保存业务内容。
+增量起点；隐藏 SQLite 保存可重建的 Atom→路径定位和向量检索投影，JSON 始终
+是业务事实源。
 
-向量索引（基于 atom 的 ``summary or intent`` 嵌入）持久化在 ``<root>/index.pkl``。
+向量索引（基于 atom 的 ``summary or intent`` 嵌入）持久化在隐藏 SQLite；
+``<root>/index.pkl`` 仅保留兼容旧发现路径的小型标记。
 ``HybridSearch`` (在 ``xskill.utils.search``) 把本模块的 ``vector_search`` 跟
 BM25 关键字检索做 union+dedup。
 
@@ -31,6 +33,7 @@ from typing import Iterator
 import numpy as np
 
 from xskill._sqlite_connect import connect_with_lock
+from xskill.pipeline.atom_vector_index import VECTOR_DB_FILE, AtomVectorProjection
 
 logger = logging.getLogger("xskill.ux_score")
 
@@ -88,19 +91,18 @@ class AtomTask:
 
 
 class AtomTaskStore:
-    """文件系统存储：``<root>/<traj_id>/tasks/atom_*.json`` + ``<root>/index.pkl``。
+    """JSON 事实源 + Atom 定位/向量 SQLite 投影 + 小型 ``index.pkl`` 标记。
 
     设计取舍：
-    - **JSON 是事实源**: 文件读写直接、调试方便；SQLite 仅作可重建定位投影。
+    - **JSON 是事实源**: 文件读写直接、调试方便；SQLite 仅作可重建投影。
     - **每 traj 一个子目录**: 让 watcher 按 traj 粒度做增量处理，``list_by_traj``
       不需要全表扫。
-    - **向量索引增量重建**: TaskAgent 每给一条 traj 拆出新 atom 后由 watcher
-      触发一次 ``rebuild_vector_index``；按 ``atom_id`` 复用旧 index.pkl 中同
-      模型的向量，只对新原子调 embedding（换模型则整体重算，护栏见方法内），
-      避免攒了上万原子的 client 新增几条就全量重 embed。
+    - **向量索引增量维护**: ``save_many`` 只登记变化 Atom，watcher 只 embed / 写
+      这些行；模型变化和低频一致性核对才从 JSON 原子重建。
     """
 
     INDEX_FILE = "index.pkl"
+    VECTOR_INDEX_FILE = VECTOR_DB_FILE
     LOCATION_INDEX_FILE = ".atom_locations.sqlite3"
     _LOCATION_SCHEMA = """
     CREATE TABLE IF NOT EXISTS atom_locations (
@@ -124,6 +126,10 @@ class AtomTaskStore:
         self._location_lock = _location_lock_for(self.root)
         self._location_schema_ready = False
         self._location_index_complete: bool | None = None
+        self._vector_projection = AtomVectorProjection(
+            self.root,
+            self._location_lock,
+        )
 
     # ── paths ─────────────────────────────────────────────────────
 
@@ -319,9 +325,12 @@ class AtomTaskStore:
         return count
 
     def remove_locations_for_trajs(self, traj_ids) -> None:
-        """Atom 文件删除/reset 后同步清理对应轨迹的定位行。"""
+        """Atom 文件删除/reset 后同步清理对应轨迹的定位行与向量行。"""
         ids = sorted({str(traj_id) for traj_id in traj_ids if traj_id})
-        if not ids or not self._location_index_path().is_file():
+        if not ids:
+            return
+        self._vector_projection.remove_trajs(ids)
+        if not self._location_index_path().is_file():
             return
         try:
             connection = self._location_connection()
@@ -382,6 +391,15 @@ class AtomTaskStore:
             logger.warning(
                 "atom location projection batch update failed: %s",
                 [str(path) for path, _traj_id in saved],
+                exc_info=True,
+            )
+        try:
+            self._vector_projection.record_atoms(atoms)
+        except (OSError, sqlite3.DatabaseError):
+            # JSON 是事实源；向量投影失败不回滚事实写，后续 rebuild/低频核对修复。
+            logger.warning(
+                "atom vector projection batch update failed: %s",
+                [atom.atom_id for atom in atoms],
                 exc_info=True,
             )
         return [path for path, _traj_id in saved]
@@ -561,73 +579,37 @@ class AtomTaskStore:
 
     # ── vector index ──────────────────────────────────────────────
 
-    def _load_vector_cache(self, model: str) -> dict:
-        """增量 embedding 复用源：``{atom_id: 归一化向量(D,)}``。
+    def rebuild_vector_index(self, embed_client, *, force_full: bool = False) -> dict:
+        """消费增量向量行；模型变化、显式请求或低频到期时原子全量重建。"""
+        return self._vector_projection.rebuild(
+            embed_client,
+            force_full=force_full,
+        )
 
-        仅当已落盘 index.pkl 的 ``model`` 字段与当前 ``model`` 一致才返回缓存
-        （换 embedding 模型 → 旧向量与当前模型不同源作废，返回空 dict 强制整体
-        重算，护栏在此不混用不同模型的向量）。无索引文件 / 结构缺字段 → 空 dict。
-        """
-        p = self._index_path()
-        if not p.is_file():
-            return {}
-        with open(p, "rb") as f:
-            data = pickle.load(f)
-        if (data.get("model") or "") != (model or ""):
-            return {}
-        atom_ids = data.get("atom_ids") or []
-        embeddings = data.get("embeddings")
-        if embeddings is None:
-            return {}
-        return {
-            aid: embeddings[i]
-            for i, aid in enumerate(atom_ids)
-            if i < len(embeddings) and aid
-        }
-
-    def rebuild_vector_index(self, embed_client) -> None:
-        """增量重建索引：复用旧 index.pkl 中同模型的向量，只对新原子调 embedding。
-
-        - 旧索引 ``model`` 与当前 ``embed_client.model`` 一致时，按 ``atom_id``
-          复用其向量（atom 内容随 id 不可变，复用安全）；换模型则整体重算。
-        - 只对**没在缓存里的** atom_id 调 ``encode_batch``，其余复用缓存向量。
-        - 新索引只含当前 ``all_atoms()`` 的原子——被删除/reset 的原子自然不残留。
-        - 复用向量本就归一化落盘；新算向量照旧 L2 归一。最终 embeddings 行顺序
-          与 atom_ids、与 ``all_atoms()`` 顺序严格对齐。
-
-        无 atom 时直接返回（不写空索引文件——``vector_search`` 自己处理无索引情况）。
-        """
-        atoms = list(self.all_atoms())
-        if not atoms:
-            return
-        model = getattr(embed_client, "model", "")
-        cache = self._load_vector_cache(model)
-        missing = [a for a in atoms if a.atom_id not in cache]
-        if missing:
-            texts = [a.summary or a.intent for a in missing]
-            fresh = np.asarray(embed_client.encode_batch(texts))
-            norms = np.linalg.norm(fresh, axis=1, keepdims=True)
-            norms[norms == 0] = 1
-            fresh = fresh / norms
-            cache = dict(cache)
-            for a, v in zip(missing, fresh):
-                cache[a.atom_id] = v
-        vecs = np.asarray([cache[a.atom_id] for a in atoms])
-        self.root.mkdir(parents=True, exist_ok=True)
-        with open(self._index_path(), "wb") as f:
-            pickle.dump({
-                "atom_ids": [a.atom_id for a in atoms],
-                "embeddings": vecs,
-                "model": model,
-                "dim": int(vecs.shape[1]),
-            }, f)
+    def vector_index_reconcile_due(self) -> bool:
+        """空闲 watcher 是否需执行启动迁移或低频事实源一致性核对。"""
+        return self._vector_projection.reconcile_due()
 
     def vector_search(self, query: str, embed_client, top_k: int = 5) -> list[dict]:
+        if top_k <= 0:
+            return []
+        projected = self._vector_projection.search(
+            query,
+            embed_client,
+            top_k=top_k,
+        )
+        if projected is not None:
+            return projected
+        # 升级期间、首次 watcher 对账前兼容旧 index.pkl。
         p = self._index_path()
         if not p.is_file():
             return []
         with open(p, "rb") as f:
             data = pickle.load(f)
+        if data.get("format") or (
+            data.get("model") or ""
+        ) != (getattr(embed_client, "model", "") or ""):
+            return []
         q = embed_client.encode(query)
         qn = np.linalg.norm(q)
         if qn > 0:

--- a/src/xskill/pipeline/atom.py
+++ b/src/xskill/pipeline/atom.py
@@ -396,7 +396,9 @@ class AtomTaskStore:
         try:
             self._vector_projection.record_atoms(atoms)
         except (OSError, sqlite3.DatabaseError):
-            # JSON 是事实源；向量投影失败不回滚事实写，后续 rebuild/低频核对修复。
+            # JSON 是事实源；向量投影失败不回滚事实写，但必须立刻标 dirty
+            # 否则 complete 索引会干等 24h 才把新 atom 补进检索。
+            self._vector_projection.mark_rebuild_needed()
             logger.warning(
                 "atom vector projection batch update failed: %s",
                 [atom.atom_id for atom in atoms],

--- a/src/xskill/pipeline/atom_vector_index.py
+++ b/src/xskill/pipeline/atom_vector_index.py
@@ -1,0 +1,721 @@
+"""Atom JSON 事实源的可重建、增量 SQLite 向量投影。"""
+from __future__ import annotations
+
+import hashlib
+import heapq
+import json
+import logging
+import pickle
+import sqlite3
+import time
+import uuid
+from collections.abc import Iterator
+from pathlib import Path
+
+import numpy as np
+
+from xskill._sqlite_connect import connect_with_lock
+
+logger = logging.getLogger("xskill.atom_vector_index")
+
+VECTOR_DB_FILE = ".atom_vectors.sqlite3"
+LEGACY_INDEX_FILE = "index.pkl"
+FORMAT = "atom-vector-sqlite-v1"
+RECONCILE_INTERVAL_SECONDS = 24 * 60 * 60
+EMBED_BATCH_SIZE = 128
+SEARCH_FETCH_SIZE = 512
+
+_SCHEMA = """
+CREATE TABLE IF NOT EXISTS atom_vectors (
+    atom_id      TEXT PRIMARY KEY,
+    traj_id      TEXT NOT NULL,
+    vector_text  TEXT NOT NULL,
+    text_sha     TEXT NOT NULL,
+    generation   INTEGER NOT NULL DEFAULT 1,
+    embedding    BLOB,
+    dim          INTEGER NOT NULL DEFAULT 0
+);
+CREATE INDEX IF NOT EXISTS idx_atom_vectors_traj ON atom_vectors(traj_id);
+CREATE INDEX IF NOT EXISTS idx_atom_vectors_pending
+    ON atom_vectors(atom_id) WHERE embedding IS NULL;
+CREATE TABLE IF NOT EXISTS atom_vector_traj_state (
+    traj_id        TEXT PRIMARY KEY,
+    tasks_mtime_ns INTEGER NOT NULL
+);
+CREATE TABLE IF NOT EXISTS atom_vector_meta (
+    singleton     INTEGER PRIMARY KEY CHECK(singleton=1),
+    format        TEXT NOT NULL,
+    model         TEXT NOT NULL,
+    complete      INTEGER NOT NULL DEFAULT 0,
+    reconciled_at REAL NOT NULL DEFAULT 0
+);
+"""
+
+
+def _text_sha(text: str) -> str:
+    return hashlib.sha256(text.encode("utf-8")).hexdigest()[:16]
+
+
+def _vector_input(atom) -> tuple[str, str, str, str]:
+    text = atom.summary or atom.intent
+    return atom.atom_id, atom.traj_id, text, _text_sha(text)
+
+
+def _json_vector_input(path: Path, traj_id: str) -> tuple[str, str, str, str]:
+    data = json.loads(path.read_text(encoding="utf-8"))
+    text = str(data.get("summary") or data.get("intent") or "")
+    return str(data["atom_id"]), traj_id, text, _text_sha(text)
+
+
+def _normalized_rows(vectors, expected: int) -> np.ndarray:
+    fresh = np.asarray(vectors, dtype=np.float32)
+    if fresh.ndim == 1 and expected == 1:
+        fresh = fresh.reshape(1, -1)
+    if fresh.ndim != 2 or fresh.shape[0] != expected or fresh.shape[1] <= 0:
+        raise ValueError(
+            f"embedding batch shape mismatch: expected {expected} rows, got {fresh.shape}"
+        )
+    norms = np.linalg.norm(fresh, axis=1, keepdims=True)
+    norms[norms == 0] = 1
+    return fresh / norms
+
+
+class AtomVectorProjection:
+    """每个 Atom store 一份 SQLite 投影；调用方传入与 JSON 写路径共享的锁。"""
+
+    def __init__(self, root: Path, lock) -> None:
+        self.root = Path(root)
+        self.lock = lock
+        self._schema_ready = False
+        self._pending_hint = False
+        self._next_reconcile_at: float | None = None
+
+    @property
+    def path(self) -> Path:
+        return self.root / VECTOR_DB_FILE
+
+    @property
+    def marker_path(self) -> Path:
+        return self.root / LEGACY_INDEX_FILE
+
+    def _connect(self, path: Path | None = None):
+        target = path or self.path
+        connection = connect_with_lock(sqlite3.connect, str(target), timeout=5.0)
+        connection.row_factory = sqlite3.Row
+        if path is None and self._schema_ready:
+            return connection
+        try:
+            connection.executescript(_SCHEMA)
+        except Exception:
+            connection.close()
+            raise
+        if path is None:
+            self._schema_ready = True
+        return connection
+
+    @staticmethod
+    def _upsert_target(connection, target: tuple[str, str, str, str]) -> None:
+        connection.execute(
+            """
+            INSERT INTO atom_vectors(
+                atom_id, traj_id, vector_text, text_sha, generation,
+                embedding, dim
+            ) VALUES (?, ?, ?, ?, 1, NULL, 0)
+            ON CONFLICT(atom_id) DO UPDATE SET
+                traj_id=excluded.traj_id,
+                vector_text=excluded.vector_text,
+                text_sha=excluded.text_sha,
+                generation=CASE
+                    WHEN atom_vectors.text_sha != excluded.text_sha
+                    THEN atom_vectors.generation + 1
+                    ELSE atom_vectors.generation
+                END,
+                embedding=CASE
+                    WHEN atom_vectors.text_sha = excluded.text_sha
+                    THEN atom_vectors.embedding ELSE NULL
+                END,
+                dim=CASE
+                    WHEN atom_vectors.text_sha = excluded.text_sha
+                    THEN atom_vectors.dim ELSE 0
+                END
+            """,
+            target,
+        )
+
+    def _tasks_mtime(self, traj_id: str) -> int:
+        try:
+            return int((self.root / traj_id / "tasks").stat().st_mtime_ns)
+        except OSError:
+            return 0
+
+    def record_atoms(self, atoms: list) -> None:
+        """JSON 已落盘后记录目标文本；非向量字段保存不会让 embedding 失效。"""
+        if not atoms:
+            return
+        self.root.mkdir(parents=True, exist_ok=True)
+        targets = [_vector_input(atom) for atom in atoms]
+        traj_ids = sorted({target[1] for target in targets})
+        with self.lock:
+            connection = self._connect()
+            try:
+                connection.execute("BEGIN IMMEDIATE")
+                for target in targets:
+                    self._upsert_target(connection, target)
+                for traj_id in traj_ids:
+                    connection.execute(
+                        """
+                        INSERT INTO atom_vector_traj_state(traj_id, tasks_mtime_ns)
+                        VALUES (?, ?)
+                        ON CONFLICT(traj_id) DO UPDATE SET
+                            tasks_mtime_ns=excluded.tasks_mtime_ns
+                        """,
+                        (traj_id, self._tasks_mtime(traj_id)),
+                    )
+                self._pending_hint = connection.execute(
+                    "SELECT 1 FROM atom_vectors WHERE embedding IS NULL LIMIT 1"
+                ).fetchone() is not None
+                connection.commit()
+            finally:
+                connection.close()
+
+    def remove_trajs(self, traj_ids) -> None:
+        ids = sorted({str(traj_id) for traj_id in traj_ids if traj_id})
+        if not ids or not self.path.is_file():
+            return
+        with self.lock:
+            try:
+                connection = self._connect()
+                try:
+                    connection.execute("BEGIN IMMEDIATE")
+                    connection.executemany(
+                        "DELETE FROM atom_vectors WHERE traj_id=?",
+                        [(traj_id,) for traj_id in ids],
+                    )
+                    connection.executemany(
+                        "DELETE FROM atom_vector_traj_state WHERE traj_id=?",
+                        [(traj_id,) for traj_id in ids],
+                    )
+                    self._pending_hint = connection.execute(
+                        "SELECT 1 FROM atom_vectors WHERE embedding IS NULL LIMIT 1"
+                    ).fetchone() is not None
+                    connection.commit()
+                finally:
+                    connection.close()
+                self._write_marker()
+            except (OSError, sqlite3.DatabaseError):
+                logger.warning("atom vector reset failed: %s", self.path, exc_info=True)
+
+    def _meta(self) -> dict | None:
+        if not self.path.is_file():
+            return None
+        connection = self._connect()
+        try:
+            row = connection.execute(
+                """
+                SELECT format, model, complete, reconciled_at
+                FROM atom_vector_meta WHERE singleton=1
+                """
+            ).fetchone()
+        finally:
+            connection.close()
+        return dict(row) if row else None
+
+    def reconcile_due(self, *, now: float | None = None) -> bool:
+        """供 watcher 空闲轮询 O(1) 判断是否需启动/低频事实源核对。"""
+        current = time.time() if now is None else float(now)
+        if self._pending_hint:
+            return True
+        if (
+            self._next_reconcile_at is not None
+            and current < self._next_reconcile_at
+        ):
+            return False
+        if not self.path.is_file():
+            return self.marker_path.is_file()
+        try:
+            connection = self._connect()
+            try:
+                row = connection.execute(
+                    """
+                    SELECT format, model, complete, reconciled_at
+                    FROM atom_vector_meta WHERE singleton=1
+                    """
+                ).fetchone()
+                pending = connection.execute(
+                    "SELECT 1 FROM atom_vectors WHERE embedding IS NULL LIMIT 1"
+                ).fetchone()
+            finally:
+                connection.close()
+        except (OSError, sqlite3.DatabaseError):
+            return True
+        meta = dict(row) if row else None
+        if not meta or meta["format"] != FORMAT or not meta["complete"]:
+            return True
+        if pending is not None:
+            self._pending_hint = True
+            return True
+        self._next_reconcile_at = (
+            float(meta["reconciled_at"] or 0) + RECONCILE_INTERVAL_SECONDS
+        )
+        return current >= self._next_reconcile_at
+
+    def _iter_task_dirs(self) -> Iterator[tuple[str, Path]]:
+        if not self.root.is_dir():
+            return
+        for traj_dir in sorted(self.root.iterdir()):
+            if not traj_dir.is_dir():
+                continue
+            tasks = traj_dir / "tasks"
+            if tasks.is_dir():
+                yield traj_dir.name, tasks
+
+    @staticmethod
+    def _iter_task_paths(tasks: Path) -> Iterator[Path]:
+        yield from sorted(tasks.glob("atom_*.json"))
+
+    def _reconcile_changed_trajs(self, connection) -> tuple[int, int]:
+        stored = {
+            row["traj_id"]: int(row["tasks_mtime_ns"])
+            for row in connection.execute(
+                "SELECT traj_id, tasks_mtime_ns FROM atom_vector_traj_state"
+            ).fetchall()
+        }
+        current = {}
+        for traj_id, tasks in self._iter_task_dirs():
+            try:
+                current[traj_id] = (tasks, int(tasks.stat().st_mtime_ns))
+            except OSError:
+                # A direct external reset may remove the directory between
+                # discovery and stat.  Treat it as absent in this snapshot.
+                continue
+        changed = 0
+        deleted = 0
+        for traj_id in sorted(stored.keys() - current.keys()):
+            cursor = connection.execute(
+                "DELETE FROM atom_vectors WHERE traj_id=?", (traj_id,),
+            )
+            deleted += max(0, int(cursor.rowcount or 0))
+            connection.execute(
+                "DELETE FROM atom_vector_traj_state WHERE traj_id=?", (traj_id,),
+            )
+        for traj_id, (tasks, mtime_ns) in current.items():
+            if stored.get(traj_id) == mtime_ns:
+                continue
+            changed += 1
+            connection.execute(
+                "CREATE TEMP TABLE IF NOT EXISTS atom_vector_seen(atom_id TEXT PRIMARY KEY)"
+            )
+            connection.execute("DELETE FROM atom_vector_seen")
+            for atom_path in self._iter_task_paths(tasks):
+                try:
+                    target = _json_vector_input(atom_path, traj_id)
+                except OSError:
+                    # The shared lock serializes xskill writers.  This guard is
+                    # for unsupported-but-possible direct filesystem deletes.
+                    continue
+                self._upsert_target(connection, target)
+                connection.execute(
+                    "INSERT OR IGNORE INTO atom_vector_seen(atom_id) VALUES (?)",
+                    (target[0],),
+                )
+            cursor = connection.execute(
+                """
+                DELETE FROM atom_vectors
+                WHERE traj_id=? AND atom_id NOT IN (SELECT atom_id FROM atom_vector_seen)
+                """,
+                (traj_id,),
+            )
+            deleted += max(0, int(cursor.rowcount or 0))
+            connection.execute(
+                """
+                INSERT INTO atom_vector_traj_state(traj_id, tasks_mtime_ns)
+                VALUES (?, ?)
+                ON CONFLICT(traj_id) DO UPDATE SET
+                    tasks_mtime_ns=excluded.tasks_mtime_ns
+                """,
+                (traj_id, mtime_ns),
+            )
+        return changed, deleted
+
+    @staticmethod
+    def _legacy_cache(path: Path, model: str) -> dict[str, np.ndarray]:
+        if not path.is_file():
+            return {}
+        try:
+            with path.open("rb") as stream:
+                data = pickle.load(stream)
+            if data.get("format") == FORMAT or (data.get("model") or "") != model:
+                return {}
+            atom_ids = data.get("atom_ids") or []
+            embeddings = data.get("embeddings")
+            if embeddings is None:
+                return {}
+            return {
+                atom_id: np.asarray(embeddings[index], dtype=np.float32)
+                for index, atom_id in enumerate(atom_ids)
+                if atom_id and index < len(embeddings)
+            }
+        except (OSError, pickle.PickleError, EOFError, AttributeError, ValueError):
+            logger.warning("legacy atom vector index unreadable: %s", path, exc_info=True)
+            return {}
+
+    def _reuse_vector(
+        self,
+        old_connection,
+        legacy: dict[str, np.ndarray],
+        target: tuple[str, str, str, str],
+    ) -> tuple[bytes, int] | None:
+        atom_id, _traj_id, _text, text_sha = target
+        if old_connection is not None:
+            row = old_connection.execute(
+                """
+                SELECT embedding, dim FROM atom_vectors
+                WHERE atom_id=? AND text_sha=? AND embedding IS NOT NULL
+                """,
+                (atom_id, text_sha),
+            ).fetchone()
+            if row is not None:
+                blob = bytes(row["embedding"])
+                dim = int(row["dim"])
+                if dim > 0 and len(blob) == dim * np.dtype(np.float32).itemsize:
+                    return blob, dim
+        vector = legacy.get(atom_id)
+        if vector is None or vector.ndim != 1:
+            return None
+        norm = float(np.linalg.norm(vector)) or 1.0
+        normalized = np.asarray(vector / norm, dtype=np.float32)
+        return normalized.tobytes(), int(normalized.shape[0])
+
+    def _full_rebuild(self, embed_client, model: str, *, now: float) -> dict:
+        self.root.mkdir(parents=True, exist_ok=True)
+        temporary = self.root / f".{VECTOR_DB_FILE}.{uuid.uuid4().hex}.tmp"
+        old_connection = None
+        old_meta = None
+        if self.path.is_file():
+            try:
+                old_meta = self._meta()
+                if old_meta and old_meta["model"] == model:
+                    old_connection = self._connect()
+            except (OSError, sqlite3.DatabaseError):
+                old_connection = None
+        legacy = self._legacy_cache(self.marker_path, model)
+        connection = self._connect(temporary)
+        scanned = reused = 0
+        try:
+            connection.execute("BEGIN IMMEDIATE")
+            for traj_id, tasks in self._iter_task_dirs():
+                try:
+                    before_mtime_ns = int(tasks.stat().st_mtime_ns)
+                except OSError:
+                    continue
+                unstable = False
+                for atom_path in self._iter_task_paths(tasks):
+                    try:
+                        target = _json_vector_input(atom_path, traj_id)
+                    except OSError:
+                        unstable = True
+                        continue
+                    self._upsert_target(connection, target)
+                    cached = self._reuse_vector(old_connection, legacy, target)
+                    if cached is not None:
+                        connection.execute(
+                            """
+                            UPDATE atom_vectors SET embedding=?, dim=? WHERE atom_id=?
+                            """,
+                            (cached[0], cached[1], target[0]),
+                        )
+                        reused += 1
+                    scanned += 1
+                try:
+                    after_mtime_ns = int(tasks.stat().st_mtime_ns)
+                except OSError:
+                    # Do not carry rows from a trajectory removed during the
+                    # unlocked streaming pass into the replacement database.
+                    connection.execute(
+                        "DELETE FROM atom_vectors WHERE traj_id=?", (traj_id,),
+                    )
+                    continue
+                connection.execute(
+                    """
+                    INSERT INTO atom_vector_traj_state(traj_id, tasks_mtime_ns)
+                    VALUES (?, ?)
+                    """,
+                    (
+                        traj_id,
+                        -1 if unstable or before_mtime_ns != after_mtime_ns
+                        else after_mtime_ns,
+                    ),
+                )
+            connection.commit()
+            embedded = self._embed_pending(connection, embed_client)
+            with self.lock:
+                connection.execute("BEGIN IMMEDIATE")
+                late_changed, late_deleted = self._reconcile_changed_trajs(connection)
+                connection.execute(
+                    """
+                    INSERT INTO atom_vector_meta(
+                        singleton, format, model, complete, reconciled_at
+                    ) VALUES (1, ?, ?, 1, ?)
+                    ON CONFLICT(singleton) DO UPDATE SET
+                        format=excluded.format,
+                        model=excluded.model,
+                        complete=1,
+                        reconciled_at=excluded.reconciled_at
+                    """,
+                    (FORMAT, model, now),
+                )
+                connection.commit()
+                connection.close()
+                connection = None
+                if old_connection is not None:
+                    old_connection.close()
+                    old_connection = None
+                temporary.replace(self.path)
+                self._schema_ready = True
+            embedded += self._embed_pending_path(embed_client)
+            self._refresh_pending_hint()
+            self._next_reconcile_at = now + RECONCILE_INTERVAL_SECONDS
+            self._write_marker()
+            return {
+                "mode": "full",
+                "scanned": scanned,
+                "reused": reused,
+                "embedded": embedded,
+                "changed_trajs": late_changed,
+                "deleted": late_deleted,
+            }
+        finally:
+            if old_connection is not None:
+                old_connection.close()
+            if connection is not None:
+                connection.close()
+            if temporary.is_file():
+                temporary.unlink()
+
+    @staticmethod
+    def _embed_pending(connection, embed_client) -> int:
+        embedded = 0
+        while True:
+            rows = connection.execute(
+                """
+                SELECT atom_id, vector_text, generation FROM atom_vectors
+                WHERE embedding IS NULL
+                ORDER BY atom_id LIMIT ?
+                """,
+                (EMBED_BATCH_SIZE,),
+            ).fetchall()
+            if not rows:
+                return embedded
+            fresh = _normalized_rows(
+                embed_client.encode_batch([row["vector_text"] for row in rows]),
+                len(rows),
+            )
+            connection.execute("BEGIN IMMEDIATE")
+            for row, vector in zip(rows, fresh):
+                cursor = connection.execute(
+                    """
+                    UPDATE atom_vectors SET embedding=?, dim=?
+                    WHERE atom_id=? AND generation=? AND embedding IS NULL
+                    """,
+                    (
+                        np.asarray(vector, dtype=np.float32).tobytes(),
+                        int(vector.shape[0]),
+                        row["atom_id"],
+                        int(row["generation"]),
+                    ),
+                )
+                embedded += max(0, int(cursor.rowcount or 0))
+            connection.commit()
+
+    def _embed_pending_path(self, embed_client) -> int:
+        embedded = 0
+        while True:
+            connection = self._connect()
+            try:
+                rows = connection.execute(
+                    """
+                    SELECT atom_id, vector_text, generation FROM atom_vectors
+                    WHERE embedding IS NULL ORDER BY atom_id LIMIT ?
+                    """,
+                    (EMBED_BATCH_SIZE,),
+                ).fetchall()
+            finally:
+                connection.close()
+            if not rows:
+                return embedded
+            fresh = _normalized_rows(
+                embed_client.encode_batch([row["vector_text"] for row in rows]),
+                len(rows),
+            )
+            with self.lock:
+                connection = self._connect()
+                try:
+                    connection.execute("BEGIN IMMEDIATE")
+                    for row, vector in zip(rows, fresh):
+                        cursor = connection.execute(
+                            """
+                            UPDATE atom_vectors SET embedding=?, dim=?
+                            WHERE atom_id=? AND generation=? AND embedding IS NULL
+                            """,
+                            (
+                                np.asarray(vector, dtype=np.float32).tobytes(),
+                                int(vector.shape[0]),
+                                row["atom_id"],
+                                int(row["generation"]),
+                            ),
+                        )
+                        embedded += max(0, int(cursor.rowcount or 0))
+                    connection.commit()
+                finally:
+                    connection.close()
+
+    def _refresh_pending_hint(self) -> None:
+        with self.lock:
+            connection = self._connect()
+            try:
+                self._pending_hint = connection.execute(
+                    "SELECT 1 FROM atom_vectors WHERE embedding IS NULL LIMIT 1"
+                ).fetchone() is not None
+            finally:
+                connection.close()
+
+    def rebuild(self, embed_client, *, force_full: bool = False) -> dict:
+        model = str(getattr(embed_client, "model", "") or "")
+        now = time.time()
+        try:
+            meta = self._meta()
+        except (OSError, sqlite3.DatabaseError):
+            meta = None
+        full = (
+            force_full
+            or meta is None
+            or meta.get("format") != FORMAT
+            or not meta.get("complete")
+            or (meta.get("model") or "") != model
+            or now - float(meta.get("reconciled_at") or 0)
+            >= RECONCILE_INTERVAL_SECONDS
+        )
+        if full:
+            return self._full_rebuild(embed_client, model, now=now)
+
+        embedded = self._embed_pending_path(embed_client)
+        self._refresh_pending_hint()
+        if embedded or not self.marker_path.is_file():
+            self._write_marker()
+        return {
+            "mode": "incremental",
+            "scanned": 0,
+            "reused": 0,
+            "embedded": embedded,
+            "changed_trajs": 0,
+            "deleted": 0,
+        }
+
+    def _write_marker(self) -> None:
+        if not self.path.is_file():
+            return
+        connection = self._connect()
+        try:
+            meta = connection.execute(
+                "SELECT model, complete FROM atom_vector_meta WHERE singleton=1"
+            ).fetchone()
+            row = connection.execute(
+                """
+                SELECT COUNT(*) AS n, COALESCE(MAX(dim), 0) AS dim
+                FROM atom_vectors WHERE embedding IS NOT NULL
+                """
+            ).fetchone()
+        finally:
+            connection.close()
+        if not meta or not meta["complete"] or not row or not row["n"]:
+            if self.marker_path.is_file():
+                self.marker_path.unlink()
+            return
+        temporary = self.marker_path.with_name(
+            f".{self.marker_path.name}.{uuid.uuid4().hex}.tmp"
+        )
+        temporary.write_bytes(pickle.dumps({
+            "format": FORMAT,
+            "model": meta["model"],
+            "dim": int(row["dim"]),
+            "count": int(row["n"]),
+        }))
+        temporary.replace(self.marker_path)
+
+    def search(self, query: str, embed_client, *, top_k: int) -> list[dict] | None:
+        """返回 SQLite 结果；投影不存在时返回 None 让调用方兼容 legacy pickle。"""
+        if top_k <= 0:
+            return []
+        if not self.path.is_file():
+            return None
+        model = str(getattr(embed_client, "model", "") or "")
+        with self.lock:
+            try:
+                connection = self._connect()
+                try:
+                    meta = connection.execute(
+                        "SELECT model, complete FROM atom_vector_meta WHERE singleton=1"
+                    ).fetchone()
+                finally:
+                    connection.close()
+            except (OSError, sqlite3.DatabaseError):
+                logger.warning("atom vector projection search failed", exc_info=True)
+                return []
+        if not meta or not meta["complete"]:
+            return None
+        if meta["model"] != model:
+            return []
+        query_vector = np.asarray(embed_client.encode(query), dtype=np.float32)
+        norm = float(np.linalg.norm(query_vector))
+        if norm > 0:
+            query_vector = query_vector / norm
+        with self.lock:
+            connection = None
+            try:
+                connection = self._connect()
+                meta = connection.execute(
+                    "SELECT model, complete FROM atom_vector_meta WHERE singleton=1"
+                ).fetchone()
+                if not meta or not meta["complete"]:
+                    return None
+                if meta["model"] != model:
+                    return []
+                cursor = connection.execute(
+                    """
+                    SELECT atom_id, embedding, dim FROM atom_vectors
+                    WHERE embedding IS NOT NULL ORDER BY traj_id, atom_id
+                    """
+                )
+                heap: list[tuple[float, int, str]] = []
+                ordinal = 0
+                while True:
+                    rows = cursor.fetchmany(SEARCH_FETCH_SIZE)
+                    if not rows:
+                        break
+                    for row in rows:
+                        dim = int(row["dim"])
+                        if dim != query_vector.shape[0]:
+                            ordinal += 1
+                            continue
+                        vector = np.frombuffer(row["embedding"], dtype=np.float32)
+                        if vector.shape[0] != dim:
+                            ordinal += 1
+                            continue
+                        score = float(vector @ query_vector)
+                        item = (score, -ordinal, row["atom_id"])
+                        if len(heap) < max(0, top_k):
+                            heapq.heappush(heap, item)
+                        elif top_k > 0 and item > heap[0]:
+                            heapq.heapreplace(heap, item)
+                        ordinal += 1
+            except (OSError, sqlite3.DatabaseError, ValueError):
+                logger.warning("atom vector projection search failed", exc_info=True)
+                return []
+            finally:
+                if connection is not None:
+                    connection.close()
+        ranked = sorted(heap, key=lambda item: (-item[0], -item[1]))
+        return [
+            {"atom_id": atom_id, "similarity": score}
+            for score, _neg_ordinal, atom_id in ranked
+        ]

--- a/src/xskill/pipeline/atom_vector_index.py
+++ b/src/xskill/pipeline/atom_vector_index.py
@@ -90,6 +90,10 @@ class AtomVectorProjection:
         self._pending_hint = False
         self._next_reconcile_at: float | None = None
 
+    def mark_rebuild_needed(self) -> None:
+        """投影写入失败后强制 watcher 在下一轮重建，避免干等 24h 对账。"""
+        self._pending_hint = True
+
     @property
     def path(self) -> Path:
         return self.root / VECTOR_DB_FILE
@@ -175,6 +179,9 @@ class AtomVectorProjection:
                     "SELECT 1 FROM atom_vectors WHERE embedding IS NULL LIMIT 1"
                 ).fetchone() is not None
                 connection.commit()
+            except Exception:
+                self._pending_hint = True
+                raise
             finally:
                 connection.close()
 

--- a/src/xskill/pipeline/registry.py
+++ b/src/xskill/pipeline/registry.py
@@ -2240,8 +2240,8 @@ def reset_trajectories(
     而不删 atom 文件 → ``last_offset ≥ EOF`` → TaskAgent 直接返回空 → 重拆失效
     （0.6.1a1 的洞）。因此本函数**必删 atom 文件**，这才是真正触发重拆的动作。
 
-    同时删该目录的 ``index.pkl``（atom 的向量索引）——否则 atom 已删而索引仍留
-    陈旧 embedding，cluster 阶段向量检索会命中已不存在的 atom。
+    同时删对应的 Atom 向量投影行和该目录的 ``index.pkl`` 兼容标记——否则
+    cluster 阶段向量检索可能命中已不存在的 atom。
 
     DB ``status`` 翻回 ``discovered`` 让 watcher 下轮重新排 split；轨迹级
     skill / canary / UX 派生字段一并清空，避免 rebuild 后看板继续挂旧 skill。
@@ -2304,7 +2304,7 @@ def reset_trajectories(
             AtomTaskStore(Path(directory_path)).remove_locations_for_trajs(
                 trajectory_ids,
             )
-        # 清各目录的陈旧向量索引（AtomTaskStore.INDEX_FILE = "index.pkl"）。
+        # 向量投影行已按轨迹清理；再删兼容发现标记，等待重拆后重新发布。
         for directory_path in directories_seen:
             index_path = Path(directory_path) / "index.pkl"
             if index_path.is_file():

--- a/src/xskill/pipeline/runner.py
+++ b/src/xskill/pipeline/runner.py
@@ -91,7 +91,7 @@ class DirectoryWatcher:
 
     与 v1 (meta-level) 的差异：
     - splitting 阶段调 TaskAgent 拆 AtomTask，落盘到 ``<traj_root>/<traj_id>/tasks/``
-    - indexed 阶段以 AtomTask 为单位整批重建 ``<traj_root>/index.pkl``
+    - indexed 阶段增量维护 Atom SQLite 向量投影；``index.pkl`` 仅作发现标记
     - cluster 阶段**跨轨迹池化**：把所有 indexed 轨迹里尚未落地的 atom 汇成一池，
       按 ``cluster.batch_size`` 分批，提交给全局 cluster pool。
     - indexed → done 由 ``_reconcile_indexed_atoms`` 标：一条轨迹的 atom 全部落进某个
@@ -2498,9 +2498,18 @@ class DirectoryWatcher:
         # ── 提交 embed 任务（split_done → indexed，整批一个任务） ──
         if self.embed_client is not None:
             split_done_files = get_trajs_by_status(wd_id, "split_done", **kw)
-            if split_done_files and not any(
+            store = self._store_for(dir_path)
+            embed_in_flight = any(
                 i["stage"] == "embed" and i["wd_id"] == wd_id for i in self._futures.values()
-            ):
+            )
+            split_in_flight = any(
+                i["stage"] == "split" and i["wd_id"] == wd_id
+                for i in self._futures.values()
+            )
+            reconcile_due = (
+                not split_in_flight and store.vector_index_reconcile_due()
+            )
+            if (split_done_files or reconcile_due) and not embed_in_flight:
                 fut = self._pools["embed"].submit(
                     self._do_atom_index,
                     dir_path,

--- a/tests/test_atom_task_store.py
+++ b/tests/test_atom_task_store.py
@@ -2,6 +2,7 @@
 from __future__ import annotations
 
 import hashlib
+import sqlite3
 from pathlib import Path
 
 import numpy as np
@@ -308,10 +309,31 @@ class _SpyEmbed(_FakeEmbed):
         return super().encode_batch(texts)
 
 
-def _read_index(tmp_path: Path) -> dict:
-    import pickle
-    with open(tmp_path / "cc-sessions" / "index.pkl", "rb") as f:
-        return pickle.load(f)
+def _read_index(tmp_path: Path, store_name: str = "cc-sessions") -> dict:
+    path = tmp_path / store_name / AtomTaskStore.VECTOR_INDEX_FILE
+    connection = sqlite3.connect(path)
+    connection.row_factory = sqlite3.Row
+    try:
+        rows = connection.execute(
+            """
+            SELECT atom_id, embedding, dim FROM atom_vectors
+            WHERE embedding IS NOT NULL ORDER BY traj_id, atom_id
+            """
+        ).fetchall()
+        meta = connection.execute(
+            "SELECT model FROM atom_vector_meta WHERE singleton=1"
+        ).fetchone()
+    finally:
+        connection.close()
+    vectors = [
+        np.frombuffer(row["embedding"], dtype=np.float32, count=int(row["dim"]))
+        for row in rows
+    ]
+    return {
+        "atom_ids": [row["atom_id"] for row in rows],
+        "embeddings": np.stack(vectors) if vectors else np.empty((0, 0)),
+        "model": meta["model"] if meta else "",
+    }
 
 
 class TestVectorIndexIncremental:
@@ -366,9 +388,7 @@ class TestVectorIndexIncremental:
                                  offset_start=i * 10, offset_end=(i + 1) * 10,
                                  summary=f"do thing {i}"))
         ref_store.rebuild_vector_index(_SpyEmbed())
-        import pickle
-        with open(tmp_path / "ref" / "index.pkl", "rb") as f:
-            full = pickle.load(f)["embeddings"]
+        full = _read_index(tmp_path, "ref")["embeddings"]
         assert np.allclose(incremental, full)
 
     def test_model_change_reembeds_all(self, tmp_path):
@@ -395,7 +415,7 @@ class TestVectorIndexIncremental:
         (tmp_path / "cc-sessions" / "t" / "tasks" /
          "atom_t_0001.json").unlink()
         embed = _SpyEmbed()
-        store.rebuild_vector_index(embed)
+        store.rebuild_vector_index(embed, force_full=True)
         idx = _read_index(tmp_path)
         assert idx["atom_ids"] == ["atom_t_0000", "atom_t_0002"]
         # 复用命中，无需再 embed 任何原子

--- a/tests/test_atom_vector_projection.py
+++ b/tests/test_atom_vector_projection.py
@@ -1,0 +1,397 @@
+"""Atom SQLite 向量投影的增量复杂度、恢复与迁移测试。"""
+from __future__ import annotations
+
+import pickle
+import sqlite3
+from pathlib import Path
+
+import numpy as np
+import pytest
+
+from tests.test_atom_task_store import _atom, _FakeEmbed, _SpyEmbed
+from xskill.pipeline import atom_vector_index as vector_module
+from xskill.pipeline.atom import AtomTaskStore
+
+
+def _store(tmp_path: Path) -> AtomTaskStore:
+    return AtomTaskStore(tmp_path / "store")
+
+
+def _vector_rows(store: AtomTaskStore) -> list[sqlite3.Row]:
+    connection = sqlite3.connect(store.root / store.VECTOR_INDEX_FILE)
+    connection.row_factory = sqlite3.Row
+    try:
+        return connection.execute(
+            """
+            SELECT atom_id, traj_id, text_sha, generation, embedding, dim
+            FROM atom_vectors ORDER BY atom_id
+            """
+        ).fetchall()
+    finally:
+        connection.close()
+
+
+def _model(store: AtomTaskStore) -> str:
+    connection = sqlite3.connect(store.root / store.VECTOR_INDEX_FILE)
+    try:
+        row = connection.execute(
+            "SELECT model FROM atom_vector_meta WHERE singleton=1"
+        ).fetchone()
+        return row[0] if row else ""
+    finally:
+        connection.close()
+
+
+def _seed(store: AtomTaskStore, count: int, *, traj_id: str = "t") -> None:
+    store.save_many([
+        _atom(
+            atom_id=f"atom_{traj_id}_{index:04d}",
+            traj_id=traj_id,
+            offset_start=index * 10,
+            offset_end=(index + 1) * 10,
+            summary=f"task {index}",
+        )
+        for index in range(count)
+    ])
+
+
+def test_incremental_add_reads_no_historical_json(tmp_path, monkeypatch):
+    store = _store(tmp_path)
+    _seed(store, 100)
+    store.rebuild_vector_index(_SpyEmbed())
+
+    store.save(_atom(
+        atom_id="atom_t_0100", traj_id="t", offset_start=1000,
+        offset_end=1010, summary="task 100",
+    ))
+    reads = []
+    original = vector_module._json_vector_input
+
+    def counted(path, traj_id):
+        reads.append(path)
+        return original(path, traj_id)
+
+    monkeypatch.setattr(vector_module, "_json_vector_input", counted)
+    embed = _SpyEmbed()
+    stats = store.rebuild_vector_index(embed)
+    assert stats == {
+        "mode": "incremental",
+        "scanned": 0,
+        "reused": 0,
+        "embedded": 1,
+        "changed_trajs": 0,
+        "deleted": 0,
+    }
+    assert reads == []
+    assert embed.batches == [["task 100"]]
+    assert len(_vector_rows(store)) == 101
+
+
+def test_non_vector_atom_update_is_a_noop(tmp_path, monkeypatch):
+    store = _store(tmp_path)
+    atom = _atom(atom_id="atom_t_0001", traj_id="t", summary="stable")
+    store.save(atom)
+    store.rebuild_vector_index(_SpyEmbed())
+    marker_mtime = (store.root / store.INDEX_FILE).stat().st_mtime_ns
+    atom.clustered = True
+    atom.ux_score = 9
+    store.save(atom)
+
+    writes = []
+    monkeypatch.setattr(
+        store._vector_projection,
+        "_write_marker",
+        lambda: writes.append(True),
+    )
+    embed = _SpyEmbed()
+    stats = store.rebuild_vector_index(embed)
+    assert stats["embedded"] == stats["deleted"] == 0
+    assert embed.batches == []
+    assert writes == []
+    assert (store.root / store.INDEX_FILE).stat().st_mtime_ns == marker_mtime
+
+
+def test_projection_batch_failure_rolls_back_without_losing_json(
+    tmp_path, monkeypatch,
+):
+    store = _store(tmp_path)
+    atoms = [
+        _atom(atom_id=f"atom_t_{index:04d}", traj_id="t", summary=f"task {index}")
+        for index in range(3)
+    ]
+    projection = store._vector_projection
+    original = projection._upsert_target
+    calls = 0
+
+    def fail_second(connection, target):
+        nonlocal calls
+        calls += 1
+        original(connection, target)
+        if calls == 2:
+            raise sqlite3.OperationalError("injected projection failure")
+
+    monkeypatch.setattr(projection, "_upsert_target", fail_second)
+    store.save_many(atoms)
+
+    assert len(store.list_by_traj("t")) == 3
+    assert _vector_rows(store) == []
+
+
+def test_text_change_invalidates_only_one_vector(tmp_path):
+    store = _store(tmp_path)
+    _seed(store, 3)
+    store.rebuild_vector_index(_SpyEmbed())
+    before = {row["atom_id"]: row["generation"] for row in _vector_rows(store)}
+
+    store.save(_atom(
+        atom_id="atom_t_0001", traj_id="t", offset_start=10,
+        offset_end=20, summary="changed text",
+    ))
+    embed = _SpyEmbed()
+    stats = store.rebuild_vector_index(embed)
+    after = {row["atom_id"]: row["generation"] for row in _vector_rows(store)}
+    assert stats["embedded"] == 1
+    assert embed.batches == [["changed text"]]
+    assert after["atom_t_0001"] == before["atom_t_0001"] + 1
+    assert after["atom_t_0000"] == before["atom_t_0000"]
+    assert after["atom_t_0002"] == before["atom_t_0002"]
+
+
+def test_incremental_embedding_failure_keeps_old_index_and_recovers(tmp_path):
+    store = _store(tmp_path)
+    _seed(store, 2)
+    store.rebuild_vector_index(_SpyEmbed())
+    store.save(_atom(
+        atom_id="atom_t_0002", traj_id="t", offset_start=20,
+        offset_end=30, summary="late",
+    ))
+
+    class FailingEmbed(_FakeEmbed):
+        def encode_batch(self, _texts):
+            raise RuntimeError("backend unavailable")
+
+    with pytest.raises(RuntimeError, match="backend unavailable"):
+        store.rebuild_vector_index(FailingEmbed())
+    rows = _vector_rows(store)
+    assert sum(row["embedding"] is not None for row in rows) == 2
+    assert sum(row["embedding"] is None for row in rows) == 1
+    assert len(store.vector_search("task 0", _FakeEmbed(), top_k=5)) == 2
+
+    recovered = store.rebuild_vector_index(_SpyEmbed())
+    assert recovered["embedded"] == 1
+    assert all(row["embedding"] is not None for row in _vector_rows(store))
+
+
+def test_late_text_update_cannot_be_cleared_by_stale_embedding(tmp_path):
+    store = _store(tmp_path)
+    atom_v1 = _atom(atom_id="atom_t_0001", traj_id="t", summary="v1")
+    store.save(atom_v1)
+    store.rebuild_vector_index(_SpyEmbed())
+    store.save(_atom(atom_id="atom_t_0001", traj_id="t", summary="v2"))
+
+    class RacingEmbed(_SpyEmbed):
+        def encode_batch(self, texts):
+            self.batches.append(list(texts))
+            if texts == ["v2"]:
+                store.save(_atom(
+                    atom_id="atom_t_0001", traj_id="t", summary="v3",
+                ))
+            return _FakeEmbed().encode_batch(texts)
+
+    embed = RacingEmbed()
+    stats = store.rebuild_vector_index(embed)
+    assert embed.batches == [["v2"], ["v3"]]
+    assert stats["embedded"] == 1
+    row = _vector_rows(store)[0]
+    expected = _FakeEmbed().encode("v3")
+    expected = expected / (float(np.linalg.norm(expected)) or 1.0)
+    assert np.allclose(np.frombuffer(row["embedding"], dtype=np.float32), expected)
+    assert not store.vector_index_reconcile_due()
+
+
+def test_failed_model_switch_does_not_expose_mixed_vectors(tmp_path):
+    store = _store(tmp_path)
+    _seed(store, 3)
+    store.rebuild_vector_index(_SpyEmbed(model="old"))
+
+    class FailingNewModel(_SpyEmbed):
+        def __init__(self):
+            super().__init__(model="new")
+
+        def encode_batch(self, _texts):
+            raise RuntimeError("switch failed")
+
+    with pytest.raises(RuntimeError, match="switch failed"):
+        store.rebuild_vector_index(FailingNewModel())
+    assert _model(store) == "old"
+    assert len(store.vector_search("task", _SpyEmbed(model="old"), top_k=5)) == 3
+    assert store.vector_search("task", _SpyEmbed(model="new"), top_k=5) == []
+
+    switched = store.rebuild_vector_index(_SpyEmbed(model="new"))
+    assert switched["mode"] == "full"
+    assert switched["embedded"] == 3
+    assert _model(store) == "new"
+
+
+def test_force_full_repairs_in_place_json_change(tmp_path):
+    store = _store(tmp_path)
+    _seed(store, 3)
+    store.rebuild_vector_index(_SpyEmbed())
+    atom_path = store.root / "t" / "tasks" / "atom_t_0001.json"
+    atom = _atom(
+        atom_id="atom_t_0001", traj_id="t", offset_start=10,
+        offset_end=20, summary="externally changed",
+    )
+    # direct write intentionally bypasses save()/directory-mtime event semantics
+    atom_path.write_text(atom.to_json(), encoding="utf-8")
+
+    embed = _SpyEmbed()
+    stats = store.rebuild_vector_index(embed, force_full=True)
+    assert stats["mode"] == "full"
+    assert stats["scanned"] == 3
+    assert stats["reused"] == 2
+    assert stats["embedded"] == 1
+    assert embed.batches == [["externally changed"]]
+
+
+def test_embedding_batches_have_a_fixed_memory_bound(tmp_path, monkeypatch):
+    store = _store(tmp_path)
+    _seed(store, 7)
+    monkeypatch.setattr(vector_module, "EMBED_BATCH_SIZE", 2)
+    embed = _SpyEmbed()
+    stats = store.rebuild_vector_index(embed)
+    assert stats["embedded"] == 7
+    assert [len(batch) for batch in embed.batches] == [2, 2, 2, 1]
+
+
+def test_full_rebuild_drops_trajectory_removed_during_streaming_scan(
+    tmp_path, monkeypatch,
+):
+    store = _store(tmp_path)
+    _seed(store, 2)
+    projection = store._vector_projection
+    original = projection._iter_task_paths
+
+    def remove_after_first(tasks):
+        paths = list(original(tasks))
+        yield paths[0]
+        for path in paths:
+            if path.is_file():
+                path.unlink()
+        tasks.rmdir()
+        yield from paths[1:]
+
+    monkeypatch.setattr(projection, "_iter_task_paths", remove_after_first)
+    stats = store.rebuild_vector_index(_SpyEmbed(), force_full=True)
+
+    assert stats["mode"] == "full"
+    assert _vector_rows(store) == []
+
+
+def test_legacy_pickle_migration_reuses_vectors_without_embedding(tmp_path):
+    store = _store(tmp_path)
+    # Bypass save() to model a pre-migration store with JSON + full pickle only.
+    atoms = [
+        _atom(atom_id=f"atom_t_{index:04d}", traj_id="t", summary=f"task {index}")
+        for index in range(3)
+    ]
+    tasks = store.root / "t" / "tasks"
+    tasks.mkdir(parents=True)
+    embed = _FakeEmbed()
+    vectors = []
+    for atom in atoms:
+        (tasks / f"{atom.atom_id}.json").write_text(atom.to_json(), encoding="utf-8")
+        vector = embed.encode(atom.summary)
+        vectors.append(vector / (float(np.linalg.norm(vector)) or 1.0))
+    (store.root / store.INDEX_FILE).write_bytes(pickle.dumps({
+        "atom_ids": [atom.atom_id for atom in atoms],
+        "embeddings": np.asarray(vectors),
+        "model": "fake",
+        "dim": 8,
+    }))
+    # 升级后首次 save 会先创建 incomplete SQLite；迁移完成前仍读 legacy 索引。
+    store._vector_projection.record_atoms([atoms[0]])
+    assert len(store.vector_search("task 1", embed, top_k=3)) == 3
+
+    spy = _SpyEmbed()
+    stats = store.rebuild_vector_index(spy)
+    assert stats["reused"] == 3
+    assert stats["embedded"] == 0
+    assert spy.batches == []
+    marker = pickle.loads((store.root / store.INDEX_FILE).read_bytes())
+    assert marker["format"] == vector_module.FORMAT
+
+
+def test_streaming_search_matches_full_matrix_reference(tmp_path):
+    store = _store(tmp_path)
+    _seed(store, 25)
+    embed = _FakeEmbed()
+    store.rebuild_vector_index(embed)
+    query = "task 11"
+    hits = store.vector_search(query, embed, top_k=7)
+
+    query_vector = embed.encode(query)
+    query_vector = query_vector / (float(np.linalg.norm(query_vector)) or 1.0)
+    expected = []
+    for row in _vector_rows(store):
+        vector = np.frombuffer(row["embedding"], dtype=np.float32)
+        expected.append((row["atom_id"], float(vector @ query_vector)))
+    expected.sort(key=lambda item: (-item[1], item[0]))
+    assert [hit["atom_id"] for hit in hits] == [item[0] for item in expected[:7]]
+    assert np.allclose(
+        [hit["similarity"] for hit in hits],
+        [item[1] for item in expected[:7]],
+    )
+
+
+def test_non_positive_top_k_skips_query_embedding(tmp_path):
+    store = _store(tmp_path)
+    _seed(store, 3)
+    store.rebuild_vector_index(_SpyEmbed())
+
+    class QueryMustNotRun(_FakeEmbed):
+        def encode(self, _text):
+            raise AssertionError("top_k=0 must not encode or scan")
+
+    assert store.vector_search("unused", QueryMustNotRun(), top_k=0) == []
+
+
+def test_incremental_retry_repairs_missing_compatibility_marker(tmp_path):
+    store = _store(tmp_path)
+    _seed(store, 3)
+    store.rebuild_vector_index(_SpyEmbed())
+    marker = store.root / store.INDEX_FILE
+    marker.unlink()
+
+    embed = _SpyEmbed()
+    stats = store.rebuild_vector_index(embed)
+
+    assert stats["mode"] == "incremental"
+    assert stats["embedded"] == 0
+    assert embed.batches == []
+    assert marker.is_file()
+
+
+def test_low_frequency_reconcile_reuses_all_vectors(tmp_path):
+    store = _store(tmp_path)
+    _seed(store, 4)
+    store.rebuild_vector_index(_SpyEmbed())
+    assert not store.vector_index_reconcile_due()
+    connection = sqlite3.connect(store.root / store.VECTOR_INDEX_FILE)
+    try:
+        connection.execute(
+            "UPDATE atom_vector_meta SET reconciled_at=0 WHERE singleton=1"
+        )
+        connection.commit()
+    finally:
+        connection.close()
+    restarted = AtomTaskStore(store.root)
+    assert restarted.vector_index_reconcile_due()
+
+    embed = _SpyEmbed()
+    stats = restarted.rebuild_vector_index(embed)
+    assert stats["mode"] == "full"
+    assert stats["scanned"] == stats["reused"] == 4
+    assert stats["embedded"] == 0
+    assert embed.batches == []
+    assert not restarted.vector_index_reconcile_due()

--- a/tests/test_atom_vector_projection.py
+++ b/tests/test_atom_vector_projection.py
@@ -135,6 +135,28 @@ def test_projection_batch_failure_rolls_back_without_losing_json(
 
     assert len(store.list_by_traj("t")) == 3
     assert _vector_rows(store) == []
+    assert store.vector_index_reconcile_due()
+
+
+def test_projection_write_failure_after_complete_index_stays_due(
+    tmp_path, monkeypatch,
+):
+    store = _store(tmp_path)
+    _seed(store, 2)
+    store.rebuild_vector_index(_SpyEmbed())
+    assert not store.vector_index_reconcile_due()
+
+    def fail(_connection, _target):
+        raise sqlite3.OperationalError("injected projection failure")
+
+    monkeypatch.setattr(store._vector_projection, "_upsert_target", fail)
+    store.save(_atom(
+        atom_id="atom_t_0002", traj_id="t", offset_start=20,
+        offset_end=30, summary="late",
+    ))
+
+    assert store.load("atom_t_0002").summary == "late"
+    assert store.vector_index_reconcile_due()
 
 
 def test_text_change_invalidates_only_one_vector(tmp_path):

--- a/tests/test_rebuild.py
+++ b/tests/test_rebuild.py
@@ -6,6 +6,7 @@ from __future__ import annotations
 
 import argparse
 import json
+import sqlite3
 from unittest.mock import Mock
 
 import pytest
@@ -108,6 +109,32 @@ def test_reset_deletes_stale_index_pkl(tmp_path, db_path):
     reset_trajectories(eco="ngagent", db_path=db_path)
 
     assert not idx.exists(), "reset 应删陈旧 index.pkl"
+
+
+def test_reset_removes_only_target_trajectory_from_vector_projection(tmp_path, db_path):
+    from tests.test_atom_task_store import _FakeEmbed
+    from xskill.pipeline.atom import AtomTaskStore
+
+    directory, _watch_dir_id = _seed_done_traj(
+        tmp_path, db_path, with_atoms=True,
+    )
+    store = AtomTaskStore(directory)
+    store.rebuild_vector_index(_FakeEmbed())
+    connection = sqlite3.connect(directory / store.VECTOR_INDEX_FILE)
+    try:
+        assert connection.execute("SELECT COUNT(*) FROM atom_vectors").fetchone()[0]
+    finally:
+        connection.close()
+
+    reset_trajectories(traj_id="traj_ng_x", db_path=db_path)
+    connection = sqlite3.connect(directory / store.VECTOR_INDEX_FILE)
+    try:
+        remaining = connection.execute(
+            "SELECT COUNT(*) FROM atom_vectors WHERE traj_id='traj_ng_x'"
+        ).fetchone()[0]
+    finally:
+        connection.close()
+    assert remaining == 0
 
 
 def test_reset_deletes_atom_location_projection_rows(tmp_path, db_path):


### PR DESCRIPTION
## 变更内容

- 以 SQLite 可重建投影替代每次更新都重写完整 `index.pkl` 的路径。
- 新增 Atom 只执行增量 upsert，删除与 reset 会同步清理失效向量。
- 使用 generation CAS 和事务提交，避免并发写入被旧任务误清或暴露半写状态。
- embedding 模型变化时强制完整 rebuild，禁止不同模型的向量混用。
- 搜索与 rebuild 采用分批读取，限制内存峰值，并保留旧 pickle 的兼容迁移。

## 前置依赖

本 PR 基于 #306 的 Atom 定位投影实现。#306 合并前，GitHub 的 changed files 会暂时包含该前置提交，因此先保持 Draft；#306 合并后再确认差异仅剩本 Issue 的向量索引改动并转为 Ready。

## 验证

- 相关 Atom store、向量投影与 rebuild 测试：85 passed。
- 完整单元测试：2311 passed, 9 skipped。
- Ruff 与 diff check 已通过。
- 本地 Docker E2E 在安装阶段受 Aliyun Debian 镜像 502 阻断，未进入产品场景；线上 CI 将重新验证标准环境。

Closes #299