### PR TITLE
feat(tasks): 实现 Logical Task 与 Task Attempt 运行时

### DIFF
--- a/docs/adr/0002-logical-task-and-attempt-model.md
+++ b/docs/adr/0002-logical-task-and-attempt-model.md
@@ -32,6 +32,19 @@ xskill 当前有两层与轨迹处理有关的数据：
 
 Session 和 Atom 仍是证据层；LogicalTask 和 TaskAttempt 是可追溯、可修正的语义层。Skill 路由与 Task 归组是正交关系：一个 Atom 可以继续支撑多个 Skill，但其主 Task 归属遵守下文的唯一性规则。
 
+### 对现有 Atom → Skill 流程的影响
+
+本 ADR 合并时不改变现有生产数据流，也不为 `AtomTask` 增加 Task 或 Attempt 字段。当前路径仍是 `Session → TaskAgent → AtomTask → TaskClusterAgent → candidate → SkillEditAgent → Skill`；`used_skills`、`ux_score`、每个 `(atom_id, skill)` 关联上的 `weightscore`、candidate 写入和 SkillEdit 触发语义均保持不变。
+
+后续 Task Graph 实现会在 Atom 形成后建立一条独立的语义与评测支路，而不是插入或取代现有 Skill 路由：
+
+```text
+Session → Atom ─┬─→ TaskClusterAgent → candidate → SkillEditAgent → Skill
+                └─→ TaskAtomMembership → LogicalTask → TaskAttempt → outcome / usage attribution
+```
+
+`TaskAtomMembership` 是独立关系，`TaskAttempt` 通过 `EvidenceRange` 引用 Session 或 Atom 中的执行证据；两者都不是 Atom 内嵌属性，也不能作为 candidate 去重键或限制一个 Atom 只能支撑一个 Skill。Task/Attempt 对 `Atom → Skill` 的作用仅是让 Skill 使用、执行结果和成本能够在目标与尝试粒度被观测和归因；若未来希望 Task 上下文参与 Skill 路由，必须由独立算法设计和生产 PR 明确输入、回退及评测，不由本 ADR 隐式引入。
+
 ### 1. 身份与作用域
 
 所有引用都必须带作用域，不能把裸 `traj_id` 或 `atom_id` 当作全局唯一键，也不能把“有权读取同一批数据”误当成“属于同一个用户任务”：

--- a/docs/adr/0002-logical-task-and-attempt-model.md
+++ b/docs/adr/0002-logical-task-and-attempt-model.md
@@ -1,0 +1,399 @@
+# ADR-0002: 在 Atom 之上引入 Logical Task 与 Task Attempt
+
+**状态:** Proposed（本 ADR 合并后即为 Accepted）
+
+**日期:** 2026-08-23
+
+**关联 issue:** SkillNerds/xskill#324
+
+## 背景
+
+xskill 当前有两层与轨迹处理有关的数据：
+
+- `Trajectory`（下文称 Session）保留一次 Harness 会话的完整原始轨迹；
+- `AtomTask` 把 Session 拆成按时间连续的单意图片段。
+
+`AtomTask.pre_atom_id` / `post_atom_id` 只表达时间相邻，`used_skills` 表达
+一个 Atom 实际使用过的多个 Skill。Registry 中的 `status`、`retry_count` 和
+`error_msg` 描述 xskill 流水线是否完成处理，不描述用户目标是否完成。
+
+因此，现有结构不能稳定表达 A → B → A 的目标恢复、跨 Session 延续、父子任务、
+同一目标的多次执行，以及成功率、Token、成本和错误的目标级归因。把这些语义继续
+塞进 Atom 或 Session 会混淆连续证据片段、逻辑目标与执行尝试。
+
+本 ADR 只定义模型与不变量，不增加生产聚合算法、持久化迁移、历史回填或 Dashboard。
+#22 的 Trajectory → Skill provenance API 可以消费后续 Task Graph 投影，但不由本
+ADR 改变接口范围。
+
+## 决策
+
+在 Session 与 Atom 之上增加 `LogicalTask`，并在 LogicalTask 之下增加
+`TaskAttempt`。四层各自回答不同问题：
+
+| 层 | 回答的问题 | 不负责 |
+| --- | --- | --- |
+| Session | Harness 在一次会话中按什么顺序发生了什么？ | 判断一个逻辑目标是否完成 |
+| Atom | 哪段连续轨迹围绕一个用户意图？ | 表达非连续恢复、父子目标和重试次数 |
+| LogicalTask | 哪些 Atom 共同服务于同一个用户目标？ | 表示每一次具体执行 |
+| TaskAttempt | 该目标的一次执行或重试使用了什么，并得到什么结果？ | 取代原始轨迹证据 |
+
+Session 和 Atom 仍是证据层；LogicalTask 和 TaskAttempt 是可追溯、可修正的
+语义层。Skill 路由与 Task 归组是正交关系：一个 Atom 可以继续支撑多个 Skill，
+但其主 Task 归属遵守下文的唯一性规则。
+
+### 1. 身份与作用域
+
+所有引用都必须带作用域，不能把裸 `traj_id` 或 `atom_id` 当作全局唯一键，也不能
+把“有权读取同一批数据”误当成“属于同一个用户任务”：
+
+```text
+TenantScope = 权限与隐私边界
+TaskScope   = 可进行 Task 关联的语义所有权边界
+SourceScope = Trajectory / Atom 的摄取命名空间
+SessionRef  = (tenant_id, task_scope_id, source_scope_id, traj_id)
+AtomRef     = (tenant_id, task_scope_id, source_scope_id, traj_id, atom_id)
+TaskRef     = (tenant_id, task_scope_id, task_id)
+AttemptRef  = (tenant_id, task_scope_id, task_id, attempt_id)
+```
+
+- `tenant_id` 限定权限与隐私边界；算法和查询不得跨 tenant 读取或聚合。
+- `task_scope_id` 默认绑定稳定 actor 与 workspace/project。同一团队中两个成员提出
+  相同需求，仍是两个 LogicalTask；只有带明确协作身份和权限证据的共享任务才允许
+  跨 actor 关联。
+- `source_scope_id` 区分独立 watch dir、客户端或其他摄取命名空间。它可以映射到
+  持久 watch-dir key 或 server 端客户端身份，但不能由可变目录路径或展示标签临时
+  拼接。
+- `task_id` 和 `attempt_id` 使用不含业务语义的稳定 opaque id。标题、摘要、Atom
+  顺序或模型输出变化不得导致 id 自动变化。
+- `AtomRef` 保留 `traj_id`，即使现有 `atom_id` 通常包含轨迹片段；实现不能依赖
+  这种字符串命名约定。该规则与 #234 / PR #260 的跨成员身份处理兼容。
+
+LogicalTask 可以跨多个 Session，但只能在同一 TaskScope 内。一次 TaskAttempt 只
+属于一个 LogicalTask；Session 边界本身既不能证明 Attempt 结束，也不能证明执行连续。
+有稳定 run id、workspace 状态、Harness resume 事件或等价连续性证据时，一个 Attempt
+可以引用多个 Session。无法证明连续性时创建新的 Attempt，并把 `continuation_of`
+保留为 proposed 关系；没有失败和重新执行证据时不能误标为 `retry_of`。
+
+### 2. Atom 到 LogicalTask 的归属
+
+使用显式 `TaskAtomMembership`，至少包含：
+
+```text
+task_ref, atom_ref, role, confidence, decision, decided_by, evidence_refs
+```
+
+- `role` 为 `primary` 或 `context`。`primary` 表示该 Atom 的主要目标归属；
+  `context` 只提供背景证据，不能参与覆盖率、成本或成功率的重复计数。
+- 每个 Atom 最多有一个 `decision=confirmed` 的 primary membership；一个
+  LogicalTask 必须至少有一个 confirmed primary Atom 才能进入正式统计。
+- 边界不明确时允许存在多个 `proposed` membership，但不得选择最高分后静默
+  合并。它们保持未决，并进入 review/uncertain 集合。
+- 人工确认或拒绝的 membership 优先于后续自动重建；自动算法不能覆盖人工决定。
+
+`pre_atom_id` / `post_atom_id` 继续只表示时间相邻，不推导 membership、父子或
+继续关系。A → B → A 中的两个 A Atom 通过 membership 指向同一个 LogicalTask，
+不需要伪造 Atom 邻接关系。
+
+### 3. 语义关系属于哪一层
+
+关系按下列规则落层：
+
+| 关系 | 所属层 | 语义 |
+| --- | --- | --- |
+| 时间前后 | Atom → Atom | 现有 `pre_atom_id` / `post_atom_id` |
+| 非连续继续 | Atom → LogicalTask | 多个 Atom 归入同一 Task |
+| parent / subtask | LogicalTask → LogicalTask | 目标分解；每个 Task 最多一个 primary parent |
+| depends_on / follows_up | LogicalTask → LogicalTask | 不改变两个目标各自的身份 |
+| continuation_of | TaskAttempt → TaskAttempt | 新执行片段继续同一目标，但没有 retry 证据 |
+| retry_of | TaskAttempt → TaskAttempt | 相同目标的再次执行 |
+| correction_of / supersedes | TaskAttempt → TaskAttempt | 新执行修正或取代旧执行结果 |
+
+Task 的 parent/subtask 边必须构成有向无环图。`depends_on` 和 `follows_up` 也不能
+被用来规避环检测。用户说“继续”而目标和输出契约未改变时，仍是同一个 Task；只有
+形成可独立执行、可独立判断终态的新目标时才创建 `follows_up` 或子 Task。
+
+### 4. TaskAttempt 与证据范围
+
+一个 Attempt 至少包含 `task_ref`、`attempt_id`、一个或多个 `EvidenceRange`、
+开始/结束时间、执行身份和 outcome。`EvidenceRange` 使用稳定定位信息：
+
+```text
+session_ref, atom_ref?, locator_kind, start, end, content_hash
+```
+
+范围采用半开区间 `[start, end)`。适配器有稳定事件 id 时优先使用事件范围；否则
+使用 Atom 内或标准化轨迹内的行范围，并用 `content_hash` 检测来源漂移。
+
+一个 Atom 内出现多次执行或重试时，不复制 Atom，也不把它强行拆成多个 Task；为
+同一 LogicalTask 创建多个 Attempt，并让每个 Attempt 引用各自事件范围。一个
+Attempt 可以覆盖同一 TaskScope 内的多个 Atom 或 Session，但所有 primary Atom
+必须属于该 Attempt 的 Task。模型、Harness 和 Skill 版本绑定到具体 EvidenceRange
+或执行 segment，再汇总到 Attempt；跨 Session 时不能用一个标量覆盖中途发生的版本
+变化。
+
+### 5. Lifecycle、Outcome 与可核验证据
+
+生命周期、任务结果、客观验证和用户反馈是不同维度，不能压缩进一个分数或枚举：
+
+```text
+TaskLifecycle    = open | blocked | closed
+TaskOutcome      = succeeded | partially_succeeded | failed |
+                   cancelled | abandoned | unknown
+AttemptLifecycle = running | finished
+AttemptOutcome   = succeeded | partially_succeeded | failed |
+                   blocked | cancelled | unknown
+Verification     = unverified | verified | contradicted | conflicted |
+                   not_applicable
+UserDisposition  = accepted | rejected | corrected | cancelled | unknown
+```
+
+- `blocked` 是可恢复的 Task 生命周期状态，不是 Task 终态。当前执行因外部条件停止时，
+  Attempt 可以 `finished + blocked`，Task 则保持 `blocked + unknown`；后续恢复不会
+  改写旧 Attempt 的事件范围。
+- `closed` 表示当前观察版本已经形成终态。后续证据重新打开 Task 或修正旧 outcome
+  时，应追加新的决策记录并保留历史值。
+- `abandoned` 需要用户明确放弃或版本化策略给出的可核验证据；仅仅 Session 结束或
+  用户转向其他目标时，Task 仍为 `open/unknown`。
+- LogicalTask outcome 从 Attempt 和目标要求派生，不是“最后一个 Attempt outcome”
+  的简单复制。Registry `DONE`、Trajectory `meta.success` 和 Harness 会话结束都只能
+  作为 Session/流水线证据，不能单独证明 Task 成功。
+
+只有目标要求的输出已经满足，且之后没有相冲突的纠正时，Task 才能判为
+`succeeded`。只有部分可独立判断的要求完成时使用 `partially_succeeded`；观察到明确
+失败但仍有后续 Attempt 在运行时，Task 保持 `open`，而不是提前记为 `failed`。
+
+每次 lifecycle、outcome、verification 或 user disposition 判断都必须分别记录
+`evidence_refs`、`confidence`、`decided_by` 和 `observed_at`。证据按其能证明的事实
+类型使用，而不是采用一条全局优先级链：
+
+- 用户明确验收、拒绝、取消或纠正决定 `UserDisposition`，并可作为目标是否满足的
+  证据，但不能覆盖相冲突的结构化执行事实；
+- 与 Attempt 绑定的测试、工具结果、退出码或 Harness 终态决定客观验证状态；
+- 可定位的产物变化提供补充验证证据；
+- Assistant 的自然语言自报只能作为弱证据，不能单独产生 `verified`。
+
+证据冲突时使用 `Verification=conflicted` 和 `needs_review`，不得硬选一个成功或失败
+终态。现有 `ux_score` 衡量 Atom 使用某个 Skill 的体验，`weightscore` 衡量 Atom 对
+Skill 的贡献；两者均不能复用为 Task outcome、verification 或关联 confidence。
+
+### 6. 不确定性
+
+边界、Task 关联、关系类型、lifecycle、outcome、verification 和 user disposition
+分别记录独立的 `confidence`，不能共用一个总分。confidence 为 `[0, 1]` 的概率值，
+必须同时记录产生它的算法/模型版本；没有经过概率校准的启发式分数不得冒充
+confidence。
+
+每个决定使用以下状态之一：
+
+```text
+proposed | confirmed | rejected | needs_review
+```
+
+生产阈值不在本 ADR 中固定。无论采用什么阈值，低置信关系都必须保留为 proposed，
+不得自动合并后丢弃备选边界。#325 的离线回放负责检验误合并、误拆分及置信度校准。
+
+### 7. 模型、Harness、Skill 与用量归因
+
+模型、Harness 和 Skill 的执行版本先绑定到 TaskAttempt 的 EvidenceRange/segment，
+再从 Attempt 聚合到 LogicalTask：
+
+- 用户任务模型记录 provider、model id 和可用的版本/快照；
+- 用户 Harness 记录 name 和可用的版本；
+- Skill 使用记录为多值，每项独立携带 name、version/commit 和使用证据；
+- 缺失版本使用 `unavailable + reason`，不能用空串伪装一个版本。
+
+Token/成本必须先区分两个不能互相替代的 usage plane：
+
+```text
+execution         原 Harness 执行用户 Task 的模型、工具与工作区成本
+xskill_processing xskill 拆 Atom、关联 Task、路由、编辑 Skill 和打分的处理成本
+```
+
+`execution` usage 才能用于比较模型/Harness/Skill 执行 Task 的效率。当前
+`UsageLedger` / Registry `llm_usage` 记录的是 `atom_split`、`skill_route`、
+`skill_edit`、`ux_score` 等 xskill processing 调用，不能混入用户 Task 的执行 Token。
+xskill processing 成本可以关联到生成它的 Session、Atom、Task Graph generation 或
+Skill 流水线，但必须独立展示和守恒。
+
+每条原始 Token/成本记录必须带唯一 `usage_event_id`、`usage_plane`，并把测量质量
+和分摊方式分开记录：
+
+```text
+measurement_quality = measured | estimated | unavailable
+allocation_mode     = direct | shared | unattributed
+```
+
+- `measured` 表示上游提供；`estimated` 必须携带估算方法及版本；`unavailable` 表示
+  上游未提供且无法可靠估算；
+- `direct` 表示事件只服务一个对象；`shared` 使用显式方法分摊给多个对象；
+  `unattributed` 保留无法可靠分配的余额。
+
+`price_source` 只描述单价来源，不等同于 Token 测量质量。原始事件记录 Session/source
+scope 和可用的 Harness event id；Task 归组完成后再产生独立 allocation，不回写原始
+用量事件。
+
+归因必须在每个 usage plane 内分别守恒：同一 `usage_event_id` 的 Attempt 或处理步骤
+分摊之和加未归因余额，等于原始事件用量；不得把 shared 开销完整复制给多个 Task。
+`unavailable` 使用 `null` 和原因，不记为 0。Session、Task 和 Skill 视图从同一原始
+ledger 和 allocation 派生，不能各自维护会漂移的总数，也不能把两个 usage plane
+相加后作为模型执行成本。
+
+现有 `llm_usage` 行缺少稳定 event id、Session/Atom 引用和 measurement quality，历史
+行继续作为 `xskill_processing + legacy_unattributed` 保留；本 ADR 不推测回填这些
+字段。未来扩展先新增并回填可确定的字段，再建立索引或约束。
+
+### 8. 事实源、覆盖与 SQLite 投影
+
+存储分为四类：
+
+1. Session 三件套和 Atom JSON：原始证据与拆分事实源，现状不变；
+2. append-only usage event ledger：原始 execution / xskill processing 用量事实；
+3. versioned Task Graph generation：LogicalTask、membership、relation、Attempt、
+   outcome 与 usage allocation 的可重放版本；
+4. append-only override log：人工确认、拒绝、拆分、合并和终态修正。
+
+Registry SQLite 当前同时承担不同角色，不能笼统称为投影：Trajectory 状态和未来的
+Task 查询表可以是可重建投影；现有 `llm_usage` 则是已经发生并支付的 xskill processing
+用量事实，rebuild 会刻意保留。除非独立迁移把原始 usage event 无损搬到新的权威 ledger，
+否则删除该表无法从 Session/Atom 重建。历史 `llm_usage` 不在本 ADR 中清洗或推测关联。
+
+Task Graph 的逻辑 manifest 使用 UTF-8 JSON，至少包含 `schema_version`、
+`generation_id`、`tenant_id`、`task_scope_id`、`source_revision`、`generator`、
+`base_override_seq`、`tasks`、`memberships`、`relations`、`attempts` 和
+`usage_allocations`。小数据集可以使用单一快照；大数据集可以让 manifest 索引不可变
+JSON/JSONL shard。发布方必须先完整写入新 generation，再原子切换一个小型 current
+pointer，并复用未变化的 shard，不能要求每次增量更新都重写整个 TaskScope。具体目录
+名和分片策略由后续存储 PR 决定，引用中不得写入本机绝对路径。
+
+`source_revision` 覆盖所有输入 Session/Atom 的 scoped id 与内容哈希；实现可以使用
+Merkle root 增量维护，避免为了计算 revision 重扫全部输入。override log 使用带唯一
+`event_id` 和单调 `override_seq` 的 JSONL，保留目标 id、操作、证据和时间；重放顺序
+明确，人工决定优先于 manifest 中的自动结果。generation 记录已经吸收的
+`base_override_seq`，读取时只叠加其后的事件，避免重复应用。
+
+xskill 是 Task Graph generation、current pointer 和 override log 的唯一写入者；Harness
+只提供证据事件。写入由 TaskScope 级锁或等价事务串行化，current pointer 同时发布
+`generation_id` 和 override watermark。override log 可以做带校验点的压缩，但旧段必须
+保留可审计摘要和内容哈希，不能为了缩短重放时间丢失人工决定。
+
+SQLite 中新增的 Task 表只保存 effective graph 的可重建查询投影。删除这些 Task 投影
+表后，必须能从证据事实源、usage ledger、最新 manifest 和 override log 重建相同结果。
+任何只写 SQLite、无法重放的 Task 关系都违反本 ADR；该要求不追溯改变现有
+`llm_usage` 的权威 telemetry 语义。
+
+### 9. 增量更新、重建与删除
+
+- Session 续写或新增 Atom 只重新分类候选边及受影响的连通分量；未受影响的 Task id
+  不变。候选检索可以查询全局索引，但不能因此全量重算所有 Atom 对。
+- 自动重建应复用仍含 confirmed primary anchor 的 Task id。Task 拆分时，显式人工
+  canonical override 优先；否则原 id 留给含最早人工 confirmed primary anchor 的
+  分量，再退化到最早 confirmed anchor，其他分量获得新 id。
+- Task 合并时按“显式人工 canonical override → 最早人工 confirmed anchor → 最早
+  created task”的顺序选择 canonical id。其他 id 作为 alias/tombstone 保留，避免
+  历史链接失效。自动算法不得合并被人工拒绝的关系。
+- Atom 删除后，自动 membership 可以失效；人工 override 保留但标记 stale。若 Task
+  失去全部 confirmed primary Atom，则从正式统计移出并保留 tombstone，不得把旧 id
+  分配给新目标。
+- EvidenceRange 的 `content_hash` 不匹配时，该证据标记 stale；仅依赖 stale 证据的
+  outcome 降为 `unknown/needs_review`。
+- 历史 Atom 不要求本 ADR 合并时立即回填；未来回填必须生成独立 source revision，
+  可重复运行且不覆盖人工 override。
+
+### 10. 生产算法与查询性能边界
+
+若 TaskScope 中有 `n` 个 Atom，生产关联不能对所有 Atom 做全量两两模型判断。候选
+生成应组合同 Session 邻域、显式 continuation/retry 证据、关键词/向量 Top-K 和已确认
+Task anchor，把分类数量限制为 `O(nk)`（`k` 为有上限的候选数）；LLM 只处理规则与
+检索无法确认的歧义边。实现必须记录候选数、模型判断数和受影响分量大小，以确定性计数
+测试保护复杂度，不能用墙钟阈值掩盖退化。
+
+Task Graph generation 复用未变化 shard，override replay 使用 checkpoint/watermark，
+内存只保留当前 TaskScope 所需的有界工作集。Dashboard 不得直接连接 Task × Atom ×
+Skill × Attempt 后求和；应先按唯一 relation/usage event 聚合或使用物化投影，防止
+笛卡尔积造成重复计数。
+
+## 必须保持的不变量
+
+后续实现与 #325 离线回放至少验证以下不变量：
+
+1. 裸 `traj_id` / `atom_id` 不跨 source scope 判等，也不跨 tenant 读取。
+2. LogicalTask 不跨 TaskScope 自动聚合；团队共享 Skill 不等于共享 Task。
+3. 每个 Atom 最多一个 confirmed primary Task；proposed 关系不进入正式统计。
+4. Atom 时间链不推导 Task 语义关系。
+5. Task parent/subtask 图无环，TaskAttempt 只属于一个 Task。
+6. Session 边界不自动切 Attempt；跨 Session 连续性必须有证据。
+7. 一个 Atom 可以包含多个 Attempt，一个 Atom 仍可支撑多个 Skill。
+8. Lifecycle、outcome、verification 和 user disposition 分开记录。
+9. Registry 状态和 Trajectory `meta.success` 不能作为 Task 成功的唯一证据。
+10. Task/Attempt outcome 必须可定位到证据；无证据为 `unknown`。
+11. execution 与 xskill processing usage 分账，并在各自 plane 内守恒。
+12. shared usage 不重复计算，unavailable 不伪装为 0。
+13. SQLite Task 投影可由事实源、usage ledger、manifest 和 override log 重建；现有
+    `llm_usage` 仍按权威 telemetry 处理。
+14. 增量更新不重编号未受影响的 Task，删除不复用旧 id，canonical 选择遵守人工优先。
+15. 人工决定不被自动重建覆盖，失效引用显式标为 stale。
+16. 低置信边界与关系保留未决状态，不静默误合并。
+17. 生产关联使用有界候选集，不做 Atom 全量两两模型判断；查询聚合不重复计数。
+
+## 典型场景
+
+1. **单 Session、单目标**：所有 primary Atom 归入一个 LogicalTask；一次执行对应
+   一个 Attempt。
+2. **单 Session、多目标**：不同目标各自成 Task；仅时间相邻不会产生 Task 关系。
+3. **A → B → A**：两个非连续 A Atom 指向同一 Task，B 指向另一个 Task；Atom
+   时间链保持原顺序。
+4. **纠正与重试**：目标未变，Atom 仍归同一 Task；新 Attempt 以 `retry_of` 或
+   `correction_of` 指向旧 Attempt，旧结果不被改写。
+5. **父任务与子任务**：可独立验收的子目标创建子 Task，并以 `parent/subtask`
+   连接；父 Task outcome 不能只复制任一子 Task outcome。
+6. **跨 Session 延续**：同一 TaskScope 内有执行连续性证据时，原 Attempt 增加新的
+   EvidenceRange；证据不足时创建新 Attempt，并保留 proposed `continuation_of`。
+7. **边界不确定**：Atom 保留多个 proposed membership，无 confirmed primary；
+   execution Token/成本进入未归因余额，直到算法或人工确认。
+8. **团队成员目标相似**：两个 actor 的相似 Atom 可以共同支撑一个 Skill，但默认属于
+   不同 TaskScope 和 LogicalTask，不因向量相似而合并。
+9. **双用量平面**：用户 Harness 执行成本归到 Attempt；xskill 为拆分、关联和蒸馏支付
+   的成本归到 processing step/generation，两者分别展示且分别守恒。
+
+## 被否决的方案
+
+### 只给 AtomTask 增加字段
+
+这会把连续片段、非连续目标和执行尝试混在同一实体中，无法表达一个 Atom 内多次
+重试，也会让 Atom 的多 Skill 关系与 Task 唯一主归属互相污染。
+
+### 只使用 Session 粒度
+
+一个 Session 可以混合多个目标、重试和用户纠正，成功率、成本、错误与版本效果无法
+准确归因。
+
+### 只在 SQLite 中增加 Task 表
+
+SQLite 在现有架构中是可重建投影。只把 Task 关系写入 SQLite 会让核心业务语义无法
+从事实源重放，也无法安全处理重建、迁移和人工修正。
+
+### 把 Session 边界直接当成 Attempt 边界
+
+Harness 的上下文压缩、断线恢复或显式 resume 可能产生新 Session，但执行仍然连续；
+反过来，一个 Session 内也可能包含多次失败重试。Attempt 必须由执行证据决定，不能由
+文件或会话边界代替。
+
+### 把 execution 与 xskill processing 成本放进同一总账
+
+两者回答的问题不同：前者衡量模型/Harness/Skill 完成用户目标的效率，后者衡量 xskill
+自身分析和蒸馏的开销。直接相加会同时破坏模型比较、Task 归因和成本守恒。
+
+### 让 Harness 持有 Task 状态机
+
+Harness 可以提供结构化执行事件，但 xskill 必须继续拥有流水线、Task 状态与事务边界；
+否则不同 Harness 会产生互不兼容、不可重放的任务语义。
+
+## 后续顺序
+
+1. #325 增加固定 fixture、gold annotation、TaskScope/Attempt/lifecycle 指标和双平面
+   attribution 守恒检查；
+2. 在离线基线保护下实现有界候选检索、Task 关联与不确定性输出；
+3. 独立 PR 实现 usage event/Task Graph 事实源、SQLite Task 投影及旧数据兼容；
+4. 最后增加 Session / Atom / LogicalTask 三种 Dashboard 视图。
+
+在第 1 步完成前，不应把自动 Task 合并接入生产流水线。

--- a/docs/adr/0002-logical-task-and-attempt-model.md
+++ b/docs/adr/0002-logical-task-and-attempt-model.md
@@ -13,22 +13,15 @@ xskill 当前有两层与轨迹处理有关的数据：
 - `Trajectory`（下文称 Session）保留一次 Harness 会话的完整原始轨迹；
 - `AtomTask` 把 Session 拆成按时间连续的单意图片段。
 
-`AtomTask.pre_atom_id` / `post_atom_id` 只表达时间相邻，`used_skills` 表达
-一个 Atom 实际使用过的多个 Skill。Registry 中的 `status`、`retry_count` 和
-`error_msg` 描述 xskill 流水线是否完成处理，不描述用户目标是否完成。
+`AtomTask.pre_atom_id` / `post_atom_id` 只表达时间相邻，`used_skills` 表达一个 Atom 实际使用过的多个 Skill。Registry 中的 `status`、`retry_count` 和 `error_msg` 描述 xskill 流水线是否完成处理，不描述用户目标是否完成。
 
-因此，现有结构不能稳定表达 A → B → A 的目标恢复、跨 Session 延续、父子任务、
-同一目标的多次执行，以及成功率、Token、成本和错误的目标级归因。把这些语义继续
-塞进 Atom 或 Session 会混淆连续证据片段、逻辑目标与执行尝试。
+因此，现有结构不能稳定表达 A → B → A 的目标恢复、跨 Session 延续、父子任务、同一目标的多次执行，以及成功率、Token、成本和错误的目标级归因。把这些语义继续塞进 Atom 或 Session 会混淆连续证据片段、逻辑目标与执行尝试。
 
-本 ADR 只定义模型与不变量，不增加生产聚合算法、持久化迁移、历史回填或 Dashboard。
-#22 的 Trajectory → Skill provenance API 可以消费后续 Task Graph 投影，但不由本
-ADR 改变接口范围。
+本 ADR 只定义模型与不变量，不增加生产聚合算法、持久化迁移、历史回填或 Dashboard。#22 的 Trajectory → Skill provenance API 可以消费后续 Task Graph 投影，但不由本 ADR 改变接口范围。
 
 ## 决策
 
-在 Session 与 Atom 之上增加 `LogicalTask`，并在 LogicalTask 之下增加
-`TaskAttempt`。四层各自回答不同问题：
+在 Session 与 Atom 之上增加 `LogicalTask`，并在 LogicalTask 之下增加 `TaskAttempt`。四层各自回答不同问题：
 
 | 层 | 回答的问题 | 不负责 |
 | --- | --- | --- |
@@ -37,14 +30,11 @@ ADR 改变接口范围。
 | LogicalTask | 哪些 Atom 共同服务于同一个用户目标？ | 表示每一次具体执行 |
 | TaskAttempt | 该目标的一次执行或重试使用了什么，并得到什么结果？ | 取代原始轨迹证据 |
 
-Session 和 Atom 仍是证据层；LogicalTask 和 TaskAttempt 是可追溯、可修正的
-语义层。Skill 路由与 Task 归组是正交关系：一个 Atom 可以继续支撑多个 Skill，
-但其主 Task 归属遵守下文的唯一性规则。
+Session 和 Atom 仍是证据层；LogicalTask 和 TaskAttempt 是可追溯、可修正的语义层。Skill 路由与 Task 归组是正交关系：一个 Atom 可以继续支撑多个 Skill，但其主 Task 归属遵守下文的唯一性规则。
 
 ### 1. 身份与作用域
 
-所有引用都必须带作用域，不能把裸 `traj_id` 或 `atom_id` 当作全局唯一键，也不能
-把“有权读取同一批数据”误当成“属于同一个用户任务”：
+所有引用都必须带作用域，不能把裸 `traj_id` 或 `atom_id` 当作全局唯一键，也不能把“有权读取同一批数据”误当成“属于同一个用户任务”：
 
 ```text
 TenantScope = 权限与隐私边界
@@ -57,22 +47,12 @@ AttemptRef  = (tenant_id, task_scope_id, task_id, attempt_id)
 ```
 
 - `tenant_id` 限定权限与隐私边界；算法和查询不得跨 tenant 读取或聚合。
-- `task_scope_id` 默认绑定稳定 actor 与 workspace/project。同一团队中两个成员提出
-  相同需求，仍是两个 LogicalTask；只有带明确协作身份和权限证据的共享任务才允许
-  跨 actor 关联。
-- `source_scope_id` 区分独立 watch dir、客户端或其他摄取命名空间。它可以映射到
-  持久 watch-dir key 或 server 端客户端身份，但不能由可变目录路径或展示标签临时
-  拼接。
-- `task_id` 和 `attempt_id` 使用不含业务语义的稳定 opaque id。标题、摘要、Atom
-  顺序或模型输出变化不得导致 id 自动变化。
-- `AtomRef` 保留 `traj_id`，即使现有 `atom_id` 通常包含轨迹片段；实现不能依赖
-  这种字符串命名约定。该规则与 #234 / PR #260 的跨成员身份处理兼容。
+- `task_scope_id` 默认绑定稳定 actor 与 workspace/project。同一团队中两个成员提出相同需求，仍是两个 LogicalTask；只有带明确协作身份和权限证据的共享任务才允许跨 actor 关联。
+- `source_scope_id` 区分独立 watch dir、客户端或其他摄取命名空间。它可以映射到持久 watch-dir key 或 server 端客户端身份，但不能由可变目录路径或展示标签临时拼接。
+- `task_id` 和 `attempt_id` 使用不含业务语义的稳定 opaque id。标题、摘要、Atom 顺序或模型输出变化不得导致 id 自动变化。
+- `AtomRef` 保留 `traj_id`，即使现有 `atom_id` 通常包含轨迹片段；实现不能依赖这种字符串命名约定。该规则与 #234 / PR #260 的跨成员身份处理兼容。
 
-LogicalTask 可以跨多个 Session，但只能在同一 TaskScope 内。一次 TaskAttempt 只
-属于一个 LogicalTask；Session 边界本身既不能证明 Attempt 结束，也不能证明执行连续。
-有稳定 run id、workspace 状态、Harness resume 事件或等价连续性证据时，一个 Attempt
-可以引用多个 Session。无法证明连续性时创建新的 Attempt，并把 `continuation_of`
-保留为 proposed 关系；没有失败和重新执行证据时不能误标为 `retry_of`。
+LogicalTask 可以跨多个 Session，但只能在同一 TaskScope 内。一次 TaskAttempt 只属于一个 LogicalTask；Session 边界本身既不能证明 Attempt 结束，也不能证明执行连续。有稳定 run id、workspace 状态、Harness resume 事件或等价连续性证据时，一个 Attempt 可以引用多个 Session。无法证明连续性时创建新的 Attempt，并把 `continuation_of` 保留为 proposed 关系；没有失败和重新执行证据时不能误标为 `retry_of`。
 
 ### 2. Atom 到 LogicalTask 的归属
 
@@ -82,17 +62,12 @@ LogicalTask 可以跨多个 Session，但只能在同一 TaskScope 内。一次 
 task_ref, atom_ref, role, confidence, decision, decided_by, evidence_refs
 ```
 
-- `role` 为 `primary` 或 `context`。`primary` 表示该 Atom 的主要目标归属；
-  `context` 只提供背景证据，不能参与覆盖率、成本或成功率的重复计数。
-- 每个 Atom 最多有一个 `decision=confirmed` 的 primary membership；一个
-  LogicalTask 必须至少有一个 confirmed primary Atom 才能进入正式统计。
-- 边界不明确时允许存在多个 `proposed` membership，但不得选择最高分后静默
-  合并。它们保持未决，并进入 review/uncertain 集合。
+- `role` 为 `primary` 或 `context`。`primary` 表示该 Atom 的主要目标归属；`context` 只提供背景证据，不能参与覆盖率、成本或成功率的重复计数。
+- 每个 Atom 最多有一个 `decision=confirmed` 的 primary membership；一个 LogicalTask 必须至少有一个 confirmed primary Atom 才能进入正式统计。
+- 边界不明确时允许存在多个 `proposed` membership，但不得选择最高分后静默合并。它们保持未决，并进入 review/uncertain 集合。
 - 人工确认或拒绝的 membership 优先于后续自动重建；自动算法不能覆盖人工决定。
 
-`pre_atom_id` / `post_atom_id` 继续只表示时间相邻，不推导 membership、父子或
-继续关系。A → B → A 中的两个 A Atom 通过 membership 指向同一个 LogicalTask，
-不需要伪造 Atom 邻接关系。
+`pre_atom_id` / `post_atom_id` 继续只表示时间相邻，不推导 membership、父子或继续关系。A → B → A 中的两个 A Atom 通过 membership 指向同一个 LogicalTask，不需要伪造 Atom 邻接关系。
 
 ### 3. 语义关系属于哪一层
 
@@ -108,28 +83,19 @@ task_ref, atom_ref, role, confidence, decision, decided_by, evidence_refs
 | retry_of | TaskAttempt → TaskAttempt | 相同目标的再次执行 |
 | correction_of / supersedes | TaskAttempt → TaskAttempt | 新执行修正或取代旧执行结果 |
 
-Task 的 parent/subtask 边必须构成有向无环图。`depends_on` 和 `follows_up` 也不能
-被用来规避环检测。用户说“继续”而目标和输出契约未改变时，仍是同一个 Task；只有
-形成可独立执行、可独立判断终态的新目标时才创建 `follows_up` 或子 Task。
+Task 的 parent/subtask 边必须构成有向无环图。`depends_on` 和 `follows_up` 也不能被用来规避环检测。用户说“继续”而目标和输出契约未改变时，仍是同一个 Task；只有形成可独立执行、可独立判断终态的新目标时才创建 `follows_up` 或子 Task。
 
 ### 4. TaskAttempt 与证据范围
 
-一个 Attempt 至少包含 `task_ref`、`attempt_id`、一个或多个 `EvidenceRange`、
-开始/结束时间、执行身份和 outcome。`EvidenceRange` 使用稳定定位信息：
+一个 Attempt 至少包含 `task_ref`、`attempt_id`、一个或多个 `EvidenceRange`、开始/结束时间、执行身份和 outcome。`EvidenceRange` 使用稳定定位信息：
 
 ```text
 session_ref, atom_ref?, locator_kind, start, end, content_hash
 ```
 
-范围采用半开区间 `[start, end)`。适配器有稳定事件 id 时优先使用事件范围；否则
-使用 Atom 内或标准化轨迹内的行范围，并用 `content_hash` 检测来源漂移。
+范围采用半开区间 `[start, end)`。适配器有稳定事件 id 时优先使用事件范围；否则使用 Atom 内或标准化轨迹内的行范围，并用 `content_hash` 检测来源漂移。
 
-一个 Atom 内出现多次执行或重试时，不复制 Atom，也不把它强行拆成多个 Task；为
-同一 LogicalTask 创建多个 Attempt，并让每个 Attempt 引用各自事件范围。一个
-Attempt 可以覆盖同一 TaskScope 内的多个 Atom 或 Session，但所有 primary Atom
-必须属于该 Attempt 的 Task。模型、Harness 和 Skill 版本绑定到具体 EvidenceRange
-或执行 segment，再汇总到 Attempt；跨 Session 时不能用一个标量覆盖中途发生的版本
-变化。
+一个 Atom 内出现多次执行或重试时，不复制 Atom，也不把它强行拆成多个 Task；为同一 LogicalTask 创建多个 Attempt，并让每个 Attempt 引用各自事件范围。一个 Attempt 可以覆盖同一 TaskScope 内的多个 Atom 或 Session，但所有 primary Atom 必须属于该 Attempt 的 Task。模型、Harness 和 Skill 版本绑定到具体 EvidenceRange 或执行 segment，再汇总到 Attempt；跨 Session 时不能用一个标量覆盖中途发生的版本变化。
 
 ### 5. Lifecycle、Outcome 与可核验证据
 
@@ -147,41 +113,25 @@ Verification     = unverified | verified | contradicted | conflicted |
 UserDisposition  = accepted | rejected | corrected | cancelled | unknown
 ```
 
-- `blocked` 是可恢复的 Task 生命周期状态，不是 Task 终态。当前执行因外部条件停止时，
-  Attempt 可以 `finished + blocked`，Task 则保持 `blocked + unknown`；后续恢复不会
-  改写旧 Attempt 的事件范围。
-- `closed` 表示当前观察版本已经形成终态。后续证据重新打开 Task 或修正旧 outcome
-  时，应追加新的决策记录并保留历史值。
-- `abandoned` 需要用户明确放弃或版本化策略给出的可核验证据；仅仅 Session 结束或
-  用户转向其他目标时，Task 仍为 `open/unknown`。
-- LogicalTask outcome 从 Attempt 和目标要求派生，不是“最后一个 Attempt outcome”
-  的简单复制。Registry `DONE`、Trajectory `meta.success` 和 Harness 会话结束都只能
-  作为 Session/流水线证据，不能单独证明 Task 成功。
+- `blocked` 是可恢复的 Task 生命周期状态，不是 Task 终态。当前执行因外部条件停止时，Attempt 可以 `finished + blocked`，Task 则保持 `blocked + unknown`；后续恢复不会改写旧 Attempt 的事件范围。
+- `closed` 表示当前观察版本已经形成终态。后续证据重新打开 Task 或修正旧 outcome 时，应追加新的决策记录并保留历史值。
+- `abandoned` 需要用户明确放弃或版本化策略给出的可核验证据；仅仅 Session 结束或用户转向其他目标时，Task 仍为 `open/unknown`。
+- LogicalTask outcome 从 Attempt 和目标要求派生，不是“最后一个 Attempt outcome”的简单复制。Registry `DONE`、Trajectory `meta.success` 和 Harness 会话结束都只能作为 Session/流水线证据，不能单独证明 Task 成功。
 
-只有目标要求的输出已经满足，且之后没有相冲突的纠正时，Task 才能判为
-`succeeded`。只有部分可独立判断的要求完成时使用 `partially_succeeded`；观察到明确
-失败但仍有后续 Attempt 在运行时，Task 保持 `open`，而不是提前记为 `failed`。
+只有目标要求的输出已经满足，且之后没有相冲突的纠正时，Task 才能判为 `succeeded`。只有部分可独立判断的要求完成时使用 `partially_succeeded`；观察到明确失败但仍有后续 Attempt 在运行时，Task 保持 `open`，而不是提前记为 `failed`。
 
-每次 lifecycle、outcome、verification 或 user disposition 判断都必须分别记录
-`evidence_refs`、`confidence`、`decided_by` 和 `observed_at`。证据按其能证明的事实
-类型使用，而不是采用一条全局优先级链：
+每次 lifecycle、outcome、verification 或 user disposition 判断都必须分别记录 `evidence_refs`、`confidence`、`decided_by` 和 `observed_at`。证据按其能证明的事实类型使用，而不是采用一条全局优先级链：
 
-- 用户明确验收、拒绝、取消或纠正决定 `UserDisposition`，并可作为目标是否满足的
-  证据，但不能覆盖相冲突的结构化执行事实；
+- 用户明确验收、拒绝、取消或纠正决定 `UserDisposition`，并可作为目标是否满足的证据，但不能覆盖相冲突的结构化执行事实；
 - 与 Attempt 绑定的测试、工具结果、退出码或 Harness 终态决定客观验证状态；
 - 可定位的产物变化提供补充验证证据；
 - Assistant 的自然语言自报只能作为弱证据，不能单独产生 `verified`。
 
-证据冲突时使用 `Verification=conflicted` 和 `needs_review`，不得硬选一个成功或失败
-终态。现有 `ux_score` 衡量 Atom 使用某个 Skill 的体验，`weightscore` 衡量 Atom 对
-Skill 的贡献；两者均不能复用为 Task outcome、verification 或关联 confidence。
+证据冲突时使用 `Verification=conflicted` 和 `needs_review`，不得硬选一个成功或失败终态。现有 `ux_score` 衡量 Atom 使用某个 Skill 的体验，`weightscore` 衡量 Atom 对 Skill 的贡献；两者均不能复用为 Task outcome、verification 或关联 confidence。
 
 ### 6. 不确定性
 
-边界、Task 关联、关系类型、lifecycle、outcome、verification 和 user disposition
-分别记录独立的 `confidence`，不能共用一个总分。confidence 为 `[0, 1]` 的概率值，
-必须同时记录产生它的算法/模型版本；没有经过概率校准的启发式分数不得冒充
-confidence。
+边界、Task 关联、关系类型、lifecycle、outcome、verification 和 user disposition 分别记录独立的 `confidence`，不能共用一个总分。confidence 为 `[0, 1]` 的概率值，必须同时记录产生它的算法/模型版本；没有经过概率校准的启发式分数不得冒充 confidence。
 
 每个决定使用以下状态之一：
 
@@ -189,13 +139,11 @@ confidence。
 proposed | confirmed | rejected | needs_review
 ```
 
-生产阈值不在本 ADR 中固定。无论采用什么阈值，低置信关系都必须保留为 proposed，
-不得自动合并后丢弃备选边界。#325 的离线回放负责检验误合并、误拆分及置信度校准。
+生产阈值不在本 ADR 中固定。无论采用什么阈值，低置信关系都必须保留为 proposed，不得自动合并后丢弃备选边界。#325 的离线回放负责检验误合并、误拆分及置信度校准。
 
 ### 7. 模型、Harness、Skill 与用量归因
 
-模型、Harness 和 Skill 的执行版本先绑定到 TaskAttempt 的 EvidenceRange/segment，
-再从 Attempt 聚合到 LogicalTask：
+模型、Harness 和 Skill 的执行版本先绑定到 TaskAttempt 的 EvidenceRange/segment，再从 Attempt 聚合到 LogicalTask：
 
 - 用户任务模型记录 provider、model id 和可用的版本/快照；
 - 用户 Harness 记录 name 和可用的版本；
@@ -209,38 +157,23 @@ execution         原 Harness 执行用户 Task 的模型、工具与工作区�
 xskill_processing xskill 拆 Atom、关联 Task、路由、编辑 Skill 和打分的处理成本
 ```
 
-`execution` usage 才能用于比较模型/Harness/Skill 执行 Task 的效率。当前
-`UsageLedger` / Registry `llm_usage` 记录的是 `atom_split`、`skill_route`、
-`skill_edit`、`ux_score` 等 xskill processing 调用，不能混入用户 Task 的执行 Token。
-xskill processing 成本可以关联到生成它的 Session、Atom、Task Graph generation 或
-Skill 流水线，但必须独立展示和守恒。
+`execution` usage 才能用于比较模型/Harness/Skill 执行 Task 的效率。当前 `UsageLedger` / Registry `llm_usage` 记录的是 `atom_split`、`skill_route`、`skill_edit`、`ux_score` 等 xskill processing 调用，不能混入用户 Task 的执行 Token。xskill processing 成本可以关联到生成它的 Session、Atom、Task Graph generation 或 Skill 流水线，但必须独立展示和守恒。
 
-每条原始 Token/成本记录必须带唯一 `usage_event_id`、`usage_plane`，并把测量质量
-和分摊方式分开记录：
+每条原始 Token/成本记录必须带唯一 `usage_event_id`、`usage_plane`，并把测量质量和分摊方式分开记录：
 
 ```text
 measurement_quality = measured | estimated | unavailable
 allocation_mode     = direct | shared | unattributed
 ```
 
-- `measured` 表示上游提供；`estimated` 必须携带估算方法及版本；`unavailable` 表示
-  上游未提供且无法可靠估算；
-- `direct` 表示事件只服务一个对象；`shared` 使用显式方法分摊给多个对象；
-  `unattributed` 保留无法可靠分配的余额。
+- `measured` 表示上游提供；`estimated` 必须携带估算方法及版本；`unavailable` 表示上游未提供且无法可靠估算；
+- `direct` 表示事件只服务一个对象；`shared` 使用显式方法分摊给多个对象；`unattributed` 保留无法可靠分配的余额。
 
-`price_source` 只描述单价来源，不等同于 Token 测量质量。原始事件记录 Session/source
-scope 和可用的 Harness event id；Task 归组完成后再产生独立 allocation，不回写原始
-用量事件。
+`price_source` 只描述单价来源，不等同于 Token 测量质量。原始事件记录 Session/source scope 和可用的 Harness event id；Task 归组完成后再产生独立 allocation，不回写原始用量事件。
 
-归因必须在每个 usage plane 内分别守恒：同一 `usage_event_id` 的 Attempt 或处理步骤
-分摊之和加未归因余额，等于原始事件用量；不得把 shared 开销完整复制给多个 Task。
-`unavailable` 使用 `null` 和原因，不记为 0。Session、Task 和 Skill 视图从同一原始
-ledger 和 allocation 派生，不能各自维护会漂移的总数，也不能把两个 usage plane
-相加后作为模型执行成本。
+归因必须在每个 usage plane 内分别守恒：同一 `usage_event_id` 的 Attempt 或处理步骤分摊之和加未归因余额，等于原始事件用量；不得把 shared 开销完整复制给多个 Task。`unavailable` 使用 `null` 和原因，不记为 0。Session、Task 和 Skill 视图从同一原始 ledger 和 allocation 派生，不能各自维护会漂移的总数，也不能把两个 usage plane 相加后作为模型执行成本。
 
-现有 `llm_usage` 行缺少稳定 event id、Session/Atom 引用和 measurement quality，历史
-行继续作为 `xskill_processing + legacy_unattributed` 保留；本 ADR 不推测回填这些
-字段。未来扩展先新增并回填可确定的字段，再建立索引或约束。
+现有 `llm_usage` 行缺少稳定 event id、Session/Atom 引用和 measurement quality，历史行继续作为 `xskill_processing + legacy_unattributed` 保留；本 ADR 不推测回填这些字段。未来扩展先新增并回填可确定的字段，再建立索引或约束。
 
 ### 8. 事实源、覆盖与 SQLite 投影
 
@@ -248,69 +181,33 @@ ledger 和 allocation 派生，不能各自维护会漂移的总数，也不能�
 
 1. Session 三件套和 Atom JSON：原始证据与拆分事实源，现状不变；
 2. append-only usage event ledger：原始 execution / xskill processing 用量事实；
-3. versioned Task Graph generation：LogicalTask、membership、relation、Attempt、
-   outcome 与 usage allocation 的可重放版本；
+3. versioned Task Graph generation：LogicalTask、membership、relation、Attempt、outcome 与 usage allocation 的可重放版本；
 4. append-only override log：人工确认、拒绝、拆分、合并和终态修正。
 
-Registry SQLite 当前同时承担不同角色，不能笼统称为投影：Trajectory 状态和未来的
-Task 查询表可以是可重建投影；现有 `llm_usage` 则是已经发生并支付的 xskill processing
-用量事实，rebuild 会刻意保留。除非独立迁移把原始 usage event 无损搬到新的权威 ledger，
-否则删除该表无法从 Session/Atom 重建。历史 `llm_usage` 不在本 ADR 中清洗或推测关联。
+Registry SQLite 当前同时承担不同角色，不能笼统称为投影：Trajectory 状态和未来的 Task 查询表可以是可重建投影；现有 `llm_usage` 则是已经发生并支付的 xskill processing 用量事实，rebuild 会刻意保留。除非独立迁移把原始 usage event 无损搬到新的权威 ledger，否则删除该表无法从 Session/Atom 重建。历史 `llm_usage` 不在本 ADR 中清洗或推测关联。
 
-Task Graph 的逻辑 manifest 使用 UTF-8 JSON，至少包含 `schema_version`、
-`generation_id`、`tenant_id`、`task_scope_id`、`source_revision`、`generator`、
-`base_override_seq`、`tasks`、`memberships`、`relations`、`attempts` 和
-`usage_allocations`。小数据集可以使用单一快照；大数据集可以让 manifest 索引不可变
-JSON/JSONL shard。发布方必须先完整写入新 generation，再原子切换一个小型 current
-pointer，并复用未变化的 shard，不能要求每次增量更新都重写整个 TaskScope。具体目录
-名和分片策略由后续存储 PR 决定，引用中不得写入本机绝对路径。
+Task Graph 的逻辑 manifest 使用 UTF-8 JSON，至少包含 `schema_version`、`generation_id`、`tenant_id`、`task_scope_id`、`source_revision`、`generator`、`base_override_seq`、`tasks`、`memberships`、`relations`、`attempts` 和 `usage_allocations`。小数据集可以使用单一快照；大数据集可以让 manifest 索引不可变 JSON/JSONL shard。发布方必须先完整写入新 generation，再原子切换一个小型 current pointer，并复用未变化的 shard，不能要求每次增量更新都重写整个 TaskScope。具体目录名和分片策略由后续存储 PR 决定，引用中不得写入本机绝对路径。
 
-`source_revision` 覆盖所有输入 Session/Atom 的 scoped id 与内容哈希；实现可以使用
-Merkle root 增量维护，避免为了计算 revision 重扫全部输入。override log 使用带唯一
-`event_id` 和单调 `override_seq` 的 JSONL，保留目标 id、操作、证据和时间；重放顺序
-明确，人工决定优先于 manifest 中的自动结果。generation 记录已经吸收的
-`base_override_seq`，读取时只叠加其后的事件，避免重复应用。
+`source_revision` 覆盖所有输入 Session/Atom 的 scoped id 与内容哈希；实现可以使用 Merkle root 增量维护，避免为了计算 revision 重扫全部输入。override log 使用带唯一 `event_id` 和单调 `override_seq` 的 JSONL，保留目标 id、操作、证据和时间；重放顺序明确，人工决定优先于 manifest 中的自动结果。generation 记录已经吸收的 `base_override_seq`，读取时只叠加其后的事件，避免重复应用。
 
-xskill 是 Task Graph generation、current pointer 和 override log 的唯一写入者；Harness
-只提供证据事件。写入由 TaskScope 级锁或等价事务串行化，current pointer 同时发布
-`generation_id` 和 override watermark。override log 可以做带校验点的压缩，但旧段必须
-保留可审计摘要和内容哈希，不能为了缩短重放时间丢失人工决定。
+xskill 是 Task Graph generation、current pointer 和 override log 的唯一写入者；Harness 只提供证据事件。写入由 TaskScope 级锁或等价事务串行化，current pointer 同时发布 `generation_id` 和 override watermark。override log 可以做带校验点的压缩，但旧段必须保留可审计摘要和内容哈希，不能为了缩短重放时间丢失人工决定。
 
-SQLite 中新增的 Task 表只保存 effective graph 的可重建查询投影。删除这些 Task 投影
-表后，必须能从证据事实源、usage ledger、最新 manifest 和 override log 重建相同结果。
-任何只写 SQLite、无法重放的 Task 关系都违反本 ADR；该要求不追溯改变现有
-`llm_usage` 的权威 telemetry 语义。
+SQLite 中新增的 Task 表只保存 effective graph 的可重建查询投影。删除这些 Task 投影表后，必须能从证据事实源、usage ledger、最新 manifest 和 override log 重建相同结果。任何只写 SQLite、无法重放的 Task 关系都违反本 ADR；该要求不追溯改变现有 `llm_usage` 的权威 telemetry 语义。
 
 ### 9. 增量更新、重建与删除
 
-- Session 续写或新增 Atom 只重新分类候选边及受影响的连通分量；未受影响的 Task id
-  不变。候选检索可以查询全局索引，但不能因此全量重算所有 Atom 对。
-- 自动重建应复用仍含 confirmed primary anchor 的 Task id。Task 拆分时，显式人工
-  canonical override 优先；否则原 id 留给含最早人工 confirmed primary anchor 的
-  分量，再退化到最早 confirmed anchor，其他分量获得新 id。
-- Task 合并时按“显式人工 canonical override → 最早人工 confirmed anchor → 最早
-  created task”的顺序选择 canonical id。其他 id 作为 alias/tombstone 保留，避免
-  历史链接失效。自动算法不得合并被人工拒绝的关系。
-- Atom 删除后，自动 membership 可以失效；人工 override 保留但标记 stale。若 Task
-  失去全部 confirmed primary Atom，则从正式统计移出并保留 tombstone，不得把旧 id
-  分配给新目标。
-- EvidenceRange 的 `content_hash` 不匹配时，该证据标记 stale；仅依赖 stale 证据的
-  outcome 降为 `unknown/needs_review`。
-- 历史 Atom 不要求本 ADR 合并时立即回填；未来回填必须生成独立 source revision，
-  可重复运行且不覆盖人工 override。
+- Session 续写或新增 Atom 只重新分类候选边及受影响的连通分量；未受影响的 Task id 不变。候选检索可以查询全局索引，但不能因此全量重算所有 Atom 对。
+- 自动重建应复用仍含 confirmed primary anchor 的 Task id。Task 拆分时，显式人工 canonical override 优先；否则原 id 留给含最早人工 confirmed primary anchor 的分量，再退化到最早 confirmed anchor，其他分量获得新 id。
+- Task 合并时按“显式人工 canonical override → 最早人工 confirmed anchor → 最早 created task”的顺序选择 canonical id。其他 id 作为 alias/tombstone 保留，避免历史链接失效。自动算法不得合并被人工拒绝的关系。
+- Atom 删除后，自动 membership 可以失效；人工 override 保留但标记 stale。若 Task 失去全部 confirmed primary Atom，则从正式统计移出并保留 tombstone，不得把旧 id 分配给新目标。
+- EvidenceRange 的 `content_hash` 不匹配时，该证据标记 stale；仅依赖 stale 证据的 outcome 降为 `unknown/needs_review`。
+- 历史 Atom 不要求本 ADR 合并时立即回填；未来回填必须生成独立 source revision，可重复运行且不覆盖人工 override。
 
 ### 10. 生产算法与查询性能边界
 
-若 TaskScope 中有 `n` 个 Atom，生产关联不能对所有 Atom 做全量两两模型判断。候选
-生成应组合同 Session 邻域、显式 continuation/retry 证据、关键词/向量 Top-K 和已确认
-Task anchor，把分类数量限制为 `O(nk)`（`k` 为有上限的候选数）；LLM 只处理规则与
-检索无法确认的歧义边。实现必须记录候选数、模型判断数和受影响分量大小，以确定性计数
-测试保护复杂度，不能用墙钟阈值掩盖退化。
+若 TaskScope 中有 `n` 个 Atom，生产关联不能对所有 Atom 做全量两两模型判断。候选生成应组合同 Session 邻域、显式 continuation/retry 证据、关键词/向量 Top-K 和已确认 Task anchor，把分类数量限制为 `O(nk)`（`k` 为有上限的候选数）；LLM 只处理规则与检索无法确认的歧义边。实现必须记录候选数、模型判断数和受影响分量大小，以确定性计数测试保护复杂度，不能用墙钟阈值掩盖退化。
 
-Task Graph generation 复用未变化 shard，override replay 使用 checkpoint/watermark，
-内存只保留当前 TaskScope 所需的有界工作集。Dashboard 不得直接连接 Task × Atom ×
-Skill × Attempt 后求和；应先按唯一 relation/usage event 聚合或使用物化投影，防止
-笛卡尔积造成重复计数。
+Task Graph generation 复用未变化 shard，override replay 使用 checkpoint/watermark，内存只保留当前 TaskScope 所需的有界工作集。Dashboard 不得直接连接 Task × Atom × Skill × Attempt 后求和；应先按唯一 relation/usage event 聚合或使用物化投影，防止笛卡尔积造成重复计数。
 
 ## 必须保持的不变量
 
@@ -328,8 +225,7 @@ Skill × Attempt 后求和；应先按唯一 relation/usage event 聚合或使�
 10. Task/Attempt outcome 必须可定位到证据；无证据为 `unknown`。
 11. execution 与 xskill processing usage 分账，并在各自 plane 内守恒。
 12. shared usage 不重复计算，unavailable 不伪装为 0。
-13. SQLite Task 投影可由事实源、usage ledger、manifest 和 override log 重建；现有
-    `llm_usage` 仍按权威 telemetry 处理。
+13. SQLite Task 投影可由事实源、usage ledger、manifest 和 override log 重建；现有 `llm_usage` 仍按权威 telemetry 处理。
 14. 增量更新不重编号未受影响的 Task，删除不复用旧 id，canonical 选择遵守人工优先。
 15. 人工决定不被自动重建覆盖，失效引用显式标为 stale。
 16. 低置信边界与关系保留未决状态，不静默误合并。
@@ -337,61 +233,45 @@ Skill × Attempt 后求和；应先按唯一 relation/usage event 聚合或使�
 
 ## 典型场景
 
-1. **单 Session、单目标**：所有 primary Atom 归入一个 LogicalTask；一次执行对应
-   一个 Attempt。
+1. **单 Session、单目标**：所有 primary Atom 归入一个 LogicalTask；一次执行对应一个 Attempt。
 2. **单 Session、多目标**：不同目标各自成 Task；仅时间相邻不会产生 Task 关系。
-3. **A → B → A**：两个非连续 A Atom 指向同一 Task，B 指向另一个 Task；Atom
-   时间链保持原顺序。
-4. **纠正与重试**：目标未变，Atom 仍归同一 Task；新 Attempt 以 `retry_of` 或
-   `correction_of` 指向旧 Attempt，旧结果不被改写。
-5. **父任务与子任务**：可独立验收的子目标创建子 Task，并以 `parent/subtask`
-   连接；父 Task outcome 不能只复制任一子 Task outcome。
-6. **跨 Session 延续**：同一 TaskScope 内有执行连续性证据时，原 Attempt 增加新的
-   EvidenceRange；证据不足时创建新 Attempt，并保留 proposed `continuation_of`。
-7. **边界不确定**：Atom 保留多个 proposed membership，无 confirmed primary；
-   execution Token/成本进入未归因余额，直到算法或人工确认。
-8. **团队成员目标相似**：两个 actor 的相似 Atom 可以共同支撑一个 Skill，但默认属于
-   不同 TaskScope 和 LogicalTask，不因向量相似而合并。
-9. **双用量平面**：用户 Harness 执行成本归到 Attempt；xskill 为拆分、关联和蒸馏支付
-   的成本归到 processing step/generation，两者分别展示且分别守恒。
+3. **A → B → A**：两个非连续 A Atom 指向同一 Task，B 指向另一个 Task；Atom 时间链保持原顺序。
+4. **纠正与重试**：目标未变，Atom 仍归同一 Task；新 Attempt 以 `retry_of` 或 `correction_of` 指向旧 Attempt，旧结果不被改写。
+5. **父任务与子任务**：可独立验收的子目标创建子 Task，并以 `parent/subtask` 连接；父 Task outcome 不能只复制任一子 Task outcome。
+6. **跨 Session 延续**：同一 TaskScope 内有执行连续性证据时，原 Attempt 增加新的 EvidenceRange；证据不足时创建新 Attempt，并保留 proposed `continuation_of`。
+7. **边界不确定**：Atom 保留多个 proposed membership，无 confirmed primary；execution Token/成本进入未归因余额，直到算法或人工确认。
+8. **团队成员目标相似**：两个 actor 的相似 Atom 可以共同支撑一个 Skill，但默认属于不同 TaskScope 和 LogicalTask，不因向量相似而合并。
+9. **双用量平面**：用户 Harness 执行成本归到 Attempt；xskill 为拆分、关联和蒸馏支付的成本归到 processing step/generation，两者分别展示且分别守恒。
 
 ## 被否决的方案
 
 ### 只给 AtomTask 增加字段
 
-这会把连续片段、非连续目标和执行尝试混在同一实体中，无法表达一个 Atom 内多次
-重试，也会让 Atom 的多 Skill 关系与 Task 唯一主归属互相污染。
+这会把连续片段、非连续目标和执行尝试混在同一实体中，无法表达一个 Atom 内多次重试，也会让 Atom 的多 Skill 关系与 Task 唯一主归属互相污染。
 
 ### 只使用 Session 粒度
 
-一个 Session 可以混合多个目标、重试和用户纠正，成功率、成本、错误与版本效果无法
-准确归因。
+一个 Session 可以混合多个目标、重试和用户纠正，成功率、成本、错误与版本效果无法准确归因。
 
 ### 只在 SQLite 中增加 Task 表
 
-SQLite 在现有架构中是可重建投影。只把 Task 关系写入 SQLite 会让核心业务语义无法
-从事实源重放，也无法安全处理重建、迁移和人工修正。
+SQLite 在现有架构中是可重建投影。只把 Task 关系写入 SQLite 会让核心业务语义无法从事实源重放，也无法安全处理重建、迁移和人工修正。
 
 ### 把 Session 边界直接当成 Attempt 边界
 
-Harness 的上下文压缩、断线恢复或显式 resume 可能产生新 Session，但执行仍然连续；
-反过来，一个 Session 内也可能包含多次失败重试。Attempt 必须由执行证据决定，不能由
-文件或会话边界代替。
+Harness 的上下文压缩、断线恢复或显式 resume 可能产生新 Session，但执行仍然连续；反过来，一个 Session 内也可能包含多次失败重试。Attempt 必须由执行证据决定，不能由文件或会话边界代替。
 
 ### 把 execution 与 xskill processing 成本放进同一总账
 
-两者回答的问题不同：前者衡量模型/Harness/Skill 完成用户目标的效率，后者衡量 xskill
-自身分析和蒸馏的开销。直接相加会同时破坏模型比较、Task 归因和成本守恒。
+两者回答的问题不同：前者衡量模型/Harness/Skill 完成用户目标的效率，后者衡量 xskill 自身分析和蒸馏的开销。直接相加会同时破坏模型比较、Task 归因和成本守恒。
 
 ### 让 Harness 持有 Task 状态机
 
-Harness 可以提供结构化执行事件，但 xskill 必须继续拥有流水线、Task 状态与事务边界；
-否则不同 Harness 会产生互不兼容、不可重放的任务语义。
+Harness 可以提供结构化执行事件，但 xskill 必须继续拥有流水线、Task 状态与事务边界；否则不同 Harness 会产生互不兼容、不可重放的任务语义。
 
 ## 后续顺序
 
-1. #325 增加固定 fixture、gold annotation、TaskScope/Attempt/lifecycle 指标和双平面
-   attribution 守恒检查；
+1. #325 增加固定 fixture、gold annotation、TaskScope/Attempt/lifecycle 指标和双平面 attribution 守恒检查；
 2. 在离线基线保护下实现有界候选检索、Task 关联与不确定性输出；
 3. 独立 PR 实现 usage event/Task Graph 事实源、SQLite Task 投影及旧数据兼容；
 4. 最后增加 Session / Atom / LogicalTask 三种 Dashboard 视图。

--- a/docs/task-graph-runtime.md
+++ b/docs/task-graph-runtime.md
@@ -121,6 +121,8 @@ Task 与 Attempt relation 在写入 override log 前完成唯一 parent、同 Ta
 
 首次启用会把已有 `split_done`、`indexed` 和 `done` 轨迹加入持久回填队列，并按 `max_scopes_per_run` 分批处理。
 
+worker 启动时会比较已投影 generation 与当前 linker 版本及有界候选参数，算法或参数变化的 TaskScope 会自动加入重建队列。
+
 关闭开关只停止新增 Task Graph 处理，已投影来源的变化仍以轻量脏记录保留供后续重新启用时追平，从未投影的来源由首次启用回填扫描发现，同时不会删除 Session、Atom、usage ledger、generation、override 或 SQLite 投影。
 
 `xskill rebuild --force` 会清理可重建 Task 投影和 generation source state，但保留已经发生且付费的原始 usage ledger。

--- a/docs/task-graph-runtime.md
+++ b/docs/task-graph-runtime.md
@@ -1,0 +1,126 @@
+# Logical Task Graph 运行时说明
+
+## 状态
+
+本实现把 #326 定义的 Logical Task 与 Task Attempt 模型落成可运行代码，但在 #326 与 #325 评审完成前通过 `task_graph.enabled: false` 默认关闭。
+
+关闭时，现有 `Session → Atom → candidate → Skill` 生产路径、Atom 多 Skill 语义、`ux_score` 和 `weightscore` 均保持不变。
+
+开启后，Task Graph 使用独立 worker 消费持久脏队列，不阻塞 Atom 到 Skill 的拆分、路由和编辑流水线。
+
+## 数据流
+
+1. Harness 适配器从 Codex、DeepSeek Harness 和 OpenClaw 轨迹中保留模型、Harness、run id、结构化终态和 execution usage event。
+2. TaskAgent 继续生成现有 AtomTask，Task Graph 只读取 Atom 事实，不修改 Atom 属性或 Skill 路由结果。
+3. ScopeResolver 为实例、actor、workspace 和 watch dir 解析稳定且不含原始路径的 TenantScope、TaskScope 和 SourceScope。
+4. BoundedTaskLinker 复用未变化的 confirmed membership，只为变化 Atom 查询有界候选集，并把未校准的歧义保留为 proposed。
+5. Linker 根据 Atom 邻接、稳定 run id、显式继续、重试和纠正证据生成 TaskAttempt 与 Attempt relation。
+6. 原 Harness execution usage 先写入不可变 ledger，再按 confirmed primary Atom 的证据跨度守恒分摊到 Attempt 和 Task。
+7. generation 以内容寻址 shard 写入事实源，全部 shard 持久化后才原子切换 `current.json`。
+8. SQLite 在一个事务中替换当前 TaskScope 的查询投影，失败时脏队列保留并在后续轮询恢复。
+
+## 作用域与身份
+
+`tenant_id` 是权限与隐私边界，所有查询都必须显式携带 tenant。
+
+`task_scope_id` 默认由 tenant、actor 和 workspace 共同确定，自动关联不得跨 TaskScope。
+
+`source_scope_id` 是 watch dir 的持久随机身份，引用判等直接使用该身份而不使用可变目录路径或展示 label。
+
+`SessionRef` 与 `AtomRef` 始终包含 tenant、TaskScope、SourceScope 和轨迹身份，生产代码不使用裸 `traj_id` 或 `atom_id` 跨来源查询。
+
+Task、Attempt、generation、override 和 usage event 均使用无业务语义的 opaque id，标题、摘要和本机路径不会进入 id。
+
+## 关联算法
+
+每个 Atom 最多生成 `top_k` 个候选，候选来自有上限的倒排 posting 和同 Session 最近 Task。
+
+每个 Atom 最多提取 32 个规范化词项，每个 Task anchor 最多保留 256 个词项和 128 个完整意图，避免长 Task 的 anchor 比较退化为 O(n²)。
+
+显式继续、重试或纠正只有在最佳候选超过阈值且与次优候选拉开 margin 时才自动复用 Task。
+
+普通相似 Atom 默认建立独立 confirmed Task，并把相似旧 Task 记录为 confidence 为空的 proposed membership，避免把未校准启发式分数冒充概率。
+
+未变化 Atom 通过 Atom 内容哈希复用 Task 和 Attempt id，重建不会给未受影响事实重新编号。
+
+自动 Attempt outcome 只接受 sole-Task Session 上的结构化 Harness 终态，Harness success 可以结束 Attempt 但 verification 仍保持 unverified，只有另有可核验目标证据的 succeeded 或 partially_succeeded Attempt 才能派生 Task 结果，单次 failed 或 cancelled Attempt 也不能证明 Logical Task 已终止。
+
+结构化终态被撤销或证据内容漂移时，自动 Task outcome 降为 `unknown`，旧证据保留为 stale 事实供审计。
+
+## Attempt 规则
+
+同一 Task 内直接相邻的 Atom 或具有相同稳定 run id 的跨 Session Atom 可以属于同一 Attempt。
+
+同一个 Atom 内出现可定位的显式重试或纠正用户回合时，Linker 会按轨迹半开行区间拆成多个 EvidenceRange 和 Attempt，不复制或修改原 Atom。
+
+没有稳定执行连续性证据的非连续 Atom 创建新 Attempt，并产生 proposed `continuation_of`。
+
+显式重试和纠正创建新 Attempt，并分别产生 confirmed `retry_of` 或 `correction_of`。
+
+历史 confirmed Attempt 边界优先于后续自动分组，增量重建不会静默折叠两个已有 Attempt。
+
+最后一个 Attempt 没有结构化终态时保持 `running + unknown`，不能因为 Session 文件结束而伪造 finished 或 succeeded。
+
+人工可以确认或拒绝 Attempt relation，confirmed Attempt relation 必须属于同一 Task 且构成 DAG。
+
+## 用量与成本
+
+`execution` 记录原 Harness 完成用户目标的用量，`xskill_processing` 记录 xskill 拆分、路由、编辑和评分自身消耗的用量。
+
+两个 usage plane 分别保存和展示，不允许合并成一个模型执行成本。
+
+上游缺少整条 usage event 时仍保存一个 `null + unavailable_reason` 的 Session 级不可用事实，上游只缺少 Token 或成本字段时也保留对应原因，数字字符串、布尔值和非整数 Token 不会被自动转换。
+
+同一 `usage_event_id` 的原始事实不可变，重复摄取必须内容一致，冲突事件会保留脏队列且不会发布引用冲突用量的新 generation。
+
+一个 Session 包含多个 Attempt 时，execution usage 按 confirmed primary Atom 行跨度分摊，并使用最大余数法保证整数 Token 精确守恒。
+
+无法定位到 confirmed primary membership 的余额保存为 `unattributed`，不会被丢弃或重复复制。
+
+单个 Session 的共享 allocation 边数硬限制为 4096，超过上限时该 Session 的事件保守保留为 unattributed，避免 usage event 与 Attempt 形成最坏 O(n²) 投影。
+
+Codex 的累计 Token 事件先转换为逐事件增量，中途切换模型时每条 usage event 绑定当时的模型，而不是统一归到 Session 的首个模型。
+
+## 事实源与事务
+
+每个 TaskScope 有独立的 `current.json`、不可变 generation manifest、内容寻址 shard、override log 和事务锁。
+
+每个 shard 最多包含 256 条记录，未变化 shard 按内容哈希复用，避免为每条 Atom 创建一个小文件或每次重写完整 TaskScope。
+
+发布顺序是验证原始 usage ledger、写完 immutable shard、原子切换 current pointer、事务替换 SQLite 投影、最后按 generation fence 确认脏队列。
+
+任一步骤失败都不会确认脏记录，后续 worker 可以从事实源和 current pointer 幂等恢复。
+
+常驻 worker 最多缓存 `source_cache_size` 个未变化 source evidence，并以投影中的 source revision 校验命中，避免每次局部更新都重读整个 TaskScope，同时保持有界内存。
+
+人工 override 在 TaskScope 文件锁内完成加载、校验、追加和立即重建，两个并发 override 不能分别基于旧图写入组合后成环的关系。
+
+人工 override 在追加前写入独立的 TaskScope 持久恢复栅栏，generation 与 SQLite 投影成功后才按版本确认，因此来源全部删除或进程中途退出也不会遗失待重放的控制面变更。
+
+override event 使用唯一 `event_id` 和连续 `override_seq`，同 event id 重试必须保持相同语义。
+
+## 人工修正能力
+
+Dashboard 管理员敏感路由提供 Task overview、Scope 列表、Task 列表、Session 视图、Atom 视图和 Task 详情。
+
+管理端 override 支持 membership 确认或拒绝、Task/Attempt 状态修正、Task/Attempt relation 确认或拒绝、Task 合并、Atom 移动和 Task 拆分。
+
+`split_task` 只允许移动来源 Task confirmed primary Atom 的非空真子集，并在事件中保存新 Task id 与完整 scoped AtomRef，因此删除来源 Atom 后仍可重放为 stale 人工事实。
+
+Atom 移动或 Task 拆分不得切开一个已有 Attempt，也不得把人工 confirmed Attempt relation 的两端分到不同 Task，当前版本会拒绝这类操作并保留原图，细粒度 EvidenceRange 或 Attempt 边界编辑需要后续独立操作。
+
+`merge_tasks` 使用调用方显式指定的 canonical Task，其他 Task id 作为 alias/tombstone 保留。
+
+Task 与 Attempt relation 在写入 override log 前完成唯一 parent、同 Task ownership 和 DAG 校验，非法事件不会污染后续重放。
+
+所有 Task Graph 读写接口都要求 admin 身份且位于 sensitive router，公开 standalone Dashboard 不挂载 Task、Atom、轨迹内容或人工 override 端点。
+
+## 启用与回退
+
+完成 #326 模型评审和 #325 离线回放门禁后，可在配置中设置 `task_graph.enabled: true`。
+
+首次启用会把已有 `split_done`、`indexed` 和 `done` 轨迹加入持久回填队列，并按 `max_scopes_per_run` 分批处理。
+
+关闭开关只停止新增 Task Graph 处理，已投影来源的变化仍以轻量脏记录保留供后续重新启用时追平，从未投影的来源由首次启用回填扫描发现，同时不会删除 Session、Atom、usage ledger、generation、override 或 SQLite 投影。
+
+`xskill rebuild --force` 会清理可重建 Task 投影和 generation source state，但保留已经发生且付费的原始 usage ledger。

--- a/src/xskill/agents/context_budget.py
+++ b/src/xskill/agents/context_budget.py
@@ -1470,7 +1470,7 @@ class ContextManager:
                 )
                 resp = original_invoke(messages, **kwargs)
             usage = extract_usage(resp)
-            if usage.prompt > 0 and est_raw > 0:
+            if usage.prompt is not None and usage.prompt > 0 and est_raw > 0:
                 ratio = usage.prompt / est_raw
                 ratio = max(0.3, min(3.0, ratio))
                 self._calibration = 0.5 * self._calibration + 0.5 * ratio

--- a/src/xskill/api/app.py
+++ b/src/xskill/api/app.py
@@ -1308,6 +1308,6 @@ def create_app(home_root: Path | str | None = None,
 
     # 看板:仅当 config.dashboard.enabled 时挂载(默认不挂)
     from xskill.dashboard.mount import mount_dashboard
-    mount_dashboard(app, _config)
+    mount_dashboard(app, _config, server_mode=team_server)
 
     return app

--- a/src/xskill/config.py
+++ b/src/xskill/config.py
@@ -205,6 +205,16 @@ watcher:
   full_reconcile_interval: 60   # idle polls only stat the directory; this
                                 # periodic full scan catches in-place rewrites
 
+# ===== Logical Task Graph =====
+# Deterministic semantic branch above Session/Atom; it never changes Atom→Skill routing, and uncertain links remain proposed without consuming LLM tokens.
+task_graph:
+  enabled: false                 # enable after ADR/replay-baseline review
+  top_k: 8                      # hard bound on classified candidates per Atom
+  recent_k: 6                   # same-Session recent Task candidates
+  posting_cap: 64               # bounded inverted-index posting list
+  max_scopes_per_run: 4         # fairness bound for one background pass
+  source_cache_size: 128        # bounded in-memory cache for unchanged source evidence
+
 # ===== Persistent agent worker =====
 # Every pool has an automatic waiting capacity of workers * 2. Running plus
 # waiting capacity is workers * 3; a full pool never blocks the watcher.
@@ -338,6 +348,26 @@ def normalize_runtime_config(config_data: dict) -> dict:
     watcher.pop("max_concurrent", None)
     watcher.pop("cluster_batch_size", None)
     runtime_config["watcher"] = watcher
+
+    task_graph = runtime_config.get("task_graph")
+    if task_graph is None:
+        task_graph = {}
+    if not isinstance(task_graph, dict):
+        raise ValueError("task_graph 必须是 mapping")
+    task_graph = dict(task_graph)
+    enabled = task_graph.get("enabled", False)
+    if not isinstance(enabled, bool):
+        raise ValueError("task_graph.enabled 必须是布尔")
+    task_graph["enabled"] = enabled
+    for field_name, default in (
+        ("top_k", 8), ("recent_k", 6),
+        ("posting_cap", 64), ("max_scopes_per_run", 4),
+        ("source_cache_size", 128),
+    ):
+        task_graph[field_name] = _positive_int_or_default(
+            task_graph.get(field_name), f"task_graph.{field_name}", default,
+        )
+    runtime_config["task_graph"] = task_graph
 
     worker = runtime_config.get("agent_worker")
     if worker is None:

--- a/src/xskill/dashboard/mount.py
+++ b/src/xskill/dashboard/mount.py
@@ -19,7 +19,8 @@ def _team_registry_provider():
 
 
 def mount_dashboard(app, cfg: dict, *, db_path: Optional[Path] = None,
-                    serve_builtin: bool = True) -> None:
+                    serve_builtin: bool = True,
+                    server_mode: bool = False) -> None:
     """``serve_builtin=False`` = 独立只读实例（D4）：只挂聚合 GET 端点；
     登录、写操作及内容级敏感路由均物理不挂载。"""
     dc = dashboard_config(cfg)
@@ -29,7 +30,8 @@ def mount_dashboard(app, cfg: dict, *, db_path: Optional[Path] = None,
         db_path=db_path,
         default_harness=dc["default_harness"],
         default_model=dc["default_model"],
-        expose_sensitive=serve_builtin))
+        expose_sensitive=serve_builtin,
+        server_mode=server_mode))
     if serve_builtin:
         # P2-2.2 登录与角色:仅 serve 内置形态挂载(D4)。
         from xskill.dashboard.auth import (

--- a/src/xskill/dashboard/router.py
+++ b/src/xskill/dashboard/router.py
@@ -6,14 +6,16 @@
 from __future__ import annotations
 
 import json
+import re
 from pathlib import Path
 from typing import Optional
 
 from fastapi import APIRouter, Depends, HTTPException, Request
 from fastapi.responses import HTMLResponse, Response
+from pydantic import BaseModel, Field, StrictStr
 
-from xskill.dashboard.metrics import DashboardMetrics, skills_catalog_page
 from xskill.dashboard.auth import _identity_from_request, require_admin
+from xskill.dashboard.metrics import DashboardMetrics, skills_catalog_page
 from xskill.pipeline.registry import (
     harness_share,
     list_watch_dirs,
@@ -21,9 +23,22 @@ from xskill.pipeline.registry import (
     trigger_eval_for_skill,
     usage_summary,
 )
+from xskill.tasks.store import OVERRIDE_OPERATIONS
 
 _STATIC = Path(__file__).with_name("static")
 _STANDALONE_SKILL_SOURCES = frozenset(("native", "skillhub"))
+_TASK_GRAPH_OVERRIDE_PATTERN = "^(?:" + "|".join(
+    re.escape(operation) for operation in sorted(OVERRIDE_OPERATIONS)
+) + ")$"
+
+
+class TaskGraphOverrideRequest(BaseModel):
+    task_scope_id: StrictStr = Field(min_length=1, max_length=200)
+    operation: StrictStr = Field(pattern=_TASK_GRAPH_OVERRIDE_PATTERN)
+    target_id: StrictStr = Field(min_length=1, max_length=200)
+    payload: dict = Field(default_factory=dict)
+    evidence_refs: list[StrictStr] = Field(default_factory=list, max_length=100)
+    event_id: Optional[StrictStr] = Field(default=None, max_length=200)
 
 
 def _skill_dir_for(db_path: Optional[Path]) -> Path:
@@ -40,7 +55,8 @@ def _skill_dir_for(db_path: Optional[Path]) -> Path:
 def build_dashboard_router(db_path: Optional[Path] = None, *,
                            default_harness: Optional[str] = None,
                            default_model: Optional[str] = None,
-                           expose_sensitive: bool = True) -> APIRouter:
+                           expose_sensitive: bool = True,
+                           server_mode: bool = False) -> APIRouter:
     """``expose_sensitive=False`` = 公网只读实例内容白名单（§1.3）：轨迹原文、
     原子详情、用户连接状态、skill 文件/版本/评测 case 等内容级端点和所有写
     端点**物理不注册**（404），只保留聚合数字类 GET 端点。这是给独立只读部署
@@ -130,6 +146,143 @@ def build_dashboard_router(db_path: Optional[Path] = None, *,
         """团队用户(client)列表 + 总数（纯 registry 分析式）。"""
         u = metrics.users()
         return {"total": len(u), "users": u}
+
+    def _task_graph_identity() -> tuple[str, Path]:
+        from xskill.config import get_registry_db_path
+        from xskill.tasks.scopes import ScopeResolver
+
+        registry_path = Path(db_path) if db_path else get_registry_db_path()
+        state_root = registry_path.parent
+        tenant_id = ScopeResolver(
+            state_root, db_path=registry_path,
+        ).existing_tenant_id
+        return tenant_id or "", registry_path
+
+    @sensitive_router.get("/api/v1/dashboard/task-graph/overview")
+    def task_graph_overview_ep(_ident=Depends(require_admin)) -> dict:
+        from xskill.tasks.projection import task_graph_overview
+
+        tenant_id, registry_path = _task_graph_identity()
+        return task_graph_overview(tenant_id, db_path=registry_path)
+
+    @sensitive_router.get("/api/v1/dashboard/task-graph/scopes")
+    def task_graph_scopes_ep(
+        limit: int = 100,
+        offset: int = 0,
+        _ident=Depends(require_admin),
+    ) -> dict:
+        from xskill.tasks.projection import list_task_scopes
+
+        tenant_id, registry_path = _task_graph_identity()
+        return {
+            "scopes": list_task_scopes(
+                tenant_id,
+                limit=max(1, min(limit, 500)),
+                offset=max(0, offset),
+                db_path=registry_path,
+            )
+        }
+
+    @sensitive_router.get("/api/v1/dashboard/task-graph/tasks")
+    def task_graph_tasks_ep(
+        task_scope_id: Optional[str] = None,
+        include_tombstones: bool = False,
+        limit: int = 100,
+        offset: int = 0,
+        _ident=Depends(require_admin),
+    ) -> dict:
+        from xskill.tasks.projection import list_logical_tasks
+
+        tenant_id, registry_path = _task_graph_identity()
+        return {
+            "tasks": list_logical_tasks(
+                tenant_id,
+                task_scope_id=task_scope_id,
+                include_tombstones=include_tombstones,
+                limit=max(1, min(limit, 500)),
+                offset=max(0, offset),
+                db_path=registry_path,
+            )
+        }
+
+    @sensitive_router.get("/api/v1/dashboard/task-graph/by-session")
+    def task_graph_by_session_ep(
+        source_scope_id: str,
+        traj_id: str,
+        _ident=Depends(require_admin),
+    ) -> dict:
+        from xskill.tasks.projection import tasks_for_session
+
+        tenant_id, registry_path = _task_graph_identity()
+        return tasks_for_session(
+            tenant_id, source_scope_id, traj_id, db_path=registry_path,
+        )
+
+    @sensitive_router.get("/api/v1/dashboard/task-graph/by-atom")
+    def task_graph_by_atom_ep(
+        source_scope_id: str,
+        traj_id: str,
+        atom_id: str,
+        _ident=Depends(require_admin),
+    ) -> dict:
+        from xskill.tasks.projection import tasks_for_atom
+
+        tenant_id, registry_path = _task_graph_identity()
+        return tasks_for_atom(
+            tenant_id, source_scope_id, traj_id, atom_id,
+            db_path=registry_path,
+        )
+
+    @sensitive_router.get("/api/v1/dashboard/task-graph/task/{task_id}")
+    def task_graph_task_ep(
+        task_id: str,
+        task_scope_id: str,
+        _ident=Depends(require_admin),
+    ) -> dict:
+        from xskill.tasks.projection import get_logical_task
+
+        tenant_id, registry_path = _task_graph_identity()
+        result = get_logical_task(
+            tenant_id, task_scope_id, task_id, db_path=registry_path,
+        )
+        if result is None:
+            raise HTTPException(status_code=404, detail="Logical Task not found")
+        return result
+
+    @sensitive_router.post("/api/v1/dashboard/task-graph/override")
+    def task_graph_override_ep(
+        body: TaskGraphOverrideRequest,
+        ident=Depends(require_admin),
+    ) -> dict:
+        from xskill.config import get_config
+        from xskill.tasks.service import TaskGraphService
+
+        _tenant_id, registry_path = _task_graph_identity()
+        runtime_config = get_config()
+        service = TaskGraphService(
+            state_root=registry_path.parent,
+            db_path=registry_path,
+            server_mode=server_mode,
+            config=runtime_config,
+        )
+        actor = str(ident.get("user") or ident.get("role") or "admin")
+        try:
+            event = service.append_override(
+                task_scope_id=body.task_scope_id,
+                operation=body.operation,
+                target_id=body.target_id,
+                payload=body.payload,
+                actor=actor,
+                evidence_refs=body.evidence_refs,
+                event_id=body.event_id,
+            )
+        except KeyError as error:
+            raise HTTPException(status_code=404, detail=str(error)) from error
+        except ValueError as error:
+            raise HTTPException(status_code=400, detail=str(error)) from error
+        except RuntimeError as error:
+            raise HTTPException(status_code=409, detail=str(error)) from error
+        return {"override": event.to_dict()}
 
     @router.get("/api/v1/dashboard/tags")
     def tags() -> dict:

--- a/src/xskill/ecosystems/codex.py
+++ b/src/xskill/ecosystems/codex.py
@@ -218,9 +218,14 @@ def _adapt_codex_rollout_jsonl(content: str, metadata: dict) -> tuple[str, dict]
     originator = ""
     cli_version = ""
     model_provider = ""
+    source_model = ""
+    current_model = ""
     first_user_query = ""
+    execution_usage_events: list[dict] = []
+    previous_cumulative_usage: dict = {}
     t = 0
     response_count = 0
+    usage_ordinal = 0
 
     for raw_line in content.splitlines():
         raw_line = raw_line.strip()
@@ -256,6 +261,72 @@ def _adapt_codex_rollout_jsonl(content: str, metadata: dict) -> tuple[str, dict]
                         "content": msg[:2000],
                     })
                     t += 1
+            elif sub_type == "token_count":
+                info = payload.get("info") or {}
+                usage = info.get("last_token_usage") or {}
+                usage_ordinal += 1
+                if isinstance(usage, dict) and usage:
+                    execution_usage_events.append({
+                        "source_event_id": (
+                            f"{session_id or 'codex'}:token-last:"
+                            f"{event.get('ordinal') or usage_ordinal}"
+                        ),
+                        "usage": {
+                            "input_tokens": usage.get("input_tokens"),
+                            "output_tokens": usage.get("output_tokens"),
+                            "total_tokens": usage.get("total_tokens"),
+                            "cached_input_tokens": usage.get(
+                                "cached_input_tokens"
+                            ),
+                        },
+                        "model": {
+                            "model_id": current_model or source_model or None,
+                            "provider": model_provider or None,
+                        },
+                        "observed_at": event.get("timestamp"),
+                    })
+                    if isinstance(info.get("total_token_usage"), dict):
+                        previous_cumulative_usage = dict(
+                            info["total_token_usage"]
+                        )
+                elif isinstance(info.get("total_token_usage"), dict):
+                    cumulative_usage = info["total_token_usage"]
+                    delta_usage = {}
+                    for field_name in (
+                        "input_tokens", "output_tokens", "total_tokens",
+                        "cached_input_tokens",
+                    ):
+                        current_value = cumulative_usage.get(field_name)
+                        previous_value = previous_cumulative_usage.get(field_name)
+                        if not isinstance(current_value, int):
+                            delta_usage[field_name] = None
+                        elif (
+                            isinstance(previous_value, int)
+                            and current_value >= previous_value
+                        ):
+                            delta_usage[field_name] = current_value - previous_value
+                        else:
+                            delta_usage[field_name] = current_value
+                    execution_usage_events.append({
+                        "source_event_id": (
+                            f"{session_id or 'codex'}:token-delta:"
+                            f"{event.get('ordinal') or usage_ordinal}"
+                        ),
+                        "usage": delta_usage,
+                        "model": {
+                            "model_id": current_model or source_model or None,
+                            "provider": model_provider or None,
+                        },
+                        "observed_at": event.get("timestamp"),
+                    })
+                    previous_cumulative_usage = dict(cumulative_usage)
+            continue
+
+        if ev_type == "turn_context":
+            model = payload.get("model")
+            if model:
+                current_model = str(model)
+                source_model = source_model or current_model
             continue
 
         if ev_type == "response_item":
@@ -289,7 +360,7 @@ def _adapt_codex_rollout_jsonl(content: str, metadata: dict) -> tuple[str, dict]
             t += 1
             continue
 
-        # turn_context / compacted / 未来变体：透传，不深析
+        # compacted / 未来变体：透传，不深析
         timeline.append({
             "t": t, "role": "event",
             "kind": ev_type or "unknown",
@@ -346,6 +417,20 @@ def _adapt_codex_rollout_jsonl(content: str, metadata: dict) -> tuple[str, dict]
         meta.setdefault("cli_version", cli_version)
     if model_provider:
         meta.setdefault("model_provider", model_provider)
+        meta.setdefault("source_provider", model_provider)
+    if source_model:
+        meta.setdefault("source_model", source_model)
+    if execution_usage_events:
+        for usage_event in execution_usage_events:
+            usage_event.setdefault("model", {
+                "model_id": source_model or None,
+                "provider": model_provider or None,
+            })
+            usage_event["harness"] = {
+                "name": "codex",
+                "version": cli_version or None,
+            }
+        meta["execution_usage_events"] = execution_usage_events
     meta["timeline"] = timeline
     meta["total_turns"] = len(timeline)
     meta["response_items"] = response_count

--- a/src/xskill/ecosystems/deepseek_harness.py
+++ b/src/xskill/ecosystems/deepseek_harness.py
@@ -264,6 +264,10 @@ def _adapt_deepseek_harness_session_jsonl(
     session_id = ""
     cwd = ""
     agent_preset = ""
+    execution_usage_events: list[dict] = []
+    source_model = ""
+    source_provider = ""
+    assistant_message_ordinal = 0
     t = 0
 
     for raw_line in content.splitlines():
@@ -313,7 +317,34 @@ def _adapt_deepseek_harness_session_jsonl(
             role = "assistant"
             message = data.get("message")
             if isinstance(message, dict):
+                assistant_message_ordinal += 1
                 body = _text_from_message_content(message.get("content"))
+                source = message.get("source")
+                response = (
+                    (source.get("replayState") or {}).get("response")
+                    if isinstance(source, dict) else None
+                )
+                response = response if isinstance(response, dict) else {}
+                source_model = str(
+                    response.get("model") or source_model
+                )
+                source_provider = str(
+                    response.get("provider") or source_provider
+                )
+                usage = data.get("usage") or message.get("usage")
+                if isinstance(usage, dict):
+                    execution_usage_events.append({
+                        "source_event_id": str(
+                            response.get("responseId") or message.get("id")
+                            or f"assistant-message-{assistant_message_ordinal}"
+                        ),
+                        "usage": usage,
+                        "model": {
+                            "provider": source_provider or "unavailable",
+                            "model_id": source_model or "unavailable",
+                        },
+                        "observed_at": record.get("time"),
+                    })
         elif rtype == "tool/call":
             role = "assistant"
             name = str(data.get("name") or "tool")
@@ -353,6 +384,12 @@ def _adapt_deepseek_harness_session_jsonl(
         meta.setdefault("cwd", cwd)
     if agent_preset:
         meta.setdefault("agent_preset", agent_preset)
+    if source_model:
+        meta.setdefault("model", source_model)
+    if source_provider:
+        meta.setdefault("provider", source_provider)
+    if execution_usage_events:
+        meta["execution_usage_events"] = execution_usage_events
     meta["timeline"] = timeline
     meta["tool_names"] = tool_names
     meta["total_turns"] = len(timeline)

--- a/src/xskill/ecosystems/openclaw.py
+++ b/src/xskill/ecosystems/openclaw.py
@@ -319,6 +319,11 @@ def _adapt_openclaw_trajectory_jsonl(content: str, metadata: dict) -> tuple[str,
     model_id = ""
     message_provider = ""
     final_status = ""
+    session_status = ""
+    run_id = ""
+    harness_name = ""
+    harness_version = ""
+    execution_usage_events: list[dict] = []
     last_snapshot: list = []
     eligible_skills: list[str] = []
 
@@ -345,8 +350,24 @@ def _adapt_openclaw_trajectory_jsonl(content: str, metadata: dict) -> tuple[str,
             provider = provider or event.get("provider", "") or ""
             model_id = model_id or event.get("modelId", "") or ""
             message_provider = message_provider or data.get("messageProvider", "") or ""
+            run_id = run_id or event.get("runId", "") or ""
 
         elif ev_type == "trace.metadata":
+            harness_meta = data.get("harness")
+            if isinstance(harness_meta, dict):
+                harness_name = harness_name or str(
+                    harness_meta.get("type") or harness_meta.get("name") or ""
+                )
+                harness_version = harness_version or str(
+                    harness_meta.get("version") or ""
+                )
+            model_meta = data.get("model")
+            if isinstance(model_meta, dict):
+                provider = provider or str(model_meta.get("provider") or "")
+                model_id = model_id or str(
+                    model_meta.get("name") or model_meta.get("modelId") or ""
+                )
+            run_id = run_id or str(event.get("runId") or "")
             skills_meta = data.get("skills")
             if isinstance(skills_meta, list):
                 for s in skills_meta:
@@ -367,6 +388,33 @@ def _adapt_openclaw_trajectory_jsonl(content: str, metadata: dict) -> tuple[str,
             fs = data.get("finalStatus")
             if fs:
                 final_status = str(fs)
+            usage = data.get("usage")
+            if isinstance(usage, dict):
+                event_identity = str(
+                    event.get("runId") or run_id or event.get("traceId")
+                    or "openclaw"
+                )
+                artifact_identity = str(
+                    data.get("capturedAt") or event.get("ts")
+                    or event.get("sourceSeq") or event.get("seq") or len(
+                        execution_usage_events
+                    )
+                )
+                source_event_id = (
+                    f"{event_identity}:trace-artifacts:{artifact_identity}"
+                )
+                execution_usage_events.append({
+                    "source_event_id": source_event_id,
+                    "usage": usage,
+                    "model": {
+                        "provider": event.get("provider") or provider,
+                        "model_id": event.get("modelId") or model_id,
+                    },
+                    "observed_at": event.get("ts") or data.get("capturedAt"),
+                })
+        elif ev_type == "session.ended":
+            session_status = str(data.get("status") or session_status)
+            run_id = run_id or event.get("runId", "") or ""
 
     # 从 messagesSnapshot 构 timeline
     timeline: list[dict] = []
@@ -539,6 +587,16 @@ def _adapt_openclaw_trajectory_jsonl(content: str, metadata: dict) -> tuple[str,
         meta.setdefault("message_provider", message_provider)
     if final_status:
         meta.setdefault("final_status", final_status)
+    if session_status:
+        meta.setdefault("session_status", session_status)
+    if run_id:
+        meta.setdefault("run_id", run_id)
+    if harness_name:
+        meta.setdefault("source_harness", harness_name)
+    if harness_version:
+        meta.setdefault("harness_version", harness_version)
+    if execution_usage_events:
+        meta["execution_usage_events"] = execution_usage_events
     if eligible_skills:
         meta.setdefault("eligible_skills", eligible_skills)
     meta["timeline"] = timeline

--- a/src/xskill/pipeline/registry.py
+++ b/src/xskill/pipeline/registry.py
@@ -456,6 +456,7 @@ CREATE TABLE IF NOT EXISTS task_graph_generations (
     task_scope_id      TEXT NOT NULL,
     generation_id     TEXT NOT NULL,
     source_revision    TEXT NOT NULL,
+    generator_json    TEXT NOT NULL DEFAULT '{}',
     base_override_seq  INTEGER NOT NULL,
     created_at         TEXT NOT NULL,
     task_count         INTEGER NOT NULL DEFAULT 0,
@@ -1078,6 +1079,17 @@ def _migrate(conn: sqlite3.Connection) -> None:
         conn.execute(
             "ALTER TABLE execution_usage_events"
             " ADD COLUMN estimation_method TEXT NOT NULL DEFAULT ''"
+        )
+    task_generation_columns = {
+        row[1]
+        for row in conn.execute(
+            "PRAGMA table_info(task_graph_generations)"
+        ).fetchall()
+    }
+    if "generator_json" not in task_generation_columns:
+        conn.execute(
+            "ALTER TABLE task_graph_generations"
+            " ADD COLUMN generator_json TEXT NOT NULL DEFAULT '{}'"
         )
 
     # skills_catalog.content_sha：与 Milvus 向量索引对齐的一致性键

--- a/src/xskill/pipeline/registry.py
+++ b/src/xskill/pipeline/registry.py
@@ -17,10 +17,12 @@ from __future__ import annotations
 
 import json
 import logging
+import math
 import sqlite3
 import threading
 import time
 import zlib
+import uuid
 from contextlib import contextmanager
 from datetime import datetime, timezone
 from enum import Enum
@@ -125,6 +127,7 @@ CREATE TABLE IF NOT EXISTS watch_dirs (
     label      TEXT DEFAULT '',
     auto_index INTEGER DEFAULT 1,
     ecosystem  TEXT DEFAULT 'manual',
+    source_scope_id TEXT UNIQUE,
     created_at TEXT DEFAULT (datetime('now'))
 );
 
@@ -162,7 +165,20 @@ CREATE TABLE IF NOT EXISTS llm_usage (
     completion   INTEGER DEFAULT 0,
     total        INTEGER DEFAULT 0,
     cost_usd     REAL DEFAULT 0,
-    price_source TEXT
+    price_source TEXT,
+    usage_event_id TEXT UNIQUE,
+    usage_plane TEXT DEFAULT 'xskill_processing',
+    measurement_quality TEXT,
+    allocation_mode TEXT DEFAULT 'unattributed',
+    estimation_method TEXT,
+    unavailable_reason TEXT,
+    tenant_id TEXT,
+    task_scope_id TEXT,
+    source_scope_id TEXT,
+    traj_id TEXT,
+    atom_id TEXT,
+    generation_id TEXT,
+    legacy INTEGER NOT NULL DEFAULT 0
 );
 CREATE INDEX IF NOT EXISTS idx_llm_usage_ts ON llm_usage(ts);
 
@@ -433,6 +449,260 @@ CREATE TABLE IF NOT EXISTS skill_origin (
     ts         TEXT DEFAULT (datetime('now'))
 );
 CREATE INDEX IF NOT EXISTS idx_skill_origin_user ON skill_origin(user_key);
+
+-- Logical Task 事实源位于 task_graph/scopes；下列表均为可重建查询投影。
+CREATE TABLE IF NOT EXISTS task_graph_generations (
+    tenant_id          TEXT NOT NULL,
+    task_scope_id      TEXT NOT NULL,
+    generation_id     TEXT NOT NULL,
+    source_revision    TEXT NOT NULL,
+    base_override_seq  INTEGER NOT NULL,
+    created_at         TEXT NOT NULL,
+    task_count         INTEGER NOT NULL DEFAULT 0,
+    atom_count         INTEGER NOT NULL DEFAULT 0,
+    candidate_count    INTEGER NOT NULL DEFAULT 0,
+    model_judgement_count INTEGER NOT NULL DEFAULT 0,
+    PRIMARY KEY (tenant_id, task_scope_id)
+);
+
+CREATE TABLE IF NOT EXISTS logical_tasks (
+    tenant_id          TEXT NOT NULL,
+    task_scope_id      TEXT NOT NULL,
+    task_id            TEXT NOT NULL,
+    generation_id      TEXT NOT NULL,
+    title              TEXT NOT NULL DEFAULT '',
+    summary            TEXT NOT NULL DEFAULT '',
+    lifecycle          TEXT NOT NULL,
+    outcome            TEXT NOT NULL,
+    verification       TEXT NOT NULL,
+    user_disposition   TEXT NOT NULL,
+    created_at         TEXT NOT NULL,
+    tombstoned         INTEGER NOT NULL DEFAULT 0,
+    aliases_json       TEXT NOT NULL DEFAULT '[]',
+    decisions_json     TEXT NOT NULL DEFAULT '[]',
+    primary_atom_count INTEGER NOT NULL DEFAULT 0,
+    attempt_count      INTEGER NOT NULL DEFAULT 0,
+    execution_tokens   INTEGER,
+    execution_cost_usd REAL,
+    PRIMARY KEY (tenant_id, task_scope_id, task_id)
+);
+CREATE INDEX IF NOT EXISTS idx_logical_tasks_scope_state
+    ON logical_tasks(tenant_id, task_scope_id, tombstoned, created_at, task_id);
+CREATE INDEX IF NOT EXISTS idx_logical_tasks_tenant_state
+    ON logical_tasks(tenant_id, tombstoned, created_at, task_id);
+
+CREATE TABLE IF NOT EXISTS task_atom_memberships (
+    tenant_id        TEXT NOT NULL,
+    task_scope_id    TEXT NOT NULL,
+    membership_id   TEXT NOT NULL,
+    generation_id   TEXT NOT NULL,
+    task_id          TEXT NOT NULL,
+    source_scope_id TEXT NOT NULL,
+    traj_id          TEXT NOT NULL,
+    atom_id          TEXT NOT NULL,
+    role             TEXT NOT NULL,
+    decision         TEXT NOT NULL,
+    confidence       REAL,
+    decided_by       TEXT NOT NULL,
+    algorithm_version TEXT NOT NULL,
+    evidence_refs_json TEXT NOT NULL DEFAULT '[]',
+    observed_at      TEXT NOT NULL,
+    stale            INTEGER NOT NULL DEFAULT 0,
+    PRIMARY KEY (tenant_id, task_scope_id, membership_id)
+);
+CREATE INDEX IF NOT EXISTS idx_task_membership_atom
+    ON task_atom_memberships(
+        tenant_id, task_scope_id, source_scope_id, traj_id, atom_id, decision, role
+    );
+CREATE INDEX IF NOT EXISTS idx_task_membership_task
+    ON task_atom_memberships(tenant_id, task_scope_id, task_id, decision, role);
+CREATE INDEX IF NOT EXISTS idx_task_membership_session
+    ON task_atom_memberships(
+        tenant_id, source_scope_id, traj_id, atom_id, decision, role
+    );
+
+CREATE TABLE IF NOT EXISTS task_relations (
+    tenant_id        TEXT NOT NULL,
+    task_scope_id    TEXT NOT NULL,
+    relation_id     TEXT NOT NULL,
+    generation_id   TEXT NOT NULL,
+    from_task_id    TEXT NOT NULL,
+    to_task_id      TEXT NOT NULL,
+    relation_type   TEXT NOT NULL,
+    decision        TEXT NOT NULL,
+    confidence      REAL,
+    decided_by      TEXT NOT NULL,
+    algorithm_version TEXT NOT NULL,
+    evidence_refs_json TEXT NOT NULL DEFAULT '[]',
+    observed_at     TEXT NOT NULL,
+    stale           INTEGER NOT NULL DEFAULT 0,
+    PRIMARY KEY (tenant_id, task_scope_id, relation_id)
+);
+CREATE INDEX IF NOT EXISTS idx_task_relations_from
+    ON task_relations(tenant_id, task_scope_id, from_task_id, decision);
+CREATE INDEX IF NOT EXISTS idx_task_relations_to
+    ON task_relations(tenant_id, task_scope_id, to_task_id, decision);
+
+CREATE TABLE IF NOT EXISTS task_attempts (
+    tenant_id        TEXT NOT NULL,
+    task_scope_id    TEXT NOT NULL,
+    attempt_id       TEXT NOT NULL,
+    generation_id   TEXT NOT NULL,
+    task_id          TEXT NOT NULL,
+    started_at       TEXT NOT NULL,
+    ended_at         TEXT,
+    lifecycle        TEXT NOT NULL,
+    outcome          TEXT NOT NULL,
+    verification     TEXT NOT NULL,
+    user_disposition TEXT NOT NULL,
+    decisions_json   TEXT NOT NULL DEFAULT '[]',
+    execution_identity_json TEXT NOT NULL DEFAULT '{}',
+    evidence_count   INTEGER NOT NULL DEFAULT 0,
+    execution_tokens INTEGER,
+    execution_cost_usd REAL,
+    PRIMARY KEY (tenant_id, task_scope_id, attempt_id)
+);
+CREATE INDEX IF NOT EXISTS idx_task_attempts_task
+    ON task_attempts(tenant_id, task_scope_id, task_id, started_at, attempt_id);
+
+CREATE TABLE IF NOT EXISTS task_evidence_ranges (
+    tenant_id        TEXT NOT NULL,
+    task_scope_id    TEXT NOT NULL,
+    evidence_id      TEXT NOT NULL,
+    generation_id   TEXT NOT NULL,
+    attempt_id       TEXT NOT NULL,
+    source_scope_id TEXT NOT NULL,
+    traj_id          TEXT NOT NULL,
+    atom_id          TEXT,
+    locator_kind     TEXT NOT NULL,
+    locator_start    TEXT NOT NULL,
+    locator_end      TEXT NOT NULL,
+    content_hash     TEXT NOT NULL,
+    atom_hash        TEXT NOT NULL DEFAULT '',
+    stale            INTEGER NOT NULL DEFAULT 0,
+    model_json       TEXT NOT NULL DEFAULT '{}',
+    harness_json     TEXT NOT NULL DEFAULT '{}',
+    skills_json      TEXT NOT NULL DEFAULT '[]',
+    PRIMARY KEY (tenant_id, task_scope_id, evidence_id)
+);
+CREATE INDEX IF NOT EXISTS idx_task_evidence_session
+    ON task_evidence_ranges(tenant_id, task_scope_id, source_scope_id, traj_id);
+CREATE INDEX IF NOT EXISTS idx_task_evidence_attempt
+    ON task_evidence_ranges(tenant_id, task_scope_id, attempt_id);
+
+CREATE TABLE IF NOT EXISTS task_attempt_relations (
+    tenant_id        TEXT NOT NULL,
+    task_scope_id    TEXT NOT NULL,
+    relation_id      TEXT NOT NULL,
+    generation_id    TEXT NOT NULL,
+    from_attempt_id  TEXT NOT NULL,
+    to_attempt_id    TEXT NOT NULL,
+    relation_type    TEXT NOT NULL,
+    decision         TEXT NOT NULL,
+    confidence       REAL,
+    decided_by       TEXT NOT NULL,
+    algorithm_version TEXT NOT NULL,
+    evidence_refs_json TEXT NOT NULL DEFAULT '[]',
+    observed_at      TEXT NOT NULL,
+    PRIMARY KEY (tenant_id, task_scope_id, relation_id)
+);
+CREATE INDEX IF NOT EXISTS idx_task_attempt_relations_from
+    ON task_attempt_relations(tenant_id, task_scope_id, from_attempt_id);
+CREATE INDEX IF NOT EXISTS idx_task_attempt_relations_to
+    ON task_attempt_relations(tenant_id, task_scope_id, to_attempt_id);
+
+-- 原 Harness execution usage 是不可由 Atom 重建的 append-only 事实。
+CREATE TABLE IF NOT EXISTS execution_usage_events (
+    usage_event_id      TEXT PRIMARY KEY,
+    usage_plane         TEXT NOT NULL CHECK(usage_plane='execution'),
+    source_event_id     TEXT NOT NULL,
+    tenant_id           TEXT NOT NULL,
+    task_scope_id       TEXT NOT NULL,
+    source_scope_id     TEXT NOT NULL,
+    traj_id             TEXT NOT NULL,
+    model_json          TEXT NOT NULL DEFAULT '{}',
+    harness_json        TEXT NOT NULL DEFAULT '{}',
+    prompt_tokens       INTEGER,
+    completion_tokens   INTEGER,
+    total_tokens        INTEGER,
+    cache_read_tokens   INTEGER,
+    cost_usd            REAL,
+    measurement_quality TEXT NOT NULL,
+    estimation_method   TEXT NOT NULL DEFAULT '',
+    unavailable_reason  TEXT NOT NULL DEFAULT '',
+    observed_at         TEXT NOT NULL,
+    ingested_at         TEXT NOT NULL DEFAULT (datetime('now'))
+);
+CREATE INDEX IF NOT EXISTS idx_execution_usage_session
+    ON execution_usage_events(
+        tenant_id, task_scope_id, source_scope_id, traj_id, observed_at
+    );
+
+CREATE TABLE IF NOT EXISTS task_usage_allocations (
+    tenant_id        TEXT NOT NULL,
+    task_scope_id    TEXT NOT NULL,
+    allocation_id   TEXT NOT NULL,
+    generation_id   TEXT NOT NULL,
+    usage_event_id  TEXT NOT NULL,
+    usage_plane     TEXT NOT NULL,
+    allocation_mode TEXT NOT NULL,
+    fraction        REAL NOT NULL,
+    task_id         TEXT,
+    attempt_id      TEXT,
+    processing_step TEXT,
+    prompt_tokens   INTEGER,
+    completion_tokens INTEGER,
+    total_tokens    INTEGER,
+    cache_read_tokens INTEGER,
+    cost_usd        REAL,
+    method          TEXT NOT NULL DEFAULT '',
+    method_version  TEXT NOT NULL DEFAULT '',
+    PRIMARY KEY (tenant_id, task_scope_id, allocation_id)
+);
+CREATE INDEX IF NOT EXISTS idx_task_usage_task
+    ON task_usage_allocations(tenant_id, task_scope_id, task_id, usage_plane);
+CREATE INDEX IF NOT EXISTS idx_task_usage_event
+    ON task_usage_allocations(usage_plane, usage_event_id);
+
+CREATE TABLE IF NOT EXISTS task_graph_source_state (
+    tenant_id        TEXT NOT NULL,
+    task_scope_id    TEXT NOT NULL,
+    source_scope_id TEXT NOT NULL,
+    watch_dir_id     INTEGER NOT NULL,
+    traj_id          TEXT NOT NULL,
+    source_revision  TEXT NOT NULL,
+    generation_id    TEXT NOT NULL,
+    updated_at       TEXT NOT NULL DEFAULT (datetime('now')),
+    PRIMARY KEY (source_scope_id, traj_id)
+);
+CREATE INDEX IF NOT EXISTS idx_task_source_scope
+    ON task_graph_source_state(tenant_id, task_scope_id);
+
+CREATE TABLE IF NOT EXISTS task_graph_dirty_sources (
+    watch_dir_id     INTEGER NOT NULL,
+    filename         TEXT NOT NULL,
+    source_scope_id TEXT,
+    tenant_id        TEXT,
+    task_scope_id    TEXT,
+    deleted          INTEGER NOT NULL DEFAULT 0,
+    generation       INTEGER NOT NULL DEFAULT 1,
+    reason           TEXT NOT NULL DEFAULT '',
+    marked_at        TEXT NOT NULL DEFAULT (datetime('now')),
+    PRIMARY KEY (watch_dir_id, filename)
+);
+CREATE INDEX IF NOT EXISTS idx_task_dirty_marked
+    ON task_graph_dirty_sources(marked_at, watch_dir_id, filename);
+
+CREATE TABLE IF NOT EXISTS task_graph_dirty_scopes (
+    tenant_id        TEXT NOT NULL,
+    task_scope_id    TEXT NOT NULL,
+    generation       INTEGER NOT NULL DEFAULT 1,
+    reason           TEXT NOT NULL DEFAULT '',
+    marked_at        TEXT NOT NULL DEFAULT (datetime('now')),
+    PRIMARY KEY (tenant_id, task_scope_id)
+);
+CREATE INDEX IF NOT EXISTS idx_task_dirty_scope_marked
+    ON task_graph_dirty_scopes(marked_at, tenant_id, task_scope_id);
 """
 
 _WATCH_STATUS_INDEX_SQL = """
@@ -722,6 +992,93 @@ def _migrate(conn: sqlite3.Connection) -> None:
         )
         # 已有行历史上都是用户手动 register，标 'manual'
         conn.execute("UPDATE watch_dirs SET ecosystem='manual' WHERE ecosystem IS NULL")
+    if "source_scope_id" not in wd_cols:
+        conn.execute("ALTER TABLE watch_dirs ADD COLUMN source_scope_id TEXT")
+    missing_source_scopes = conn.execute(
+        "SELECT id, path FROM watch_dirs"
+        " WHERE source_scope_id IS NULL OR source_scope_id=''"
+    ).fetchall()
+    for watch_dir_row in missing_source_scopes:
+        conn.execute(
+            "UPDATE watch_dirs SET source_scope_id=? WHERE id=?",
+            (f"src_{uuid.uuid4().hex}", watch_dir_row["id"]),
+        )
+    conn.execute(
+        "CREATE UNIQUE INDEX IF NOT EXISTS idx_watch_dirs_source_scope"
+        " ON watch_dirs(source_scope_id)"
+        " WHERE source_scope_id IS NOT NULL AND source_scope_id != ''"
+    )
+
+    # Logical Task usage identity.  Historical rows intentionally retain their
+    # original numeric values without inventing measurement quality or scope.
+    cur = conn.execute("PRAGMA table_info(llm_usage)")
+    usage_cols = {row[1] for row in cur.fetchall()}
+    usage_migrations = [
+        ("usage_event_id", "TEXT"),
+        ("usage_plane", "TEXT DEFAULT 'xskill_processing'"),
+        ("measurement_quality", "TEXT"),
+        ("allocation_mode", "TEXT DEFAULT 'unattributed'"),
+        ("estimation_method", "TEXT"),
+        ("unavailable_reason", "TEXT"),
+        ("tenant_id", "TEXT"),
+        ("task_scope_id", "TEXT"),
+        ("source_scope_id", "TEXT"),
+        ("traj_id", "TEXT"),
+        ("atom_id", "TEXT"),
+        ("generation_id", "TEXT"),
+        ("legacy", "INTEGER NOT NULL DEFAULT 0"),
+    ]
+    for column_name, column_type in usage_migrations:
+        if column_name not in usage_cols:
+            conn.execute(
+                f"ALTER TABLE llm_usage ADD COLUMN {column_name} {column_type}"
+            )
+    conn.execute(
+        "UPDATE llm_usage SET usage_event_id='xsp_legacy_' || id,"
+        " usage_plane='xskill_processing', allocation_mode='unattributed',"
+        " legacy=1 WHERE usage_event_id IS NULL OR usage_event_id=''"
+    )
+    conn.execute(
+        "CREATE UNIQUE INDEX IF NOT EXISTS idx_llm_usage_event"
+        " ON llm_usage(usage_event_id) WHERE usage_event_id IS NOT NULL"
+    )
+    conn.execute(
+        "CREATE INDEX IF NOT EXISTS idx_llm_usage_scope"
+        " ON llm_usage(tenant_id, task_scope_id, usage_plane)"
+    )
+    task_usage_columns = {
+        row[1]
+        for row in conn.execute(
+            "PRAGMA table_info(task_usage_allocations)"
+        ).fetchall()
+    }
+    if "cache_read_tokens" not in task_usage_columns:
+        conn.execute(
+            "ALTER TABLE task_usage_allocations"
+            " ADD COLUMN cache_read_tokens INTEGER"
+        )
+    task_evidence_columns = {
+        row[1]
+        for row in conn.execute(
+            "PRAGMA table_info(task_evidence_ranges)"
+        ).fetchall()
+    }
+    if "atom_hash" not in task_evidence_columns:
+        conn.execute(
+            "ALTER TABLE task_evidence_ranges"
+            " ADD COLUMN atom_hash TEXT NOT NULL DEFAULT ''"
+        )
+    execution_usage_columns = {
+        row[1]
+        for row in conn.execute(
+            "PRAGMA table_info(execution_usage_events)"
+        ).fetchall()
+    }
+    if "estimation_method" not in execution_usage_columns:
+        conn.execute(
+            "ALTER TABLE execution_usage_events"
+            " ADD COLUMN estimation_method TEXT NOT NULL DEFAULT ''"
+        )
 
     # skills_catalog.content_sha：与 Milvus 向量索引对齐的一致性键
     cur = conn.execute("PRAGMA table_info(skills_catalog)")
@@ -776,18 +1133,91 @@ def _migrate(conn: sqlite3.Connection) -> None:
 # LLM usage / cost accounting  (Issue #43)  —— 唯一"无家可归"数据的持久化
 # ---------------------------------------------------------------------------
 
-def record_usage(*, step: str, model: str, prompt: int, completion: int,
-                 total: int, cost_usd: float, price_source: str,
-                 db_path: Optional[Path] = None) -> None:
+def record_usage(*, step: str, model: str, prompt: Optional[int],
+                 completion: Optional[int], total: Optional[int],
+                 cost_usd: Optional[float], price_source: str,
+                 usage_event_id: Optional[str] = None,
+                 measurement_quality: str = "measured",
+                 allocation_mode: str = "unattributed",
+                 estimation_method: Optional[str] = None,
+                 unavailable_reason: Optional[str] = None,
+                 tenant_id: Optional[str] = None,
+                 task_scope_id: Optional[str] = None,
+                 source_scope_id: Optional[str] = None,
+                 traj_id: Optional[str] = None,
+                 atom_id: Optional[str] = None,
+                 generation_id: Optional[str] = None,
+                 db_path: Optional[Path] = None) -> str:
     """追加一条 LLM/embedding 调用的 token+成本记录。旁路 telemetry。"""
+    if measurement_quality not in ("measured", "estimated", "unavailable"):
+        raise ValueError("invalid measurement_quality")
+    if allocation_mode not in ("direct", "shared", "unattributed"):
+        raise ValueError("invalid allocation_mode")
+    if usage_event_id is None:
+        event_id = f"xsp_{uuid.uuid4().hex}"
+    elif not isinstance(usage_event_id, str) or not usage_event_id.strip():
+        raise ValueError("usage_event_id must be a non-empty string")
+    else:
+        event_id = usage_event_id.strip()
+    if len(event_id) > 200:
+        raise ValueError("usage_event_id is limited to 200 characters")
+
+    def non_negative_number(value, name: str, *, integer: bool):
+        if value is None:
+            return None
+        if isinstance(value, bool):
+            raise ValueError(f"{name} must be numeric or None")
+        if integer:
+            if not isinstance(value, int):
+                raise ValueError(f"{name} must be an integer or None")
+            normalized = value
+        else:
+            if not isinstance(value, (int, float)):
+                raise ValueError(f"{name} must be numeric or None")
+            normalized = float(value)
+        if not math.isfinite(float(normalized)) or normalized < 0:
+            raise ValueError(f"{name} must be non-negative")
+        return normalized
+
+    prompt_value = non_negative_number(prompt, "prompt", integer=True)
+    completion_value = non_negative_number(
+        completion, "completion", integer=True,
+    )
+    total_value = non_negative_number(total, "total", integer=True)
+    cost_value = non_negative_number(cost_usd, "cost_usd", integer=False)
+    if measurement_quality == "estimated" and not str(
+        estimation_method or ""
+    ).strip():
+        raise ValueError("estimated usage requires estimation_method")
+    if measurement_quality == "unavailable":
+        if not str(unavailable_reason or "").strip():
+            raise ValueError("unavailable usage requires unavailable_reason")
+        prompt_value = completion_value = total_value = cost_value = None
+    elif all(
+        value is None
+        for value in (
+            prompt_value, completion_value, total_value, cost_value,
+        )
+    ):
+        raise ValueError("measured or estimated usage requires a numeric value")
     with pooled_connection(db_path) as conn:
         conn.execute(
-            "INSERT INTO llm_usage(step,model,prompt,completion,total,cost_usd,price_source)"
-            " VALUES(?,?,?,?,?,?,?)",
-            (step, model, int(prompt), int(completion), int(total),
-             float(cost_usd), price_source),
+            "INSERT INTO llm_usage("
+            "step,model,prompt,completion,total,cost_usd,price_source,"
+            "usage_event_id,usage_plane,measurement_quality,allocation_mode,"
+            "estimation_method,unavailable_reason,tenant_id,task_scope_id,"
+            "source_scope_id,traj_id,atom_id,generation_id,legacy)"
+            " VALUES(?,?,?,?,?,?,?,?,?,?,?,?,?,?,?,?,?,?,?,0)",
+            (
+                step, model, prompt_value, completion_value, total_value,
+                cost_value, price_source, event_id, "xskill_processing",
+                measurement_quality, allocation_mode, estimation_method,
+                unavailable_reason, tenant_id, task_scope_id, source_scope_id,
+                traj_id, atom_id, generation_id,
+            ),
         )
         conn.commit()
+    return event_id
 
 
 # ---------------------------------------------------------------------------
@@ -1777,6 +2207,15 @@ def clear_rebuild_derived_state(
         deleted_counts["canary_decision"] = cursor.rowcount
         cursor = connection.execute("DELETE FROM skill_trigger_eval")
         deleted_counts["skill_trigger_eval"] = cursor.rowcount
+        for table_name in (
+            "task_usage_allocations", "task_attempt_relations",
+            "task_evidence_ranges", "task_attempts", "task_relations",
+            "task_atom_memberships", "logical_tasks", "task_graph_generations",
+            "task_graph_source_state",
+            "task_graph_dirty_sources",
+            "task_graph_dirty_scopes",
+        ):
+            connection.execute(f"DELETE FROM {table_name}")
         connection.commit()
         return deleted_counts
 
@@ -1916,18 +2355,49 @@ def register_dir(
     """
     dir_path = str(Path(dir_path).resolve())
     with pooled_connection(db_path) as conn:
+        source_scope_id = f"src_{uuid.uuid4().hex}"
         conn.execute(
-            "INSERT INTO watch_dirs (path, label, auto_index, ecosystem)"
-            " VALUES (?, ?, ?, ?)"
+            "INSERT INTO watch_dirs (path, label, auto_index, ecosystem, source_scope_id)"
+            " VALUES (?, ?, ?, ?, ?)"
             " ON CONFLICT(path) DO UPDATE SET"
             "   label=excluded.label,"
             "   auto_index=excluded.auto_index,"
             "   ecosystem=excluded.ecosystem",
-            (dir_path, label, int(auto_index), ecosystem),
+            (dir_path, label, int(auto_index), ecosystem, source_scope_id),
         )
         conn.commit()
         row = conn.execute("SELECT id FROM watch_dirs WHERE path=?", (dir_path,)).fetchone()
         return row["id"]
+
+
+def ensure_watch_dir_source_scope(
+    watch_dir_id: int, *, db_path: Optional[Path] = None,
+) -> str:
+    """Return the persisted opaque ingestion namespace for one watch dir."""
+    if isinstance(watch_dir_id, bool) or not isinstance(watch_dir_id, int):
+        raise ValueError("watch_dir_id must be an integer")
+    with pooled_connection(db_path) as conn:
+        row = conn.execute(
+            "SELECT source_scope_id FROM watch_dirs WHERE id=?",
+            (watch_dir_id,),
+        ).fetchone()
+        if row is None:
+            raise KeyError(f"watch_dir id={watch_dir_id} does not exist")
+        existing = str(row["source_scope_id"] or "").strip()
+        if existing:
+            return existing
+        source_scope_id = f"src_{uuid.uuid4().hex}"
+        conn.execute(
+            "UPDATE watch_dirs SET source_scope_id=?"
+            " WHERE id=? AND (source_scope_id IS NULL OR source_scope_id='')",
+            (source_scope_id, watch_dir_id),
+        )
+        conn.commit()
+        resolved = conn.execute(
+            "SELECT source_scope_id FROM watch_dirs WHERE id=?",
+            (watch_dir_id,),
+        ).fetchone()["source_scope_id"]
+        return str(resolved)
 
 
 def unregister_dir(dir_path: str | Path, *, db_path: Optional[Path] = None) -> bool:
@@ -1938,17 +2408,40 @@ def unregister_dir(dir_path: str | Path, *, db_path: Optional[Path] = None) -> b
     """
     dir_path = str(Path(dir_path).resolve())
     with pooled_connection(db_path) as conn:
-        stems = [
-            (r["filename"][:-3] if r["filename"].endswith(".md") else r["filename"])
-            for r in conn.execute(
-                "SELECT t.filename FROM trajectories t"
-                " JOIN watch_dirs w ON t.watch_dir_id=w.id WHERE w.path=?",
-                (dir_path,),
-            ).fetchall()
-        ]
-        for stem in stems:
+        source_rows = conn.execute(
+            "SELECT t.watch_dir_id,t.filename,w.source_scope_id"
+            " FROM trajectories t JOIN watch_dirs w ON t.watch_dir_id=w.id"
+            " WHERE w.path=?",
+            (dir_path,),
+        ).fetchall()
+        for source_row in source_rows:
+            stem = (
+                source_row["filename"][:-3]
+                if source_row["filename"].endswith(".md")
+                else source_row["filename"]
+            )
             conn.execute("DELETE FROM atom_adoption WHERE atom_id GLOB ?",
                          (f"atom_{stem}_*",))
+            state = conn.execute(
+                "SELECT tenant_id,task_scope_id FROM task_graph_source_state"
+                " WHERE source_scope_id=? AND traj_id=?",
+                (source_row["source_scope_id"], stem),
+            ).fetchone()
+            if state is not None:
+                conn.execute(
+                    "INSERT INTO task_graph_dirty_sources("
+                    "watch_dir_id,filename,source_scope_id,tenant_id,task_scope_id,"
+                    "deleted,generation,reason,marked_at)"
+                    " VALUES(?,?,?,?,?,1,1,'watch_dir_removed',datetime('now'))"
+                    " ON CONFLICT(watch_dir_id,filename) DO UPDATE SET"
+                    " deleted=1,generation=generation+1,reason='watch_dir_removed',"
+                    " marked_at=datetime('now')",
+                    (
+                        source_row["watch_dir_id"], source_row["filename"],
+                        source_row["source_scope_id"], state["tenant_id"],
+                        state["task_scope_id"],
+                    ),
+                )
         cur = conn.execute("DELETE FROM watch_dirs WHERE path=?", (dir_path,))
         conn.commit()
         return cur.rowcount > 0
@@ -2511,7 +3004,8 @@ def reset_trajectories(
     """
     with pooled_connection(db_path) as conn:
         query_text = (
-            "SELECT t.id, t.filename, t.user_key, w.path FROM trajectories t "
+            "SELECT t.id, t.watch_dir_id, t.filename, t.user_key, w.path,"
+            " w.source_scope_id FROM trajectories t "
             "JOIN watch_dirs w ON t.watch_dir_id = w.id WHERE 1=1"
         )
         query_parameters: list = []
@@ -2550,6 +3044,28 @@ def reset_trajectories(
             # 否则采纳率分子留历史累计、分母归零后比率虚高（审计 P1-7）。
             conn.execute("DELETE FROM atom_adoption WHERE atom_id GLOB ?",
                          (f"atom_{trajectory_stem}_*",))
+            source_state = conn.execute(
+                "SELECT tenant_id,task_scope_id FROM task_graph_source_state"
+                " WHERE source_scope_id=? AND traj_id=?",
+                (trajectory_row["source_scope_id"], trajectory_stem),
+            ).fetchone()
+            if source_state is not None:
+                conn.execute(
+                    "INSERT INTO task_graph_dirty_sources("
+                    "watch_dir_id,filename,source_scope_id,tenant_id,task_scope_id,"
+                    "deleted,generation,reason,marked_at)"
+                    " VALUES(?,?,?,?,?,1,1,'atom_reset',datetime('now'))"
+                    " ON CONFLICT(watch_dir_id,filename) DO UPDATE SET"
+                    " deleted=1,generation=generation+1,reason='atom_reset',"
+                    " marked_at=datetime('now')",
+                    (
+                        trajectory_row["watch_dir_id"],
+                        trajectory_row["filename"],
+                        trajectory_row["source_scope_id"],
+                        source_state["tenant_id"],
+                        source_state["task_scope_id"],
+                    ),
+                )
             directories_seen.add(trajectory_row["path"])
             if trajectory_row["user_key"]:
                 profile_store_roots.add(trajectory_row["path"])

--- a/src/xskill/pipeline/runner.py
+++ b/src/xskill/pipeline/runner.py
@@ -24,6 +24,7 @@ v2 (AtomTask) 流水线下，对一个 atom 的"cluster → 触发 SkillEdit"是
 from __future__ import annotations
 
 import asyncio
+import contextlib
 import hashlib
 import logging
 import os
@@ -206,6 +207,16 @@ class DirectoryWatcher:
             name: BoundedExecutor(name, int(self.pool_config[name]["workers"]))
             for name in ("split", "cluster", "edit", "embed")
         }
+        # TaskScope writes are intentionally serialized: generation publication,
+        # override replay and SQLite projection share one transaction boundary.
+        self._task_graph_pool = BoundedExecutor("task_graph", 1)
+        from xskill.tasks.service import TaskGraphService
+        self._task_graph_service = TaskGraphService(
+            state_root=xskill_state_root,
+            db_path=Path(db_path) if db_path is not None else None,
+            server_mode=self.server_mode,
+            config=self.config,
+        )
         self.cluster_write_queue = ClusterWriteQueue()
         self._futures: dict[Future, dict] = {}
         # Only the watcher thread mutates these scheduling collections.
@@ -239,6 +250,7 @@ class DirectoryWatcher:
             "atoms_clustered": 0,    # v2: 累计 cluster 调用次数
             "skills_edited": 0,      # v2: 触发的 SkillEdit 次数
             "scores": 0, "errors": 0, "retries": 0,
+            "task_graph_generations": 0,
         }
         # generate 与 SkillEdit 共用 edit 池；完成/失败单独记，给流水线第四栏。
         self._generate_completed = 0
@@ -262,6 +274,7 @@ class DirectoryWatcher:
         # SHUTTING_DOWN 事件叫停（agno_factory 重试循环），不在这里等。
         for pool in self._pools.values():
             pool.shutdown(wait=False, cancel_futures=True)
+        self._task_graph_pool.shutdown(wait=False, cancel_futures=True)
         self.cluster_write_queue.shutdown(wait=False)
         logger.info("watcher stopped")
 
@@ -302,6 +315,10 @@ class DirectoryWatcher:
             "heartbeat_at": time.time(),
             "watcher": self.stats,
             "pools": {name: pool.status for name, pool in self._pools.items()},
+            "task_graph": {
+                "enabled": self._task_graph_service.enabled,
+                **self._task_graph_pool.status,
+            },
             # 看板「流水线」页配置 chip 的展示值（席位/配额比/批量）；
             # 配置键不变，热更在 P1 另行评审。
             "pool_config": {
@@ -464,6 +481,7 @@ class DirectoryWatcher:
         # 全部 watch_dir 共用一个 pending/claimed 队列；持续提交到 cluster 池满。
         # 最后不足 batch_size 的尾批也立即提交。
         self._submit_cluster_batches()
+        self._submit_task_graph()
 
         # ── Step 5a: 用户点名的 generate 入队到 SkillEdit 同一线程池 ──
         # 先于自动 SkillEdit 提交，避免后台整理把用户任务挤到池外。
@@ -501,6 +519,35 @@ class DirectoryWatcher:
         # CS 模式的分桶在 client 的 reconcile_skill_sides 里按 client_id 做。
         if not self.server_mode:
             self._reconcile_skill_sides()
+
+    def _submit_task_graph(self) -> None:
+        """Run the durable semantic branch without delaying Atom→Skill work."""
+        if not self._task_graph_service.enabled:
+            return
+        if any(info.get("stage") == "task_graph" for info in self._futures.values()):
+            return
+        try:
+            from xskill.tasks.projection import (
+                list_dirty_task_scopes,
+                list_dirty_sources,
+            )
+            self._task_graph_service.ensure_backfill_enqueued()
+            if (
+                not list_dirty_sources(limit=1, db_path=self.db_path)
+                and not list_dirty_task_scopes(
+                    limit=1, db_path=self.db_path,
+                )
+            ):
+                return
+        except Exception:
+            logger.warning("Task Graph dirty reconciliation failed", exc_info=True)
+            return
+        future = self._task_graph_pool.submit(
+            self._task_graph_service.process_dirty,
+            task={"kind": "task_graph_rebuild"},
+        )
+        if future is not None:
+            self._futures[future] = {"stage": "task_graph"}
 
     def _submit_generate_jobs(self):
         """把 web 进程入队的 generate 任务提交到 SkillEdit 同一线程池。
@@ -2562,6 +2609,21 @@ class DirectoryWatcher:
                     from xskill.team.server import generate_jobs as gen_jobs
                     gen_jobs.finish_claim(self.logs_dir, job_id)
                 continue
+            if stage == "task_graph":
+                try:
+                    result = fut.result(timeout=0)
+                    self._stats["task_graph_generations"] += int(
+                        result.get("scopes", 0)
+                    )
+                    self._stats["errors"] += len(
+                        result.get("failed_scopes") or ()
+                    )
+                except Exception:
+                    self._stats["errors"] += 1
+                    logger.exception(
+                        "Task Graph rebuild failed; durable dirty sources remain queued"
+                    )
+                continue
             if stage == "skill_edit":
                 # SkillEditAgent.maybe_run() 自己吞异常返回 (d, False)——正常
                 # 不会走到 except，这里兜底仅防池化层面的意外（cancel 等）。
@@ -2667,6 +2729,7 @@ class DirectoryWatcher:
                         self._do_split,
                         dir_path,
                         fname,
+                        wd_id,
                         task={
                             "kind": "traj",
                             "traj_id": (dir_path / fname).stem,
@@ -2794,7 +2857,7 @@ class DirectoryWatcher:
 
     # v2 流水线任务：split / atom_index / cluster
 
-    def _do_split(self, dir_path, fname):
+    def _do_split(self, dir_path, fname, wd_id=None):
         """跑 TaskAgent 拆 AtomTask。返回 (fname, num_atoms_added, last_offset, last_atom_id, err)。
 
         v2.3: TaskAgent 走 agentic 工具调用（submit_atom/readfile/grep），用
@@ -2836,16 +2899,43 @@ class DirectoryWatcher:
             usage_ledger=self.usage_ledger,
             registry_db_path=self.db_path,
         )
+        usage_scope = {}
+        if wd_id is not None and self._task_graph_service.enabled:
+            try:
+                from xskill.tasks.projection import live_source_row
+                source_row = live_source_row(
+                    int(wd_id), fname, db_path=self.db_path,
+                )
+                if source_row is not None:
+                    watch_dir, trajectory = source_row
+                    scope = self._task_graph_service.resolver.resolve(
+                        watch_dir=watch_dir, trajectory=trajectory,
+                    )
+                    usage_scope = {
+                        "tenant_id": scope.tenant_id,
+                        "task_scope_id": scope.task_scope_id,
+                        "source_scope_id": scope.source_scope_id,
+                        "traj_id": traj_id,
+                        "allocation_mode": "direct",
+                    }
+            except Exception:  # pylint: disable=broad-exception-caught
+                logger.debug("split usage scope unavailable", exc_info=True)
+        from xskill.usage import use_processing_scope
         try:
-            with agent_tools.use_agent_tool_context(tool_context):
-                atoms = TaskAgent(
-                    agno_agent_factory=self._factory(),
-                    store=store,
-                    traj_root=dir_path,
-                    skill_dir=self.skill_dir,
-                    interests=current_interests,
-                    logs_dir=self.logs_dir,
-                ).run(traj_id=traj_id, traj_path=md_path)
+            scope_context = (
+                use_processing_scope(**usage_scope)
+                if usage_scope else contextlib.nullcontext()
+            )
+            with scope_context:
+                with agent_tools.use_agent_tool_context(tool_context):
+                    atoms = TaskAgent(
+                        agno_agent_factory=self._factory(),
+                        store=store,
+                        traj_root=dir_path,
+                        skill_dir=self.skill_dir,
+                        interests=current_interests,
+                        logs_dir=self.logs_dir,
+                    ).run(traj_id=traj_id, traj_path=md_path)
         except TrajectoryNotFit as not_fit_error:
             logger.info(
                 "⊘ split not_fit %s（interest_fingerprint=%s）: %s",
@@ -3073,6 +3163,16 @@ class DirectoryWatcher:
             tasks_extracted=total_atoms, **kw,
         )
         self._stats["atoms_extracted"] += n_atoms
+        if wd_id is not None:
+            try:
+                self._task_graph_service.mark_dirty(
+                    wd_id, fname, reason="atom_split",
+                )
+            except Exception:  # pylint: disable=broad-exception-caught
+                logger.warning(
+                    "Task Graph dirty mark failed after split %s", fname,
+                    exc_info=True,
+                )
         if n_atoms:
             try:
                 from xskill.recommend.profile_dirty import (

--- a/src/xskill/tasks/__init__.py
+++ b/src/xskill/tasks/__init__.py
@@ -1,0 +1,6 @@
+"""Logical Task production graph built above Session and Atom evidence."""
+
+from xskill.tasks.models import TaskGraphGeneration
+from xskill.tasks.service import TaskGraphService
+
+__all__ = ["TaskGraphGeneration", "TaskGraphService"]

--- a/src/xskill/tasks/evidence.py
+++ b/src/xskill/tasks/evidence.py
@@ -1,0 +1,487 @@
+"""Collect scoped Atom, Session and execution-usage evidence for Task Graphs."""
+from __future__ import annotations
+
+import hashlib
+import json
+import math
+from dataclasses import dataclass
+from datetime import datetime, timezone
+from functools import cached_property
+from pathlib import Path
+from typing import Any
+
+from xskill.pipeline.atom import AtomTask, AtomTaskStore
+from xskill.tasks.models import (
+    MEASUREMENT_QUALITIES,
+    AtomRef,
+    SessionRef,
+    model_from_dict,
+)
+from xskill.tasks.scopes import ScopeIdentity
+
+
+def _hash_json(value: Any) -> str:
+    payload = json.dumps(
+        value, ensure_ascii=False, sort_keys=True, separators=(",", ":"),
+        allow_nan=False,
+    ).encode("utf-8")
+    return hashlib.sha256(payload).hexdigest()
+
+
+def _read_object(path: Path) -> dict:
+    if not path.is_file():
+        return {}
+    try:
+        value = json.loads(path.read_text(encoding="utf-8"))
+    except (OSError, json.JSONDecodeError) as error:
+        raise RuntimeError(f"invalid trajectory metadata: {path}") from error
+    if not isinstance(value, dict):
+        raise RuntimeError(f"trajectory metadata must contain an object: {path}")
+    return value
+
+
+def _number(value: Any, *, integer: bool = True) -> int | float | None:
+    if isinstance(value, bool):
+        return None
+    if integer:
+        if not isinstance(value, int):
+            return None
+        normalized: int | float = value
+    else:
+        if not isinstance(value, (int, float)):
+            return None
+        normalized = float(value)
+    return normalized if math.isfinite(float(normalized)) and normalized >= 0 else None
+
+
+def _overlay_identity(defaults: dict, override: Any) -> dict:
+    result = dict(defaults)
+    if isinstance(override, dict):
+        result.update({
+            key: value for key, value in override.items()
+            if value not in (None, "", [], {})
+        })
+    return model_from_dict(result)
+
+
+def _first_number(value: dict, keys: tuple[str, ...]) -> int | None:
+    for key in keys:
+        number = _number(value.get(key))
+        if number is not None:
+            return int(number)
+    return None
+
+
+@dataclass(frozen=True)
+class ExecutionUsageEvent:
+    usage_event_id: str
+    source_event_id: str
+    session_ref: SessionRef
+    model: dict
+    harness: dict
+    prompt_tokens: int | None
+    completion_tokens: int | None
+    total_tokens: int | None
+    cache_read_tokens: int | None
+    cost_usd: float | None
+    measurement_quality: str
+    estimation_method: str
+    unavailable_reason: str
+    observed_at: str
+
+    def __post_init__(self) -> None:
+        if not self.usage_event_id or not self.source_event_id:
+            raise ValueError("execution usage event identities must be non-empty")
+        if self.measurement_quality not in MEASUREMENT_QUALITIES:
+            raise ValueError("invalid execution usage measurement_quality")
+        if not self.observed_at:
+            raise ValueError("execution usage observed_at must be non-empty")
+        if self.measurement_quality == "unavailable" and not self.unavailable_reason:
+            raise ValueError("unavailable execution usage requires a reason")
+        if self.measurement_quality == "estimated" and not self.estimation_method:
+            raise ValueError("estimated execution usage requires estimation_method")
+        for field_name in (
+            "prompt_tokens", "completion_tokens", "total_tokens",
+            "cache_read_tokens",
+        ):
+            value = getattr(self, field_name)
+            if value is not None and (
+                isinstance(value, bool)
+                or not isinstance(value, int)
+                or value < 0
+            ):
+                raise ValueError(f"{field_name} must be a non-negative integer or None")
+        if self.cost_usd is not None and (
+            isinstance(self.cost_usd, bool)
+            or not isinstance(self.cost_usd, (int, float))
+            or not math.isfinite(float(self.cost_usd))
+            or self.cost_usd < 0
+        ):
+            raise ValueError("cost_usd must be a non-negative number or None")
+        if self.measurement_quality == "unavailable" and any(
+            value is not None
+            for value in (
+                self.prompt_tokens, self.completion_tokens,
+                self.total_tokens, self.cache_read_tokens, self.cost_usd,
+            )
+        ):
+            raise ValueError("unavailable execution usage cannot contain numeric values")
+        if self.measurement_quality != "unavailable" and all(
+            value is None
+            for value in (
+                self.prompt_tokens, self.completion_tokens,
+                self.total_tokens, self.cache_read_tokens, self.cost_usd,
+            )
+        ):
+            raise ValueError("measured or estimated execution usage needs a value")
+
+    def to_record(self) -> dict:
+        return {
+            "usage_event_id": self.usage_event_id,
+            "usage_plane": "execution",
+            "source_event_id": self.source_event_id,
+            "tenant_id": self.session_ref.tenant_id,
+            "task_scope_id": self.session_ref.task_scope_id,
+            "source_scope_id": self.session_ref.source_scope_id,
+            "traj_id": self.session_ref.traj_id,
+            "model": self.model,
+            "harness": self.harness,
+            "prompt_tokens": self.prompt_tokens,
+            "completion_tokens": self.completion_tokens,
+            "total_tokens": self.total_tokens,
+            "cache_read_tokens": self.cache_read_tokens,
+            "cost_usd": self.cost_usd,
+            "measurement_quality": self.measurement_quality,
+            "estimation_method": self.estimation_method,
+            "unavailable_reason": self.unavailable_reason,
+            "observed_at": self.observed_at,
+        }
+
+
+@dataclass(frozen=True)
+class ScopedAtomEvidence:
+    atom: AtomTask
+    atom_ref: AtomRef
+    atom_hash: str
+    session_hash: str
+    source_model: dict
+    source_harness: dict
+    observed_at: str
+
+    @property
+    def text(self) -> str:
+        return "\n".join(
+            item for item in (self.atom.intent, self.atom.summary, self.atom.raw_segment)
+            if item
+        )
+
+
+@dataclass(frozen=True)
+class ScopedTrajectoryEvidence:
+    watch_dir_id: int
+    watch_dir_path: Path
+    filename: str
+    scope: ScopeIdentity
+    session_ref: SessionRef
+    session_hash: str
+    metadata: dict
+    atoms: tuple[ScopedAtomEvidence, ...]
+    usage_events: tuple[ExecutionUsageEvent, ...]
+    explicit_outcome: dict
+
+    @cached_property
+    def source_revision(self) -> str:
+        return _hash_json({
+            "session_ref": self.session_ref.to_dict(),
+            "session_hash": self.session_hash,
+            "atoms": [
+                {
+                    "atom_ref": atom.atom_ref.to_dict(),
+                    "atom_hash": atom.atom_hash,
+                    "locator": [
+                        atom.atom.offset_start, atom.atom.offset_end,
+                    ],
+                    "neighbors": [
+                        atom.atom.pre_atom_id, atom.atom.post_atom_id,
+                    ],
+                    "raw_segment_hash": hashlib.sha256(
+                        atom.atom.raw_segment.encode("utf-8")
+                    ).hexdigest(),
+                    "used_skills": list(atom.atom.used_skills),
+                    "source_model": atom.source_model,
+                    "source_harness": atom.source_harness,
+                }
+                for atom in self.atoms
+            ],
+            "usage_events": [event.to_record() for event in self.usage_events],
+            "explicit_outcome": self.explicit_outcome,
+            "continuity": {
+                "run_id": self.metadata.get("run_id"),
+                "session_id": self.metadata.get("session_id"),
+            },
+        })
+
+
+def _execution_identity(metadata: dict, trajectory: dict) -> tuple[dict, dict]:
+    provider = (
+        metadata.get("provider") or metadata.get("source_provider")
+        or metadata.get("model_provider")
+    )
+    model_id = (
+        metadata.get("model_id") or metadata.get("model")
+        or metadata.get("source_model") or trajectory.get("source_model")
+    )
+    model = model_from_dict({
+        "provider": provider or "unavailable",
+        "model_id": model_id or "unavailable",
+        "version": metadata.get("model_version") or metadata.get("model_snapshot"),
+        "unavailable_reason": None if model_id else "source_did_not_report_model",
+    })
+    harness_name = (
+        trajectory.get("source_harness") or metadata.get("source_harness")
+        or metadata.get("harness")
+    )
+    harness = model_from_dict({
+        "name": harness_name or metadata.get("source") or "unavailable",
+        "version": (
+            metadata.get("harness_version") or metadata.get("cli_version")
+            or metadata.get("version")
+        ),
+        "unavailable_reason": (
+            None if harness_name or metadata.get("source")
+            else "source_did_not_report_harness"
+        ),
+    })
+    return model, harness
+
+
+def _normalize_usage_event(
+    raw: dict,
+    *,
+    index: int,
+    session_ref: SessionRef,
+    default_model: dict,
+    default_harness: dict,
+    observed_at: str,
+) -> ExecutionUsageEvent:
+    usage = raw.get("usage") if isinstance(raw.get("usage"), dict) else raw
+    prompt = _first_number(usage, (
+        "prompt_tokens", "input_tokens", "inputTokens", "input",
+    ))
+    completion = _first_number(usage, (
+        "completion_tokens", "output_tokens", "outputTokens", "output",
+    ))
+    total = _first_number(usage, ("total_tokens", "totalTokens", "total"))
+    if total is None and (prompt is not None or completion is not None):
+        total = (prompt or 0) + (completion or 0)
+    cache_read = _first_number(usage, (
+        "cache_read_tokens", "cached_input_tokens", "cacheRead", "cache_read",
+    ))
+    cost_value = raw.get("cost_usd")
+    if cost_value is None:
+        cost_container = raw.get("cost")
+        if cost_container is None:
+            cost_container = usage.get("cost")
+        if isinstance(cost_container, dict):
+            cost_value = cost_container.get("total")
+    cost = _number(cost_value, integer=False)
+    source_event_id = str(
+        raw.get("source_event_id") or raw.get("event_id") or raw.get("response_id")
+        or raw.get("run_id") or f"usage-{index}"
+    )
+    event_seed = "\x1f".join((
+        session_ref.tenant_id, session_ref.task_scope_id, session_ref.source_scope_id,
+        session_ref.traj_id, source_event_id,
+    ))
+    available = any(
+        value is not None
+        for value in (prompt, completion, total, cache_read, cost)
+    )
+    raw_quality = raw.get("measurement_quality")
+    measurement_quality = (
+        str(raw_quality)
+        if raw_quality is not None
+        else "measured" if available else "unavailable"
+    )
+    estimation_method = str(raw.get("estimation_method") or "")
+    if measurement_quality == "unavailable":
+        unavailable_reason = str(
+            raw.get("unavailable_reason") or "source_did_not_report_usage"
+        )
+    else:
+        missing_fields = [
+            field_name
+            for field_name, field_value in (
+                ("prompt_tokens", prompt),
+                ("completion_tokens", completion),
+                ("total_tokens", total),
+                ("cost_usd", cost),
+            )
+            if field_value is None
+        ]
+        unavailable_reason = str(raw.get("unavailable_reason") or "")
+        if missing_fields and not unavailable_reason:
+            unavailable_reason = "source_did_not_report:" + ",".join(
+                missing_fields
+            )
+    return ExecutionUsageEvent(
+        usage_event_id=f"use_{hashlib.sha256(event_seed.encode('utf-8')).hexdigest()[:32]}",
+        source_event_id=source_event_id,
+        session_ref=session_ref,
+        model=_overlay_identity(default_model, raw.get("model")),
+        harness=_overlay_identity(default_harness, raw.get("harness")),
+        prompt_tokens=prompt,
+        completion_tokens=completion,
+        total_tokens=total,
+        cache_read_tokens=cache_read,
+        cost_usd=float(cost) if cost is not None else None,
+        measurement_quality=measurement_quality,
+        estimation_method=estimation_method,
+        unavailable_reason=unavailable_reason,
+        observed_at=str(raw.get("observed_at") or observed_at),
+    )
+
+
+def _usage_events(
+    metadata: dict,
+    *,
+    session_ref: SessionRef,
+    model: dict,
+    harness: dict,
+    observed_at: str,
+) -> tuple[ExecutionUsageEvent, ...]:
+    raw_events = metadata.get("execution_usage_events")
+    if not isinstance(raw_events, list):
+        raw_usage = metadata.get("usage") or metadata.get("token_usage")
+        raw_events = [raw_usage] if isinstance(raw_usage, dict) else []
+    events = []
+    seen: dict[str, dict] = {}
+    for index, raw in enumerate(raw_events):
+        if not isinstance(raw, dict):
+            continue
+        event = _normalize_usage_event(
+            raw,
+            index=index,
+            session_ref=session_ref,
+            default_model=model,
+            default_harness=harness,
+            observed_at=observed_at,
+        )
+        record = event.to_record()
+        previous = seen.get(event.usage_event_id)
+        if previous is not None:
+            if previous != record:
+                raise RuntimeError(
+                    "execution usage source_event_id is duplicated with "
+                    f"different content: {event.source_event_id}"
+                )
+            continue
+        seen[event.usage_event_id] = record
+        events.append(event)
+    if not events:
+        events.append(_normalize_usage_event(
+            {
+                "source_event_id": "session-usage-unavailable",
+                "measurement_quality": "unavailable",
+                "unavailable_reason": "source_did_not_report_usage",
+            },
+            index=0,
+            session_ref=session_ref,
+            default_model=model,
+            default_harness=harness,
+            observed_at=observed_at,
+        ))
+    return tuple(events)
+
+
+def _explicit_outcome(metadata: dict) -> dict:
+    value = (
+        metadata.get("final_status") or metadata.get("exit_status")
+        or metadata.get("result_status") or metadata.get("session_status")
+    )
+    if value is None and isinstance(metadata.get("result"), dict):
+        value = metadata["result"].get("status")
+    normalized = str(value or "").strip().lower()
+    if normalized in {"success", "succeeded", "completed", "passed", "ok"}:
+        return {
+            "outcome": "succeeded",
+            "verification": "unverified",
+            "source": "structured_harness_status",
+        }
+    if normalized in {"partial", "partially_succeeded", "partially-succeeded"}:
+        return {
+            "outcome": "partially_succeeded",
+            "verification": "unverified",
+            "source": "structured_harness_status",
+        }
+    if normalized in {"failure", "failed", "error", "timed_out", "timeout"}:
+        return {"outcome": "failed", "verification": "contradicted", "source": "structured_harness_status"}
+    if normalized in {"cancelled", "canceled", "aborted"}:
+        return {"outcome": "cancelled", "verification": "unverified", "source": "structured_harness_status"}
+    return {}
+
+
+def collect_trajectory_evidence(
+    *, watch_dir: dict, trajectory: dict, scope: ScopeIdentity,
+) -> ScopedTrajectoryEvidence:
+    filename = str(trajectory["filename"])
+    traj_id = filename.removesuffix(".md")
+    root = Path(watch_dir["path"])
+    markdown_path = root / filename
+    metadata = _read_object(root / f"{traj_id}.json")
+    try:
+        markdown_payload = markdown_path.read_bytes()
+        observed_at = datetime.fromtimestamp(
+            markdown_path.stat().st_mtime, tz=timezone.utc,
+        ).isoformat(timespec="milliseconds")
+    except OSError as error:
+        raise FileNotFoundError(f"trajectory evidence is unavailable: {markdown_path}") from error
+    session_hash = hashlib.sha256(markdown_payload).hexdigest()
+    session_ref = SessionRef(
+        tenant_id=scope.tenant_id,
+        task_scope_id=scope.task_scope_id,
+        source_scope_id=scope.source_scope_id,
+        traj_id=traj_id,
+    )
+    model, harness = _execution_identity(metadata, trajectory)
+    atoms = []
+    for atom in AtomTaskStore(root).list_by_traj(traj_id):
+        atom_ref = AtomRef(
+            tenant_id=scope.tenant_id,
+            task_scope_id=scope.task_scope_id,
+            source_scope_id=scope.source_scope_id,
+            traj_id=traj_id,
+            atom_id=atom.atom_id,
+        )
+        atom_hash = _hash_json({
+            "intent": atom.intent,
+            "summary": atom.summary,
+        })
+        atom_model = dict(model)
+        if atom.source_model:
+            atom_model["model_id"] = atom.source_model
+            atom_model.pop("unavailable_reason", None)
+        atoms.append(ScopedAtomEvidence(
+            atom=atom,
+            atom_ref=atom_ref,
+            atom_hash=atom_hash,
+            session_hash=session_hash,
+            source_model=atom_model,
+            source_harness=harness,
+            observed_at=observed_at,
+        ))
+    return ScopedTrajectoryEvidence(
+        watch_dir_id=int(watch_dir["id"]),
+        watch_dir_path=root,
+        filename=filename,
+        scope=scope,
+        session_ref=session_ref,
+        session_hash=session_hash,
+        metadata=metadata,
+        atoms=tuple(atoms),
+        usage_events=_usage_events(
+            metadata, session_ref=session_ref, model=model, harness=harness,
+            observed_at=observed_at,
+        ),
+        explicit_outcome=_explicit_outcome(metadata),
+    )

--- a/src/xskill/tasks/evidence.py
+++ b/src/xskill/tasks/evidence.py
@@ -262,7 +262,6 @@ def _normalize_usage_event(
     session_ref: SessionRef,
     default_model: dict,
     default_harness: dict,
-    observed_at: str,
 ) -> ExecutionUsageEvent:
     usage = raw.get("usage") if isinstance(raw.get("usage"), dict) else raw
     prompt = _first_number(usage, (
@@ -338,7 +337,7 @@ def _normalize_usage_event(
         measurement_quality=measurement_quality,
         estimation_method=estimation_method,
         unavailable_reason=unavailable_reason,
-        observed_at=str(raw.get("observed_at") or observed_at),
+        observed_at=str(raw.get("observed_at") or "unavailable"),
     )
 
 
@@ -348,7 +347,6 @@ def _usage_events(
     session_ref: SessionRef,
     model: dict,
     harness: dict,
-    observed_at: str,
 ) -> tuple[ExecutionUsageEvent, ...]:
     raw_events = metadata.get("execution_usage_events")
     if not isinstance(raw_events, list):
@@ -365,7 +363,6 @@ def _usage_events(
             session_ref=session_ref,
             default_model=model,
             default_harness=harness,
-            observed_at=observed_at,
         )
         record = event.to_record()
         previous = seen.get(event.usage_event_id)
@@ -389,7 +386,6 @@ def _usage_events(
             session_ref=session_ref,
             default_model=model,
             default_harness=harness,
-            observed_at=observed_at,
         ))
     return tuple(events)
 
@@ -481,7 +477,6 @@ def collect_trajectory_evidence(
         atoms=tuple(atoms),
         usage_events=_usage_events(
             metadata, session_ref=session_ref, model=model, harness=harness,
-            observed_at=observed_at,
         ),
         explicit_outcome=_explicit_outcome(metadata),
     )

--- a/src/xskill/tasks/linker.py
+++ b/src/xskill/tasks/linker.py
@@ -40,7 +40,12 @@ _RETRY_RE = re.compile(
     r"(?:重试|再试|重新执行|重新跑|retry|try\s+again|rerun)", re.IGNORECASE,
 )
 _CORRECTION_RE = re.compile(
-    r"(?:纠正|更正|修正|改一下|不是.+是|correction|correct|fix\s+that)", re.IGNORECASE,
+    r"(?:纠正|更正|修正|改一下|不是.+是|"
+    r"(?:^|[。！？!?\n]\s*)(?:(?<!对)不对(?!称)|错了|搞错了|有误)|"
+    r"(?:刚才|前面|之前|上一个|这个).{0,20}"
+    r"(?:(?<!对)不对(?!称)|错了|有误)|"
+    r"correction|correct|fix\s+that)",
+    re.IGNORECASE,
 )
 _STOP_TERMS = frozenset((
     "the", "a", "an", "to", "of", "and", "or", "is", "are", "in", "on",

--- a/src/xskill/tasks/linker.py
+++ b/src/xskill/tasks/linker.py
@@ -1,0 +1,1654 @@
+"""Deterministic bounded production linker for Logical Tasks and Attempts."""
+from __future__ import annotations
+
+import hashlib
+import math
+import re
+import unicodedata
+import uuid
+from collections import defaultdict, deque
+from collections.abc import Iterable
+from dataclasses import dataclass, replace
+from functools import partial
+from operator import attrgetter
+
+from xskill.tasks.evidence import ScopedAtomEvidence, ScopedTrajectoryEvidence
+from xskill.tasks.models import (
+    AtomRef,
+    AttemptRelation,
+    DecisionRecord,
+    EvidenceRange,
+    LogicalTask,
+    TaskAtomMembership,
+    TaskAttempt,
+    TaskGraphGeneration,
+    TaskRelation,
+    UsageAllocation,
+    stable_ref_key,
+)
+from xskill.tasks.store import OverrideEvent, utc_now
+
+ALGORITHM_VERSION = "bounded-rules-v1"
+GENERATOR_NAME = "xskill.task_graph.linker"
+MAX_SHARED_USAGE_ALLOCATION_EDGES = 4096
+_WORD_RE = re.compile(r"[a-z0-9_./+-]+", re.IGNORECASE)
+_CJK_RE = re.compile(r"[\u3400-\u4dbf\u4e00-\u9fff]+")
+_CONTINUATION_RE = re.compile(
+    r"(?:继续|接着|续上|恢复|沿着|按照前面|continue|resume|carry\s+on)", re.IGNORECASE,
+)
+_RETRY_RE = re.compile(
+    r"(?:重试|再试|重新执行|重新跑|retry|try\s+again|rerun)", re.IGNORECASE,
+)
+_CORRECTION_RE = re.compile(
+    r"(?:纠正|更正|修正|改一下|不是.+是|correction|correct|fix\s+that)", re.IGNORECASE,
+)
+_STOP_TERMS = frozenset((
+    "the", "a", "an", "to", "of", "and", "or", "is", "are", "in", "on",
+    "for", "with", "this", "that", "it", "please", "帮我", "一下", "这个", "那个",
+    "我们", "目前", "现在", "然后", "进行", "相关", "问题",
+))
+
+
+def _opaque(prefix: str) -> str:
+    return f"{prefix}_{uuid.uuid4().hex}"
+
+
+def _digest(prefix: str, *values: str) -> str:
+    payload = "\x1f".join(values).encode("utf-8")
+    return f"{prefix}_{hashlib.sha256(payload).hexdigest()[:32]}"
+
+
+def _normalize(text: str) -> str:
+    normalized = unicodedata.normalize("NFKC", text or "").lower()
+    return " ".join(normalized.split())
+
+
+def _terms(text: str, *, limit: int = 32) -> tuple[str, ...]:
+    normalized = _normalize(text)
+    terms: list[str] = []
+    seen: set[str] = set()
+    for match in _WORD_RE.finditer(normalized):
+        term = match.group(0).strip("._/+-")
+        if len(term) < 2 or term in _STOP_TERMS or term in seen:
+            continue
+        seen.add(term)
+        terms.append(term)
+        if len(terms) >= limit:
+            return tuple(terms)
+    for match in _CJK_RE.finditer(normalized):
+        chunk = match.group(0)
+        candidates = [chunk] if len(chunk) <= 4 else [chunk[index:index + 2] for index in range(len(chunk) - 1)]
+        for term in candidates:
+            if term in _STOP_TERMS or term in seen:
+                continue
+            seen.add(term)
+            terms.append(term)
+            if len(terms) >= limit:
+                return tuple(terms)
+    return tuple(terms)
+
+
+def _similarity(left: set[str], right: set[str]) -> float:
+    if not left or not right:
+        return 0.0
+    return len(left & right) / len(left | right)
+
+
+def _marker_kind(text: str) -> str:
+    if _CORRECTION_RE.search(text):
+        return "correction"
+    if _RETRY_RE.search(text):
+        return "retry"
+    if _CONTINUATION_RE.search(text):
+        return "continuation"
+    return ""
+
+
+def _atom_sort_key(atom: ScopedAtomEvidence) -> tuple:
+    return (
+        atom.observed_at,
+        atom.atom_ref.source_scope_id,
+        atom.atom_ref.traj_id,
+        atom.atom.offset_start,
+        atom.atom.atom_id,
+    )
+
+
+def _candidate_sort_key(item: tuple[str, float]) -> tuple[float, str]:
+    return -item[1], item[0]
+
+
+def _weighted_attempt_sort_key(item: tuple[TaskAttempt, int]) -> str:
+    return item[0].attempt_id
+
+
+@dataclass(frozen=True)
+class _AttemptSegment:
+    atom: ScopedAtomEvidence
+    evidence: EvidenceRange
+    marker: str
+    previous_attempt_id: str | None = None
+
+
+class _TaskAnchor:
+    def __init__(self, *, term_cap: int = 256, intent_cap: int = 128):
+        self.terms: set[str] = set()
+        self.normalized_intents: set[str] = set()
+        self.term_cap = term_cap
+        self.intent_cap = intent_cap
+
+    def add(self, atom: ScopedAtomEvidence) -> tuple[str, ...]:
+        added_terms = []
+        for term in _terms(f"{atom.atom.intent}\n{atom.atom.summary}"):
+            if term in self.terms or len(self.terms) >= self.term_cap:
+                continue
+            self.terms.add(term)
+            added_terms.append(term)
+        normalized_intent = _normalize(atom.atom.intent)
+        if (
+            normalized_intent
+            and (
+                normalized_intent in self.normalized_intents
+                or len(self.normalized_intents) < self.intent_cap
+            )
+        ):
+            self.normalized_intents.add(normalized_intent)
+        return tuple(added_terms)
+
+
+class BoundedTaskLinker:
+    """Link only bounded candidates and keep every uncertain alternative."""
+
+    def __init__(self, *, top_k: int = 8, recent_k: int = 6,
+                 posting_cap: int = 64):
+        for name, value in (("top_k", top_k), ("recent_k", recent_k), ("posting_cap", posting_cap)):
+            if isinstance(value, bool) or not isinstance(value, int) or value <= 0:
+                raise ValueError(f"{name} must be a positive integer")
+        self.top_k = top_k
+        self.recent_k = recent_k
+        self.posting_cap = posting_cap
+
+    def build(
+        self,
+        *,
+        tenant_id: str,
+        task_scope_id: str,
+        trajectories: Iterable[ScopedTrajectoryEvidence],
+        previous: TaskGraphGeneration | None = None,
+        overrides: Iterable[OverrideEvent] = (),
+        source_revision: str,
+    ) -> TaskGraphGeneration:
+        now = utc_now()
+        trajectory_list = tuple(trajectories)
+        atoms = sorted(
+            (atom for trajectory in trajectory_list for atom in trajectory.atoms),
+            key=_atom_sort_key,
+        )
+        previous_tasks = {task.task_id: task for task in previous.tasks} if previous else {}
+        previous_memberships = self._previous_memberships(previous)
+        (
+            previous_attempt_by_evidence,
+            previous_attempt_ids_by_atom,
+        ) = self._previous_attempt_indexes(previous)
+        previous_membership_hash_by_atom = self._previous_membership_hash_by_atom(
+            previous
+        )
+        tasks: dict[str, LogicalTask] = {
+            task_id: replace(
+                task,
+                lifecycle="open",
+                outcome="unknown",
+                verification="unverified",
+                user_disposition="unknown",
+                decisions=tuple(
+                    decision for decision in task.decisions
+                    if decision.decided_by.startswith("human:")
+                ),
+                tombstoned=True,
+            )
+            for task_id, task in previous_tasks.items()
+        }
+        memberships: list[TaskAtomMembership] = []
+        anchors: dict[str, _TaskAnchor] = {}
+        postings: dict[str, deque[str]] = defaultdict(
+            partial(deque, maxlen=self.posting_cap)
+        )
+        recent_by_session: dict[tuple[str, str], deque[str]] = defaultdict(
+            partial(deque, maxlen=self.recent_k),
+        )
+        candidate_count = 0
+        proposed_count = 0
+        confirmed_reuse_count = 0
+        changed_atom_count = 0
+        affected_task_ids: set[str] = set()
+        atoms_by_key = {stable_ref_key(atom.atom_ref): atom for atom in atoms}
+
+        reusable_memberships: dict[str, TaskAtomMembership] = {}
+        for atom in atoms:
+            atom_key = stable_ref_key(atom.atom_ref)
+            old_membership = previous_memberships.get(atom_key)
+            if (
+                old_membership is None
+                or old_membership.task_id not in tasks
+                or previous_membership_hash_by_atom.get(atom_key) != atom.atom_hash
+            ):
+                continue
+            reusable_memberships[atom_key] = old_membership
+            task_id = old_membership.task_id
+            tasks[task_id] = replace(tasks[task_id], tombstoned=False)
+            anchor = anchors.setdefault(task_id, _TaskAnchor())
+            anchor.add(atom)
+        for task_id, anchor in anchors.items():
+            self._index_anchor(postings, task_id, anchor)
+        previous_attempt_ids_by_atom = {
+            atom_key: attempt_ids
+            for atom_key, attempt_ids in previous_attempt_ids_by_atom.items()
+            if atom_key in reusable_memberships
+        }
+
+        for atom in atoms:
+            atom_key = stable_ref_key(atom.atom_ref)
+            old_membership = reusable_memberships.get(atom_key)
+            if old_membership is not None:
+                task_id = old_membership.task_id
+                membership = replace(
+                    old_membership,
+                    membership_id=_digest("mem", task_id, atom_key, "primary"),
+                    atom_ref=atom.atom_ref,
+                    stale=False,
+                )
+                memberships.append(membership)
+                recent_by_session[(atom.atom_ref.source_scope_id, atom.atom_ref.traj_id)].append(task_id)
+                confirmed_reuse_count += 1
+                continue
+
+            changed_atom_count += 1
+            candidates = self._candidates(atom, anchors, postings, recent_by_session)
+            candidate_count += len(candidates)
+            affected_task_ids.update(task_id for task_id, _score in candidates)
+            marker = _marker_kind(atom.atom.intent)
+            previous_membership = previous_memberships.get(atom_key)
+            confirmed_task_id = (
+                previous_membership.task_id
+                if previous_membership is not None
+                and previous_membership.task_id in tasks
+                else self._confirmed_candidate(candidates, marker)
+            )
+            if confirmed_task_id is None:
+                task_id = _opaque("tsk")
+                task = LogicalTask(
+                    task_id=task_id,
+                    title=(atom.atom.intent or atom.atom.summary or "Untitled task")[:240],
+                    summary=(atom.atom.summary or atom.atom.intent)[:1000],
+                    created_at=now,
+                )
+                tasks[task_id] = task
+                affected_task_ids.add(task_id)
+                memberships.append(TaskAtomMembership(
+                    membership_id=_digest("mem", task_id, atom_key, "primary"),
+                    task_id=task_id,
+                    atom_ref=atom.atom_ref,
+                    role="primary",
+                    confidence=None,
+                    decision="confirmed",
+                    decided_by="rule:new_atom_boundary",
+                    algorithm_version=f"{ALGORITHM_VERSION}:uncalibrated",
+                    evidence_refs=(),
+                    observed_at=atom.observed_at,
+                ))
+                for candidate_id, score in candidates:
+                    if score < 0.18:
+                        continue
+                    proposed_count += 1
+                    memberships.append(TaskAtomMembership(
+                        membership_id=_digest("mem", candidate_id, atom_key, "proposed"),
+                        task_id=candidate_id,
+                        atom_ref=atom.atom_ref,
+                        role="primary",
+                        confidence=None,
+                        decision="proposed",
+                        decided_by=f"heuristic:lexical_score={score:.4f}",
+                        algorithm_version=f"{ALGORITHM_VERSION}:uncalibrated",
+                        evidence_refs=(),
+                        observed_at=atom.observed_at,
+                    ))
+            else:
+                task_id = confirmed_task_id
+                affected_task_ids.add(task_id)
+                tasks[task_id] = replace(tasks[task_id], tombstoned=False)
+                stable_atom_reuse = previous_membership is not None
+                if (
+                    stable_atom_reuse
+                    and previous_membership.decided_by.startswith("human:")
+                ):
+                    memberships.append(replace(
+                        previous_membership,
+                        membership_id=_digest(
+                            "mem", task_id, atom_key, "primary",
+                        ),
+                        atom_ref=atom.atom_ref,
+                        stale=False,
+                    ))
+                else:
+                    memberships.append(TaskAtomMembership(
+                        membership_id=_digest(
+                            "mem", task_id, atom_key, "primary",
+                        ),
+                        task_id=task_id,
+                        atom_ref=atom.atom_ref,
+                        role="primary",
+                        confidence=None,
+                        decision="confirmed",
+                        decided_by=(
+                            "rule:stable_atom_identity"
+                            if stable_atom_reuse
+                            else f"rule:explicit_{marker}"
+                        ),
+                        algorithm_version=f"{ALGORITHM_VERSION}:uncalibrated",
+                        evidence_refs=(),
+                        observed_at=atom.observed_at,
+                    ))
+            anchor = anchors.setdefault(task_id, _TaskAnchor())
+            new_terms = anchor.add(atom)
+            self._index_terms(postings, task_id, new_terms)
+            recent_by_session[(atom.atom_ref.source_scope_id, atom.atom_ref.traj_id)].append(task_id)
+
+        relations = list(previous.relations) if previous else []
+        structural_operations = {
+            "confirm_membership", "reject_membership", "upsert_task_relation",
+            "reject_task_relation", "merge_tasks", "move_atoms", "split_task",
+        }
+        tasks, memberships, relations, _unused_attempts, _unused_attempt_relations = self._apply_overrides(
+            tasks=tasks,
+            memberships=memberships,
+            relations=relations,
+            attempts=[],
+            attempt_relations=[],
+            overrides=tuple(
+                event for event in overrides if event.operation in structural_operations
+            ),
+            atoms_by_key=atoms_by_key,
+        )
+        active_task_ids = {
+            membership.task_id
+            for membership in memberships
+            if membership.role == "primary"
+            and membership.decision == "confirmed"
+            and not membership.stale
+        }
+        tasks = {
+            task_id: replace(
+                task, tombstoned=task_id not in active_task_ids,
+            )
+            for task_id, task in tasks.items()
+        }
+        relations = [
+            replace(
+                relation,
+                stale=(
+                    tasks[relation.from_task_id].tombstoned
+                    or tasks[relation.to_task_id].tombstoned
+                ),
+            )
+            for relation in relations
+            if relation.from_task_id in tasks and relation.to_task_id in tasks
+        ]
+        attempts, attempt_relations = self._build_attempts(
+            tasks=tasks,
+            memberships=memberships,
+            atoms_by_key=atoms_by_key,
+            trajectories=trajectory_list,
+            previous_attempt_by_evidence=previous_attempt_by_evidence,
+            previous_attempt_ids_by_atom=previous_attempt_ids_by_atom,
+            now=now,
+        )
+        attempts, attempt_relations = self._carry_stale_attempts(
+            previous=previous,
+            tasks=tasks,
+            attempts=attempts,
+            attempt_relations=attempt_relations,
+            now=now,
+        )
+        tasks, memberships, relations, attempts, attempt_relations = self._apply_overrides(
+            tasks=tasks,
+            memberships=memberships,
+            relations=relations,
+            attempts=attempts,
+            attempt_relations=attempt_relations,
+            overrides=tuple(
+                event for event in overrides
+                if event.operation in {
+                    "set_task_state", "set_attempt_state",
+                    "upsert_attempt_relation", "reject_attempt_relation",
+                }
+            ),
+            atoms_by_key=atoms_by_key,
+        )
+        usage_allocations = self._allocate_usage(
+            trajectory_list, memberships, attempts,
+        )
+        watermark = max((event.override_seq for event in overrides), default=0)
+        generation = TaskGraphGeneration(
+            generation_id=_opaque("gen"),
+            tenant_id=tenant_id,
+            task_scope_id=task_scope_id,
+            source_revision=source_revision,
+            generator={
+                "name": GENERATOR_NAME,
+                "version": ALGORITHM_VERSION,
+                "top_k": self.top_k,
+                "recent_k": self.recent_k,
+                "posting_cap": self.posting_cap,
+            },
+            base_override_seq=watermark,
+            created_at=now,
+            tasks=tuple(sorted(
+                tasks.values(), key=attrgetter("created_at", "task_id"),
+            )),
+            memberships=tuple(sorted(
+                memberships,
+                key=attrgetter(
+                    "atom_ref.source_scope_id", "atom_ref.traj_id",
+                    "atom_ref.atom_id", "decision", "task_id",
+                ),
+            )),
+            relations=tuple(sorted(relations, key=attrgetter("relation_id"))),
+            attempts=tuple(sorted(
+                attempts, key=attrgetter("started_at", "attempt_id"),
+            )),
+            attempt_relations=tuple(sorted(
+                attempt_relations, key=attrgetter("relation_id"),
+            )),
+            usage_allocations=tuple(sorted(
+                usage_allocations, key=attrgetter("allocation_id"),
+            )),
+            metrics={
+                "atom_count": len(atoms),
+                "task_count": sum(1 for task in tasks.values() if not task.tombstoned),
+                "candidate_count": candidate_count,
+                "model_judgement_count": 0,
+                "proposed_membership_count": proposed_count,
+                "reused_membership_count": confirmed_reuse_count,
+                "max_candidates_per_atom": self.top_k,
+                "changed_atom_count": changed_atom_count,
+                "affected_component_size": len(affected_task_ids),
+            },
+        )
+        return generation
+
+    @staticmethod
+    def _previous_memberships(
+        previous: TaskGraphGeneration | None,
+    ) -> dict[str, TaskAtomMembership]:
+        if previous is None:
+            return {}
+        result = {}
+        for membership in previous.memberships:
+            if (
+                membership.role == "primary"
+                and membership.decision == "confirmed"
+                and not membership.stale
+            ):
+                result[stable_ref_key(membership.atom_ref)] = membership
+        return result
+
+    @staticmethod
+    def _previous_attempt_indexes(
+        previous: TaskGraphGeneration | None,
+    ) -> tuple[dict[str, str], dict[str, set[str]]]:
+        by_evidence: dict[str, str] = {}
+        by_atom: dict[str, set[str]] = defaultdict(set)
+        if previous is None:
+            return by_evidence, by_atom
+        for attempt in previous.attempts:
+            for evidence in attempt.evidence_ranges:
+                if evidence.atom_ref is None or evidence.stale:
+                    continue
+                by_evidence[evidence.evidence_id] = attempt.attempt_id
+                by_atom[stable_ref_key(evidence.atom_ref)].add(
+                    attempt.attempt_id
+                )
+        return by_evidence, by_atom
+
+    @staticmethod
+    def _previous_membership_hash_by_atom(
+        previous: TaskGraphGeneration | None,
+    ) -> dict[str, str]:
+        result = {}
+        if previous is None:
+            return result
+        for attempt in previous.attempts:
+            for evidence in attempt.evidence_ranges:
+                if evidence.atom_ref is not None:
+                    result[stable_ref_key(evidence.atom_ref)] = (
+                        evidence.atom_hash or evidence.content_hash
+                    )
+        return result
+
+    @staticmethod
+    def _index_anchor(
+        postings: dict[str, deque[str]], task_id: str, anchor: _TaskAnchor,
+    ) -> None:
+        BoundedTaskLinker._index_terms(postings, task_id, sorted(anchor.terms))
+
+    @staticmethod
+    def _index_terms(
+        postings: dict[str, deque[str]], task_id: str,
+        terms: Iterable[str],
+    ) -> None:
+        for term in terms:
+            posting = postings[term]
+            try:
+                posting.remove(task_id)
+            except ValueError:
+                pass
+            posting.append(task_id)
+
+    def _candidates(
+        self,
+        atom: ScopedAtomEvidence,
+        anchors: dict[str, _TaskAnchor],
+        postings: dict[str, deque[str]],
+        recent_by_session: dict[tuple[str, str], deque[str]],
+    ) -> list[tuple[str, float]]:
+        atom_terms = set(_terms(f"{atom.atom.intent}\n{atom.atom.summary}"))
+        candidate_ids: set[str] = set()
+        for term in sorted(atom_terms):
+            candidate_ids.update(postings.get(term, ()))
+        session_key = (atom.atom_ref.source_scope_id, atom.atom_ref.traj_id)
+        candidate_ids.update(recent_by_session.get(session_key, ()))
+        marker = _marker_kind(atom.atom.intent)
+        scored = []
+        normalized_intent = _normalize(atom.atom.intent)
+        recent = set(recent_by_session.get(session_key, ()))
+        for task_id in candidate_ids:
+            anchor = anchors.get(task_id)
+            if anchor is None:
+                continue
+            score = _similarity(atom_terms, anchor.terms)
+            if normalized_intent and normalized_intent in anchor.normalized_intents:
+                score = max(score, 0.75)
+            if marker and task_id in recent:
+                score = min(1.0, score + 0.35)
+            scored.append((task_id, score))
+        scored.sort(key=_candidate_sort_key)
+        return scored[:self.top_k]
+
+    @staticmethod
+    def _confirmed_candidate(
+        candidates: list[tuple[str, float]],
+        marker: str,
+    ) -> str | None:
+        if not marker or not candidates:
+            return None
+        best_id, best_score = candidates[0]
+        threshold = 0.52 if marker in ("retry", "correction") else 0.55
+        if best_score < threshold:
+            return None
+        if len(candidates) > 1 and math.isclose(best_score, candidates[1][1], abs_tol=0.05):
+            return None
+        return best_id
+
+    def _build_attempts(
+        self,
+        *,
+        tasks: dict[str, LogicalTask],
+        memberships: list[TaskAtomMembership],
+        atoms_by_key: dict[str, ScopedAtomEvidence],
+        trajectories: tuple[ScopedTrajectoryEvidence, ...],
+        previous_attempt_by_evidence: dict[str, str],
+        previous_attempt_ids_by_atom: dict[str, set[str]],
+        now: str,
+    ) -> tuple[list[TaskAttempt], list[AttemptRelation]]:
+        task_atoms: dict[str, list[ScopedAtomEvidence]] = defaultdict(list)
+        for membership in memberships:
+            if membership.role != "primary" or membership.decision != "confirmed" or membership.stale:
+                continue
+            atom = atoms_by_key.get(stable_ref_key(membership.atom_ref))
+            if atom is not None:
+                task_atoms[membership.task_id].append(atom)
+        trajectory_by_session = {
+            (
+                trajectory.session_ref.source_scope_id,
+                trajectory.session_ref.traj_id,
+            ): trajectory
+            for trajectory in trajectories
+        }
+        task_ids_by_session: dict[tuple[str, str], set[str]] = defaultdict(set)
+        for candidate_task_id, candidate_atoms in task_atoms.items():
+            for candidate_atom in candidate_atoms:
+                task_ids_by_session[(
+                    candidate_atom.atom_ref.source_scope_id,
+                    candidate_atom.atom_ref.traj_id,
+                )].add(candidate_task_id)
+        attempts: list[TaskAttempt] = []
+        relations: list[AttemptRelation] = []
+        for task_id, atom_list in task_atoms.items():
+            atom_list.sort(key=_atom_sort_key)
+            groups: list[list[_AttemptSegment]] = []
+            relation_kinds: list[str] = []
+            for atom in atom_list:
+                atom_key = stable_ref_key(atom.atom_ref)
+                previous_ids = previous_attempt_ids_by_atom.get(
+                    atom_key, set(),
+                )
+                for segment_index, raw_segment in enumerate(
+                    self._attempt_segments(atom)
+                ):
+                    previous_attempt_id = previous_attempt_by_evidence.get(
+                        raw_segment.evidence.evidence_id
+                    )
+                    if (
+                        previous_attempt_id is None
+                        and segment_index == 0
+                        and len(previous_ids) == 1
+                    ):
+                        previous_attempt_id = next(iter(previous_ids))
+                    segment = replace(
+                        raw_segment,
+                        previous_attempt_id=previous_attempt_id,
+                    )
+                    if not groups:
+                        groups.append([segment])
+                        continue
+                    previous_segment = groups[-1][-1]
+                    previous_atom = previous_segment.atom
+                    same_session = (
+                        previous_atom.atom_ref.source_scope_id
+                        == atom.atom_ref.source_scope_id
+                        and previous_atom.atom_ref.traj_id
+                        == atom.atom_ref.traj_id
+                    )
+                    same_atom = previous_atom.atom_ref.key == atom.atom_ref.key
+                    adjacent = same_session and (
+                        (
+                            same_atom
+                            and previous_segment.evidence.end
+                            == segment.evidence.start
+                        )
+                        or previous_atom.atom.post_atom_id == atom.atom.atom_id
+                    )
+                    previous_trajectory = trajectory_by_session.get((
+                        previous_atom.atom_ref.source_scope_id,
+                        previous_atom.atom_ref.traj_id,
+                    ))
+                    current_trajectory = trajectory_by_session.get((
+                        atom.atom_ref.source_scope_id,
+                        atom.atom_ref.traj_id,
+                    ))
+                    same_run = bool(
+                        previous_trajectory
+                        and current_trajectory
+                        and previous_trajectory.metadata.get("run_id")
+                        and previous_trajectory.metadata.get("run_id")
+                        == current_trajectory.metadata.get("run_id")
+                        and previous_atom.source_harness.get("name")
+                        == atom.source_harness.get("name")
+                    )
+                    group_attempt_ids = {
+                        item.previous_attempt_id
+                        for item in groups[-1]
+                        if item.previous_attempt_id
+                    }
+                    preserves_attempt_boundary = bool(
+                        segment.previous_attempt_id
+                        and group_attempt_ids
+                        and segment.previous_attempt_id
+                        not in group_attempt_ids
+                    )
+                    if segment.marker not in ("retry", "correction") and (
+                        adjacent or same_run
+                    ) and not preserves_attempt_boundary:
+                        groups[-1].append(segment)
+                        continue
+                    groups.append([segment])
+                    relation_kinds.append(segment.marker or "continuation")
+
+            task_attempts: list[TaskAttempt] = []
+            last_group_by_session = {
+                (
+                    group[-1].atom.atom_ref.source_scope_id,
+                    group[-1].atom.atom_ref.traj_id,
+                ): index
+                for index, group in enumerate(groups)
+            }
+            for group_index, group in enumerate(groups):
+                reuse_ids = {
+                    segment.previous_attempt_id
+                    for segment in group
+                    if segment.previous_attempt_id
+                }
+                if len(reuse_ids) > 1:
+                    raise RuntimeError(
+                        "incremental rebuild would collapse historical Attempt boundaries"
+                    )
+                attempt_id = min(reuse_ids) if reuse_ids else _opaque("att")
+                evidence_ranges = tuple(
+                    segment.evidence for segment in group
+                )
+                group_session = (
+                    group[-1].atom.atom_ref.source_scope_id,
+                    group[-1].atom.atom_ref.traj_id,
+                )
+                explicit = self._attempt_outcome(
+                    [segment.atom for segment in group],
+                    task_id=task_id,
+                    task_ids_by_session=task_ids_by_session,
+                    trajectory_by_session=trajectory_by_session,
+                ) if last_group_by_session[group_session] == group_index else {}
+                outcome = explicit.get("outcome", "unknown")
+                verification = explicit.get("verification", "unverified")
+                finished = bool(explicit) or group_index < len(groups) - 1
+                decisions = (
+                    DecisionRecord(
+                        decision_id=_digest("dec", attempt_id, "outcome", outcome),
+                        dimension="outcome",
+                        value=outcome,
+                        confidence=1.0 if explicit else None,
+                        decision="confirmed" if explicit else "needs_review",
+                        decided_by=explicit.get("source", "rule:no_attempt_terminal_evidence"),
+                        algorithm_version=ALGORITHM_VERSION,
+                        evidence_refs=tuple(item.evidence_id for item in evidence_ranges),
+                        observed_at=group[-1].atom.observed_at,
+                    ),
+                )
+                attempt = TaskAttempt(
+                    attempt_id=attempt_id,
+                    task_id=task_id,
+                    started_at=group[0].atom.observed_at,
+                    ended_at=group[-1].atom.observed_at if finished else None,
+                    lifecycle="finished" if finished else "running",
+                    outcome=outcome,
+                    verification=verification,
+                    user_disposition="unknown",
+                    evidence_ranges=evidence_ranges,
+                    decisions=decisions,
+                    execution_identity={
+                        "segments": [
+                            {
+                                "evidence_id": evidence.evidence_id,
+                                "model": atom.source_model,
+                                "harness": atom.source_harness,
+                                "skills": [
+                                    {"name": name, "version": "unavailable",
+                                     "unavailable_reason": "skill_commit_not_captured"}
+                                    for name in atom.atom.used_skills
+                                ],
+                            }
+                            for segment, evidence in zip(group, evidence_ranges)
+                            for atom in (segment.atom,)
+                        ]
+                    },
+                )
+                task_attempts.append(attempt)
+                attempts.append(attempt)
+            for index in range(1, len(task_attempts)):
+                kind = relation_kinds[index - 1]
+                relation_type = {
+                    "retry": "retry_of",
+                    "correction": "correction_of",
+                }.get(kind, "continuation_of")
+                confirmed = kind in ("retry", "correction")
+                relations.append(AttemptRelation(
+                    relation_id=_digest(
+                        "arel", task_attempts[index].attempt_id,
+                        task_attempts[index - 1].attempt_id, relation_type,
+                    ),
+                    from_attempt_id=task_attempts[index].attempt_id,
+                    to_attempt_id=task_attempts[index - 1].attempt_id,
+                    relation_type=relation_type,
+                    confidence=None,
+                    decision="confirmed" if confirmed else "proposed",
+                    decided_by=(
+                        f"rule:explicit_{kind}" if confirmed
+                        else "rule:discontinuous_same_task"
+                    ),
+                    algorithm_version=f"{ALGORITHM_VERSION}:uncalibrated",
+                    evidence_refs=tuple(
+                        evidence.evidence_id
+                        for evidence in task_attempts[index].evidence_ranges
+                    ),
+                    observed_at=task_attempts[index].started_at,
+                ))
+            task = tasks[task_id]
+            latest = task_attempts[-1]
+            # A succeeded sole-Task Attempt can prove the goal was satisfied.
+            # A failed/cancelled execution only proves that Attempt ended; it
+            # does not prove the Logical Task itself is terminal or abandoned.
+            if (
+                latest.outcome in {"succeeded", "partially_succeeded"}
+                and latest.verification == "verified"
+            ):
+                mapped_outcome = latest.outcome
+                tasks[task_id] = replace(
+                    task,
+                    lifecycle="closed",
+                    outcome=mapped_outcome,
+                    verification=latest.verification,
+                    decisions=(
+                        DecisionRecord(
+                            decision_id=_digest("dec", task_id, "outcome", mapped_outcome),
+                            dimension="outcome",
+                            value=mapped_outcome,
+                            confidence=1.0,
+                            decision="confirmed",
+                            decided_by="rule:sole_task_structured_attempt",
+                            algorithm_version=ALGORITHM_VERSION,
+                            evidence_refs=tuple(
+                                evidence.evidence_id for evidence in latest.evidence_ranges
+                            ),
+                            observed_at=latest.ended_at or now,
+                        ),
+                    ),
+                )
+        return attempts, relations
+
+    @staticmethod
+    def _carry_stale_attempts(
+        *,
+        previous: TaskGraphGeneration | None,
+        tasks: dict[str, LogicalTask],
+        attempts: list[TaskAttempt],
+        attempt_relations: list[AttemptRelation],
+        now: str,
+    ) -> tuple[list[TaskAttempt], list[AttemptRelation]]:
+        if previous is None:
+            return attempts, attempt_relations
+        canonical_by_alias = {
+            alias: task.task_id
+            for task in tasks.values()
+            for alias in task.aliases
+        }
+        attempt_by_id = {attempt.attempt_id: attempt for attempt in attempts}
+        live_evidence_ids = {
+            evidence.evidence_id
+            for attempt in attempts
+            for evidence in attempt.evidence_ranges
+            if not evidence.stale
+        }
+        for old_attempt in previous.attempts:
+            stale_evidence = [
+                replace(evidence, stale=True)
+                for evidence in old_attempt.evidence_ranges
+                if evidence.evidence_id not in live_evidence_ids
+            ]
+            if not stale_evidence:
+                continue
+            current = attempt_by_id.get(old_attempt.attempt_id)
+            if current is not None:
+                existing_evidence_ids = {
+                    evidence.evidence_id for evidence in current.evidence_ranges
+                }
+                merged_evidence = current.evidence_ranges + tuple(
+                    evidence for evidence in stale_evidence
+                    if evidence.evidence_id not in existing_evidence_ids
+                )
+                attempt_by_id[current.attempt_id] = replace(
+                    current, evidence_ranges=merged_evidence,
+                )
+                continue
+            task_id = canonical_by_alias.get(
+                old_attempt.task_id, old_attempt.task_id,
+            )
+            if task_id not in tasks:
+                continue
+            stale_decision = DecisionRecord(
+                decision_id=_digest(
+                    "dec", old_attempt.attempt_id, "stale_evidence", now,
+                ),
+                dimension="verification",
+                value="unverified",
+                confidence=None,
+                decision="needs_review",
+                decided_by="rule:source_content_changed_or_deleted",
+                algorithm_version=ALGORITHM_VERSION,
+                evidence_refs=tuple(
+                    evidence.evidence_id for evidence in stale_evidence
+                ),
+                observed_at=now,
+            )
+            attempt_by_id[old_attempt.attempt_id] = replace(
+                old_attempt,
+                task_id=task_id,
+                lifecycle="finished",
+                ended_at=old_attempt.ended_at or now,
+                outcome="unknown",
+                verification="unverified",
+                evidence_ranges=tuple(stale_evidence),
+                decisions=tuple(
+                    decision for decision in old_attempt.decisions
+                    if decision.decided_by
+                    != "rule:source_content_changed_or_deleted"
+                ) + (stale_decision,),
+            )
+        retained_attempt_ids = set(attempt_by_id)
+        relation_by_id = {
+            relation.relation_id: relation for relation in attempt_relations
+        }
+        task_by_attempt = {
+            attempt_id: attempt.task_id
+            for attempt_id, attempt in attempt_by_id.items()
+        }
+        for relation in previous.attempt_relations:
+            if (
+                relation.from_attempt_id not in retained_attempt_ids
+                or relation.to_attempt_id not in retained_attempt_ids
+                or task_by_attempt[relation.from_attempt_id]
+                != task_by_attempt[relation.to_attempt_id]
+            ):
+                continue
+            relation_by_id.setdefault(relation.relation_id, relation)
+        return list(attempt_by_id.values()), list(relation_by_id.values())
+
+    @staticmethod
+    def _attempt_segments(atom: ScopedAtomEvidence) -> tuple[_AttemptSegment, ...]:
+        """Split explicit retry/correction turns inside one Atom into ranges."""
+        lines = atom.atom.raw_segment.splitlines(keepends=True)
+        if not lines:
+            lines = [atom.atom.raw_segment]
+        boundary_markers: dict[int, str] = {
+            0: _marker_kind(atom.atom.intent),
+        }
+        seen_user_turn = False
+        heading_indexes = []
+        in_fenced_block = False
+        for line_index, line in enumerate(lines):
+            stripped = line.strip()
+            if stripped.startswith("```"):
+                in_fenced_block = not in_fenced_block
+                continue
+            if not in_fenced_block and stripped.startswith("## "):
+                heading_indexes.append(line_index)
+        for heading_position, line_index in enumerate(heading_indexes):
+            if lines[line_index].strip().casefold() != "## user":
+                continue
+            content_end = (
+                heading_indexes[heading_position + 1]
+                if heading_position + 1 < len(heading_indexes)
+                else len(lines)
+            )
+            marker = _marker_kind(
+                "".join(lines[line_index + 1:content_end])
+            )
+            if seen_user_turn and marker in {"retry", "correction"}:
+                boundary_markers[line_index] = marker
+            elif not seen_user_turn and marker:
+                boundary_markers[0] = marker
+            seen_user_turn = True
+        boundary_indexes = sorted(boundary_markers)
+        segments = []
+        for boundary_index, start_index in enumerate(boundary_indexes):
+            next_index = (
+                boundary_indexes[boundary_index + 1]
+                if boundary_index + 1 < len(boundary_indexes)
+                else len(lines)
+            )
+            start = atom.atom.offset_start + start_index
+            end = (
+                atom.atom.offset_start + next_index
+                if next_index < len(lines)
+                else atom.atom.offset_end
+            )
+            if end <= start:
+                raise RuntimeError(
+                    f"invalid Attempt evidence boundary for {atom.atom.atom_id}"
+                )
+            raw_segment = "".join(lines[start_index:next_index])
+            evidence = BoundedTaskLinker._evidence_range(
+                atom,
+                start=start,
+                end=end,
+                raw_segment=raw_segment,
+            )
+            segments.append(_AttemptSegment(
+                atom=atom,
+                evidence=evidence,
+                marker=boundary_markers[start_index],
+            ))
+        return tuple(segments)
+
+    @staticmethod
+    def _evidence_range(
+        atom: ScopedAtomEvidence,
+        *,
+        start: int | None = None,
+        end: int | None = None,
+        raw_segment: str | None = None,
+    ) -> EvidenceRange:
+        atom_key = stable_ref_key(atom.atom_ref)
+        locator_start = atom.atom.offset_start if start is None else start
+        locator_end = atom.atom.offset_end if end is None else end
+        content = atom.atom.raw_segment if raw_segment is None else raw_segment
+        content_hash = hashlib.sha256(
+            content.encode("utf-8")
+        ).hexdigest()
+        return EvidenceRange(
+            evidence_id=_digest(
+                "evd", atom_key, str(locator_start), str(locator_end),
+                content_hash,
+            ),
+            session_ref=atom.atom_ref.session_ref,
+            atom_ref=atom.atom_ref,
+            locator_kind="trajectory_line",
+            start=locator_start,
+            end=locator_end,
+            content_hash=content_hash,
+            atom_hash=atom.atom_hash,
+            model=atom.source_model,
+            harness=atom.source_harness,
+            skills=tuple(
+                {"name": name, "version": "unavailable",
+                 "unavailable_reason": "skill_commit_not_captured"}
+                for name in atom.atom.used_skills
+            ),
+        )
+
+    @staticmethod
+    def _attempt_outcome(
+        group: list[ScopedAtomEvidence],
+        *,
+        task_id: str,
+        task_ids_by_session: dict[tuple[str, str], set[str]],
+        trajectory_by_session: dict[tuple[str, str], ScopedTrajectoryEvidence],
+    ) -> dict:
+        last_atom = group[-1]
+        session_key = (last_atom.atom_ref.source_scope_id, last_atom.atom_ref.traj_id)
+        trajectory = trajectory_by_session.get(session_key)
+        if trajectory is None or not trajectory.explicit_outcome:
+            return {}
+        session_task_ids = task_ids_by_session.get(session_key, set())
+        if session_task_ids != {task_id}:
+            return {}
+        return trajectory.explicit_outcome
+
+    @staticmethod
+    def _integer_shares(total: int | None, weights: list[int]) -> list[int | None]:
+        if total is None:
+            return [None] * len(weights)
+        weight_sum = sum(weights)
+        if weight_sum <= 0:
+            return [None] * len(weights)
+        exact = [total * weight / weight_sum for weight in weights]
+        result = [math.floor(value) for value in exact]
+        remainder = total - sum(result)
+        def remainder_key(index: int) -> tuple[float, int]:
+            return -(exact[index] - result[index]), index
+
+        order = sorted(range(len(weights)), key=remainder_key)
+        for index in order[:remainder]:
+            result[index] += 1
+        return result
+
+    def _allocate_usage(
+        self,
+        trajectories: tuple[ScopedTrajectoryEvidence, ...],
+        memberships: list[TaskAtomMembership],
+        attempts: list[TaskAttempt],
+    ) -> list[UsageAllocation]:
+        owner_by_atom = {
+            stable_ref_key(membership.atom_ref): membership.task_id
+            for membership in memberships
+            if membership.role == "primary" and membership.decision == "confirmed"
+            and not membership.stale
+        }
+        weighted_by_session: dict[
+            tuple[str, str], dict[str, tuple[TaskAttempt, int]]
+        ] = defaultdict(dict)
+        attributed_weight_by_session: dict[tuple[str, str], int] = defaultdict(int)
+        for attempt in attempts:
+            for evidence in attempt.evidence_ranges:
+                if evidence.stale:
+                    continue
+                if evidence.atom_ref is not None:
+                    owner = owner_by_atom.get(stable_ref_key(evidence.atom_ref))
+                    if owner != attempt.task_id:
+                        continue
+                if not isinstance(evidence.start, int) or not isinstance(
+                    evidence.end, int,
+                ):
+                    continue
+                session_key = (
+                    evidence.session_ref.source_scope_id,
+                    evidence.session_ref.traj_id,
+                )
+                span = max(1, evidence.end - evidence.start)
+                current = weighted_by_session[session_key].get(
+                    attempt.attempt_id
+                )
+                weighted_by_session[session_key][attempt.attempt_id] = (
+                    attempt,
+                    span + (current[1] if current else 0),
+                )
+                attributed_weight_by_session[session_key] += span
+        allocations: list[UsageAllocation] = []
+        for trajectory in trajectories:
+            session_key = (
+                trajectory.session_ref.source_scope_id,
+                trajectory.session_ref.traj_id,
+            )
+            weighted_attempts = weighted_by_session.get(session_key, {})
+            total_atom_weight = sum(
+                max(1, atom.atom.offset_end - atom.atom.offset_start)
+                for atom in trajectory.atoms
+            )
+            unattributed_weight = max(
+                0,
+                total_atom_weight
+                - attributed_weight_by_session.get(session_key, 0),
+            )
+            ordered = sorted(
+                weighted_attempts.values(), key=_weighted_attempt_sort_key,
+            )
+            target_count = len(ordered) + int(bool(unattributed_weight))
+            allocation_overflow = (
+                target_count > 1
+                and len(trajectory.usage_events) * target_count
+                > MAX_SHARED_USAGE_ALLOCATION_EDGES
+            )
+            for event in trajectory.usage_events:
+                targets: list[tuple[TaskAttempt | None, int]] = (
+                    [] if allocation_overflow else list(ordered)
+                )
+                if unattributed_weight and not allocation_overflow:
+                    targets.append((None, unattributed_weight))
+                if not targets:
+                    targets.append((None, 1))
+                weights = [item[1] for item in targets]
+                weight_sum = sum(weights)
+                prompt_shares = self._integer_shares(event.prompt_tokens, weights)
+                completion_shares = self._integer_shares(event.completion_tokens, weights)
+                total_shares = self._integer_shares(event.total_tokens, weights)
+                cache_read_shares = self._integer_shares(
+                    event.cache_read_tokens, weights,
+                )
+                cost_remaining = event.cost_usd
+                for index, (attempt, weight) in enumerate(targets):
+                    fraction = weight / weight_sum
+                    if event.cost_usd is None:
+                        cost_share = None
+                    elif index == len(targets) - 1:
+                        cost_share = cost_remaining
+                    else:
+                        cost_share = event.cost_usd * fraction
+                        cost_remaining = (cost_remaining or 0.0) - cost_share
+                    target_key = (
+                        attempt.attempt_id if attempt is not None
+                        else "unattributed"
+                    )
+                    allocations.append(UsageAllocation(
+                        allocation_id=_digest(
+                            "all", event.usage_event_id, target_key,
+                        ),
+                        usage_event_id=event.usage_event_id,
+                        usage_plane="execution",
+                        allocation_mode=(
+                            "unattributed" if attempt is None
+                            else "direct" if len(targets) == 1
+                            else "shared"
+                        ),
+                        fraction=fraction,
+                        task_id=attempt.task_id if attempt is not None else None,
+                        attempt_id=(
+                            attempt.attempt_id if attempt is not None else None
+                        ),
+                        prompt_tokens=prompt_shares[index],
+                        completion_tokens=completion_shares[index],
+                        total_tokens=total_shares[index],
+                        cache_read_tokens=cache_read_shares[index],
+                        cost_usd=cost_share,
+                        method=(
+                            "shared_allocation_edge_limit_exceeded"
+                            if allocation_overflow
+                            else "no_confirmed_primary_membership"
+                            if attempt is None and len(targets) == 1
+                            else "atom_line_span_with_unattributed_balance"
+                        ),
+                        method_version=ALGORITHM_VERSION,
+                    ))
+        return allocations
+
+    def _apply_overrides(
+        self,
+        *,
+        tasks: dict[str, LogicalTask],
+        memberships: list[TaskAtomMembership],
+        relations: list[TaskRelation],
+        attempts: list[TaskAttempt],
+        attempt_relations: list[AttemptRelation],
+        overrides: tuple[OverrideEvent, ...],
+        atoms_by_key: dict[str, ScopedAtomEvidence],
+    ) -> tuple[
+        dict[str, LogicalTask], list[TaskAtomMembership], list[TaskRelation],
+        list[TaskAttempt], list[AttemptRelation],
+    ]:
+        for event in overrides:
+            if event.operation in ("confirm_membership", "reject_membership"):
+                memberships = self._override_membership(
+                    memberships, tasks, event, atoms_by_key,
+                )
+            elif event.operation == "set_task_state":
+                task = tasks.get(event.target_id)
+                if task is None:
+                    continue
+                allowed = {
+                    key: value for key, value in event.payload.items()
+                    if key in {"lifecycle", "outcome", "verification", "user_disposition"}
+                }
+                decision_records = list(task.decisions)
+                for dimension, value in allowed.items():
+                    decision_id = _digest("dec", event.event_id, dimension)
+                    decision_records = [
+                        decision for decision in decision_records
+                        if decision.decision_id != decision_id
+                    ]
+                    decision_records.append(DecisionRecord(
+                        decision_id=decision_id,
+                        dimension=dimension,
+                        value=str(value),
+                        confidence=1.0,
+                        decision="confirmed",
+                        decided_by=f"human:{event.actor}",
+                        algorithm_version="manual-override-v1",
+                        evidence_refs=event.evidence_refs,
+                        observed_at=event.observed_at,
+                    ))
+                tasks[event.target_id] = replace(
+                    task, decisions=tuple(decision_records), **allowed,
+                )
+            elif event.operation == "set_attempt_state":
+                attempts = [
+                    self._set_attempt_override(attempt, event)
+                    if attempt.attempt_id == event.target_id else attempt
+                    for attempt in attempts
+                ]
+            elif event.operation == "upsert_attempt_relation":
+                relation_type = str(event.payload.get("relation_type") or "")
+                from_attempt_id = str(
+                    event.payload.get("from_attempt_id") or event.target_id
+                )
+                to_attempt_id = str(event.payload.get("to_attempt_id") or "")
+                attempt_by_id = {
+                    attempt.attempt_id: attempt for attempt in attempts
+                }
+                if (
+                    from_attempt_id in attempt_by_id
+                    and to_attempt_id in attempt_by_id
+                    and attempt_by_id[from_attempt_id].task_id
+                    == attempt_by_id[to_attempt_id].task_id
+                ):
+                    relation_id = _digest(
+                        "arel", from_attempt_id, to_attempt_id, relation_type,
+                    )
+                    attempt_relations = [
+                        item for item in attempt_relations
+                        if item.relation_id != relation_id
+                    ]
+                    attempt_relations.append(AttemptRelation(
+                        relation_id=relation_id,
+                        from_attempt_id=from_attempt_id,
+                        to_attempt_id=to_attempt_id,
+                        relation_type=relation_type,
+                        confidence=1.0,
+                        decision="confirmed",
+                        decided_by=f"human:{event.actor}",
+                        algorithm_version="manual-override-v1",
+                        evidence_refs=event.evidence_refs,
+                        observed_at=event.observed_at,
+                    ))
+            elif event.operation == "reject_attempt_relation":
+                attempt_relations = [
+                    replace(
+                        relation,
+                        decision="rejected",
+                        confidence=1.0,
+                        decided_by=f"human:{event.actor}",
+                        algorithm_version="manual-override-v1",
+                        observed_at=event.observed_at,
+                    ) if relation.relation_id == event.target_id else relation
+                    for relation in attempt_relations
+                ]
+            elif event.operation == "upsert_task_relation":
+                relation_type = str(event.payload.get("relation_type") or "")
+                from_task_id = str(event.payload.get("from_task_id") or event.target_id)
+                to_task_id = str(event.payload.get("to_task_id") or "")
+                if from_task_id in tasks and to_task_id in tasks:
+                    relation_id = _digest("rel", from_task_id, to_task_id, relation_type)
+                    relations = [item for item in relations if item.relation_id != relation_id]
+                    relations.append(TaskRelation(
+                        relation_id=relation_id,
+                        from_task_id=from_task_id,
+                        to_task_id=to_task_id,
+                        relation_type=relation_type,
+                        confidence=1.0,
+                        decision="confirmed",
+                        decided_by=f"human:{event.actor}",
+                        algorithm_version="manual-override-v1",
+                        evidence_refs=event.evidence_refs,
+                        observed_at=event.observed_at,
+                    ))
+            elif event.operation == "reject_task_relation":
+                relations = [
+                    replace(
+                        relation,
+                        decision="rejected",
+                        confidence=1.0,
+                        decided_by=f"human:{event.actor}",
+                        algorithm_version="manual-override-v1",
+                        observed_at=event.observed_at,
+                    ) if relation.relation_id == event.target_id else relation
+                    for relation in relations
+                ]
+            elif event.operation == "merge_tasks":
+                canonical_id = event.target_id
+                merge_ids = {
+                    str(value) for value in event.payload.get("task_ids") or ()
+                    if str(value) in tasks and str(value) != canonical_id
+                }
+                if canonical_id in tasks:
+                    memberships, relations, attempts, attempt_relations = self._merge_tasks(
+                        canonical_id, merge_ids, tasks, memberships, relations,
+                        attempts, attempt_relations,
+                    )
+            elif event.operation == "move_atoms":
+                target_id = str(event.payload.get("target_task_id") or event.target_id)
+                atom_keys = {str(value) for value in event.payload.get("atom_keys") or ()}
+                if target_id in tasks:
+                    memberships = self._move_atoms(
+                        target_id, atom_keys, memberships, atoms_by_key, event,
+                        event.payload.get("atom_refs") or {},
+                    )
+            elif event.operation == "split_task":
+                new_task_id = str(event.payload.get("new_task_id") or "")
+                atom_keys = {
+                    str(value) for value in event.payload.get("atom_keys") or ()
+                }
+                if event.target_id in tasks and new_task_id:
+                    existing = tasks.get(new_task_id)
+                    if existing is None:
+                        tasks[new_task_id] = LogicalTask(
+                            task_id=new_task_id,
+                            title=str(event.payload.get("title") or "")[:240],
+                            summary=str(event.payload.get("summary") or "")[:1000],
+                            created_at=event.observed_at,
+                        )
+                    else:
+                        tasks[new_task_id] = replace(
+                            existing,
+                            title=str(event.payload.get("title") or existing.title)[:240],
+                            summary=str(
+                                event.payload.get("summary") or existing.summary
+                            )[:1000],
+                            tombstoned=False,
+                        )
+                    memberships = self._move_atoms(
+                        new_task_id, atom_keys, memberships, atoms_by_key,
+                        event, event.payload.get("atom_refs") or {},
+                    )
+        return tasks, memberships, relations, attempts, attempt_relations
+
+    @staticmethod
+    def _override_membership(
+        memberships: list[TaskAtomMembership],
+        tasks: dict[str, LogicalTask],
+        event: OverrideEvent,
+        atoms_by_key: dict[str, ScopedAtomEvidence],
+    ) -> list[TaskAtomMembership]:
+        result = list(memberships)
+        target_index = next((
+            index for index, item in enumerate(result)
+            if item.membership_id == event.target_id
+        ), None)
+        if target_index is None:
+            atom_key = str(event.payload.get("atom_key") or "")
+            task_id = str(event.payload.get("task_id") or "")
+            atom = atoms_by_key.get(atom_key)
+            atom_ref_payload = event.payload.get("atom_ref")
+            if task_id not in tasks:
+                return result
+            if atom is not None:
+                atom_ref = atom.atom_ref
+                stale = False
+            elif isinstance(atom_ref_payload, dict):
+                try:
+                    atom_ref = AtomRef.from_dict(atom_ref_payload)
+                except (KeyError, TypeError, ValueError):
+                    return result
+                stale = True
+            else:
+                return result
+            role = str(event.payload.get("role") or "primary")
+            effective_membership_id = _digest("mem", task_id, atom_key, role)
+            target_index = next((
+                index for index, item in enumerate(result)
+                if item.membership_id == effective_membership_id
+            ), None)
+            if target_index is None:
+                result.append(TaskAtomMembership(
+                    membership_id=effective_membership_id,
+                    task_id=task_id,
+                    atom_ref=atom_ref,
+                    role=role,
+                    confidence=1.0,
+                    decision=(
+                        "confirmed"
+                        if event.operation == "confirm_membership"
+                        else "rejected"
+                    ),
+                    decided_by=f"human:{event.actor}",
+                    algorithm_version="manual-override-v1",
+                    evidence_refs=event.evidence_refs,
+                    observed_at=event.observed_at,
+                    stale=stale,
+                ))
+                target_index = len(result) - 1
+        target = result[target_index]
+        if event.operation == "confirm_membership" and target.role == "primary":
+            result = [
+                replace(
+                    item,
+                    decision="rejected",
+                    confidence=1.0,
+                    decided_by=f"human:{event.actor}",
+                    algorithm_version="manual-override-v1",
+                    evidence_refs=event.evidence_refs,
+                    observed_at=event.observed_at,
+                ) if (
+                    item.atom_ref.key == target.atom_ref.key
+                    and item.role == "primary"
+                    and item.membership_id != target.membership_id
+                    and item.decision != "rejected"
+                ) else item
+                for item in result
+            ]
+            target_index = next(
+                index for index, item in enumerate(result)
+                if item.membership_id == target.membership_id
+            )
+        result[target_index] = replace(
+            result[target_index],
+            decision="confirmed" if event.operation == "confirm_membership" else "rejected",
+            confidence=1.0,
+            decided_by=f"human:{event.actor}",
+            algorithm_version="manual-override-v1",
+            evidence_refs=event.evidence_refs,
+            observed_at=event.observed_at,
+        )
+        return result
+
+    @staticmethod
+    def _set_attempt_override(attempt: TaskAttempt, event: OverrideEvent) -> TaskAttempt:
+        allowed = {
+            key: value for key, value in event.payload.items()
+            if key in {"lifecycle", "outcome", "verification", "user_disposition"}
+        }
+        decisions = list(attempt.decisions)
+        for dimension, value in allowed.items():
+            decision_id = _digest("dec", event.event_id, dimension)
+            decisions = [
+                decision for decision in decisions
+                if decision.decision_id != decision_id
+            ]
+            decisions.append(DecisionRecord(
+                decision_id=decision_id,
+                dimension=dimension,
+                value=str(value),
+                confidence=1.0,
+                decision="confirmed",
+                decided_by=f"human:{event.actor}",
+                algorithm_version="manual-override-v1",
+                evidence_refs=event.evidence_refs,
+                observed_at=event.observed_at,
+            ))
+        lifecycle = allowed.get("lifecycle", attempt.lifecycle)
+        ended_at = attempt.ended_at
+        if lifecycle == "running":
+            ended_at = None
+        elif lifecycle == "finished" and ended_at is None:
+            ended_at = event.observed_at
+        return replace(
+            attempt, decisions=tuple(decisions), ended_at=ended_at, **allowed,
+        )
+
+    @staticmethod
+    def _merge_tasks(
+        canonical_id: str,
+        merge_ids: set[str],
+        tasks: dict[str, LogicalTask],
+        memberships: list[TaskAtomMembership],
+        relations: list[TaskRelation],
+        attempts: list[TaskAttempt],
+        attempt_relations: list[AttemptRelation],
+    ) -> tuple[
+        list[TaskAtomMembership], list[TaskRelation],
+        list[TaskAttempt], list[AttemptRelation],
+    ]:
+        canonical = tasks[canonical_id]
+        aliases = set(canonical.aliases)
+        aliases.update(merge_ids)
+        tasks[canonical_id] = replace(canonical, aliases=tuple(sorted(aliases)), tombstoned=False)
+        for task_id in merge_ids:
+            task = tasks[task_id]
+            tasks[task_id] = replace(task, tombstoned=True)
+        rewritten_memberships = []
+        membership_by_id: dict[str, TaskAtomMembership] = {}
+        decision_rank = {
+            "confirmed": 3, "needs_review": 2, "proposed": 1, "rejected": 0,
+        }
+
+        def override_rank(record) -> tuple:
+            human = record.decided_by.startswith("human:")
+            return (
+                human,
+                not getattr(record, "stale", False),
+                record.observed_at if human else "",
+                decision_rank[record.decision],
+            )
+
+        for membership in memberships:
+            rewritten = replace(
+                membership,
+                task_id=canonical_id,
+                membership_id=_digest(
+                    "mem", canonical_id, stable_ref_key(membership.atom_ref), membership.role,
+                ),
+            ) if membership.task_id in merge_ids else membership
+            previous = membership_by_id.get(rewritten.membership_id)
+            rank = override_rank(rewritten)
+            previous_rank = override_rank(previous) if previous is not None else None
+            if previous_rank is None or rank > previous_rank:
+                membership_by_id[rewritten.membership_id] = rewritten
+        rewritten_memberships.extend(membership_by_id.values())
+        relation_by_id: dict[str, TaskRelation] = {}
+        for relation in relations:
+            from_task_id = (
+                canonical_id if relation.from_task_id in merge_ids
+                else relation.from_task_id
+            )
+            to_task_id = (
+                canonical_id if relation.to_task_id in merge_ids
+                else relation.to_task_id
+            )
+            if from_task_id == to_task_id:
+                continue
+            rewritten = replace(
+                relation,
+                relation_id=_digest(
+                    "rel", from_task_id, to_task_id, relation.relation_type,
+                ),
+                from_task_id=from_task_id,
+                to_task_id=to_task_id,
+            )
+            previous = relation_by_id.get(rewritten.relation_id)
+            if previous is None or override_rank(rewritten) > override_rank(previous):
+                relation_by_id[rewritten.relation_id] = rewritten
+        rewritten_attempts = [
+            replace(attempt, task_id=canonical_id)
+            if attempt.task_id in merge_ids else attempt
+            for attempt in attempts
+        ]
+        return (
+            rewritten_memberships, list(relation_by_id.values()),
+            rewritten_attempts, attempt_relations,
+        )
+
+    @staticmethod
+    def _move_atoms(
+        target_id: str,
+        atom_keys: set[str],
+        memberships: list[TaskAtomMembership],
+        atoms_by_key: dict[str, ScopedAtomEvidence],
+        event: OverrideEvent,
+        atom_ref_payloads: dict,
+    ) -> list[TaskAtomMembership]:
+        result = []
+        existing_targets: set[str] = set()
+        for membership in memberships:
+            atom_key = stable_ref_key(membership.atom_ref)
+            if atom_key not in atom_keys or membership.role != "primary":
+                result.append(membership)
+                continue
+            if membership.task_id == target_id:
+                result.append(replace(
+                    membership,
+                    decision="confirmed", confidence=1.0,
+                    decided_by=f"human:{event.actor}",
+                    algorithm_version="manual-override-v1",
+                    evidence_refs=event.evidence_refs,
+                    observed_at=event.observed_at,
+                ))
+                existing_targets.add(atom_key)
+            else:
+                result.append(replace(
+                    membership,
+                    decision="rejected", confidence=1.0,
+                    decided_by=f"human:{event.actor}",
+                    algorithm_version="manual-override-v1",
+                    evidence_refs=event.evidence_refs,
+                    observed_at=event.observed_at,
+                ))
+        for atom_key in sorted(atom_keys - existing_targets):
+            atom = atoms_by_key.get(atom_key)
+            atom_ref = atom.atom_ref if atom is not None else None
+            if atom_ref is None:
+                payload = atom_ref_payloads.get(atom_key)
+                if isinstance(payload, dict):
+                    try:
+                        atom_ref = AtomRef.from_dict(payload)
+                    except (KeyError, TypeError, ValueError):
+                        atom_ref = None
+            if atom_ref is None:
+                continue
+            result.append(TaskAtomMembership(
+                membership_id=_digest("mem", target_id, atom_key, "primary"),
+                task_id=target_id,
+                atom_ref=atom_ref,
+                role="primary",
+                confidence=1.0,
+                decision="confirmed",
+                decided_by=f"human:{event.actor}",
+                algorithm_version="manual-override-v1",
+                evidence_refs=event.evidence_refs,
+                observed_at=event.observed_at,
+                stale=atom is None,
+            ))
+        return result

--- a/src/xskill/tasks/linker.py
+++ b/src/xskill/tasks/linker.py
@@ -168,6 +168,16 @@ class BoundedTaskLinker:
         self.recent_k = recent_k
         self.posting_cap = posting_cap
 
+    def generator_descriptor(self) -> dict:
+        """Return every input that can change deterministic linker output."""
+        return {
+            "name": GENERATOR_NAME,
+            "version": ALGORITHM_VERSION,
+            "top_k": self.top_k,
+            "recent_k": self.recent_k,
+            "posting_cap": self.posting_cap,
+        }
+
     def build(
         self,
         *,
@@ -433,13 +443,7 @@ class BoundedTaskLinker:
             tenant_id=tenant_id,
             task_scope_id=task_scope_id,
             source_revision=source_revision,
-            generator={
-                "name": GENERATOR_NAME,
-                "version": ALGORITHM_VERSION,
-                "top_k": self.top_k,
-                "recent_k": self.recent_k,
-                "posting_cap": self.posting_cap,
-            },
+            generator=self.generator_descriptor(),
             base_override_seq=watermark,
             created_at=now,
             tasks=tuple(sorted(

--- a/src/xskill/tasks/locking.py
+++ b/src/xskill/tasks/locking.py
@@ -1,0 +1,88 @@
+"""Small re-entrant cross-process file lock for TaskScope transactions."""
+from __future__ import annotations
+
+import errno
+import os
+import threading
+import weakref
+from contextlib import contextmanager
+from pathlib import Path
+
+_LOCKS_GUARD = threading.Lock()
+_LOCKS: weakref.WeakValueDictionary[str, threading.RLock] = (
+    weakref.WeakValueDictionary()
+)
+_LOCAL = threading.local()
+_WINDOWS_RETRY = threading.Event()
+
+
+def _thread_lock(path: Path) -> threading.RLock:
+    key = str(path.resolve(strict=False))
+    with _LOCKS_GUARD:
+        return _LOCKS.setdefault(key, threading.RLock())
+
+
+def _is_windows_contention(error: OSError) -> bool:
+    windows_error = getattr(error, "winerror", None)
+    if windows_error is not None:
+        return windows_error in {32, 33}
+    return error.errno in {errno.EACCES, errno.EAGAIN, errno.EDEADLK}
+
+
+def _lock_windows(lock_file) -> None:
+    import msvcrt  # pylint: disable=import-error
+
+    lock_file.seek(0, os.SEEK_END)
+    if lock_file.tell() == 0:
+        lock_file.write(b"\0")
+        lock_file.flush()
+    lock_file.seek(0)
+    while True:
+        try:
+            msvcrt.locking(lock_file.fileno(), msvcrt.LK_NBLCK, 1)
+            return
+        except OSError as error:
+            if not _is_windows_contention(error):
+                raise
+            _WINDOWS_RETRY.wait(0.05)
+
+
+@contextmanager
+def task_file_lock(lock_path: Path):
+    """Serialize one TaskScope across threads and worker processes."""
+    lock_path = Path(lock_path)
+    lock_path.parent.mkdir(parents=True, exist_ok=True)
+    canonical = str(lock_path.resolve(strict=False))
+    depths = getattr(_LOCAL, "depths", None)
+    if depths is None:
+        depths = {}
+        _LOCAL.depths = depths
+    with _thread_lock(lock_path):
+        if depths.get(canonical, 0):
+            depths[canonical] += 1
+            try:
+                yield
+            finally:
+                depths[canonical] -= 1
+            return
+        with lock_path.open("a+b") as lock_file:
+            if os.name == "nt":
+                _lock_windows(lock_file)
+            else:
+                import fcntl
+
+                fcntl.flock(lock_file.fileno(), fcntl.LOCK_EX)
+            depths[canonical] = 1
+            try:
+                yield
+            finally:
+                depths.pop(canonical, None)
+                if os.name == "nt":
+                    import msvcrt  # pylint: disable=import-error
+
+                    lock_file.seek(0)
+                    msvcrt.locking(lock_file.fileno(), msvcrt.LK_UNLCK, 1)
+                else:
+                    import fcntl
+
+                    fcntl.flock(lock_file.fileno(), fcntl.LOCK_UN)

--- a/src/xskill/tasks/models.py
+++ b/src/xskill/tasks/models.py
@@ -1,0 +1,816 @@
+"""Typed Logical Task graph records and production invariants.
+
+The graph deliberately does not extend :class:`AtomTask`.  Atom-to-Skill routing
+and Atom-to-Task membership are independent relations with different keys and
+different cardinality rules.
+"""
+from __future__ import annotations
+
+import math
+from collections import deque
+from collections.abc import Iterable
+from dataclasses import asdict, dataclass, field
+from typing import Any
+
+SCHEMA_VERSION = 1
+MEMBERSHIP_ROLES = frozenset(("primary", "context"))
+DECISIONS = frozenset(("proposed", "confirmed", "rejected", "needs_review"))
+TASK_LIFECYCLES = frozenset(("open", "blocked", "closed"))
+TASK_OUTCOMES = frozenset((
+    "succeeded", "partially_succeeded", "failed", "cancelled",
+    "abandoned", "unknown",
+))
+ATTEMPT_LIFECYCLES = frozenset(("running", "finished"))
+ATTEMPT_OUTCOMES = frozenset((
+    "succeeded", "partially_succeeded", "failed", "blocked", "cancelled",
+    "unknown",
+))
+VERIFICATIONS = frozenset((
+    "unverified", "verified", "contradicted", "conflicted", "not_applicable",
+))
+USER_DISPOSITIONS = frozenset((
+    "accepted", "rejected", "corrected", "cancelled", "unknown",
+))
+TASK_RELATION_TYPES = frozenset(("parent", "subtask", "depends_on", "follows_up"))
+ATTEMPT_RELATION_TYPES = frozenset((
+    "continuation_of", "retry_of", "correction_of", "supersedes",
+))
+USAGE_PLANES = frozenset(("execution", "xskill_processing"))
+MEASUREMENT_QUALITIES = frozenset(("measured", "estimated", "unavailable"))
+ALLOCATION_MODES = frozenset(("direct", "shared", "unattributed"))
+DECISION_VALUES = {
+    "lifecycle": TASK_LIFECYCLES | ATTEMPT_LIFECYCLES,
+    "outcome": TASK_OUTCOMES | ATTEMPT_OUTCOMES,
+    "verification": VERIFICATIONS,
+    "user_disposition": USER_DISPOSITIONS,
+}
+
+
+def _required(value: str, name: str) -> str:
+    if not isinstance(value, str) or not value.strip():
+        raise ValueError(f"{name} must be a non-empty string")
+    if value != value.strip():
+        raise ValueError(f"{name} must not contain surrounding whitespace")
+    return value.strip()
+
+
+def _choice(value: str, choices: frozenset[str], name: str) -> str:
+    if value not in choices:
+        raise ValueError(f"{name} must be one of {sorted(choices)!r}, got {value!r}")
+    return value
+
+
+def _confidence(value: float | None, name: str = "confidence") -> float | None:
+    if value is None:
+        return None
+    if isinstance(value, bool) or not isinstance(value, (int, float)):
+        raise ValueError(f"{name} must be numeric")
+    result = float(value)
+    if not math.isfinite(result) or result < 0 or result > 1:
+        raise ValueError(f"{name} must be within [0, 1]")
+    return result
+
+
+@dataclass(frozen=True)
+class SessionRef:
+    tenant_id: str
+    task_scope_id: str
+    source_scope_id: str
+    traj_id: str
+
+    def __post_init__(self) -> None:
+        for field_name in ("tenant_id", "task_scope_id", "source_scope_id", "traj_id"):
+            _required(getattr(self, field_name), field_name)
+
+    def to_dict(self) -> dict:
+        return asdict(self)
+
+    @classmethod
+    def from_dict(cls, value: dict) -> SessionRef:
+        return cls(**value)
+
+
+@dataclass(frozen=True)
+class AtomRef:
+    tenant_id: str
+    task_scope_id: str
+    source_scope_id: str
+    traj_id: str
+    atom_id: str
+
+    def __post_init__(self) -> None:
+        for field_name in (
+            "tenant_id", "task_scope_id", "source_scope_id", "traj_id", "atom_id",
+        ):
+            _required(getattr(self, field_name), field_name)
+
+    @property
+    def session_ref(self) -> SessionRef:
+        return SessionRef(
+            tenant_id=self.tenant_id,
+            task_scope_id=self.task_scope_id,
+            source_scope_id=self.source_scope_id,
+            traj_id=self.traj_id,
+        )
+
+    @property
+    def key(self) -> tuple[str, str, str, str, str]:
+        return (
+            self.tenant_id, self.task_scope_id, self.source_scope_id,
+            self.traj_id, self.atom_id,
+        )
+
+    def to_dict(self) -> dict:
+        return asdict(self)
+
+    @classmethod
+    def from_dict(cls, value: dict) -> AtomRef:
+        return cls(**value)
+
+
+@dataclass(frozen=True)
+class EvidenceRange:
+    evidence_id: str
+    session_ref: SessionRef
+    locator_kind: str
+    start: int | str
+    end: int | str
+    content_hash: str
+    atom_hash: str = ""
+    atom_ref: AtomRef | None = None
+    stale: bool = False
+    model: dict = field(default_factory=dict)
+    harness: dict = field(default_factory=dict)
+    skills: tuple[dict, ...] = ()
+
+    def __post_init__(self) -> None:
+        _required(self.evidence_id, "evidence_id")
+        _required(self.locator_kind, "locator_kind")
+        _required(self.content_hash, "content_hash")
+        if isinstance(self.start, bool) or isinstance(self.end, bool):
+            raise ValueError("EvidenceRange locators cannot be booleans")
+        if not isinstance(self.start, (int, str)) or not isinstance(
+            self.end, (int, str)
+        ):
+            raise ValueError("EvidenceRange locators must be integers or strings")
+        if type(self.start) is not type(self.end):
+            raise ValueError("EvidenceRange start and end locator types must match")
+        if isinstance(self.start, str):
+            _required(self.start, "evidence.start")
+            _required(self.end, "evidence.end")
+        if isinstance(self.start, int) and isinstance(self.end, int) and self.end <= self.start:
+            raise ValueError("EvidenceRange uses half-open [start, end) with end > start")
+        if self.atom_ref is not None and self.atom_ref.session_ref != self.session_ref:
+            raise ValueError("atom_ref and session_ref scopes must match")
+        if not isinstance(self.model, dict) or not isinstance(self.harness, dict):
+            raise ValueError("EvidenceRange model and harness must be objects")
+        if not all(isinstance(skill, dict) for skill in self.skills):
+            raise ValueError("EvidenceRange skills must contain objects")
+
+    def to_dict(self) -> dict:
+        result = asdict(self)
+        result["session_ref"] = self.session_ref.to_dict()
+        result["atom_ref"] = self.atom_ref.to_dict() if self.atom_ref else None
+        result["skills"] = list(self.skills)
+        return result
+
+    @classmethod
+    def from_dict(cls, value: dict) -> EvidenceRange:
+        data = dict(value)
+        data["session_ref"] = SessionRef.from_dict(data["session_ref"])
+        if data.get("atom_ref"):
+            data["atom_ref"] = AtomRef.from_dict(data["atom_ref"])
+        data["skills"] = tuple(data.get("skills") or ())
+        return cls(**data)
+
+
+@dataclass(frozen=True)
+class DecisionRecord:
+    decision_id: str
+    dimension: str
+    value: str
+    confidence: float | None
+    decision: str
+    decided_by: str
+    algorithm_version: str
+    evidence_refs: tuple[str, ...]
+    observed_at: str
+    stale: bool = False
+
+    def __post_init__(self) -> None:
+        _required(self.decision_id, "decision_id")
+        _required(self.dimension, "dimension")
+        _required(self.value, "value")
+        if self.dimension not in DECISION_VALUES:
+            raise ValueError(f"unsupported decision dimension: {self.dimension!r}")
+        if self.value not in DECISION_VALUES[self.dimension]:
+            raise ValueError(
+                f"invalid {self.dimension} decision value: {self.value!r}"
+            )
+        _confidence(self.confidence)
+        _choice(self.decision, DECISIONS, "decision")
+        _required(self.decided_by, "decided_by")
+        _required(self.algorithm_version, "algorithm_version")
+        _required(self.observed_at, "observed_at")
+        if not all(isinstance(item, str) and item for item in self.evidence_refs):
+            raise ValueError("decision evidence_refs must contain non-empty strings")
+
+    def to_dict(self) -> dict:
+        result = asdict(self)
+        result["evidence_refs"] = list(self.evidence_refs)
+        return result
+
+    @classmethod
+    def from_dict(cls, value: dict) -> DecisionRecord:
+        data = dict(value)
+        data["evidence_refs"] = tuple(data.get("evidence_refs") or ())
+        return cls(**data)
+
+
+@dataclass(frozen=True)
+class LogicalTask:
+    task_id: str
+    title: str
+    summary: str
+    created_at: str
+    lifecycle: str = "open"
+    outcome: str = "unknown"
+    verification: str = "unverified"
+    user_disposition: str = "unknown"
+    decisions: tuple[DecisionRecord, ...] = ()
+    aliases: tuple[str, ...] = ()
+    tombstoned: bool = False
+
+    def __post_init__(self) -> None:
+        _required(self.task_id, "task_id")
+        _required(self.created_at, "created_at")
+        _choice(self.lifecycle, TASK_LIFECYCLES, "task.lifecycle")
+        _choice(self.outcome, TASK_OUTCOMES, "task.outcome")
+        _choice(self.verification, VERIFICATIONS, "task.verification")
+        _choice(self.user_disposition, USER_DISPOSITIONS, "task.user_disposition")
+        if not isinstance(self.title, str) or not isinstance(self.summary, str):
+            raise ValueError("Task title and summary must be strings")
+        if not isinstance(self.tombstoned, bool):
+            raise ValueError("Task tombstoned must be a boolean")
+        if not all(isinstance(alias, str) and alias for alias in self.aliases):
+            raise ValueError("Task aliases must contain non-empty strings")
+        if len(set(self.aliases)) != len(self.aliases):
+            raise ValueError("Task aliases must be unique")
+        if self.lifecycle in {"open", "blocked"} and self.outcome != "unknown":
+            raise ValueError("open or blocked Task outcome must be unknown")
+        if self.lifecycle == "closed" and self.outcome == "unknown":
+            raise ValueError("closed Task requires a terminal outcome")
+        for decision in self.decisions:
+            if decision.dimension == "lifecycle" and decision.value not in TASK_LIFECYCLES:
+                raise ValueError("Task lifecycle decision uses an Attempt value")
+            if decision.dimension == "outcome" and decision.value not in TASK_OUTCOMES:
+                raise ValueError("Task outcome decision uses an Attempt value")
+
+    def to_dict(self) -> dict:
+        result = asdict(self)
+        result["decisions"] = [decision.to_dict() for decision in self.decisions]
+        result["aliases"] = list(self.aliases)
+        return result
+
+    @classmethod
+    def from_dict(cls, value: dict) -> LogicalTask:
+        data = dict(value)
+        data["decisions"] = tuple(
+            DecisionRecord.from_dict(item) for item in data.get("decisions") or ()
+        )
+        data["aliases"] = tuple(data.get("aliases") or ())
+        return cls(**data)
+
+
+@dataclass(frozen=True)
+class TaskAtomMembership:
+    membership_id: str
+    task_id: str
+    atom_ref: AtomRef
+    role: str
+    confidence: float | None
+    decision: str
+    decided_by: str
+    algorithm_version: str
+    evidence_refs: tuple[str, ...]
+    observed_at: str
+    stale: bool = False
+
+    def __post_init__(self) -> None:
+        _required(self.membership_id, "membership_id")
+        _required(self.task_id, "task_id")
+        _choice(self.role, MEMBERSHIP_ROLES, "membership.role")
+        _confidence(self.confidence)
+        _choice(self.decision, DECISIONS, "membership.decision")
+        _required(self.decided_by, "membership.decided_by")
+        _required(self.algorithm_version, "membership.algorithm_version")
+        _required(self.observed_at, "membership.observed_at")
+        if not isinstance(self.stale, bool):
+            raise ValueError("membership.stale must be a boolean")
+        if not all(
+            isinstance(item, str) and item for item in self.evidence_refs
+        ):
+            raise ValueError("membership evidence_refs must contain strings")
+
+    def to_dict(self) -> dict:
+        result = asdict(self)
+        result["atom_ref"] = self.atom_ref.to_dict()
+        result["evidence_refs"] = list(self.evidence_refs)
+        return result
+
+    @classmethod
+    def from_dict(cls, value: dict) -> TaskAtomMembership:
+        data = dict(value)
+        data["atom_ref"] = AtomRef.from_dict(data["atom_ref"])
+        data["evidence_refs"] = tuple(data.get("evidence_refs") or ())
+        return cls(**data)
+
+
+@dataclass(frozen=True)
+class TaskRelation:
+    relation_id: str
+    from_task_id: str
+    to_task_id: str
+    relation_type: str
+    confidence: float | None
+    decision: str
+    decided_by: str
+    algorithm_version: str
+    evidence_refs: tuple[str, ...]
+    observed_at: str
+    stale: bool = False
+
+    def __post_init__(self) -> None:
+        _required(self.relation_id, "relation_id")
+        _required(self.from_task_id, "from_task_id")
+        _required(self.to_task_id, "to_task_id")
+        if self.from_task_id == self.to_task_id:
+            raise ValueError("task relation cannot point to itself")
+        _choice(self.relation_type, TASK_RELATION_TYPES, "task_relation.relation_type")
+        _confidence(self.confidence)
+        _choice(self.decision, DECISIONS, "task_relation.decision")
+        _required(self.decided_by, "task_relation.decided_by")
+        _required(self.algorithm_version, "task_relation.algorithm_version")
+        _required(self.observed_at, "task_relation.observed_at")
+        if not isinstance(self.stale, bool):
+            raise ValueError("task relation stale must be a boolean")
+        if not all(
+            isinstance(item, str) and item for item in self.evidence_refs
+        ):
+            raise ValueError("Task relation evidence_refs must contain strings")
+
+    def to_dict(self) -> dict:
+        result = asdict(self)
+        result["evidence_refs"] = list(self.evidence_refs)
+        return result
+
+    @classmethod
+    def from_dict(cls, value: dict) -> TaskRelation:
+        data = dict(value)
+        data["evidence_refs"] = tuple(data.get("evidence_refs") or ())
+        return cls(**data)
+
+
+@dataclass(frozen=True)
+class AttemptRelation:
+    relation_id: str
+    from_attempt_id: str
+    to_attempt_id: str
+    relation_type: str
+    confidence: float | None
+    decision: str
+    decided_by: str
+    algorithm_version: str
+    evidence_refs: tuple[str, ...]
+    observed_at: str
+
+    def __post_init__(self) -> None:
+        _required(self.relation_id, "relation_id")
+        _required(self.from_attempt_id, "from_attempt_id")
+        _required(self.to_attempt_id, "to_attempt_id")
+        if self.from_attempt_id == self.to_attempt_id:
+            raise ValueError("attempt relation cannot point to itself")
+        _choice(self.relation_type, ATTEMPT_RELATION_TYPES, "attempt_relation.relation_type")
+        _confidence(self.confidence)
+        _choice(self.decision, DECISIONS, "attempt_relation.decision")
+        _required(self.decided_by, "attempt_relation.decided_by")
+        _required(self.algorithm_version, "attempt_relation.algorithm_version")
+        _required(self.observed_at, "attempt_relation.observed_at")
+        if not all(
+            isinstance(item, str) and item for item in self.evidence_refs
+        ):
+            raise ValueError("Attempt relation evidence_refs must contain strings")
+
+    def to_dict(self) -> dict:
+        result = asdict(self)
+        result["evidence_refs"] = list(self.evidence_refs)
+        return result
+
+    @classmethod
+    def from_dict(cls, value: dict) -> AttemptRelation:
+        data = dict(value)
+        data["evidence_refs"] = tuple(data.get("evidence_refs") or ())
+        return cls(**data)
+
+
+@dataclass(frozen=True)
+class TaskAttempt:
+    attempt_id: str
+    task_id: str
+    started_at: str
+    ended_at: str | None
+    lifecycle: str
+    outcome: str
+    verification: str
+    user_disposition: str
+    evidence_ranges: tuple[EvidenceRange, ...]
+    decisions: tuple[DecisionRecord, ...] = ()
+    execution_identity: dict = field(default_factory=dict)
+
+    def __post_init__(self) -> None:
+        _required(self.attempt_id, "attempt_id")
+        _required(self.task_id, "attempt.task_id")
+        _required(self.started_at, "attempt.started_at")
+        _choice(self.lifecycle, ATTEMPT_LIFECYCLES, "attempt.lifecycle")
+        _choice(self.outcome, ATTEMPT_OUTCOMES, "attempt.outcome")
+        _choice(self.verification, VERIFICATIONS, "attempt.verification")
+        _choice(self.user_disposition, USER_DISPOSITIONS, "attempt.user_disposition")
+        if not self.evidence_ranges:
+            raise ValueError("TaskAttempt must contain at least one EvidenceRange")
+        if self.lifecycle == "running" and self.ended_at is not None:
+            raise ValueError("running TaskAttempt cannot have ended_at")
+        if self.lifecycle == "running" and self.outcome != "unknown":
+            raise ValueError("running TaskAttempt outcome must be unknown")
+        if self.lifecycle == "finished" and not self.ended_at:
+            raise ValueError("finished TaskAttempt requires ended_at")
+        if not isinstance(self.execution_identity, dict):
+            raise ValueError("TaskAttempt execution_identity must be an object")
+        for decision in self.decisions:
+            if (
+                decision.dimension == "lifecycle"
+                and decision.value not in ATTEMPT_LIFECYCLES
+            ):
+                raise ValueError("Attempt lifecycle decision uses a Task value")
+            if (
+                decision.dimension == "outcome"
+                and decision.value not in ATTEMPT_OUTCOMES
+            ):
+                raise ValueError("Attempt outcome decision uses a Task value")
+
+    def to_dict(self) -> dict:
+        result = asdict(self)
+        result["evidence_ranges"] = [item.to_dict() for item in self.evidence_ranges]
+        result["decisions"] = [item.to_dict() for item in self.decisions]
+        return result
+
+    @classmethod
+    def from_dict(cls, value: dict) -> TaskAttempt:
+        data = dict(value)
+        data["evidence_ranges"] = tuple(
+            EvidenceRange.from_dict(item) for item in data.get("evidence_ranges") or ()
+        )
+        data["decisions"] = tuple(
+            DecisionRecord.from_dict(item) for item in data.get("decisions") or ()
+        )
+        return cls(**data)
+
+
+@dataclass(frozen=True)
+class UsageAllocation:
+    allocation_id: str
+    usage_event_id: str
+    usage_plane: str
+    allocation_mode: str
+    fraction: float
+    task_id: str | None = None
+    attempt_id: str | None = None
+    processing_step: str | None = None
+    prompt_tokens: int | None = None
+    completion_tokens: int | None = None
+    total_tokens: int | None = None
+    cache_read_tokens: int | None = None
+    cost_usd: float | None = None
+    method: str = ""
+    method_version: str = ""
+
+    def __post_init__(self) -> None:
+        _required(self.allocation_id, "allocation_id")
+        _required(self.usage_event_id, "usage_event_id")
+        _choice(self.usage_plane, USAGE_PLANES, "usage_plane")
+        _choice(self.allocation_mode, ALLOCATION_MODES, "allocation_mode")
+        _confidence(self.fraction, "allocation.fraction")
+        if self.fraction <= 0:
+            raise ValueError("allocation.fraction must be greater than zero")
+        if self.allocation_mode == "unattributed" and any((self.task_id, self.attempt_id)):
+            raise ValueError("unattributed usage cannot target a Task or Attempt")
+        if self.attempt_id and not self.task_id:
+            raise ValueError("attempt allocation must also carry task_id")
+        for field_name in (
+            "prompt_tokens", "completion_tokens", "total_tokens",
+            "cache_read_tokens",
+        ):
+            value = getattr(self, field_name)
+            if value is not None and (
+                isinstance(value, bool)
+                or not isinstance(value, int)
+                or value < 0
+            ):
+                raise ValueError(f"{field_name} must be a non-negative integer or None")
+        if self.cost_usd is not None and (
+            isinstance(self.cost_usd, bool)
+            or not isinstance(self.cost_usd, (int, float))
+            or not math.isfinite(float(self.cost_usd))
+            or self.cost_usd < 0
+        ):
+            raise ValueError("cost_usd must be a non-negative number or None")
+
+    def to_dict(self) -> dict:
+        return asdict(self)
+
+    @classmethod
+    def from_dict(cls, value: dict) -> UsageAllocation:
+        return cls(**value)
+
+
+@dataclass(frozen=True)
+class TaskGraphGeneration:
+    generation_id: str
+    tenant_id: str
+    task_scope_id: str
+    source_revision: str
+    generator: dict
+    base_override_seq: int
+    created_at: str
+    tasks: tuple[LogicalTask, ...]
+    memberships: tuple[TaskAtomMembership, ...]
+    relations: tuple[TaskRelation, ...]
+    attempts: tuple[TaskAttempt, ...]
+    attempt_relations: tuple[AttemptRelation, ...]
+    usage_allocations: tuple[UsageAllocation, ...]
+    metrics: dict = field(default_factory=dict)
+    schema_version: int = SCHEMA_VERSION
+
+    def __post_init__(self) -> None:
+        _required(self.generation_id, "generation_id")
+        _required(self.tenant_id, "tenant_id")
+        _required(self.task_scope_id, "task_scope_id")
+        _required(self.source_revision, "source_revision")
+        _required(self.created_at, "created_at")
+        if self.schema_version != SCHEMA_VERSION:
+            raise ValueError(f"unsupported Task Graph schema_version={self.schema_version}")
+        if (
+            isinstance(self.base_override_seq, bool)
+            or not isinstance(self.base_override_seq, int)
+            or self.base_override_seq < 0
+        ):
+            raise ValueError("base_override_seq must be a non-negative integer")
+        if not isinstance(self.generator, dict) or not isinstance(self.metrics, dict):
+            raise ValueError("Task Graph generator and metrics must be objects")
+        validate_generation(self)
+
+    def to_dict(self) -> dict:
+        return {
+            "schema_version": self.schema_version,
+            "generation_id": self.generation_id,
+            "tenant_id": self.tenant_id,
+            "task_scope_id": self.task_scope_id,
+            "source_revision": self.source_revision,
+            "generator": self.generator,
+            "base_override_seq": self.base_override_seq,
+            "created_at": self.created_at,
+            "tasks": [item.to_dict() for item in self.tasks],
+            "memberships": [item.to_dict() for item in self.memberships],
+            "relations": [item.to_dict() for item in self.relations],
+            "attempts": [item.to_dict() for item in self.attempts],
+            "attempt_relations": [item.to_dict() for item in self.attempt_relations],
+            "usage_allocations": [item.to_dict() for item in self.usage_allocations],
+            "metrics": self.metrics,
+        }
+
+    @classmethod
+    def from_dict(cls, value: dict) -> TaskGraphGeneration:
+        return cls(
+            schema_version=value.get("schema_version", 0),
+            generation_id=value["generation_id"],
+            tenant_id=value["tenant_id"],
+            task_scope_id=value["task_scope_id"],
+            source_revision=value["source_revision"],
+            generator=dict(value.get("generator") or {}),
+            base_override_seq=value.get("base_override_seq", 0),
+            created_at=value["created_at"],
+            tasks=tuple(LogicalTask.from_dict(item) for item in value.get("tasks") or ()),
+            memberships=tuple(
+                TaskAtomMembership.from_dict(item) for item in value.get("memberships") or ()
+            ),
+            relations=tuple(TaskRelation.from_dict(item) for item in value.get("relations") or ()),
+            attempts=tuple(TaskAttempt.from_dict(item) for item in value.get("attempts") or ()),
+            attempt_relations=tuple(
+                AttemptRelation.from_dict(item) for item in value.get("attempt_relations") or ()
+            ),
+            usage_allocations=tuple(
+                UsageAllocation.from_dict(item) for item in value.get("usage_allocations") or ()
+            ),
+            metrics=dict(value.get("metrics") or {}),
+        )
+
+
+def _task_relation_edge(relation: TaskRelation) -> tuple[str, str]:
+    if relation.relation_type == "subtask":
+        return relation.to_task_id, relation.from_task_id
+    return relation.from_task_id, relation.to_task_id
+
+
+def _assert_acyclic(task_ids: set[str], relations: Iterable[TaskRelation]) -> None:
+    graph = {task_id: [] for task_id in task_ids}
+    indegree = {task_id: 0 for task_id in task_ids}
+    for relation in relations:
+        if relation.decision != "confirmed" or relation.stale:
+            continue
+        from_task_id, to_task_id = _task_relation_edge(relation)
+        graph[from_task_id].append(to_task_id)
+        indegree[to_task_id] += 1
+    ready = deque(
+        task_id for task_id, degree in indegree.items() if degree == 0
+    )
+    visited = 0
+    while ready:
+        task_id = ready.popleft()
+        visited += 1
+        for target_id in graph[task_id]:
+            indegree[target_id] -= 1
+            if indegree[target_id] == 0:
+                ready.append(target_id)
+    if visited != len(task_ids):
+        raise ValueError("confirmed Task relations must form a DAG")
+
+
+def validate_generation(generation: TaskGraphGeneration) -> None:
+    """Validate the ADR invariants that are decidable from one generation."""
+    task_ids = {task.task_id for task in generation.tasks}
+    if len(task_ids) != len(generation.tasks):
+        raise ValueError("task_id must be unique within a TaskScope generation")
+    attempt_ids = {attempt.attempt_id for attempt in generation.attempts}
+    if len(attempt_ids) != len(generation.attempts):
+        raise ValueError("attempt_id must be unique within a TaskScope generation")
+
+    def require_unique(records: Iterable[Any], attribute: str) -> None:
+        values = [getattr(record, attribute) for record in records]
+        if len(set(values)) != len(values):
+            raise ValueError(
+                f"{attribute} must be unique within a TaskScope generation"
+            )
+
+    require_unique(generation.memberships, "membership_id")
+    require_unique(generation.relations, "relation_id")
+    require_unique(generation.attempt_relations, "relation_id")
+    require_unique(generation.usage_allocations, "allocation_id")
+
+    confirmed_primary: dict[tuple[str, str, str, str, str], str] = {}
+    primary_counts = {task_id: 0 for task_id in task_ids}
+    evidence_ids: set[str] = set()
+    for membership in generation.memberships:
+        if membership.task_id not in task_ids:
+            raise ValueError("membership references a missing Task")
+        atom_ref = membership.atom_ref
+        if atom_ref.tenant_id != generation.tenant_id or atom_ref.task_scope_id != generation.task_scope_id:
+            raise ValueError("membership cannot cross TenantScope or TaskScope")
+        if membership.role == "primary" and membership.decision == "confirmed" and not membership.stale:
+            if atom_ref.key in confirmed_primary:
+                raise ValueError(
+                    "an Atom may have at most one confirmed primary membership"
+                )
+            confirmed_primary[atom_ref.key] = membership.task_id
+            primary_counts[membership.task_id] += 1
+
+    parent_targets: dict[str, str] = {}
+    for relation in generation.relations:
+        if relation.from_task_id not in task_ids or relation.to_task_id not in task_ids:
+            raise ValueError("Task relation references a missing Task")
+        if (
+            relation.decision == "confirmed"
+            and not relation.stale
+            and relation.relation_type in ("parent", "subtask")
+        ):
+            child_id = (
+                relation.to_task_id if relation.relation_type == "parent"
+                else relation.from_task_id
+            )
+            parent_id = (
+                relation.from_task_id if relation.relation_type == "parent"
+                else relation.to_task_id
+            )
+            previous = parent_targets.setdefault(child_id, parent_id)
+            if previous != parent_id:
+                raise ValueError("a Task may have at most one confirmed primary parent")
+    _assert_acyclic(task_ids, generation.relations)
+
+    attempts_by_task: dict[str, set[str]] = {task_id: set() for task_id in task_ids}
+    attempt_task_by_id: dict[str, str] = {}
+    live_line_ranges: dict[
+        tuple[str, str], list[tuple[int, int, str]]
+    ] = {}
+    for attempt in generation.attempts:
+        if attempt.task_id not in task_ids:
+            raise ValueError("Attempt references a missing Task")
+        attempts_by_task[attempt.task_id].add(attempt.attempt_id)
+        attempt_task_by_id[attempt.attempt_id] = attempt.task_id
+        for evidence in attempt.evidence_ranges:
+            if evidence.evidence_id in evidence_ids:
+                raise ValueError("evidence_id must be unique within a generation")
+            evidence_ids.add(evidence.evidence_id)
+            if (
+                evidence.session_ref.tenant_id != generation.tenant_id
+                or evidence.session_ref.task_scope_id != generation.task_scope_id
+            ):
+                raise ValueError("Attempt evidence cannot cross TenantScope or TaskScope")
+            if evidence.atom_ref is not None and not evidence.stale:
+                owner = confirmed_primary.get(evidence.atom_ref.key)
+                if owner is not None and owner != attempt.task_id:
+                    raise ValueError("Attempt evidence primary Atom belongs to another Task")
+            if (
+                not evidence.stale
+                and evidence.locator_kind == "trajectory_line"
+                and isinstance(evidence.start, int)
+                and isinstance(evidence.end, int)
+            ):
+                session_key = (
+                    evidence.session_ref.source_scope_id,
+                    evidence.session_ref.traj_id,
+                )
+                live_line_ranges.setdefault(session_key, []).append((
+                    evidence.start,
+                    evidence.end,
+                    evidence.evidence_id,
+                ))
+
+    for ranges in live_line_ranges.values():
+        ranges.sort()
+        for previous, current in zip(ranges, ranges[1:]):
+            if current[0] < previous[1]:
+                raise ValueError(
+                    "live Attempt EvidenceRanges cannot overlap within a Session"
+                )
+
+    for relation in generation.attempt_relations:
+        if relation.from_attempt_id not in attempt_ids or relation.to_attempt_id not in attempt_ids:
+            raise ValueError("Attempt relation references a missing Attempt")
+        from_task = attempt_task_by_id[relation.from_attempt_id]
+        to_task = attempt_task_by_id[relation.to_attempt_id]
+        if from_task != to_task:
+            raise ValueError("Attempt relations cannot cross Logical Tasks")
+
+    attempt_edges = {attempt_id: [] for attempt_id in attempt_ids}
+    attempt_indegree = {attempt_id: 0 for attempt_id in attempt_ids}
+    for relation in generation.attempt_relations:
+        if relation.decision != "confirmed":
+            continue
+        attempt_edges[relation.from_attempt_id].append(relation.to_attempt_id)
+        attempt_indegree[relation.to_attempt_id] += 1
+    attempt_ready = deque(
+        attempt_id
+        for attempt_id, degree in attempt_indegree.items()
+        if degree == 0
+    )
+    attempt_visited = 0
+    while attempt_ready:
+        attempt_id = attempt_ready.popleft()
+        attempt_visited += 1
+        for target_id in attempt_edges[attempt_id]:
+            attempt_indegree[target_id] -= 1
+            if attempt_indegree[target_id] == 0:
+                attempt_ready.append(target_id)
+    if attempt_visited != len(attempt_ids):
+        raise ValueError("confirmed Attempt relations must form a DAG")
+
+    allocation_sums: dict[tuple[str, str], float] = {}
+    for allocation in generation.usage_allocations:
+        if allocation.task_id is not None and allocation.task_id not in task_ids:
+            raise ValueError("usage allocation references a missing Task")
+        if allocation.attempt_id is not None:
+            if allocation.attempt_id not in attempts_by_task.get(allocation.task_id or "", set()):
+                raise ValueError("usage allocation Attempt does not belong to Task")
+        key = (allocation.usage_plane, allocation.usage_event_id)
+        allocation_sums[key] = allocation_sums.get(key, 0.0) + allocation.fraction
+    for key, total in allocation_sums.items():
+        if abs(total - 1.0) > 1e-9:
+            raise ValueError(
+                f"usage allocation must conserve event {key!r}: fraction={total}"
+            )
+
+    task_by_id = {task.task_id: task for task in generation.tasks}
+    for task_id, task in task_by_id.items():
+        should_be_tombstoned = primary_counts[task_id] == 0
+        if task.tombstoned != should_be_tombstoned:
+            raise ValueError(
+                "Task tombstone state must match live confirmed primary ownership"
+            )
+
+
+def stable_ref_key(atom_ref: AtomRef) -> str:
+    """Canonical scoped Atom key used in JSON maps without path semantics."""
+    return "\x1f".join(atom_ref.key)
+
+
+def model_from_dict(value: dict[str, Any]) -> dict[str, Any]:
+    """Drop empty execution-version fields while preserving unavailable reasons."""
+    return {key: item for key, item in value.items() if item not in (None, "", [], {})}

--- a/src/xskill/tasks/projection.py
+++ b/src/xskill/tasks/projection.py
@@ -16,6 +16,16 @@ def _json(value) -> str:
     )
 
 
+def _generator_json(value: dict) -> str:
+    return json.dumps(
+        value,
+        ensure_ascii=False,
+        sort_keys=True,
+        separators=(",", ":"),
+        allow_nan=False,
+    )
+
+
 def mark_task_graph_dirty(
     watch_dir_id: int,
     filename: str,
@@ -93,6 +103,30 @@ def enqueue_untracked_sources(*, db_path: Path | None = None) -> int:
             queued += max(0, cursor.rowcount)
         connection.commit()
         return queued
+
+
+def enqueue_changed_generator_scopes(
+    tenant_id: str,
+    generator: dict,
+    *,
+    db_path: Path | None = None,
+) -> int:
+    """Queue projected scopes whose deterministic generator has changed."""
+    if not isinstance(tenant_id, str) or not tenant_id.strip():
+        raise ValueError("tenant_id must be a non-empty string")
+    generator_json = _generator_json(generator)
+    with pooled_connection(db_path) as connection:
+        cursor = connection.execute(
+            "INSERT INTO task_graph_dirty_scopes("
+            "tenant_id,task_scope_id,generation,reason,marked_at)"
+            " SELECT tenant_id,task_scope_id,1,'generator_changed',datetime('now')"
+            " FROM task_graph_generations"
+            " WHERE tenant_id=? AND generator_json<>?"
+            " ON CONFLICT(tenant_id,task_scope_id) DO NOTHING",
+            (tenant_id, generator_json),
+        )
+        connection.commit()
+        return max(0, cursor.rowcount)
 
 
 def list_dirty_sources(
@@ -360,19 +394,22 @@ def project_generation(
                 )
             connection.execute(
                 "INSERT INTO task_graph_generations("
-                "tenant_id,task_scope_id,generation_id,source_revision,"
+                "tenant_id,task_scope_id,generation_id,source_revision,generator_json,"
                 "base_override_seq,created_at,task_count,atom_count,candidate_count,"
-                "model_judgement_count) VALUES(?,?,?,?,?,?,?,?,?,?)"
+                "model_judgement_count) VALUES(?,?,?,?,?,?,?,?,?,?,?)"
                 " ON CONFLICT(tenant_id,task_scope_id) DO UPDATE SET"
                 " generation_id=excluded.generation_id,"
                 " source_revision=excluded.source_revision,"
+                " generator_json=excluded.generator_json,"
                 " base_override_seq=excluded.base_override_seq,"
                 " created_at=excluded.created_at,task_count=excluded.task_count,"
                 " atom_count=excluded.atom_count,candidate_count=excluded.candidate_count,"
                 " model_judgement_count=excluded.model_judgement_count",
                 (
                     tenant_id, task_scope_id, generation.generation_id,
-                    generation.source_revision, generation.base_override_seq,
+                    generation.source_revision,
+                    _generator_json(generation.generator),
+                    generation.base_override_seq,
                     generation.created_at, generation.metrics.get("task_count", 0),
                     generation.metrics.get("atom_count", 0),
                     generation.metrics.get("candidate_count", 0),

--- a/src/xskill/tasks/projection.py
+++ b/src/xskill/tasks/projection.py
@@ -1,0 +1,813 @@
+"""Registry queue, Task Graph projection and bounded query functions."""
+from __future__ import annotations
+
+import json
+from collections.abc import Iterable
+from pathlib import Path
+
+from xskill.pipeline.registry import pooled_connection
+from xskill.tasks.evidence import ExecutionUsageEvent, ScopedTrajectoryEvidence
+from xskill.tasks.models import TaskGraphGeneration
+
+
+def _json(value) -> str:
+    return json.dumps(
+        value, ensure_ascii=False, separators=(",", ":"), allow_nan=False,
+    )
+
+
+def mark_task_graph_dirty(
+    watch_dir_id: int,
+    filename: str,
+    *,
+    reason: str,
+    deleted: bool = False,
+    tracked_only: bool = False,
+    db_path: Path | None = None,
+) -> None:
+    """Durably mark one source; generation prevents lost concurrent updates."""
+    with pooled_connection(db_path) as connection:
+        watch_dir = connection.execute(
+            "SELECT source_scope_id FROM watch_dirs WHERE id=?",
+            (watch_dir_id,),
+        ).fetchone()
+        traj_id = filename.removesuffix(".md")
+        state = None
+        if watch_dir is not None and watch_dir["source_scope_id"]:
+            state = connection.execute(
+                "SELECT tenant_id, task_scope_id FROM task_graph_source_state"
+                " WHERE source_scope_id=? AND traj_id=?",
+                (watch_dir["source_scope_id"], traj_id),
+            ).fetchone()
+        if tracked_only and state is None:
+            return
+        connection.execute(
+            "INSERT INTO task_graph_dirty_sources("
+            "watch_dir_id,filename,source_scope_id,tenant_id,task_scope_id,"
+            "deleted,generation,reason,marked_at)"
+            " VALUES(?,?,?,?,?,?,1,?,datetime('now'))"
+            " ON CONFLICT(watch_dir_id,filename) DO UPDATE SET"
+            " source_scope_id=COALESCE(excluded.source_scope_id,source_scope_id),"
+            " tenant_id=COALESCE(excluded.tenant_id,tenant_id),"
+            " task_scope_id=COALESCE(excluded.task_scope_id,task_scope_id),"
+            " deleted=excluded.deleted,generation=generation+1,"
+            " reason=excluded.reason,marked_at=datetime('now')",
+            (
+                watch_dir_id, filename,
+                watch_dir["source_scope_id"] if watch_dir is not None else None,
+                state["tenant_id"] if state is not None else None,
+                state["task_scope_id"] if state is not None else None,
+                int(deleted), reason,
+            ),
+        )
+        connection.commit()
+
+
+def enqueue_untracked_sources(*, db_path: Path | None = None) -> int:
+    """Backfill the durable queue for existing Atom sources after upgrade."""
+    with pooled_connection(db_path) as connection:
+        rows = connection.execute(
+            "SELECT t.watch_dir_id,t.filename,w.source_scope_id"
+            " FROM trajectories t JOIN watch_dirs w ON w.id=t.watch_dir_id"
+            " WHERE t.status IN ('split_done','indexed','done')"
+            " OR COALESCE(t.tasks_extracted,0)>0"
+        ).fetchall()
+        tracked = {
+            (row["source_scope_id"], row["traj_id"])
+            for row in connection.execute(
+                "SELECT source_scope_id,traj_id FROM task_graph_source_state"
+            ).fetchall()
+        }
+        queued = 0
+        for row in rows:
+            traj_id = row["filename"].removesuffix(".md")
+            if (row["source_scope_id"], traj_id) in tracked:
+                continue
+            cursor = connection.execute(
+                "INSERT INTO task_graph_dirty_sources("
+                "watch_dir_id,filename,source_scope_id,deleted,generation,reason,marked_at)"
+                " VALUES(?,?,?,0,1,'initial_backfill',datetime('now'))"
+                " ON CONFLICT(watch_dir_id,filename) DO NOTHING",
+                (row["watch_dir_id"], row["filename"], row["source_scope_id"]),
+            )
+            queued += max(0, cursor.rowcount)
+        connection.commit()
+        return queued
+
+
+def list_dirty_sources(
+    *, limit: int = 128, db_path: Path | None = None,
+) -> list[dict]:
+    if isinstance(limit, bool) or not isinstance(limit, int) or limit <= 0:
+        raise ValueError("limit must be a positive integer")
+    with pooled_connection(db_path) as connection:
+        return [dict(row) for row in connection.execute(
+            "SELECT * FROM task_graph_dirty_sources"
+            " ORDER BY marked_at,watch_dir_id,filename LIMIT ?",
+            (limit,),
+        ).fetchall()]
+
+
+def acknowledge_dirty_sources(
+    rows: Iterable[dict], *, db_path: Path | None = None,
+) -> None:
+    with pooled_connection(db_path) as connection:
+        connection.executemany(
+            "DELETE FROM task_graph_dirty_sources"
+            " WHERE watch_dir_id=? AND filename=? AND generation=?",
+            [
+                (row["watch_dir_id"], row["filename"], row["generation"])
+                for row in rows
+            ],
+        )
+        connection.commit()
+
+
+def mark_task_graph_scope_dirty(
+    tenant_id: str,
+    task_scope_id: str,
+    *,
+    reason: str,
+    db_path: Path | None = None,
+) -> dict:
+    """Fence a TaskScope mutation independently of live source rows."""
+    for field_name, value in (
+        ("tenant_id", tenant_id),
+        ("task_scope_id", task_scope_id),
+        ("reason", reason),
+    ):
+        if not isinstance(value, str) or not value.strip():
+            raise ValueError(f"{field_name} must be a non-empty string")
+    with pooled_connection(db_path) as connection:
+        connection.execute(
+            "INSERT INTO task_graph_dirty_scopes("
+            "tenant_id,task_scope_id,generation,reason,marked_at)"
+            " VALUES(?,?,1,?,datetime('now'))"
+            " ON CONFLICT(tenant_id,task_scope_id) DO UPDATE SET"
+            " generation=generation+1,reason=excluded.reason,"
+            " marked_at=datetime('now')",
+            (tenant_id, task_scope_id, reason),
+        )
+        row = connection.execute(
+            "SELECT * FROM task_graph_dirty_scopes"
+            " WHERE tenant_id=? AND task_scope_id=?",
+            (tenant_id, task_scope_id),
+        ).fetchone()
+        connection.commit()
+    return dict(row)
+
+
+def list_dirty_task_scopes(
+    *, limit: int = 128, db_path: Path | None = None,
+) -> list[dict]:
+    if isinstance(limit, bool) or not isinstance(limit, int) or limit <= 0:
+        raise ValueError("limit must be a positive integer")
+    with pooled_connection(db_path) as connection:
+        return [dict(row) for row in connection.execute(
+            "SELECT * FROM task_graph_dirty_scopes"
+            " ORDER BY marked_at,tenant_id,task_scope_id LIMIT ?",
+            (limit,),
+        ).fetchall()]
+
+
+def acknowledge_dirty_task_scopes(
+    rows: Iterable[dict], *, db_path: Path | None = None,
+) -> None:
+    with pooled_connection(db_path) as connection:
+        connection.executemany(
+            "DELETE FROM task_graph_dirty_scopes"
+            " WHERE tenant_id=? AND task_scope_id=? AND generation=?",
+            [
+                (row["tenant_id"], row["task_scope_id"], row["generation"])
+                for row in rows
+            ],
+        )
+        connection.commit()
+
+
+def source_states_for_scope(
+    tenant_id: str, task_scope_id: str, *, db_path: Path | None = None,
+) -> list[dict]:
+    with pooled_connection(db_path) as connection:
+        return [dict(row) for row in connection.execute(
+            "SELECT * FROM task_graph_source_state"
+            " WHERE tenant_id=? AND task_scope_id=?"
+            " ORDER BY source_scope_id,traj_id",
+            (tenant_id, task_scope_id),
+        ).fetchall()]
+
+
+def live_source_row(
+    watch_dir_id: int, filename: str, *, db_path: Path | None = None,
+) -> tuple[dict, dict] | None:
+    with pooled_connection(db_path) as connection:
+        row = connection.execute(
+            "SELECT t.*,w.path,w.label,w.auto_index,w.ecosystem,w.source_scope_id"
+            " FROM trajectories t JOIN watch_dirs w ON w.id=t.watch_dir_id"
+            " WHERE t.watch_dir_id=? AND t.filename=?",
+            (watch_dir_id, filename),
+        ).fetchone()
+        if row is None:
+            return None
+        combined = dict(row)
+        watch_dir = {
+            key: combined[key]
+            for key in ("watch_dir_id", "path", "label", "auto_index", "ecosystem", "source_scope_id")
+        }
+        watch_dir["id"] = watch_dir.pop("watch_dir_id")
+        return watch_dir, combined
+
+
+def upsert_execution_usage_events(
+    events: Iterable[ExecutionUsageEvent], *, db_path: Path | None = None,
+) -> int:
+    events_by_id: dict[str, ExecutionUsageEvent] = {}
+    for event in events:
+        previous = events_by_id.get(event.usage_event_id)
+        if previous is not None and previous.to_record() != event.to_record():
+            raise ValueError(
+                f"execution usage event identity collision: {event.usage_event_id}"
+            )
+        events_by_id[event.usage_event_id] = event
+    if not events_by_id:
+        return 0
+    with pooled_connection(db_path) as connection:
+        connection.execute("BEGIN IMMEDIATE")
+        existing_by_id: dict[str, dict] = {}
+        event_ids = sorted(events_by_id)
+        for offset in range(0, len(event_ids), 500):
+            chunk = event_ids[offset:offset + 500]
+            placeholders = ",".join("?" for _ in chunk)
+            for row in connection.execute(
+                "SELECT * FROM execution_usage_events"
+                f" WHERE usage_event_id IN ({placeholders})",
+                chunk,
+            ).fetchall():
+                existing_by_id[row["usage_event_id"]] = dict(row)
+        inserted = 0
+        rows = []
+        for event_id, event in events_by_id.items():
+            existing = existing_by_id.get(event_id)
+            if existing is not None:
+                expected = event.to_record()
+                actual = {
+                    "usage_event_id": existing["usage_event_id"],
+                    "usage_plane": existing["usage_plane"],
+                    "source_event_id": existing["source_event_id"],
+                    "tenant_id": existing["tenant_id"],
+                    "task_scope_id": existing["task_scope_id"],
+                    "source_scope_id": existing["source_scope_id"],
+                    "traj_id": existing["traj_id"],
+                    "model": json.loads(existing["model_json"]),
+                    "harness": json.loads(existing["harness_json"]),
+                    "prompt_tokens": existing["prompt_tokens"],
+                    "completion_tokens": existing["completion_tokens"],
+                    "total_tokens": existing["total_tokens"],
+                    "cache_read_tokens": existing["cache_read_tokens"],
+                    "cost_usd": existing["cost_usd"],
+                    "measurement_quality": existing["measurement_quality"],
+                    "estimation_method": existing["estimation_method"],
+                    "unavailable_reason": existing["unavailable_reason"],
+                }
+                expected.pop("observed_at", None)
+                if actual != expected:
+                    connection.rollback()
+                    raise RuntimeError(
+                        f"immutable execution usage event changed: {event_id}"
+                    )
+                continue
+            rows.append(event)
+            inserted += 1
+        connection.executemany(
+            "INSERT INTO execution_usage_events("
+            "usage_event_id,usage_plane,source_event_id,tenant_id,task_scope_id,"
+            "source_scope_id,traj_id,model_json,harness_json,prompt_tokens,"
+            "completion_tokens,total_tokens,cache_read_tokens,cost_usd,"
+            "measurement_quality,estimation_method,unavailable_reason,observed_at)"
+            " VALUES(?,'execution',?,?,?,?,?,?,?,?,?,?,?,?,?,?,?,?)"
+            " ON CONFLICT(usage_event_id) DO NOTHING",
+            [
+                (
+                    event.usage_event_id, event.source_event_id,
+                    event.session_ref.tenant_id, event.session_ref.task_scope_id,
+                    event.session_ref.source_scope_id, event.session_ref.traj_id,
+                    _json(event.model), _json(event.harness), event.prompt_tokens,
+                    event.completion_tokens, event.total_tokens,
+                    event.cache_read_tokens, event.cost_usd,
+                    event.measurement_quality, event.estimation_method,
+                    event.unavailable_reason,
+                    event.observed_at,
+                )
+                for event in rows
+            ],
+        )
+        connection.commit()
+        return inserted
+
+
+_PROJECTED_TABLES = (
+    "task_usage_allocations", "task_attempt_relations", "task_evidence_ranges",
+    "task_attempts", "task_relations", "task_atom_memberships", "logical_tasks",
+)
+
+
+def project_generation(
+    generation: TaskGraphGeneration,
+    *,
+    sources: Iterable[ScopedTrajectoryEvidence],
+    db_path: Path | None = None,
+) -> None:
+    """Replace one effective TaskScope projection in a single transaction."""
+    task_primary_counts: dict[str, int] = {}
+    for membership in generation.memberships:
+        if membership.role == "primary" and membership.decision == "confirmed" and not membership.stale:
+            task_primary_counts[membership.task_id] = task_primary_counts.get(membership.task_id, 0) + 1
+    task_attempt_counts: dict[str, int] = {}
+    for attempt in generation.attempts:
+        task_attempt_counts[attempt.task_id] = task_attempt_counts.get(attempt.task_id, 0) + 1
+    task_tokens: dict[str, int] = {}
+    task_costs: dict[str, float] = {}
+    attempt_tokens: dict[str, int] = {}
+    attempt_costs: dict[str, float] = {}
+    task_has_tokens: set[str] = set()
+    task_has_cost: set[str] = set()
+    attempt_has_tokens: set[str] = set()
+    attempt_has_cost: set[str] = set()
+    for allocation in generation.usage_allocations:
+        if allocation.task_id and allocation.total_tokens is not None:
+            task_has_tokens.add(allocation.task_id)
+            task_tokens[allocation.task_id] = task_tokens.get(allocation.task_id, 0) + allocation.total_tokens
+        if allocation.task_id and allocation.cost_usd is not None:
+            task_has_cost.add(allocation.task_id)
+            task_costs[allocation.task_id] = task_costs.get(allocation.task_id, 0.0) + allocation.cost_usd
+        if allocation.attempt_id and allocation.total_tokens is not None:
+            attempt_has_tokens.add(allocation.attempt_id)
+            attempt_tokens[allocation.attempt_id] = attempt_tokens.get(allocation.attempt_id, 0) + allocation.total_tokens
+        if allocation.attempt_id and allocation.cost_usd is not None:
+            attempt_has_cost.add(allocation.attempt_id)
+            attempt_costs[allocation.attempt_id] = attempt_costs.get(allocation.attempt_id, 0.0) + allocation.cost_usd
+
+    tenant_id = generation.tenant_id
+    task_scope_id = generation.task_scope_id
+    source_list = tuple(sources)
+    with pooled_connection(db_path) as connection:
+        connection.execute("BEGIN IMMEDIATE")
+        try:
+            for table_name in _PROJECTED_TABLES:
+                connection.execute(
+                    f"DELETE FROM {table_name} WHERE tenant_id=? AND task_scope_id=?",
+                    (tenant_id, task_scope_id),
+                )
+            connection.execute(
+                "INSERT INTO task_graph_generations("
+                "tenant_id,task_scope_id,generation_id,source_revision,"
+                "base_override_seq,created_at,task_count,atom_count,candidate_count,"
+                "model_judgement_count) VALUES(?,?,?,?,?,?,?,?,?,?)"
+                " ON CONFLICT(tenant_id,task_scope_id) DO UPDATE SET"
+                " generation_id=excluded.generation_id,"
+                " source_revision=excluded.source_revision,"
+                " base_override_seq=excluded.base_override_seq,"
+                " created_at=excluded.created_at,task_count=excluded.task_count,"
+                " atom_count=excluded.atom_count,candidate_count=excluded.candidate_count,"
+                " model_judgement_count=excluded.model_judgement_count",
+                (
+                    tenant_id, task_scope_id, generation.generation_id,
+                    generation.source_revision, generation.base_override_seq,
+                    generation.created_at, generation.metrics.get("task_count", 0),
+                    generation.metrics.get("atom_count", 0),
+                    generation.metrics.get("candidate_count", 0),
+                    generation.metrics.get("model_judgement_count", 0),
+                ),
+            )
+            connection.executemany(
+                "INSERT INTO logical_tasks("
+                "tenant_id,task_scope_id,task_id,generation_id,title,summary,"
+                "lifecycle,outcome,verification,user_disposition,created_at,"
+                "tombstoned,aliases_json,decisions_json,primary_atom_count,"
+                "attempt_count,execution_tokens,execution_cost_usd)"
+                " VALUES(?,?,?,?,?,?,?,?,?,?,?,?,?,?,?,?,?,?)",
+                [
+                    (
+                        tenant_id, task_scope_id, task.task_id,
+                        generation.generation_id, task.title, task.summary,
+                        task.lifecycle, task.outcome, task.verification,
+                        task.user_disposition, task.created_at, int(task.tombstoned),
+                        _json(list(task.aliases)),
+                        _json([item.to_dict() for item in task.decisions]),
+                        task_primary_counts.get(task.task_id, 0),
+                        task_attempt_counts.get(task.task_id, 0),
+                        task_tokens.get(task.task_id) if task.task_id in task_has_tokens else None,
+                        task_costs.get(task.task_id) if task.task_id in task_has_cost else None,
+                    )
+                    for task in generation.tasks
+                ],
+            )
+            connection.executemany(
+                "INSERT INTO task_atom_memberships("
+                "tenant_id,task_scope_id,membership_id,generation_id,task_id,"
+                "source_scope_id,traj_id,atom_id,role,decision,confidence,"
+                "decided_by,algorithm_version,evidence_refs_json,observed_at,stale)"
+                " VALUES(?,?,?,?,?,?,?,?,?,?,?,?,?,?,?,?)",
+                [
+                    (
+                        tenant_id, task_scope_id, item.membership_id,
+                        generation.generation_id, item.task_id,
+                        item.atom_ref.source_scope_id, item.atom_ref.traj_id,
+                        item.atom_ref.atom_id, item.role, item.decision,
+                        item.confidence, item.decided_by, item.algorithm_version,
+                        _json(list(item.evidence_refs)), item.observed_at,
+                        int(item.stale),
+                    )
+                    for item in generation.memberships
+                ],
+            )
+            connection.executemany(
+                "INSERT INTO task_relations("
+                "tenant_id,task_scope_id,relation_id,generation_id,from_task_id,"
+                "to_task_id,relation_type,decision,confidence,decided_by,"
+                "algorithm_version,evidence_refs_json,observed_at,stale)"
+                " VALUES(?,?,?,?,?,?,?,?,?,?,?,?,?,?)",
+                [
+                    (
+                        tenant_id, task_scope_id, item.relation_id,
+                        generation.generation_id, item.from_task_id,
+                        item.to_task_id, item.relation_type, item.decision,
+                        item.confidence, item.decided_by, item.algorithm_version,
+                        _json(list(item.evidence_refs)), item.observed_at,
+                        int(item.stale),
+                    )
+                    for item in generation.relations
+                ],
+            )
+            connection.executemany(
+                "INSERT INTO task_attempts("
+                "tenant_id,task_scope_id,attempt_id,generation_id,task_id,"
+                "started_at,ended_at,lifecycle,outcome,verification,"
+                "user_disposition,decisions_json,execution_identity_json,"
+                "evidence_count,execution_tokens,execution_cost_usd)"
+                " VALUES(?,?,?,?,?,?,?,?,?,?,?,?,?,?,?,?)",
+                [
+                    (
+                        tenant_id, task_scope_id, item.attempt_id,
+                        generation.generation_id, item.task_id, item.started_at,
+                        item.ended_at, item.lifecycle, item.outcome,
+                        item.verification, item.user_disposition,
+                        _json([decision.to_dict() for decision in item.decisions]),
+                        _json(item.execution_identity), len(item.evidence_ranges),
+                        attempt_tokens.get(item.attempt_id)
+                        if item.attempt_id in attempt_has_tokens else None,
+                        attempt_costs.get(item.attempt_id)
+                        if item.attempt_id in attempt_has_cost else None,
+                    )
+                    for item in generation.attempts
+                ],
+            )
+            evidence_rows = []
+            for attempt in generation.attempts:
+                for evidence in attempt.evidence_ranges:
+                    evidence_rows.append((
+                        tenant_id, task_scope_id, evidence.evidence_id,
+                        generation.generation_id, attempt.attempt_id,
+                        evidence.session_ref.source_scope_id,
+                        evidence.session_ref.traj_id,
+                        evidence.atom_ref.atom_id if evidence.atom_ref else None,
+                        evidence.locator_kind, str(evidence.start), str(evidence.end),
+                        evidence.content_hash, evidence.atom_hash,
+                        int(evidence.stale),
+                        _json(evidence.model), _json(evidence.harness),
+                        _json(list(evidence.skills)),
+                    ))
+            connection.executemany(
+                "INSERT INTO task_evidence_ranges("
+                "tenant_id,task_scope_id,evidence_id,generation_id,attempt_id,"
+                "source_scope_id,traj_id,atom_id,locator_kind,locator_start,"
+                "locator_end,content_hash,atom_hash,stale,model_json,harness_json,skills_json)"
+                " VALUES(?,?,?,?,?,?,?,?,?,?,?,?,?,?,?,?,?)",
+                evidence_rows,
+            )
+            connection.executemany(
+                "INSERT INTO task_attempt_relations("
+                "tenant_id,task_scope_id,relation_id,generation_id,from_attempt_id,"
+                "to_attempt_id,relation_type,decision,confidence,decided_by,"
+                "algorithm_version,evidence_refs_json,observed_at)"
+                " VALUES(?,?,?,?,?,?,?,?,?,?,?,?,?)",
+                [
+                    (
+                        tenant_id, task_scope_id, item.relation_id,
+                        generation.generation_id, item.from_attempt_id,
+                        item.to_attempt_id, item.relation_type, item.decision,
+                        item.confidence, item.decided_by, item.algorithm_version,
+                        _json(list(item.evidence_refs)), item.observed_at,
+                    )
+                    for item in generation.attempt_relations
+                ],
+            )
+            connection.executemany(
+                "INSERT INTO task_usage_allocations("
+                "tenant_id,task_scope_id,allocation_id,generation_id,usage_event_id,"
+                "usage_plane,allocation_mode,fraction,task_id,attempt_id,"
+                "processing_step,prompt_tokens,completion_tokens,total_tokens,"
+                "cache_read_tokens,cost_usd,method,method_version)"
+                " VALUES(?,?,?,?,?,?,?,?,?,?,?,?,?,?,?,?,?,?)",
+                [
+                    (
+                        tenant_id, task_scope_id, item.allocation_id,
+                        generation.generation_id, item.usage_event_id,
+                        item.usage_plane, item.allocation_mode, item.fraction,
+                        item.task_id, item.attempt_id, item.processing_step,
+                        item.prompt_tokens, item.completion_tokens,
+                        item.total_tokens, item.cache_read_tokens,
+                        item.cost_usd, item.method,
+                        item.method_version,
+                    )
+                    for item in generation.usage_allocations
+                ],
+            )
+            connection.execute(
+                "DELETE FROM task_graph_source_state"
+                " WHERE tenant_id=? AND task_scope_id=?",
+                (tenant_id, task_scope_id),
+            )
+            connection.executemany(
+                "INSERT INTO task_graph_source_state("
+                "tenant_id,task_scope_id,source_scope_id,watch_dir_id,traj_id,"
+                "source_revision,generation_id,updated_at)"
+                " VALUES(?,?,?,?,?,?,?,datetime('now'))"
+                " ON CONFLICT(source_scope_id,traj_id) DO UPDATE SET"
+                " tenant_id=excluded.tenant_id,"
+                " task_scope_id=excluded.task_scope_id,"
+                " watch_dir_id=excluded.watch_dir_id,"
+                " source_revision=excluded.source_revision,"
+                " generation_id=excluded.generation_id,"
+                " updated_at=datetime('now')",
+                [
+                    (
+                        tenant_id, task_scope_id, source.session_ref.source_scope_id,
+                        source.watch_dir_id, source.session_ref.traj_id,
+                        source.source_revision, generation.generation_id,
+                    )
+                    for source in source_list
+                ],
+            )
+            connection.commit()
+        except Exception:
+            connection.rollback()
+            raise
+
+
+def _decode_json_fields(row: dict, fields: Iterable[str]) -> dict:
+    for field_name in fields:
+        raw = row.get(field_name)
+        if raw is None:
+            continue
+        try:
+            row[field_name.removesuffix("_json")] = json.loads(raw)
+        except json.JSONDecodeError:
+            row[field_name.removesuffix("_json")] = None
+        row.pop(field_name, None)
+    return row
+
+
+def list_task_scopes(
+    tenant_id: str, *, limit: int = 100, offset: int = 0,
+    db_path: Path | None = None,
+) -> list[dict]:
+    with pooled_connection(db_path) as connection:
+        return [dict(row) for row in connection.execute(
+            "SELECT * FROM task_graph_generations WHERE tenant_id=?"
+            " ORDER BY created_at DESC,task_scope_id LIMIT ? OFFSET ?",
+            (tenant_id, limit, offset),
+        ).fetchall()]
+
+
+def list_logical_tasks(
+    tenant_id: str,
+    *,
+    task_scope_id: str | None = None,
+    include_tombstones: bool = False,
+    limit: int = 100,
+    offset: int = 0,
+    db_path: Path | None = None,
+) -> list[dict]:
+    clauses = ["tenant_id=?"]
+    parameters: list = [tenant_id]
+    if task_scope_id:
+        clauses.append("task_scope_id=?")
+        parameters.append(task_scope_id)
+    if not include_tombstones:
+        clauses.append("tombstoned=0")
+    parameters.extend((limit, offset))
+    with pooled_connection(db_path) as connection:
+        rows = connection.execute(
+            "SELECT * FROM logical_tasks WHERE " + " AND ".join(clauses)
+            + " ORDER BY created_at DESC,task_id LIMIT ? OFFSET ?",
+            parameters,
+        ).fetchall()
+    return [
+        _decode_json_fields(dict(row), ("aliases_json", "decisions_json"))
+        for row in rows
+    ]
+
+
+def get_logical_task(
+    tenant_id: str, task_scope_id: str, task_id: str,
+    *, db_path: Path | None = None,
+) -> dict | None:
+    with pooled_connection(db_path) as connection:
+        task = connection.execute(
+            "SELECT * FROM logical_tasks"
+            " WHERE tenant_id=? AND task_scope_id=? AND task_id=?",
+            (tenant_id, task_scope_id, task_id),
+        ).fetchone()
+        if task is None:
+            return None
+        memberships = [dict(row) for row in connection.execute(
+            "SELECT * FROM task_atom_memberships"
+            " WHERE tenant_id=? AND task_scope_id=? AND task_id=?"
+            " ORDER BY observed_at,membership_id",
+            (tenant_id, task_scope_id, task_id),
+        ).fetchall()]
+        attempts = [dict(row) for row in connection.execute(
+            "SELECT * FROM task_attempts"
+            " WHERE tenant_id=? AND task_scope_id=? AND task_id=?"
+            " ORDER BY started_at,attempt_id",
+            (tenant_id, task_scope_id, task_id),
+        ).fetchall()]
+        evidence = [dict(row) for row in connection.execute(
+            "SELECT e.* FROM task_evidence_ranges e"
+            " JOIN task_attempts a ON a.tenant_id=e.tenant_id"
+            " AND a.task_scope_id=e.task_scope_id"
+            " AND a.attempt_id=e.attempt_id"
+            " WHERE a.tenant_id=? AND a.task_scope_id=? AND a.task_id=?"
+            " ORDER BY e.source_scope_id,e.traj_id,"
+            " CASE WHEN e.locator_kind='trajectory_line'"
+            " THEN CAST(e.locator_start AS INTEGER) END,"
+            " e.locator_start,e.evidence_id",
+            (tenant_id, task_scope_id, task_id),
+        ).fetchall()]
+        relations = [dict(row) for row in connection.execute(
+            "SELECT * FROM task_relations"
+            " WHERE tenant_id=? AND task_scope_id=?"
+            " AND (from_task_id=? OR to_task_id=?) ORDER BY relation_id",
+            (tenant_id, task_scope_id, task_id, task_id),
+        ).fetchall()]
+        attempt_relations = [dict(row) for row in connection.execute(
+            "SELECT r.* FROM task_attempt_relations r"
+            " JOIN task_attempts a ON a.tenant_id=r.tenant_id"
+            " AND a.task_scope_id=r.task_scope_id"
+            " AND a.attempt_id=r.from_attempt_id"
+            " WHERE a.tenant_id=? AND a.task_scope_id=? AND a.task_id=?"
+            " ORDER BY r.relation_id",
+            (tenant_id, task_scope_id, task_id),
+        ).fetchall()]
+        allocations = [dict(row) for row in connection.execute(
+            "SELECT * FROM task_usage_allocations"
+            " WHERE tenant_id=? AND task_scope_id=? AND task_id=?"
+            " ORDER BY usage_plane,usage_event_id,allocation_id",
+            (tenant_id, task_scope_id, task_id),
+        ).fetchall()]
+        usage_event_ids = sorted({
+            row["usage_event_id"] for row in allocations
+            if row["usage_plane"] == "execution"
+        })
+        usage_events = []
+        if usage_event_ids:
+            placeholders = ",".join("?" for _ in usage_event_ids)
+            usage_events = [dict(row) for row in connection.execute(
+                "SELECT * FROM execution_usage_events"
+                " WHERE tenant_id=? AND task_scope_id=?"
+                f" AND usage_event_id IN ({placeholders})"
+                " ORDER BY observed_at,usage_event_id",
+                [tenant_id, task_scope_id, *usage_event_ids],
+            ).fetchall()]
+    return {
+        "task": _decode_json_fields(dict(task), ("aliases_json", "decisions_json")),
+        "memberships": [
+            _decode_json_fields(row, ("evidence_refs_json",)) for row in memberships
+        ],
+        "attempts": [
+            _decode_json_fields(
+                row, ("decisions_json", "execution_identity_json"),
+            ) for row in attempts
+        ],
+        "evidence_ranges": [
+            _decode_json_fields(
+                row, ("model_json", "harness_json", "skills_json"),
+            ) for row in evidence
+        ],
+        "relations": [
+            _decode_json_fields(row, ("evidence_refs_json",)) for row in relations
+        ],
+        "attempt_relations": [
+            _decode_json_fields(row, ("evidence_refs_json",))
+            for row in attempt_relations
+        ],
+        "usage_allocations": allocations,
+        "usage_events": [
+            _decode_json_fields(row, ("model_json", "harness_json"))
+            for row in usage_events
+        ],
+    }
+
+
+def tasks_for_session(
+    tenant_id: str, source_scope_id: str, traj_id: str,
+    *, db_path: Path | None = None,
+) -> dict:
+    with pooled_connection(db_path) as connection:
+        memberships = [dict(row) for row in connection.execute(
+            "SELECT * FROM task_atom_memberships"
+            " WHERE tenant_id=? AND source_scope_id=? AND traj_id=?"
+            " ORDER BY observed_at,membership_id",
+            (tenant_id, source_scope_id, traj_id),
+        ).fetchall()]
+        task_rows = connection.execute(
+            "SELECT DISTINCT l.* FROM logical_tasks l"
+            " JOIN task_atom_memberships m ON m.tenant_id=l.tenant_id"
+            " AND m.task_scope_id=l.task_scope_id AND m.task_id=l.task_id"
+            " WHERE m.tenant_id=? AND m.source_scope_id=? AND m.traj_id=?"
+            " ORDER BY l.created_at,l.task_id",
+            (tenant_id, source_scope_id, traj_id),
+        ).fetchall()
+        tasks = [
+            _decode_json_fields(
+                dict(row), ("aliases_json", "decisions_json"),
+            )
+            for row in task_rows
+        ]
+    return {
+        "tasks": tasks,
+        "memberships": [
+            _decode_json_fields(row, ("evidence_refs_json",))
+            for row in memberships
+        ],
+    }
+
+
+def tasks_for_atom(
+    tenant_id: str, source_scope_id: str, traj_id: str, atom_id: str,
+    *, db_path: Path | None = None,
+) -> dict:
+    with pooled_connection(db_path) as connection:
+        memberships = [dict(row) for row in connection.execute(
+            "SELECT * FROM task_atom_memberships"
+            " WHERE tenant_id=? AND source_scope_id=? AND traj_id=? AND atom_id=?"
+            " ORDER BY observed_at,membership_id",
+            (tenant_id, source_scope_id, traj_id, atom_id),
+        ).fetchall()]
+        task_rows = connection.execute(
+            "SELECT DISTINCT l.* FROM logical_tasks l"
+            " JOIN task_atom_memberships m ON m.tenant_id=l.tenant_id"
+            " AND m.task_scope_id=l.task_scope_id AND m.task_id=l.task_id"
+            " WHERE m.tenant_id=? AND m.source_scope_id=?"
+            " AND m.traj_id=? AND m.atom_id=?"
+            " ORDER BY l.created_at,l.task_id",
+            (tenant_id, source_scope_id, traj_id, atom_id),
+        ).fetchall()
+    return {
+        "tasks": [
+            _decode_json_fields(
+                dict(row), ("aliases_json", "decisions_json"),
+            )
+            for row in task_rows
+        ],
+        "memberships": [
+            _decode_json_fields(row, ("evidence_refs_json",))
+            for row in memberships
+        ],
+    }
+
+
+def task_graph_overview(
+    tenant_id: str, *, db_path: Path | None = None,
+) -> dict:
+    with pooled_connection(db_path) as connection:
+        task_row = connection.execute(
+            "SELECT COUNT(*) AS tasks,"
+            " SUM(CASE WHEN outcome='unknown' THEN 1 ELSE 0 END) AS unknown_outcomes,"
+            " SUM(CASE WHEN tombstoned=0 THEN primary_atom_count ELSE 0 END) AS primary_atoms,"
+            " SUM(CASE WHEN tombstoned=0 THEN attempt_count ELSE 0 END) AS attempts,"
+            " SUM(CASE WHEN tombstoned=0 THEN execution_tokens ELSE 0 END) AS execution_tokens,"
+            " SUM(CASE WHEN tombstoned=0 THEN execution_cost_usd ELSE 0 END) AS execution_cost_usd"
+            " FROM logical_tasks WHERE tenant_id=? AND tombstoned=0",
+            (tenant_id,),
+        ).fetchone()
+        uncertain = connection.execute(
+            "SELECT COUNT(*) FROM task_atom_memberships"
+            " WHERE tenant_id=? AND decision IN ('proposed','needs_review')",
+            (tenant_id,),
+        ).fetchone()[0]
+        scopes = connection.execute(
+            "SELECT COUNT(*) FROM task_graph_generations WHERE tenant_id=?",
+            (tenant_id,),
+        ).fetchone()[0]
+    return {
+        "scopes": scopes,
+        "tasks": task_row["tasks"] or 0,
+        "primary_atoms": task_row["primary_atoms"] or 0,
+        "attempts": task_row["attempts"] or 0,
+        "unknown_outcomes": task_row["unknown_outcomes"] or 0,
+        "uncertain_memberships": uncertain,
+        "execution_tokens": task_row["execution_tokens"],
+        "execution_cost_usd": task_row["execution_cost_usd"],
+    }

--- a/src/xskill/tasks/scopes.py
+++ b/src/xskill/tasks/scopes.py
@@ -1,0 +1,176 @@
+"""Resolve stable Tenant, Task and Source scopes from Registry evidence."""
+from __future__ import annotations
+
+import hashlib
+import json
+import os
+import uuid
+from dataclasses import dataclass
+from pathlib import Path
+
+from xskill.tasks.locking import task_file_lock
+
+
+@dataclass(frozen=True)
+class ScopeIdentity:
+    tenant_id: str
+    task_scope_id: str
+    source_scope_id: str
+    actor_id: str
+    workspace_id: str
+
+
+def _opaque(prefix: str, value: str, length: int = 24) -> str:
+    digest = hashlib.sha256(value.encode("utf-8")).hexdigest()[:length]
+    return f"{prefix}_{digest}"
+
+
+def _read_sidecar(path: Path) -> dict:
+    if not path.is_file():
+        return {}
+    try:
+        value = json.loads(path.read_text(encoding="utf-8"))
+    except (OSError, json.JSONDecodeError) as error:
+        raise RuntimeError(f"invalid trajectory metadata: {path}") from error
+    if not isinstance(value, dict):
+        raise RuntimeError(f"trajectory metadata must contain an object: {path}")
+    return value
+
+
+class ScopeResolver:
+    """Map mutable paths and labels to persisted opaque scope identifiers."""
+
+    IDENTITY_SCHEMA_VERSION = 1
+
+    def __init__(self, state_root: Path, *, db_path: Path | None = None,
+                 server_mode: bool = False):
+        self.state_root = Path(state_root).expanduser().resolve()
+        self.db_path = Path(db_path) if db_path is not None else None
+        self.server_mode = bool(server_mode)
+        self.graph_root = self.state_root / "task_graph"
+        self._tenant_id: str | None = None
+
+    def _read_tenant_identity(self) -> str | None:
+        identity_path = self.graph_root / "identity.json"
+        if not identity_path.is_file():
+            return None
+        try:
+            payload = json.loads(identity_path.read_text(encoding="utf-8"))
+        except (OSError, json.JSONDecodeError) as error:
+            raise RuntimeError(
+                f"invalid Task Graph identity: {identity_path}"
+            ) from error
+        tenant_id = payload.get("tenant_id")
+        if (
+            payload.get("schema_version") != self.IDENTITY_SCHEMA_VERSION
+            or not isinstance(tenant_id, str)
+            or not tenant_id
+        ):
+            raise RuntimeError(f"invalid Task Graph identity: {identity_path}")
+        return tenant_id
+
+    @property
+    def existing_tenant_id(self) -> str | None:
+        """Read the tenant boundary without creating state on query paths."""
+        if self._tenant_id is not None:
+            return self._tenant_id
+        tenant_id = self._read_tenant_identity()
+        if tenant_id is not None:
+            self._tenant_id = tenant_id
+        return tenant_id
+
+    @property
+    def tenant_id(self) -> str:
+        if self._tenant_id is not None:
+            return self._tenant_id
+        identity_path = self.graph_root / "identity.json"
+        lock_path = self.graph_root / "locks" / "identity.lock"
+        with task_file_lock(lock_path):
+            tenant_id = self._read_tenant_identity()
+            if tenant_id is not None:
+                self._tenant_id = tenant_id
+                return tenant_id
+            identity_path.parent.mkdir(parents=True, exist_ok=True)
+            payload = {
+                "schema_version": self.IDENTITY_SCHEMA_VERSION,
+                "instance_id": f"ins_{uuid.uuid4().hex}",
+                "tenant_id": f"ten_{uuid.uuid4().hex}",
+                "mode": "team_server" if self.server_mode else "standalone",
+            }
+            temporary = identity_path.with_name(f".{identity_path.name}.{uuid.uuid4().hex}.tmp")
+            encoded = json.dumps(
+                payload, ensure_ascii=False, separators=(",", ":"),
+            ).encode("utf-8")
+            with temporary.open("wb") as output:
+                output.write(encoded)
+                output.flush()
+                os.fsync(output.fileno())
+            if os.name != "nt":
+                temporary.chmod(0o600)
+            os.replace(temporary, identity_path)
+            if os.name != "nt":
+                directory_fd = os.open(identity_path.parent, os.O_RDONLY)
+                try:
+                    os.fsync(directory_fd)
+                finally:
+                    os.close(directory_fd)
+            self._tenant_id = payload["tenant_id"]
+            return payload["tenant_id"]
+
+    def resolve(self, *, watch_dir: dict, trajectory: dict) -> ScopeIdentity:
+        source_scope_id = str(watch_dir.get("source_scope_id") or "").strip()
+        if not source_scope_id:
+            from xskill.pipeline.registry import ensure_watch_dir_source_scope
+
+            source_scope_id = ensure_watch_dir_source_scope(
+                int(watch_dir["id"]), db_path=self.db_path,
+            )
+        user_key = str(trajectory.get("user_key") or "").strip()
+        if self.server_mode:
+            # Team actors must never be merged merely because they ingest into
+            # the same server-side watch directory.  Anonymous uploads stay
+            # isolated by SourceScope because no stronger actor evidence exists.
+            actor_seed = (
+                f"team:{user_key}" if user_key else f"source:{source_scope_id}"
+            )
+        else:
+            # One standalone xskill instance represents one local actor.  Using
+            # SourceScope here would prevent an explicitly identical workspace
+            # observed through Codex and another Harness from ever sharing a
+            # Logical Task.
+            actor_seed = f"standalone:{self.tenant_id}"
+        actor_id = _opaque("act", actor_seed)
+        filename = str(trajectory.get("filename") or "")
+        traj_id = filename.removesuffix(".md")
+        sidecar = _read_sidecar(Path(watch_dir["path"]) / f"{traj_id}.json")
+        workspace_seed = ""
+        for key in ("workspace_id", "repo_id", "cwd", "workspace_dir", "workspace", "repo"):
+            candidate = sidecar.get(key)
+            if isinstance(candidate, str) and candidate.strip():
+                workspace_seed = candidate.strip()
+                break
+        if workspace_seed:
+            workspace_id = _opaque("wrk", workspace_seed)
+        else:
+            workspace_id = _opaque("wrk", f"source:{source_scope_id}")
+        tenant_id = self.tenant_id
+        task_scope_id = _opaque(
+            "tsc", f"{tenant_id}\x1f{actor_id}\x1f{workspace_id}", length=32,
+        )
+        return ScopeIdentity(
+            tenant_id=tenant_id,
+            task_scope_id=task_scope_id,
+            source_scope_id=source_scope_id,
+            actor_id=actor_id,
+            workspace_id=workspace_id,
+        )
+
+    def scope_dir(self, task_scope_id: str) -> Path:
+        if (
+            not isinstance(task_scope_id, str)
+            or len(task_scope_id) != 36
+            or not task_scope_id.startswith("tsc_")
+            or any(character not in "0123456789abcdef" for character in task_scope_id[4:])
+        ):
+            raise ValueError("invalid task_scope_id")
+        return self.graph_root / "scopes" / task_scope_id

--- a/src/xskill/tasks/service.py
+++ b/src/xskill/tasks/service.py
@@ -1,0 +1,1151 @@
+"""Production orchestration for dirty-source Task Graph rebuilds."""
+from __future__ import annotations
+
+import hashlib
+import json
+import logging
+import uuid
+from collections import OrderedDict, deque
+from operator import attrgetter
+from pathlib import Path
+
+from xskill.tasks.evidence import (
+    ScopedTrajectoryEvidence,
+    collect_trajectory_evidence,
+)
+from xskill.tasks.linker import BoundedTaskLinker
+from xskill.tasks.locking import task_file_lock
+from xskill.tasks.models import (
+    ATTEMPT_LIFECYCLES,
+    ATTEMPT_OUTCOMES,
+    ATTEMPT_RELATION_TYPES,
+    TASK_LIFECYCLES,
+    TASK_OUTCOMES,
+    TASK_RELATION_TYPES,
+    USER_DISPOSITIONS,
+    VERIFICATIONS,
+    stable_ref_key,
+)
+from xskill.tasks.projection import (
+    acknowledge_dirty_task_scopes,
+    acknowledge_dirty_sources,
+    enqueue_untracked_sources,
+    list_dirty_task_scopes,
+    list_dirty_sources,
+    live_source_row,
+    mark_task_graph_scope_dirty,
+    mark_task_graph_dirty,
+    project_generation,
+    source_states_for_scope,
+    upsert_execution_usage_events,
+)
+from xskill.tasks.scopes import ScopeResolver
+from xskill.tasks.store import OverrideEvent, TaskGraphStore
+
+logger = logging.getLogger("xskill.task_graph")
+
+
+def _task_relation_edge(
+    from_task_id: str, to_task_id: str, relation_type: str,
+) -> tuple[str, str]:
+    if relation_type == "subtask":
+        return to_task_id, from_task_id
+    return from_task_id, to_task_id
+
+
+def _require_acyclic(edges: dict[str, set[str]], message: str) -> None:
+    indegree = {task_id: 0 for task_id in edges}
+    for targets in edges.values():
+        for target_id in targets:
+            indegree[target_id] += 1
+    ready = deque(
+        task_id for task_id, degree in indegree.items() if degree == 0
+    )
+    visited = 0
+    while ready:
+        task_id = ready.popleft()
+        visited += 1
+        for target_id in edges[task_id]:
+            indegree[target_id] -= 1
+            if indegree[target_id] == 0:
+                ready.append(target_id)
+    if visited != len(edges):
+        raise ValueError(message)
+
+
+def _scope_revision(sources: list[ScopedTrajectoryEvidence]) -> str:
+    records = [
+        {
+            "tenant_id": source.session_ref.tenant_id,
+            "task_scope_id": source.session_ref.task_scope_id,
+            "source_scope_id": source.session_ref.source_scope_id,
+            "traj_id": source.session_ref.traj_id,
+            "source_revision": source.source_revision,
+        }
+        for source in sorted(
+            sources,
+            key=attrgetter(
+                "session_ref.source_scope_id", "session_ref.traj_id",
+            ),
+        )
+    ]
+    payload = json.dumps(
+        records, ensure_ascii=False, sort_keys=True, separators=(",", ":"),
+    ).encode("utf-8")
+    return hashlib.sha256(payload).hexdigest()
+
+
+class TaskGraphService:
+    """Consume durable changes, publish facts, then atomically project queries."""
+
+    def __init__(
+        self,
+        *,
+        state_root: Path,
+        db_path: Path | None = None,
+        server_mode: bool = False,
+        config: dict | None = None,
+    ):
+        self.state_root = Path(state_root).expanduser().resolve()
+        self.db_path = Path(db_path) if db_path is not None else None
+        self.server_mode = bool(server_mode)
+        if config is not None and not isinstance(config, dict):
+            raise ValueError("Task Graph config must be a mapping")
+        self.config = config or {}
+        task_config = self.config.get("task_graph") or {}
+        if not isinstance(task_config, dict):
+            raise ValueError("task_graph config must be a mapping")
+        enabled = task_config.get("enabled", False)
+        if not isinstance(enabled, bool):
+            raise ValueError("task_graph.enabled must be a boolean")
+        self.enabled = enabled
+
+        def positive_integer(name: str, default: int) -> int:
+            value = task_config.get(name, default)
+            if isinstance(value, bool) or not isinstance(value, int) or value <= 0:
+                raise ValueError(f"task_graph.{name} must be a positive integer")
+            return value
+
+        self.max_scopes_per_run = positive_integer("max_scopes_per_run", 4)
+        self.source_cache_size = positive_integer("source_cache_size", 128)
+        self._backfill_enqueued = False
+        self._evidence_cache: OrderedDict[
+            tuple[str, str], ScopedTrajectoryEvidence
+        ] = OrderedDict()
+        self._stores: OrderedDict[str, TaskGraphStore] = OrderedDict()
+        self.resolver = ScopeResolver(
+            self.state_root,
+            db_path=self.db_path,
+            server_mode=self.server_mode,
+        )
+        self.linker = BoundedTaskLinker(
+            top_k=positive_integer("top_k", 8),
+            recent_k=positive_integer("recent_k", 6),
+            posting_cap=positive_integer("posting_cap", 64),
+        )
+
+    def store_for_scope(self, task_scope_id: str) -> TaskGraphStore:
+        store = self._stores.get(task_scope_id)
+        if store is None:
+            store = TaskGraphStore(self.resolver.scope_dir(task_scope_id))
+            self._stores[task_scope_id] = store
+            while len(self._stores) > 128:
+                self._stores.popitem(last=False)
+        else:
+            self._stores.move_to_end(task_scope_id)
+        return store
+
+    def _cache_evidence(self, evidence: ScopedTrajectoryEvidence) -> None:
+        key = (
+            evidence.session_ref.source_scope_id,
+            evidence.session_ref.traj_id,
+        )
+        self._evidence_cache[key] = evidence
+        self._evidence_cache.move_to_end(key)
+        while len(self._evidence_cache) > self.source_cache_size:
+            self._evidence_cache.popitem(last=False)
+
+    def mark_dirty(
+        self, watch_dir_id: int, filename: str, *, reason: str,
+        deleted: bool = False,
+    ) -> None:
+        # Keep the durable source fence while disabled so a later enable does
+        # not miss changes to an already-projected trajectory.
+        mark_task_graph_dirty(
+            watch_dir_id, filename, reason=reason, deleted=deleted,
+            tracked_only=not self.enabled,
+            db_path=self.db_path,
+        )
+
+    def ensure_backfill_enqueued(self) -> int:
+        """Queue pre-existing Atom sources exactly once for this worker."""
+        if not self.enabled or self._backfill_enqueued:
+            return 0
+        queued = enqueue_untracked_sources(db_path=self.db_path)
+        self._backfill_enqueued = True
+        return queued
+
+    def process_dirty(self, *, max_sources: int = 128) -> dict:
+        if not self.enabled:
+            return {"enabled": False, "sources": 0, "scopes": 0}
+        self.ensure_backfill_enqueued()
+        dirty_rows = list_dirty_sources(
+            limit=max_sources, db_path=self.db_path,
+        )
+        dirty_scope_rows = list_dirty_task_scopes(
+            limit=self.max_scopes_per_run,
+            db_path=self.db_path,
+        )
+        if not dirty_rows and not dirty_scope_rows:
+            return {"enabled": True, "sources": 0, "scopes": 0}
+
+        resolved: dict[tuple[int, str], ScopedTrajectoryEvidence | None] = {}
+        collection_failed: set[tuple[int, str]] = set()
+        old_scopes_by_key: dict[tuple[int, str], tuple[str, str] | None] = {}
+        for row in dirty_rows:
+            key = (int(row["watch_dir_id"]), str(row["filename"]))
+            old_scope = self._old_scope(row)
+            old_scopes_by_key[key] = old_scope
+            if row.get("deleted"):
+                resolved[key] = None
+                source_scope_id = str(row.get("source_scope_id") or "")
+                filename = str(row["filename"])
+                traj_id = filename.removesuffix(".md")
+                self._evidence_cache.pop((source_scope_id, traj_id), None)
+                continue
+            live = live_source_row(*key, db_path=self.db_path)
+            if live is None:
+                resolved[key] = None
+                source_scope_id = str(row.get("source_scope_id") or "")
+                filename = str(row["filename"])
+                self._evidence_cache.pop(
+                    (source_scope_id, filename.removesuffix(".md")), None,
+                )
+                continue
+            watch_dir, trajectory = live
+            try:
+                scope = self.resolver.resolve(
+                    watch_dir=watch_dir, trajectory=trajectory,
+                )
+                evidence = collect_trajectory_evidence(
+                    watch_dir=watch_dir, trajectory=trajectory, scope=scope,
+                )
+            except FileNotFoundError:
+                logger.info(
+                    "Task Graph source disappeared before collection: %s/%s",
+                    watch_dir.get("path"), row["filename"],
+                )
+                evidence = None
+            except (OSError, RuntimeError, ValueError):
+                logger.warning(
+                    "Task Graph source collection failed; source remains dirty: %s/%s",
+                    watch_dir.get("path"), row["filename"], exc_info=True,
+                )
+                collection_failed.add(key)
+                continue
+            resolved[key] = evidence
+            if evidence is not None:
+                self._cache_evidence(evidence)
+
+        selected_scope_set: set[tuple[str, str]] = {
+            (str(row["tenant_id"]), str(row["task_scope_id"]))
+            for row in dirty_scope_rows
+        }
+        for row in dirty_rows:
+            key = (int(row["watch_dir_id"]), str(row["filename"]))
+            if key in collection_failed:
+                continue
+            current = resolved.get(key)
+            row_scopes = {
+                scope for scope in (
+                    old_scopes_by_key.get(key),
+                    (
+                        (current.scope.tenant_id, current.scope.task_scope_id)
+                        if current is not None else None
+                    ),
+                ) if scope is not None
+            }
+            proposed = selected_scope_set | row_scopes
+            if (
+                selected_scope_set
+                and len(proposed) > self.max_scopes_per_run
+            ):
+                continue
+            selected_scope_set = proposed
+        selected_scopes = sorted(selected_scope_set)
+        processed_rows: list[dict] = []
+        built = []
+        failed_scopes = []
+        successful_scope_set: set[tuple[str, str]] = set()
+        for tenant_id, task_scope_id in selected_scopes:
+            try:
+                generation, source_count = self._rebuild_scope(
+                    tenant_id, task_scope_id, resolved,
+                )
+            except (OSError, RuntimeError, ValueError):
+                logger.exception(
+                    "Task Graph scope rebuild failed; durable sources remain dirty: %s",
+                    task_scope_id,
+                )
+                failed_scopes.append(task_scope_id)
+                continue
+            successful_scope_set.add((tenant_id, task_scope_id))
+            built.append({
+                "tenant_id": tenant_id,
+                "task_scope_id": task_scope_id,
+                "generation_id": generation.generation_id,
+                "sources": source_count,
+                "tasks": generation.metrics.get("task_count", 0),
+                "atoms": generation.metrics.get("atom_count", 0),
+            })
+        for row in dirty_rows:
+            key = (int(row["watch_dir_id"]), str(row["filename"]))
+            if key in collection_failed:
+                continue
+            old_scope = old_scopes_by_key.get(key)
+            current = resolved.get(key)
+            current_scope = (
+                (current.scope.tenant_id, current.scope.task_scope_id)
+                if current is not None else None
+            )
+            row_scopes = {scope for scope in (old_scope, current_scope) if scope is not None}
+            if not row_scopes or row_scopes.issubset(successful_scope_set):
+                processed_rows.append(row)
+        acknowledge_dirty_sources(processed_rows, db_path=self.db_path)
+        processed_scope_rows = [
+            row for row in dirty_scope_rows
+            if (str(row["tenant_id"]), str(row["task_scope_id"]))
+            in successful_scope_set
+        ]
+        acknowledge_dirty_task_scopes(
+            processed_scope_rows, db_path=self.db_path,
+        )
+        return {
+            "enabled": True,
+            "sources": len(processed_rows),
+            "scopes": len(built),
+            "override_scopes": len(processed_scope_rows),
+            "failed_scopes": failed_scopes,
+            "generations": built,
+        }
+
+    def _old_scope(self, row: dict) -> tuple[str, str] | None:
+        tenant_id = str(row.get("tenant_id") or "")
+        task_scope_id = str(row.get("task_scope_id") or "")
+        if tenant_id and task_scope_id:
+            return tenant_id, task_scope_id
+        source_scope_id = str(row.get("source_scope_id") or "")
+        filename = str(row.get("filename") or "")
+        traj_id = filename.removesuffix(".md")
+        if not source_scope_id:
+            return None
+        from xskill.pipeline.registry import pooled_connection
+
+        with pooled_connection(self.db_path) as connection:
+            state = connection.execute(
+                "SELECT tenant_id,task_scope_id FROM task_graph_source_state"
+                " WHERE source_scope_id=? AND traj_id=?",
+                (source_scope_id, traj_id),
+            ).fetchone()
+        return (
+            (str(state["tenant_id"]), str(state["task_scope_id"]))
+            if state is not None else None
+        )
+
+    def _sources_for_scope(
+        self,
+        tenant_id: str,
+        task_scope_id: str,
+        resolved_dirty: dict[tuple[int, str], ScopedTrajectoryEvidence | None],
+    ) -> list[ScopedTrajectoryEvidence]:
+        sources: dict[tuple[str, str], ScopedTrajectoryEvidence] = {}
+        states = source_states_for_scope(
+            tenant_id, task_scope_id, db_path=self.db_path,
+        )
+        for state in states:
+            filename = f"{state['traj_id']}.md"
+            dirty_key = (int(state["watch_dir_id"]), filename)
+            if dirty_key in resolved_dirty:
+                evidence = resolved_dirty[dirty_key]
+            else:
+                source_key = (
+                    str(state["source_scope_id"]), str(state["traj_id"]),
+                )
+                cached = self._evidence_cache.get(source_key)
+                if (
+                    cached is not None
+                    and cached.source_revision == state["source_revision"]
+                ):
+                    self._evidence_cache.move_to_end(source_key)
+                    evidence = cached
+                    sources[source_key] = evidence
+                    continue
+                live = live_source_row(*dirty_key, db_path=self.db_path)
+                if live is None:
+                    evidence = None
+                else:
+                    watch_dir, trajectory = live
+                    scope = self.resolver.resolve(
+                        watch_dir=watch_dir, trajectory=trajectory,
+                    )
+                    if (
+                        scope.tenant_id == tenant_id
+                        and scope.task_scope_id == task_scope_id
+                    ):
+                        try:
+                            evidence = collect_trajectory_evidence(
+                                watch_dir=watch_dir,
+                                trajectory=trajectory,
+                                scope=scope,
+                            )
+                            self._cache_evidence(evidence)
+                        except FileNotFoundError:
+                            evidence = None
+                    else:
+                        evidence = None
+            if (
+                evidence is not None
+                and evidence.scope.tenant_id == tenant_id
+                and evidence.scope.task_scope_id == task_scope_id
+            ):
+                sources[(
+                    evidence.session_ref.source_scope_id,
+                    evidence.session_ref.traj_id,
+                )] = evidence
+        for evidence in resolved_dirty.values():
+            if evidence is None:
+                continue
+            if (
+                evidence.scope.tenant_id == tenant_id
+                and evidence.scope.task_scope_id == task_scope_id
+            ):
+                sources[(
+                    evidence.session_ref.source_scope_id,
+                    evidence.session_ref.traj_id,
+                )] = evidence
+        return sorted(
+            sources.values(),
+            key=attrgetter(
+                "session_ref.source_scope_id", "session_ref.traj_id",
+            ),
+        )
+
+    def _rebuild_scope(
+        self,
+        tenant_id: str,
+        task_scope_id: str,
+        resolved_dirty: dict[
+            tuple[int, str], ScopedTrajectoryEvidence | None
+        ],
+    ):
+        store = self.store_for_scope(task_scope_id)
+        with task_file_lock(store.lock_path):
+            sources = self._sources_for_scope(
+                tenant_id, task_scope_id, resolved_dirty,
+            )
+            generation = self._build_scope(
+                tenant_id, task_scope_id, sources,
+            )
+            return generation, len(sources)
+
+    def _build_scope(
+        self,
+        tenant_id: str,
+        task_scope_id: str,
+        sources: list[ScopedTrajectoryEvidence],
+    ):
+        store = self.store_for_scope(task_scope_id)
+        previous = store.load_current()
+        overrides = store.read_overrides()
+        if any(
+            event.tenant_id != tenant_id
+            or event.task_scope_id != task_scope_id
+            for event in overrides
+        ):
+            raise RuntimeError("Task Graph override log contains a cross-scope event")
+        source_revision = _scope_revision(sources)
+        if (
+            previous is not None
+            and previous.source_revision == source_revision
+            and previous.base_override_seq == (overrides[-1].override_seq if overrides else 0)
+        ):
+            generation = previous
+            should_publish = False
+        else:
+            generation = self.linker.build(
+                tenant_id=tenant_id,
+                task_scope_id=task_scope_id,
+                trajectories=sources,
+                previous=previous,
+                overrides=overrides,
+                source_revision=source_revision,
+            )
+            should_publish = True
+        upsert_execution_usage_events(
+            (
+                event for source in sources for event in source.usage_events
+            ),
+            db_path=self.db_path,
+        )
+        if should_publish:
+            store.publish(generation)
+        project_generation(
+            generation, sources=sources, db_path=self.db_path,
+        )
+        logger.info(
+            "Task Graph published scope=%s generation=%s sources=%d atoms=%d tasks=%d",
+            task_scope_id,
+            generation.generation_id,
+            len(sources),
+            generation.metrics.get("atom_count", 0),
+            generation.metrics.get("task_count", 0),
+        )
+        return generation
+
+    def append_override(
+        self,
+        *,
+        task_scope_id: str,
+        operation: str,
+        target_id: str,
+        payload: dict,
+        actor: str,
+        evidence_refs=(),
+        event_id: str | None = None,
+    ) -> OverrideEvent:
+        if not self.enabled:
+            raise RuntimeError("Task Graph is disabled by task_graph.enabled")
+        store = self.store_for_scope(task_scope_id)
+        with task_file_lock(store.lock_path):
+            return self._append_override_locked(
+                store=store,
+                task_scope_id=task_scope_id,
+                operation=operation,
+                target_id=target_id,
+                payload=payload,
+                actor=actor,
+                evidence_refs=evidence_refs,
+                event_id=event_id,
+            )
+
+    def _append_override_locked(
+        self,
+        *,
+        store: TaskGraphStore,
+        task_scope_id: str,
+        operation: str,
+        target_id: str,
+        payload: dict,
+        actor: str,
+        evidence_refs,
+        event_id: str | None,
+    ) -> OverrideEvent:
+        current = store.load_current()
+        if current is None:
+            raise KeyError(f"TaskScope has no current graph: {task_scope_id}")
+        if current.tenant_id != self.resolver.tenant_id:
+            raise ValueError("TaskScope does not belong to this xskill tenant")
+        if current.task_scope_id != task_scope_id:
+            raise ValueError("TaskScope store identity does not match the request")
+        if not isinstance(actor, str) or not actor.strip():
+            raise ValueError("override actor must be a non-empty string")
+        actor = actor.strip()
+        if not isinstance(target_id, str) or not target_id.strip():
+            raise ValueError("override target_id must be a non-empty string")
+        target_id = target_id.strip()
+        if len(actor) > 200 or len(target_id) > 200:
+            raise ValueError("override actor and target_id are limited to 200 characters")
+        if not isinstance(payload, dict):
+            raise ValueError("override payload must be an object")
+        try:
+            payload_size = len(json.dumps(
+                payload,
+                ensure_ascii=False,
+                sort_keys=True,
+                separators=(",", ":"),
+                allow_nan=False,
+            ).encode("utf-8"))
+        except (TypeError, ValueError) as error:
+            raise ValueError("override payload must be strict JSON") from error
+        if payload_size > 65_536:
+            raise ValueError("override payload is limited to 64 KiB")
+        if isinstance(evidence_refs, (str, bytes)):
+            raise ValueError("override evidence_refs must be an iterable of strings")
+        evidence_refs = tuple(evidence_refs)
+        if len(evidence_refs) > 100 or any(
+            not isinstance(item, str) or not item or len(item) > 200
+            for item in evidence_refs
+        ):
+            raise ValueError(
+                "override evidence_refs are limited to 100 non-empty 200-character ids"
+            )
+        if event_id is not None:
+            if not isinstance(event_id, str) or not event_id.strip():
+                raise ValueError("override event_id must be a non-empty string")
+            event_id = event_id.strip()
+            if len(event_id) > 200:
+                raise ValueError("override event_id is limited to 200 characters")
+        if event_id:
+            for existing in store.read_overrides():
+                if existing.event_id != event_id:
+                    continue
+                supplied_payload = dict(payload or {})
+                for unordered_field in ("task_ids", "atom_keys"):
+                    supplied = supplied_payload.get(unordered_field)
+                    if isinstance(supplied, list) and all(
+                        isinstance(item, str) for item in supplied
+                    ):
+                        supplied_payload[unordered_field] = sorted(set(supplied))
+                compatible_payload = all(
+                    existing.payload.get(key) == value
+                    for key, value in supplied_payload.items()
+                )
+                if not (
+                    existing.tenant_id == current.tenant_id
+                    and existing.task_scope_id == task_scope_id
+                    and existing.operation == operation
+                    and existing.target_id == target_id
+                    and existing.actor == actor
+                    and existing.evidence_refs == evidence_refs
+                    and compatible_payload
+                ):
+                    raise ValueError(
+                        "override event_id already exists with different content"
+                    )
+                self._rebuild_after_override(
+                    current=current,
+                    task_scope_id=task_scope_id,
+                )
+                return existing
+        normalized_payload = self._validate_override(
+            current, operation, target_id, payload,
+        )
+        dirty_scope = mark_task_graph_scope_dirty(
+            current.tenant_id,
+            task_scope_id,
+            reason="manual_override",
+            db_path=self.db_path,
+        )
+        event = store.append_override(
+            tenant_id=current.tenant_id,
+            task_scope_id=task_scope_id,
+            operation=operation,
+            target_id=target_id,
+            payload=normalized_payload,
+            evidence_refs=evidence_refs,
+            actor=actor,
+            event_id=event_id,
+        )
+        self._rebuild_after_override(
+            current=current,
+            task_scope_id=task_scope_id,
+            dirty_scope=dirty_scope,
+        )
+        return event
+
+    def _rebuild_after_override(
+        self, *, current, task_scope_id: str, dirty_scope: dict | None = None,
+    ) -> None:
+        """Fence and materialize an override, including idempotent retries."""
+        if dirty_scope is None:
+            dirty_scope = mark_task_graph_scope_dirty(
+                current.tenant_id,
+                task_scope_id,
+                reason="manual_override_retry",
+                db_path=self.db_path,
+            )
+        states = source_states_for_scope(
+            current.tenant_id, task_scope_id, db_path=self.db_path,
+        )
+        if states:
+            first = states[0]
+            mark_task_graph_dirty(
+                int(first["watch_dir_id"]), f"{first['traj_id']}.md",
+                reason="manual_override", db_path=self.db_path,
+            )
+        self._rebuild_scope(current.tenant_id, task_scope_id, {})
+        acknowledge_dirty_task_scopes(
+            [dirty_scope], db_path=self.db_path,
+        )
+
+    @staticmethod
+    def _validate_override(current, operation: str, target_id: str, payload: dict) -> dict:
+        normalized = dict(payload or {})
+        tasks = {task.task_id: task for task in current.tasks}
+        attempts = {attempt.attempt_id: attempt for attempt in current.attempts}
+        memberships = {
+            membership.membership_id: membership
+            for membership in current.memberships
+        }
+        relations = {
+            relation.relation_id: relation for relation in current.relations
+        }
+        attempt_relations = {
+            relation.relation_id: relation
+            for relation in current.attempt_relations
+        }
+
+        def only_fields(allowed: set[str]) -> None:
+            unknown = set(normalized) - allowed
+            if unknown:
+                raise ValueError(
+                    f"unsupported {operation} payload fields: {sorted(unknown)!r}"
+                )
+
+        def required_id(field_name: str, *, fallback: str | None = None) -> str:
+            value = normalized.get(field_name, fallback)
+            if not isinstance(value, str) or not value.strip():
+                raise ValueError(
+                    f"{operation} {field_name} must be a non-empty string"
+                )
+            value = value.strip()
+            if len(value) > 200:
+                raise ValueError(
+                    f"{operation} {field_name} is limited to 200 characters"
+                )
+            return value
+
+        def required_id_set(field_name: str) -> set[str]:
+            value = normalized.get(field_name)
+            if not isinstance(value, list):
+                raise ValueError(f"{operation} {field_name} must be a JSON list")
+            if not value:
+                raise ValueError(f"{operation} {field_name} cannot be empty")
+            if any(
+                not isinstance(item, str)
+                or not item.strip()
+                or len(item.strip()) > 200
+                for item in value
+            ):
+                raise ValueError(
+                    f"{operation} {field_name} must contain non-empty strings "
+                    "of at most 200 characters"
+                )
+            return {item.strip() for item in value}
+
+        if operation in {"confirm_membership", "reject_membership"}:
+            only_fields({"atom_key", "atom_ref", "task_id", "role"})
+            membership = memberships.get(target_id)
+            if membership is not None:
+                expected = {
+                    "atom_key": stable_ref_key(membership.atom_ref),
+                    "atom_ref": membership.atom_ref.to_dict(),
+                    "task_id": membership.task_id,
+                    "role": membership.role,
+                }
+                for field_name, field_value in expected.items():
+                    supplied = normalized.get(field_name)
+                    if supplied is not None and supplied != field_value:
+                        raise ValueError(
+                            "membership override payload conflicts with target "
+                            f"{field_name}"
+                        )
+                normalized.update(expected)
+            if not normalized.get("task_id") or normalized["task_id"] not in tasks:
+                raise ValueError("membership override references a missing Task")
+            if normalized.get("role") not in {"primary", "context"}:
+                raise ValueError("membership role must be primary or context")
+            if not normalized.get("atom_key") or not isinstance(
+                normalized.get("atom_ref"), dict,
+            ):
+                raise ValueError("membership override requires a scoped Atom reference")
+            try:
+                from xskill.tasks.models import AtomRef
+
+                atom_ref = AtomRef.from_dict(normalized["atom_ref"])
+            except (KeyError, TypeError, ValueError) as error:
+                raise ValueError("membership override has an invalid AtomRef") from error
+            if stable_ref_key(atom_ref) != normalized["atom_key"]:
+                raise ValueError("membership atom_key does not match atom_ref")
+            if (
+                atom_ref.tenant_id != current.tenant_id
+                or atom_ref.task_scope_id != current.task_scope_id
+            ):
+                raise ValueError("membership override cannot cross TaskScope")
+            known_atom_keys = {
+                stable_ref_key(item.atom_ref) for item in current.memberships
+            }
+            if normalized["atom_key"] not in known_atom_keys:
+                raise ValueError("membership override references a missing scoped Atom")
+            return normalized
+
+        if operation == "set_task_state":
+            only_fields({"lifecycle", "outcome", "verification", "user_disposition"})
+            if target_id not in tasks:
+                raise ValueError("Task state override references a missing Task")
+            choices = {
+                "lifecycle": TASK_LIFECYCLES,
+                "outcome": TASK_OUTCOMES,
+                "verification": VERIFICATIONS,
+                "user_disposition": USER_DISPOSITIONS,
+            }
+            if not normalized:
+                raise ValueError("Task state override must change at least one dimension")
+            for field_name, value in normalized.items():
+                if value not in choices[field_name]:
+                    raise ValueError(f"invalid Task {field_name}: {value!r}")
+            task = tasks[target_id]
+            if "outcome" in normalized and "lifecycle" not in normalized:
+                normalized["lifecycle"] = (
+                    "open" if normalized["outcome"] == "unknown" else "closed"
+                )
+            if normalized.get("lifecycle") in {"open", "blocked"}:
+                normalized.setdefault("outcome", "unknown")
+            effective_lifecycle = normalized.get("lifecycle", task.lifecycle)
+            effective_outcome = normalized.get("outcome", task.outcome)
+            if (
+                effective_lifecycle in {"open", "blocked"}
+                and effective_outcome != "unknown"
+            ):
+                raise ValueError("open or blocked Task outcome must be unknown")
+            if effective_lifecycle == "closed" and effective_outcome == "unknown":
+                raise ValueError("closed Task requires a terminal outcome")
+            return normalized
+
+        if operation == "set_attempt_state":
+            only_fields({"lifecycle", "outcome", "verification", "user_disposition"})
+            if target_id not in attempts:
+                raise ValueError("Attempt state override references a missing Attempt")
+            choices = {
+                "lifecycle": ATTEMPT_LIFECYCLES,
+                "outcome": ATTEMPT_OUTCOMES,
+                "verification": VERIFICATIONS,
+                "user_disposition": USER_DISPOSITIONS,
+            }
+            if not normalized:
+                raise ValueError("Attempt state override must change at least one dimension")
+            for field_name, value in normalized.items():
+                if value not in choices[field_name]:
+                    raise ValueError(f"invalid Attempt {field_name}: {value!r}")
+            if normalized.get("lifecycle") == "running":
+                if normalized.get("outcome", "unknown") != "unknown":
+                    raise ValueError("running Attempt outcome must be unknown")
+                normalized.setdefault("outcome", "unknown")
+                normalized.setdefault("verification", "unverified")
+            elif (
+                attempts[target_id].lifecycle == "running"
+                and normalized.get("outcome") not in (None, "unknown")
+            ):
+                normalized.setdefault("lifecycle", "finished")
+            return normalized
+
+        if operation == "upsert_attempt_relation":
+            only_fields({"from_attempt_id", "to_attempt_id", "relation_type"})
+            from_attempt_id = required_id(
+                "from_attempt_id", fallback=target_id,
+            )
+            to_attempt_id = required_id("to_attempt_id")
+            relation_type = required_id("relation_type")
+            if from_attempt_id not in attempts or to_attempt_id not in attempts:
+                raise ValueError("Attempt relation references a missing Attempt")
+            if from_attempt_id == to_attempt_id:
+                raise ValueError("Attempt relation cannot point to itself")
+            if attempts[from_attempt_id].task_id != attempts[to_attempt_id].task_id:
+                raise ValueError("Attempt relations cannot cross Logical Tasks")
+            if relation_type not in ATTEMPT_RELATION_TYPES:
+                raise ValueError(
+                    f"invalid Attempt relation type: {relation_type!r}"
+                )
+            normalized.update({
+                "from_attempt_id": from_attempt_id,
+                "to_attempt_id": to_attempt_id,
+                "relation_type": relation_type,
+            })
+            TaskGraphService._validate_attempt_relation_dag(
+                current, from_attempt_id, to_attempt_id, relation_type,
+            )
+            return normalized
+
+        if operation == "reject_attempt_relation":
+            only_fields(set())
+            if target_id not in attempt_relations:
+                raise ValueError("Attempt relation override references a missing relation")
+            return normalized
+
+        if operation == "upsert_task_relation":
+            only_fields({"from_task_id", "to_task_id", "relation_type"})
+            from_task_id = required_id("from_task_id", fallback=target_id)
+            to_task_id = required_id("to_task_id")
+            relation_type = required_id("relation_type")
+            if from_task_id not in tasks or to_task_id not in tasks:
+                raise ValueError("Task relation references a missing Task")
+            if from_task_id == to_task_id:
+                raise ValueError("Task relation cannot point to itself")
+            if relation_type not in TASK_RELATION_TYPES:
+                raise ValueError(f"invalid Task relation type: {relation_type!r}")
+            normalized.update({
+                "from_task_id": from_task_id,
+                "to_task_id": to_task_id,
+                "relation_type": relation_type,
+            })
+            TaskGraphService._validate_relation_dag(
+                current, from_task_id, to_task_id, relation_type,
+            )
+            return normalized
+
+        if operation == "reject_task_relation":
+            only_fields(set())
+            if target_id not in relations:
+                raise ValueError("relation override references a missing relation")
+            return normalized
+
+        if operation == "merge_tasks":
+            only_fields({"task_ids"})
+            task_ids = required_id_set("task_ids")
+            if target_id not in tasks:
+                raise ValueError("merge requires a canonical Task and at least one source Task")
+            if target_id in task_ids or not task_ids.issubset(tasks):
+                raise ValueError("merge references an invalid source Task")
+            TaskGraphService._validate_merge_dag(
+                current, target_id, task_ids,
+            )
+            normalized["task_ids"] = sorted(task_ids)
+            return normalized
+
+        if operation == "move_atoms":
+            only_fields({"target_task_id", "atom_keys"})
+            target_task_id = required_id(
+                "target_task_id", fallback=target_id,
+            )
+            atom_keys = required_id_set("atom_keys")
+            known_atom_keys = {
+                stable_ref_key(membership.atom_ref)
+                for membership in current.memberships
+            }
+            if target_task_id not in tasks:
+                raise ValueError("move_atoms references a missing target Task")
+            if not atom_keys or not atom_keys.issubset(known_atom_keys):
+                raise ValueError("move_atoms references missing scoped Atoms")
+            TaskGraphService._validate_atom_move(
+                current, atom_keys, target_task_id,
+            )
+            normalized["target_task_id"] = target_task_id
+            normalized["atom_keys"] = sorted(atom_keys)
+            normalized["atom_refs"] = TaskGraphService._atom_ref_payloads(
+                current, atom_keys,
+            )
+            return normalized
+
+        if operation == "split_task":
+            only_fields({"atom_keys", "title", "summary"})
+            if target_id not in tasks:
+                raise ValueError("split_task references a missing source Task")
+            atom_keys = required_id_set("atom_keys")
+            source_atom_keys = {
+                stable_ref_key(membership.atom_ref)
+                for membership in current.memberships
+                if membership.task_id == target_id
+                and membership.role == "primary"
+                and membership.decision == "confirmed"
+                and not membership.stale
+            }
+            if not atom_keys or not atom_keys < source_atom_keys:
+                raise ValueError(
+                    "split_task must move a non-empty proper subset of source Atoms"
+                )
+            TaskGraphService._validate_atom_move(
+                current, atom_keys, "__new_split_task__",
+            )
+            title = normalized.get("title", tasks[target_id].title)
+            summary = normalized.get("summary", tasks[target_id].summary)
+            if not isinstance(title, str) or not isinstance(summary, str):
+                raise ValueError("split_task title and summary must be strings")
+            normalized.update({
+                "atom_keys": sorted(atom_keys),
+                "atom_refs": TaskGraphService._atom_ref_payloads(
+                    current, atom_keys,
+                ),
+                "new_task_id": f"tsk_{uuid.uuid4().hex}",
+                "title": title[:240],
+                "summary": summary[:1000],
+            })
+            return normalized
+
+        raise ValueError(f"unknown Task Graph override operation: {operation!r}")
+
+    @staticmethod
+    def _atom_ref_payloads(current, atom_keys: set[str]) -> dict[str, dict]:
+        result = {}
+        for membership in current.memberships:
+            atom_key = stable_ref_key(membership.atom_ref)
+            if atom_key in atom_keys:
+                result[atom_key] = membership.atom_ref.to_dict()
+        if set(result) != atom_keys:
+            raise ValueError("override cannot resolve every scoped Atom reference")
+        return result
+
+    @staticmethod
+    def _validate_atom_move(
+        current, atom_keys: set[str], target_task_id: str,
+    ) -> None:
+        owner_by_atom = {
+            stable_ref_key(membership.atom_ref): membership.task_id
+            for membership in current.memberships
+            if membership.role == "primary"
+            and membership.decision == "confirmed"
+            and not membership.stale
+        }
+        attempt_atom_keys: dict[str, set[str]] = {}
+        attempt_task_ids: dict[str, str] = {}
+        for attempt in current.attempts:
+            keys = {
+                stable_ref_key(evidence.atom_ref)
+                for evidence in attempt.evidence_ranges
+                if evidence.atom_ref is not None and not evidence.stale
+            }
+            if keys:
+                attempt_atom_keys[attempt.attempt_id] = keys
+                attempt_task_ids[attempt.attempt_id] = attempt.task_id
+            overlap = keys & atom_keys
+            if overlap and overlap != keys:
+                raise ValueError(
+                    "Atom move cannot divide one existing Attempt; split or "
+                    "correct the Attempt boundary first"
+                )
+        moved_attempt_ids = {
+            attempt_id
+            for attempt_id, keys in attempt_atom_keys.items()
+            if keys and keys <= atom_keys
+        }
+        resulting_task = {
+            attempt_id: (
+                target_task_id
+                if attempt_id in moved_attempt_ids
+                else attempt_task_ids[attempt_id]
+            )
+            for attempt_id in attempt_task_ids
+        }
+        for relation in current.attempt_relations:
+            if (
+                relation.decision != "confirmed"
+                or not relation.decided_by.startswith("human:")
+            ):
+                continue
+            if (
+                resulting_task.get(relation.from_attempt_id)
+                != resulting_task.get(relation.to_attempt_id)
+            ):
+                raise ValueError(
+                    "Atom move would separate a human-confirmed Attempt relation"
+                )
+        if not atom_keys.issubset(owner_by_atom):
+            raise ValueError("Atom move requires live confirmed primary ownership")
+
+    @staticmethod
+    def _validate_relation_dag(
+        current, from_task_id: str, to_task_id: str, relation_type: str,
+    ) -> None:
+        if relation_type in {"parent", "subtask"}:
+            child_id = (
+                to_task_id if relation_type == "parent" else from_task_id
+            )
+            parent_id = (
+                from_task_id if relation_type == "parent" else to_task_id
+            )
+            for relation in current.relations:
+                if (
+                    relation.decision != "confirmed"
+                    or relation.stale
+                    or relation.relation_type not in {"parent", "subtask"}
+                ):
+                    continue
+                existing_child = (
+                    relation.to_task_id
+                    if relation.relation_type == "parent"
+                    else relation.from_task_id
+                )
+                existing_parent = (
+                    relation.from_task_id
+                    if relation.relation_type == "parent"
+                    else relation.to_task_id
+                )
+                if existing_child == child_id and existing_parent != parent_id:
+                    raise ValueError(
+                        "a Task may have at most one confirmed primary parent"
+                    )
+        edges: dict[str, set[str]] = {
+            task.task_id: set() for task in current.tasks
+        }
+        for relation in current.relations:
+            if relation.decision != "confirmed" or relation.stale:
+                continue
+            if (
+                relation.from_task_id == from_task_id
+                and relation.to_task_id == to_task_id
+                and relation.relation_type == relation_type
+            ):
+                continue
+            edge_from, edge_to = _task_relation_edge(
+                relation.from_task_id,
+                relation.to_task_id,
+                relation.relation_type,
+            )
+            edges[edge_from].add(edge_to)
+        edge_from, edge_to = _task_relation_edge(
+            from_task_id, to_task_id, relation_type,
+        )
+        edges[edge_from].add(edge_to)
+        _require_acyclic(
+            edges, "confirmed Task relations must form a DAG",
+        )
+
+    @staticmethod
+    def _validate_attempt_relation_dag(
+        current, from_attempt_id: str, to_attempt_id: str,
+        relation_type: str,
+    ) -> None:
+        edges: dict[str, set[str]] = {
+            attempt.attempt_id: set() for attempt in current.attempts
+        }
+        for relation in current.attempt_relations:
+            if relation.decision != "confirmed":
+                continue
+            if (
+                relation.from_attempt_id == from_attempt_id
+                and relation.to_attempt_id == to_attempt_id
+                and relation.relation_type == relation_type
+            ):
+                continue
+            edges[relation.from_attempt_id].add(relation.to_attempt_id)
+        edges[from_attempt_id].add(to_attempt_id)
+        _require_acyclic(
+            edges, "confirmed Attempt relations must form a DAG",
+        )
+
+    @staticmethod
+    def _validate_merge_dag(current, canonical_id: str, merge_ids: set[str]) -> None:
+        def canonical(task_id: str) -> str:
+            return canonical_id if task_id in merge_ids else task_id
+
+        edges: dict[str, set[str]] = {
+            canonical(task.task_id): set() for task in current.tasks
+        }
+        parent_by_child: dict[str, str] = {}
+        for relation in current.relations:
+            if relation.decision != "confirmed" or relation.stale:
+                continue
+            from_task_id = canonical(relation.from_task_id)
+            to_task_id = canonical(relation.to_task_id)
+            if from_task_id == to_task_id:
+                continue
+            edge_from, edge_to = _task_relation_edge(
+                from_task_id, to_task_id, relation.relation_type,
+            )
+            edges[edge_from].add(edge_to)
+            if relation.relation_type in {"parent", "subtask"}:
+                child_id = (
+                    to_task_id
+                    if relation.relation_type == "parent"
+                    else from_task_id
+                )
+                parent_id = (
+                    from_task_id
+                    if relation.relation_type == "parent"
+                    else to_task_id
+                )
+                existing = parent_by_child.setdefault(child_id, parent_id)
+                if existing != parent_id:
+                    raise ValueError(
+                        "merge would give a Task more than one primary parent"
+                    )
+        _require_acyclic(edges, "merge would create a Task relation cycle")

--- a/src/xskill/tasks/service.py
+++ b/src/xskill/tasks/service.py
@@ -29,6 +29,7 @@ from xskill.tasks.models import (
 from xskill.tasks.projection import (
     acknowledge_dirty_task_scopes,
     acknowledge_dirty_sources,
+    enqueue_changed_generator_scopes,
     enqueue_untracked_sources,
     list_dirty_task_scopes,
     list_dirty_sources,
@@ -182,6 +183,13 @@ class TaskGraphService:
         if not self.enabled or self._backfill_enqueued:
             return 0
         queued = enqueue_untracked_sources(db_path=self.db_path)
+        tenant_id = self.resolver.existing_tenant_id
+        if tenant_id is not None:
+            queued += enqueue_changed_generator_scopes(
+                tenant_id,
+                self.linker.generator_descriptor(),
+                db_path=self.db_path,
+            )
         self._backfill_enqueued = True
         return queued
 
@@ -468,6 +476,7 @@ class TaskGraphService:
             previous is not None
             and previous.source_revision == source_revision
             and previous.base_override_seq == (overrides[-1].override_seq if overrides else 0)
+            and previous.generator == self.linker.generator_descriptor()
         ):
             generation = previous
             should_publish = False
@@ -653,15 +662,6 @@ class TaskGraphService:
                 task_scope_id,
                 reason="manual_override_retry",
                 db_path=self.db_path,
-            )
-        states = source_states_for_scope(
-            current.tenant_id, task_scope_id, db_path=self.db_path,
-        )
-        if states:
-            first = states[0]
-            mark_task_graph_dirty(
-                int(first["watch_dir_id"]), f"{first['traj_id']}.md",
-                reason="manual_override", db_path=self.db_path,
             )
         self._rebuild_scope(current.tenant_id, task_scope_id, {})
         acknowledge_dirty_task_scopes(

--- a/src/xskill/tasks/store.py
+++ b/src/xskill/tasks/store.py
@@ -1,0 +1,504 @@
+"""Versioned Task Graph fact store with atomic publication and overrides."""
+from __future__ import annotations
+
+import hashlib
+import json
+import os
+import uuid
+from collections.abc import Iterable
+from dataclasses import dataclass
+from datetime import datetime, timezone
+from pathlib import Path
+from typing import Any
+
+from xskill.tasks.locking import task_file_lock
+from xskill.tasks.models import TaskGraphGeneration
+
+OVERRIDE_OPERATIONS = frozenset((
+    "confirm_membership", "reject_membership", "set_task_state",
+    "set_attempt_state", "upsert_task_relation", "reject_task_relation",
+    "upsert_attempt_relation", "reject_attempt_relation", "merge_tasks",
+    "move_atoms", "split_task",
+))
+_ENTITY_FIELDS = (
+    "tasks", "memberships", "relations", "attempts", "attempt_relations",
+    "usage_allocations",
+)
+
+
+def utc_now() -> str:
+    return datetime.now(timezone.utc).isoformat(timespec="milliseconds")
+
+
+def _canonical_json(value: Any) -> bytes:
+    return json.dumps(
+        value, ensure_ascii=False, sort_keys=True, separators=(",", ":"),
+        allow_nan=False,
+    ).encode("utf-8")
+
+
+def _sha(value: bytes) -> str:
+    return hashlib.sha256(value).hexdigest()
+
+
+def _write_atomic(path: Path, payload: bytes, *, mode: int | None = 0o600) -> None:
+    path.parent.mkdir(parents=True, exist_ok=True)
+    temporary = path.with_name(f".{path.name}.{uuid.uuid4().hex}.tmp")
+    with temporary.open("wb") as output:
+        output.write(payload)
+        output.flush()
+        os.fsync(output.fileno())
+    if mode is not None and os.name != "nt":
+        temporary.chmod(mode)
+    os.replace(temporary, path)
+    if os.name != "nt":
+        directory_fd = os.open(path.parent, os.O_RDONLY)
+        try:
+            os.fsync(directory_fd)
+        finally:
+            os.close(directory_fd)
+
+
+@dataclass(frozen=True)
+class OverrideEvent:
+    event_id: str
+    override_seq: int
+    tenant_id: str
+    task_scope_id: str
+    operation: str
+    target_id: str
+    payload: dict
+    evidence_refs: tuple[str, ...]
+    actor: str
+    observed_at: str
+
+    def __post_init__(self) -> None:
+        if self.operation not in OVERRIDE_OPERATIONS:
+            raise ValueError(
+                f"unknown Task Graph override operation: {self.operation!r}"
+            )
+        if (
+            isinstance(self.override_seq, bool)
+            or not isinstance(self.override_seq, int)
+            or self.override_seq <= 0
+        ):
+            raise ValueError("override_seq must be a positive integer")
+        for field_name in (
+            "event_id", "tenant_id", "task_scope_id", "target_id", "actor",
+            "observed_at",
+        ):
+            value = getattr(self, field_name)
+            if not isinstance(value, str) or not value.strip():
+                raise ValueError(f"override {field_name} must be a non-empty string")
+            if field_name != "observed_at" and len(value.strip()) > 200:
+                raise ValueError(
+                    f"override {field_name} is limited to 200 characters"
+                )
+        if not isinstance(self.payload, dict):
+            raise ValueError("override payload must be an object")
+        try:
+            payload_size = len(_canonical_json(self.payload))
+        except (TypeError, ValueError) as error:
+            raise ValueError("override payload must be strict JSON") from error
+        if payload_size > 65_536:
+            raise ValueError("override payload is limited to 64 KiB")
+        if len(self.evidence_refs) > 100 or any(
+            not isinstance(item, str) or not item or len(item) > 200
+            for item in self.evidence_refs
+        ):
+            raise ValueError(
+                "override evidence_refs are limited to 100 non-empty "
+                "200-character strings"
+            )
+
+    def to_dict(self) -> dict:
+        return {
+            "event_id": self.event_id,
+            "override_seq": self.override_seq,
+            "tenant_id": self.tenant_id,
+            "task_scope_id": self.task_scope_id,
+            "operation": self.operation,
+            "target_id": self.target_id,
+            "payload": self.payload,
+            "evidence_refs": list(self.evidence_refs),
+            "actor": self.actor,
+            "observed_at": self.observed_at,
+        }
+
+    @classmethod
+    def from_dict(cls, value: dict) -> OverrideEvent:
+        operation = value.get("operation")
+        if not isinstance(operation, str):
+            raise ValueError("override operation must be a string")
+        if operation not in OVERRIDE_OPERATIONS:
+            raise ValueError(f"unknown Task Graph override operation: {operation!r}")
+        sequence = value.get("override_seq")
+        if isinstance(sequence, bool) or not isinstance(sequence, int) or sequence <= 0:
+            raise ValueError("override_seq must be a positive integer")
+        required_fields = {
+            "event_id": value.get("event_id"),
+            "tenant_id": value.get("tenant_id"),
+            "task_scope_id": value.get("task_scope_id"),
+            "target_id": value.get("target_id"),
+            "actor": value.get("actor"),
+            "observed_at": value.get("observed_at"),
+        }
+        for field_name, field_value in required_fields.items():
+            if not isinstance(field_value, str) or not field_value.strip():
+                raise ValueError(f"override {field_name} must be a non-empty string")
+            if field_name != "observed_at" and len(field_value.strip()) > 200:
+                raise ValueError(
+                    f"override {field_name} is limited to 200 characters"
+                )
+        payload = value.get("payload")
+        evidence_refs = value.get("evidence_refs")
+        if not isinstance(payload, dict):
+            raise ValueError("override payload must be an object")
+        if (
+            not isinstance(evidence_refs, list)
+            or len(evidence_refs) > 100
+            or not all(
+                isinstance(item, str) and item and len(item) <= 200
+                for item in evidence_refs
+            )
+        ):
+            raise ValueError(
+                "override evidence_refs must contain at most 100 non-empty "
+                "200-character strings"
+            )
+        try:
+            payload_size = len(_canonical_json(payload))
+        except (TypeError, ValueError) as error:
+            raise ValueError("override payload must be strict JSON") from error
+        if payload_size > 65_536:
+            raise ValueError("override payload is limited to 64 KiB")
+        return cls(
+            event_id=str(value["event_id"]),
+            override_seq=sequence,
+            tenant_id=str(value["tenant_id"]),
+            task_scope_id=str(value["task_scope_id"]),
+            operation=operation,
+            target_id=str(value["target_id"]),
+            payload=dict(payload),
+            evidence_refs=tuple(evidence_refs),
+            actor=str(value.get("actor") or "unknown"),
+            observed_at=str(value["observed_at"]),
+        )
+
+
+class TaskGraphStore:
+    """Immutable content-addressed generations plus an append-only override log."""
+
+    SHARD_RECORD_LIMIT = 256
+
+    def __init__(self, scope_dir: Path):
+        self.scope_dir = Path(scope_dir)
+        self.current_path = self.scope_dir / "current.json"
+        self.generations_dir = self.scope_dir / "generations"
+        self.shards_dir = self.scope_dir / "shards"
+        self.overrides_path = self.scope_dir / "overrides.jsonl"
+        self.lock_path = self.scope_dir / "transaction.lock"
+        self._cached_pointer_payload: bytes | None = None
+        self._cached_generation: TaskGraphGeneration | None = None
+
+    def _secure_scope_dir(self) -> None:
+        self.scope_dir.mkdir(parents=True, exist_ok=True)
+        if os.name != "nt":
+            self.scope_dir.chmod(0o700)
+
+    def _store_records(self, entity: str, records: list[dict]) -> list[dict]:
+        references = []
+        for offset in range(0, len(records), self.SHARD_RECORD_LIMIT):
+            chunk = records[offset:offset + self.SHARD_RECORD_LIMIT]
+            references.append(self._store_shard(entity, chunk))
+        return references
+
+    def _store_shard(self, entity: str, records: list[dict]) -> dict:
+        payload = _canonical_json(records)
+        digest = _sha(payload)
+        relative = Path("shards") / entity / f"{digest}.json"
+        path = self.scope_dir / relative
+        if not path.is_file():
+            _write_atomic(path, payload)
+        elif os.name != "nt":
+            path.chmod(0o600)
+        return {
+            "sha256": digest,
+            "path": relative.as_posix(),
+            "record_count": len(records),
+        }
+
+    def _read_shard(self, reference: dict) -> list[dict]:
+        relative = Path(str(reference.get("path") or ""))
+        if relative.is_absolute() or ".." in relative.parts:
+            raise RuntimeError("Task Graph shard reference escapes scope directory")
+        payload = (self.scope_dir / relative).read_bytes()
+        expected = str(reference.get("sha256") or "")
+        if _sha(payload) != expected:
+            raise RuntimeError(f"Task Graph shard checksum mismatch: {relative}")
+        value = json.loads(payload.decode("utf-8", errors="strict"))
+        if isinstance(value, dict):
+            return [value]
+        if not isinstance(value, list) or not all(
+            isinstance(record, dict) for record in value
+        ):
+            raise RuntimeError(
+                f"Task Graph shard must contain records: {relative}"
+            )
+        expected_count = reference.get("record_count")
+        if expected_count is not None and expected_count != len(value):
+            raise RuntimeError(f"Task Graph shard count mismatch: {relative}")
+        return value
+
+    def publish(self, generation: TaskGraphGeneration) -> dict:
+        """Durably write all immutable facts before switching ``current.json``."""
+        with task_file_lock(self.lock_path):
+            self._secure_scope_dir()
+            if any(
+                separator in generation.generation_id
+                for separator in ("/", "\\", "..")
+            ):
+                raise ValueError("generation_id is not a safe opaque identifier")
+            if self.current_path.is_file():
+                current = self.load_current()
+                if current is not None:
+                    if current.tenant_id != generation.tenant_id:
+                        raise ValueError("cannot publish another tenant into this TaskScope")
+                    if current.task_scope_id != generation.task_scope_id:
+                        raise ValueError("scope directory does not match Task Graph generation")
+                    if generation.base_override_seq < current.base_override_seq:
+                        raise ValueError("override watermark cannot move backwards")
+            expanded = generation.to_dict()
+            manifest = {
+                key: expanded[key]
+                for key in (
+                    "schema_version", "generation_id", "tenant_id", "task_scope_id",
+                    "source_revision", "generator", "base_override_seq", "created_at",
+                    "metrics",
+                )
+            }
+            for entity in _ENTITY_FIELDS:
+                manifest[entity] = self._store_records(
+                    entity, expanded[entity],
+                )
+            manifest_payload = _canonical_json(manifest)
+            manifest_sha = _sha(manifest_payload)
+            generation_dir = self.generations_dir / generation.generation_id
+            manifest_path = generation_dir / "manifest.json"
+            if manifest_path.is_file():
+                existing = manifest_path.read_bytes()
+                if existing != manifest_payload:
+                    raise RuntimeError("generation_id already exists with different content")
+                if os.name != "nt":
+                    manifest_path.chmod(0o600)
+            else:
+                _write_atomic(manifest_path, manifest_payload)
+            pointer = {
+                "schema_version": generation.schema_version,
+                "generation_id": generation.generation_id,
+                "manifest_sha256": manifest_sha,
+                "base_override_seq": generation.base_override_seq,
+                "published_at": utc_now(),
+            }
+            pointer_payload = _canonical_json(pointer)
+            _write_atomic(self.current_path, pointer_payload)
+            self._cached_pointer_payload = pointer_payload
+            self._cached_generation = generation
+            return pointer
+
+    def load_current(self) -> TaskGraphGeneration | None:
+        if not self.current_path.is_file():
+            return None
+        try:
+            pointer_payload = self.current_path.read_bytes()
+            if (
+                pointer_payload == self._cached_pointer_payload
+                and self._cached_generation is not None
+            ):
+                return self._cached_generation
+            pointer = json.loads(pointer_payload.decode("utf-8", errors="strict"))
+            if not isinstance(pointer, dict):
+                raise TypeError("Task Graph current pointer must be an object")
+            generation_id = str(pointer["generation_id"])
+            if any(
+                separator in generation_id for separator in ("/", "\\", "..")
+            ):
+                raise ValueError("unsafe generation_id in current pointer")
+            manifest_path = self.generations_dir / generation_id / "manifest.json"
+            manifest_payload = manifest_path.read_bytes()
+        except (
+            OSError, json.JSONDecodeError, KeyError, TypeError, ValueError,
+        ) as error:
+            raise RuntimeError(f"invalid Task Graph current pointer: {self.current_path}") from error
+        if _sha(manifest_payload) != pointer.get("manifest_sha256"):
+            raise RuntimeError("Task Graph manifest checksum mismatch")
+        try:
+            manifest = json.loads(
+                manifest_payload.decode("utf-8", errors="strict")
+            )
+            if not isinstance(manifest, dict):
+                raise TypeError("Task Graph manifest must be an object")
+            expanded = dict(manifest)
+            for entity in _ENTITY_FIELDS:
+                references = manifest[entity]
+                if not isinstance(references, list) or not all(
+                    isinstance(reference, dict) for reference in references
+                ):
+                    raise TypeError(
+                        f"Task Graph manifest {entity} must contain shard objects"
+                    )
+                expanded[entity] = [
+                    record
+                    for reference in references
+                    for record in self._read_shard(reference)
+                ]
+            generation = TaskGraphGeneration.from_dict(expanded)
+        except (
+            OSError, json.JSONDecodeError, KeyError, TypeError, ValueError,
+        ) as error:
+            raise RuntimeError(
+                f"invalid Task Graph manifest: {manifest_path}"
+            ) from error
+        if generation.generation_id != generation_id:
+            raise RuntimeError("Task Graph pointer and manifest generation_id differ")
+        if pointer.get("schema_version") != generation.schema_version:
+            raise RuntimeError("Task Graph pointer and manifest schema_version differ")
+        if pointer.get("base_override_seq") != generation.base_override_seq:
+            raise RuntimeError("Task Graph pointer and manifest override watermark differ")
+        self._cached_pointer_payload = pointer_payload
+        self._cached_generation = generation
+        return generation
+
+    def read_overrides(self, *, after_seq: int = 0) -> list[OverrideEvent]:
+        if not self.overrides_path.is_file():
+            return []
+        events: list[OverrideEvent] = []
+        previous_sequence = 0
+        seen_ids: set[str] = set()
+        with self.overrides_path.open(encoding="utf-8") as source:
+            for line_number, raw_line in enumerate(source, 1):
+                raw_line = raw_line.strip()
+                if not raw_line:
+                    continue
+                try:
+                    event = OverrideEvent.from_dict(json.loads(raw_line))
+                except (json.JSONDecodeError, KeyError, TypeError, ValueError) as error:
+                    raise RuntimeError(
+                        f"invalid override log at {self.overrides_path}:{line_number}"
+                    ) from error
+                if event.override_seq != previous_sequence + 1:
+                    raise RuntimeError("Task Graph override sequence is not contiguous")
+                if event.event_id in seen_ids:
+                    raise RuntimeError("Task Graph override event_id is duplicated")
+                previous_sequence = event.override_seq
+                seen_ids.add(event.event_id)
+                if event.override_seq > after_seq:
+                    events.append(event)
+        return events
+
+    def override_watermark(self) -> int:
+        events = self.read_overrides()
+        return events[-1].override_seq if events else 0
+
+    def append_override(
+        self,
+        *,
+        tenant_id: str,
+        task_scope_id: str,
+        operation: str,
+        target_id: str,
+        payload: dict,
+        evidence_refs: Iterable[str] = (),
+        actor: str,
+        event_id: str | None = None,
+        observed_at: str | None = None,
+    ) -> OverrideEvent:
+        if operation not in OVERRIDE_OPERATIONS:
+            raise ValueError(f"unknown Task Graph override operation: {operation!r}")
+        if event_id is not None:
+            if not isinstance(event_id, str) or not event_id.strip():
+                raise ValueError("override event_id must be a non-empty string")
+            event_id = event_id.strip()
+            if len(event_id) > 200:
+                raise ValueError("override event_id is limited to 200 characters")
+        for field_name, field_value in (
+            ("tenant_id", tenant_id), ("task_scope_id", task_scope_id),
+            ("target_id", target_id), ("actor", actor),
+        ):
+            if not isinstance(field_value, str) or not field_value.strip():
+                raise ValueError(f"override {field_name} must be a non-empty string")
+        if not isinstance(payload, dict):
+            raise ValueError("override payload must be an object")
+        try:
+            payload_size = len(_canonical_json(payload))
+        except (TypeError, ValueError) as error:
+            raise ValueError("override payload must be strict JSON") from error
+        if payload_size > 65_536:
+            raise ValueError("override payload is limited to 64 KiB")
+        if isinstance(evidence_refs, (str, bytes)):
+            raise ValueError("override evidence_refs must be an iterable of strings")
+        normalized_payload = dict(payload)
+        normalized_evidence_refs = tuple(evidence_refs)
+        if len(normalized_evidence_refs) > 100 or any(
+            not isinstance(item, str) or not item or len(item) > 200
+            for item in normalized_evidence_refs
+        ):
+            raise ValueError(
+                "override evidence_refs are limited to 100 non-empty "
+                "200-character strings"
+            )
+        normalized_actor = actor.strip()
+        with task_file_lock(self.lock_path):
+            self._secure_scope_dir()
+            existing = self.read_overrides()
+            if event_id:
+                for item in existing:
+                    if item.event_id == event_id:
+                        requested = {
+                            "tenant_id": tenant_id,
+                            "task_scope_id": task_scope_id,
+                            "operation": operation,
+                            "target_id": target_id,
+                            "payload": normalized_payload,
+                            "evidence_refs": normalized_evidence_refs,
+                            "actor": normalized_actor,
+                        }
+                        actual = {
+                            "tenant_id": item.tenant_id,
+                            "task_scope_id": item.task_scope_id,
+                            "operation": item.operation,
+                            "target_id": item.target_id,
+                            "payload": item.payload,
+                            "evidence_refs": item.evidence_refs,
+                            "actor": item.actor,
+                        }
+                        if requested != actual:
+                            raise ValueError(
+                                "override event_id already exists with different content"
+                            )
+                        return item
+            event = OverrideEvent(
+                event_id=event_id or f"ovr_{uuid.uuid4().hex}",
+                override_seq=(existing[-1].override_seq + 1) if existing else 1,
+                tenant_id=tenant_id,
+                task_scope_id=task_scope_id,
+                operation=operation,
+                target_id=target_id,
+                payload=normalized_payload,
+                evidence_refs=normalized_evidence_refs,
+                actor=normalized_actor,
+                observed_at=observed_at or utc_now(),
+            )
+            if existing:
+                first = existing[0]
+                if first.tenant_id != tenant_id or first.task_scope_id != task_scope_id:
+                    raise ValueError("override log scope mismatch")
+            line = _canonical_json(event.to_dict()) + b"\n"
+            existing_payload = (
+                self.overrides_path.read_bytes()
+                if self.overrides_path.is_file() else b""
+            )
+            _write_atomic(
+                self.overrides_path, existing_payload + line, mode=0o600,
+            )
+            return event

--- a/src/xskill/usage.py
+++ b/src/xskill/usage.py
@@ -32,6 +32,7 @@ logger = logging.getLogger("xskill.usage")
 # 当前流水线步骤(atom_split / skill_route / skill_edit / ux_score …)。
 # 收口点记账时用它归因;pipeline 用 `with use_step("atom_split"):` 包住即可。
 _STEP = threading.local()
+_ATTRIBUTION = threading.local()
 
 
 def current_step() -> str:
@@ -47,6 +48,23 @@ def use_step(name: str):
     finally:
         _STEP.name = prev
 
+
+@contextlib.contextmanager
+def use_processing_scope(**scope):
+    """Attach scoped provenance to xskill-processing usage in this worker."""
+    previous = getattr(_ATTRIBUTION, "value", None)
+    _ATTRIBUTION.value = {
+        key: value for key, value in scope.items()
+        if key in {
+            "tenant_id", "task_scope_id", "source_scope_id", "traj_id",
+            "atom_id", "generation_id", "allocation_mode",
+        } and value not in (None, "")
+    }
+    try:
+        yield
+    finally:
+        _ATTRIBUTION.value = previous
+
 # 出厂兜底单价(USD / 1M token)。config.pricing.default 可覆盖。
 _FALLBACK_DEFAULT = {"input_per_1m": 1.0, "output_per_1m": 3.0, "embed_per_1m": 0.05}
 
@@ -54,11 +72,13 @@ _FALLBACK_DEFAULT = {"input_per_1m": 1.0, "output_per_1m": 3.0, "embed_per_1m": 
 @dataclass(frozen=True)
 class Usage:
     """一次调用的 token 拆分。embedding 调用只有 prompt(=total)。"""
-    prompt: int = 0
-    completion: int = 0
-    total: int = 0
-    cache_hit: int = 0      # DeepSeek prompt_cache_hit_tokens
-    cache_miss: int = 0     # DeepSeek prompt_cache_miss_tokens
+    prompt: Optional[int] = 0
+    completion: Optional[int] = 0
+    total: Optional[int] = 0
+    cache_hit: Optional[int] = 0      # DeepSeek prompt_cache_hit_tokens
+    cache_miss: Optional[int] = 0     # DeepSeek prompt_cache_miss_tokens
+    measurement_quality: str = "measured"
+    unavailable_reason: str = ""
 
 
 @dataclass(frozen=True)
@@ -72,7 +92,7 @@ class ModelPrice:
 
 
 def extract_usage(resp: Any) -> Usage:
-    """从 LLM/embedding 响应提取 token,缺失补 0。
+    """从 LLM/embedding 响应提取 token，缺失时显式标记 unavailable。
 
     支持的响应形态:
     - 原始 dict(embedding HTTP JSON): ``resp["usage"]``
@@ -87,30 +107,104 @@ def extract_usage(resp: Any) -> Usage:
         if obj is None:
             return None
         v = obj.get(key) if isinstance(obj, dict) else getattr(obj, key, None)
-        return int(v) if isinstance(v, (int, float)) else None
+        return (
+            v
+            if not isinstance(v, bool) and isinstance(v, int) and v >= 0
+            else None
+        )
 
     agno_metrics = getattr(resp, "response_usage", None)
     if agno_metrics is not None:
-        prompt = g(agno_metrics, "input_tokens") or 0
-        completion = g(agno_metrics, "output_tokens") or 0
-        total = g(agno_metrics, "total_tokens") or (prompt + completion)
+        raw_prompt = g(agno_metrics, "input_tokens")
+        raw_completion = g(agno_metrics, "output_tokens")
+        raw_total = g(agno_metrics, "total_tokens")
+        if all(value is None for value in (raw_prompt, raw_completion, raw_total)):
+            return Usage(
+                prompt=None,
+                completion=None,
+                total=None,
+                cache_hit=None,
+                cache_miss=None,
+                measurement_quality="unavailable",
+                unavailable_reason="response_did_not_report_usage",
+            )
+        prompt = raw_prompt
+        completion = raw_completion
+        total = (
+            prompt + completion
+            if raw_total in (None, 0)
+            and prompt is not None
+            and completion is not None
+            and prompt + completion > 0
+            else raw_total
+        )
         # cost_usd 按 hit+miss=prompt 分档计费,miss 须补未命中余量,
         # 否则配了 cache 价时 prompt 非命中段会漏计。
         hit = g(agno_metrics, "cache_read_tokens") or 0
-        miss = max(0, prompt - hit)
+        miss = max(0, prompt - hit) if prompt is not None else None
+        missing_fields = [
+            name for name, value in (
+                ("prompt_tokens", prompt),
+                ("completion_tokens", completion),
+                ("total_tokens", total),
+            ) if value is None
+        ]
         return Usage(prompt=prompt, completion=completion, total=total,
-                     cache_hit=hit, cache_miss=miss)
+                     cache_hit=hit, cache_miss=miss,
+                     unavailable_reason=(
+                         "response_did_not_report:" + ",".join(missing_fields)
+                         if missing_fields else ""
+                     ))
 
     usage = resp.get("usage") if isinstance(resp, dict) else getattr(resp, "usage", None)
     if usage is None:
-        return Usage()
-    prompt = g(usage, "prompt_tokens") or 0
-    completion = g(usage, "completion_tokens") or 0
-    total = g(usage, "total_tokens") or (prompt + completion)
+        return Usage(
+            prompt=None,
+            completion=None,
+            total=None,
+            cache_hit=None,
+            cache_miss=None,
+            measurement_quality="unavailable",
+            unavailable_reason="response_did_not_report_usage",
+        )
+    raw_prompt = g(usage, "prompt_tokens")
+    raw_completion = g(usage, "completion_tokens")
+    raw_total = g(usage, "total_tokens")
+    if all(value is None for value in (raw_prompt, raw_completion, raw_total)):
+        return Usage(
+            prompt=None,
+            completion=None,
+            total=None,
+            cache_hit=None,
+            cache_miss=None,
+            measurement_quality="unavailable",
+            unavailable_reason="response_did_not_report_usage",
+        )
+    prompt = raw_prompt
+    completion = raw_completion
+    total = (
+        prompt + completion
+        if raw_total in (None, 0)
+        and prompt is not None
+        and completion is not None
+        and prompt + completion > 0
+        else raw_total
+    )
     hit = g(usage, "prompt_cache_hit_tokens") or 0
     miss = g(usage, "prompt_cache_miss_tokens") or 0
+    missing_fields = [
+        name for name, value in (
+            ("prompt_tokens", prompt),
+            ("completion_tokens", completion),
+            ("total_tokens", total),
+        ) if value is None
+    ]
     return Usage(prompt=prompt, completion=completion, total=total,
-                 cache_hit=hit, cache_miss=miss)
+                 cache_hit=hit, cache_miss=miss,
+                 unavailable_reason=(
+                     "response_did_not_report:" + ",".join(missing_fields)
+                     if missing_fields else ""
+                 ))
 
 
 class PriceTable:
@@ -145,17 +239,26 @@ def _opt_float(v: Any) -> Optional[float]:
     return float(v) if isinstance(v, (int, float)) else None
 
 
-def cost_usd(usage: Usage, price: ModelPrice, *, is_embed: bool = False) -> float:
+def cost_usd(
+    usage: Usage, price: ModelPrice, *, is_embed: bool = False,
+) -> Optional[float]:
     """token × 单价 → USD。embedding 走 embed 价;否则 prompt(含 cache 分档)+ completion。"""
     M = 1_000_000
     if is_embed:
+        if usage.total is None:
+            return None
         per = price.embed_per_1m if price.embed_per_1m is not None else price.input_per_1m
         return usage.total / M * per
+    if usage.prompt is None or usage.completion is None:
+        return None
     # prompt 段:有 cache 拆分且配了 cache 价 → 分档计;否则整段 input 价
     if (usage.cache_hit or usage.cache_miss) and price.cache_hit_per_1m is not None:
         hit_p = price.cache_hit_per_1m
         miss_p = price.cache_miss_per_1m if price.cache_miss_per_1m is not None else price.input_per_1m
-        prompt_cost = (usage.cache_hit * hit_p + usage.cache_miss * miss_p) / M
+        prompt_cost = (
+            (usage.cache_hit or 0) * hit_p
+            + (usage.cache_miss or 0) * miss_p
+        ) / M
     else:
         prompt_cost = usage.prompt / M * price.input_per_1m
     return prompt_cost + usage.completion / M * price.output_per_1m
@@ -195,25 +298,28 @@ class UsageLedger:
 
     def _record(self, step: str, model: str, usage: Usage, *, is_embed: bool) -> None:
         try:
-            price, source = self._prices.resolve(model)
+            price, pricing_kind = self._prices.resolve(model)
             usd = cost_usd(usage, price, is_embed=is_embed)
+            total_tokens = usage.total or 0
+            accounted_cost = usd or 0.0
             with self._lock:
-                if source != "config":
+                if pricing_kind != "config":
                     self._estimated = True
                 for d, key in ((self._by_step, step), (self._by_model, model)):
                     b = d.setdefault(key, _Bucket())
-                    b.calls += 1; b.tokens += usage.total; b.cost += usd
+                    b.calls += 1; b.tokens += total_tokens; b.cost += accounted_cost
                 self._total.calls += 1
-                self._total.tokens += usage.total
-                self._total.cost += usd
-            logger.debug("[LLM] model=%s step=%s tokens=%d cost=$%.5f src=%s",
-                         model, step, usage.total, usd, source)
+                self._total.tokens += total_tokens
+                self._total.cost += accounted_cost
             _persist(
                 step,
                 model,
                 usage,
                 usd,
-                source,
+                pricing_kind,
+                measurement_quality=usage.measurement_quality,
+                unavailable_reason=usage.unavailable_reason,
+                attribution=getattr(_ATTRIBUTION, "value", None),
                 db_path=self.db_path,
             )
         except Exception:  # pylint: disable=broad-exception-caught
@@ -276,20 +382,40 @@ def _persist(
     step: str,
     model: str,
     usage: Usage,
-    usd: float,
+    usd: Optional[float],
     source: str,
     *,
+    measurement_quality: str = "measured",
+    unavailable_reason: str = "",
+    attribution: Optional[dict] = None,
     db_path: Path | None = None,
-) -> None:
+) -> Optional[str]:
     """best-effort 落 registry llm_usage 表(函数内 import 防环;失败仅 warn)。"""
     try:
         from xskill.pipeline.registry import record_usage
-        record_usage(step=step, model=model, prompt=usage.prompt,
-                     completion=usage.completion, total=usage.total,
-                     cost_usd=usd, price_source=source,
-                     db_path=db_path)
+        scoped = attribution or {}
+        return record_usage(
+            step=step,
+            model=model,
+            prompt=usage.prompt,
+            completion=usage.completion,
+            total=usage.total,
+            cost_usd=usd,
+            price_source=source,
+            measurement_quality=measurement_quality,
+            allocation_mode=str(scoped.get("allocation_mode") or "unattributed"),
+            unavailable_reason=unavailable_reason or None,
+            tenant_id=scoped.get("tenant_id"),
+            task_scope_id=scoped.get("task_scope_id"),
+            source_scope_id=scoped.get("source_scope_id"),
+            traj_id=scoped.get("traj_id"),
+            atom_id=scoped.get("atom_id"),
+            generation_id=scoped.get("generation_id"),
+            db_path=db_path,
+        )
     except Exception:  # pylint: disable=broad-exception-caught
         logger.debug("usage persist skipped", exc_info=True)
+        return None
 
 
 def _fmt_tokens(n: int) -> str:

--- a/tests/test_codex_adapter.py
+++ b/tests/test_codex_adapter.py
@@ -317,7 +317,7 @@ class TestJsonlIngesterSpecDispatch:
             sessions_path=lambda h: h / "fake",
             sessions_glob="*.db",
             session_id_from_path=lambda p: p.stem,
-            cwd_from_content=lambda c: "",
+            cwd_from_content=lambda _c: "",
             adapter_format="raw",
             traj_id_prefix="traj_x_",
             skills_install_path=lambda h: h / "fake_skills",
@@ -393,8 +393,8 @@ class TestInstallToCodexFallback:
         skill_path = _build_codex_skill(tmp_path / "src")
         fake_home = tmp_path / "home"
 
-        monkeypatch.setattr(install_fallback, "_try_symlink", lambda s, d: False)
-        monkeypatch.setattr(install_fallback, "_try_junction", lambda s, d: False)
+        monkeypatch.setattr(install_fallback, "_try_symlink", lambda _s, _d: False)
+        monkeypatch.setattr(install_fallback, "_try_junction", lambda _s, _d: False)
 
         with caplog.at_level(logging.WARNING, logger="xskill.ecosystems"):
             dest = install_to_codex(skill_path, target_root=fake_home)
@@ -527,9 +527,11 @@ class TestCodexRollout0148:
         assert "<cwd>" not in md
 
     def test_session_meta_still_parsed(self):
-        md, _meta = self._adapt()
+        md, meta = self._adapt()
         assert "**cli_version**: 0.148.0" in md
         assert "**originator**: codex_exec" in md
+        assert meta["source_model"] == "mock-model"
+        assert meta["execution_usage_events"][0]["usage"]["total_tokens"] == 2
 
     def test_old_format_fixture_unchanged(self):
         """两种格式并存：旧 fixture（event_msg::user_message）行为不变。"""

--- a/tests/test_config_autoinit.py
+++ b/tests/test_config_autoinit.py
@@ -47,12 +47,13 @@ def test_template_is_valid_yaml_with_required_sections():
     parsed = yaml.safe_load(CONFIG_TEMPLATE)
     # 必填段都在
     for key in (
-        "skill_dir", "llm", "embedding", "canary", "watcher", "agent_worker",
+        "skill_dir", "llm", "embedding", "canary", "watcher", "task_graph", "agent_worker",
     ):
         assert key in parsed, f"template missing {key}"
     # llm / embedding 带 api_key 占位符（用户要填）
     assert parsed["llm"]["api_key"] == "PUT_YOUR_LLM_API_KEY_HERE"
     assert parsed["embedding"]["api_key"] == "PUT_YOUR_EMBEDDING_API_KEY_HERE"
+    assert parsed["task_graph"]["enabled"] is False
 
 
 def test_template_top_level_keys_are_exactly_live_set():
@@ -63,7 +64,7 @@ def test_template_top_level_keys_are_exactly_live_set():
     """
     parsed = yaml.safe_load(CONFIG_TEMPLATE)
     assert set(parsed.keys()) == {
-        "skill_dir", "llm", "embedding", "canary", "watcher", "agent_worker",
+        "skill_dir", "llm", "embedding", "canary", "watcher", "task_graph", "agent_worker",
         "team", "dashboard",
         "skill_opt", "ingest", "interests", "server",
         # ingest 段由 config.ingest_config 消费（settle 屏障/去壳掩码）

--- a/tests/test_dashboard_standalone.py
+++ b/tests/test_dashboard_standalone.py
@@ -36,6 +36,13 @@ _STANDALONE_ALLOWED_OPERATIONS = {
 _BUILTIN_ONLY_OPERATIONS = {
     # 用户、原始轨迹、原子、skill 内容及逐 case 数据。
     ("get", "/api/v1/dashboard/users"),
+    ("get", "/api/v1/dashboard/task-graph/overview"),
+    ("get", "/api/v1/dashboard/task-graph/scopes"),
+    ("get", "/api/v1/dashboard/task-graph/tasks"),
+    ("get", "/api/v1/dashboard/task-graph/by-session"),
+    ("get", "/api/v1/dashboard/task-graph/by-atom"),
+    ("get", "/api/v1/dashboard/task-graph/task/{task_id}"),
+    ("post", "/api/v1/dashboard/task-graph/override"),
     # 单任务 agent trace 日志尾巴（内容级）。
     ("get", "/api/v1/dashboard/pipeline/log"),
     ("get", "/api/v1/dashboard/skill/{name}/detail"),

--- a/tests/test_deepseek_harness_adapter.py
+++ b/tests/test_deepseek_harness_adapter.py
@@ -132,6 +132,8 @@ class TestAdapter:
         assert "agent_preset" not in meta  # headless run wrote no agentPreset
         assert meta["source"] == "deepseek_harness_session_jsonl"
         assert meta["category"] == "deepseek_harness_session"
+        assert meta["execution_usage_events"]
+        assert meta["execution_usage_events"][0]["source_event_id"]
 
     def test_adapter_handles_empty(self):
         md, meta = adapt_trajectory("", "deepseek_harness_session_jsonl")
@@ -455,7 +457,7 @@ class TestInstall:
         started = []
 
         class _FakeIngester:
-            def __init__(self, spec=None, *a, **kw):
+            def __init__(self, spec=None, *_a, **_kw):
                 self.spec = spec
 
             def start(self):

--- a/tests/test_openclaw_adapter.py
+++ b/tests/test_openclaw_adapter.py
@@ -102,6 +102,13 @@ class TestOpenClawAdapter:
         assert meta["source"] == "openclaw_trajectory_jsonl"
         assert meta["category"] == "openclaw_session"
         assert meta["final_status"] == "success"
+        assert meta["source_harness"] == "openclaw"
+        assert meta["harness_version"] == "2026.5.7"
+        assert len(meta["execution_usage_events"]) == 8
+        assert len({
+            event["source_event_id"]
+            for event in meta["execution_usage_events"]
+        }) == 8
         assert meta["total_turns"] > 0
 
     def test_adapter_handles_empty_input(self):
@@ -424,7 +431,7 @@ class TestInstallToOpenClawProtectsPendingDestEdits:
         from xskill.agents.user_edit_absorb_agent import reverse_sync_openclaw_dest as _orig
         monkeypatch.setattr(
             "xskill.agents.user_edit_absorb_agent.reverse_sync_openclaw_dest",
-            lambda d, s, **k: _orig(d, s, quiet_seconds=0),
+            lambda d, s, **_k: _orig(d, s, quiet_seconds=0),
         )
 
         # user 改 dest

--- a/tests/test_task_graph_runtime.py
+++ b/tests/test_task_graph_runtime.py
@@ -1,0 +1,1034 @@
+from __future__ import annotations
+
+import json
+import os
+import sqlite3
+from pathlib import Path
+
+import pytest
+
+from xskill.pipeline.atom import AtomTask, AtomTaskStore
+from xskill.pipeline.registry import (
+    discover_trajectories,
+    get_connection,
+    pooled_connection,
+    register_dir,
+)
+from xskill.tasks.models import stable_ref_key
+from xskill.tasks.projection import (
+    get_logical_task,
+    list_dirty_task_scopes,
+    list_dirty_sources,
+    list_logical_tasks,
+    list_task_scopes,
+    task_graph_overview,
+    tasks_for_atom,
+)
+from xskill.tasks.scopes import ScopeResolver
+from xskill.tasks.service import TaskGraphService
+from xskill.tasks.store import TaskGraphStore
+
+
+def _add_source(
+    root: Path,
+    db_path: Path,
+    *,
+    source_name: str,
+    atoms: list[dict],
+    workspace: str = "/workspace/demo",
+    usage: dict | None = None,
+    final_status: str | None = None,
+) -> tuple[int, str]:
+    watch_dir = root / "trajectories"
+    watch_dir.mkdir(parents=True, exist_ok=True)
+    filename = f"traj_{source_name}.md"
+    trajectory_path = watch_dir / filename
+    lines = ["# Trajectory", ""]
+    for atom in atoms:
+        lines.extend(("## User", atom["intent"], "", "## Assistant", atom.get("summary", "done"), ""))
+    trajectory_path.write_text("\n".join(lines), encoding="utf-8")
+    metadata = {
+        "source": "codex_rollout_jsonl",
+        "source_model": "model-test",
+        "model_provider": "provider-test",
+        "cwd": workspace,
+    }
+    if usage is not None:
+        metadata["execution_usage_events"] = [{
+            "source_event_id": f"usage-{source_name}",
+            "usage": usage,
+        }]
+    if final_status is not None:
+        metadata["final_status"] = final_status
+    trajectory_path.with_suffix(".json").write_text(
+        json.dumps(metadata), encoding="utf-8",
+    )
+    trajectory_id = filename[:-3]
+    offset = 1
+    atom_records = []
+    for index, atom in enumerate(atoms, 1):
+        span = int(atom.get("span", 5))
+        atom_records.append(AtomTask(
+            atom_id=f"atom_{trajectory_id}_{index:04d}",
+            traj_id=trajectory_id,
+            offset_start=offset,
+            offset_end=offset + span,
+            intent=atom["intent"],
+            summary=atom.get("summary", atom["intent"]),
+            used_skills=list(atom.get("used_skills") or ()),
+            pre_atom_id=(
+                f"atom_{trajectory_id}_{index - 1:04d}" if index > 1 else None
+            ),
+            post_atom_id=(
+                f"atom_{trajectory_id}_{index + 1:04d}"
+                if index < len(atoms) else None
+            ),
+            raw_segment=f"{atom['intent']}\n{atom.get('summary', '')}",
+            source_model="model-test",
+        ))
+        offset += span
+    store = AtomTaskStore(watch_dir)
+    for atom_record in atom_records:
+        store.save(atom_record)
+    watch_dir_id = register_dir(watch_dir, db_path=db_path)
+    discover_trajectories(watch_dir_id, watch_dir, db_path=db_path)
+    with pooled_connection(db_path) as connection:
+        connection.execute(
+            "UPDATE trajectories SET status='split_done',tasks_extracted=?"
+            " WHERE watch_dir_id=? AND filename=?",
+            (len(atom_records), watch_dir_id, filename),
+        )
+        connection.commit()
+    return watch_dir_id, filename
+
+
+def _build(root: Path, db_path: Path, sources: list[tuple[int, str]]) -> TaskGraphService:
+    service = TaskGraphService(
+        state_root=root,
+        db_path=db_path,
+        config={"task_graph": {"enabled": True}},
+    )
+    for watch_dir_id, filename in sources:
+        service.mark_dirty(watch_dir_id, filename, reason="test")
+    result = service.process_dirty()
+    assert result["sources"] == len(sources)
+    return service
+
+
+def test_reading_missing_tenant_identity_has_no_filesystem_side_effect(tmp_path):
+    resolver = ScopeResolver(tmp_path, db_path=tmp_path / "registry.db")
+    assert resolver.existing_tenant_id is None
+    assert not (tmp_path / "task_graph").exists()
+
+
+def test_runtime_projects_task_attempt_evidence_and_conserved_usage(tmp_path):
+    db_path = tmp_path / "registry.db"
+    source = _add_source(
+        tmp_path,
+        db_path,
+        source_name="usage",
+        atoms=[
+            {"intent": "修复登录问题", "summary": "修复认证错误", "span": 3, "used_skills": ["debug"]},
+            {"intent": "编写发布说明", "summary": "整理版本文档", "span": 7, "used_skills": ["docs"]},
+        ],
+        usage={
+            "input_tokens": 80,
+            "output_tokens": 20,
+            "total_tokens": 100,
+            "cached_input_tokens": 40,
+        },
+    )
+    service = _build(tmp_path, db_path, [source])
+    tenant_id = service.resolver.tenant_id
+    tasks = list_logical_tasks(tenant_id, db_path=db_path)
+    assert len(tasks) == 2
+    details = [
+        get_logical_task(
+            tenant_id, task["task_scope_id"], task["task_id"], db_path=db_path,
+        )
+        for task in tasks
+    ]
+    allocations = [
+        allocation
+        for detail in details
+        for allocation in detail["usage_allocations"]
+    ]
+    assert sum(item["fraction"] for item in allocations) == pytest.approx(1.0)
+    assert sum(item["total_tokens"] for item in allocations) == 100
+    assert sum(item["cache_read_tokens"] for item in allocations) == 40
+    assert {item["allocation_mode"] for item in allocations} == {"shared"}
+    assert all(detail["attempts"][0]["lifecycle"] == "running" for detail in details)
+    assert all(detail["usage_events"][0]["measurement_quality"] == "measured" for detail in details)
+    overview = task_graph_overview(tenant_id, db_path=db_path)
+    assert overview["execution_tokens"] == 100
+
+
+def test_explicit_retry_reuses_task_and_creates_attempt_relation(tmp_path):
+    db_path = tmp_path / "registry.db"
+    source = _add_source(
+        tmp_path,
+        db_path,
+        source_name="retry",
+        atoms=[
+            {"intent": "修复登录问题", "summary": "定位认证失败"},
+            {"intent": "重试修复登录问题", "summary": "重新执行认证修复"},
+        ],
+    )
+    service = _build(tmp_path, db_path, [source])
+    tenant_id = service.resolver.tenant_id
+    tasks = list_logical_tasks(tenant_id, db_path=db_path)
+    assert len(tasks) == 1
+    detail = get_logical_task(
+        tenant_id, tasks[0]["task_scope_id"], tasks[0]["task_id"], db_path=db_path,
+    )
+    assert len(detail["attempts"]) == 2
+    assert detail["attempt_relations"][0]["relation_type"] == "retry_of"
+    assert detail["attempt_relations"][0]["decision"] == "confirmed"
+    assert detail["usage_events"][0]["measurement_quality"] == "unavailable"
+    assert detail["usage_events"][0]["unavailable_reason"] == (
+        "source_did_not_report_usage"
+    )
+
+
+def test_ambiguous_similarity_stays_proposed_instead_of_silent_merge(tmp_path):
+    db_path = tmp_path / "registry.db"
+    source = _add_source(
+        tmp_path,
+        db_path,
+        source_name="ambiguous",
+        atoms=[
+            {"intent": "优化数据库登录查询", "summary": "检查登录查询性能"},
+            {"intent": "分析数据库登录查询", "summary": "分析登录查询索引"},
+        ],
+    )
+    service = _build(tmp_path, db_path, [source])
+    tenant_id = service.resolver.tenant_id
+    tasks = list_logical_tasks(tenant_id, db_path=db_path)
+    assert len(tasks) == 2
+    with pooled_connection(db_path) as connection:
+        proposed = connection.execute(
+            "SELECT task_scope_id,membership_id,confidence,decision"
+            " FROM task_atom_memberships"
+            " WHERE decision='proposed'",
+        ).fetchall()
+    assert proposed
+    assert all(row["confidence"] is None for row in proposed)
+    service.append_override(
+        task_scope_id=proposed[0]["task_scope_id"],
+        operation="confirm_membership",
+        target_id=proposed[0]["membership_id"],
+        payload={},
+        actor="reviewer",
+    )
+    service.mark_dirty(*source, reason="repeat_manual_membership")
+    service.process_dirty()
+    current = service.store_for_scope(proposed[0]["task_scope_id"]).load_current()
+    confirmed_primary = [
+        membership for membership in current.memberships
+        if membership.role == "primary"
+        and membership.decision == "confirmed"
+        and not membership.stale
+    ]
+    assert len(confirmed_primary) == 2
+    assert any(
+        membership.decided_by == "human:reviewer"
+        for membership in confirmed_primary
+    )
+
+
+def test_stable_ids_and_bounded_candidates_on_unchanged_rebuild(tmp_path):
+    db_path = tmp_path / "registry.db"
+    atoms = [
+        {"intent": f"处理模块 {index} 性能", "summary": f"模块 {index} 性能分析"}
+        for index in range(40)
+    ]
+    source = _add_source(
+        tmp_path, db_path, source_name="bounded", atoms=atoms,
+    )
+    service = _build(tmp_path, db_path, [source])
+    store = next((tmp_path / "task_graph" / "scopes").iterdir())
+    first = service.store_for_scope(store.name).load_current()
+    assert first.metrics["candidate_count"] <= len(atoms) * 8
+    pointer = json.loads((store / "current.json").read_text(encoding="utf-8"))
+    manifest = json.loads(
+        (store / "generations" / pointer["generation_id"] / "manifest.json")
+        .read_text(encoding="utf-8")
+    )
+    assert len(manifest["memberships"]) <= 2
+    assert all("record_count" in shard for shard in manifest["memberships"])
+    service.mark_dirty(*source, reason="repeat")
+    service.process_dirty()
+    second = service.store_for_scope(store.name).load_current()
+    assert {task.task_id for task in first.tasks} == {task.task_id for task in second.tasks}
+    assert second.generation_id == first.generation_id
+
+
+def test_restart_reloads_manifest_shards_and_preserves_generation(tmp_path):
+    db_path = tmp_path / "registry.db"
+    source = _add_source(
+        tmp_path,
+        db_path,
+        source_name="restart-replay",
+        atoms=[
+            {"intent": "验证重启恢复", "summary": "读取不可变分片"},
+            {"intent": "编写恢复说明", "summary": "保持任务身份"},
+        ],
+        usage={
+            "input_tokens": 10,
+            "output_tokens": 2,
+            "total_tokens": 12,
+        },
+    )
+    first_service = _build(tmp_path, db_path, [source])
+    tenant_id = first_service.resolver.tenant_id
+    first_tasks = list_logical_tasks(tenant_id, db_path=db_path)
+    scope_id = first_tasks[0]["task_scope_id"]
+    first_generation = first_service.store_for_scope(scope_id).load_current()
+    if os.name != "nt":
+        scope_dir = tmp_path / "task_graph" / "scopes" / scope_id
+        assert scope_dir.stat().st_mode & 0o777 == 0o700
+        assert all(
+            path.stat().st_mode & 0o777 == 0o600
+            for path in scope_dir.rglob("*.json")
+        )
+
+    restarted = TaskGraphService(
+        state_root=tmp_path,
+        db_path=db_path,
+        config={"task_graph": {"enabled": True}},
+    )
+    reloaded = restarted.store_for_scope(scope_id).load_current()
+    assert reloaded.generation_id == first_generation.generation_id
+    assert reloaded.to_dict() == first_generation.to_dict()
+
+    restarted.mark_dirty(*source, reason="restart_reconcile")
+    result = restarted.process_dirty()
+    assert result["failed_scopes"] == []
+    replayed = restarted.store_for_scope(scope_id).load_current()
+    assert replayed.generation_id == first_generation.generation_id
+    assert {
+        task.task_id for task in replayed.tasks
+    } == {
+        task["task_id"] for task in first_tasks
+    }
+
+
+def test_invalid_current_pointer_is_reported_as_recoverable_store_error(tmp_path):
+    store = TaskGraphStore(tmp_path / "task_graph" / "scopes" / ("tsc_" + "a" * 32))
+    store.current_path.parent.mkdir(parents=True)
+    store.current_path.write_text("[]", encoding="utf-8")
+    with pytest.raises(RuntimeError, match="invalid Task Graph current pointer"):
+        store.load_current()
+
+
+def test_manual_membership_survives_deleted_atom_as_stale_fact(tmp_path):
+    db_path = tmp_path / "registry.db"
+    source = _add_source(
+        tmp_path,
+        db_path,
+        source_name="delete",
+        atoms=[{"intent": "修复删除测试", "summary": "保留人工事实"}],
+    )
+    service = _build(tmp_path, db_path, [source])
+    tenant_id = service.resolver.tenant_id
+    task = list_logical_tasks(tenant_id, db_path=db_path)[0]
+    detail = get_logical_task(
+        tenant_id, task["task_scope_id"], task["task_id"], db_path=db_path,
+    )
+    membership = detail["memberships"][0]
+    service.append_override(
+        task_scope_id=task["task_scope_id"],
+        operation="confirm_membership",
+        target_id=membership["membership_id"],
+        payload={},
+        actor="reviewer",
+    )
+    atom_path = next((tmp_path / "trajectories" / "traj_delete" / "tasks").glob("*.json"))
+    atom_path.unlink()
+    service.mark_dirty(*source, reason="deleted", deleted=True)
+    service.process_dirty()
+    current = service.store_for_scope(task["task_scope_id"]).load_current()
+    stale = [item for item in current.memberships if item.decided_by == "human:reviewer"]
+    assert len(stale) == 1
+    assert stale[0].stale is True
+    assert next(item for item in current.tasks if item.task_id == task["task_id"]).tombstoned
+    assert current.attempts[0].outcome == "unknown"
+    assert all(evidence.stale for evidence in current.attempts[0].evidence_ranges)
+
+
+def test_invalid_relation_cycle_is_rejected_before_override_log_append(tmp_path):
+    db_path = tmp_path / "registry.db"
+    source = _add_source(
+        tmp_path,
+        db_path,
+        source_name="cycle",
+        atoms=[
+            {"intent": "目标甲", "summary": "完成甲"},
+            {"intent": "目标乙", "summary": "完成乙"},
+        ],
+    )
+    service = _build(tmp_path, db_path, [source])
+    tenant_id = service.resolver.tenant_id
+    tasks = list_logical_tasks(tenant_id, db_path=db_path)
+    scope_id = tasks[0]["task_scope_id"]
+    first_id, second_id = sorted(task["task_id"] for task in tasks)
+    service.append_override(
+        task_scope_id=scope_id,
+        operation="upsert_task_relation",
+        target_id=first_id,
+        payload={
+            "from_task_id": first_id,
+            "to_task_id": second_id,
+            "relation_type": "depends_on",
+        },
+        actor="reviewer",
+    )
+    with pytest.raises(ValueError, match="DAG"):
+        service.append_override(
+            task_scope_id=scope_id,
+            operation="upsert_task_relation",
+            target_id=second_id,
+            payload={
+                "from_task_id": second_id,
+                "to_task_id": first_id,
+                "relation_type": "depends_on",
+            },
+            actor="reviewer",
+        )
+    assert service.store_for_scope(scope_id).override_watermark() == 1
+
+
+def test_override_ids_are_not_coerced_from_json_numbers(tmp_path):
+    db_path = tmp_path / "registry.db"
+    source = _add_source(
+        tmp_path,
+        db_path,
+        source_name="strict-override-ids",
+        atoms=[
+            {"intent": "目标甲", "summary": "完成甲"},
+            {"intent": "目标乙", "summary": "完成乙"},
+        ],
+    )
+    service = _build(tmp_path, db_path, [source])
+    tenant_id = service.resolver.tenant_id
+    tasks = list_logical_tasks(tenant_id, db_path=db_path)
+    scope_id = tasks[0]["task_scope_id"]
+    canonical_id = tasks[0]["task_id"]
+    with pytest.raises(ValueError, match="must contain non-empty strings"):
+        service.append_override(
+            task_scope_id=scope_id,
+            operation="merge_tasks",
+            target_id=canonical_id,
+            payload={"task_ids": [8]},
+            actor="reviewer",
+        )
+    with pytest.raises(ValueError, match="event_id"):
+        service.append_override(
+            task_scope_id=scope_id,
+            operation="set_task_state",
+            target_id=canonical_id,
+            payload={"lifecycle": "open"},
+            actor="reviewer",
+            event_id=8,
+        )
+    assert service.store_for_scope(scope_id).override_watermark() == 0
+
+
+def test_idempotent_override_retry_rebuilds_an_unmaterialized_event(
+    tmp_path, monkeypatch,
+):
+    db_path = tmp_path / "registry.db"
+    source = _add_source(
+        tmp_path,
+        db_path,
+        source_name="override-retry",
+        atoms=[{"intent": "修正任务状态", "summary": "验证幂等恢复"}],
+    )
+    service = _build(tmp_path, db_path, [source])
+    tenant_id = service.resolver.tenant_id
+    task = list_logical_tasks(tenant_id, db_path=db_path)[0]
+    scope_id = task["task_scope_id"]
+    original_rebuild = service._rebuild_scope
+
+    def fail_rebuild(*_args, **_kwargs):
+        raise RuntimeError("injected projection failure")
+
+    monkeypatch.setattr(service, "_rebuild_scope", fail_rebuild)
+    with pytest.raises(RuntimeError, match="injected projection failure"):
+        service.append_override(
+            task_scope_id=scope_id,
+            operation="set_task_state",
+            target_id=task["task_id"],
+            payload={"lifecycle": "blocked"},
+            actor="reviewer",
+            event_id="override-retry-1",
+        )
+    store = service.store_for_scope(scope_id)
+    assert store.override_watermark() == 1
+    assert store.load_current().base_override_seq == 0
+
+    monkeypatch.setattr(service, "_rebuild_scope", original_rebuild)
+    retried = service.append_override(
+        task_scope_id=scope_id,
+        operation="set_task_state",
+        target_id=task["task_id"],
+        payload={"lifecycle": "blocked"},
+        actor="reviewer",
+        event_id="override-retry-1",
+    )
+    assert retried.override_seq == 1
+    current = store.load_current()
+    assert current.base_override_seq == 1
+    assert next(
+        item for item in current.tasks if item.task_id == task["task_id"]
+    ).lifecycle == "blocked"
+
+
+def test_override_scope_queue_recovers_without_any_live_source(
+    tmp_path, monkeypatch,
+):
+    db_path = tmp_path / "registry.db"
+    source = _add_source(
+        tmp_path,
+        db_path,
+        source_name="scope-only-recovery",
+        atoms=[{"intent": "保留删除后的任务", "summary": "修正 tombstone"}],
+    )
+    service = _build(tmp_path, db_path, [source])
+    tenant_id = service.resolver.tenant_id
+    task = list_logical_tasks(
+        tenant_id, include_tombstones=True, db_path=db_path,
+    )[0]
+    scope_id = task["task_scope_id"]
+    service.mark_dirty(*source, reason="source_deleted", deleted=True)
+    service.process_dirty()
+    assert list_dirty_sources(db_path=db_path) == []
+
+    def fail_rebuild(*_args, **_kwargs):
+        raise RuntimeError("injected no-source projection failure")
+
+    monkeypatch.setattr(service, "_rebuild_scope", fail_rebuild)
+    with pytest.raises(RuntimeError, match="injected no-source projection failure"):
+        service.append_override(
+            task_scope_id=scope_id,
+            operation="set_task_state",
+            target_id=task["task_id"],
+            payload={"lifecycle": "blocked"},
+            actor="reviewer",
+            event_id="scope-only-recovery-1",
+        )
+    assert len(list_dirty_task_scopes(db_path=db_path)) == 1
+
+    restarted = TaskGraphService(
+        state_root=tmp_path,
+        db_path=db_path,
+        config={"task_graph": {"enabled": True}},
+    )
+    result = restarted.process_dirty()
+    assert result["override_scopes"] == 1
+    assert list_dirty_task_scopes(db_path=db_path) == []
+    current = restarted.store_for_scope(scope_id).load_current()
+    assert current.base_override_seq == 1
+    assert next(
+        item for item in current.tasks if item.task_id == task["task_id"]
+    ).lifecycle == "blocked"
+
+
+def test_parent_and_subtask_directions_share_one_dag(tmp_path):
+    db_path = tmp_path / "registry.db"
+    source = _add_source(
+        tmp_path,
+        db_path,
+        source_name="parent-subtask-cycle",
+        atoms=[
+            {"intent": "目标甲", "summary": "完成甲"},
+            {"intent": "目标乙", "summary": "完成乙"},
+        ],
+    )
+    service = _build(tmp_path, db_path, [source])
+    tenant_id = service.resolver.tenant_id
+    tasks = list_logical_tasks(tenant_id, db_path=db_path)
+    scope_id = tasks[0]["task_scope_id"]
+    first_id, second_id = sorted(task["task_id"] for task in tasks)
+    service.append_override(
+        task_scope_id=scope_id,
+        operation="upsert_task_relation",
+        target_id=first_id,
+        payload={
+            "from_task_id": first_id,
+            "to_task_id": second_id,
+            "relation_type": "parent",
+        },
+        actor="reviewer",
+    )
+    with pytest.raises(ValueError, match="DAG"):
+        service.append_override(
+            task_scope_id=scope_id,
+            operation="upsert_task_relation",
+            target_id=first_id,
+            payload={
+                "from_task_id": first_id,
+                "to_task_id": second_id,
+                "relation_type": "subtask",
+            },
+            actor="reviewer",
+        )
+    assert service.store_for_scope(scope_id).override_watermark() == 1
+
+
+def test_scoped_atom_lookup_does_not_use_bare_atom_id(tmp_path):
+    db_path = tmp_path / "registry.db"
+    source = _add_source(
+        tmp_path,
+        db_path,
+        source_name="lookup",
+        atoms=[{"intent": "检查作用域", "summary": "验证 scoped ref"}],
+    )
+    service = _build(tmp_path, db_path, [source])
+    tenant_id = service.resolver.tenant_id
+    task = list_logical_tasks(tenant_id, db_path=db_path)[0]
+    detail = get_logical_task(
+        tenant_id, task["task_scope_id"], task["task_id"], db_path=db_path,
+    )
+    membership = detail["memberships"][0]
+    hit = tasks_for_atom(
+        tenant_id,
+        membership["source_scope_id"],
+        membership["traj_id"],
+        membership["atom_id"],
+        db_path=db_path,
+    )
+    miss = tasks_for_atom(
+        tenant_id,
+        "src_wrong",
+        membership["traj_id"],
+        membership["atom_id"],
+        db_path=db_path,
+    )
+    assert len(hit["tasks"]) == 1
+    assert miss == {"tasks": [], "memberships": []}
+
+
+def test_registry_migration_preserves_legacy_usage_without_inventing_scope(tmp_path):
+    db_path = tmp_path / "registry.db"
+    connection = sqlite3.connect(db_path)
+    connection.executescript(
+        "CREATE TABLE watch_dirs("
+        "id INTEGER PRIMARY KEY AUTOINCREMENT,path TEXT UNIQUE NOT NULL,"
+        "label TEXT DEFAULT '',auto_index INTEGER DEFAULT 1,"
+        "ecosystem TEXT DEFAULT 'manual',created_at TEXT);"
+        "CREATE TABLE trajectories("
+        "id INTEGER PRIMARY KEY AUTOINCREMENT,watch_dir_id INTEGER NOT NULL,"
+        "filename TEXT NOT NULL,has_meta INTEGER DEFAULT 0,"
+        "has_embedding INTEGER DEFAULT 0,UNIQUE(watch_dir_id,filename));"
+        "CREATE TABLE llm_usage("
+        "id INTEGER PRIMARY KEY AUTOINCREMENT,ts TEXT,step TEXT,model TEXT,"
+        "prompt INTEGER DEFAULT 0,completion INTEGER DEFAULT 0,"
+        "total INTEGER DEFAULT 0,cost_usd REAL DEFAULT 0,price_source TEXT);"
+        "INSERT INTO watch_dirs(path,label,auto_index,ecosystem)"
+        " VALUES('/legacy/path','legacy',1,'manual');"
+        "INSERT INTO llm_usage(step,model,prompt,completion,total,cost_usd,price_source)"
+        " VALUES('split','legacy-model',10,2,12,0.1,'static');"
+    )
+    connection.commit()
+    connection.close()
+    migrated = get_connection(db_path)
+    watch_dir = migrated.execute(
+        "SELECT source_scope_id FROM watch_dirs",
+    ).fetchone()
+    usage = migrated.execute(
+        "SELECT usage_event_id,usage_plane,measurement_quality,tenant_id,"
+        "total,cost_usd,legacy FROM llm_usage",
+    ).fetchone()
+    migrated.close()
+    assert watch_dir["source_scope_id"].startswith("src_")
+    assert usage["usage_event_id"].startswith("xsp_legacy_")
+    assert usage["usage_plane"] == "xskill_processing"
+    assert usage["measurement_quality"] is None
+    assert usage["tenant_id"] is None
+    assert usage["total"] == 12
+    assert usage["cost_usd"] == pytest.approx(0.1)
+    assert usage["legacy"] == 1
+
+
+def test_structured_harness_success_finishes_attempt_without_verifying_task(tmp_path):
+    db_path = tmp_path / "registry.db"
+    source = _add_source(
+        tmp_path,
+        db_path,
+        source_name="outcome",
+        atoms=[{"intent": "完成发布", "summary": "生成发布产物"}],
+        final_status="succeeded",
+    )
+    service = _build(tmp_path, db_path, [source])
+    tenant_id = service.resolver.tenant_id
+    task = list_logical_tasks(tenant_id, db_path=db_path)[0]
+    assert task["lifecycle"] == "open"
+    assert task["outcome"] == "unknown"
+    detail = get_logical_task(
+        tenant_id, task["task_scope_id"], task["task_id"], db_path=db_path,
+    )
+    assert detail["attempts"][0]["lifecycle"] == "finished"
+    assert detail["attempts"][0]["outcome"] == "succeeded"
+    assert detail["attempts"][0]["verification"] == "unverified"
+    metadata_path = tmp_path / "trajectories" / "traj_outcome.json"
+    metadata = json.loads(metadata_path.read_text(encoding="utf-8"))
+    metadata.pop("final_status")
+    metadata_path.write_text(json.dumps(metadata), encoding="utf-8")
+    service.mark_dirty(*source, reason="outcome_removed")
+    service.process_dirty()
+    task = list_logical_tasks(tenant_id, db_path=db_path)[0]
+    assert task["lifecycle"] == "open"
+    assert task["outcome"] == "unknown"
+    detail = get_logical_task(
+        tenant_id, task["task_scope_id"], task["task_id"], db_path=db_path,
+    )
+    assert detail["attempts"][0]["lifecycle"] == "running"
+
+
+def test_human_split_task_and_attempt_relation_overrides_are_replayable(tmp_path):
+    db_path = tmp_path / "registry.db"
+    source = _add_source(
+        tmp_path,
+        db_path,
+        source_name="manual-graph",
+        atoms=[
+            {"intent": "修复支付失败", "summary": "定位支付错误"},
+            {"intent": "重试修复支付失败", "summary": "再次执行支付修复"},
+        ],
+    )
+    service = _build(tmp_path, db_path, [source])
+    tenant_id = service.resolver.tenant_id
+    task = list_logical_tasks(tenant_id, db_path=db_path)[0]
+    current = service.store_for_scope(task["task_scope_id"]).load_current()
+    relation = current.attempt_relations[0]
+    service.append_override(
+        task_scope_id=task["task_scope_id"],
+        operation="reject_attempt_relation",
+        target_id=relation.relation_id,
+        payload={},
+        actor="reviewer",
+    )
+    service.append_override(
+        task_scope_id=task["task_scope_id"],
+        operation="upsert_attempt_relation",
+        target_id=relation.from_attempt_id,
+        payload={
+            "to_attempt_id": relation.to_attempt_id,
+            "relation_type": "supersedes",
+        },
+        actor="reviewer",
+    )
+    current = service.store_for_scope(task["task_scope_id"]).load_current()
+    supersedes = next(
+        item for item in current.attempt_relations
+        if item.relation_type == "supersedes"
+    )
+    service.append_override(
+        task_scope_id=task["task_scope_id"],
+        operation="reject_attempt_relation",
+        target_id=supersedes.relation_id,
+        payload={},
+        actor="reviewer",
+    )
+    current = service.store_for_scope(task["task_scope_id"]).load_current()
+    atom_keys = sorted(
+        stable_ref_key(membership.atom_ref)
+        for membership in current.memberships
+        if membership.role == "primary"
+        and membership.decision == "confirmed"
+        and not membership.stale
+    )
+    service.append_override(
+        task_scope_id=task["task_scope_id"],
+        operation="split_task",
+        target_id=task["task_id"],
+        payload={
+            "atom_keys": [atom_keys[-1]],
+            "title": "单独处理第二次支付修复",
+        },
+        actor="reviewer",
+    )
+    current = service.store_for_scope(task["task_scope_id"]).load_current()
+    active_tasks = [item for item in current.tasks if not item.tombstoned]
+    assert len(active_tasks) == 2
+    confirmed = [
+        membership for membership in current.memberships
+        if membership.role == "primary"
+        and membership.decision == "confirmed"
+        and not membership.stale
+    ]
+    assert len(confirmed) == 2
+    assert len({membership.task_id for membership in confirmed}) == 2
+    assert service.store_for_scope(task["task_scope_id"]).override_watermark() == 4
+
+
+def test_invalid_metadata_stays_in_durable_dirty_queue(tmp_path):
+    db_path = tmp_path / "registry.db"
+    source = _add_source(
+        tmp_path,
+        db_path,
+        source_name="invalid-metadata",
+        atoms=[{"intent": "检查元数据", "summary": "不吞损坏输入"}],
+    )
+    service = TaskGraphService(
+        state_root=tmp_path,
+        db_path=db_path,
+        config={"task_graph": {"enabled": True}},
+    )
+    (tmp_path / "trajectories" / "traj_invalid-metadata.json").write_text(
+        "{invalid", encoding="utf-8",
+    )
+    service.mark_dirty(*source, reason="invalid_metadata")
+    result = service.process_dirty()
+    assert result["sources"] == 0
+    assert len(list_dirty_sources(db_path=db_path)) == 1
+
+
+def test_changed_usage_event_does_not_publish_a_conflicting_generation(tmp_path):
+    db_path = tmp_path / "registry.db"
+    source = _add_source(
+        tmp_path,
+        db_path,
+        source_name="immutable-usage",
+        atoms=[{"intent": "统计成本", "summary": "保存原始用量"}],
+        usage={"input_tokens": 10, "output_tokens": 2, "total_tokens": 12},
+    )
+    service = _build(tmp_path, db_path, [source])
+    tenant_id = service.resolver.tenant_id
+    task = list_logical_tasks(tenant_id, db_path=db_path)[0]
+    store = service.store_for_scope(task["task_scope_id"])
+    generation_id = store.load_current().generation_id
+    metadata_path = tmp_path / "trajectories" / "traj_immutable-usage.json"
+    metadata = json.loads(metadata_path.read_text(encoding="utf-8"))
+    metadata["execution_usage_events"][0]["usage"]["total_tokens"] = 13
+    metadata_path.write_text(json.dumps(metadata), encoding="utf-8")
+    service.mark_dirty(*source, reason="conflicting_usage")
+    result = service.process_dirty()
+    assert result["failed_scopes"] == [task["task_scope_id"]]
+    assert store.load_current().generation_id == generation_id
+    assert len(list_dirty_sources(db_path=db_path)) == 1
+
+
+def test_atom_content_skill_and_score_updates_do_not_change_task_identity(tmp_path):
+    db_path = tmp_path / "registry.db"
+    source = _add_source(
+        tmp_path,
+        db_path,
+        source_name="orthogonal",
+        atoms=[{"intent": "优化缓存", "summary": "降低缓存延迟"}],
+    )
+    service = _build(tmp_path, db_path, [source])
+    tenant_id = service.resolver.tenant_id
+    first_task = list_logical_tasks(tenant_id, db_path=db_path)[0]
+    scope_store = service.store_for_scope(first_task["task_scope_id"])
+    first_generation = scope_store.load_current().generation_id
+    atom_store = AtomTaskStore(tmp_path / "trajectories")
+    atom = atom_store.list_by_traj("traj_orthogonal")[0]
+    atom.used_skills = ["cache-analysis", "profiling"]
+    atom.ux_score = 9
+    atom.clustered = True
+    atom.summary = "降低缓存延迟并减少重复读取"
+    atom_store.save(atom)
+    service.mark_dirty(*source, reason="skill_metadata_changed")
+    service.process_dirty()
+    second_task = list_logical_tasks(tenant_id, db_path=db_path)[0]
+    assert second_task["task_id"] == first_task["task_id"]
+    assert scope_store.load_current().generation_id != first_generation
+
+
+def test_retry_inside_one_atom_creates_line_scoped_attempts(tmp_path):
+    db_path = tmp_path / "registry.db"
+    source = _add_source(
+        tmp_path,
+        db_path,
+        source_name="intra-atom-retry",
+        atoms=[{"intent": "修复登录问题", "summary": "执行并重试修复"}],
+        usage={"input_tokens": 80, "output_tokens": 20, "total_tokens": 100},
+        final_status="succeeded",
+    )
+    raw_segment = (
+        "## User\n修复登录问题\n\n"
+        "## Assistant\n第一次执行失败\n\n"
+        "## User\n重试修复登录问题\n\n"
+        "## Assistant\n第二次执行成功\n"
+    )
+    atom_store = AtomTaskStore(tmp_path / "trajectories")
+    atom = atom_store.list_by_traj("traj_intra-atom-retry")[0]
+    atom.raw_segment = raw_segment
+    atom.offset_start = 1
+    atom.offset_end = len(raw_segment.splitlines()) + 1
+    atom_store.save(atom)
+    service = _build(tmp_path, db_path, [source])
+    tenant_id = service.resolver.tenant_id
+    task = list_logical_tasks(tenant_id, db_path=db_path)[0]
+    detail = get_logical_task(
+        tenant_id, task["task_scope_id"], task["task_id"], db_path=db_path,
+    )
+    assert len(detail["attempts"]) == 2
+    assert len(detail["evidence_ranges"]) == 2
+    assert detail["evidence_ranges"][0]["locator_end"] == detail["evidence_ranges"][1]["locator_start"]
+    assert detail["attempt_relations"][0]["relation_type"] == "retry_of"
+    assert sum(
+        allocation["total_tokens"]
+        for allocation in detail["usage_allocations"]
+    ) == 100
+    assert sum(
+        allocation["fraction"]
+        for allocation in detail["usage_allocations"]
+    ) == pytest.approx(1.0)
+
+
+def test_failed_attempt_does_not_close_logical_task(tmp_path):
+    db_path = tmp_path / "registry.db"
+    source = _add_source(
+        tmp_path,
+        db_path,
+        source_name="attempt-failed",
+        atoms=[{"intent": "修复支付问题", "summary": "执行修复"}],
+        final_status="failed",
+    )
+    service = _build(tmp_path, db_path, [source])
+    tenant_id = service.resolver.tenant_id
+    task = list_logical_tasks(tenant_id, db_path=db_path)[0]
+    assert task["lifecycle"] == "open"
+    assert task["outcome"] == "unknown"
+    detail = get_logical_task(
+        tenant_id, task["task_scope_id"], task["task_id"], db_path=db_path,
+    )
+    assert detail["attempts"][0]["lifecycle"] == "finished"
+    assert detail["attempts"][0]["outcome"] == "failed"
+
+
+def test_standalone_actor_can_link_same_workspace_across_source_scopes(tmp_path):
+    db_path = tmp_path / "registry.db"
+    first = _add_source(
+        tmp_path / "codex",
+        db_path,
+        source_name="cross-source-a",
+        atoms=[{"intent": "实现任务图", "summary": "开始任务图实现"}],
+        workspace="/workspace/shared",
+    )
+    second = _add_source(
+        tmp_path / "openclaw",
+        db_path,
+        source_name="cross-source-b",
+        atoms=[{"intent": "继续实现任务图", "summary": "补全任务图实现"}],
+        workspace="/workspace/shared",
+    )
+    service = _build(tmp_path, db_path, [first, second])
+    tenant_id = service.resolver.tenant_id
+    tasks = list_logical_tasks(tenant_id, db_path=db_path)
+    assert len({task["task_scope_id"] for task in tasks}) == 1
+    with pooled_connection(db_path) as connection:
+        source_scopes = connection.execute(
+            "SELECT DISTINCT source_scope_id FROM task_atom_memberships",
+        ).fetchall()
+    assert len(source_scopes) == 2
+
+
+def test_workspace_change_moves_source_between_task_scopes(tmp_path):
+    db_path = tmp_path / "registry.db"
+    source = _add_source(
+        tmp_path,
+        db_path,
+        source_name="workspace-move",
+        atoms=[{"intent": "修复部署", "summary": "修复发布流程"}],
+        workspace="/workspace/first",
+    )
+    service = _build(tmp_path, db_path, [source])
+    tenant_id = service.resolver.tenant_id
+    first_task = list_logical_tasks(tenant_id, db_path=db_path)[0]
+    metadata_path = tmp_path / "trajectories" / "traj_workspace-move.json"
+    metadata = json.loads(metadata_path.read_text(encoding="utf-8"))
+    metadata["cwd"] = "/workspace/second"
+    metadata_path.write_text(json.dumps(metadata), encoding="utf-8")
+    service.mark_dirty(*source, reason="workspace_changed")
+    result = service.process_dirty()
+    assert result["failed_scopes"] == []
+    assert result["sources"] == 1
+    assert list_dirty_sources(db_path=db_path) == []
+    live_tasks = list_logical_tasks(tenant_id, db_path=db_path)
+    assert len(live_tasks) == 1
+    assert live_tasks[0]["task_scope_id"] != first_task["task_scope_id"]
+    assert len(list_task_scopes(tenant_id, db_path=db_path)) == 2
+
+
+def test_disabled_runtime_keeps_dirty_fence_for_later_enable(tmp_path):
+    db_path = tmp_path / "registry.db"
+    source = _add_source(
+        tmp_path,
+        db_path,
+        source_name="disabled-dirty-fence",
+        atoms=[{"intent": "保留变更", "summary": "等待后续启用"}],
+    )
+    enabled_service = _build(tmp_path, db_path, [source])
+    tenant_id = enabled_service.resolver.tenant_id
+    first_task = list_logical_tasks(tenant_id, db_path=db_path)[0]
+    service = TaskGraphService(
+        state_root=tmp_path,
+        db_path=db_path,
+        config={"task_graph": {"enabled": False}},
+    )
+    service.mark_dirty(*source, reason="changed_while_disabled")
+    assert service.process_dirty() == {
+        "enabled": False,
+        "sources": 0,
+        "scopes": 0,
+    }
+    assert len(list_dirty_sources(db_path=db_path)) == 1
+    assert first_task["task_scope_id"]
+
+
+def test_disabled_runtime_does_not_queue_never_projected_sources(tmp_path):
+    db_path = tmp_path / "registry.db"
+    source = _add_source(
+        tmp_path,
+        db_path,
+        source_name="disabled-untracked",
+        atoms=[{"intent": "暂不启用", "summary": "等待首次回填"}],
+    )
+    service = TaskGraphService(
+        state_root=tmp_path,
+        db_path=db_path,
+        config={"task_graph": {"enabled": False}},
+    )
+    service.mark_dirty(*source, reason="changed_while_never_enabled")
+    assert list_dirty_sources(db_path=db_path) == []
+
+
+def test_shared_usage_allocation_edges_have_a_hard_bound(tmp_path):
+    db_path = tmp_path / "registry.db"
+    atoms = [
+        {"intent": f"处理独立目标 {index}", "summary": f"目标 {index} 的执行"}
+        for index in range(65)
+    ]
+    source = _add_source(
+        tmp_path,
+        db_path,
+        source_name="usage-edge-bound",
+        atoms=atoms,
+    )
+    metadata_path = tmp_path / "trajectories" / "traj_usage-edge-bound.json"
+    metadata = json.loads(metadata_path.read_text(encoding="utf-8"))
+    metadata["execution_usage_events"] = [
+        {
+            "source_event_id": f"usage-edge-{index}",
+            "usage": {"input_tokens": 10, "output_tokens": 2, "total_tokens": 12},
+        }
+        for index in range(65)
+    ]
+    metadata_path.write_text(json.dumps(metadata), encoding="utf-8")
+    _build(tmp_path, db_path, [source])
+    with pooled_connection(db_path) as connection:
+        allocations = connection.execute(
+            "SELECT allocation_mode,method,fraction,total_tokens"
+            " FROM task_usage_allocations",
+        ).fetchall()
+    assert len(allocations) == 65
+    assert {row["allocation_mode"] for row in allocations} == {"unattributed"}
+    assert {row["method"] for row in allocations} == {
+        "shared_allocation_edge_limit_exceeded"
+    }
+    assert all(row["fraction"] == 1.0 for row in allocations)
+    assert sum(row["total_tokens"] for row in allocations) == 65 * 12

--- a/tests/test_task_graph_runtime.py
+++ b/tests/test_task_graph_runtime.py
@@ -6,13 +6,22 @@ import sqlite3
 from pathlib import Path
 
 import pytest
+from fastapi import FastAPI
+from fastapi.testclient import TestClient
 
+from xskill.dashboard.auth import (
+    build_auth_router,
+    configure_auth,
+    ensure_dashboard_secret,
+)
+from xskill.dashboard.router import build_dashboard_router
 from xskill.pipeline.atom import AtomTask, AtomTaskStore
 from xskill.pipeline.registry import (
     discover_trajectories,
     get_connection,
     pooled_connection,
     register_dir,
+    unregister_dir,
 )
 from xskill.tasks.models import stable_ref_key
 from xskill.tasks.projection import (
@@ -163,6 +172,61 @@ def test_runtime_projects_task_attempt_evidence_and_conserved_usage(tmp_path):
     assert overview["execution_tokens"] == 100
 
 
+def test_task_graph_dashboard_routes_require_admin_and_apply_override(
+    tmp_path, monkeypatch,
+):
+    db_path = tmp_path / "registry.db"
+    source = _add_source(
+        tmp_path,
+        db_path,
+        source_name="dashboard-admin",
+        atoms=[{"intent": "审核任务状态", "summary": "等待管理员修正"}],
+    )
+    service = _build(tmp_path, db_path, [source])
+    tenant_id = service.resolver.tenant_id
+    task = list_logical_tasks(tenant_id, db_path=db_path)[0]
+    monkeypatch.setattr(
+        "xskill.config.get_config",
+        lambda: {"task_graph": {"enabled": True}},
+    )
+    configure_auth(
+        secret=ensure_dashboard_secret(tmp_path / "dashboard-secret.json"),
+        admins=["reviewer"],
+        admin_password="secret",
+    )
+    app = FastAPI()
+    app.include_router(build_auth_router())
+    app.include_router(build_dashboard_router(db_path=db_path))
+
+    anonymous = TestClient(app)
+    assert anonymous.get(
+        "/api/v1/dashboard/task-graph/overview",
+    ).status_code == 401
+    admin = TestClient(app)
+    login = admin.post(
+        "/api/v1/dashboard/login",
+        json={"user_name": "reviewer", "secret": "secret"},
+    )
+    assert login.status_code == 200
+    assert admin.get(
+        "/api/v1/dashboard/task-graph/overview",
+    ).json()["tasks"] == 1
+    response = admin.post(
+        "/api/v1/dashboard/task-graph/override",
+        json={
+            "task_scope_id": task["task_scope_id"],
+            "operation": "set_task_state",
+            "target_id": task["task_id"],
+            "payload": {"lifecycle": "blocked"},
+        },
+    )
+    assert response.status_code == 200
+    current = service.store_for_scope(task["task_scope_id"]).load_current()
+    assert next(
+        item for item in current.tasks if item.task_id == task["task_id"]
+    ).lifecycle == "blocked"
+
+
 def test_explicit_retry_reuses_task_and_creates_attempt_relation(tmp_path):
     db_path = tmp_path / "registry.db"
     source = _add_source(
@@ -261,6 +325,35 @@ def test_stable_ids_and_bounded_candidates_on_unchanged_rebuild(tmp_path):
     second = service.store_for_scope(store.name).load_current()
     assert {task.task_id for task in first.tasks} == {task.task_id for task in second.tasks}
     assert second.generation_id == first.generation_id
+
+
+def test_changed_linker_config_forces_a_new_generation(tmp_path):
+    db_path = tmp_path / "registry.db"
+    source = _add_source(
+        tmp_path,
+        db_path,
+        source_name="generator-change",
+        atoms=[{"intent": "检查生成器版本", "summary": "重建派生图"}],
+    )
+    service = _build(tmp_path, db_path, [source])
+    tenant_id = service.resolver.tenant_id
+    task = list_logical_tasks(tenant_id, db_path=db_path)[0]
+    first = service.store_for_scope(task["task_scope_id"]).load_current()
+
+    changed = TaskGraphService(
+        state_root=tmp_path,
+        db_path=db_path,
+        config={"task_graph": {"enabled": True, "top_k": 3}},
+    )
+    result = changed.process_dirty()
+    second = changed.store_for_scope(task["task_scope_id"]).load_current()
+
+    assert result["failed_scopes"] == []
+    assert second.generation_id != first.generation_id
+    assert second.generator["top_k"] == 3
+    assert {item.task_id for item in second.tasks} == {
+        item.task_id for item in first.tasks
+    }
 
 
 def test_restart_reloads_manifest_shards_and_preserves_generation(tmp_path):
@@ -482,6 +575,44 @@ def test_idempotent_override_retry_rebuilds_an_unmaterialized_event(
     assert next(
         item for item in current.tasks if item.task_id == task["task_id"]
     ).lifecycle == "blocked"
+    assert list_dirty_sources(db_path=db_path) == []
+    assert list_dirty_task_scopes(db_path=db_path) == []
+
+
+def test_unregister_dir_reconciles_the_removed_source(tmp_path):
+    db_path = tmp_path / "registry.db"
+    source = _add_source(
+        tmp_path,
+        db_path,
+        source_name="unregister",
+        atoms=[{"intent": "注销轨迹目录", "summary": "清理派生任务"}],
+    )
+    service = _build(tmp_path, db_path, [source])
+    tenant_id = service.resolver.tenant_id
+    task = list_logical_tasks(tenant_id, db_path=db_path)[0]
+
+    assert unregister_dir(tmp_path / "trajectories", db_path=db_path)
+    dirty = list_dirty_sources(db_path=db_path)
+    assert len(dirty) == 1
+    assert dirty[0]["deleted"] == 1
+    assert dirty[0]["task_scope_id"] == task["task_scope_id"]
+
+    restarted = TaskGraphService(
+        state_root=tmp_path,
+        db_path=db_path,
+        config={"task_graph": {"enabled": True}},
+    )
+    result = restarted.process_dirty()
+
+    assert result["failed_scopes"] == []
+    assert result["sources"] == 1
+    assert list_dirty_sources(db_path=db_path) == []
+    assert list_logical_tasks(tenant_id, db_path=db_path) == []
+    historical = list_logical_tasks(
+        tenant_id, include_tombstones=True, db_path=db_path,
+    )
+    assert len(historical) == 1
+    assert historical[0]["task_id"] == task["task_id"]
 
 
 def test_override_scope_queue_recovers_without_any_live_source(
@@ -625,10 +756,22 @@ def test_registry_migration_preserves_legacy_usage_without_inventing_scope(tmp_p
         "id INTEGER PRIMARY KEY AUTOINCREMENT,ts TEXT,step TEXT,model TEXT,"
         "prompt INTEGER DEFAULT 0,completion INTEGER DEFAULT 0,"
         "total INTEGER DEFAULT 0,cost_usd REAL DEFAULT 0,price_source TEXT);"
+        "CREATE TABLE task_graph_generations("
+        "tenant_id TEXT NOT NULL,task_scope_id TEXT NOT NULL,"
+        "generation_id TEXT NOT NULL,source_revision TEXT NOT NULL,"
+        "base_override_seq INTEGER NOT NULL,created_at TEXT NOT NULL,"
+        "task_count INTEGER NOT NULL DEFAULT 0,atom_count INTEGER NOT NULL DEFAULT 0,"
+        "candidate_count INTEGER NOT NULL DEFAULT 0,"
+        "model_judgement_count INTEGER NOT NULL DEFAULT 0,"
+        "PRIMARY KEY(tenant_id,task_scope_id));"
         "INSERT INTO watch_dirs(path,label,auto_index,ecosystem)"
         " VALUES('/legacy/path','legacy',1,'manual');"
         "INSERT INTO llm_usage(step,model,prompt,completion,total,cost_usd,price_source)"
         " VALUES('split','legacy-model',10,2,12,0.1,'static');"
+        "INSERT INTO task_graph_generations("
+        "tenant_id,task_scope_id,generation_id,source_revision,base_override_seq,"
+        "created_at) VALUES('ten_legacy','tsc_legacy','gen_legacy','rev_legacy',0,"
+        "'2026-01-01T00:00:00Z');"
     )
     connection.commit()
     connection.close()
@@ -640,6 +783,9 @@ def test_registry_migration_preserves_legacy_usage_without_inventing_scope(tmp_p
         "SELECT usage_event_id,usage_plane,measurement_quality,tenant_id,"
         "total,cost_usd,legacy FROM llm_usage",
     ).fetchone()
+    generation = migrated.execute(
+        "SELECT generator_json FROM task_graph_generations",
+    ).fetchone()
     migrated.close()
     assert watch_dir["source_scope_id"].startswith("src_")
     assert usage["usage_event_id"].startswith("xsp_legacy_")
@@ -649,6 +795,7 @@ def test_registry_migration_preserves_legacy_usage_without_inventing_scope(tmp_p
     assert usage["total"] == 12
     assert usage["cost_usd"] == pytest.approx(0.1)
     assert usage["legacy"] == 1
+    assert generation["generator_json"] == "{}"
 
 
 def test_structured_harness_success_finishes_attempt_without_verifying_task(tmp_path):
@@ -808,6 +955,37 @@ def test_changed_usage_event_does_not_publish_a_conflicting_generation(tmp_path)
     assert result["failed_scopes"] == [task["task_scope_id"]]
     assert store.load_current().generation_id == generation_id
     assert len(list_dirty_sources(db_path=db_path)) == 1
+
+
+def test_session_append_without_usage_reuses_the_unavailable_fact(tmp_path):
+    db_path = tmp_path / "registry.db"
+    source = _add_source(
+        tmp_path,
+        db_path,
+        source_name="append-without-usage",
+        atoms=[{"intent": "持续处理任务", "summary": "等待后续消息"}],
+    )
+    service = _build(tmp_path, db_path, [source])
+    trajectory_path = tmp_path / "trajectories" / "traj_append-without-usage.md"
+    trajectory_path.write_text(
+        trajectory_path.read_text(encoding="utf-8") + "\n追加一轮消息\n",
+        encoding="utf-8",
+    )
+
+    service.mark_dirty(*source, reason="session_appended")
+    result = service.process_dirty()
+
+    assert result["failed_scopes"] == []
+    assert result["sources"] == 1
+    assert list_dirty_sources(db_path=db_path) == []
+    with pooled_connection(db_path) as connection:
+        events = connection.execute(
+            "SELECT observed_at,measurement_quality"
+            " FROM execution_usage_events",
+        ).fetchall()
+    assert [(row["observed_at"], row["measurement_quality"]) for row in events] == [
+        ("unavailable", "unavailable")
+    ]
 
 
 def test_atom_content_skill_and_score_updates_do_not_change_task_identity(tmp_path):

--- a/tests/test_task_graph_runtime.py
+++ b/tests/test_task_graph_runtime.py
@@ -1057,6 +1057,91 @@ def test_retry_inside_one_atom_creates_line_scoped_attempts(tmp_path):
     ) == pytest.approx(1.0)
 
 
+@pytest.mark.parametrize(
+    "correction_text",
+    (
+        "不对，根因是缺少数据库索引，请回退超时改动",
+        "错了，请回退刚才的修改并添加数据库索引",
+        "刚才的方向有误，请改为添加数据库索引",
+    ),
+)
+def test_correction_inside_one_atom_creates_line_scoped_attempts(
+    tmp_path, correction_text,
+):
+    db_path = tmp_path / "registry.db"
+    source = _add_source(
+        tmp_path,
+        db_path,
+        source_name="intra-atom-correction",
+        atoms=[{"intent": "修复登录问题", "summary": "纠正方案后完成修复"}],
+    )
+    raw_segment = (
+        "## User\n修复登录问题\n\n"
+        "## Assistant\n把请求超时改成 30 秒\n\n"
+        f"## User\n{correction_text}\n\n"
+        "## Assistant\n已回退并添加索引\n"
+    )
+    atom_store = AtomTaskStore(tmp_path / "trajectories")
+    atom = atom_store.list_by_traj("traj_intra-atom-correction")[0]
+    atom.raw_segment = raw_segment
+    atom.offset_start = 1
+    atom.offset_end = len(raw_segment.splitlines()) + 1
+    atom_store.save(atom)
+
+    service = _build(tmp_path, db_path, [source])
+    tenant_id = service.resolver.tenant_id
+    task = list_logical_tasks(tenant_id, db_path=db_path)[0]
+    detail = get_logical_task(
+        tenant_id, task["task_scope_id"], task["task_id"], db_path=db_path,
+    )
+
+    assert len(detail["attempts"]) == 2
+    assert len(detail["evidence_ranges"]) == 2
+    assert len(detail["attempt_relations"]) == 1
+    assert detail["attempt_relations"][0]["relation_type"] == "correction_of"
+    assert detail["attempt_relations"][0]["decision"] == "confirmed"
+
+
+@pytest.mark.parametrize(
+    "ordinary_text",
+    (
+        "使用不对称加密保护登录凭据",
+        "检查这个答案对不对",
+        "如果结果不对，请保留诊断日志",
+    ),
+)
+def test_non_correction_phrases_do_not_split_attempts(tmp_path, ordinary_text):
+    db_path = tmp_path / "registry.db"
+    source = _add_source(
+        tmp_path,
+        db_path,
+        source_name="not-a-correction",
+        atoms=[{"intent": "完善登录安全", "summary": "检查安全方案"}],
+    )
+    raw_segment = (
+        "## User\n完善登录安全\n\n"
+        "## Assistant\n开始检查\n\n"
+        f"## User\n{ordinary_text}\n\n"
+        "## Assistant\n检查完成\n"
+    )
+    atom_store = AtomTaskStore(tmp_path / "trajectories")
+    atom = atom_store.list_by_traj("traj_not-a-correction")[0]
+    atom.raw_segment = raw_segment
+    atom.offset_start = 1
+    atom.offset_end = len(raw_segment.splitlines()) + 1
+    atom_store.save(atom)
+
+    service = _build(tmp_path, db_path, [source])
+    tenant_id = service.resolver.tenant_id
+    task = list_logical_tasks(tenant_id, db_path=db_path)[0]
+    detail = get_logical_task(
+        tenant_id, task["task_scope_id"], task["task_id"], db_path=db_path,
+    )
+
+    assert len(detail["attempts"]) == 1
+    assert detail["attempt_relations"] == []
+
+
 def test_failed_attempt_does_not_close_logical_task(tmp_path):
     db_path = tmp_path / "registry.db"
     source = _add_source(

--- a/tests/test_usage.py
+++ b/tests/test_usage.py
@@ -30,13 +30,74 @@ def test_extract_usage_sdk_object_total_derived():
 
 
 def test_extract_usage_missing_usage():
-    assert extract_usage({"choices": []}) == Usage()
-    assert extract_usage(None) == Usage()
+    expected = Usage(
+        prompt=None,
+        completion=None,
+        total=None,
+        cache_hit=None,
+        cache_miss=None,
+        measurement_quality="unavailable",
+        unavailable_reason="response_did_not_report_usage",
+    )
+    assert extract_usage({"choices": []}) == expected
+    assert extract_usage(None) == expected
+
+
+def test_partial_usage_keeps_missing_fields_unavailable(tmp_path):
+    from xskill.pipeline.registry import pooled_connection
+
+    db_path = tmp_path / "registry.db"
+    response = {
+        "usage": {"completion_tokens": 5, "total_tokens": 5},
+    }
+    usage = extract_usage(response)
+    assert usage.prompt is None
+    assert usage.completion == 5
+    assert usage.total == 5
+    assert usage.unavailable_reason == "response_did_not_report:prompt_tokens"
+    assert cost_usd(
+        usage, ModelPrice(input_per_1m=1.0, output_per_1m=2.0),
+    ) is None
+
+    ledger = UsageLedger(_table(), db_path=db_path)
+    ledger.record_llm("atom_split", "deepseek-v4-flash", response)
+    with pooled_connection(db_path) as connection:
+        row = connection.execute(
+            "SELECT prompt,completion,total,cost_usd,unavailable_reason"
+            " FROM llm_usage",
+        ).fetchone()
+    assert row["prompt"] is None
+    assert row["completion"] == 5
+    assert row["total"] == 5
+    assert row["cost_usd"] is None
+    assert row["unavailable_reason"] == (
+        "response_did_not_report:prompt_tokens"
+    )
+
+
+def test_record_usage_rejects_numeric_event_id(tmp_path):
+    from xskill.pipeline.registry import record_usage
+
+    with pytest.raises(ValueError, match="usage_event_id"):
+        record_usage(
+            step="atom_split",
+            model="model-test",
+            prompt=1,
+            completion=1,
+            total=2,
+            cost_usd=0.0,
+            price_source="test",
+            usage_event_id=8,
+            db_path=tmp_path / "registry.db",
+        )
 
 
 def _agno_response(**metrics_kwargs):
     """构造真实 agno ModelResponse —— agent LLM 记账点的实际传入形态。"""
-    from agno.models.metrics import MessageMetrics
+    try:
+        from agno.metrics import MessageMetrics
+    except ImportError:  # pragma: no cover - Agno < 3 compatibility
+        from agno.models.metrics import MessageMetrics
     from agno.models.response import ModelResponse
 
     resp = ModelResponse()
@@ -125,7 +186,7 @@ def test_cost_embedding_uses_embed_price():
 
 # ── UsageLedger ──────────────────────────────────────────────────
 def test_ledger_accumulates_and_flags_estimated(monkeypatch):
-    monkeypatch.setattr(U, "_persist", lambda *a, **k: None)  # 不碰真实 registry
+    monkeypatch.setattr(U, "_persist", lambda *_a, **_k: None)  # 不碰真实 registry
     led = UsageLedger(_table())
     led.record_llm("atom_split", "deepseek-v4-flash",
                    {"usage": {"prompt_tokens": 1000, "completion_tokens": 200,
@@ -142,7 +203,7 @@ def test_ledger_accumulates_and_flags_estimated(monkeypatch):
 
 
 def test_ledger_record_never_raises(monkeypatch):
-    monkeypatch.setattr(U, "_persist", lambda *a, **k: None)
+    monkeypatch.setattr(U, "_persist", lambda *_a, **_k: None)
     led = UsageLedger(_table())
     led.record_llm("x", "m", object())      # 垃圾 resp,不应抛
     led.record_llm("x", "m", None)


### PR DESCRIPTION
## Summary

在现有 Session 与 Atom 证据层之上实现可持久化、可回放的 Logical Task 与 Task Attempt 分支，用于表达跨 Atom 目标、重试、纠正、终态及 Task 级用量归因。

该分支默认通过 `task_graph.enabled: false` 关闭，不改变现有 Atom → candidate → Skill 主流水线、Atom 多 Skill 语义、`ux_score` 或 `weightscore`。

## Changes

- 增加 LogicalTask、TaskAttempt、EvidenceRange、membership、关系和 usage allocation 的强校验模型。
- 增加 TenantScope、TaskScope 与 SourceScope 的稳定身份解析，所有关联和查询均保留完整作用域。
- 增加有界候选 Linker，复用未变化事实，并将未校准的歧义关联保留为 proposed。
- 支持同一 Atom 内显式重试和纠正的 EvidenceRange 拆分，以及 `retry_of`、`correction_of` 和 `continuation_of` 关系。
- 增加内容寻址 generation、人工 override 日志、文件锁、崩溃恢复和 SQLite 可重建投影。
- 从 Codex、DeepSeek Harness 与 OpenClaw 轨迹保留执行身份、结构化终态和 execution usage，并按 confirmed primary evidence 守恒分摊。
- 增加独立 Task Graph worker、持久脏队列、流水线状态以及受管理员权限保护的查询和人工修正 API。
- 保持候选查询、posting、anchor、缓存、共享 allocation 边数和单轮 scope 数量有界，Task Graph 不调用 LLM。

## Algorithm and evaluation scope

本 PR 的 Linker 是确定性的有界规则算法，不调用或占用 LLM API，且默认关闭并不参与 Atom → candidate → Skill 路由，因此当前 PR 对 qwen3.8-27b + Spreadsheet/OfficeQA 的端到端分数预期是无变化，而不是以正向增益作为合并条件。

#325 负责建立 Logical Task 关联、Attempt 终态、不确定性和 Token/成本归因的固定离线回放基线；#262 负责 OfficeQA 可复现 runner 与结果口径，未来若让 Task Graph 默认启用或参与路由，应先用 #325 验证语义层没有退化，再接入 #262 的同模型、同 harness 端到端对照。

当前 PR 已提供 Task Graph worker 状态和 Dashboard 管理端查询/人工修正 API，但不增加新的前端可视化页面；前端流水线展示可以在模型与查询契约稳定后作为独立小 PR 推进。

## Test plan

- [x] `make test` passes（2459 passed, 9 skipped）
- [x] Added/updated unit tests for the change
- [x] `make e2e` passes（2 Docker runtime discovery/bridge scenarios）
- [x] Manually verified the affected user flow；使用本地 OpenAI-compatible 模型回放了显式重试、显式纠正、新目标、重启和用量守恒路径
- [x] Synced with `main` after Agno 3 compatibility, Atom language/dedup, DSH zstd provisioning and Docker mirror fallback changes

## Linked issues

Closes #324

Related to #325

Related to #262
