### PR TITLE
fix(agents): 应用 Agno 生成请求配置

### DIFF
--- a/src/xskill/agents/agno_factory.py
+++ b/src/xskill/agents/agno_factory.py
@@ -188,12 +188,25 @@ def build_chat_model(
                              connect=min(connect_timeout, request_timeout))
     client_max_retries = int(llm_cfg.get("client_max_retries", 0) or 0)
 
+    # Keep the agentic Agno path aligned with ``LLMClient`` and the public
+    # config template.  Previously these documented settings were silently
+    # dropped, so providers used their own temperature/output defaults.
+    max_tokens = int(llm_cfg.get("max_tokens", 10000))
+    if max_tokens <= 0:
+        raise ValueError("llm.max_tokens must be a positive integer")
+    temperature = float(llm_cfg.get("temperature", 0.0))
+    extra_body = llm_cfg.get("extra_body")
+    if extra_body is not None and not isinstance(extra_body, dict):
+        raise ValueError("llm.extra_body must be a mapping")
+
     common_kwargs = dict(
         id=model_id,
         base_url=llm_cfg.get("base_url", ""),
         api_key=api_key,
         timeout=timeout,
         max_retries=client_max_retries,
+        max_tokens=max_tokens,
+        temperature=temperature,
         role_map={
             "system": "system",
             "user": "user",
@@ -202,6 +215,12 @@ def build_chat_model(
             "model": "assistant",
         },
     )
+    if extra_body is not None:
+        # ``extra_body`` is the OpenAI SDK's explicit extension point for
+        # provider-owned options (for example llama.cpp/Qwen chat-template
+        # flags).  Copy the top-level mapping so model construction cannot
+        # mutate the caller's config object.
+        common_kwargs["extra_body"] = dict(extra_body)
 
     if "api.deepseek.com" in base_url:
         from agno.models.deepseek import DeepSeek

--- a/src/xskill/config.py
+++ b/src/xskill/config.py
@@ -94,6 +94,10 @@ llm:
   # compact_keep_recent_messages: 6 # optional; recent complete message blocks
                          # kept verbatim after compact. Default 6.
   # temperature: 0.0     # optional; default 0 (deterministic)
+  # extra_body:          # optional provider-specific OpenAI request fields;
+  #   chat_template_kwargs:  # e.g. llama.cpp/Qwen chat-template controls.
+  #     enable_thinking: false # changing reasoning can affect quality; replay
+                         # representative trajectories before disabling it.
   # request_timeout: 60  # optional; per-request wall-clock cap in seconds
                          # (default 60). Explicit so an unreachable endpoint
                          # fails loud instead of hanging forever.

--- a/tests/test_agent_model_routing.py
+++ b/tests/test_agent_model_routing.py
@@ -89,3 +89,48 @@ class TestBuildChatModelRouting:
         }, log)
         assert m.id == "deepseek-reasoner"
         assert "deepseek.com" in m.base_url
+
+    def test_generation_defaults_match_public_config(self, log):
+        m = _build_chat_model({
+            "base_url": "http://localhost:8000/v1",
+            "model": "local-model",
+            "api_key": "sk-no",
+        }, log)
+        assert m.max_tokens == 10000
+        assert m.temperature == 0.0
+
+    def test_generation_parameters_and_extra_body_propagate(self, log):
+        extra_body = {
+            "chat_template_kwargs": {"enable_thinking": False},
+        }
+        m = _build_chat_model({
+            "base_url": "http://localhost:8000/v1",
+            "model": "local-model",
+            "api_key": "sk-no",
+            "max_tokens": "2048",
+            "temperature": "0.25",
+            "extra_body": extra_body,
+        }, log)
+        assert m.max_tokens == 2048
+        assert m.temperature == 0.25
+        assert m.extra_body == extra_body
+        assert m.extra_body is not extra_body
+
+    @pytest.mark.parametrize("value", (0, -1))
+    def test_non_positive_max_tokens_is_rejected(self, log, value):
+        with pytest.raises(ValueError, match="max_tokens"):
+            _build_chat_model({
+                "base_url": "http://localhost:8000/v1",
+                "model": "local-model",
+                "api_key": "sk-no",
+                "max_tokens": value,
+            }, log)
+
+    def test_non_mapping_extra_body_is_rejected(self, log):
+        with pytest.raises(ValueError, match="extra_body"):
+            _build_chat_model({
+                "base_url": "http://localhost:8000/v1",
+                "model": "local-model",
+                "api_key": "sk-no",
+                "extra_body": ["enable_thinking"],
+            }, log)

--- a/tests/test_usage.py
+++ b/tests/test_usage.py
@@ -36,7 +36,10 @@ def test_extract_usage_missing_usage():
 
 def _agno_response(**metrics_kwargs):
     """构造真实 agno ModelResponse —— agent LLM 记账点的实际传入形态。"""
-    from agno.models.metrics import MessageMetrics
+    try:
+        from agno.metrics import MessageMetrics
+    except ImportError:  # agno < 3
+        from agno.models.metrics import MessageMetrics
     from agno.models.response import ModelResponse
 
     resp = ModelResponse()


### PR DESCRIPTION
## Summary

让统一 Agno 模型工厂真正应用公开的 `max_tokens` 与 `temperature` 配置，并提供受校验的 `extra_body` 扩展入口，避免配置文件与实际模型请求不一致。

默认值继续与旧 `LLMClient` 保持一致，不改变模型路由、重试、上下文管理或用量记账顺序。

## Changes

- 向 DeepSeek 专用模型和通用 OpenAI-compatible 模型共同使用的构造参数传递 `max_tokens` 与 `temperature`。
- 保留 `max_tokens=10000` 和 `temperature=0.0` 的现有公开默认行为。
- 支持可选 mapping 类型 `extra_body`，并在传递前进行浅复制，避免持有调用方可变对象。
- 拒绝非正整数 `max_tokens` 和非 mapping 的 `extra_body`，使错误配置在模型请求前失败。
- 在配置模板中说明如何通过 `extra_body.chat_template_kwargs` 传递供应商特定参数，并提醒关闭 thinking 前先做质量回放。
- 增加默认值、显式覆盖、对象复制和非法配置的回归测试。

## Test plan

- [x] `make test` passes（2420 passed, 9 skipped）
- [x] Added/updated unit tests for the change
- [ ] `make e2e` passes (if the change touches ingestion / install / daemon)；本 PR 不涉及 ingestion、install 或 daemon，未运行 Docker E2E
- [x] Manually verified the affected user flow；使用本地 OpenAI-compatible endpoint 验证参数进入生产模型工厂，并完成真实 Agno tool call

## Linked issues

Closes #336
