### PR TITLE
fix(atoms): 合并相邻近重复 Atom 并保持源轨迹语言

### DIFF
--- a/src/xskill/agents/agent_tools.py
+++ b/src/xskill/agents/agent_tools.py
@@ -1617,6 +1617,7 @@ def make_task_agent_tools(
     valid = set(valid_lines)
     ordered_valid = sorted(valid_lines)
     source_user_blocks = dict(user_blocks or {})
+    last_valid_start_line: int | None = None
 
     @tool(name="submit_atom")
     def submit_atom(start_line: int, intent: str, summary: str,
@@ -1633,6 +1634,7 @@ def make_task_agent_tools(
             used_skills: agent 实际触发的 skill 名列表,没有传 []。
             ux_score: 1~10 整数。
         """
+        nonlocal last_valid_start_line
         if not_fit_reasons:
             return (
                 "error: 已调用 mark_not_fit，不能再调用 submit_atom；"
@@ -1648,9 +1650,9 @@ def make_task_agent_tools(
         if sl < resume_line:
             return (f"error: start_line {sl} < 续接点 {resume_line}；"
                     "只能拆续接点之后的新增内容")
-        if submitted and sl <= submitted[-1]["start_line"]:
+        if last_valid_start_line is not None and sl <= last_valid_start_line:
             return (f"error: start_line 必须严格大于上一条 "
-                    f"({submitted[-1]['start_line']})，本次 {sl}")
+                    f"({last_valid_start_line})，本次 {sl}")
         normalized_intent = (intent or "").strip()
         normalized_summary = (summary or "").strip()
         if not normalized_intent or not normalized_summary:
@@ -1677,6 +1679,10 @@ def make_task_agent_tools(
                             if str(s).strip()],
             "ux_score": ux_score,
         }
+        # A merged candidate is still a consumed boundary proposal.  Track it
+        # separately from ``submitted`` so a later out-of-order call cannot slip
+        # behind the merged line and corrupt derived ranges.
+        last_valid_start_line = sl
         if submitted and adjacent_atoms_are_near_duplicates(
             submitted[-1],
             candidate,

--- a/src/xskill/agents/agent_tools.py
+++ b/src/xskill/agents/agent_tools.py
@@ -32,6 +32,12 @@ from typing import Any, Optional
 from agno.tools import tool
 from pydantic import BaseModel, ConfigDict, Field, StrictInt
 
+from xskill.agents.atom_text import (
+    adjacent_atoms_are_near_duplicates,
+    detect_source_language,
+    output_language_matches,
+    stable_union,
+)
 from xskill.skill.frontmatter import (
     parse as fm_parse,
     parse_strict as fm_parse_strict,
@@ -1599,11 +1605,18 @@ def make_task_agent_tools(
     total_lines: int,
     all_lines: list[str],
     user_msg: str,
+    source_language: str = "unknown",
+    user_blocks: Mapping[int, str] | None = None,
     not_fit_reasons: list[str] | None = None,
 ):
-    """Create TaskAgent run-scoped tools bound to one trajectory."""
+    """Create TaskAgent run-scoped tools bound to one trajectory.
+
+    ``submit_atom`` enforces the source-language contract and merges only adjacent,
+    high-confidence lexical duplicates.  Both checks are deterministic and local.
+    """
     valid = set(valid_lines)
     ordered_valid = sorted(valid_lines)
+    source_user_blocks = dict(user_blocks or {})
 
     @tool(name="submit_atom")
     def submit_atom(start_line: int, intent: str, summary: str,
@@ -1638,19 +1651,55 @@ def make_task_agent_tools(
         if submitted and sl <= submitted[-1]["start_line"]:
             return (f"error: start_line 必须严格大于上一条 "
                     f"({submitted[-1]['start_line']})，本次 {sl}")
-        if not (intent or "").strip() or not (summary or "").strip():
+        normalized_intent = (intent or "").strip()
+        normalized_summary = (summary or "").strip()
+        if not normalized_intent or not normalized_summary:
             return "error: intent 和 summary 必填"
         if not 1 <= ux_score <= 10:
             return f"error: ux_score 必须是 1~10 的整数 (got {ux_score})"
-        submitted.append({
+        for field_name, value in (
+            ("intent", normalized_intent),
+            ("summary", normalized_summary),
+        ):
+            if not output_language_matches(value, source_language):
+                detected = detect_source_language(value)
+                return (
+                    f"error: {field_name} 的语言 {detected} 与源轨迹主导语言 "
+                    f"{source_language} 不一致；请保持源语言后重提"
+                )
+
+        candidate = {
             "start_line": sl,
-            "intent": intent.strip(),
-            "summary": summary.strip(),
+            "intent": normalized_intent,
+            "summary": normalized_summary,
             "tags": [str(t).strip() for t in (tags or []) if str(t).strip()],
             "used_skills": [str(s).strip() for s in (used_skills or [])
                             if str(s).strip()],
             "ux_score": ux_score,
-        })
+        }
+        if submitted and adjacent_atoms_are_near_duplicates(
+            submitted[-1],
+            candidate,
+            current_user_text=source_user_blocks.get(sl, ""),
+        ):
+            previous = submitted[-1]
+            previous["tags"] = stable_union(previous["tags"], candidate["tags"])
+            previous["used_skills"] = stable_union(
+                previous["used_skills"], candidate["used_skills"]
+            )
+            previous["ux_score"] = min(previous["ux_score"], ux_score)
+            logger.info(
+                "TaskAgent merged near-duplicate adjacent submissions at lines "
+                "%s and %s",
+                previous["start_line"],
+                sl,
+            )
+            return (
+                "ok: 与上一 atom 高度近似，已合并其 tags / used_skills / "
+                f"ux_score (start_line={previous['start_line']})"
+            )
+
+        submitted.append(candidate)
         return f"ok: 已记录 atom #{len(submitted)} (start_line={sl})"
 
     @tool(name="mark_not_fit")

--- a/src/xskill/agents/atom_text.py
+++ b/src/xskill/agents/atom_text.py
@@ -1,0 +1,221 @@
+"""Deterministic text guards used by the TaskAgent Atom write boundary.
+
+The helpers in this module deliberately avoid model, embedding, and network calls.
+They operate on the short ``intent`` / ``summary`` fields and on user-message text,
+so their cost stays linear in the number of submitted Atoms for one trajectory.
+"""
+
+from __future__ import annotations
+
+import re
+from collections.abc import Iterable, Mapping
+from typing import Any
+
+
+_FENCED_CODE_RE = re.compile(r"```.*?(?:```|\Z)", re.DOTALL)
+_INLINE_CODE_RE = re.compile(r"`[^`]*`")
+_SHELL_PROMPT_LINE_RE = re.compile(
+    r"^\s*(?:\$|%|PS>)\s+.*$",
+    re.IGNORECASE | re.MULTILINE,
+)
+_BARE_COMMAND_LINE_RE = re.compile(
+    r"^\s*(?:"
+    r"git\s+(?:add|branch|checkout|clone|commit|diff|fetch|init|log|merge|pull|"
+    r"push|rebase|remote|reset|restore|show|status|switch|tag|worktree)\b|"
+    r"docker\s+(?:build|compose|exec|images|logs|ps|pull|push|run|stop)\b|"
+    r"(?:npm|pnpm|yarn)\s+(?:add|build|install|run|start|test)\b|"
+    r"(?:cargo|go)\s+(?:build|check|clean|fmt|install|run|test|vet)\b|"
+    r"(?:pip|pytest|python\d*|uv)\s+(?:-[^\s]+|[^\s]*[/\\.][^\s]*)(?:\s+.*)?"
+    r").*$",
+    re.IGNORECASE | re.MULTILINE,
+)
+_URL_RE = re.compile(r"\b(?:https?|file)://\S+", re.IGNORECASE)
+_PATH_TOKEN_RE = re.compile(
+    r"(?<!\w)(?:[A-Za-z]:)?(?:[.~]?[/\\])?"
+    r"(?:[\w@+-]+[/\\])+[\w.@+-]+|"
+    r"(?<!\w)[\w@+-]+\."
+    r"(?:py|js|jsx|ts|tsx|json|ya?ml|toml|md|sql|sh|ps1|go|rs|java|kt|"
+    r"swift|c|cc|cpp|h|hpp)(?!\w)",
+    re.IGNORECASE,
+)
+_EN_TOKEN_RE = re.compile(r"[a-z0-9]+")
+_CJK_RUN_RE = re.compile(r"[\u3400-\u4dbf\u4e00-\u9fff]+")
+
+# Keep this list intentionally small: it normalizes grammatical filler and the
+# generic verbs/nouns that produced the known #21 utility/helper duplicate.  It
+# must not collapse domain modifiers such as ``csv`` / ``json`` or
+# ``login`` / ``logout``.
+_EN_STOPWORDS = {
+    "a",
+    "an",
+    "and",
+    "for",
+    "in",
+    "is",
+    "of",
+    "on",
+    "requested",
+    "same",
+    "task",
+    "the",
+    "to",
+    "turn",
+    "turns",
+}
+_EN_CANONICAL = {
+    "build": "create",
+    "built": "create",
+    "building": "create",
+    "create": "create",
+    "created": "create",
+    "creating": "create",
+    "helper": "helper",
+    "helpers": "helper",
+    "implement": "create",
+    "implemented": "create",
+    "make": "create",
+    "utility": "helper",
+    "utilities": "helper",
+    "write": "create",
+    "written": "create",
+    "writing": "create",
+}
+_CONTINUATION_RE = re.compile(
+    r"(?:\b(?:continue|it|keep|still|that|the\s+(?:helper|utility)|this)\b|"
+    r"这个|那个|它|继续|还是|仍然|刚才|刚刚|同一个|不要另|补充|再完善)",
+    re.IGNORECASE,
+)
+
+# Conservative thresholds calibrated against the checked-in replay's
+# ``en-near-duplicate-observation`` case plus distinct CSV/JSON and
+# login/logout controls in the unit tests.
+_MIN_INTENT_TOKENS = 3
+_INTENT_CONTAINMENT_MIN = 0.80
+_COMBINED_CONTAINMENT_MIN = 0.75
+_INTENT_JACCARD_MIN = 0.70
+
+
+def strip_technical_text(text: str) -> str:
+    """Remove code, command lines, URLs, and path-like tokens from ``text``."""
+    natural = _FENCED_CODE_RE.sub(" ", str(text or ""))
+    natural = _INLINE_CODE_RE.sub(" ", natural)
+    natural = _SHELL_PROMPT_LINE_RE.sub(" ", natural)
+    natural = _BARE_COMMAND_LINE_RE.sub(" ", natural)
+    natural = _URL_RE.sub(" ", natural)
+    return _PATH_TOKEN_RE.sub(" ", natural)
+
+
+def detect_source_language(text: str) -> str:
+    """Return ``zh``, ``en``, or ``unknown`` for natural-language text.
+
+    CJK characters carry more lexical information than individual Latin letters,
+    so the same 20% CJK threshold used by the offline replay baseline is applied.
+    """
+    natural = strip_technical_text(text)
+    cjk = sum(
+        "\u3400" <= char <= "\u4dbf" or "\u4e00" <= char <= "\u9fff" for char in natural
+    )
+    latin = sum(char.isascii() and char.isalpha() for char in natural)
+    other = sum(
+        char.isalpha()
+        and not char.isascii()
+        and not ("\u3400" <= char <= "\u4dbf" or "\u4e00" <= char <= "\u9fff")
+        for char in natural
+    )
+    if other > max(cjk, latin):
+        return "unknown"
+    total = cjk + latin
+    if total == 0:
+        return "unknown"
+    return "zh" if cjk / total >= 0.20 else "en"
+
+
+def dominant_language(blocks: Iterable[str]) -> str:
+    """Detect the dominant language across source user-message blocks."""
+    return detect_source_language("\n".join(str(block) for block in blocks))
+
+
+def output_language_matches(text: str, source_language: str) -> bool:
+    """Whether output text is compatible with a detected source language.
+
+    ``unknown`` output is accepted because short labels or technical names may not
+    contain enough natural-language evidence.  A confidently opposite language is
+    rejected at ``submit_atom`` so the agent can correct it before persistence.
+    """
+    expected = str(source_language or "unknown").lower()
+    if expected not in {"en", "zh"}:
+        return True
+    actual = detect_source_language(text)
+    return actual in {"unknown", expected}
+
+
+def _lexical_tokens(text: str) -> set[str]:
+    natural = strip_technical_text(text).lower()
+    tokens: set[str] = set()
+    for token in _EN_TOKEN_RE.findall(natural):
+        if token in _EN_STOPWORDS:
+            continue
+        tokens.add(_EN_CANONICAL.get(token, token))
+    for run in _CJK_RUN_RE.findall(natural):
+        if len(run) == 1:
+            tokens.add(run)
+        else:
+            tokens.update(run[index : index + 2] for index in range(len(run) - 1))
+    return tokens
+
+
+def _containment(left: set[str], right: set[str]) -> float:
+    smaller = min(len(left), len(right))
+    return len(left & right) / smaller if smaller else 0.0
+
+
+def _jaccard(left: set[str], right: set[str]) -> float:
+    union = left | right
+    return len(left & right) / len(union) if union else 0.0
+
+
+def adjacent_atoms_are_near_duplicates(
+    previous: Mapping[str, Any],
+    current: Mapping[str, Any],
+    *,
+    current_user_text: str = "",
+) -> bool:
+    """High-precision lexical duplicate check for adjacent submitted Atoms.
+
+    The check requires substantial intent and combined intent/summary containment.
+    A lower lexical-Jaccard shape is only accepted when the new user turn contains
+    an explicit continuation/reference cue.  This avoids merging merely related
+    sibling tasks such as CSV vs JSON utilities.
+    """
+    previous_intent = _lexical_tokens(str(previous.get("intent") or ""))
+    current_intent = _lexical_tokens(str(current.get("intent") or ""))
+    if min(len(previous_intent), len(current_intent)) < _MIN_INTENT_TOKENS:
+        return False
+    if _containment(previous_intent, current_intent) < _INTENT_CONTAINMENT_MIN:
+        return False
+
+    previous_combined = _lexical_tokens(
+        f"{previous.get('intent') or ''}\n{previous.get('summary') or ''}"
+    )
+    current_combined = _lexical_tokens(
+        f"{current.get('intent') or ''}\n{current.get('summary') or ''}"
+    )
+    if _containment(previous_combined, current_combined) < _COMBINED_CONTAINMENT_MIN:
+        return False
+
+    return _jaccard(previous_intent, current_intent) >= _INTENT_JACCARD_MIN or bool(
+        _CONTINUATION_RE.search(strip_technical_text(current_user_text))
+    )
+
+
+def stable_union(left: Iterable[Any], right: Iterable[Any]) -> list[str]:
+    """Return a normalized, order-preserving union of two metadata lists."""
+    result: list[str] = []
+    seen: set[str] = set()
+    for values in (left, right):
+        for value in values:
+            normalized = str(value).strip()
+            if normalized and normalized not in seen:
+                seen.add(normalized)
+                result.append(normalized)
+    return result

--- a/src/xskill/agents/atom_text.py
+++ b/src/xskill/agents/atom_text.py
@@ -38,8 +38,25 @@ _PATH_TOKEN_RE = re.compile(
     r"swift|c|cc|cpp|h|hpp)(?!\w)",
     re.IGNORECASE,
 )
+_TECHNICAL_IDENTIFIER_RE = re.compile(
+    r"\b(?:"
+    r"[A-Za-z][A-Za-z0-9]*_[A-Za-z0-9_]+|"
+    r"[A-Z][A-Z0-9_]{1,}|"
+    r"[A-Za-z]+(?:[A-Z][A-Za-z0-9]*)+"
+    r")\b"
+)
 _EN_TOKEN_RE = re.compile(r"[a-z0-9]+")
 _CJK_RUN_RE = re.compile(r"[\u3400-\u4dbf\u4e00-\u9fff]+")
+_ZH_PROSE_CUE_RE = re.compile(
+    r"请|帮(?:我|忙)?|把|将|需要|能否|是否|如何|怎么|为什么|"
+    r"修复|优化|增加|添加|删除|修改|更新|检查|支持|实现|保持|"
+    r"改成|调整|继续|完成|生成|这个|那个|的"
+)
+_EN_PROSE_CUE_RE = re.compile(
+    r"\b(?:please|can|could|would|should|fix|create|update|add|remove|"
+    r"change|implement|improve|keep|continue|need|want|the|this|that)\b",
+    re.IGNORECASE,
+)
 
 # Keep this list intentionally small: it normalizes grammatical filler and the
 # generic verbs/nouns that produced the known #21 utility/helper duplicate.  It
@@ -55,6 +72,7 @@ _EN_STOPWORDS = {
     "of",
     "on",
     "requested",
+    "reusable",
     "same",
     "task",
     "the",
@@ -80,9 +98,9 @@ _EN_CANONICAL = {
     "written": "create",
     "writing": "create",
 }
-_CONTINUATION_RE = re.compile(
-    r"(?:\b(?:continue|it|keep|still|that|the\s+(?:helper|utility)|this)\b|"
-    r"这个|那个|它|继续|还是|仍然|刚才|刚刚|同一个|不要另|补充|再完善)",
+_STRONG_CONTINUATION_RE = re.compile(
+    r"(?:\b(?:continue|keep|still|same|the\s+(?:helper|utility))\b|"
+    r"继续|还是|仍然|刚才|刚刚|同一个|不要另|补充|再完善)",
     re.IGNORECASE,
 )
 
@@ -90,7 +108,7 @@ _CONTINUATION_RE = re.compile(
 # ``en-near-duplicate-observation`` case plus distinct CSV/JSON and
 # login/logout controls in the unit tests.
 _MIN_INTENT_TOKENS = 3
-_INTENT_CONTAINMENT_MIN = 0.80
+_INTENT_CONTAINMENT_MIN = 1.0
 _COMBINED_CONTAINMENT_MIN = 0.75
 _INTENT_JACCARD_MIN = 0.70
 
@@ -108,10 +126,11 @@ def strip_technical_text(text: str) -> str:
 def detect_source_language(text: str) -> str:
     """Return ``zh``, ``en``, or ``unknown`` for natural-language text.
 
-    CJK characters carry more lexical information than individual Latin letters,
-    so the same 20% CJK threshold used by the offline replay baseline is applied.
+    Code-like identifiers are ignored and common prose cues disambiguate mixed
+    technical requests before falling back to the replay baseline's 20% CJK
+    threshold.
     """
-    natural = strip_technical_text(text)
+    natural = _TECHNICAL_IDENTIFIER_RE.sub(" ", strip_technical_text(text))
     cjk = sum(
         "\u3400" <= char <= "\u4dbf" or "\u4e00" <= char <= "\u9fff" for char in natural
     )
@@ -122,11 +141,17 @@ def detect_source_language(text: str) -> str:
         and not ("\u3400" <= char <= "\u4dbf" or "\u4e00" <= char <= "\u9fff")
         for char in natural
     )
-    if other > max(cjk, latin):
+    if other > max(cjk, latin) or (
+        other > 0 and other * 2 >= cjk and other >= latin
+    ):
         return "unknown"
     total = cjk + latin
     if total == 0:
         return "unknown"
+    zh_cue = bool(_ZH_PROSE_CUE_RE.search(natural))
+    en_cue = bool(_EN_PROSE_CUE_RE.search(natural))
+    if zh_cue != en_cue:
+        return "zh" if zh_cue else "en"
     return "zh" if cjk / total >= 0.20 else "en"
 
 
@@ -183,9 +208,9 @@ def adjacent_atoms_are_near_duplicates(
     """High-precision lexical duplicate check for adjacent submitted Atoms.
 
     The check requires substantial intent and combined intent/summary containment.
-    A lower lexical-Jaccard shape is only accepted when the new user turn contains
-    an explicit continuation/reference cue.  This avoids merging merely related
-    sibling tasks such as CSV vs JSON utilities.
+    The smaller intent must be fully contained by the larger one and the new user
+    turn must carry a strong continuation cue.  This avoids silently merging
+    merely related sibling tasks that differ by one domain term.
     """
     previous_intent = _lexical_tokens(str(previous.get("intent") or ""))
     current_intent = _lexical_tokens(str(current.get("intent") or ""))
@@ -203,9 +228,9 @@ def adjacent_atoms_are_near_duplicates(
     if _containment(previous_combined, current_combined) < _COMBINED_CONTAINMENT_MIN:
         return False
 
-    return _jaccard(previous_intent, current_intent) >= _INTENT_JACCARD_MIN or bool(
-        _CONTINUATION_RE.search(strip_technical_text(current_user_text))
-    )
+    if not _STRONG_CONTINUATION_RE.search(strip_technical_text(current_user_text)):
+        return False
+    return _jaccard(previous_intent, current_intent) >= _INTENT_JACCARD_MIN
 
 
 def stable_union(left: Iterable[Any], right: Iterable[Any]) -> list[str]:

--- a/src/xskill/agents/task_agent.py
+++ b/src/xskill/agents/task_agent.py
@@ -48,6 +48,7 @@ from operator import attrgetter
 from pathlib import Path
 from typing import Any, Callable
 
+from xskill.agents.atom_text import dominant_language
 from xskill.config import interests_config
 from xskill.pipeline.atom import AtomTask, AtomTaskStore
 
@@ -98,6 +99,8 @@ SYSTEM_PROMPT = """你是 AtomTask 拆分员。给你一条 agent 与用户的�
 3. **不要**因为 tool 切换、代码块出现、子目录变化、agent 自我更正等结构性事件
    而切——避免过度拆分。
 4. 如果整条轨迹只完成一件事,输出 1 个 atom 即可。不要硬凑数量。
+5. **禁止同义重复**：同一目标的澄清、加细、催促不得换一种措辞再提交第二个
+   atom。拿不准就用 ``look``；确认仍是同一目标时保留为一个 atom。
 
 边界与坐标（重要）
 ==================
@@ -133,6 +136,15 @@ SYSTEM_PROMPT = """你是 AtomTask 拆分员。给你一条 agent 与用户的�
 - tags（3-5 个,小写下划线）
 - used_skills（这段对话里 agent 实际触发了哪些 skill 名；没有就传空列表）
 - ux_score（1~10 整数；只评这段 atom 的用户体验,不评整条 traj）
+
+输出语言（重要）
+================
+- 元信息里的 ``source_language`` 是从源轨迹 **User 消息正文**确定性识别的主导
+  语言；代码、路径、URL 和命令不参与识别。
+- ``intent`` 和 ``summary`` 必须使用 ``source_language``。代码、路径、命令及
+  专有名词保持原文；本规则暂不约束 tags / used_skills。
+- ``submit_atom`` 会拒绝与已知源语言明显相反的 intent/summary；收到 error 后按
+  source_language 改正再提交。source_language=unknown 时按用户自然语言上下文写。
 
 ux_score 严格分档表
 ====================
@@ -181,6 +193,7 @@ USER_MSG_TEMPLATE = """\
   trajid: {traj_id}
   trajpath: {traj_path}
   source_model: {source_model}
+  source_language: {source_language}
   total_lines: {total_lines}
   上次拆分到（续接点）: 第 {resume_line} 行
 
@@ -287,8 +300,24 @@ def _extract_user_queries(lines: list[str]) -> list[tuple[int, str]]:
     用户意图边界,不让 agent 误切。摘要取该回合标题后第一条非空、非新标题的
     行,截 80 字。
     """
-    out: list[tuple[int, str]] = []
-    n = len(lines)
+    return [
+        (line_no, _first_nonblank(block_lines)[:80])
+        for line_no, block_lines in _extract_user_blocks(lines).items()
+    ]
+
+
+def _first_nonblank(lines: list[str]) -> str:
+    """Return the first nonblank line in one user-message body."""
+    for line in lines:
+        stripped = line.strip()
+        if stripped:
+            return stripped
+    return ""
+
+
+def _extract_user_blocks(lines: list[str]) -> dict[int, list[str]]:
+    """Return non-noise user-message bodies keyed by their 1-based header line."""
+    out: dict[int, list[str]] = {}
     for i, line in enumerate(lines):
         body = line.rstrip("\r\n").rstrip()
         if not _is_user_header(body):
@@ -296,15 +325,7 @@ def _extract_user_queries(lines: list[str]) -> list[tuple[int, str]]:
         block = _block_after_user(lines, i)
         if _is_machine_noise_block(block):
             continue
-        snippet = ""
-        for j in range(i + 1, n):
-            t = lines[j].strip()
-            if t.startswith("## "):
-                break
-            if t:
-                snippet = t
-                break
-        out.append((i + 1, snippet[:80]))
+        out[i + 1] = block
     return out
 
 
@@ -365,7 +386,16 @@ class TaskAgent:
         if resume_line > total_lines:
             return []  # 没有新增行,省一次 LLM 调用
 
-        queries = _extract_user_queries(lines)
+        user_blocks = _extract_user_blocks(lines)
+        queries = [
+            (line_no, _first_nonblank(block_lines)[:80])
+            for line_no, block_lines in user_blocks.items()
+        ]
+        source_language = dominant_language(
+            line
+            for block_lines in user_blocks.values()
+            for line in block_lines
+        )
         # 续拆：只保留 ≥ resume_line 的 User 回合作为可切边界。
         new_queries = [(ln, snip) for ln, snip in queries if ln >= resume_line]
         if not new_queries:
@@ -383,6 +413,7 @@ class TaskAgent:
             resume_line=resume_line, prior_atoms=prior_atoms,
             all_lines=lines, total_lines=total_lines,
             queries=queries, valid_lines=valid_lines,
+            user_blocks=user_blocks, source_language=source_language,
         )
         if not submitted:
             # 有 User 轮却 0 提交 → 静默空,绝不收下（设计 §4.4）。
@@ -472,7 +503,7 @@ class TaskAgent:
 
     def _run_agent(self, *, traj_id, traj_path, source_model, resume_line,
                    prior_atoms, all_lines, total_lines, queries,
-                   valid_lines) -> list[dict]:
+                   valid_lines, user_blocks, source_language) -> list[dict]:
         """构造 agent + run-scoped 工具,跑一趟工具调用循环。
 
         返回按提交顺序的 ``submitted`` 列表。``submit_atom`` 把校验通过的 atom
@@ -485,6 +516,7 @@ class TaskAgent:
             traj_id=traj_id, traj_path=traj_path, source_model=source_model,
             resume_line=resume_line, prior_atoms=prior_atoms,
             total_lines=total_lines, queries=queries,
+            source_language=source_language,
         )
         from xskill.agents import agent_tools
         tools = agent_tools.make_task_agent_tools(
@@ -494,6 +526,11 @@ class TaskAgent:
             total_lines=total_lines,
             all_lines=all_lines,
             user_msg=user_msg,
+            source_language=source_language,
+            user_blocks={
+                line_no: "".join(user_blocks[line_no])
+                for line_no in valid_lines
+            },
             not_fit_reasons=not_fit_reasons if self.interests else None,
         )
         agent = self.agno_agent_factory(
@@ -560,7 +597,8 @@ class TaskAgent:
         return text[:200] + f"\n\n[省略 {char_off - 200} 字符]\n\n"
 
     def _build_user_msg(self, *, traj_id, traj_path, source_model, resume_line,
-                        prior_atoms, total_lines, queries) -> str:
+                        prior_atoms, total_lines, queries,
+                        source_language) -> str:
         """构造 user 消息（discover / update 共用一份模板）。
 
         context-0 只放 User 提问地图（不含 assistant 正文）+ 元信息 + 续拆衔接块。
@@ -593,6 +631,7 @@ class TaskAgent:
             traj_id=str(traj_id),
             traj_path=str(traj_path),
             source_model=source_model or "(unknown)",
+            source_language=str(source_language),
             total_lines=str(total_lines),
             resume_line=str(resume_line),
             prior_block=prior_block,

--- a/src/xskill/agents/task_agent.py
+++ b/src/xskill/agents/task_agent.py
@@ -406,6 +406,11 @@ class TaskAgent:
 
         prior_atoms = self.store.list_by_traj(traj_id)
         prior_atom = prior_atoms[-1] if prior_atoms else None
+        # Do not feed ``prior_atom`` into the in-run deduper.  A persisted Atom
+        # may already have been embedded, clustered, and consumed by SkillEdit;
+        # mutating it here would require an explicit downstream invalidation and
+        # replay transaction.  This PR only compacts adjacent submissions within
+        # one TaskAgent run.
         valid_lines = [ln for ln, _ in new_queries]
 
         submitted = self._run_agent(

--- a/tests/test_atom_text.py
+++ b/tests/test_atom_text.py
@@ -1,0 +1,91 @@
+"""Deterministic TaskAgent language and adjacent-Atom dedupe contracts."""
+
+from __future__ import annotations
+
+import json
+from pathlib import Path
+
+import pytest
+
+from xskill.agents.atom_text import (
+    adjacent_atoms_are_near_duplicates,
+    detect_source_language,
+    output_language_matches,
+)
+
+
+@pytest.mark.parametrize(
+    ("text", "expected"),
+    [
+        ("Please update `src/中文.py`.\n$ pytest 测试.py", "en"),
+        ("请更新 `src/english.py`。\n$ pytest tests/test_agent.py", "zh"),
+        ("请帮我运行测试。\npytest tests/test_agent.py -q", "zh"),
+        ("```bash\npytest tests/test_agent.py\n```", "unknown"),
+        ("```bash\npytest tests/test_agent.py", "unknown"),
+        ("Make the user interface responsive.", "en"),
+        ("このテストを修正してください。", "unknown"),
+    ],
+)
+def test_source_language_ignores_code_paths_and_commands(text, expected):
+    assert detect_source_language(text) == expected
+
+
+def test_opposite_output_language_is_rejected_but_technical_text_is_allowed():
+    assert output_language_matches("Create a reusable helper.", "en")
+    assert not output_language_matches("创建可复用工具。", "en")
+    assert output_language_matches("`src/xskill/agents/task_agent.py`", "en")
+
+
+def test_replay_near_duplicate_is_detected_without_model_calls():
+    fixture = (
+        Path(__file__).parent.parent
+        / "scripts"
+        / "bench"
+        / "algorithm_replay"
+        / "fixtures"
+        / "baseline_v1.json"
+    )
+    suite = json.loads(fixture.read_text(encoding="utf-8"))
+    case = next(
+        case
+        for case in suite["cases"]
+        if case["case_id"] == "en-near-duplicate-observation"
+    )
+    previous, current = case["predicted_atoms"]
+
+    assert adjacent_atoms_are_near_duplicates(
+        previous,
+        current,
+        current_user_text=case["source_lines"][4],
+    )
+
+
+@pytest.mark.parametrize(
+    ("previous", "current", "user_text"),
+    [
+        (
+            {"intent": "Create a CSV file utility", "summary": "Handle CSV rows."},
+            {"intent": "Create a JSON file utility", "summary": "Handle JSON data."},
+            "Now create a JSON utility.",
+        ),
+        (
+            {"intent": "Fix login validation", "summary": "Validate login."},
+            {"intent": "Fix logout validation", "summary": "Validate logout."},
+            "Now fix logout validation.",
+        ),
+    ],
+)
+def test_related_but_distinct_intents_are_not_merged(previous, current, user_text):
+    assert not adjacent_atoms_are_near_duplicates(
+        previous,
+        current,
+        current_user_text=user_text,
+    )
+
+
+def test_chinese_continuation_is_detected_as_near_duplicate():
+    assert adjacent_atoms_are_near_duplicates(
+        {"intent": "修复登录校验", "summary": "修复登录请求的参数校验。"},
+        {"intent": "继续修复登录校验", "summary": "继续完善登录请求的参数校验。"},
+        current_user_text="继续完善这个登录校验。",
+    )

--- a/tests/test_atom_text.py
+++ b/tests/test_atom_text.py
@@ -3,6 +3,7 @@
 from __future__ import annotations
 
 import json
+from copy import deepcopy
 from pathlib import Path
 
 import pytest
@@ -12,6 +13,7 @@ from xskill.agents.atom_text import (
     detect_source_language,
     output_language_matches,
 )
+from scripts.bench.algorithm_replay.evaluate import evaluate_suite
 
 
 @pytest.mark.parametrize(
@@ -23,7 +25,14 @@ from xskill.agents.atom_text import (
         ("```bash\npytest tests/test_agent.py\n```", "unknown"),
         ("```bash\npytest tests/test_agent.py", "unknown"),
         ("Make the user interface responsive.", "en"),
+        (
+            "请把 atom_candidate_pending 的 PRIMARY KEY 改成 atom_id 和 skill。",
+            "zh",
+        ),
+        ("请优化 ContextManager token cache performance。", "zh"),
+        ("Fix 登录 API", "en"),
         ("このテストを修正してください。", "unknown"),
+        ("日本語のテストを修正", "unknown"),
     ],
 )
 def test_source_language_ignores_code_paths_and_commands(text, expected):
@@ -34,6 +43,9 @@ def test_opposite_output_language_is_rejected_but_technical_text_is_allowed():
     assert output_language_matches("Create a reusable helper.", "en")
     assert not output_language_matches("创建可复用工具。", "en")
     assert output_language_matches("`src/xskill/agents/task_agent.py`", "en")
+    assert output_language_matches(
+        "请优化 ContextManager token cache performance。", "zh"
+    )
 
 
 def test_replay_near_duplicate_is_detected_without_model_calls():
@@ -60,6 +72,39 @@ def test_replay_near_duplicate_is_detected_without_model_calls():
     )
 
 
+def test_replay_duplicate_merge_improves_segmentation_without_coverage_loss():
+    fixture = (
+        Path(__file__).parent.parent
+        / "scripts"
+        / "bench"
+        / "algorithm_replay"
+        / "fixtures"
+        / "baseline_v1.json"
+    )
+    suite = json.loads(fixture.read_text(encoding="utf-8"))
+    before = evaluate_suite(deepcopy(suite))["metrics"]
+    case = next(
+        case
+        for case in suite["cases"]
+        if case["case_id"] == "en-near-duplicate-observation"
+    )
+    previous, current = case["predicted_atoms"]
+    merged = {
+        **previous,
+        "end_line": max(previous["end_line"], current["end_line"]),
+    }
+    case["predicted_atoms"] = [merged]
+
+    after = evaluate_suite(suite)["metrics"]
+
+    assert after["duplicate_rate"] < before["duplicate_rate"]
+    assert after["overlap_rate"] < before["overlap_rate"]
+    assert after["segmentation"]["pk"] < before["segmentation"]["pk"]
+    assert after["segmentation"]["window_diff"] < before["segmentation"]["window_diff"]
+    assert after["coverage"] == before["coverage"] == 1.0
+    assert after["language_consistency"] == before["language_consistency"] == 1.0
+
+
 @pytest.mark.parametrize(
     ("previous", "current", "user_text"),
     [
@@ -72,6 +117,28 @@ def test_replay_near_duplicate_is_detected_without_model_calls():
             {"intent": "Fix login validation", "summary": "Validate login."},
             {"intent": "Fix logout validation", "summary": "Validate logout."},
             "Now fix logout validation.",
+        ),
+        (
+            {
+                "intent": "Create password reset email template",
+                "summary": "Create the email template for password reset requests.",
+            },
+            {
+                "intent": "Create password reset email endpoint",
+                "summary": "Create the email endpoint for password reset requests.",
+            },
+            "Now implement this endpoint.",
+        ),
+        (
+            {
+                "intent": "Create password reset HTML email template",
+                "summary": "Create an HTML email template for password resets.",
+            },
+            {
+                "intent": "Create password reset SMS email template",
+                "summary": "Create an SMS email template for password resets.",
+            },
+            "Continue with this SMS variant.",
         ),
     ],
 )

--- a/tests/test_task_agent.py
+++ b/tests/test_task_agent.py
@@ -607,8 +607,44 @@ class TestSubmitValidation:
         assert atoms[0].intent == "Deploy the service"
         assert "source_language: en" in factory.captured["user_msg"]
 
+    def test_chinese_request_with_technical_identifiers_stays_chinese(self, tmp_path):
+        traj_dir = tmp_path / "cc-sessions"
+        traj_dir.mkdir()
+        traj_path = traj_dir / "traj_technical.md"
+        traj_path.write_text(
+            "## User\n\n"
+            "请把 atom_candidate_pending 的 PRIMARY KEY 改成 atom_id 和 skill。\n\n"
+            "## Assistant\n\n已完成。\n",
+            encoding="utf-8",
+        )
+        store = AtomTaskStore(root=traj_dir)
+        factory = _scripted_factory([
+            dict(
+                start_line=1,
+                intent="修改待处理 Atom 的联合主键",
+                summary="将待处理关联改为 Atom 与 Skill 的联合主键。",
+                ux_score=8,
+            ),
+        ])
+
+        atoms = TaskAgent(agno_agent_factory=factory, store=store).run(
+            traj_id="traj_technical", traj_path=traj_path)
+
+        assert factory.captured["results"] == [
+            "ok: 已记录 atom #1 (start_line=1)"
+        ]
+        assert "source_language: zh" in factory.captured["user_msg"]
+        assert len(atoms) == 1
+
     def test_adjacent_near_duplicates_merge_metadata_and_ranges(self, tmp_path):
         traj_path, store = self._setup(tmp_path)
+        traj_path.write_text(
+            _TRAJ_MD.replace(
+                "Now redesign the frontend.",
+                "Keep improving the same Python file helper.",
+            ),
+            encoding="utf-8",
+        )
         factory = _scripted_factory([
             dict(
                 start_line=5,
@@ -663,6 +699,45 @@ class TestSubmitValidation:
 
         assert len(atoms) == 2
         assert atoms[0].offset_end == atoms[1].offset_start == 17
+
+    def test_merged_submission_still_advances_start_line_guard(self, tmp_path):
+        traj_path, store = self._setup(tmp_path)
+        traj_path.write_text(
+            _TRAJ_MD.replace(
+                "Now redesign the frontend.",
+                "Keep improving the same Python file helper.",
+            ),
+            encoding="utf-8",
+        )
+        factory = _scripted_factory([
+            dict(
+                start_line=5,
+                intent="Create a Python file utility",
+                summary="Write the requested reusable file helper.",
+                ux_score=8,
+            ),
+            dict(
+                start_line=17,
+                intent="Build a reusable Python file helper",
+                summary="The later turns continue the same file-helper task.",
+                ux_score=7,
+            ),
+            dict(
+                start_line=5,
+                intent="Create a JSON parser utility",
+                summary="Parse JSON payloads in a separate utility.",
+                ux_score=8,
+            ),
+        ])
+
+        atoms = TaskAgent(agno_agent_factory=factory, store=store).run(
+            traj_id="traj_e", traj_path=traj_path)
+
+        assert factory.captured["results"][1].startswith("ok:")
+        assert "已合并" in factory.captured["results"][1]
+        assert factory.captured["results"][2].startswith("error:")
+        assert "上一条 (17)" in factory.captured["results"][2]
+        assert len(atoms) == 1
 
 
 # ────────────────────────────────────────────────────────────────────

--- a/tests/test_task_agent.py
+++ b/tests/test_task_agent.py
@@ -52,12 +52,15 @@ def autosplit_submit(user_msg: str, tools: dict) -> None:
     submit = tools.get("submit_atom")
     if submit is None:
         return
+    source_is_zh = bool(re.search(
+        r"^\s*source_language:\s*zh\s*$", user_msg, re.MULTILINE,
+    ))
     for ln in [int(n) for n in re.findall(r"\[line:(\d+)\]", user_msg)]:
         _call_tool(
             submit,
             start_line=ln,
-            intent="stub intent",
-            summary="stub summary",
+            intent="测试意图" if source_is_zh else "stub intent",
+            summary="测试摘要" if source_is_zh else "stub summary",
             tags=["stub"],
             used_skills=[],
             ux_score=7,
@@ -276,10 +279,16 @@ class TestFirstRunSinglePass:
         traj_path.write_text(_TRAJ_MD, encoding="utf-8")
         store = AtomTaskStore(root=traj_dir)
         factory = _scripted_factory([
-            dict(start_line=5, intent="部署", summary="克隆并部署 xquiz",
-                 tags=["deploy"], used_skills=[], ux_score=7),
-            dict(start_line=17, intent="前端", summary="编辑 CSS",
-                 tags=["frontend"], used_skills=["frontend-design"], ux_score=8),
+            dict(
+                start_line=5, intent="Deploy xquiz",
+                summary="Clone and deploy xquiz", tags=["deploy"],
+                used_skills=[], ux_score=7,
+            ),
+            dict(
+                start_line=17, intent="Redesign frontend",
+                summary="Edit the CSS", tags=["frontend"],
+                used_skills=["frontend-design"], ux_score=8,
+            ),
         ])
         atoms = TaskAgent(agno_agent_factory=factory, store=store).run(
             traj_id="traj_p", traj_path=traj_path)
@@ -368,9 +377,11 @@ class TestIncrementalRun:
         total_lines = len(full.splitlines(keepends=True))
 
         factory = _scripted_factory([
-            dict(start_line=new_user_line, intent="补单元测试",
-                 summary="用户要求加测试；agent 写 pytest",
-                 tags=["testing"], used_skills=[], ux_score=7),
+            dict(
+                start_line=new_user_line, intent="Add unit tests",
+                summary="The user requested tests and the agent wrote pytest",
+                tags=["testing"], used_skills=[], ux_score=7,
+            ),
         ])
         new_atoms = TaskAgent(agno_agent_factory=factory, store=store).run(
             traj_id="traj_y", traj_path=traj_path)
@@ -573,6 +584,86 @@ class TestSubmitValidation:
         assert len(atoms) == 1
         assert atoms[0].ux_score == 8
 
+    def test_source_language_mismatch_rejected_then_corrected(self, tmp_path):
+        traj_path, store = self._setup(tmp_path)
+        factory = _scripted_factory([
+            dict(
+                start_line=5, intent="部署服务", summary="克隆并部署应用",
+                ux_score=7,
+            ),
+            dict(
+                start_line=5, intent="Deploy the service",
+                summary="Clone and deploy the application", ux_score=7,
+            ),
+        ])
+
+        atoms = TaskAgent(agno_agent_factory=factory, store=store).run(
+            traj_id="traj_e", traj_path=traj_path)
+
+        assert factory.captured["results"][0].startswith("error:")
+        assert "源轨迹主导语言 en" in factory.captured["results"][0]
+        assert factory.captured["results"][1].startswith("ok:")
+        assert len(atoms) == 1
+        assert atoms[0].intent == "Deploy the service"
+        assert "source_language: en" in factory.captured["user_msg"]
+
+    def test_adjacent_near_duplicates_merge_metadata_and_ranges(self, tmp_path):
+        traj_path, store = self._setup(tmp_path)
+        factory = _scripted_factory([
+            dict(
+                start_line=5,
+                intent="Create a Python file utility",
+                summary="Write the requested reusable file helper.",
+                tags=["python", "files"],
+                used_skills=["skill-a", "skill-b"],
+                ux_score=8,
+            ),
+            dict(
+                start_line=17,
+                intent="Build a reusable Python file helper",
+                summary="The later turns continue the same file-helper task.",
+                tags=["files", "reusable"],
+                used_skills=["skill-b", "skill-c", "skill-d"],
+                ux_score=6,
+            ),
+        ])
+
+        atoms = TaskAgent(agno_agent_factory=factory, store=store).run(
+            traj_id="traj_e", traj_path=traj_path)
+
+        assert len(atoms) == 1
+        assert atoms[0].offset_start == 1
+        assert atoms[0].offset_end == 24
+        assert atoms[0].tags == ["python", "files", "reusable"]
+        assert atoms[0].used_skills == [
+            "skill-a", "skill-b", "skill-c", "skill-d",
+        ]
+        assert atoms[0].ux_score == 6
+        assert "已合并" in factory.captured["results"][1]
+
+    def test_similar_sibling_tasks_remain_separate(self, tmp_path):
+        traj_path, store = self._setup(tmp_path)
+        factory = _scripted_factory([
+            dict(
+                start_line=5,
+                intent="Create a CSV file utility",
+                summary="Create a reusable helper for CSV rows.",
+                ux_score=8,
+            ),
+            dict(
+                start_line=17,
+                intent="Create a JSON file utility",
+                summary="Create a reusable helper for JSON data.",
+                ux_score=8,
+            ),
+        ])
+
+        atoms = TaskAgent(agno_agent_factory=factory, store=store).run(
+            traj_id="traj_e", traj_path=traj_path)
+
+        assert len(atoms) == 2
+        assert atoms[0].offset_end == atoms[1].offset_start == 17
+
 
 # ────────────────────────────────────────────────────────────────────
 # look 工具：读某行附近原文（含向前看）
@@ -688,6 +779,10 @@ class TestSystemPrompt:
         # 弃窗 + 撤销原则
         assert "弃窗单趟" in system_msg
         assert "撤销" in system_msg
+        # #21/#24: no synonymous duplicate Atom and source-language output.
+        assert "禁止同义重复" in system_msg
+        assert "source_language" in system_msg
+        assert "intent" in system_msg and "summary" in system_msg
 
     def test_literal_braces_in_query_snippet_are_safe(self, tmp_path):
         """User 提问含 ``{}`` 字面量时,模板注入不二次解析。"""
@@ -700,7 +795,7 @@ class TestSystemPrompt:
         )
         store = AtomTaskStore(root=traj_dir)
         factory = _scripted_factory([
-            dict(start_line=1, intent="i", summary="s", ux_score=7),
+            dict(start_line=1, intent="测试意图", summary="测试摘要", ux_score=7),
         ])
         atoms = TaskAgent(agno_agent_factory=factory, store=store).run(
             traj_id="traj_b", traj_path=traj_path)


### PR DESCRIPTION
## Summary

在 TaskAgent 的 Atom 写入边界增加两道确定性质量保护：相邻近重复 Atom 不再重复落盘，`intent` / `summary` 必须跟随源轨迹 User 消息的主导语言。实现不增加 embedding、网络依赖或数据库迁移。

## Changes

- 强化拆分提示词，明确同一目标的澄清、补充和催促不能产生同义重复 Atom。
- 从非噪声 User 消息识别 `en` / `zh` / `unknown`；语言判断忽略代码、路径、URL、命令及常见技术标识符。
- 在 `submit_atom` 写入前拒绝与已知源语言明显不一致的 `intent` / `summary`，允许 agent 当轮纠正。
- 仅对同一次 TaskAgent 运行中的相邻提交执行保守的字面去重；命中后保留最早边界，按稳定顺序合并 tags 和任意数量的 used_skills，并采用更保守的 ux_score。
- 合并候选仍会推进严格递增的 `start_line` 游标，避免后续 Atom 回退并产生错误覆盖区间。
- 复用既有离线回放样本，增加指标差分、误合并对照、混合技术文本、顺序不变量、多 Skill 关系和覆盖区间回归测试。
- 本 PR 不修改已持久化的历史 Atom，也不扩展到 Cluster、SkillEdit、candidates、UX reasons 或全局 `output_language` 配置；跨运行合并需要单独设计下游失效与重放事务。

## Test plan

- [x] `make test` passes
- [x] Added/updated unit tests for the change
- [ ] `make e2e` passes (if the change touches ingestion / install / daemon)
- [ ] Manually verified the affected user flow

完整单元测试结果：2407 passed, 10 skipped。相关模块聚焦测试 90 passed；Focused Ruff 和 `git diff --check` 通过。该改动不涉及 ingestion、install 或 daemon，因此未运行 Docker E2E；未调用真实 LLM。

## Linked issues

Closes #21
Refs #24
