### PR TITLE
test(perf): 建立确定性热路径复杂度契约

### DIFF
--- a/pyproject.toml
+++ b/pyproject.toml
@@ -131,6 +131,7 @@ markers = [
     "estimate: token estimation accuracy behavior",
     "coverage: message field coverage in token estimation",
     "overhead: token estimation overhead bounds",
+    "performance_contract: deterministic hot-path complexity contract",
     "family-band: model family error band behavior",
     "trigger: spill/compact trigger behavior",
     "spill: spill trigger behavior",

--- a/tests/PERFORMANCE_CONTRACTS.md
+++ b/tests/PERFORMANCE_CONTRACTS.md
@@ -1,0 +1,23 @@
+# 确定性性能契约
+
+本套件用调用次数、处理规模和禁止访问断言约束热路径复杂度，不使用墙钟耗时。可通过以下命令单独运行：
+
+```bash
+pytest tests/ --ignore=tests/e2e --ignore=tests/bdd -m performance_contract
+```
+
+规模符号：`S` 为技能数，`C` 为客户端或 watch_dir 数，`T` 为轨迹数，`A` 为 Atom 数，`B` 为 Cluster batch 数，`K` 为单个 Atom 关联的技能数，`D` 为当前脏记录数。
+
+| 热路径 | 规模 | 当前实现 | 回归上限 | 契约测试 |
+|---|---:|---|---|---|
+| Cluster catalog 快照 | S, B | generation 首次读取 O(S)，其余 batch 复用快照 | 目录读取 O(S)，不随 B 增长 | `test_task_cluster_agent.py::TestSkillCatalogBudget::test_projection_snapshot_singleflights_until_generation_changes` |
+| SkillEdit 空闲调度 | S | 按脏记录工作 O(D) | D=0 时不扫描技能目录或 candidates | `test_skill_edit_dirty_queue.py::test_idle_round_does_not_rescan_skill_directories_or_candidates` |
+| Canary 轮询 | S | 稳态 O(S_active) | 不探测非 staging 仓库 | `test_canary_rotation.py::TestRotateCanarySide::test_canary_decisions_probe_only_projected_active_skills` |
+| 用户画像刷新 | C, A | O(C + C_dirty + A_dirty) | 未变化轮次只枚举 client，不读取用户画像 | `test_profile_refresh_once.py::test_unchanged_second_tick_reads_no_client_profiles` |
+| Atom 定位 | C, T | O(C) 次投影查询 | 不跨 O(C × T) 个轨迹目录扫描 | `test_multi_atom_store.py::TestMultiStoreRouting::test_load_does_not_scan_any_store_trajectory_directories` |
+| Watcher Atom 快照 | T, A | 单轮 O(T + A) | 每条轨迹最多加载一次 Atom 快照 | `test_watcher_atom.py::TestPollAtomSnapshot::test_indexed_traj_is_loaded_once_per_poll` |
+| 多技能 pending 投影 | K | 写入和读取 O(K) | 保留全部 Atom–Skill 关系 | `test_atom_candidate_pending.py::test_backfill_and_dashboard_keep_multi_skill_pending_associations` |
+| Skill 向量同步 | S | 稳态 O(D) | 只更新脏技能且空闲轮次不扫描索引 | `test_skill_vector_incremental.py::test_idle_tick_does_not_scan_vector_index`、`test_skill_vector_incremental.py::test_one_dirty_skill_only_updates_that_key` |
+| Atom 向量同步 | A | 增量更新 O(A_delta) | 不读取历史 JSON，embedding 批次大小有界 | `test_atom_vector_projection.py::test_incremental_add_reads_no_historical_json`、`test_atom_vector_projection.py::test_embedding_batches_have_a_fixed_memory_bound` |
+
+低频 reconcile 和显式 rebuild 允许 O(S)、O(C + T) 或 O(A) 全量工作，用于修复外部写入和旧版本数据；这些慢路径必须由间隔、版本变化或显式操作触发，不能进入每轮稳态轮询。

--- a/tests/test_atom_candidate_pending.py
+++ b/tests/test_atom_candidate_pending.py
@@ -6,6 +6,8 @@ import sqlite3
 from pathlib import Path
 from unittest import mock
 
+import pytest
+
 from xskill.dashboard.explore import TrajExplorer, skill_lineage
 from xskill.pipeline import registry as reg
 from xskill.skill.candidates import (
@@ -217,6 +219,7 @@ def test_candidates_save_syncs_pending_projection(tmp_path: Path) -> None:
     assert left == [("atom_t1_0001", "bar", 3)]
 
 
+@pytest.mark.performance_contract
 def test_backfill_and_dashboard_keep_multi_skill_pending_associations(
     tmp_path: Path,
 ) -> None:

--- a/tests/test_atom_vector_projection.py
+++ b/tests/test_atom_vector_projection.py
@@ -55,6 +55,7 @@ def _seed(store: AtomTaskStore, count: int, *, traj_id: str = "t") -> None:
     ])
 
 
+@pytest.mark.performance_contract
 def test_incremental_add_reads_no_historical_json(tmp_path, monkeypatch):
     store = _store(tmp_path)
     _seed(store, 100)
@@ -276,6 +277,7 @@ def test_force_full_repairs_in_place_json_change(tmp_path):
     assert embed.batches == [["externally changed"]]
 
 
+@pytest.mark.performance_contract
 def test_embedding_batches_have_a_fixed_memory_bound(tmp_path, monkeypatch):
     store = _store(tmp_path)
     _seed(store, 7)

--- a/tests/test_canary_rotation.py
+++ b/tests/test_canary_rotation.py
@@ -176,6 +176,7 @@ def _make_watcher(skill_dir: Path, tmp_path: Path, *, probability: float):
 
 
 class TestRotateCanarySide:
+    @pytest.mark.performance_contract
     def test_canary_decisions_probe_only_projected_active_skills(
         self,
         tmp_path,

--- a/tests/test_multi_atom_store.py
+++ b/tests/test_multi_atom_store.py
@@ -11,6 +11,8 @@ import logging
 import os
 from pathlib import Path
 
+import pytest
+
 from xskill.pipeline.atom import AtomTask, AtomTaskStore, MultiAtomTaskStore
 from xskill.agents import agent_tools
 
@@ -48,6 +50,7 @@ def _set_mtime(path: Path, ts: int) -> None:
 
 
 class TestMultiStoreRouting:
+    @pytest.mark.performance_contract
     def test_load_does_not_scan_any_store_trajectory_directories(
         self,
         tmp_path,

--- a/tests/test_profile_refresh_once.py
+++ b/tests/test_profile_refresh_once.py
@@ -1,6 +1,8 @@
 """块 3 画像短命子进程:profile-refresh --once 遍历所有 client、写状态文件、失败可控。"""
 from __future__ import annotations
 
+import pytest
+
 from xskill import _workers
 from xskill.utils.status_file import PROFILE_STATUS_FILE, read_status_file
 
@@ -97,6 +99,7 @@ def test_empty_client_list_is_ok(tmp_path, monkeypatch):
     assert read_status_file(tmp_path / PROFILE_STATUS_FILE)["stats"]["clients"] == 0
 
 
+@pytest.mark.performance_contract
 def test_unchanged_second_tick_reads_no_client_profiles(tmp_path, monkeypatch):
     from xskill.recommend.profile_dirty import mark_profile_dirty
 

--- a/tests/test_skill_edit_dirty_queue.py
+++ b/tests/test_skill_edit_dirty_queue.py
@@ -8,6 +8,8 @@ from concurrent.futures import Future
 from pathlib import Path
 from unittest import mock
 
+import pytest
+
 from xskill.pipeline import registry as reg
 from xskill.pipeline.atom import AtomTaskStore
 from xskill.pipeline.registry import register_dir
@@ -102,6 +104,7 @@ def test_candidate_writes_coalesce_per_skill_and_use_generation_fence(
     ] == ["bar"]
 
 
+@pytest.mark.performance_contract
 def test_idle_round_does_not_rescan_skill_directories_or_candidates(
     tmp_path: Path,
     monkeypatch,

--- a/tests/test_skill_vector_incremental.py
+++ b/tests/test_skill_vector_incremental.py
@@ -130,6 +130,7 @@ def _write_native_skill(root: Path, name: str, description: str) -> Path:
     return skill
 
 
+@pytest.mark.performance_contract
 def test_idle_tick_does_not_scan_vector_index(registry_db):
     index = CountingIndex()
     _store_catalog(registry_db, _catalog_row("native:alpha", "alpha"))
@@ -177,6 +178,7 @@ def test_upgrade_bootstrap_reuses_matching_legacy_vectors(registry_db):
     assert embeds == []
 
 
+@pytest.mark.performance_contract
 def test_one_dirty_skill_only_updates_that_key(registry_db):
     index = CountingIndex()
     _store_catalog(registry_db, _catalog_row("native:alpha", "alpha"))

--- a/tests/test_task_cluster_agent.py
+++ b/tests/test_task_cluster_agent.py
@@ -146,6 +146,7 @@ class TestSkillCatalogBudget:
         block = build_skill_catalog_block(skill_dir, max_chars=10000)
         assert "no skills" in block.lower()
 
+    @pytest.mark.performance_contract
     def test_projection_snapshot_singleflights_until_generation_changes(
         self, tmp_path, monkeypatch,
     ):

--- a/tests/test_watcher_atom.py
+++ b/tests/test_watcher_atom.py
@@ -8,6 +8,8 @@ import time
 from unittest.mock import Mock
 import weakref
 
+import pytest
+
 from xskill.pipeline.atom import AtomTaskStore
 from xskill.pipeline.registry import (
     register_dir, discover_trajectories, update_traj_status,
@@ -251,6 +253,7 @@ def _seed_indexed_with_atoms(wd, store, db, n_trajs, atoms_per_traj):
 class TestPollAtomSnapshot:
     """每条轨迹共享 Atom 视图；下一条前释放，下一轮重读 durable JSON。"""
 
+    @pytest.mark.performance_contract
     def test_indexed_traj_is_loaded_once_per_poll(self, tmp_path, monkeypatch):
         db = tmp_path / "test.db"
         wd = tmp_path / "wd"


### PR DESCRIPTION
## Summary

将已合入主分支的热路径性能断言收口为可独立运行的确定性复杂度契约套件。该套件用调用次数、禁止访问和批次规模约束回归，不引入依赖机器性能的墙钟阈值，也不修改生产代码。

## Changes

- 注册 `performance_contract` pytest marker，并标记 11 条现有确定性回归测试。
- 覆盖技能数 S、客户端/watch_dir 数 C、轨迹数 T、Atom 数 A、Cluster batch 数 B、单 Atom 关联 Skill 数 K，以及脏记录数 D。
- 覆盖 Cluster catalog 快照、SkillEdit 空闲调度、Canary 活跃集合、用户画像脏刷新、Atom 定位、Watcher Atom 快照、多 Skill pending 投影及 Skill/Atom 向量增量同步。
- 新增 `tests/PERFORMANCE_CONTRACTS.md`，逐项记录当前复杂度、允许的回归上限和对应契约测试。
- 契约集继续作为普通测试的一部分运行，也可在约 1 秒内独立执行，便于后续性能 PR 直接扩展。

## Test plan

- [x] `python -m pytest tests/ --ignore=tests/docker_e2e --ignore=tests/live -q -p no:cacheprovider`：2363 passed, 10 skipped
- [x] `python -m pytest tests/ --ignore=tests/e2e --ignore=tests/bdd -m performance_contract -q -p no:cacheprovider`：11 passed, 2316 deselected
- [x] 变更测试文件按项目 Ruff 规则检查通过
- [ ] `make e2e`（本 PR 不修改 ingestion、install 或 daemon 生产链路）

## Linked issues

Closes #301
