### PR TITLE
fix(stress): 对齐 Nightly 控制面压力测试与当前运行时契约

### DIFF
--- a/.github/workflows/nightly-control-plane-stress.yml
+++ b/.github/workflows/nightly-control-plane-stress.yml
@@ -52,8 +52,8 @@ jobs:
         with:
           python-version: "3.11"
           cache: pip
-      - name: Install package with dev extras
-        run: pip install -e .[dev]
+      - name: Install package with dev and Milvus extras
+        run: pip install -e '.[dev,milvus]'
       - name: Run 300x300 control-plane stress test
         run: >-
           pytest tests/stress/test_control_plane_300.py -v

--- a/scripts/loadtest_300_control_plane.py
+++ b/scripts/loadtest_300_control_plane.py
@@ -36,7 +36,11 @@ PROFILE_REFRESH_INTERVAL_S = 1.0
 PROFILE_REFRESH_POLL_INTERVAL_S = 0.2
 WATCHER_COUNT_FIELDS = (
     "polls", "new_trajs", "atoms_extracted", "indexed", "atoms_clustered",
-    "skills_edited", "scores", "errors", "retries", "in_flight",
+    "skills_edited", "scores", "errors", "retries", "scans",
+)
+PROFILE_REFRESH_COUNT_FIELDS = ("queued", "running", "failed", "embed_items")
+RECOMMEND_HEAVY_COUNT_FIELDS = (
+    "profile_rc", "vector_upserted", "vector_deleted", "recommends",
 )
 logger = logging.getLogger("xskill.loadtest.control_plane")
 
@@ -188,8 +192,12 @@ def _skill_from_messages(messages: list[dict[str, Any]]) -> tuple[str, str]:
 def _tool_call_response(body: dict[str, Any], request_number: int) -> dict[str, Any]:
     messages = body.get("messages") or []
     model = body.get("model", "mock-tool-model")
-    has_tool_result = any(m.get("role") == "tool" for m in messages if isinstance(m, dict))
-    if has_tool_result:
+    tool_results = [
+        str(message.get("content") or "")
+        for message in messages
+        if isinstance(message, dict) and message.get("role") == "tool"
+    ]
+    if any("Created baby checkpoint" in result for result in tool_results):
         return {
             "id": f"chatcmpl-final-{request_number}",
             "object": "chat.completion",
@@ -216,27 +224,27 @@ def _tool_call_response(body: dict[str, Any], request_number: int) -> dict[str, 
         f"# {skill_name}\n\n"
         f"Mock-generated content for {skill_name}.\n"
     )
-    tool_calls = [
-        {
+    if any("wrote:" in result for result in tool_results):
+        tool_calls = [{
+            "id": f"call-commit-{request_number}",
+            "type": "function",
+            "function": {
+                "name": "commit_baby",
+                "arguments": json.dumps({
+                    "skill_name": skill_name,
+                    "message": f"mock load test: checkpoint {skill_name}",
+                }),
+            },
+        }]
+    else:
+        tool_calls = [{
             "id": f"call-write-{request_number}",
             "type": "function",
             "function": {
                 "name": "write_file",
                 "arguments": json.dumps({"path": skill_path, "content": content}),
             },
-        },
-        {
-            "id": f"call-commit-{request_number}",
-            "type": "function",
-            "function": {
-                "name": "commit_baby_to_main",
-                "arguments": json.dumps({
-                    "skill_name": skill_name,
-                    "message": f"mock load test: graduate {skill_name}",
-                }),
-            },
-        },
-    ]
+        }]
     return {
         "id": f"chatcmpl-tool-{request_number}",
         "object": "chat.completion",
@@ -687,17 +695,34 @@ async def _profile_metrics(client) -> dict[str, Any] | None:
         if not isinstance(stats, dict):
             raise StatusContractError("profile_refresh stats is not an object")
         if profile_status["ok"]:
-            for key in ("queued", "running", "failed", "embed_items"):
-                value = stats.get(key)
-                if (
-                    not isinstance(value, int)
-                    or isinstance(value, bool)
-                    or value < 0
-                ):
-                    raise StatusContractError(
-                        f"profile_refresh {key} is not a non-negative integer"
-                    )
+            _profile_status_kind(stats)
     return profile_status
+
+
+def _profile_status_kind(stats: dict[str, Any]) -> str:
+    if any(key in stats for key in RECOMMEND_HEAVY_COUNT_FIELDS):
+        kind = "recommend_heavy"
+        required_fields = RECOMMEND_HEAVY_COUNT_FIELDS
+    elif any(key in stats for key in PROFILE_REFRESH_COUNT_FIELDS):
+        kind = "profile_refresh"
+        required_fields = PROFILE_REFRESH_COUNT_FIELDS
+    else:
+        raise StatusContractError("profile_refresh stats has no recognized schema")
+    for key in required_fields:
+        value = stats.get(key)
+        if (
+            not isinstance(value, int)
+            or isinstance(value, bool)
+            or value < 0
+        ):
+            raise StatusContractError(
+                f"profile_refresh {key} is not a non-negative integer"
+            )
+    if kind == "recommend_heavy" and stats["profile_rc"] != 0:
+        raise StatusContractError(
+            "profile_refresh profile_rc is nonzero for a successful round"
+        )
+    return kind
 
 
 def _profile_round_ended_at(profile_status: dict[str, Any] | None) -> float | None:
@@ -721,7 +746,7 @@ def _safe_profile_status(
     if isinstance(stats, dict):
         safe_stats = {
             key: stats[key]
-            for key in ("queued", "running", "failed", "embed_items")
+            for key in (*PROFILE_REFRESH_COUNT_FIELDS, *RECOMMEND_HEAVY_COUNT_FIELDS)
             if isinstance(stats.get(key), int) and not isinstance(stats[key], bool)
         }
     return {
@@ -768,11 +793,13 @@ async def _wait_profile_idle(
                 )
             current_ended_at = _profile_round_ended_at(last_status)
             stats = last_status["stats"]
-            counters = (stats["queued"], stats["running"])
             is_new_round = (
                 after_ended_at is None or current_ended_at > after_ended_at
             )
-            if is_new_round and counters == (0, 0):
+            # recommend-heavy first writes an intermediate profile-refresh
+            # status, then overwrites it after vector reconcile + precompute.
+            # Only the combined status proves the scheduled round completed.
+            if is_new_round and _profile_status_kind(stats) == "recommend_heavy":
                 return stats
         await asyncio.sleep(PROFILE_REFRESH_POLL_INTERVAL_S)
     safe_status = _safe_profile_status(last_status, last_poll_error_type)
@@ -816,14 +843,14 @@ async def _watcher_status(client) -> dict[str, Any] | None:
             raise StatusContractError("watcher running is not boolean")
         if not isinstance(stats.get("paused"), bool):
             raise StatusContractError("watcher paused is not boolean")
-        last_poll = stats.get("last_poll")
+        last_scan = stats.get("last_scan")
         if (
-            not isinstance(last_poll, (int, float))
-            or isinstance(last_poll, bool)
-            or last_poll < 0
+            not isinstance(last_scan, (int, float))
+            or isinstance(last_scan, bool)
+            or last_scan < 0
         ):
             raise StatusContractError(
-                "watcher last_poll is not a non-negative number"
+                "watcher last_scan is not a non-negative number"
             )
     return payload
 
@@ -926,7 +953,6 @@ async def run_sync_wave(
     join_token: str,
     state: MockState,
     server_pid: int,
-    profile_workers: int,
     gated_embedding: bool,
     wave: dict[str, Any],
     checkpoint,
@@ -955,9 +981,8 @@ async def run_sync_wave(
     phase_error: Exception | None = None
     try:
         if gated_embedding:
-            desired_active = min(len(client_rows), profile_workers)
             additional_starts = max(
-                0, desired_active - int(embedding_before["active"]),
+                0, min(1, len(client_rows)) - int(embedding_before["active"]),
             )
             target_started = (
                 int(embedding_before["request_count"]) + additional_starts
@@ -1028,7 +1053,11 @@ async def run_sync_wave(
     return wave
 
 
-def _seed_delta_atoms(client_rows: list[dict[str, str]]) -> None:
+def _seed_delta_atoms(
+    client_rows: list[dict[str, str]], *, registry_db: Path,
+) -> None:
+    from xskill.recommend.profile_dirty import mark_profile_dirty_for_store
+
     for row in client_rows:
         index = int(row["index"])
         _write_atom(
@@ -1036,6 +1065,9 @@ def _seed_delta_atoms(client_rows: list[dict[str, str]]) -> None:
             traj_id=f"traj_client_{index:03d}",
             atom_id=f"atom_client_{index:03d}_0002",
             summary=f"delta summary client {index:03d}",
+        )
+        mark_profile_dirty_for_store(
+            row["root"], reason="loadtest_delta", db_path=registry_db,
         )
 
 
@@ -1248,7 +1280,6 @@ async def run_scenario(
                 join_token=prepared["join_token"],
                 state=state,
                 server_pid=process.pid,
-                profile_workers=args.profile_refresh_workers,
                 gated_embedding=True,
                 wave=cold_wave,
                 checkpoint=checkpoint,
@@ -1285,7 +1316,6 @@ async def run_scenario(
                 join_token=prepared["join_token"],
                 state=state,
                 server_pid=process.pid,
-                profile_workers=args.profile_refresh_workers,
                 gated_embedding=False,
                 wave=cached_wave,
                 checkpoint=checkpoint,
@@ -1308,7 +1338,10 @@ async def run_scenario(
             # 先关 embedding gate 再写增量，避免 1s 周期恰好在基线与写入之间
             # 启动并完成，导致本波变化被上一轮提前消费。
             state.set_embed_phase("one_new_atom", released=False)
-            _seed_delta_atoms(prepared["clients"])
+            _seed_delta_atoms(
+                prepared["clients"],
+                registry_db=Path(prepared["xhome"]) / "registry.db",
+            )
             await run_sync_wave(
                 client,
                 phase="one_new_atom",
@@ -1316,7 +1349,6 @@ async def run_scenario(
                 join_token=prepared["join_token"],
                 state=state,
                 server_pid=process.pid,
-                profile_workers=args.profile_refresh_workers,
                 gated_embedding=True,
                 wave=delta_wave,
                 checkpoint=checkpoint,
@@ -1506,9 +1538,9 @@ def validate_result(result: dict[str, Any]) -> list[str]:
             failures.append(f"{phase}: sync max={latency['max_s']}")
         if phase != "cache_hit" and not wave.get("all_sync_completed_before_embedding_release"):
             failures.append(f"{phase}: sync remained blocked by embedding gate")
-        idle = wave.get("profile_idle_metrics", {})
-        if idle.get("queued") != 0 or idle.get("running") != 0:
-            failures.append(f"{phase}: profile service not idle: {idle}")
+        completed = wave.get("profile_idle_metrics", {})
+        if completed.get("profile_rc") != 0:
+            failures.append(f"{phase}: recommend-heavy did not complete: {completed}")
 
     probes = _all_probes(result)
     for probe in probes:
@@ -1529,16 +1561,23 @@ def validate_result(result: dict[str, Any]) -> list[str]:
 
     mock = result.get("mock", {})
     llm = mock.get("llm", {})
-    if llm.get("initial_requests") != skills or llm.get("followup_requests") != skills:
+    if (
+        llm.get("initial_requests") != skills
+        or llm.get("followup_requests") != 2 * skills
+    ):
         failures.append(f"LLM request split incorrect: {llm}")
-    if llm.get("started") != 2 * skills or llm.get("completed") != 2 * skills:
+    if llm.get("started") != 3 * skills or llm.get("completed") != 3 * skills:
         failures.append(f"LLM completion count incorrect: {llm}")
     if int(llm.get("max_active", workers + 1)) > int(config["llm_max_inflight"]):
         failures.append(f"LLM active limit exceeded: {llm.get('max_active')}")
 
     embedding = mock.get("embedding", {})
     items_by_phase = embedding.get("items_by_phase", {})
-    expected_items = {"cold": clients, "cache_hit": 0, "one_new_atom": clients}
+    expected_items = {
+        "cold": skills + clients,
+        "cache_hit": 0,
+        "one_new_atom": clients,
+    }
     actual_items = {phase: int(items_by_phase.get(phase, 0)) for phase in expected_items}
     if actual_items != expected_items:
         failures.append(f"embedding phase items incorrect: {actual_items}")
@@ -1548,11 +1587,11 @@ def validate_result(result: dict[str, Any]) -> list[str]:
     }
     if actual_requests != expected_items:
         failures.append(f"embedding phase requests incorrect: {actual_requests}")
-    if embedding.get("input_item_count") != 2 * clients:
+    if embedding.get("input_item_count") != skills + 2 * clients:
         failures.append(f"embedding item count incorrect: {embedding.get('input_item_count')}")
-    if embedding.get("request_count") != 2 * clients:
+    if embedding.get("request_count") != skills + 2 * clients:
         failures.append(f"embedding request count incorrect: {embedding.get('request_count')}")
-    if embedding.get("unique_inputs") != 2 * clients:
+    if embedding.get("unique_inputs") != skills + 2 * clients:
         failures.append(f"embedding unique inputs incorrect: {embedding.get('unique_inputs')}")
     if embedding.get("duplicate_input_calls") != 0:
         failures.append(f"embedding duplicate inputs: {embedding.get('duplicate_input_calls')}")
@@ -1562,12 +1601,10 @@ def validate_result(result: dict[str, Any]) -> list[str]:
     final_metrics = result.get("profile_metrics", {}).get("final_idle", {})
     if (
         not isinstance(final_metrics, dict)
-        or type(final_metrics.get("queued")) is not int
-        or type(final_metrics.get("running")) is not int
-        or final_metrics["queued"] != 0
-        or final_metrics["running"] != 0
+        or type(final_metrics.get("profile_rc")) is not int
+        or final_metrics["profile_rc"] != 0
     ):
-        failures.append(f"profile service final state is not idle: {final_metrics}")
+        failures.append(f"recommend-heavy final state is invalid: {final_metrics}")
     profile_rounds = []
     for round_name in ("after_cold", "after_cache_hit", "after_one_new_atom"):
         metrics = result.get("profile_metrics", {}).get(round_name)
@@ -1576,7 +1613,7 @@ def validate_result(result: dict[str, Any]) -> list[str]:
             continue
         invalid_fields = [
             field_name
-            for field_name in ("queued", "running", "failed", "embed_items")
+            for field_name in RECOMMEND_HEAVY_COUNT_FIELDS
             if type(metrics.get(field_name)) is not int
         ]
         if invalid_fields:
@@ -1585,30 +1622,10 @@ def validate_result(result: dict[str, Any]) -> list[str]:
             )
             continue
         profile_rounds.append(metrics)
-    if len(profile_rounds) == 3:
-        failed_profiles = sum(metrics["failed"] for metrics in profile_rounds)
-        if failed_profiles != 0:
-            failures.append(f"profile refresh failures: {failed_profiles}")
-        # 状态文件只保留最近一次短命画像进程；cold 的实际计算轮可能在读取前
-        # 已被紧随其后的 unchanged 空轮覆盖，因此不能把三份“最近一轮”快照
-        # 相加当累计值。累计量由上面的 mock phase 计数和最终 DB 收敛共同校验。
-        cold_embed_items = profile_rounds[0]["embed_items"]
-        cache_hit_embed_items = profile_rounds[1]["embed_items"]
-        delta_embed_items = profile_rounds[2]["embed_items"]
-        if cold_embed_items not in (0, clients):
-            failures.append(
-                f"cold profile embed_items incorrect: {cold_embed_items}"
-            )
-        if cache_hit_embed_items != 0:
-            failures.append(
-                f"cache_hit profile embed_items incorrect: "
-                f"{cache_hit_embed_items}"
-            )
-        if delta_embed_items != clients:
-            failures.append(
-                f"one_new_atom profile embed_items incorrect: "
-                f"{delta_embed_items}"
-            )
+    if len(profile_rounds) == 3 and any(
+        metrics["profile_rc"] != 0 for metrics in profile_rounds
+    ):
+        failures.append(f"profile refresh failures: {profile_rounds}")
 
     skill = result.get("skill_convergence", {})
     if (
@@ -1687,13 +1704,13 @@ def validate_result(result: dict[str, Any]) -> list[str]:
                 invalid_final_fields.append("running")
             if not isinstance(final_watcher_stats.get("paused"), bool):
                 invalid_final_fields.append("paused")
-            final_last_poll = final_watcher_stats.get("last_poll")
+            final_last_scan = final_watcher_stats.get("last_scan")
             if (
-                not isinstance(final_last_poll, (int, float))
-                or isinstance(final_last_poll, bool)
-                or final_last_poll < 0
+                not isinstance(final_last_scan, (int, float))
+                or isinstance(final_last_scan, bool)
+                or final_last_scan < 0
             ):
-                invalid_final_fields.append("last_poll")
+                invalid_final_fields.append("last_scan")
         if final_watcher_status.get("ok") is not True:
             invalid_final_fields.append("ok")
         final_ended_at = final_watcher_status.get("ended_at")

--- a/tests/stress/test_control_plane_300.py
+++ b/tests/stress/test_control_plane_300.py
@@ -20,7 +20,7 @@ REPO_ROOT = Path(__file__).resolve().parents[2]
 HARNESS = REPO_ROOT / "scripts" / "loadtest_300_control_plane.py"
 WATCHER_COUNT_FIELDS = (
     "polls", "new_trajs", "atoms_extracted", "indexed", "atoms_clustered",
-    "skills_edited", "scores", "errors", "retries", "in_flight",
+    "skills_edited", "scores", "errors", "retries", "scans",
 )
 
 
@@ -144,36 +144,32 @@ def test_control_plane_300(tmp_path: Path) -> None:
     assert type(result["diagnostics"]["traceback_count"]) is int, artifact
     assert result["diagnostics"]["traceback_count"] == 0, artifact
     llm = result["mock"]["llm"]
-    assert llm["started"] == 2 * skills, artifact
-    assert llm["completed"] == 2 * skills, artifact
+    assert llm["started"] == 3 * skills, artifact
+    assert llm["completed"] == 3 * skills, artifact
     assert llm["initial_requests"] == skills, artifact
-    assert llm["followup_requests"] == skills, artifact
+    assert llm["followup_requests"] == 2 * skills, artifact
     assert llm["max_active"] <= concurrency, artifact
 
     embedding = result["mock"]["embedding"]
-    assert embedding["requests_by_phase"].get("cold", 0) == clients, artifact
+    assert embedding["requests_by_phase"].get("cold", 0) == skills + clients, artifact
     assert embedding["requests_by_phase"].get("cache_hit", 0) == 0, artifact
     assert embedding["requests_by_phase"].get("one_new_atom", 0) == clients, artifact
-    assert embedding["items_by_phase"].get("cold", 0) == clients, artifact
+    assert embedding["items_by_phase"].get("cold", 0) == skills + clients, artifact
     assert embedding["items_by_phase"].get("cache_hit", 0) == 0, artifact
     assert embedding["items_by_phase"].get("one_new_atom", 0) == clients, artifact
-    assert embedding["request_count"] == 2 * clients, artifact
-    assert embedding["input_item_count"] == 2 * clients, artifact
-    assert embedding["unique_inputs"] == 2 * clients, artifact
+    assert embedding["request_count"] == skills + 2 * clients, artifact
+    assert embedding["input_item_count"] == skills + 2 * clients, artifact
+    assert embedding["unique_inputs"] == skills + 2 * clients, artifact
     assert embedding["duplicate_input_calls"] == 0, artifact
     assert embedding["max_active"] <= profile_workers, artifact
 
     profile_metrics = result["profile_metrics"]["final_idle"]
-    assert profile_metrics["queued"] == 0, artifact
-    assert profile_metrics["running"] == 0, artifact
+    assert profile_metrics["profile_rc"] == 0, artifact
     profile_rounds = [
         result["profile_metrics"][key]
         for key in ("after_cold", "after_cache_hit", "after_one_new_atom")
     ]
-    assert sum(metrics["failed"] for metrics in profile_rounds) == 0, artifact
-    assert profile_rounds[0]["embed_items"] in (0, clients), artifact
-    assert profile_rounds[1]["embed_items"] == 0, artifact
-    assert profile_rounds[2]["embed_items"] == clients, artifact
+    assert all(metrics["profile_rc"] == 0 for metrics in profile_rounds), artifact
     assert result["profile_convergence"]["rows"] == clients, artifact
     assert result["profile_convergence"]["revision_rows"] == clients, artifact
     assert result["profile_convergence"]["revision_matches"] == clients, artifact
@@ -206,5 +202,7 @@ def test_control_plane_300(tmp_path: Path) -> None:
     assert final_watcher["stats"]["errors"] == 0, artifact
     assert type(final_watcher["stats"]["running"]) is bool, artifact
     assert type(final_watcher["stats"]["paused"]) is bool, artifact
+    assert type(final_watcher["stats"]["last_scan"]) in (int, float), artifact
+    assert final_watcher["stats"]["last_scan"] >= 0, artifact
     assert result["server"]["shutdown"]["clean"] is True, artifact
     assert result["server"]["shutdown"]["forced_kill"] is False, artifact

--- a/tests/stress/test_loadtest_harness_unit.py
+++ b/tests/stress/test_loadtest_harness_unit.py
@@ -151,12 +151,45 @@ def _watcher_round(
             "scores": 0,
             "errors": errors,
             "retries": 0,
-            "last_poll": ended_at - 0.1,
+            "scans": 1,
+            "last_scan": ended_at - 0.1,
             "running": False,
             "paused": False,
-            "in_flight": 0,
         },
     }
+
+
+def _tool_names(response: dict) -> list[str]:
+    return [
+        call["function"]["name"]
+        for call in response["choices"][0]["message"].get("tool_calls", [])
+    ]
+
+
+def test_mock_skill_edit_follows_current_three_request_protocol() -> None:
+    initial = HARNESS._tool_call_response({"messages": [{
+        "role": "user",
+        "content": "目标 skill 目录: /tmp/skills/example-skill\n"
+                   "目标 SKILL.md 路径: /tmp/skills/example-skill/SKILL.md",
+    }]}, 1)
+    assert _tool_names(initial) == ["write_file"]
+
+    after_write = HARNESS._tool_call_response({"messages": [{
+        "role": "tool", "content": "wrote: /tmp/skills/example-skill/SKILL.md",
+    }]}, 2)
+    assert _tool_names(after_write) == ["commit_baby"]
+    arguments = json.loads(
+        after_write["choices"][0]["message"]["tool_calls"][0]
+        ["function"]["arguments"]
+    )
+    assert set(arguments) == {"skill_name", "message"}
+
+    after_checkpoint = HARNESS._tool_call_response({"messages": [{
+        "role": "tool", "content": "Created baby checkpoint abc1234.",
+    }]}, 3)
+    message = after_checkpoint["choices"][0]["message"]
+    assert message["content"] == "Mock SkillEdit complete."
+    assert "tool_calls" not in message
 
 
 def test_gated_wave_releases_embedding_before_gather(monkeypatch, tmp_path) -> None:
@@ -184,7 +217,6 @@ def test_gated_wave_releases_embedding_before_gather(monkeypatch, tmp_path) -> N
             join_token="token",
             state=state,
             server_pid=-1,
-            profile_workers=1,
             gated_embedding=True,
             wave=wave,
             checkpoint=checkpoint,
@@ -201,7 +233,7 @@ def test_gated_wave_releases_embedding_before_gather(monkeypatch, tmp_path) -> N
     assert persisted["waves"]["blocked_sync"]["sync"]["statuses"] == {"200": 1}
 
 
-def test_gated_wave_accepts_profile_workers_already_saturated(monkeypatch) -> None:
+def test_gated_wave_accepts_embedding_already_active(monkeypatch) -> None:
     release = threading.Event()
     state = _AlreadySaturatedState(release)
     client = _BlockedSyncClient(release)
@@ -219,7 +251,6 @@ def test_gated_wave_accepts_profile_workers_already_saturated(monkeypatch) -> No
         join_token="token",
         state=state,
         server_pid=-1,
-        profile_workers=1,
         gated_embedding=True,
         wave={},
         checkpoint=checkpoint_records.clear,
@@ -242,7 +273,8 @@ def test_profile_wait_requires_new_nested_idle_round(monkeypatch) -> None:
         {
             "ok": True, "error": None, "ended_at": 11.0,
             "stats": {
-                "queued": 0, "running": 0, "failed": 0, "embed_items": 0,
+                "profile_rc": 0, "vector_upserted": 1,
+                "vector_deleted": 0, "recommends": 1,
             },
         },
     ])
@@ -253,7 +285,8 @@ def test_profile_wait_requires_new_nested_idle_round(monkeypatch) -> None:
 
     assert client.calls == 2
     assert metrics == {
-        "queued": 0, "running": 0, "failed": 0, "embed_items": 0,
+        "profile_rc": 0, "vector_upserted": 1,
+        "vector_deleted": 0, "recommends": 1,
     }
 
 
@@ -338,9 +371,12 @@ def test_successful_profile_poll_clears_previous_poll_error(monkeypatch) -> None
         (
             {
                 "ok": True, "error": None, "ended_at": 11.0,
-                "stats": {"queued": 0, "running": 0, "failed": 0},
+                "stats": {
+                    "profile_rc": 0, "vector_upserted": 0,
+                    "vector_deleted": 0,
+                },
             },
-            "embed_items",
+            "recommends",
         ),
         (
             {
@@ -442,9 +478,9 @@ def test_watcher_nonzero_errors_fail_the_gate() -> None:
     [
         ("polls", None),
         ("skills_edited", True),
-        ("in_flight", -1),
+        ("scans", -1),
         ("running", 0),
-        ("last_poll", "late"),
+        ("last_scan", "late"),
     ],
 )
 def test_successful_watcher_status_requires_complete_strict_stats(


### PR DESCRIPTION
## Summary

恢复长期稳定失败的 `Nightly Control-Plane Stress`：让 300×300 harness 与当前四池 Watcher、SkillEdit checkpoint、dirty-only 画像刷新和 `recommend-heavy` 状态契约保持一致，同时让该 team server 压力场景使用持久化 Milvus Lite。

## Changes

- 将 Watcher 严格状态字段从旧 `in_flight` / `last_poll` 对齐为当前 `scans` / `last_scan`。
- 将 mock SkillEdit 从同轮 `write_file + commit_baby_to_main` 改为 `write_file → commit_baby → final` 三请求协议，由框架在候选清空后自动 graduate。
- 同时校验画像刷新中间状态和 `recommend-heavy` 最终状态，只以后者作为定时重活完成证据。
- delta fixture 写入 Atom 后调用现有 `mark_profile_dirty_for_store`，与生产拆分回调的 dirty-only 刷新语义一致。
- 压力 job 安装 `dev,milvus` extras，并按当前持久化向量架构更新 cold/cache-hit/delta embedding 与最终状态断言。
- 将 gated embedding 的启动条件改为至少阻塞一个真实请求；dirty-only 调度可能在首个用户变脏时立即启动短命任务，不再假设所有 worker 同批饱和。

## Test plan

- [x] `make test` passes
- [x] Added/updated unit tests for the change
- [ ] `make e2e` passes (if the change touches ingestion / install / daemon)
- [x] Manually verified the affected user flow

完整单元测试结果：2408 passed, 10 skipped。harness 聚焦单测：21 passed。使用真实 uvicorn、worker、Git、SQLite 与 Milvus Lite 的 3 Skill × 3 client 缩小压力路径：1 passed。`git diff --check` 通过；本 PR 不修改生产 ingestion、install 或 daemon 代码，因此未运行 Docker E2E。

## Linked issues

Closes #331

Depends on #330；应先合并 Milvus extra 运行时修复，再重跑 300×300 Nightly 验证线上 artifact。
