### PR TITLE
fix(dsh): zstandard 移出主依赖，探测到 ~/.dsh 后再无窗补装一次

### DIFF
--- a/pyproject.toml
+++ b/pyproject.toml
@@ -46,12 +46,6 @@ dependencies = [
     # ``python:3.9-slim``）默认没装 git，SkillEditAgent 等链路又要跑 git
     # init/commit/branch；走 dulwich 后零依赖系统 git。
     "dulwich>=0.21",
-    # DeepSeek Harness (dsh) 默认把会话写成 zstd 帧序列（session.jsonl.zstd），
-    # 采集时需要解码。列为主依赖（维护者决定，PR #243）：dsh 是重要生态，
-    # 默认安装就应能收到它的轨迹；zstandard 约 1.8 MB，Python 3.9–3.13 各
-    # 平台均有预编译包，不存在「部分环境装不上而阻断客户端自动更新」的风险
-    # （那类体积大、平台覆盖不全的库应走 optional extra，见下）。
-    "zstandard>=0.21",
     # Python 3.9 上 pydantic 需要它来求值 `X | Y` 联合注解（PEP 604 语法
     # 3.10 才原生支持）；3.10+ 不安装。
     "eval_type_backport; python_version < '3.10'",
@@ -63,6 +57,13 @@ dependencies = [
 # 不进主依赖——pymilvus 体积大、部分环境装不上，曾阻断 client 自动更新。
 milvus = [
     "pymilvus>=2.4.2",
+]
+# DeepSeek Harness 默认写 session.jsonl.zstd。不进主依赖：0.6.32a2 把它
+# 放进 Requires-Dist 后，内网客户端装 server wheel 还要穿过坏代理去拉
+# 传递依赖，全员自动更新失败（#334）。有 dsh 的机器由
+# ``ensure_zstandard_for_dsh`` 现场补装；也可 ``pip install 'xskill[dsh]'``。
+dsh = [
+    "zstandard>=0.21",
 ]
 dev = [
     "pytest>=7",
@@ -79,6 +80,8 @@ dev = [
     # Mutation testing is a developer/CI concern and never enters the wheel's
     # runtime dependency set.
     "mutmut>=3.6,<4; python_version >= '3.10'",
+    # dsh 默认 zstd 会话的解码单测（``xskill[dsh]`` 运行时依赖）。
+    "zstandard>=0.21",
 ]
 
 [project.urls]

--- a/requirements.txt
+++ b/requirements.txt
@@ -2,7 +2,7 @@ pyyaml>=6.0
 numpy>=1.24
 openai>=1.0                 # LLM + Embedding API 客户端 (兼容各种 provider)
 agno
-zstandard>=0.21             # DeepSeek Harness 默认 zstd 会话文件的解码
+# zstandard>=0.21          # extra xskill[dsh]；探测到 ~/.dsh 时现场补装
 
 # Optional:
 # anthropic>=0.25           # 仅当直接用 anthropic SDK 时需要

--- a/src/xskill/ecosystems/__init__.py
+++ b/src/xskill/ecosystems/__init__.py
@@ -83,6 +83,7 @@ from xskill.ecosystems.cursor import (
 )
 from xskill.ecosystems.deepseek_harness import (
     DSH_SPEC,
+    ensure_zstandard_for_dsh,
     install_to_deepseek_harness,
     install_all_to_deepseek_harness,
     ingest_deepseek_harness_sessions,
@@ -166,6 +167,7 @@ __all__ = [
     "JsonlIngester", "SqliteIngester", "CCSessionIngester",
     "detect_known_ecosystems",
     "ensure_claude_code_install",
+    "ensure_zstandard_for_dsh",
     "install_to_claude_code", "install_to_codex", "install_to_nga3",
     "install_to_cursor",
     "install_to_deepseek_harness",

--- a/src/xskill/ecosystems/deepseek_harness.py
+++ b/src/xskill/ecosystems/deepseek_harness.py
@@ -16,9 +16,10 @@ session.jsonl``）桥接回 xskill 的标准 ``traj_*.md`` 格式。
 - session 存储：``@deepseek-ai/dsh-session-persistence-jsonl``。**默认**
   写 ``session.jsonl.zstd``——多个独立 Zstandard 帧顺序拼接（首帧只含
   header 行，之后每次落盘一帧），不能按行读；``compression: 'none'`` 时
-  为明文 ``session.jsonl``。两种都桥接：``.zstd`` 用 ``zstandard``（主依赖）
-  流式跨帧解码为同样的逐行文本，再走同一个 adapter。若环境缺 ``zstandard``
-  （安装不完整），只警告一次并跳过压缩文件（明文仍正常）。逻辑行：首行
+  为明文 ``session.jsonl``。两种都桥接：``.zstd`` 用 ``zstandard``
+  （extra ``xskill[dsh]``，不进主依赖，见 #334）流式跨帧解码为同样的
+  逐行文本，再走同一个 adapter。探测到 ``~/.dsh`` 且缺库时现场补装一次；
+  仍缺失则只警告一次并跳过压缩文件（明文仍正常）。逻辑行：首行
   ``{"type": "session", ...}`` SessionHeader
   （带 ``cwd``），随后每行一个 ``{type, seq, time, data}`` SessionEvent。
   ``assistant/chunk`` 与打包行（``text-chunks`` / ``reasoning-chunks`` /
@@ -35,6 +36,9 @@ from __future__ import annotations
 
 import json
 import logging
+import os
+import subprocess
+import sys
 from pathlib import Path
 from typing import Iterable, Optional
 
@@ -44,6 +48,7 @@ from xskill.ecosystems._shared import (
     _install_all_with,
     _install_skill_into,
 )
+from xskill.utils.proc import windowless_subprocess_kwargs
 
 logger = logging.getLogger("xskill.ecosystems")
 
@@ -163,6 +168,118 @@ def _read_cwd_from_dsh_jsonl(content: str) -> str:
 # ─────────────────────────────────────────────────────────────────
 
 _ZSTD_MISSING_WARNED = False
+_ZSTD_REQUIREMENT = "zstandard>=0.21"
+_PROVISION_FILENAME = "dsh-zstandard-provision.json"
+_PIP_TIMEOUT_S = 90
+
+
+def zstandard_available() -> bool:
+    try:
+        import zstandard  # noqa: F401
+        return True
+    except ImportError:
+        return False
+
+
+def _provision_state_path(home_root: Path) -> Path:
+    return Path(home_root) / ".xskill" / _PROVISION_FILENAME
+
+
+def _home_root_from_dsh_session(path: Path) -> Path | None:
+    """``<home>/.dsh/sessions/.../session.jsonl.zstd`` → ``<home>``。"""
+    for parent in path.parents:
+        if parent.name == ".dsh":
+            return parent.parent
+    return None
+
+
+def _read_provision_state(path: Path) -> dict | None:
+    if not path.is_file():
+        return None
+    try:
+        data = json.loads(path.read_text(encoding="utf-8", errors="replace"))
+    except (OSError, json.JSONDecodeError):
+        return None
+    return data if isinstance(data, dict) else None
+
+
+def _write_provision_state(path: Path, *, status: str, detail: str) -> None:
+    path.parent.mkdir(parents=True, exist_ok=True)
+    payload = {
+        "package": _ZSTD_REQUIREMENT,
+        "status": status,
+        "detail": detail,
+    }
+    path.write_text(
+        json.dumps(payload, ensure_ascii=False, indent=2) + "\n",
+        encoding="utf-8",
+    )
+
+
+def _install_zstandard_with_pip() -> tuple[bool, str]:
+    """现场装 zstandard。不传 ``-i`` / ``--proxy``：尊重 pip.ini，
+    也不把 Windows 系统代理强塞进去（#334 升级失败的根因）。"""
+    cmd = [
+        sys.executable, "-m", "pip", "install",
+        _ZSTD_REQUIREMENT,
+        "--timeout", "15",
+        "--retries", "1",
+        "--disable-pip-version-check",
+    ]
+    try:
+        result = subprocess.run(
+            cmd,
+            capture_output=True,
+            timeout=_PIP_TIMEOUT_S,
+            encoding="utf-8",
+            errors="replace",
+            env={**os.environ, "PYTHONIOENCODING": "utf-8"},
+            **windowless_subprocess_kwargs(),
+        )
+    except subprocess.TimeoutExpired:
+        return False, f"pip 超过 {_PIP_TIMEOUT_S}s 未退出"
+    except Exception as exc:
+        return False, f"执行 pip 异常: {exc}"
+    if result.returncode != 0:
+        detail = (result.stderr or result.stdout or "pip 返回非零退出码").strip()
+        return False, (detail.splitlines()[-1] if detail else "pip 返回非零退出码")
+    return True, ""
+
+
+def ensure_zstandard_for_dsh(home_root: Path | str | None = None) -> bool:
+    """探测到 ``~/.dsh`` 且缺 ``zstandard`` 时，无窗现场补装一次。
+
+    已能 import、没有 dsh 目录、或 ``~/.xskill/dsh-zstandard-provision.json``
+    里已有一次尝试记录，都不再起 pip。采集 / detect 循环不得反复弹窗。
+    """
+    if zstandard_available():
+        return True
+    root = Path(home_root) if home_root else Path.home()
+    if not (root / ".dsh").is_dir():
+        return False
+
+    state_path = _provision_state_path(root)
+    if _read_provision_state(state_path) is not None:
+        return zstandard_available()
+
+    logger.info(
+        "探测到 %s，现场安装 %s（不走系统代理、无窗）",
+        root / ".dsh", _ZSTD_REQUIREMENT,
+    )
+    ok, detail = _install_zstandard_with_pip()
+    if ok and zstandard_available():
+        _write_provision_state(state_path, status="ok", detail="")
+        logger.info("已安装 %s，可以解码 dsh 默认 zstd 会话", _ZSTD_REQUIREMENT)
+        return True
+    reason = detail or "装完仍无法 import zstandard"
+    _write_provision_state(state_path, status="failed", detail=reason)
+    logger.warning(
+        "现场安装 %s 失败（%s）。压缩会话暂不桥接；可手工 "
+        "pip install zstandard 或 pip install 'xskill[dsh]'。"
+        "明文会话不受影响。",
+        _ZSTD_REQUIREMENT, reason,
+    )
+    return False
 
 
 def _read_dsh_session(path: Path) -> Optional[str]:
@@ -171,12 +288,16 @@ def _read_dsh_session(path: Path) -> Optional[str]:
 
     dsh 的压缩产物是**独立帧的顺序拼接**（首帧 header、之后每批一帧），
     ``ZstdDecompressor.stream_reader(read_across_frames=True)`` 正好对应
-    这一布局。``zstandard`` 是主依赖；若环境仍缺失（安装不完整）返回 None：
-    只警告一次（避免每 5 秒刷屏），ingester 跳过该文件；明文文件不受影响。
+    这一布局。``zstandard`` 在 extra ``xskill[dsh]``；缺库时先对
+    ``~/.dsh`` 做一次现场补装，仍缺失则返回 None：只警告一次（避免每
+    5 秒刷屏），ingester 跳过该文件；明文文件不受影响。
     """
     global _ZSTD_MISSING_WARNED
     if path.suffix != ".zstd":
         return path.read_text(encoding="utf-8", errors="ignore")
+    if not zstandard_available():
+        home = _home_root_from_dsh_session(path)
+        ensure_zstandard_for_dsh(home)
     try:
         import zstandard
     except ImportError:
@@ -184,8 +305,8 @@ def _read_dsh_session(path: Path) -> Optional[str]:
             _ZSTD_MISSING_WARNED = True
             logger.warning(
                 "DeepSeek Harness 会话默认为 zstd 压缩（%s），解码需要依赖 "
-                "zstandard（xskill 主依赖之一，安装不完整时缺失）："
-                "pip install zstandard。安装前压缩会话不会被桥接；明文会话"
+                "zstandard（extra xskill[dsh]）：pip install zstandard 或 "
+                "pip install 'xskill[dsh]'。安装前压缩会话不会被桥接；明文会话"
                 "不受影响。",
                 path,
             )
@@ -377,10 +498,12 @@ def ingest_deepseek_harness_sessions(
     trajectory directory.
 
     Scans ``<home_root>/.dsh/sessions/*/*/session.jsonl`` and
-    ``session.jsonl.zstd``（后者用主依赖 ``zstandard`` 解码；环境缺失时警告
-    一次并跳过压缩文件）and submits any session whose encoded-id directory is not
-    in ``seen_sessions`` as a new trajectory under ``target_traj_dir``.
+    ``session.jsonl.zstd``（后者用 ``zstandard`` 解码；缺库时现场补装一次，
+    仍缺失则警告并跳过压缩文件）and submits any session whose encoded-id
+    directory is not in ``seen_sessions`` as a new trajectory under
+    ``target_traj_dir``.
     """
+    ensure_zstandard_for_dsh(home_root)
     return JsonlIngester(DSH_SPEC).scan_and_bridge(
         target_traj_dir=Path(target_traj_dir),
         home_root=Path(home_root) if home_root else None,

--- a/src/xskill/pipeline/watcher_factory.py
+++ b/src/xskill/pipeline/watcher_factory.py
@@ -115,6 +115,7 @@ def ingest_detected_ecosystems_once(config: dict, home_root: Path,
         OPENCODE_SPEC,
         detect_known_ecosystems,
         ensure_claude_code_install,
+        ensure_zstandard_for_dsh,
         install_all_to_claude_code,
         install_all_to_codex, install_all_to_cursor,
         install_all_to_deepseek_harness,
@@ -279,6 +280,7 @@ def ingest_detected_ecosystems_once(config: dict, home_root: Path,
                           registry_db_path=registry_db_path).run_once()
 
         elif eco == "deepseek_harness":
+            ensure_zstandard_for_dsh(home_root)
             try:
                 installed = install_all_to_deepseek_harness(
                     skill_dir, target_root=home_root,
@@ -293,8 +295,6 @@ def ingest_detected_ecosystems_once(config: dict, home_root: Path,
                     skill="<startup_all>", agent="deepseek_harness",
                     reason=str(exc)[:200],
                 )
-            # 仅明文 session.jsonl；默认的 session.jsonl.zstd 不在 glob 内，
-            # 本期不解码（见 deepseek_harness.py 模块 docstring）。
             JsonlIngester(DSH_SPEC, target_traj_dir=bridge, home_root=home_root,
                           poll_interval=poll_interval,
                           registry_db_path=registry_db_path).run_once()

--- a/src/xskill/team/client/collector.py
+++ b/src/xskill/team/client/collector.py
@@ -134,6 +134,7 @@ class TeamCollector:
             TraeIngester,
             CC_SPEC, CODEX_SPEC, DSH_SPEC, NGA3_SPEC, OPENCODE_SPEC,
             NGAGENT_SPEC,
+            ensure_zstandard_for_dsh,
         )
         for det in detect_known_ecosystems(home_root=self.home_root):
             eco = det["ecosystem"]
@@ -174,6 +175,7 @@ class TeamCollector:
                 # daemon 侧 watcher_factory 有这条分支，collector 这条
                 # 平行分发链也必须接上，否则 connect 后 dsh 会话不会被
                 # 镜像进 bridge，团队模式下永远采不到（PR #243 评审发现）。
+                ensure_zstandard_for_dsh(self.home_root)
                 ing = JsonlIngester(DSH_SPEC, target_traj_dir=bridge,
                                     home_root=self.home_root,
                                     poll_interval=self.poll_interval)

--- a/tests/test_deepseek_harness_adapter.py
+++ b/tests/test_deepseek_harness_adapter.py
@@ -301,6 +301,8 @@ class TestIngest:
 
         monkeypatch.setattr(builtins, "__import__", _no_zstd)
         monkeypatch.setattr(dsh_mod, "_ZSTD_MISSING_WARNED", False)
+        monkeypatch.setattr(dsh_mod, "ensure_zstandard_for_dsh", lambda *_a, **_k: False)
+        monkeypatch.setattr(dsh_mod, "zstandard_available", lambda: False)
 
         z1 = tmp_path / ".dsh" / "sessions" / "--p--" / "z1"
         z2 = tmp_path / ".dsh" / "sessions" / "--p--" / "z2"

--- a/tests/test_dsh_zstandard_provision.py
+++ b/tests/test_dsh_zstandard_provision.py
@@ -1,0 +1,112 @@
+"""zstandard 不进主依赖；探测到 ~/.dsh 时现场补装一次（#334）。"""
+from __future__ import annotations
+
+import json
+import subprocess
+from pathlib import Path
+
+from xskill.ecosystems import deepseek_harness as dsh_mod
+from xskill.ecosystems.deepseek_harness import (
+    _ZSTD_REQUIREMENT,
+    ensure_zstandard_for_dsh,
+)
+
+
+def test_pyproject_keeps_zstandard_optional_only():
+    text = Path("pyproject.toml").read_text(encoding="utf-8")
+    deps_start = text.index("dependencies = [")
+    extras_start = text.index("[project.optional-dependencies]")
+    deps_block = text[deps_start:extras_start]
+    assert "zstandard" not in deps_block
+    extras = text[extras_start:]
+    assert "dsh = [" in extras or "dsh=[" in extras
+    assert "zstandard>=0.21" in extras
+
+
+def test_provision_skips_without_dsh_dir(monkeypatch, tmp_path):
+    monkeypatch.setattr(dsh_mod, "zstandard_available", lambda: False)
+    called = []
+    monkeypatch.setattr(
+        dsh_mod, "_install_zstandard_with_pip",
+        lambda: called.append(True) or (True, ""),
+    )
+    assert ensure_zstandard_for_dsh(tmp_path) is False
+    assert called == []
+    assert not (tmp_path / ".xskill" / "dsh-zstandard-provision.json").exists()
+
+
+def test_provision_skips_when_already_importable(monkeypatch, tmp_path):
+    (tmp_path / ".dsh").mkdir()
+    monkeypatch.setattr(dsh_mod, "zstandard_available", lambda: True)
+    called = []
+    monkeypatch.setattr(
+        dsh_mod, "_install_zstandard_with_pip",
+        lambda: called.append(True) or (True, ""),
+    )
+    assert ensure_zstandard_for_dsh(tmp_path) is True
+    assert called == []
+
+
+def test_provision_pip_omits_proxy_and_index(monkeypatch, tmp_path):
+    (tmp_path / ".dsh").mkdir()
+    calls = {"n": 0}
+
+    def _available() -> bool:
+        calls["n"] += 1
+        return calls["n"] > 1
+
+    captured: dict = {}
+
+    def _fake_run(cmd, **kwargs):
+        captured["cmd"] = list(cmd)
+        captured["kwargs"] = kwargs
+        return subprocess.CompletedProcess(cmd, 0, "", "")
+
+    monkeypatch.setattr(dsh_mod, "zstandard_available", _available)
+    monkeypatch.setattr(dsh_mod.subprocess, "run", _fake_run)
+
+    assert ensure_zstandard_for_dsh(tmp_path) is True
+    assert "--proxy" not in captured["cmd"]
+    assert "-i" not in captured["cmd"]
+    assert _ZSTD_REQUIREMENT in captured["cmd"]
+    state = json.loads(
+        (tmp_path / ".xskill" / "dsh-zstandard-provision.json").read_text(
+            encoding="utf-8",
+        )
+    )
+    assert state["status"] == "ok"
+
+
+def test_provision_does_not_retry_after_failure(monkeypatch, tmp_path):
+    (tmp_path / ".dsh").mkdir()
+    sentinel = tmp_path / ".xskill" / "dsh-zstandard-provision.json"
+    sentinel.parent.mkdir(parents=True)
+    sentinel.write_text(
+        json.dumps({"package": _ZSTD_REQUIREMENT, "status": "failed", "detail": "once"}),
+        encoding="utf-8",
+    )
+    monkeypatch.setattr(dsh_mod, "zstandard_available", lambda: False)
+    called = []
+    monkeypatch.setattr(
+        dsh_mod, "_install_zstandard_with_pip",
+        lambda: called.append(True) or (True, ""),
+    )
+    assert ensure_zstandard_for_dsh(tmp_path) is False
+    assert called == []
+
+
+def test_provision_writes_failed_sentinel(monkeypatch, tmp_path):
+    (tmp_path / ".dsh").mkdir()
+    monkeypatch.setattr(dsh_mod, "zstandard_available", lambda: False)
+    monkeypatch.setattr(
+        dsh_mod, "_install_zstandard_with_pip",
+        lambda: (False, "ProxyError handshake timed out"),
+    )
+    assert ensure_zstandard_for_dsh(tmp_path) is False
+    state = json.loads(
+        (tmp_path / ".xskill" / "dsh-zstandard-provision.json").read_text(
+            encoding="utf-8",
+        )
+    )
+    assert state["status"] == "failed"
+    assert "ProxyError" in state["detail"]


### PR DESCRIPTION
## Summary
- 把 `zstandard` 从主依赖挪到 extra `xskill[dsh]`，旧客户端装新 wheel 不必再穿过代理拉这个包，自动更新先恢复。
- 探测到 `~/.dsh` 且缺库时，无窗现场 `pip install zstandard>=0.21` 一次；不传 `--proxy`，尊重 pip.ini。失败写入 `~/.xskill/dsh-zstandard-provision.json`，采集循环不再重试。
- dsh 默认仍是 zstd：补装成功就能继续采压缩会话；失败则跳过 `.zstd`，明文和 skill 安装不受影响。

Fixes #334

## Test plan
- [x] `pytest tests/test_dsh_zstandard_provision.py tests/test_deepseek_harness_adapter.py`
- [ ] 内网客户端从 0.6.32a1 升到本版本，不再因 zstandard 卡在 ProxyError
- [ ] 有 `~/.dsh` 的机器补装一次后能解码 `session.jsonl.zstd`


Made with [Cursor](https://cursor.com)