### PR TITLE
test(ci): 将 Team C/S 完整闭环纳入常规 PR E2E

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -1,7 +1,7 @@
 # CI workflow — see docs/dev-plan/testing-strategy.md
 #
 # Trigger matrix:
-#   pull_request / push to main → risk-axis ut-it + smoke/connect/BDD/build
+#   pull_request / push to main → risk-axis ut-it + smoke/team lifecycle/BDD/build
 #                                 + Ubuntu live-agent E2E
 #   workflow_dispatch / schedule → same + cross-platform live-agent E2E
 #                                  + real-llm-e2e (graceful skip without secret)
@@ -112,7 +112,7 @@ jobs:
         run: pytest tests/e2e/test_smoke.py -v --durations=25
 
   connect-lifecycle-e2e:
-    name: connect lifecycle e2e (linux/wsl mode)
+    name: connect + team C/S lifecycle e2e (linux/wsl mode)
     runs-on: ubuntu-latest
     steps:
       - uses: actions/checkout@v4
@@ -122,8 +122,11 @@ jobs:
           cache: pip
       - name: Install xskill (with dev extras)
         run: pip install -e .[dev]
-      - name: Connect lifecycle E2E (local stub, no network)
-        run: pytest tests/e2e/test_connect_lifecycle_e2e.py -v --durations=25
+      - name: Team lifecycle E2E (local fake LLM, no network)
+        run: >-
+          pytest tests/e2e/test_connect_lifecycle_e2e.py
+          tests/e2e/test_team_cs_e2e.py
+          -v --durations=25
 
   real-llm-e2e:
     name: real-llm-e2e (linux)

--- a/docs/dev-plan/testing-strategy.md
+++ b/docs/dev-plan/testing-strategy.md
@@ -9,7 +9,7 @@
 | **UT + IT** | 纯逻辑、状态机、持久化与模块协作 | ❌ | ❌ | Ubuntu × Python 3.9–3.12，macOS / Windows × Python 3.11，共 6 jobs |
 | **SkillEdit BDD** | 通过本地 aimock 验证 SkillEdit 行为场景 | ❌ | ❌ | Ubuntu × Python 3.11，共 1 job |
 | **Smoke E2E** | fixture 轨迹 → ingester → installer，验证三种生态路径 | ❌ | ❌ | 三个平台各运行完整测试文件，共 3 jobs |
-| **Connect lifecycle E2E** | 本地 stub 下的 connect 生命周期 | ❌ | ❌ | Ubuntu × Python 3.11，共 1 job |
+| **Team lifecycle E2E** | 本地 fake LLM 下的 connect 生命周期与 Team C/S 完整闭环 | ❌ | ❌ | Ubuntu × Python 3.11，共 1 job |
 | **Live-agent E2E** | mock LLM 驱动真实 Codex / OpenCode 进程并采集会话 | ❌ | ✅ | PR/main 为 Ubuntu × 2 agents，共 2 jobs |
 | **Real-LLM E2E** | 用 DeepSeek 验证真实模型边界 | ✅ | ❌ | 非 PR 事件的 Linux job；无密钥时安全跳过 |
 | **Control-plane stress** | 300×300 压力与 nightly 标记用例 | ❌ | ❌ | 独立 nightly workflow，不阻塞常规 PR |
@@ -26,7 +26,7 @@
 
 ### 触发表
 
-| 事件 | UT + IT | BDD | Smoke / Connect | Live-agent | Real-LLM | Build |
+| 事件 | UT + IT | BDD | Smoke / Team lifecycle | Live-agent | Real-LLM | Build |
 | --- | :--: | :--: | :--: | :--: | :--: | :--: |
 | `pull_request` to main | ✅ 6 | ✅ 1 | ✅ 3 + 1 | ✅ Ubuntu × 2 | ❌ | ✅ 1 |
 | `push` to main | ✅ 6 | ✅ 1 | ✅ 3 + 1 | ✅ Ubuntu × 2 | ✅ 1 | ✅ 1 |
@@ -97,7 +97,7 @@ pytest tests/ --ignore=tests/e2e --ignore=tests/bdd -q -m "not nightly" --durati
 ```bash
 XSKILL_AIMOCK_E2E=1 pytest tests/bdd -v --timeout=120 --durations=25
 pytest tests/e2e/test_smoke.py -v --durations=25
-pytest tests/e2e/test_connect_lifecycle_e2e.py -v --durations=25
+pytest tests/e2e/test_connect_lifecycle_e2e.py tests/e2e/test_team_cs_e2e.py -v --durations=25
 ```
 
 涉及 ingestion、install 或 daemon 的代码改动还必须按贡献指南运行 `make e2e`。live-agent 测试需要本机安装对应 CLI，并显式覆盖 pytest 的默认 `tests/live` 忽略设置。

--- a/tests/test_ci_workflow.py
+++ b/tests/test_ci_workflow.py
@@ -57,6 +57,17 @@ def test_smoke_runs_all_contracts_once_per_platform_without_agent_clis() -> None
     assert "opencode-ai" not in commands
 
 
+def test_team_lifecycle_job_runs_connect_and_team_cs_e2e_together() -> None:
+    job = _jobs()["connect-lifecycle-e2e"]
+    test_commands = [command for command in _run_steps(job) if "pytest " in command]
+
+    assert "if" not in job
+    assert len(test_commands) == 1
+    command = test_commands[0]
+    assert "tests/e2e/test_connect_lifecycle_e2e.py" in command
+    assert "tests/e2e/test_team_cs_e2e.py" in command
+
+
 def test_live_agent_trigger_scope_and_cli_versions_are_explicit() -> None:
     job = _jobs()["live-agent-e2e"]
     matrix = job["strategy"]["matrix"]


### PR DESCRIPTION
## Summary

将现有 Team C/S 完整闭环测试纳入常规 PR CI，补齐脱敏、上传、同步、reconcile、push-edit 和 cleanup 的回归检测。复用现有 lifecycle Job，不新增 Runner 或重复依赖安装。

## Changes

- 在 `connect-lifecycle-e2e` Job 的同一次 pytest 调用中执行 connect lifecycle 与 Team C/S E2E。
- 增加静态工作流契约，确保该 Job 对常规 PR 无条件执行且不会再次漏掉任一测试文件。
- 同步 CI 测试分层文档和本地验证命令。

## Test plan

- [x] `make test` passes：2368 passed, 10 skipped
- [x] Added/updated unit tests for the change：`tests/test_ci_workflow.py` 5 passed
- [ ] `make e2e` passes (if the change touches ingestion / install / daemon)
- [ ] Manually verified the affected user flow

补充验证：Ruff 通过；组合命令在隔离 WSL 容器中为 1 passed、1 skipped，其中原有 connect lifecycle 用例按其 `non-WSL Linux` 条件跳过，Team C/S 完整闭环通过。GitHub Ubuntu Job 将验证两项均实际执行。

## Linked issues

Closes #321