### PR TITLE
test(algorithms): 建立 Atom 拆分与路由离线回放基线

### DIFF
--- a/pyproject.toml
+++ b/pyproject.toml
@@ -132,6 +132,7 @@ markers = [
     "coverage: message field coverage in token estimation",
     "overhead: token estimation overhead bounds",
     "performance_contract: deterministic hot-path complexity contract",
+    "algorithm_replay: deterministic Atom splitting and routing quality replay",
     "family-band: model family error band behavior",
     "trigger: spill/compact trigger behavior",
     "spill: spill trigger behavior",

--- a/scripts/bench/README.md
+++ b/scripts/bench/README.md
@@ -15,6 +15,7 @@ scripts/bench/
 ├── run_baseline.py           跑第一遍基线(现行窗机制,无 LLM)
 ├── baseline_window.md        基线报告(合成/真实两套并排)
 ├── baseline_window.json      基线机器可读结果(run_baseline.py 产出)
+├── algorithm_replay/         拆分 + 路由的版本化离线质量回放（普通 CI）
 ├── synthetic/
 │   ├── gen_cases_v2.py       合成集生成器(纯数据,无 LLM/无网络)
 │   ├── ground_truth.json     合成集真值 {case: {scenario,total_lines,boundaries,...}}

--- a/scripts/bench/algorithm_replay/README.md
+++ b/scripts/bench/algorithm_replay/README.md
@@ -1,0 +1,76 @@
+# Atom splitting and routing replay
+
+This suite evaluates immutable, recorded algorithm outputs. It does not call an
+LLM, an embedding endpoint, Milvus, or a coding-agent CLI during normal tests.
+
+Run the checked-in baseline:
+
+```bash
+python -m scripts.bench.algorithm_replay.evaluate \
+  scripts/bench/algorithm_replay/fixtures/baseline_v1.json
+```
+
+Use `--format json` for a machine-readable report. The test suite compares that
+report with `baseline_v1.report.json`, so metric-definition changes are explicit
+and reviewable.
+
+## Fixture contract
+
+The root object contains:
+
+- `schema_version`: currently `1`; unsupported versions fail loudly.
+- `metric_config.routing_recall_k`: the candidate cutoff used by Recall@K.
+- `metric_config.atom_alignment_min_iou`: the minimum interval IoU used to
+  align a prediction with a gold Atom for duplicate and routing metrics.
+- `run_manifest`: repository revision, model, harness, prompt fingerprint, seed,
+  generation parameters, token counts, cost, and generation time for the
+  recorded predictions.
+- `skill_catalog`: the only valid routing labels in the suite.
+- `cases`: a line-addressable synthetic trajectory, human-authored gold atoms,
+  and immutable predicted atoms. `line_count` must exactly match `source_lines`.
+
+Atom ranges are 1-based half-open intervals `[start_line, end_line)`. Gold ranges
+must not overlap. Predicted ranges may overlap because overlap is a measured
+failure mode. `scorable_ranges` identifies the source lines used by coverage and
+overlap metrics.
+
+The checked-in fixture is synthetic and privacy-safe. Its model name is
+`recorded-fixture`; it is an evaluator contract, not a claim about current online
+model quality. Its prompt fingerprint hashes the literal sentinel
+`no-model-prompt:synthetic-baseline-v1`, because no model prompt was used. A real
+offline run must replace the run manifest and prediction section while preserving
+the same schema.
+
+## Metric definitions
+
+- Boundary precision/recall/F1 compares exact internal Atom start lines. The
+  forced start of each scorable range is excluded. When both sides have no
+  internal boundary, all three values are `1.0`.
+- Pk and WindowDiff reuse the repository's existing, independently tested
+  `scripts/bench/evaluate.py` implementations. They expose near-miss and
+  over/under-segmentation behavior that exact boundary F1 cannot represent.
+- Coverage is the fraction of scorable lines covered by at least one predicted
+  Atom. Overlap rate counts repeated predicted coverage over the same denominator.
+- Duplicate rate aligns each prediction to the gold Atom with maximum interval
+  IoU at or above `atom_alignment_min_iou`, then counts additional predictions
+  aligned to an already matched gold Atom.
+- Language consistency detects the dominant script of `intent + summary` after
+  removing inline code and path-like tokens. An output with no detectable
+  natural language is a mismatch, not an excluded sample. Version 1 supports
+  English and Chinese fixtures only.
+- Routing micro precision/recall/F1 compares `(gold_atom_id, skill)` relations
+  after interval alignment. Macro precision/recall/F1 is the unweighted mean of
+  per-case scores. Recall@K uses each prediction's ordered `candidates` list.
+- Multi-Skill relation retention measures gold relations belonging to atoms with
+  more than one expected Skill. It prevents an optimization from collapsing a
+  valid one-to-many relation into one label.
+
+Empty-set behavior follows the existing benchmark: precision/recall/F1 is `1.0`
+only when true-positive, false-positive, and false-negative counts are all zero.
+Duplicate and overlap rates are `0.0` when there is no applicable denominator;
+other vacuously satisfied ratios are `1.0`. An unknown detected language still
+has a denominator and therefore scores as a mismatch.
+
+Do not turn a metric into a blocking quality threshold until a maintainer has
+reviewed a representative recorded baseline. Deterministic schema and metric
+tests remain blocking regardless of model quality.

--- a/scripts/bench/algorithm_replay/__init__.py
+++ b/scripts/bench/algorithm_replay/__init__.py
@@ -1,0 +1,1 @@
+"""Deterministic offline evaluation helpers for Atom splitting and routing."""

--- a/scripts/bench/algorithm_replay/evaluate.py
+++ b/scripts/bench/algorithm_replay/evaluate.py
@@ -1,0 +1,624 @@
+"""Evaluate recorded Atom splitting and routing outputs without model calls.
+
+The replay input is deliberately independent from xskill runtime objects.  A model
+or harness may produce a recorded prediction out of band; regular CI only validates
+the fixture and scores that immutable prediction against human-authored gold data.
+"""
+
+from __future__ import annotations
+
+import argparse
+import hashlib
+import json
+import re
+from collections import Counter
+from pathlib import Path
+from typing import Any, Iterable
+
+from scripts.bench.evaluate import pk, prf, score_case, window_diff
+
+
+SCHEMA_VERSION = 1
+SUPPORTED_LANGUAGES = {"en", "zh"}
+_SHA256_RE = re.compile(r"^sha256:[0-9a-f]{64}$")
+_CODE_SPAN_RE = re.compile(r"`[^`]*`")
+_TECHNICAL_TOKEN_RE = re.compile(r"\b\S*[/_.:-]\S*\b")
+
+
+class ReplayValidationError(ValueError):
+    """Raised when a replay fixture violates the versioned input contract."""
+
+
+def load_suite(path: Path | str) -> dict[str, Any]:
+    """Load and validate a replay suite from JSON."""
+    suite_path = Path(path)
+    try:
+        payload = json.loads(suite_path.read_text(encoding="utf-8"))
+    except json.JSONDecodeError as error:
+        raise ReplayValidationError(f"invalid JSON in {suite_path}: {error}") from error
+    validate_suite(payload)
+    return payload
+
+
+def _require(mapping: dict[str, Any], key: str, expected_type: type, context: str) -> Any:
+    if key not in mapping:
+        raise ReplayValidationError(f"{context}: missing required field {key!r}")
+    value = mapping[key]
+    if expected_type is int and isinstance(value, bool):
+        raise ReplayValidationError(f"{context}.{key}: expected int, got bool")
+    if not isinstance(value, expected_type):
+        raise ReplayValidationError(
+            f"{context}.{key}: expected {expected_type.__name__}, "
+            f"got {type(value).__name__}"
+        )
+    return value
+
+
+def _validate_range(value: Any, *, line_count: int, context: str) -> tuple[int, int]:
+    if not isinstance(value, list) or len(value) != 2:
+        raise ReplayValidationError(f"{context}: expected [start, end]")
+    start, end = value
+    if any(isinstance(item, bool) or not isinstance(item, int) for item in value):
+        raise ReplayValidationError(f"{context}: boundaries must be integers")
+    if not 1 <= start < end <= line_count + 1:
+        raise ReplayValidationError(
+            f"{context}: expected 1 <= start < end <= {line_count + 1}, "
+            f"got [{start}, {end}]"
+        )
+    return start, end
+
+
+def _validate_atoms(
+    atoms: Any,
+    *,
+    line_count: int,
+    skill_catalog: set[str],
+    context: str,
+    require_non_overlapping: bool,
+) -> None:
+    if not isinstance(atoms, list):
+        raise ReplayValidationError(f"{context}: expected a list")
+    seen_ids: set[str] = set()
+    ranges: list[tuple[int, int]] = []
+    for index, atom in enumerate(atoms):
+        atom_context = f"{context}[{index}]"
+        if not isinstance(atom, dict):
+            raise ReplayValidationError(f"{atom_context}: expected an object")
+        atom_id = _require(atom, "id", str, atom_context)
+        if not atom_id or atom_id in seen_ids:
+            raise ReplayValidationError(f"{atom_context}.id: empty or duplicate id")
+        seen_ids.add(atom_id)
+        start = _require(atom, "start_line", int, atom_context)
+        end = _require(atom, "end_line", int, atom_context)
+        ranges.append(
+            _validate_range(
+                [start, end], line_count=line_count, context=f"{atom_context}.range"
+            )
+        )
+        _require(atom, "intent", str, atom_context)
+        _require(atom, "summary", str, atom_context)
+        skills = _require(atom, "skills", list, atom_context)
+        candidates = _require(atom, "candidates", list, atom_context)
+        for field, labels in (("skills", skills), ("candidates", candidates)):
+            if any(not isinstance(label, str) or not label for label in labels):
+                raise ReplayValidationError(
+                    f"{atom_context}.{field}: labels must be non-empty strings"
+                )
+            unknown = set(labels) - skill_catalog
+            if unknown:
+                raise ReplayValidationError(
+                    f"{atom_context}.{field}: unknown skill labels {sorted(unknown)}"
+                )
+            if len(set(labels)) != len(labels):
+                raise ReplayValidationError(
+                    f"{atom_context}.{field}: duplicate labels are not allowed"
+                )
+    if require_non_overlapping:
+        ordered = sorted(ranges)
+        for previous, current in zip(ordered, ordered[1:]):
+            if current[0] < previous[1]:
+                raise ReplayValidationError(
+                    f"{context}: gold atom ranges overlap: {previous} and {current}"
+                )
+
+
+def validate_suite(suite: Any) -> None:
+    """Fail loudly on malformed or unsupported replay data."""
+    if not isinstance(suite, dict):
+        raise ReplayValidationError("suite: expected an object")
+    version = _require(suite, "schema_version", int, "suite")
+    if version != SCHEMA_VERSION:
+        raise ReplayValidationError(
+            f"suite.schema_version: supported={SCHEMA_VERSION}, got={version}"
+        )
+    _require(suite, "suite_id", str, "suite")
+    config = _require(suite, "metric_config", dict, "suite")
+    recall_k = _require(config, "routing_recall_k", int, "suite.metric_config")
+    if recall_k <= 0:
+        raise ReplayValidationError("suite.metric_config.routing_recall_k must be > 0")
+    alignment_min_iou = config.get("atom_alignment_min_iou")
+    if (
+        isinstance(alignment_min_iou, bool)
+        or not isinstance(alignment_min_iou, (int, float))
+        or not 0 < alignment_min_iou <= 1
+    ):
+        raise ReplayValidationError(
+            "suite.metric_config.atom_alignment_min_iou must satisfy 0 < value <= 1"
+        )
+
+    manifest = _require(suite, "run_manifest", dict, "suite")
+    for key in (
+        "repository_revision",
+        "model",
+        "harness",
+        "prompt_fingerprint",
+        "generated_at",
+    ):
+        _require(manifest, key, str, "suite.run_manifest")
+    if not _SHA256_RE.fullmatch(manifest["prompt_fingerprint"]):
+        raise ReplayValidationError(
+            "suite.run_manifest.prompt_fingerprint must be sha256:<64 lowercase hex>"
+        )
+    for key in ("seed", "input_tokens", "output_tokens"):
+        value = _require(manifest, key, int, "suite.run_manifest")
+        if value < 0:
+            raise ReplayValidationError(f"suite.run_manifest.{key} must be >= 0")
+    cost = manifest.get("cost_usd")
+    if isinstance(cost, bool) or not isinstance(cost, (int, float)) or cost < 0:
+        raise ReplayValidationError("suite.run_manifest.cost_usd must be a number >= 0")
+    generation_config = _require(
+        manifest, "generation_config", dict, "suite.run_manifest"
+    )
+    temperature = generation_config.get("temperature")
+    if (
+        isinstance(temperature, bool)
+        or not isinstance(temperature, (int, float))
+        or temperature < 0
+    ):
+        raise ReplayValidationError(
+            "suite.run_manifest.generation_config.temperature must be a number >= 0"
+        )
+    top_p = generation_config.get("top_p")
+    if (
+        isinstance(top_p, bool)
+        or not isinstance(top_p, (int, float))
+        or not 0 < top_p <= 1
+    ):
+        raise ReplayValidationError(
+            "suite.run_manifest.generation_config.top_p must satisfy 0 < top_p <= 1"
+        )
+    max_output_tokens = generation_config.get("max_output_tokens")
+    if (
+        isinstance(max_output_tokens, bool)
+        or not isinstance(max_output_tokens, int)
+        or max_output_tokens <= 0
+    ):
+        raise ReplayValidationError(
+            "suite.run_manifest.generation_config.max_output_tokens must be an int > 0"
+        )
+
+    catalog_raw = _require(suite, "skill_catalog", list, "suite")
+    if any(not isinstance(label, str) or not label for label in catalog_raw):
+        raise ReplayValidationError("suite.skill_catalog must contain non-empty strings")
+    skill_catalog = set(catalog_raw)
+    if len(skill_catalog) != len(catalog_raw):
+        raise ReplayValidationError("suite.skill_catalog contains duplicate labels")
+
+    cases = _require(suite, "cases", list, "suite")
+    if not cases:
+        raise ReplayValidationError("suite.cases must not be empty")
+    seen_case_ids: set[str] = set()
+    for index, case in enumerate(cases):
+        context = f"suite.cases[{index}]"
+        if not isinstance(case, dict):
+            raise ReplayValidationError(f"{context}: expected an object")
+        case_id = _require(case, "case_id", str, context)
+        if not case_id or case_id in seen_case_ids:
+            raise ReplayValidationError(f"{context}.case_id: empty or duplicate id")
+        seen_case_ids.add(case_id)
+        language = _require(case, "expected_language", str, context)
+        if language not in SUPPORTED_LANGUAGES:
+            raise ReplayValidationError(
+                f"{context}.expected_language: supported={sorted(SUPPORTED_LANGUAGES)}"
+            )
+        line_count = _require(case, "line_count", int, context)
+        if line_count <= 0:
+            raise ReplayValidationError(f"{context}.line_count must be > 0")
+        source_lines = _require(case, "source_lines", list, context)
+        if any(not isinstance(line, str) for line in source_lines):
+            raise ReplayValidationError(
+                f"{context}.source_lines must contain strings"
+            )
+        if len(source_lines) != line_count:
+            raise ReplayValidationError(
+                f"{context}.source_lines must contain exactly {line_count} lines"
+            )
+        scorable = _require(case, "scorable_ranges", list, context)
+        if not scorable:
+            raise ReplayValidationError(f"{context}.scorable_ranges must not be empty")
+        parsed_ranges = [
+            _validate_range(
+                value,
+                line_count=line_count,
+                context=f"{context}.scorable_ranges[{range_index}]",
+            )
+            for range_index, value in enumerate(scorable)
+        ]
+        if _range_units(parsed_ranges) != sum(end - start for start, end in parsed_ranges):
+            raise ReplayValidationError(f"{context}.scorable_ranges must not overlap")
+        _validate_atoms(
+            _require(case, "gold_atoms", list, context),
+            line_count=line_count,
+            skill_catalog=skill_catalog,
+            context=f"{context}.gold_atoms",
+            require_non_overlapping=True,
+        )
+        _validate_atoms(
+            _require(case, "predicted_atoms", list, context),
+            line_count=line_count,
+            skill_catalog=skill_catalog,
+            context=f"{context}.predicted_atoms",
+            require_non_overlapping=False,
+        )
+
+
+def _range_set(ranges: Iterable[tuple[int, int]]) -> set[int]:
+    units: set[int] = set()
+    for start, end in ranges:
+        units.update(range(start, end))
+    return units
+
+
+def _range_units(ranges: Iterable[tuple[int, int]]) -> int:
+    return len(_range_set(ranges))
+
+
+def _atom_range(atom: dict[str, Any]) -> tuple[int, int]:
+    return int(atom["start_line"]), int(atom["end_line"])
+
+
+def _overlap_size(left: tuple[int, int], right: tuple[int, int]) -> int:
+    return max(0, min(left[1], right[1]) - max(left[0], right[0]))
+
+
+def _interval_iou(left: tuple[int, int], right: tuple[int, int]) -> float:
+    intersection = _overlap_size(left, right)
+    union = (left[1] - left[0]) + (right[1] - right[0]) - intersection
+    return intersection / union if union else 0.0
+
+
+def _align_predictions(
+    gold_atoms: list[dict[str, Any]],
+    predicted_atoms: list[dict[str, Any]],
+    alignment_min_iou: float,
+) -> dict[str, str | None]:
+    alignment: dict[str, str | None] = {}
+    for predicted in predicted_atoms:
+        ranked = sorted(
+            (
+                (_interval_iou(_atom_range(predicted), _atom_range(gold)), gold["id"])
+                for gold in gold_atoms
+            ),
+            key=lambda item: (-item[0], item[1]),
+        )
+        alignment[predicted["id"]] = (
+            ranked[0][1]
+            if ranked and ranked[0][0] >= alignment_min_iou
+            else None
+        )
+    return alignment
+
+
+def _prf(gold: set[Any], predicted: set[Any]) -> dict[str, float | int]:
+    true_positive = len(gold & predicted)
+    false_positive = len(predicted - gold)
+    false_negative = len(gold - predicted)
+    precision, recall, f1 = prf(true_positive, false_positive, false_negative)
+    return {
+        "true_positive": true_positive,
+        "false_positive": false_positive,
+        "false_negative": false_negative,
+        "precision": round(precision, 6),
+        "recall": round(recall, 6),
+        "f1": round(f1, 6),
+    }
+
+
+def detect_language(text: str) -> str:
+    """Detect the dominant natural-language script for English/Chinese fixtures.
+
+    Inline code and path-like tokens are removed first so identifiers do not turn a
+    Chinese explanation into an English classification.  Chinese characters carry
+    more lexical information than individual Latin letters, so a 20% CJK share is
+    considered Chinese for this deliberately small two-language baseline.
+    """
+    natural = _CODE_SPAN_RE.sub(" ", text)
+    natural = _TECHNICAL_TOKEN_RE.sub(" ", natural)
+    cjk = sum("\u4e00" <= char <= "\u9fff" for char in natural)
+    latin = sum(char.isascii() and char.isalpha() for char in natural)
+    total = cjk + latin
+    if total == 0:
+        return "unknown"
+    return "zh" if cjk / total >= 0.2 else "en"
+
+
+def _case_counts(
+    case: dict[str, Any], recall_k: int, alignment_min_iou: float
+) -> dict[str, Any]:
+    gold_atoms = case["gold_atoms"]
+    predicted_atoms = case["predicted_atoms"]
+    alignment = _align_predictions(gold_atoms, predicted_atoms, alignment_min_iou)
+    scorable_ranges = [tuple(value) for value in case["scorable_ranges"]]
+    scorable_units = _range_set(scorable_ranges)
+    predicted_ranges = [_atom_range(atom) for atom in predicted_atoms]
+    predicted_units = _range_set(predicted_ranges) & scorable_units
+    predicted_total = sum(
+        len(set(range(start, end)) & scorable_units)
+        for start, end in predicted_ranges
+    )
+
+    excluded_starts = {start for start, _end in scorable_ranges}
+    gold_boundaries = {
+        atom["start_line"] for atom in gold_atoms if atom["start_line"] not in excluded_starts
+    }
+    predicted_boundaries = {
+        atom["start_line"]
+        for atom in predicted_atoms
+        if atom["start_line"] not in excluded_starts
+    }
+    boundary = score_case(
+        sorted(predicted_boundaries), sorted(gold_boundaries), tol=0
+    )
+
+    assignments = Counter(
+        gold_id for gold_id in alignment.values() if gold_id is not None
+    )
+    duplicate_extras = sum(max(0, count - 1) for count in assignments.values())
+
+    language_total = len(predicted_atoms)
+    language_matches = 0
+    for atom in predicted_atoms:
+        detected = detect_language(f"{atom['intent']}\n{atom['summary']}")
+        language_matches += detected == case["expected_language"]
+
+    gold_relations = {
+        (atom["id"], skill) for atom in gold_atoms for skill in atom["skills"]
+    }
+    predicted_relations: set[tuple[str, str]] = set()
+    candidate_relations: set[tuple[str, str]] = set()
+    for atom in predicted_atoms:
+        target = alignment[atom["id"]] or f"__unmatched__:{atom['id']}"
+        predicted_relations.update((target, skill) for skill in atom["skills"])
+        candidate_relations.update(
+            (target, skill) for skill in atom["candidates"][:recall_k]
+        )
+    multi_skill_gold = {
+        (atom["id"], skill)
+        for atom in gold_atoms
+        if len(atom["skills"]) > 1
+        for skill in atom["skills"]
+    }
+
+    return {
+        "boundary_true_positive": boundary["tp"],
+        "boundary_false_positive": boundary["fp"],
+        "boundary_false_negative": boundary["fn"],
+        "boundary_exact": int(boundary["exact"]),
+        "segmentation_pk_sum": pk(
+            case["line_count"],
+            sorted(gold_boundaries),
+            sorted(predicted_boundaries),
+        ),
+        "segmentation_window_diff_sum": window_diff(
+            case["line_count"],
+            sorted(gold_boundaries),
+            sorted(predicted_boundaries),
+        ),
+        "case_count": 1,
+        "scorable_units": len(scorable_units),
+        "covered_units": len(predicted_units),
+        "overlap_units": max(0, predicted_total - len(predicted_units)),
+        "predicted_atoms": len(predicted_atoms),
+        "duplicate_extras": duplicate_extras,
+        "language_total": language_total,
+        "language_matches": language_matches,
+        "gold_relations": gold_relations,
+        "predicted_relations": predicted_relations,
+        "candidate_relations": candidate_relations,
+        "multi_skill_gold": multi_skill_gold,
+    }
+
+
+def _safe_ratio(numerator: int, denominator: int, *, empty: float = 1.0) -> float:
+    return round(numerator / denominator, 6) if denominator else empty
+
+
+def _macro_prf(case_counts: list[dict[str, Any]]) -> dict[str, float]:
+    scores = [
+        _prf(counts["gold_relations"], counts["predicted_relations"])
+        for counts in case_counts
+    ]
+    return {
+        metric: round(sum(float(score[metric]) for score in scores) / len(scores), 6)
+        for metric in ("precision", "recall", "f1")
+    }
+
+
+def _public_metrics(counts: dict[str, Any]) -> dict[str, Any]:
+    precision, recall, f1 = prf(
+        counts["boundary_true_positive"],
+        counts["boundary_false_positive"],
+        counts["boundary_false_negative"],
+    )
+    boundary = {
+        "true_positive": counts["boundary_true_positive"],
+        "false_positive": counts["boundary_false_positive"],
+        "false_negative": counts["boundary_false_negative"],
+        "precision": round(precision, 6),
+        "recall": round(recall, 6),
+        "f1": round(f1, 6),
+        "exact_match": _safe_ratio(
+            counts["boundary_exact"], counts["case_count"]
+        ),
+    }
+    routing = _prf(counts["gold_relations"], counts["predicted_relations"])
+    return {
+        "boundary": boundary,
+        "segmentation": {
+            "pk": round(
+                counts["segmentation_pk_sum"] / counts["case_count"], 6
+            ),
+            "window_diff": round(
+                counts["segmentation_window_diff_sum"] / counts["case_count"], 6
+            ),
+        },
+        "coverage": _safe_ratio(counts["covered_units"], counts["scorable_units"]),
+        "overlap_rate": _safe_ratio(
+            counts["overlap_units"], counts["scorable_units"], empty=0.0
+        ),
+        "duplicate_rate": _safe_ratio(
+            counts["duplicate_extras"], counts["predicted_atoms"], empty=0.0
+        ),
+        "language_consistency": _safe_ratio(
+            counts["language_matches"], counts["language_total"]
+        ),
+        "routing_micro": routing,
+        "routing_recall_at_k": _safe_ratio(
+            len(counts["gold_relations"] & counts["candidate_relations"]),
+            len(counts["gold_relations"]),
+        ),
+        "multi_skill_relation_retention": _safe_ratio(
+            len(counts["multi_skill_gold"] & counts["predicted_relations"]),
+            len(counts["multi_skill_gold"]),
+        ),
+    }
+
+
+def _merge_counts(all_counts: list[dict[str, Any]]) -> dict[str, Any]:
+    merged: dict[str, Any] = {
+        "boundary_true_positive": 0,
+        "boundary_false_positive": 0,
+        "boundary_false_negative": 0,
+        "boundary_exact": 0,
+        "segmentation_pk_sum": 0.0,
+        "segmentation_window_diff_sum": 0.0,
+        "case_count": 0,
+        "scorable_units": 0,
+        "covered_units": 0,
+        "overlap_units": 0,
+        "predicted_atoms": 0,
+        "duplicate_extras": 0,
+        "language_total": 0,
+        "language_matches": 0,
+        "gold_relations": set(),
+        "predicted_relations": set(),
+        "candidate_relations": set(),
+        "multi_skill_gold": set(),
+    }
+    set_keys = {
+        "gold_relations",
+        "predicted_relations",
+        "candidate_relations",
+        "multi_skill_gold",
+    }
+    for index, counts in enumerate(all_counts):
+        prefix = f"case-{index}:"
+        for key, value in counts.items():
+            if key in set_keys:
+                merged[key].update((prefix, item) for item in value)
+            else:
+                merged[key] += value
+    return merged
+
+
+def evaluate_suite(suite: dict[str, Any]) -> dict[str, Any]:
+    """Return a stable JSON-serializable report for a validated replay suite."""
+    validate_suite(suite)
+    recall_k = suite["metric_config"]["routing_recall_k"]
+    alignment_min_iou = suite["metric_config"]["atom_alignment_min_iou"]
+    case_counts = [
+        _case_counts(case, recall_k, alignment_min_iou) for case in suite["cases"]
+    ]
+    cases = [
+        {
+            "case_id": case["case_id"],
+            "expected_language": case["expected_language"],
+            "metrics": _public_metrics(counts),
+        }
+        for case, counts in zip(suite["cases"], case_counts)
+    ]
+    report = {
+        "schema_version": SCHEMA_VERSION,
+        "suite_id": suite["suite_id"],
+        "run_manifest": suite["run_manifest"],
+        "metric_config": suite["metric_config"],
+        "metrics": {
+            **_public_metrics(_merge_counts(case_counts)),
+            "routing_macro": _macro_prf(case_counts),
+        },
+        "cases": cases,
+    }
+    canonical = json.dumps(report, ensure_ascii=False, sort_keys=True).encode("utf-8")
+    report["report_sha256"] = hashlib.sha256(canonical).hexdigest()
+    return report
+
+
+def render_text(report: dict[str, Any]) -> str:
+    """Render a compact reviewer-facing summary."""
+    metrics = report["metrics"]
+    boundary = metrics["boundary"]
+    routing = metrics["routing_micro"]
+    return "\n".join(
+        (
+            f"suite: {report['suite_id']}",
+            f"revision: {report['run_manifest']['repository_revision']}",
+            (
+                "boundary: "
+                f"P={boundary['precision']:.3f} "
+                f"R={boundary['recall']:.3f} F1={boundary['f1']:.3f}"
+            ),
+            (
+                f"coverage={metrics['coverage']:.3f} "
+                f"overlap={metrics['overlap_rate']:.3f} "
+                f"duplicates={metrics['duplicate_rate']:.3f}"
+            ),
+            f"language_consistency={metrics['language_consistency']:.3f}",
+            (
+                "routing: "
+                f"P={routing['precision']:.3f} "
+                f"R={routing['recall']:.3f} F1={routing['f1']:.3f}"
+            ),
+            (
+                f"routing_recall@{report['metric_config']['routing_recall_k']}="
+                f"{metrics['routing_recall_at_k']:.3f} "
+                f"multi_skill_retention="
+                f"{metrics['multi_skill_relation_retention']:.3f}"
+            ),
+            f"report_sha256={report['report_sha256']}",
+        )
+    )
+
+
+def _parser() -> argparse.ArgumentParser:
+    parser = argparse.ArgumentParser(
+        description="Evaluate a recorded xskill Atom splitting/routing replay suite."
+    )
+    parser.add_argument("suite", type=Path, help="Path to the versioned replay JSON")
+    parser.add_argument(
+        "--format", choices=("text", "json"), default="text", help="Output format"
+    )
+    return parser
+
+
+def main(argv: list[str] | None = None) -> int:
+    args = _parser().parse_args(argv)
+    report = evaluate_suite(load_suite(args.suite))
+    if args.format == "json":
+        print(json.dumps(report, ensure_ascii=False, indent=2, sort_keys=True))
+    else:
+        print(render_text(report))
+    return 0
+
+
+if __name__ == "__main__":
+    raise SystemExit(main())

--- a/scripts/bench/algorithm_replay/fixtures/baseline_v1.json
+++ b/scripts/bench/algorithm_replay/fixtures/baseline_v1.json
@@ -1,0 +1,252 @@
+{
+  "schema_version": 1,
+  "suite_id": "atom-routing-baseline-v1",
+  "metric_config": {
+    "routing_recall_k": 3,
+    "atom_alignment_min_iou": 0.5
+  },
+  "run_manifest": {
+    "repository_revision": "d7ab781068aa366e9b19bf25c30e7d6acb7fafa2",
+    "model": "recorded-fixture",
+    "harness": "offline-replay",
+    "prompt_fingerprint": "sha256:7066be5248c28498173ab2d0057896e8e1fde3732c185e3e6b3d17f6e5a172d5",
+    "seed": 0,
+    "generation_config": {
+      "temperature": 0.0,
+      "top_p": 1.0,
+      "max_output_tokens": 2048
+    },
+    "input_tokens": 0,
+    "output_tokens": 0,
+    "cost_usd": 0.0,
+    "generated_at": "2026-08-22T00:00:00Z"
+  },
+  "skill_catalog": [
+    "python-file-grouping",
+    "python-file-utility-scripts",
+    "sqlite-migration",
+    "sqlite-validation",
+    "spreadsheet-formatting",
+    "spreadsheet-validation"
+  ],
+  "cases": [
+    {
+      "case_id": "en-follow-up-single-intent",
+      "expected_language": "en",
+      "line_count": 12,
+      "source_lines": [
+        "user: Group the Python files by purpose.",
+        "assistant: I will inspect the package layout.",
+        "assistant: tool read src/xskill/task_agent.py",
+        "tool: task_agent.py defines the ingestion worker.",
+        "user: Keep command-line files separate.",
+        "assistant: I will preserve a CLI category.",
+        "assistant: tool read src/xskill/cli.py",
+        "tool: cli.py contains the command entry points.",
+        "user: Put tests beside their matching purpose.",
+        "assistant: I will map tests to the same groups.",
+        "user: Summarize the final grouping.",
+        "assistant: The package, CLI, and tests are grouped by purpose."
+      ],
+      "scorable_ranges": [[1, 13]],
+      "gold_atoms": [
+        {
+          "id": "gold-en-1",
+          "start_line": 1,
+          "end_line": 13,
+          "intent": "Group Python files by purpose",
+          "summary": "The user refined one file-grouping task across several turns.",
+          "skills": ["python-file-grouping"],
+          "candidates": ["python-file-grouping"]
+        }
+      ],
+      "predicted_atoms": [
+        {
+          "id": "pred-en-1",
+          "start_line": 1,
+          "end_line": 13,
+          "intent": "Group Python files by purpose",
+          "summary": "The follow-up messages refine the same grouping goal.",
+          "skills": ["python-file-grouping"],
+          "candidates": [
+            "python-file-grouping",
+            "python-file-utility-scripts"
+          ]
+        }
+      ]
+    },
+    {
+      "case_id": "zh-two-intents",
+      "expected_language": "zh",
+      "line_count": 16,
+      "source_lines": [
+        "user: 请给 SQLite 表增加 skill 字段。",
+        "assistant: 我先检查现有表结构。",
+        "assistant: tool read registry.py",
+        "tool: 当前表使用 atom_id 单列主键。",
+        "user: 历史数据不能丢失。",
+        "assistant: 我会增加无损迁移。",
+        "assistant: tool inspect sqlite schema",
+        "tool: 旧表中有三条待处理记录。",
+        "user: 迁移完成后再检查约束。",
+        "assistant: 我会验证联合主键。",
+        "assistant: tool query pragma table_info",
+        "tool: 主键列为 atom_id 和 skill。",
+        "user: 也检查对应索引。",
+        "assistant: 我会查看查询计划。",
+        "tool: 查询命中了目标索引。",
+        "assistant: 迁移、约束和索引均已验证。"
+      ],
+      "scorable_ranges": [[1, 17]],
+      "gold_atoms": [
+        {
+          "id": "gold-zh-1",
+          "start_line": 1,
+          "end_line": 9,
+          "intent": "迁移 SQLite 表结构",
+          "summary": "先增加字段并完成旧数据迁移。",
+          "skills": ["sqlite-migration"],
+          "candidates": ["sqlite-migration"]
+        },
+        {
+          "id": "gold-zh-2",
+          "start_line": 9,
+          "end_line": 17,
+          "intent": "验证迁移后的约束",
+          "summary": "随后检查索引、主键和历史数据。",
+          "skills": ["sqlite-validation"],
+          "candidates": ["sqlite-validation"]
+        }
+      ],
+      "predicted_atoms": [
+        {
+          "id": "pred-zh-1",
+          "start_line": 1,
+          "end_line": 9,
+          "intent": "迁移 SQLite 表结构",
+          "summary": "增加字段并无损迁移旧数据。",
+          "skills": ["sqlite-migration"],
+          "candidates": ["sqlite-migration", "sqlite-validation"]
+        },
+        {
+          "id": "pred-zh-2",
+          "start_line": 9,
+          "end_line": 17,
+          "intent": "验证迁移后的约束",
+          "summary": "检查联合主键和索引是否正确。",
+          "skills": ["sqlite-validation"],
+          "candidates": ["sqlite-validation", "sqlite-migration"]
+        }
+      ]
+    },
+    {
+      "case_id": "en-near-duplicate-observation",
+      "expected_language": "en",
+      "line_count": 12,
+      "source_lines": [
+        "user: Create a reusable Python file utility.",
+        "assistant: I will extract the shared file operations.",
+        "assistant: tool read src/xskill/io.py",
+        "tool: The module repeats path validation.",
+        "user: The helper should validate paths too.",
+        "assistant: I will include path validation in that utility.",
+        "assistant: tool search repeated path checks",
+        "tool: Three callers use the same validation steps.",
+        "user: Keep this as one reusable helper.",
+        "assistant: I will not create a second utility.",
+        "assistant: tool run focused tests",
+        "assistant: The single utility and its callers pass the tests."
+      ],
+      "scorable_ranges": [[1, 13]],
+      "gold_atoms": [
+        {
+          "id": "gold-dup-1",
+          "start_line": 1,
+          "end_line": 13,
+          "intent": "Create a reusable Python file utility",
+          "summary": "All turns serve one utility-script goal.",
+          "skills": ["python-file-utility-scripts"],
+          "candidates": ["python-file-utility-scripts"]
+        }
+      ],
+      "predicted_atoms": [
+        {
+          "id": "pred-dup-1",
+          "start_line": 1,
+          "end_line": 8,
+          "intent": "Create a Python file utility",
+          "summary": "Write the requested reusable file helper.",
+          "skills": ["python-file-utility-scripts"],
+          "candidates": [
+            "python-file-utility-scripts",
+            "python-file-grouping"
+          ]
+        },
+        {
+          "id": "pred-dup-2",
+          "start_line": 5,
+          "end_line": 13,
+          "intent": "Build a reusable Python file helper",
+          "summary": "The later turns continue the same file-helper task.",
+          "skills": ["python-file-grouping"],
+          "candidates": [
+            "python-file-grouping",
+            "python-file-utility-scripts"
+          ]
+        }
+      ]
+    },
+    {
+      "case_id": "zh-multi-skill-routing",
+      "expected_language": "zh",
+      "line_count": 10,
+      "source_lines": [
+        "user: 修复这份电子表格的格式。",
+        "assistant: 我会检查样式和单元格类型。",
+        "assistant: tool inspect workbook",
+        "tool: 标题样式不一致，公式列存在空值。",
+        "user: 保存后还要验证内容没有损坏。",
+        "assistant: 我会同时执行写后校验。",
+        "assistant: tool format workbook",
+        "tool: 已写入修复后的工作簿。",
+        "assistant: tool reopen and validate workbook",
+        "assistant: 样式、公式和值均通过校验。"
+      ],
+      "scorable_ranges": [[1, 11]],
+      "gold_atoms": [
+        {
+          "id": "gold-multi-1",
+          "start_line": 1,
+          "end_line": 11,
+          "intent": "格式化并验证电子表格",
+          "summary": "同一任务既要求样式修复，也要求写后校验。",
+          "skills": [
+            "spreadsheet-formatting",
+            "spreadsheet-validation"
+          ],
+          "candidates": [
+            "spreadsheet-formatting",
+            "spreadsheet-validation"
+          ]
+        }
+      ],
+      "predicted_atoms": [
+        {
+          "id": "pred-multi-1",
+          "start_line": 1,
+          "end_line": 11,
+          "intent": "格式化并验证电子表格",
+          "summary": "完成格式调整，并核对输出值与结构。",
+          "skills": [
+            "spreadsheet-formatting",
+            "spreadsheet-validation"
+          ],
+          "candidates": [
+            "spreadsheet-validation",
+            "spreadsheet-formatting"
+          ]
+        }
+      ]
+    }
+  ]
+}

--- a/scripts/bench/algorithm_replay/fixtures/baseline_v1.report.json
+++ b/scripts/bench/algorithm_replay/fixtures/baseline_v1.report.json
@@ -1,0 +1,193 @@
+{
+  "cases": [
+    {
+      "case_id": "en-follow-up-single-intent",
+      "expected_language": "en",
+      "metrics": {
+        "boundary": {
+          "exact_match": 1.0,
+          "f1": 1.0,
+          "false_negative": 0,
+          "false_positive": 0,
+          "precision": 1.0,
+          "recall": 1.0,
+          "true_positive": 0
+        },
+        "coverage": 1.0,
+        "duplicate_rate": 0.0,
+        "language_consistency": 1.0,
+        "multi_skill_relation_retention": 1.0,
+        "overlap_rate": 0.0,
+        "routing_micro": {
+          "f1": 1.0,
+          "false_negative": 0,
+          "false_positive": 0,
+          "precision": 1.0,
+          "recall": 1.0,
+          "true_positive": 1
+        },
+        "routing_recall_at_k": 1.0,
+        "segmentation": {
+          "pk": 0.0,
+          "window_diff": 0.0
+        }
+      }
+    },
+    {
+      "case_id": "zh-two-intents",
+      "expected_language": "zh",
+      "metrics": {
+        "boundary": {
+          "exact_match": 1.0,
+          "f1": 1.0,
+          "false_negative": 0,
+          "false_positive": 0,
+          "precision": 1.0,
+          "recall": 1.0,
+          "true_positive": 1
+        },
+        "coverage": 1.0,
+        "duplicate_rate": 0.0,
+        "language_consistency": 1.0,
+        "multi_skill_relation_retention": 1.0,
+        "overlap_rate": 0.0,
+        "routing_micro": {
+          "f1": 1.0,
+          "false_negative": 0,
+          "false_positive": 0,
+          "precision": 1.0,
+          "recall": 1.0,
+          "true_positive": 2
+        },
+        "routing_recall_at_k": 1.0,
+        "segmentation": {
+          "pk": 0.0,
+          "window_diff": 0.0
+        }
+      }
+    },
+    {
+      "case_id": "en-near-duplicate-observation",
+      "expected_language": "en",
+      "metrics": {
+        "boundary": {
+          "exact_match": 0.0,
+          "f1": 0.0,
+          "false_negative": 0,
+          "false_positive": 1,
+          "precision": 0.0,
+          "recall": 0.0,
+          "true_positive": 0
+        },
+        "coverage": 1.0,
+        "duplicate_rate": 0.5,
+        "language_consistency": 1.0,
+        "multi_skill_relation_retention": 1.0,
+        "overlap_rate": 0.25,
+        "routing_micro": {
+          "f1": 0.666667,
+          "false_negative": 0,
+          "false_positive": 1,
+          "precision": 0.5,
+          "recall": 1.0,
+          "true_positive": 1
+        },
+        "routing_recall_at_k": 1.0,
+        "segmentation": {
+          "pk": 0.666667,
+          "window_diff": 0.666667
+        }
+      }
+    },
+    {
+      "case_id": "zh-multi-skill-routing",
+      "expected_language": "zh",
+      "metrics": {
+        "boundary": {
+          "exact_match": 1.0,
+          "f1": 1.0,
+          "false_negative": 0,
+          "false_positive": 0,
+          "precision": 1.0,
+          "recall": 1.0,
+          "true_positive": 0
+        },
+        "coverage": 1.0,
+        "duplicate_rate": 0.0,
+        "language_consistency": 1.0,
+        "multi_skill_relation_retention": 1.0,
+        "overlap_rate": 0.0,
+        "routing_micro": {
+          "f1": 1.0,
+          "false_negative": 0,
+          "false_positive": 0,
+          "precision": 1.0,
+          "recall": 1.0,
+          "true_positive": 2
+        },
+        "routing_recall_at_k": 1.0,
+        "segmentation": {
+          "pk": 0.0,
+          "window_diff": 0.0
+        }
+      }
+    }
+  ],
+  "metric_config": {
+    "atom_alignment_min_iou": 0.5,
+    "routing_recall_k": 3
+  },
+  "metrics": {
+    "boundary": {
+      "exact_match": 0.75,
+      "f1": 0.666667,
+      "false_negative": 0,
+      "false_positive": 1,
+      "precision": 0.5,
+      "recall": 1.0,
+      "true_positive": 1
+    },
+    "coverage": 1.0,
+    "duplicate_rate": 0.166667,
+    "language_consistency": 1.0,
+    "multi_skill_relation_retention": 1.0,
+    "overlap_rate": 0.06,
+    "routing_macro": {
+      "f1": 0.916667,
+      "precision": 0.875,
+      "recall": 1.0
+    },
+    "routing_micro": {
+      "f1": 0.923077,
+      "false_negative": 0,
+      "false_positive": 1,
+      "precision": 0.857143,
+      "recall": 1.0,
+      "true_positive": 6
+    },
+    "routing_recall_at_k": 1.0,
+    "segmentation": {
+      "pk": 0.166667,
+      "window_diff": 0.166667
+    }
+  },
+  "report_sha256": "6cbfa924c9f37ea1e191edcd87c145cd0fe4814b52c40082059e54f29fa61cd2",
+  "run_manifest": {
+    "cost_usd": 0.0,
+    "generated_at": "2026-08-22T00:00:00Z",
+    "generation_config": {
+      "max_output_tokens": 2048,
+      "temperature": 0.0,
+      "top_p": 1.0
+    },
+    "harness": "offline-replay",
+    "input_tokens": 0,
+    "model": "recorded-fixture",
+    "output_tokens": 0,
+    "prompt_fingerprint": "sha256:7066be5248c28498173ab2d0057896e8e1fde3732c185e3e6b3d17f6e5a172d5",
+    "repository_revision": "d7ab781068aa366e9b19bf25c30e7d6acb7fafa2",
+    "seed": 0
+  },
+  "schema_version": 1,
+  "suite_id": "atom-routing-baseline-v1"
+}

--- a/tests/test_algorithm_replay.py
+++ b/tests/test_algorithm_replay.py
@@ -1,0 +1,162 @@
+"""Contracts for the deterministic Atom splitting/routing replay evaluator."""
+
+from __future__ import annotations
+
+import json
+from copy import deepcopy
+from pathlib import Path
+
+import pytest
+
+from scripts.bench.algorithm_replay.evaluate import (
+    ReplayValidationError,
+    detect_language,
+    evaluate_suite,
+    load_suite,
+    main,
+    render_text,
+    validate_suite,
+)
+
+
+FIXTURE_DIR = (
+    Path(__file__).parent.parent / "scripts" / "bench" / "algorithm_replay" / "fixtures"
+)
+BASELINE_PATH = FIXTURE_DIR / "baseline_v1.json"
+REPORT_PATH = FIXTURE_DIR / "baseline_v1.report.json"
+
+
+pytestmark = pytest.mark.algorithm_replay
+
+
+def test_baseline_report_matches_checked_in_snapshot():
+    report = evaluate_suite(load_suite(BASELINE_PATH))
+
+    assert report == json.loads(REPORT_PATH.read_text(encoding="utf-8"))
+
+
+def test_baseline_exposes_expected_regression_signals():
+    report = evaluate_suite(load_suite(BASELINE_PATH))
+
+    assert report["metrics"]["coverage"] == 1.0
+    assert report["metrics"]["overlap_rate"] > 0.0
+    assert report["metrics"]["duplicate_rate"] > 0.0
+    assert report["metrics"]["segmentation"]["pk"] > 0.0
+    assert report["metrics"]["segmentation"]["window_diff"] > 0.0
+    assert report["metrics"]["language_consistency"] == 1.0
+    assert report["metrics"]["multi_skill_relation_retention"] == 1.0
+    assert set(report["metrics"]["routing_macro"]) == {"precision", "recall", "f1"}
+
+
+def test_duplicate_and_overlap_rates_match_handworked_case():
+    report = evaluate_suite(load_suite(BASELINE_PATH))
+    metrics = report["cases"][2]["metrics"]
+
+    # Two predictions align with one gold Atom: one of two is extra. Their
+    # 3-line overlap is measured against the 12-line scorable trajectory.
+    assert metrics["duplicate_rate"] == 0.5
+    assert metrics["overlap_rate"] == 0.25
+
+
+def test_missing_second_skill_reduces_multi_skill_retention():
+    suite = load_suite(BASELINE_PATH)
+    suite["cases"][3]["predicted_atoms"][0]["skills"] = [
+        "spreadsheet-formatting"
+    ]
+
+    metrics = evaluate_suite(suite)["cases"][3]["metrics"]
+
+    assert metrics["routing_micro"]["recall"] == 0.5
+    assert metrics["multi_skill_relation_retention"] == 0.5
+
+
+def test_recall_at_k_uses_ordered_candidates():
+    suite = load_suite(BASELINE_PATH)
+    suite["metric_config"]["routing_recall_k"] = 1
+    suite["cases"][0]["predicted_atoms"][0]["candidates"] = [
+        "python-file-utility-scripts",
+        "python-file-grouping",
+    ]
+
+    metrics = evaluate_suite(suite)["cases"][0]["metrics"]
+
+    assert metrics["routing_recall_at_k"] == 0.0
+
+
+def test_prediction_below_alignment_threshold_is_unmatched():
+    suite = load_suite(BASELINE_PATH)
+    predicted = suite["cases"][0]["predicted_atoms"][0]
+    predicted["end_line"] = 2
+
+    metrics = evaluate_suite(suite)["cases"][0]["metrics"]
+
+    assert metrics["routing_micro"]["true_positive"] == 0
+    assert metrics["routing_micro"]["false_positive"] == 1
+    assert metrics["routing_micro"]["false_negative"] == 1
+
+
+def test_unknown_routing_label_fails_loudly():
+    suite = load_suite(BASELINE_PATH)
+    broken = deepcopy(suite)
+    broken["cases"][0]["predicted_atoms"][0]["skills"] = ["unknown-skill"]
+
+    with pytest.raises(ReplayValidationError, match="unknown skill labels"):
+        validate_suite(broken)
+
+
+def test_overlapping_gold_ranges_fail_loudly():
+    suite = load_suite(BASELINE_PATH)
+    broken = deepcopy(suite)
+    broken["cases"][1]["gold_atoms"][1]["start_line"] = 8
+
+    with pytest.raises(ReplayValidationError, match="gold atom ranges overlap"):
+        validate_suite(broken)
+
+
+def test_source_line_count_mismatch_fails_loudly():
+    suite = load_suite(BASELINE_PATH)
+    broken = deepcopy(suite)
+    broken["cases"][0]["source_lines"].pop()
+
+    with pytest.raises(ReplayValidationError, match="exactly 12 lines"):
+        validate_suite(broken)
+
+
+def test_unsupported_schema_version_fails_loudly():
+    suite = load_suite(BASELINE_PATH)
+    suite["schema_version"] = 2
+
+    with pytest.raises(ReplayValidationError, match="supported=1, got=2"):
+        validate_suite(suite)
+
+
+@pytest.mark.parametrize(
+    ("text", "expected"),
+    [
+        ("Group files after reading `src/xskill/task_agent.py`.", "en"),
+        ("读取 `src/xskill/task_agent.py` 后整理文件。", "zh"),
+        ("`src/xskill/task_agent.py`", "unknown"),
+    ],
+)
+def test_language_detection_ignores_technical_tokens(text, expected):
+    assert detect_language(text) == expected
+
+
+def test_unknown_language_counts_as_inconsistent():
+    suite = load_suite(BASELINE_PATH)
+    suite["cases"][0]["predicted_atoms"][0]["intent"] = "`src/xskill/task_agent.py`"
+    suite["cases"][0]["predicted_atoms"][0]["summary"] = "`pytest -q`"
+
+    report = evaluate_suite(suite)
+
+    assert report["cases"][0]["metrics"]["language_consistency"] == 0.0
+
+
+def test_cli_renders_text_and_json(capsys):
+    assert main([str(BASELINE_PATH)]) == 0
+    text_output = capsys.readouterr().out
+    assert text_output == render_text(evaluate_suite(load_suite(BASELINE_PATH))) + "\n"
+
+    assert main([str(BASELINE_PATH), "--format", "json"]) == 0
+    json_output = json.loads(capsys.readouterr().out)
+    assert json_output == evaluate_suite(load_suite(BASELINE_PATH))


### PR DESCRIPTION
## Summary

为 Atom 拆分与路由增加一个确定性的离线回放基线，使后续 #21/#24 等算法改动可以在不调用真实 LLM、embedding 或网络的前提下比较质量变化。本 PR 只增加 benchmark 数据、指标、固定运行清单和测试，不修改生产行为。

## Changes

- 增加 4 条脱敏、可逐行寻址的中英文合成轨迹，覆盖单/多意图、近重复 Atom 和一个 Atom 对应多个 Skill。
- 增加带显式 schema 校验的纯函数评测器，输出边界 P/R/F1、覆盖/重叠/重复率、语言一致率、路由 micro/macro P/R/F1、Recall@K 和多 Skill 关系保留率。
- 复用现有 `scripts/bench/evaluate.py` 的 Pk/WindowDiff 实现，避免产生第二套分段指标口径。
- 固定并校验 repository revision、model、harness、prompt fingerprint、seed、生成参数、Token 和成本等 run manifest 字段。
- 提交机器可读基线报告及稳定 SHA-256；当前 `recorded-fixture` 仅用于验证评测器契约，不代表线上模型质量。
- 对缺字段、非法/重叠边界、未知 Skill、source line 数量漂移、未知语言和多 Skill 关系丢失等回归 fail loud。

## Test plan

- [x] `make test` passes（2382 passed, 10 skipped）
- [x] Added/updated unit tests for the change（新增回放 + 既有 benchmark 共 29 passed）
- [ ] `make e2e` passes (if the change touches ingestion / install / daemon) — N/A，本 PR 不修改这些路径
- [x] Manually verified the affected user flow（Python 3.9 下运行文本报告；Python 3.11 下验证 JSON 快照）

补充验证：CI 等价 UT/IT 选择集 2339 passed, 4 skipped, 3 deselected；新增文件 Ruff 规则检查通过。

## Linked issues

Closes #315
