### PR TITLE
fix(deps): 修复 Milvus extra 缺少本地运行时依赖

### DIFF
--- a/pyproject.toml
+++ b/pyproject.toml
@@ -62,7 +62,7 @@ dependencies = [
 # 大库上会更慢。team server 建议：pip install 'xskill[milvus]'。
 # 不进主依赖——pymilvus 体积大、部分环境装不上，曾阻断 client 自动更新。
 milvus = [
-    "pymilvus>=2.4.2",
+    "pymilvus[milvus_lite]>=2.4.2",
 ]
 dev = [
     "pytest>=7",

--- a/tests/test_optional_pymilvus.py
+++ b/tests/test_optional_pymilvus.py
@@ -78,4 +78,4 @@ def test_pyproject_keeps_pymilvus_optional_only():
     deps_block = text[deps_start:extras_start]
     assert "pymilvus" not in deps_block
     assert 'milvus = [' in text or 'milvus=[' in text
-    assert 'pymilvus>=2.4.2' in text[extras_start:]
+    assert 'pymilvus[milvus_lite]>=2.4.2' in text[extras_start:]


### PR DESCRIPTION
## Summary

修复 `xskill[milvus]` 只安装 Python SDK、却未安装本地 Milvus Lite 运行时的问题，避免 team server 按文档安装 extra 后仍静默退化为短命进程内存索引和重复全量向量化。

## Changes

- 将 `milvus` optional dependency 从 `pymilvus>=2.4.2` 改为 `pymilvus[milvus_lite]>=2.4.2`。
- 更新已有 optional dependency 契约测试，确保 `pymilvus` 仍不进入默认依赖，同时锁定 Milvus extra 必须包含 `milvus_lite`。
- 保留未安装 extra 时使用 numpy/内存 fallback 的现有行为。

## Test plan

- [x] `make test` passes
- [x] Added/updated unit tests for the change
- [ ] `make e2e` passes (if the change touches ingestion / install / daemon)
- [x] Manually verified the affected user flow

完整单元测试结果：2408 passed, 10 skipped。聚焦测试 `tests/test_optional_pymilvus.py`：5 passed。实际依赖解析得到 `pymilvus 3.0.1` 与 `milvus_lite 3.2.0`，两者均可导入；本改动不涉及 ingestion、install 或 daemon，因此未运行 Docker E2E。

## Linked issues

Closes #329
