### PR TITLE
test(perf): 去除容量测试中的批量 Git 初始化

### DIFF
--- a/tests/test_task_cluster_agent.py
+++ b/tests/test_task_cluster_agent.py
@@ -11,6 +11,7 @@ from xskill.pipeline.atom import AtomTask, AtomTaskStore
 from xskill.agents.task_cluster_agent import (
     TaskClusterAgent,
     _clear_catalog_block_cache,
+    _format_skill_catalog_block,
     build_skill_catalog_block,
 )
 
@@ -75,23 +76,19 @@ class TestSkillCatalogBudget:
         assert "a-skill[main]: deals with A" in block
         assert "b-skill[main]: deals with B" in block
 
-    def test_overflow_truncates_descriptions(self, tmp_path):
-        skill_dir = tmp_path / "skill"
+    def test_overflow_truncates_descriptions(self):
         # 100 skills, desc 100 chars 各，约 10k chars desc；预算 4000 强制截断
-        for i in range(100):
-            _make_skill(skill_dir, f"s-{i:03d}", "x" * 100)
-        block = build_skill_catalog_block(skill_dir, max_chars=4000)
+        entries = [(f"s-{i:03d}", "main", "x" * 100) for i in range(100)]
+        block = _format_skill_catalog_block(entries, max_chars=4000)
         for i in range(100):
             assert f"s-{i:03d}" in block
         # 不允许完整 100 字 desc
         assert "x" * 100 not in block
 
-    def test_extreme_overflow_drops_all_descriptions(self, tmp_path):
-        skill_dir = tmp_path / "skill"
+    def test_extreme_overflow_drops_all_descriptions(self):
         # 500 skills, 200 字 desc → 100k 字 desc，预算 5000 → per_desc 远 < 75
-        for i in range(500):
-            _make_skill(skill_dir, f"big-{i:04d}", "y" * 200)
-        block = build_skill_catalog_block(skill_dir, max_chars=5000)
+        entries = [(f"big-{i:04d}", "main", "y" * 200) for i in range(500)]
+        block = _format_skill_catalog_block(entries, max_chars=5000)
         for i in range(500):
             assert f"big-{i:04d}" in block
         # 该模式下不留 desc

--- a/tests/test_team_skill_manifest.py
+++ b/tests/test_team_skill_manifest.py
@@ -5,10 +5,13 @@ import subprocess
 from pathlib import Path
 
 import numpy as np
+import pytest
 
 from xskill.pipeline.atom import AtomTask, AtomTaskStore
+from xskill.skill.skill import Skill
+from xskill.team.server import skill_manifest
 from xskill.team.server.profile_reco import ClientProfileRecommender
-from xskill.team.server.skill_manifest import build_manifest, _ROUTER
+from xskill.team.server.skill_manifest import _ROUTER, build_manifest
 
 
 def _git(args, cwd):
@@ -70,17 +73,47 @@ def test_manifest_skips_baby_skill_without_main(tmp_path):
     assert "still-baby" not in names
 
 
-def test_manifest_caps_total_slots(tmp_path):
+def test_manifest_caps_total_slots(tmp_path, monkeypatch):
     skill_dir = tmp_path / "skill"
-    skill_dir.mkdir()
-    for i in range(150):
-        _make_skill(skill_dir, f"skill-{i:03d}")
-    resp = build_manifest(client_id="cid-1", skill_dir=skill_dir,
-                          probability=0.2, ranked_slots=80, total_slots=100)
+    names = [f"skill-{i:03d}" for i in range(150)]
+    skills = tuple(Skill(skill_dir / name) for name in names)
+    refs = {
+        name: (f"{index + 1:040x}", None)
+        for index, name in enumerate(names)
+    }
+    catalog = skill_manifest._CatalogSnapshot(
+        skills=skills,
+        refs=refs,
+        search_by_id={},
+        built_at=0.0,
+    )
+    # Capacity semantics consume an immutable catalog snapshot.  Neighboring
+    # tests retain the real-repository coverage for catalog construction.
+    monkeypatch.setattr(skill_manifest._catalog_cache, "get", lambda _path: catalog)
+    monkeypatch.setattr(
+        skill_manifest,
+        "main_sha",
+        lambda _path: pytest.fail("capacity test must use snapshot refs"),
+    )
+    monkeypatch.setattr(
+        skill_manifest,
+        "staging_sha",
+        lambda _path: pytest.fail("capacity test must use snapshot refs"),
+    )
+    resp = build_manifest(
+        client_id="cid-1",
+        skill_dir=skill_dir,
+        probability=0.2,
+        ranked_slots=80,
+        total_slots=100,
+        telemetry_submit=lambda _func: True,
+    )
     assert len(resp.slots) == 100
     ranked = [s for s in resp.slots if s.bucket == "ranked"]
     recommended = [s for s in resp.slots if s.bucket == "recommended"]
     assert len(ranked) == 80 and len(recommended) == 20
+    assert [slot.skill_name for slot in ranked] == names[:80]
+    assert [slot.skill_name for slot in recommended] == names[80:100]
 
 
 def test_manifest_can_defer_recommendation_telemetry(tmp_path, monkeypatch):


### PR DESCRIPTION
## Summary

将三条容量测试从批量真实 Git 仓库夹具改为确定性的内存输入，保留对 catalog 格式化和 manifest 分桶/裁剪生产逻辑的直接覆盖。这样消除了 Windows CI 中与被测算法无关的 Git 与文件系统长尾，且不修改任何生产行为。

## Changes

- 两条 Skill catalog 容量测试直接构造 entries，继续验证全部名称保留、描述截断和极端预算行为。
- manifest 容量测试注入 150 条不可变 catalog snapshot，继续执行实际的排序、80 ranked + 20 recommended 分桶和总量裁剪逻辑。
- 增加顺序断言，并禁止容量测试绕过 snapshot 重新读取 branch SHA。
- 保留同文件中现有的真实 Git 仓库测试，继续覆盖 main、staging、baby、SHA 和 projection fallback 等集成边界。
- 三条目标测试的本地耗时由 15.71 秒降至 0.70 秒（约 22 倍）；测试准备中的 3600 次进程内 Dulwich Git 操作和 900 次系统 Git 子进程调用均降为 0。

## Test plan

- [x] `make test` passes（2367 passed, 10 skipped）
- [x] Added/updated unit tests for the change
- [ ] `make e2e` passes (if the change touches ingestion / install / daemon) — 不适用，仅调整测试夹具
- [ ] Manually verified the affected user flow — 不适用，不修改生产行为
- [x] 受影响的两个测试文件：27 passed
- [x] 性能契约：11 passed
- [x] 聚焦 Ruff 与 `git diff --check` 通过
- [x] [线上跨平台 CI](https://github.com/SkillNerds/xskill/actions/runs/32570506928) 全部通过
- [x] Windows UT/IT：2301 passed，测试阶段 15:43、整 job 17:08；相比基线 23:21 缩短 6:13。两条原 91.88s / 70.99s 的目标测试均退出最慢 25（本次第 25 名为 3.20s）

## Linked issues

Closes #317
