### PR TITLE
ci(maintenance): 升级官方 Actions 至 v7

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -45,8 +45,8 @@ jobs:
           - os: windows-latest
             python-version: "3.11"
     steps:
-      - uses: actions/checkout@v4
-      - uses: actions/setup-python@v5
+      - uses: actions/checkout@v7
+      - uses: actions/setup-python@v7
         with:
           python-version: ${{ matrix.python-version }}
           cache: pip
@@ -75,12 +75,12 @@ jobs:
     name: skill-edit BDD (aimock)
     runs-on: ubuntu-latest
     steps:
-      - uses: actions/checkout@v4
-      - uses: actions/setup-python@v5
+      - uses: actions/checkout@v7
+      - uses: actions/setup-python@v7
         with:
           python-version: "3.11"
           cache: pip
-      - uses: actions/setup-node@v4
+      - uses: actions/setup-node@v7
         with:
           node-version: "20"
       - name: Install xskill test dependencies
@@ -98,8 +98,8 @@ jobs:
       matrix:
         os: [ubuntu-latest, macos-latest, windows-latest]
     steps:
-      - uses: actions/checkout@v4
-      - uses: actions/setup-python@v5
+      - uses: actions/checkout@v7
+      - uses: actions/setup-python@v7
         with:
           python-version: "3.11"
           cache: pip
@@ -115,8 +115,8 @@ jobs:
     name: connect lifecycle e2e (linux/wsl mode)
     runs-on: ubuntu-latest
     steps:
-      - uses: actions/checkout@v4
-      - uses: actions/setup-python@v5
+      - uses: actions/checkout@v7
+      - uses: actions/setup-python@v7
         with:
           python-version: "3.11"
           cache: pip
@@ -132,8 +132,8 @@ jobs:
     runs-on: ubuntu-latest
     continue-on-error: true
     steps:
-      - uses: actions/checkout@v4
-      - uses: actions/setup-python@v5
+      - uses: actions/checkout@v7
+      - uses: actions/setup-python@v7
         with:
           python-version: "3.11"
           cache: pip
@@ -187,8 +187,8 @@ jobs:
         os: ${{ fromJSON((github.event_name == 'schedule' || github.event_name == 'workflow_dispatch') && '["ubuntu-latest","macos-latest","windows-latest"]' || '["ubuntu-latest"]') }}
         agent: [codex, opencode]
     steps:
-      - uses: actions/checkout@v4
-      - uses: actions/setup-python@v5
+      - uses: actions/checkout@v7
+      - uses: actions/setup-python@v7
         with:
           python-version: "3.11"
           cache: pip
@@ -233,10 +233,10 @@ jobs:
     name: verify-build
     runs-on: ubuntu-latest
     steps:
-      - uses: actions/checkout@v4
+      - uses: actions/checkout@v7
         with:
           fetch-depth: 0
-      - uses: actions/setup-python@v5
+      - uses: actions/setup-python@v7
         with:
           python-version: "3.11"
           cache: pip

--- a/.github/workflows/issue-privacy-guard.yml
+++ b/.github/workflows/issue-privacy-guard.yml
@@ -32,7 +32,7 @@ jobs:
       && github.event.sender.type != 'Bot'
     steps:
       - name: Checkout
-        uses: actions/checkout@v4
+        uses: actions/checkout@v7
         with:
           # pull_request_target runs in base context; use default ref (base).
           persist-credentials: false

--- a/.github/workflows/nightly-control-plane-stress.yml
+++ b/.github/workflows/nightly-control-plane-stress.yml
@@ -29,8 +29,8 @@ jobs:
         os: [ubuntu-latest, macos-latest, windows-latest]
         python-version: ["3.11"]
     steps:
-      - uses: actions/checkout@v4
-      - uses: actions/setup-python@v5
+      - uses: actions/checkout@v7
+      - uses: actions/setup-python@v7
         with:
           python-version: ${{ matrix.python-version }}
           cache: pip
@@ -47,8 +47,8 @@ jobs:
     runs-on: ubuntu-latest
     timeout-minutes: 25
     steps:
-      - uses: actions/checkout@v4
-      - uses: actions/setup-python@v5
+      - uses: actions/checkout@v7
+      - uses: actions/setup-python@v7
         with:
           python-version: "3.11"
           cache: pip
@@ -61,7 +61,7 @@ jobs:
           --basetemp=.stress-artifacts
       - name: Upload stress-test evidence
         if: always()
-        uses: actions/upload-artifact@v4
+        uses: actions/upload-artifact@v7
         with:
           name: nightly-control-plane-stress-${{ github.run_id }}
           path: .stress-artifacts/**

--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -25,8 +25,8 @@ jobs:
       matrix:
         python-version: ["3.9", "3.10", "3.11", "3.12"]
     steps:
-      - uses: actions/checkout@v4
-      - uses: actions/setup-python@v5
+      - uses: actions/checkout@v7
+      - uses: actions/setup-python@v7
         with:
           python-version: ${{ matrix.python-version }}
           cache: pip
@@ -40,8 +40,8 @@ jobs:
     runs-on: ubuntu-latest
     timeout-minutes: 25
     steps:
-      - uses: actions/checkout@v4
-      - uses: actions/setup-python@v5
+      - uses: actions/checkout@v7
+      - uses: actions/setup-python@v7
         with:
           python-version: "3.11"
           cache: pip
@@ -54,7 +54,7 @@ jobs:
           --basetemp=.skillhub-search-artifacts
       - name: Upload skillhub smoke evidence
         if: always()
-        uses: actions/upload-artifact@v4
+        uses: actions/upload-artifact@v7
         with:
           name: release-skillhub-search-smoke-${{ github.run_id }}
           path: .skillhub-search-artifacts/**
@@ -68,11 +68,11 @@ jobs:
     needs: [test, skillhub-search-smoke]
     runs-on: ubuntu-latest
     steps:
-      - uses: actions/checkout@v4
+      - uses: actions/checkout@v7
         with:
           fetch-depth: 0
 
-      - uses: actions/setup-python@v5
+      - uses: actions/setup-python@v7
         with:
           python-version: "3.11"
           cache: pip

--- a/tests/test_ci_workflow.py
+++ b/tests/test_ci_workflow.py
@@ -2,6 +2,7 @@
 
 from __future__ import annotations
 
+from collections import Counter
 from pathlib import Path
 
 import yaml
@@ -9,6 +10,23 @@ import yaml
 
 _REPO_ROOT = Path(__file__).resolve().parents[1]
 _CI_PATH = _REPO_ROOT / ".github" / "workflows" / "ci.yml"
+_WORKFLOW_PATHS = tuple(
+    sorted((_REPO_ROOT / ".github" / "workflows").glob("*.yml"))
+)
+_OFFICIAL_ACTION_MAJORS = {
+    "actions/checkout": "v7",
+    "actions/setup-node": "v7",
+    "actions/setup-python": "v7",
+    "actions/upload-artifact": "v7",
+}
+_OFFICIAL_ACTION_COUNTS = Counter(
+    {
+        "actions/checkout": 13,
+        "actions/setup-python": 12,
+        "actions/upload-artifact": 2,
+        "actions/setup-node": 1,
+    }
+)
 
 
 def _jobs() -> dict:
@@ -17,6 +35,26 @@ def _jobs() -> dict:
 
 def _run_steps(job: dict) -> list[str]:
     return [str(step["run"]) for step in job["steps"] if "run" in step]
+
+
+def test_official_javascript_actions_use_node24_majors() -> None:
+    counts: Counter[str] = Counter()
+
+    for workflow_path in _WORKFLOW_PATHS:
+        workflow = yaml.safe_load(workflow_path.read_text(encoding="utf-8"))
+        for job in workflow["jobs"].values():
+            for step in job.get("steps", []):
+                uses = str(step.get("uses", ""))
+                action, separator, version = uses.partition("@")
+                if action not in _OFFICIAL_ACTION_MAJORS:
+                    continue
+                assert separator and version == _OFFICIAL_ACTION_MAJORS[action], (
+                    f"{workflow_path.name}: expected {action}"
+                    f"@{_OFFICIAL_ACTION_MAJORS[action]}, got {uses}"
+                )
+                counts[action] += 1
+
+    assert counts == _OFFICIAL_ACTION_COUNTS
 
 
 def test_ut_matrix_covers_each_supported_risk_axis_once() -> None:


### PR DESCRIPTION
## Summary

将四个 workflow 中仍运行于旧 Node.js runtime 的 GitHub 官方 Actions 升级到当前 v7 major，消除 Node.js 20 弃用告警并降低 runner 兼容兜底被移除后的中断风险。升级保持现有测试矩阵、缓存、权限、发布条件和 artifact 配置不变。

## Changes

- 将 `actions/checkout` 的 13 处引用从 v4 升级到 v7。
- 将 `actions/setup-python` 的 12 处引用从 v5 升级到 v7。
- 将 `actions/setup-node` 的 1 处引用从 v4 升级到 v7，仍安装 Node.js 20。
- 将 `actions/upload-artifact` 的 2 处引用从 v4 升级到 v7，保留 artifact 名称、路径、隐藏文件和保留期配置。
- 新增静态 workflow 契约，扫描全部 workflow 并锁定四个官方 Action 的 major 与引用数量，防止旧 runtime 引用回归或升级时意外删除步骤。

## Test plan

- [x] `make test` passes（2368 passed, 10 skipped）
- [x] Added/updated unit tests for the change
- [ ] `make e2e` passes (if the change touches ingestion / install / daemon) — 不适用，不修改这些生产路径
- [ ] Manually verified the affected user flow — 不适用，仅修改 CI 配置
- [x] `tests/test_ci_workflow.py`：5 passed
- [x] 聚焦 Ruff 与 `git diff --check` 通过
- [x] Actionlint 1.7.12 校验四个 workflow 通过；精确忽略主分支既有且未触及的 `SC2086`
- [x] 核对 v7 action metadata：当前使用的 `fetch-depth`、`persist-credentials`、`python-version`、`cache`、`node-version` 及 artifact inputs 均继续受支持
- [x] [线上常规 CI](https://github.com/SkillNerds/xskill/actions/runs/32575891145) 全部通过；实际下载并执行 14 次 `checkout@v7`、14 次 `setup-python@v7` 和 1 次 `setup-node@v7`，未出现 Node 20 Action-runtime 弃用告警
- [x] `setup-node@v7` 保持 `node-version: 20`，线上实际安装 Node.js 20.20.2

PR CI 将覆盖常规 pull-request jobs；schedule/manual、release tag 和 publish-only 条件通过静态 YAML/Action 契约验证，本 PR 不触发真实发布。

`issue-privacy-guard.yml` 由 `pull_request_target` 触发，GitHub 会在本 PR 上读取默认分支版本，因此当前 `redact` job 仍执行合并前的 `checkout@v4` 并显示 Node 20 告警；这不是 PR head 回归，该 workflow 的 v7 结果需在合并后的后续 issue/PR 事件中确认。

## Linked issues

Closes #318
