### PR TITLE
perf(recommend): bound recommend-heavy peak memory with batched vector sweeps

### DIFF
--- a/src/xskill/_workers.py
+++ b/src/xskill/_workers.py
@@ -401,7 +401,7 @@ def run_recommend_heavy_once() -> int:
     替代原先仅跑 profile-refresh 的短命子进程；Web /sync 只读
     ``client_recommend_slots``，不再请求内 ``get_skill_for_client``。
     """
-    from xskill.config import XSKILL_HOME, load_config
+    from xskill.config import XSKILL_HOME, load_config, recommend_heavy_config
     from xskill.recommend.heavy_worker import run_recommend_heavy_once as _heavy_tick
     from xskill.team.server.engine_factory import build_recommend_engine
     from xskill.utils.status_file import PROFILE_STATUS_FILE, write_status_file
@@ -409,14 +409,33 @@ def run_recommend_heavy_once() -> int:
     status_path = XSKILL_HOME / PROFILE_STATUS_FILE
     try:
         config = load_config()
+        heavy_cfg = recommend_heavy_config(config)
         engine = build_recommend_engine(config)
         profile_rc = run_profile_refresh_once(engine=engine)
-        heavy = _heavy_tick(engine=engine)
+        heavy = _heavy_tick(
+            engine=engine,
+            vector_sync_batch_limit=heavy_cfg["batch_limit"],
+            memory_budget_mb=heavy_cfg["memory_budget_mb"],
+        )
+        vector_stats = heavy.get("vector", {})
         metrics = {
             "profile_rc": profile_rc,
-            "vector_upserted": heavy.get("vector", {}).get("upserted", 0),
-            "vector_deleted": heavy.get("vector", {}).get("deleted", 0),
+            "vector_upserted": vector_stats.get("upserted", 0),
+            "vector_deleted": vector_stats.get("deleted", 0),
+            "vector_skipped": vector_stats.get("skipped", 0),
+            "vector_mode": vector_stats.get("mode", ""),
+            "vector_reason": vector_stats.get("reason", ""),
+            # 全量对账（bootstrap/model_changed/periodic/ephemeral）还剩多少
+            # catalog_key 没追平；0 表示这一轮之后已经追平，不是「查询侧还没
+            # 收敛」——full 模式下该字段随每轮增量收敛，供看板/日志观察进度。
+            "vector_remaining": vector_stats.get("remaining"),
+            # 只在这一轮真播种了全量对账时才有值；平时纯增量运转不需要
+            # 每轮都数一遍 catalog 有多少行。
+            "vector_total_indexable": vector_stats.get("total_indexable"),
+            "vector_budget_aborted": vector_stats.get("budget_aborted", False),
             "recommends": heavy.get("recommends", 0),
+            "index_kind": heavy.get("index_kind", ""),
+            "rss_peak_mb": heavy.get("rss_peak_mb", 0.0),
         }
         write_status_file(status_path, metrics, ok=profile_rc == 0)
         return 0 if profile_rc == 0 else profile_rc

--- a/src/xskill/_workers.py
+++ b/src/xskill/_workers.py
@@ -434,6 +434,7 @@ def run_recommend_heavy_once() -> int:
             "vector_total_indexable": vector_stats.get("total_indexable"),
             "vector_budget_aborted": vector_stats.get("budget_aborted", False),
             "recommends": heavy.get("recommends", 0),
+            "recommends_deferred": heavy.get("recommends_deferred", False),
             "index_kind": heavy.get("index_kind", ""),
             "rss_peak_mb": heavy.get("rss_peak_mb", 0.0),
         }

--- a/src/xskill/config.py
+++ b/src/xskill/config.py
@@ -198,6 +198,8 @@ server:
   profile_refresh_timeout: 1800    # 单轮画像子进程硬上限(秒;冷启动大量 client 兜底)
   ux_scores_sync_interval: 30      # 盘上 .ux_scores.jsonl → registry.db 同步周期(秒)
   ux_scores_sync_timeout: 300      # 单轮 UX 同步子进程硬上限(秒)
+  vector_sync_batch_limit: 256     # 向量对账单轮最多处理的 catalog_key 数(issue #328;万级目录靠这个拆成多轮)
+  recommend_heavy_memory_budget_mb: 1024 # recommend-heavy 单轮峰值 RSS 软上限(MiB);超了本轮提前中止,留给下一轮
 
 # ===== Watcher (scan scheduling only) =====
 watcher:
@@ -936,6 +938,39 @@ def profile_refresh_config(cfg: Optional[dict] = None) -> dict:
         "shutdown_timeout": float(shutdown_timeout),
         "interval": float(interval),
         "timeout": float(timeout),
+    }
+
+
+def recommend_heavy_config(cfg: Optional[dict] = None) -> dict:
+    """recommend-heavy 重活单轮的批大小与内存预算（issue #328）。
+
+    ``vector_sync_batch_limit``：全量/增量向量对账单次调用最多处理多少
+    ``catalog_key``——万级目录时全量重建会被这个上限拆成多轮，而不是
+    一轮吃掉整份 catalog。``memory_budget_mb``：单轮峰值 RSS 软上限，
+    超过就中止本轮剩余批次（已处理的部分正常生效），留给下一轮继续；
+    默认给一个对 16 GiB 主机安全、能跟 Docker/看板/客户端共存的值。
+    """
+    section = (cfg or {}).get("server") or {}
+    batch_limit = section.get("vector_sync_batch_limit", 256)
+    memory_budget_mb = section.get("recommend_heavy_memory_budget_mb", 1024)
+
+    if not isinstance(batch_limit, int) or isinstance(batch_limit, bool) or batch_limit < 1:
+        raise ValueError(
+            f"server.vector_sync_batch_limit 必须是正整数，got {batch_limit!r}"
+        )
+    if (
+        not isinstance(memory_budget_mb, (int, float))
+        or isinstance(memory_budget_mb, bool)
+        or not math.isfinite(memory_budget_mb)
+        or memory_budget_mb <= 0
+    ):
+        raise ValueError(
+            "server.recommend_heavy_memory_budget_mb 必须是正数，"
+            f"got {memory_budget_mb!r}"
+        )
+    return {
+        "batch_limit": batch_limit,
+        "memory_budget_mb": float(memory_budget_mb),
     }
 
 

--- a/src/xskill/pipeline/registry.py
+++ b/src/xskill/pipeline/registry.py
@@ -295,10 +295,13 @@ CREATE INDEX IF NOT EXISTS idx_catalog_vector_dirty_marked
     ON catalog_vector_dirty(dirty, marked_at, catalog_key);
 
 -- 全量向量对账水位：首次升级、模型/算法变化和低频修复时更新。
+-- sweep_seeded_fingerprint 非空 = 这个指纹对应的全量播种已经做过、还没
+-- 追平（见 _migrate 里的注释，issue #328 review）。
 CREATE TABLE IF NOT EXISTS catalog_vector_sync_meta (
-    singleton          INTEGER PRIMARY KEY CHECK(singleton=1),
-    model_fingerprint  TEXT NOT NULL DEFAULT '',
-    reconciled_at      REAL NOT NULL DEFAULT 0
+    singleton                   INTEGER PRIMARY KEY CHECK(singleton=1),
+    model_fingerprint           TEXT NOT NULL DEFAULT '',
+    reconciled_at               REAL NOT NULL DEFAULT 0,
+    sweep_seeded_fingerprint    TEXT NOT NULL DEFAULT ''
 );
 
 -- 用户画像脏队列：generation 让“计算期间又发生变化”不会被旧任务误清。
@@ -748,6 +751,20 @@ def _migrate(conn: sqlite3.Connection) -> None:
     if "side" not in pref_cols:
         conn.execute(
             "ALTER TABLE skill_prefs ADD COLUMN side TEXT NOT NULL DEFAULT ''"
+        )
+
+    # catalog_vector_sync_meta.sweep_seeded_fingerprint：全量对账「已播种但
+    # 还没追平」的目标指纹（issue #328 review）。只在这里非空时代表某个
+    # bootstrap/model_changed/periodic/ephemeral 触发的全量播种正在进行中；
+    # 不能只看 catalog_vector_dirty 是否为空来判断——那张表也会因为普通的
+    # catalog 编辑产生脏项，和「已经播种过」是两回事，混用会导致播种被
+    # 有机脏项误判为「已经播种」而永久跳过，见 review 复现。
+    cur = conn.execute("PRAGMA table_info(catalog_vector_sync_meta)")
+    cvsm_cols = {row[1] for row in cur.fetchall()}
+    if "sweep_seeded_fingerprint" not in cvsm_cols:
+        conn.execute(
+            "ALTER TABLE catalog_vector_sync_meta"
+            " ADD COLUMN sweep_seeded_fingerprint TEXT NOT NULL DEFAULT ''"
         )
 
     _migrate_atom_candidate_pending(conn)

--- a/src/xskill/recommend/heavy_worker.py
+++ b/src/xskill/recommend/heavy_worker.py
@@ -592,11 +592,7 @@ def run_recommend_heavy_once(
         model_fingerprint = f"{VECTOR_SYNC_ALGORITHM}:{model}:{dim}"
     # open_skill_vector_index：无 pymilvus 时退回内存索引并 hourly warn
     index = memory_index or open_skill_vector_index(vdb, dim=dim)
-    # sweep_key 只取 算法:模型:维度 这部分，不拼索引实例标识——见
-    # run_vector_sync 的 sweep_key 说明：没有持久索引时每个子进程的
-    # index 对象都是新的，若拿它的 id() 当播种去重键，会导致「已经
-    # 播种过」永远判定为假，多轮攒下的脏表进度被每轮重新播种抹掉。
-    sweep_key = model_fingerprint
+    stable_sweep_key = model_fingerprint
     model_fingerprint = (
         f"{model_fingerprint}:{_vector_index_identity(index, vdb)}"
     )
@@ -607,6 +603,11 @@ def run_recommend_heavy_once(
     ephemeral_index = memory_index is None and isinstance(
         index, MemorySkillVectorIndex,
     )
+    # 持久索引的 sweep 必须绑定文件 identity：同路径数据库在多轮 sweep
+    # 中途被替换后，要重新播种已经从旧索引队列中清掉的 key。只有每个
+    # 子进程都会得到全新对象的内存 fallback 使用稳定 key，否则 id(index)
+    # 每轮变化会反复播种并抹掉多轮消费进度。
+    sweep_key = stable_sweep_key if ephemeral_index else model_fingerprint
     vec_stats = run_vector_sync(
         db_path=registry,
         embed=embed_fn,

--- a/src/xskill/recommend/heavy_worker.py
+++ b/src/xskill/recommend/heavy_worker.py
@@ -161,10 +161,28 @@ def _drain_full_sweep_batch(
         "upserted": 0, "deleted": 0, "skipped": 0, "deferred": 0,
         "budget_aborted": False,
     }
+    # 这一批的 catalog 行（含正文）在上面已经整批读进来了——批次加载本身
+    # 就可能把预算吃光，尤其是 limit 配得偏大时；加载完立刻查一次，不等
+    # 逐行循环里的下一次检查点才发现已经超了（issue #328 review）。
+    if (
+        memory_budget_mb is not None
+        and events
+        and current_rss_mb() > memory_budget_mb
+    ):
+        logger.warning(
+            "vector full sweep aborted before processing: rss over budget "
+            "(%.0f MiB budget) right after loading this batch's %s rows; "
+            "none processed, all stay dirty for next round",
+            memory_budget_mb, len(events),
+        )
+        stats["budget_aborted"] = True
+        return stats
     for processed, event in enumerate(events):
         if (
             memory_budget_mb is not None
-            and processed
+            # 步长为了减少 getrusage 系统调用频率；不能跳过第 0 条——批次
+            # 比步长还小时（如 10 条 vs 步长 20），跳过第 0 条会导致这批
+            # 从头到尾一次都不检查，budget 形同虚设（issue #328 review）。
             and processed % _MEMORY_BUDGET_CHECK_STRIDE == 0
             and current_rss_mb() > memory_budget_mb
         ):
@@ -238,6 +256,7 @@ def run_vector_sync(
     now: float | None = None,
     limit: int = 256,
     memory_budget_mb: Optional[float] = None,
+    sweep_key: Optional[str] = None,
 ) -> dict:
     """优先消费增量队列；首次/模型变化/低频周期触发全量对账。
 
@@ -252,13 +271,26 @@ def run_vector_sync(
     「多轮」只保证内存峰值有界、检索覆盖率会持续被下一轮的批次覆盖，
     并不会跨轮累积成一份完整索引——这是没有持久存储时物理上做不到的，
     不是本函数的缺陷。
+
+    ``sweep_key``：判断「这个全量对账目标是否已经播种过」用的稳定标识，
+    缺省等于 ``model_fingerprint``。两者分开是因为 ``model_fingerprint``
+    里可能拼了索引实例标识（``_vector_index_identity``）——持久索引按
+    db 文件的 dev/inode，重建后正确触发重新 bootstrap；但没有持久索引
+    时索引标识是 ``id(index)``，每个子进程都是全新对象，若直接拿它当
+    播种去重键，会导致「已经播种过」永远判定为假、每轮都重新播种，
+    抹掉多轮攒下的脏表进度。调用方（``run_recommend_heavy_once``）传入
+    不含索引实例标识的稳定部分。
     """
     from xskill.recommend.vector_dirty import (
         catalog_vector_reconcile_reason,
         count_catalog_vector_dirty,
         finish_catalog_vector_reconcile,
+        get_sweep_seeded_fingerprint,
+        mark_sweep_seeded,
         seed_full_catalog_vector_sweep,
     )
+
+    effective_sweep_key = sweep_key if sweep_key is not None else model_fingerprint
 
     reason = "ephemeral" if force_full else catalog_vector_reconcile_reason(
         model_fingerprint,
@@ -267,12 +299,19 @@ def run_vector_sync(
         interval_seconds=VECTOR_RECONCILE_INTERVAL_SECONDS,
     )
     seed_info = None
-    if reason and count_catalog_vector_dirty(db_path=db_path) == 0:
-        # 只在没有积压时播种一次；已经在消化上一次播种的积压时不重复播种，
-        # 否则会把已处理、已清出脏表的 key 重新标脏，抹掉已有进度。
-        seed_info = seed_full_catalog_vector_sweep(
-            db_path=db_path, existing_index_keys=index.list_keys(),
-        )
+    if reason:
+        # 播种去重看的是「这个 sweep_key 是否已经播种过」，不是「脏表是否
+        # 为空」——脏表非空可能只是普通 catalog 编辑产生的有机脏项，跟
+        # 有没有播种过全量对账是两回事，用队列是否为空来判断会导致这类
+        # 有机脏项存在时全量对账被误判成「已经播种过」而永久跳过
+        # （issue #328 review）。sweep_key 变化（比如模型中途又切换）会
+        # 重新播种一遍，让新目标下这份索引重新覆盖全部 catalog，不会把
+        # 老模型的向量和新模型的混在一起当成同一次对账完成。
+        if get_sweep_seeded_fingerprint(db_path=db_path) != effective_sweep_key:
+            seed_info = seed_full_catalog_vector_sweep(
+                db_path=db_path, existing_index_keys=index.list_keys(),
+            )
+            mark_sweep_seeded(effective_sweep_key, db_path=db_path)
 
     if reason:
         stats = _drain_full_sweep_batch(
@@ -484,6 +523,37 @@ def _vector_index_identity(index, vector_db_path: Path) -> str:
     )
 
 
+def _recommends_safe_to_recompute(vec_stats: dict, *, ephemeral_index: bool) -> bool:
+    """本轮的索引内容够不够完整、值不值得用它重算并覆盖已有推荐结果。
+
+    不安全时应该跳过重算，让已有推荐槽保持原样（哪怕已经过期）——过期
+    但完整的一份结果，好过用不完整/不一致的索引算出一份更差的覆盖上去
+    （issue #328 review）：
+
+    - 纯增量（``mode != "full"``）：索引一直在稳态累积，随时可信。
+    - 全量对账仍在进行（``remaining > 0``）：索引处于中途状态——可能是
+      增量脏项还没追完，也可能是模型切换/无持久索引导致内容还没对齐到
+      同一个目标，这时候算出来的结果只会是一份内部不一致的推荐，不能
+      发布。
+    - 全量对账在这次调用里追平（``remaining == 0``）且不是内存兜底
+      （持久索引）：安全，持久索引跨轮次真正累积，此刻磁盘上的内容就是
+      完整的。
+    - 全量对账在这次调用里追平、且是内存兜底：只有当这次调用同时完成了
+      播种和消化（``total_indexable`` 有值，即整份可索引目录一次就在这
+      批里处理完）才安全——这种情况下内存里这份索引确实覆盖了全部
+      catalog。如果 ``total_indexable`` 没有值，说明这是跨多轮播种的
+      尾轮，内存里这份索引对象只有这一轮处理的那一小批，不是全量，
+      不能发布。
+    """
+    if vec_stats.get("mode") != "full":
+        return True
+    if vec_stats.get("remaining", 0) != 0:
+        return False
+    if not ephemeral_index:
+        return True
+    return vec_stats.get("total_indexable") is not None
+
+
 def run_recommend_heavy_once(
     *,
     engine,
@@ -522,6 +592,11 @@ def run_recommend_heavy_once(
         model_fingerprint = f"{VECTOR_SYNC_ALGORITHM}:{model}:{dim}"
     # open_skill_vector_index：无 pymilvus 时退回内存索引并 hourly warn
     index = memory_index or open_skill_vector_index(vdb, dim=dim)
+    # sweep_key 只取 算法:模型:维度 这部分，不拼索引实例标识——见
+    # run_vector_sync 的 sweep_key 说明：没有持久索引时每个子进程的
+    # index 对象都是新的，若拿它的 id() 当播种去重键，会导致「已经
+    # 播种过」永远判定为假，多轮攒下的脏表进度被每轮重新播种抹掉。
+    sweep_key = model_fingerprint
     model_fingerprint = (
         f"{model_fingerprint}:{_vector_index_identity(index, vdb)}"
     )
@@ -537,6 +612,7 @@ def run_recommend_heavy_once(
         embed=embed_fn,
         index=index,
         model_fingerprint=model_fingerprint,
+        sweep_key=sweep_key,
         force_full=ephemeral_index,
         limit=vector_sync_batch_limit,
         memory_budget_mb=memory_budget_mb,
@@ -544,14 +620,32 @@ def run_recommend_heavy_once(
     if mark_catalog_dirty and (
         vec_stats.get("upserted", 0) or vec_stats.get("deleted", 0)
     ):
+        # 标脏只是排进队列，供之后「索引可信」的某一轮消费——标脏本身不
+        # 涉及用这份索引算东西，随时安全，不受下面的门禁影响。
         mark_all_recommend_dirty(reason="catalog_vector_changed", db_path=registry)
-    n = process_dirty_recommends(
-        db_path=registry, vector_index=index, engine=engine,
+    recommends_safe = _recommends_safe_to_recompute(
+        vec_stats, ephemeral_index=ephemeral_index,
     )
+    if recommends_safe:
+        n = process_dirty_recommends(
+            db_path=registry, vector_index=index, engine=engine,
+        )
+    else:
+        # 这一轮的索引不完整/不一致（全量对账还没追平，或没有持久索引时
+        # 只覆盖了这一轮处理的那一小批），不能拿它算推荐去覆盖已有槽位
+        # ——已有结果哪怕过期，也好过用不完整索引算出的一份更差结果
+        # （issue #328 review）。留给脏队列，等索引可信的那一轮再消费。
+        n = 0
+        logger.info(
+            "recommend computation deferred: vector index not yet complete "
+            "this round (mode=%s remaining=%s ephemeral=%s)",
+            vec_stats.get("mode"), vec_stats.get("remaining"), ephemeral_index,
+        )
     index_kind = "milvus" if type(index).__name__ == "MilvusLiteSkillVectorIndex" else "memory"
     return {
         "vector": vec_stats,
         "recommends": n,
+        "recommends_deferred": not recommends_safe,
         "index_kind": index_kind,
         "rss_peak_mb": current_rss_mb(),
     }

--- a/src/xskill/recommend/heavy_worker.py
+++ b/src/xskill/recommend/heavy_worker.py
@@ -2,6 +2,7 @@
 from __future__ import annotations
 
 import logging
+import sys
 import time
 from pathlib import Path
 from typing import Optional
@@ -11,6 +12,26 @@ logger = logging.getLogger("xskill.recommend.heavy_worker")
 
 VECTOR_RECONCILE_INTERVAL_SECONDS = 24 * 60 * 60
 VECTOR_SYNC_ALGORITHM = "catalog-vector-dirty-v1"
+
+# 全量对账批处理循环里，每处理这么多行才查一次内存占用——resource.getrusage
+# 是系统调用，逐行查会有可感知开销；这个粒度下预算超限最多晚发现这么多行。
+_MEMORY_BUDGET_CHECK_STRIDE = 20
+
+
+def current_rss_mb() -> float:
+    """当前进程的峰值常驻内存（MiB）。
+
+    ``resource.getrusage(...).ru_maxrss`` 单位在 Linux 上是 KiB，
+    macOS 上是字节——两个平台的内核实现从来没统一过，这里按平台换算成
+    统一的 MiB。Windows 没有 ``resource`` 模块，返回 0.0（不阻断，只是
+    这项观测在 Windows 上不可用；team server 目前只跑在 Linux 容器里）。
+    """
+    try:
+        import resource
+    except ImportError:  # Windows
+        return 0.0
+    peak = resource.getrusage(resource.RUSAGE_SELF).ru_maxrss
+    return peak / 1024.0 if sys.platform == "linux" else peak / (1024.0 * 1024.0)
 
 
 def _load_catalog_rows(
@@ -43,156 +64,20 @@ def _load_catalog_rows(
     return [dict(r) for r in rows]
 
 
-def _row_target(row: dict | None):
-    if row is None:
-        return None
-    from xskill.recommend.skill_vector_store import (
-        catalog_row_is_indexable,
-        content_sha_for_text,
-    )
-
-    if not catalog_row_is_indexable(row):
-        return None
-    description = (row.get("description") or "").strip()
-    return (
-        row.get("content_sha") or content_sha_for_text(description),
-        row.get("source") or "",
-        row.get("name") or "",
-        description,
-    )
-
-
-def _load_catalog_row(db_path: Path, catalog_key: str) -> dict | None:
-    rows = _load_catalog_rows(db_path, catalog_keys=[catalog_key])
-    return rows[0] if rows else None
-
-
-def run_vector_reconcile(
-    *,
-    db_path: Path,
-    vector_db_path: Path,
-    embed=None,
-    memory_index=None,
-    force_upsert: bool = False,
-    should_apply=None,
+def _drain_incremental_batch(
+    *, db_path: Path, index, embed, limit: int,
 ) -> dict:
-    from xskill.recommend.skill_vector_store import (
-        DEFAULT_DIM,
-        fake_embed,
-        open_skill_vector_index,
-        reconcile_catalog_to_index,
-    )
+    """消费一批「单个 key 真的变了」的自然脏项：无条件重新 embed + upsert。
 
-    rows = _load_catalog_rows(db_path)
-    embed_fn = embed or (lambda text: fake_embed(text, DEFAULT_DIM))
-    index = memory_index or open_skill_vector_index(vector_db_path, dim=DEFAULT_DIM)
-    stats = reconcile_catalog_to_index(
-        index,
-        rows,
-        embed=embed_fn,
-        force_upsert=force_upsert,
-        should_apply=should_apply,
-    )
-    logger.info(
-        "vector reconcile: upserted=%s deleted=%s skipped=%s",
-        stats["upserted"], stats["deleted"], stats["skipped"],
-    )
-    return stats
-
-
-def _full_apply_fence(
-    *,
-    db_path: Path,
-    snapshot_generations: dict[str, int],
-):
-    """构造低频全量对账的逐 key fence，避免写回扫描后的旧快照。"""
-    from xskill.pipeline.registry import pooled_connection
-    from xskill.recommend.vector_dirty import (
-        mark_catalog_vector_dirty_on_connection,
-    )
-
-    def _should_apply(catalog_key: str, snapshot_row: dict | None) -> bool:
-        with pooled_connection(db_path) as conn:
-            event = conn.execute(
-                """
-                SELECT generation FROM catalog_vector_dirty
-                WHERE catalog_key=? AND dirty=1
-                """,
-                (catalog_key,),
-            ).fetchone()
-            current_generation = int(event["generation"]) if event else None
-            expected_generation = snapshot_generations.get(catalog_key)
-            if current_generation != expected_generation:
-                return False
-        current_row = _load_catalog_row(db_path, catalog_key)
-        if _row_target(current_row) == _row_target(snapshot_row):
-            return True
-        # 非标准写入没有产生事件时也不写旧快照，并补一个可恢复的脏项。
-        target = _row_target(current_row)
-        with pooled_connection(db_path) as conn:
-            mark_catalog_vector_dirty_on_connection(
-                conn,
-                catalog_key,
-                operation="upsert" if target is not None else "delete",
-                content_sha=target[0] if target is not None else "",
-            )
-            conn.commit()
-        return False
-
-    return _should_apply
-
-
-def run_vector_sync(
-    *,
-    db_path: Path,
-    vector_db_path: Path,
-    index,
-    embed,
-    model_fingerprint: str,
-    force_full: bool = False,
-    now: float | None = None,
-    limit: int = 256,
-) -> dict:
-    """优先消费增量队列；首次/模型变化/低频周期执行全量修复。"""
+    这条路径的事件本来就是内容变化触发的（见 catalog_store.py 的写入
+    逻辑），复用旧向量的判断在这里没有意义，不必再查一次 ``index.get``。
+    """
     from xskill.recommend.skill_vector_store import indexable_catalog_rows
     from xskill.recommend.vector_dirty import (
         catalog_vector_event_is_current,
-        catalog_vector_reconcile_reason,
         clear_catalog_vector_dirty,
-        finish_catalog_vector_reconcile,
-        list_all_catalog_vector_generations,
         list_catalog_vector_dirty,
     )
-
-    reason = "ephemeral" if force_full else catalog_vector_reconcile_reason(
-        model_fingerprint,
-        db_path=db_path,
-        now=now,
-        interval_seconds=VECTOR_RECONCILE_INTERVAL_SECONDS,
-    )
-    if reason:
-        generations = list_all_catalog_vector_generations(db_path=db_path)
-        stats = run_vector_reconcile(
-            db_path=db_path,
-            vector_db_path=vector_db_path,
-            embed=embed,
-            memory_index=index,
-            # 升级 bootstrap 先复用旧索引中 content/source/name 一致的向量，
-            # 避免部署本 PR 就为整个 catalog 重付 embedding 成本。模型水位建立后，
-            # 真正的模型切换会强制全量重算；空/临时索引自然逐条 miss。
-            force_upsert=reason in {"model_changed", "ephemeral"},
-            should_apply=_full_apply_fence(
-                db_path=db_path,
-                snapshot_generations=generations,
-            ),
-        )
-        finish_catalog_vector_reconcile(
-            generations,
-            model_fingerprint=model_fingerprint,
-            reconciled_at=time.time() if now is None else now,
-            db_path=db_path,
-        )
-        return {**stats, "mode": "full", "reason": reason}
 
     events = list_catalog_vector_dirty(db_path=db_path, limit=limit)
     rows = _load_catalog_rows(
@@ -232,6 +117,195 @@ def run_vector_sync(
             stats["deleted"] += 1
         if not clear_catalog_vector_dirty(key, generation, db_path=db_path):
             stats["deferred"] += 1
+    return stats
+
+
+def _drain_full_sweep_batch(
+    *,
+    db_path: Path,
+    index,
+    embed,
+    limit: int,
+    force_upsert: bool,
+    memory_budget_mb: Optional[float] = None,
+) -> dict:
+    """消费一批「全量对账」播种出来的脏项。
+
+    与 ``_drain_incremental_batch`` 的区别：这批事件里绝大多数内容根本
+    没变（播种时不分青红皂白把整份可索引目录都标了一遍），逐条无脑
+    re-embed 会把 bootstrap/periodic 对账变成一次性全量重付 embedding
+    成本——所以这里先看 content_sha 是否真的变了，没变就跳过或复用旧
+    向量，只有 ``force_upsert``（模型切换/无持久索引）时才放弃这个判断，
+    因为旧向量是用不同模型算的，复用是错的。
+
+    ``memory_budget_mb``：给定时每隔
+    ``_MEMORY_BUDGET_CHECK_STRIDE`` 行查一次本进程峰值 RSS，超预算就
+    停止消费这一批剩下的行——已处理的行照常清脏表，没处理到的行留在
+    脏表里，下一轮接着来（issue #328：单轮内存有界，而不是等一批全处理
+    完才发现已经超了）。
+    """
+    from xskill.recommend.skill_vector_store import indexable_catalog_rows
+    from xskill.recommend.vector_dirty import (
+        catalog_vector_event_is_current,
+        clear_catalog_vector_dirty,
+        list_catalog_vector_dirty,
+    )
+
+    events = list_catalog_vector_dirty(db_path=db_path, limit=limit)
+    rows = _load_catalog_rows(
+        db_path,
+        catalog_keys=[event["catalog_key"] for event in events],
+    )
+    rows_by_key = {row["catalog_key"]: row for row in rows}
+    stats = {
+        "upserted": 0, "deleted": 0, "skipped": 0, "deferred": 0,
+        "budget_aborted": False,
+    }
+    for processed, event in enumerate(events):
+        if (
+            memory_budget_mb is not None
+            and processed
+            and processed % _MEMORY_BUDGET_CHECK_STRIDE == 0
+            and current_rss_mb() > memory_budget_mb
+        ):
+            logger.warning(
+                "vector full sweep aborted mid-batch: rss over budget "
+                "(%.0f MiB budget), processed %s/%s this batch; "
+                "remaining rows stay dirty for next round",
+                memory_budget_mb, processed, len(events),
+            )
+            stats["budget_aborted"] = True
+            break
+        key = event["catalog_key"]
+        generation = int(event["generation"])
+        row = rows_by_key.get(key)
+        wanted = indexable_catalog_rows([row]) if row is not None else []
+        if wanted:
+            target = wanted[0]
+            cur = None if force_upsert else index.get(key)
+            same_content = (
+                cur is not None and cur.get("content_sha") == target["content_sha"]
+            )
+            same_meta = (
+                same_content
+                and (cur.get("source") or "") == (target.get("source") or "")
+                and (cur.get("name") or "") == (target.get("name") or "")
+            )
+            if same_meta:
+                if not catalog_vector_event_is_current(
+                    key, generation, db_path=db_path,
+                ):
+                    stats["deferred"] += 1
+                    continue
+                stats["skipped"] += 1
+                if not clear_catalog_vector_dirty(key, generation, db_path=db_path):
+                    stats["deferred"] += 1
+                continue
+            vector = cur["vector"] if same_content else embed(target["description"])
+            if not catalog_vector_event_is_current(
+                key, generation, db_path=db_path,
+            ):
+                stats["deferred"] += 1
+                continue
+            index.upsert(
+                key,
+                vector,
+                content_sha=target["content_sha"],
+                source=target.get("source") or "",
+                name=target.get("name") or "",
+            )
+            stats["upserted"] += 1
+        else:
+            if not catalog_vector_event_is_current(
+                key, generation, db_path=db_path,
+            ):
+                stats["deferred"] += 1
+                continue
+            index.delete(key)
+            stats["deleted"] += 1
+        if not clear_catalog_vector_dirty(key, generation, db_path=db_path):
+            stats["deferred"] += 1
+    return stats
+
+
+def run_vector_sync(
+    *,
+    db_path: Path,
+    index,
+    embed,
+    model_fingerprint: str,
+    force_full: bool = False,
+    now: float | None = None,
+    limit: int = 256,
+    memory_budget_mb: Optional[float] = None,
+) -> dict:
+    """优先消费增量队列；首次/模型变化/低频周期触发全量对账。
+
+    全量对账本身也走 ``catalog_vector_dirty`` 这张脏表分批消费
+    （issue #328）：没有积压时先播种（把全部可索引 ``catalog_key`` 标脏），
+    之后每次调用只处理至多 ``limit`` 条，天然把「一次性全量重建」拆成
+    多轮——不再需要在没装持久索引（Milvus Lite）时一次性把整份 catalog
+    的正文和向量都摊进内存，用多轮换峰值内存可控；进度（本轮处理量、
+    剩余量）由返回值的 ``remaining`` 字段体现，调用方负责写进日志/状态
+    文件。持久索引的分批结果会落盘在同一个 db 文件里，跨轮次自然累积；
+    没有持久索引（内存兜底）时每轮的索引对象在子进程退出后被丢弃，
+    「多轮」只保证内存峰值有界、检索覆盖率会持续被下一轮的批次覆盖，
+    并不会跨轮累积成一份完整索引——这是没有持久存储时物理上做不到的，
+    不是本函数的缺陷。
+    """
+    from xskill.recommend.vector_dirty import (
+        catalog_vector_reconcile_reason,
+        count_catalog_vector_dirty,
+        finish_catalog_vector_reconcile,
+        seed_full_catalog_vector_sweep,
+    )
+
+    reason = "ephemeral" if force_full else catalog_vector_reconcile_reason(
+        model_fingerprint,
+        db_path=db_path,
+        now=now,
+        interval_seconds=VECTOR_RECONCILE_INTERVAL_SECONDS,
+    )
+    seed_info = None
+    if reason and count_catalog_vector_dirty(db_path=db_path) == 0:
+        # 只在没有积压时播种一次；已经在消化上一次播种的积压时不重复播种，
+        # 否则会把已处理、已清出脏表的 key 重新标脏，抹掉已有进度。
+        seed_info = seed_full_catalog_vector_sweep(
+            db_path=db_path, existing_index_keys=index.list_keys(),
+        )
+
+    if reason:
+        stats = _drain_full_sweep_batch(
+            db_path=db_path,
+            index=index,
+            embed=embed,
+            limit=limit,
+            force_upsert=reason in {"model_changed", "ephemeral"},
+            memory_budget_mb=memory_budget_mb,
+        )
+        remaining = count_catalog_vector_dirty(db_path=db_path)
+        if remaining == 0:
+            finish_catalog_vector_reconcile(
+                {},
+                model_fingerprint=model_fingerprint,
+                reconciled_at=time.time() if now is None else now,
+                db_path=db_path,
+            )
+        else:
+            logger.info(
+                "vector full sweep in progress: reason=%s upserted=%s "
+                "deleted=%s skipped=%s remaining=%s",
+                reason, stats["upserted"], stats["deleted"], stats["skipped"],
+                remaining,
+            )
+        result = {**stats, "mode": "full", "reason": reason, "remaining": remaining}
+        if seed_info is not None:
+            result["total_indexable"] = seed_info["total_indexable"]
+        return result
+
+    stats = _drain_incremental_batch(
+        db_path=db_path, index=index, embed=embed, limit=limit,
+    )
     return {**stats, "mode": "incremental", "reason": ""}
 
 
@@ -417,6 +491,8 @@ def run_recommend_heavy_once(
     vector_db_path: Path | None = None,
     memory_index=None,
     mark_catalog_dirty: bool = True,
+    vector_sync_batch_limit: int = 256,
+    memory_budget_mb: Optional[float] = None,
 ) -> dict:
     """对账向量索引并消化推荐脏队列（画像刷新由调用方先跑）。"""
     from xskill.config import XSKILL_HOME, get_registry_db_path
@@ -449,18 +525,21 @@ def run_recommend_heavy_once(
     model_fingerprint = (
         f"{model_fingerprint}:{_vector_index_identity(index, vdb)}"
     )
-    # 生产 fallback 每次都会创建空的内存索引，必须全量填充；调用方显式传入的
-    # memory_index 可跨 tick 复用，仍走增量路径（用于测试/嵌入式调用）。
+    # 生产 fallback 每次都会创建空的内存索引：force_full 让 run_vector_sync
+    # 把这轮当成需要全量对账处理（分批消费脏表，不是一次性全量重建，见
+    # run_vector_sync 的说明）；调用方显式传入的 memory_index 可跨 tick
+    # 复用，仍走增量路径（用于测试/嵌入式调用）。
     ephemeral_index = memory_index is None and isinstance(
         index, MemorySkillVectorIndex,
     )
     vec_stats = run_vector_sync(
         db_path=registry,
-        vector_db_path=vdb,
         embed=embed_fn,
         index=index,
         model_fingerprint=model_fingerprint,
         force_full=ephemeral_index,
+        limit=vector_sync_batch_limit,
+        memory_budget_mb=memory_budget_mb,
     )
     if mark_catalog_dirty and (
         vec_stats.get("upserted", 0) or vec_stats.get("deleted", 0)
@@ -469,4 +548,10 @@ def run_recommend_heavy_once(
     n = process_dirty_recommends(
         db_path=registry, vector_index=index, engine=engine,
     )
-    return {"vector": vec_stats, "recommends": n}
+    index_kind = "milvus" if type(index).__name__ == "MilvusLiteSkillVectorIndex" else "memory"
+    return {
+        "vector": vec_stats,
+        "recommends": n,
+        "index_kind": index_kind,
+        "rss_peak_mb": current_rss_mb(),
+    }

--- a/src/xskill/recommend/skill_vector_store.py
+++ b/src/xskill/recommend/skill_vector_store.py
@@ -73,11 +73,63 @@ class SkillVectorIndex(Protocol):
 
 
 class MemorySkillVectorIndex:
-    """纯内存实现：单测不依赖 pymilvus。"""
+    """纯内存实现：单测不依赖 pymilvus，生产在装不上 Milvus Lite 时兜底。
 
-    def __init__(self, dim: int = DEFAULT_DIM) -> None:
+    向量存放在一块预分配的二维 numpy 矩阵里（按行索引），不是「字典套
+    Python list」——万级技能场景下这省两笔账：一是 Python float 装箱的
+    空间（每个元素一个独立对象，vs 数组里连续的 8 字节）；二是
+    ``search()`` 不再逐行把 list 转成 numpy 数组再算余弦，而是对整块
+    矩阵一次性做向量化的归一化和矩阵乘法（issue #328）。
+
+    删除的行位标记进空闲槽位表，之后 upsert 优先复用而不是让矩阵一直
+    增长；容量不够时才整体扩容一次（``reserve()`` 可以在批量写入前把
+    容量一次开够，避免边写边翻倍拷贝——问题同样出在「不知道最终大小、
+    靠 append 摸着石头过河」，只是发生在 numpy 矩阵而不是 Python list
+    上，道理一样）。
+    """
+
+    _GROWTH_FACTOR = 2
+    _MIN_CAPACITY = 16
+
+    def __init__(self, dim: int = DEFAULT_DIM, *, capacity: int = 0) -> None:
+        import numpy as np
+
         self.dim = dim
-        self._rows: dict[str, dict] = {}
+        self._capacity = max(int(capacity), 0)
+        self._matrix = np.empty((self._capacity, dim), dtype=np.float64)
+        self._size = 0  # 已分配（含空闲槽）的行数上界
+        self._key_to_row: dict[str, int] = {}
+        self._meta: dict[str, dict] = {}
+        self._free_rows: list[int] = []
+
+    def reserve(self, n: int) -> None:
+        """把容量一次性扩到至少 ``n`` 行；批量写入前调用可以避免边写边扩容。
+
+        不是必须调用——不调用时 upsert 仍会按需自动扩容（翻倍策略），
+        只是明知最终规模时提前 reserve 能省掉中途几次整体拷贝。
+        """
+        if n > self._capacity:
+            self._grow_to(int(n))
+
+    def _grow_to(self, capacity: int) -> None:
+        import numpy as np
+
+        new_matrix = np.empty((capacity, self.dim), dtype=np.float64)
+        if self._size:
+            new_matrix[: self._size] = self._matrix[: self._size]
+        self._matrix = new_matrix
+        self._capacity = capacity
+
+    def _allocate_row(self) -> int:
+        if self._free_rows:
+            return self._free_rows.pop()
+        if self._size >= self._capacity:
+            self._grow_to(
+                max(self._capacity * self._GROWTH_FACTOR, self._MIN_CAPACITY)
+            )
+        row = self._size
+        self._size += 1
+        return row
 
     def upsert(
         self,
@@ -88,23 +140,47 @@ class MemorySkillVectorIndex:
         source: str,
         name: str,
     ) -> None:
-        self._rows[catalog_key] = {
-            "catalog_key": catalog_key,
-            "vector": list(vector),
-            "content_sha": content_sha,
-            "source": source,
-            "name": name,
+        import numpy as np
+
+        vec = np.asarray(vector, dtype=np.float64)
+        if vec.shape != (self.dim,):
+            raise ValueError(
+                f"vector dim mismatch for {catalog_key!r}: "
+                f"expected ({self.dim},), got {vec.shape}"
+            )
+        row = self._key_to_row.get(catalog_key)
+        if row is None:
+            row = self._allocate_row()
+            self._key_to_row[catalog_key] = row
+        self._matrix[row] = vec
+        self._meta[catalog_key] = {
+            "content_sha": content_sha, "source": source, "name": name,
         }
 
     def delete(self, catalog_key: str) -> None:
-        self._rows.pop(catalog_key, None)
+        row = self._key_to_row.pop(catalog_key, None)
+        self._meta.pop(catalog_key, None)
+        if row is not None:
+            self._free_rows.append(row)
 
     def get(self, catalog_key: str) -> Optional[dict]:
-        row = self._rows.get(catalog_key)
-        return dict(row) if row else None
+        row = self._key_to_row.get(catalog_key)
+        if row is None:
+            return None
+        return {
+            "catalog_key": catalog_key,
+            "vector": self._matrix[row].tolist(),
+            **self._meta[catalog_key],
+        }
 
     def list_keys(self) -> set[str]:
-        return set(self._rows)
+        return set(self._key_to_row)
+
+    @property
+    def _rows(self) -> dict:
+        """只读兼容视图（``{key: get(key)}``），供既有测试按旧的
+        「字典套行」形状断言用；生产代码不读它。"""
+        return {key: self.get(key) for key in self._key_to_row}
 
     def search(
         self, vector: Sequence[float], *, top_k: int = 10,
@@ -112,19 +188,28 @@ class MemorySkillVectorIndex:
     ) -> list[tuple[str, float]]:
         import numpy as np
 
-        q = np.asarray(vector, dtype=float)
-        qn = float(np.linalg.norm(q)) or 1.0
-        q = q / qn
-        scored: list[tuple[str, float]] = []
         skip = exclude_keys or set()
-        for key, row in self._rows.items():
-            if key in skip:
-                continue
-            v = np.asarray(row["vector"], dtype=float)
-            vn = float(np.linalg.norm(v)) or 1.0
-            scored.append((key, float(q @ (v / vn))))
-        scored.sort(key=lambda x: -x[1])
-        return scored[:top_k]
+        keys = [key for key in self._key_to_row if key not in skip]
+        if not keys:
+            return []
+        rows = np.fromiter(
+            (self._key_to_row[key] for key in keys),
+            dtype=np.int64, count=len(keys),
+        )
+        # 一次性切片整块矩阵，不逐行 np.asarray 转换；归一化和打分都是
+        # 向量化操作，不是 Python 循环里一条条算。
+        candidates = self._matrix[rows]
+        norms = np.linalg.norm(candidates, axis=1)
+        norms[norms == 0] = 1.0
+        q = np.asarray(vector, dtype=np.float64)
+        qn = float(np.linalg.norm(q)) or 1.0
+        scores = (candidates / norms[:, None]) @ (q / qn)
+        k = min(top_k, len(keys))
+        # top_k 通常远小于候选数：先用 argpartition 圈出前 k 个（均摊
+        # O(n)），再对这一小撮排序，比对全量做一次 argsort 省时间。
+        top_indices = np.argpartition(-scores, k - 1)[:k] if k > 0 else np.array([], dtype=np.int64)
+        top_indices = top_indices[np.argsort(-scores[top_indices])]
+        return [(keys[i], float(scores[i])) for i in top_indices]
 
 
 class MilvusLiteSkillVectorIndex:
@@ -345,6 +430,11 @@ def reconcile_catalog_to_index(
         r["catalog_key"]: r for r in indexable_catalog_rows(catalog_rows)
     }
     existing_keys = index.list_keys()
+    # 已知这批最终最多写入多少行，提前把索引（若支持，如
+    # MemorySkillVectorIndex）预留够容量，避免逐条 upsert 时反复翻倍扩容。
+    reserve = getattr(index, "reserve", None)
+    if callable(reserve):
+        reserve(len(existing_keys) + len(wanted))
     upserted = deleted = skipped = deferred = 0
     for key, row in wanted.items():
         cur = index.get(key)

--- a/src/xskill/recommend/vector_dirty.py
+++ b/src/xskill/recommend/vector_dirty.py
@@ -3,7 +3,7 @@ from __future__ import annotations
 
 import time
 from pathlib import Path
-from typing import Optional
+from typing import Iterable, Optional
 
 from xskill.pipeline.registry import pooled_connection
 
@@ -52,6 +52,85 @@ def list_catalog_vector_dirty(
             (max(1, int(limit)),),
         ).fetchall()
     return [dict(row) for row in rows]
+
+
+def count_catalog_vector_dirty(*, db_path: Optional[Path] = None) -> int:
+    """当前积压的脏项数——用来判断「要不要播种全量对账」和向状态文件报告进度。"""
+    with pooled_connection(db_path) as conn:
+        row = conn.execute(
+            "SELECT COUNT(*) AS n FROM catalog_vector_dirty WHERE dirty=1"
+        ).fetchone()
+    return int(row["n"]) if row else 0
+
+
+def _row_indexable_from_light_columns(
+    *, content_sha: str, source: str, distributable, retired,
+) -> bool:
+    """``catalog_row_is_indexable`` 的窄列版本：只用 ``content_sha`` 的
+    非空性代表「有正文」，不读 description 原文——避免播种全量对账时把
+    全表文本一次性摊进内存（issue #328）。``content_sha`` 只在
+    description 非空时才非空（见 ``catalog_store.py`` 写入逻辑），可以
+    安全地当「有没有正文」的代理，不需要重复两边的判定逻辑本体。
+    """
+    if retired:
+        return False
+    if not (content_sha or "").strip():
+        return False
+    return source == "skillhub" or bool(
+        distributable if distributable is not None else 1
+    )
+
+
+def seed_full_catalog_vector_sweep(
+    *,
+    db_path: Optional[Path] = None,
+    existing_index_keys: Iterable[str] = (),
+) -> dict:
+    """把当前全部可索引 catalog 行标脏，交给增量消费循环分批处理（issue #328）。
+
+    调用方只应在「没有正在进行中的积压」时播种一次——重复播种会把已经
+    处理过、已经从脏表清掉的 key 重新标脏，抹掉上一轮已经取得的进度。
+    之后每轮只消费一批（``limit`` 条），天然把一次性的全量重建拆成多轮，
+    不会因为没装持久索引就在单轮里把整份 catalog 的正文和向量都摊进内存。
+
+    ``existing_index_keys``：当前索引里已有、但按最新 catalog 状态已不
+    再可索引（被 retire、被删）的 key 会被标记 delete，交由消费循环把
+    它们从索引里清掉，行为与旧的全量对账一致。
+    """
+    with pooled_connection(db_path) as conn:
+        rows = conn.execute(
+            """
+            SELECT c.catalog_key, c.content_sha, c.source, c.distributable,
+                   CASE WHEN l.state='retired' THEN 1 ELSE 0 END AS retired
+            FROM skills_catalog AS c
+            LEFT JOIN skill_lifecycle AS l ON l.skill_name=c.name
+            """
+        ).fetchall()
+        indexable_keys: set[str] = set()
+        seeded_upsert = 0
+        for row in rows:
+            if not _row_indexable_from_light_columns(
+                content_sha=row["content_sha"], source=row["source"],
+                distributable=row["distributable"], retired=row["retired"],
+            ):
+                continue
+            indexable_keys.add(row["catalog_key"])
+            mark_catalog_vector_dirty_on_connection(
+                conn, row["catalog_key"], operation="upsert",
+                content_sha=row["content_sha"] or "",
+            )
+            seeded_upsert += 1
+        stale = set(existing_index_keys) - indexable_keys
+        for catalog_key in stale:
+            mark_catalog_vector_dirty_on_connection(
+                conn, catalog_key, operation="delete",
+            )
+        conn.commit()
+    return {
+        "total_indexable": len(indexable_keys),
+        "seeded_upsert": seeded_upsert,
+        "seeded_delete": len(stale),
+    }
 
 
 def list_all_catalog_vector_generations(

--- a/src/xskill/recommend/vector_dirty.py
+++ b/src/xskill/recommend/vector_dirty.py
@@ -88,16 +88,28 @@ def seed_full_catalog_vector_sweep(
 ) -> dict:
     """把当前全部可索引 catalog 行标脏，交给增量消费循环分批处理（issue #328）。
 
-    调用方只应在「没有正在进行中的积压」时播种一次——重复播种会把已经
-    处理过、已经从脏表清掉的 key 重新标脏，抹掉上一轮已经取得的进度。
-    之后每轮只消费一批（``limit`` 条），天然把一次性的全量重建拆成多轮，
-    不会因为没装持久索引就在单轮里把整份 catalog 的正文和向量都摊进内存。
+    调用方应该配合 ``get_sweep_seeded_fingerprint``/``mark_sweep_seeded``
+    只在「这个播种目标还没播种过」时调用一次，而不是靠脏表是否为空来
+    判断——脏表非空可能只是普通 catalog 编辑产生的有机脏项，和有没有
+    播种过全量对账是两回事（issue #328 review）。之后每轮只消费一批
+    （``limit`` 条），天然把一次性的全量重建拆成多轮，不会因为没装持久
+    索引就在单轮里把整份 catalog 的正文和向量都摊进内存。
+
+    已经脏（不管是有机变化还是上一次播种留下的）的 key 不重新标记——
+    避免播种把它们的 generation 平白再往上蹦一次，干扰「generation 只在
+    真正相关的事件上前进」这条不变量，也少几次没必要的写。
 
     ``existing_index_keys``：当前索引里已有、但按最新 catalog 状态已不
     再可索引（被 retire、被删）的 key 会被标记 delete，交由消费循环把
     它们从索引里清掉，行为与旧的全量对账一致。
     """
     with pooled_connection(db_path) as conn:
+        already_dirty = {
+            row["catalog_key"]
+            for row in conn.execute(
+                "SELECT catalog_key FROM catalog_vector_dirty WHERE dirty=1"
+            ).fetchall()
+        }
         rows = conn.execute(
             """
             SELECT c.catalog_key, c.content_sha, c.source, c.distributable,
@@ -115,12 +127,14 @@ def seed_full_catalog_vector_sweep(
             ):
                 continue
             indexable_keys.add(row["catalog_key"])
+            if row["catalog_key"] in already_dirty:
+                continue
             mark_catalog_vector_dirty_on_connection(
                 conn, row["catalog_key"], operation="upsert",
                 content_sha=row["content_sha"] or "",
             )
             seeded_upsert += 1
-        stale = set(existing_index_keys) - indexable_keys
+        stale = set(existing_index_keys) - indexable_keys - already_dirty
         for catalog_key in stale:
             mark_catalog_vector_dirty_on_connection(
                 conn, catalog_key, operation="delete",
@@ -189,7 +203,13 @@ def finish_catalog_vector_reconcile(
     reconciled_at: float | None = None,
     db_path: Optional[Path] = None,
 ) -> None:
-    """提交全量对账水位，并按 generation 清理开始时观察到的事件。"""
+    """提交全量对账水位，并按 generation 清理开始时观察到的事件。
+
+    同时清掉 ``sweep_seeded_fingerprint`` 播种标记——这一步和「记录已完成」
+    是同一个原子操作：播种标记的意义就是「这个指纹的全量对账还没追平」，
+    追平的那一刻它就该被清空，不然下一次同指纹的触发会误判成「已经播种
+    过」而跳过播种（issue #328 review）。
+    """
     with pooled_connection(db_path) as conn:
         for catalog_key, generation in generations.items():
             conn.execute(
@@ -200,16 +220,45 @@ def finish_catalog_vector_reconcile(
         conn.execute(
             """
             INSERT INTO catalog_vector_sync_meta(
-                singleton, model_fingerprint, reconciled_at
-            ) VALUES (1, ?, ?)
+                singleton, model_fingerprint, reconciled_at,
+                sweep_seeded_fingerprint
+            ) VALUES (1, ?, ?, '')
             ON CONFLICT(singleton) DO UPDATE SET
                 model_fingerprint=excluded.model_fingerprint,
-                reconciled_at=excluded.reconciled_at
+                reconciled_at=excluded.reconciled_at,
+                sweep_seeded_fingerprint=''
             """,
             (
                 model_fingerprint,
                 time.time() if reconciled_at is None else reconciled_at,
             ),
+        )
+        conn.commit()
+
+
+def get_sweep_seeded_fingerprint(*, db_path: Optional[Path] = None) -> str:
+    """当前「已经播种、还没追平」的全量对账目标指纹；没有进行中的播种返回空串。"""
+    with pooled_connection(db_path) as conn:
+        row = conn.execute(
+            "SELECT sweep_seeded_fingerprint FROM catalog_vector_sync_meta "
+            "WHERE singleton=1"
+        ).fetchone()
+    return (row["sweep_seeded_fingerprint"] or "") if row else ""
+
+
+def mark_sweep_seeded(
+    model_fingerprint: str, *, db_path: Optional[Path] = None,
+) -> None:
+    """记录「这个指纹的全量对账已经播种」，供后续轮次判断要不要重复播种。"""
+    with pooled_connection(db_path) as conn:
+        conn.execute(
+            """
+            INSERT INTO catalog_vector_sync_meta(singleton, sweep_seeded_fingerprint)
+            VALUES (1, ?)
+            ON CONFLICT(singleton) DO UPDATE SET
+                sweep_seeded_fingerprint=excluded.sweep_seeded_fingerprint
+            """,
+            (model_fingerprint,),
         )
         conn.commit()
 

--- a/tests/test_memory_vector_index.py
+++ b/tests/test_memory_vector_index.py
@@ -1,0 +1,159 @@
+"""tests/test_memory_vector_index.py — MemorySkillVectorIndex 的预分配矩阵实现（issue #328）。
+
+内部存储从「字典套 Python list」换成预分配的二维 numpy 矩阵 + 空闲槽位
+表，覆盖：容量自动增长与预留（``reserve``）、删除后槽位复用不搬迁其余
+行、``search`` 的向量化打分正确性（含 exclude_keys、top_k 超过候选数）、
+维度不匹配报错、大批量下 upsert/delete/search 混合操作的正确性。
+"""
+from __future__ import annotations
+
+import math
+
+import pytest
+
+from xskill.recommend.skill_vector_store import MemorySkillVectorIndex
+
+
+def _unit(vec: list[float]) -> list[float]:
+    norm = math.sqrt(sum(v * v for v in vec)) or 1.0
+    return [v / norm for v in vec]
+
+
+class TestCapacityGrowth:
+    def test_starts_with_zero_capacity_and_grows_on_first_upsert(self):
+        index = MemorySkillVectorIndex(dim=3)
+        assert index._capacity == 0
+        index.upsert("a", [1.0, 0.0, 0.0], content_sha="s", source="x", name="a")
+        assert index._capacity >= 1
+        assert index.get("a")["vector"] == [1.0, 0.0, 0.0]
+
+    def test_reserve_avoids_incremental_growth(self):
+        index = MemorySkillVectorIndex(dim=2)
+        index.reserve(100)
+        capacity_after_reserve = index._capacity
+        assert capacity_after_reserve >= 100
+        for i in range(100):
+            index.upsert(f"k{i}", [1.0, 0.0], content_sha="s", source="x", name="n")
+        # reserve 过的容量足够装下全部 100 条，中途不需要再扩容一次。
+        assert index._capacity == capacity_after_reserve
+
+    def test_reserve_is_noop_when_smaller_than_current_capacity(self):
+        index = MemorySkillVectorIndex(dim=2)
+        index.reserve(50)
+        cap = index._capacity
+        index.reserve(10)
+        assert index._capacity == cap
+
+    def test_values_survive_growth(self):
+        index = MemorySkillVectorIndex(dim=2, capacity=1)
+        for i in range(20):
+            index.upsert(f"k{i}", [float(i), 1.0], content_sha="s", source="x", name="n")
+        for i in range(20):
+            assert index.get(f"k{i}")["vector"] == [float(i), 1.0]
+
+
+class TestFreeSlotReuse:
+    def test_delete_then_upsert_reuses_row_without_growing(self):
+        index = MemorySkillVectorIndex(dim=2, capacity=4)
+        for i in range(4):
+            index.upsert(f"k{i}", [float(i), 0.0], content_sha="s", source="x", name="n")
+        assert index._capacity == 4
+        index.delete("k2")
+        assert "k2" not in index.list_keys()
+        index.upsert("k4", [9.0, 0.0], content_sha="s", source="x", name="n")
+        # 复用了 k2 腾出的槽位，不应触发扩容。
+        assert index._capacity == 4
+        assert index.get("k4")["vector"] == [9.0, 0.0]
+        assert index.get("k2") is None
+
+    def test_upsert_same_key_overwrites_in_place(self):
+        index = MemorySkillVectorIndex(dim=2)
+        index.upsert("a", [1.0, 0.0], content_sha="v1", source="x", name="n")
+        index.upsert("a", [0.0, 1.0], content_sha="v2", source="x", name="n")
+        assert index.list_keys() == {"a"}
+        got = index.get("a")
+        assert got["vector"] == [0.0, 1.0]
+        assert got["content_sha"] == "v2"
+
+    def test_delete_missing_key_is_noop(self):
+        index = MemorySkillVectorIndex(dim=2)
+        index.delete("nope")  # 不应报错
+        assert index.list_keys() == set()
+
+
+class TestDimensionValidation:
+    def test_wrong_dim_raises(self):
+        index = MemorySkillVectorIndex(dim=3)
+        with pytest.raises(ValueError, match="dim mismatch"):
+            index.upsert("a", [1.0, 2.0], content_sha="s", source="x", name="n")
+
+
+class TestSearch:
+    def test_search_orders_by_cosine_similarity(self):
+        index = MemorySkillVectorIndex(dim=2)
+        index.upsert("close", _unit([1.0, 0.1]), content_sha="s", source="x", name="close")
+        index.upsert("far", _unit([0.0, 1.0]), content_sha="s", source="x", name="far")
+        index.upsert("opposite", _unit([-1.0, 0.0]), content_sha="s", source="x", name="opposite")
+        results = index.search([1.0, 0.0], top_k=3)
+        assert [key for key, _score in results] == ["close", "far", "opposite"]
+
+    def test_search_respects_exclude_keys(self):
+        index = MemorySkillVectorIndex(dim=2)
+        index.upsert("a", [1.0, 0.0], content_sha="s", source="x", name="a")
+        index.upsert("b", [1.0, 0.0], content_sha="s", source="x", name="b")
+        results = index.search([1.0, 0.0], top_k=5, exclude_keys={"a"})
+        assert [key for key, _score in results] == ["b"]
+
+    def test_search_top_k_larger_than_candidates_returns_all(self):
+        index = MemorySkillVectorIndex(dim=2)
+        index.upsert("a", [1.0, 0.0], content_sha="s", source="x", name="a")
+        index.upsert("b", [0.0, 1.0], content_sha="s", source="x", name="b")
+        results = index.search([1.0, 1.0], top_k=50)
+        assert len(results) == 2
+
+    def test_search_empty_index_returns_empty(self):
+        index = MemorySkillVectorIndex(dim=2)
+        assert index.search([1.0, 0.0], top_k=5) == []
+
+    def test_search_after_deleting_only_candidate_returns_empty(self):
+        index = MemorySkillVectorIndex(dim=2)
+        index.upsert("a", [1.0, 0.0], content_sha="s", source="x", name="a")
+        index.delete("a")
+        assert index.search([1.0, 0.0], top_k=5) == []
+
+    def test_search_zero_vector_row_does_not_crash(self):
+        """全零向量范数为 0，除法要避免 NaN/inf 把整个打分弄脏。"""
+        index = MemorySkillVectorIndex(dim=2)
+        index.upsert("zero", [0.0, 0.0], content_sha="s", source="x", name="zero")
+        index.upsert("real", [1.0, 0.0], content_sha="s", source="x", name="real")
+        results = dict(index.search([1.0, 0.0], top_k=5))
+        assert math.isfinite(results["zero"])
+        assert math.isfinite(results["real"])
+
+
+class TestBulkMixedOperations:
+    def test_thousand_row_upsert_delete_search_roundtrip(self):
+        """大批量下混合增删查仍正确——预分配/复用逻辑不能只在小规模下对。"""
+        index = MemorySkillVectorIndex(dim=4)
+        index.reserve(1000)
+        for i in range(1000):
+            index.upsert(
+                f"k{i}", _unit([float(i % 7), float(i % 5), 1.0, 0.0]),
+                content_sha=f"sha{i}", source="s", name=f"n{i}",
+            )
+        assert len(index.list_keys()) == 1000
+        for i in range(0, 1000, 3):
+            index.delete(f"k{i}")
+        remaining = index.list_keys()
+        assert len(remaining) == 1000 - len(range(0, 1000, 3))
+        for i in range(0, 1000, 3):
+            assert f"k{i}" not in remaining
+        # 剩余行仍能正确检索、且 content_sha 元数据没有互相串行。
+        for i in range(1, 1000, 7):
+            if i % 3 == 0:
+                continue  # 这条已被删掉
+            got = index.get(f"k{i}")
+            assert got["content_sha"] == f"sha{i}"
+        hits = index.search(_unit([1.0, 1.0, 1.0, 0.0]), top_k=10)
+        assert len(hits) == 10
+        assert all(key in remaining for key, _score in hits)

--- a/tests/test_recommend_heavy_worker.py
+++ b/tests/test_recommend_heavy_worker.py
@@ -1,0 +1,211 @@
+"""recommend-heavy 重活单轮的内存治理（issue #328）。
+
+覆盖三层：
+1. ``recommend_heavy_config``——批大小/内存预算配置校验。
+2. ``heavy_worker.current_rss_mb`` / 内存预算中止——单轮批处理超预算时
+   提前停止，已处理的部分正常生效，没处理的留给下一轮。
+3. ``_workers.run_recommend_heavy_once`` 的接线——配置值传到
+   ``heavy_worker.run_recommend_heavy_once``，状态文件带新字段。
+"""
+from __future__ import annotations
+
+from pathlib import Path
+
+import pytest
+
+from xskill.config import recommend_heavy_config
+from xskill.recommend.heavy_worker import (
+    _drain_full_sweep_batch,
+    current_rss_mb,
+)
+from xskill.recommend.skill_vector_store import (
+    DEFAULT_DIM,
+    MemorySkillVectorIndex,
+    content_sha_for_text,
+    fake_embed,
+)
+from xskill.recommend.vector_dirty import (
+    count_catalog_vector_dirty,
+    seed_full_catalog_vector_sweep,
+)
+
+
+# ─────────────────────────────────────────────────────────────────
+# 配置校验
+# ─────────────────────────────────────────────────────────────────
+
+class TestRecommendHeavyConfig:
+    def test_defaults(self):
+        cfg = recommend_heavy_config({})
+        assert cfg == {"batch_limit": 256, "memory_budget_mb": 1024.0}
+
+    def test_custom_values(self):
+        cfg = recommend_heavy_config({
+            "server": {
+                "vector_sync_batch_limit": 50,
+                "recommend_heavy_memory_budget_mb": 512,
+            },
+        })
+        assert cfg == {"batch_limit": 50, "memory_budget_mb": 512.0}
+
+    @pytest.mark.parametrize("bad", [0, -1, 1.5, True])
+    def test_rejects_non_positive_int_batch_limit(self, bad):
+        with pytest.raises(ValueError, match="vector_sync_batch_limit"):
+            recommend_heavy_config({"server": {"vector_sync_batch_limit": bad}})
+
+    @pytest.mark.parametrize("bad", [0, -1, "big", True])
+    def test_rejects_non_positive_memory_budget(self, bad):
+        with pytest.raises(ValueError, match="recommend_heavy_memory_budget_mb"):
+            recommend_heavy_config(
+                {"server": {"recommend_heavy_memory_budget_mb": bad}}
+            )
+
+
+# ─────────────────────────────────────────────────────────────────
+# RSS 观测与内存预算中止
+# ─────────────────────────────────────────────────────────────────
+
+class TestMemoryBudget:
+    def test_current_rss_mb_returns_non_negative_float(self):
+        value = current_rss_mb()
+        assert isinstance(value, float)
+        assert value >= 0.0
+
+    def test_batch_aborts_when_over_budget(self, tmp_path, monkeypatch):
+        db = tmp_path / "registry.db"
+        from xskill.pipeline.registry import get_connection
+        get_connection(db).close()
+
+        for i in range(50):
+            _store_row(db, f"native:k{i}", f"desc-{i}")
+        seed_full_catalog_vector_sweep(db_path=db, existing_index_keys=set())
+        assert count_catalog_vector_dirty(db_path=db) == 50
+
+        calls = {"n": 0}
+
+        def fake_rss():
+            calls["n"] += 1
+            # 前几次正常，之后报「超预算」，验证批内提前中止。
+            return 10.0 if calls["n"] < 2 else 9999.0
+
+        monkeypatch.setattr(
+            "xskill.recommend.heavy_worker.current_rss_mb", fake_rss,
+        )
+        index = MemorySkillVectorIndex(dim=DEFAULT_DIM)
+        stats = _drain_full_sweep_batch(
+            db_path=db, index=index,
+            embed=lambda text: fake_embed(text, DEFAULT_DIM),
+            limit=50, force_upsert=False, memory_budget_mb=100.0,
+        )
+        assert stats["budget_aborted"] is True
+        # 没有处理完全部 50 条：一部分仍留在脏表里，交给下一轮。
+        assert count_catalog_vector_dirty(db_path=db) > 0
+        assert stats["upserted"] < 50
+
+    def test_no_budget_configured_never_aborts(self, tmp_path, monkeypatch):
+        db = tmp_path / "registry.db"
+        from xskill.pipeline.registry import get_connection
+        get_connection(db).close()
+        for i in range(30):
+            _store_row(db, f"native:k{i}", f"desc-{i}")
+        seed_full_catalog_vector_sweep(db_path=db, existing_index_keys=set())
+
+        monkeypatch.setattr(
+            "xskill.recommend.heavy_worker.current_rss_mb",
+            lambda: 9999.0,
+        )
+        index = MemorySkillVectorIndex(dim=DEFAULT_DIM)
+        stats = _drain_full_sweep_batch(
+            db_path=db, index=index,
+            embed=lambda text: fake_embed(text, DEFAULT_DIM),
+            limit=30, force_upsert=False, memory_budget_mb=None,
+        )
+        assert stats["budget_aborted"] is False
+        assert count_catalog_vector_dirty(db_path=db) == 0
+        assert stats["upserted"] == 30
+
+
+def _store_row(db: Path, key: str, description: str) -> None:
+    from xskill.pipeline.registry import pooled_connection
+
+    with pooled_connection(db) as conn:
+        conn.execute(
+            """
+            INSERT INTO skills_catalog(
+                catalog_key, name, source, state, description, distributable,
+                content_sha
+            ) VALUES (?, ?, 'native', 'main', ?, 1, ?)
+            """,
+            (key, key.split(":", 1)[-1], description, content_sha_for_text(description)),
+        )
+        conn.commit()
+
+
+# ─────────────────────────────────────────────────────────────────
+# _workers.run_recommend_heavy_once 接线
+# ─────────────────────────────────────────────────────────────────
+
+class TestWorkersWiring:
+    def test_config_values_flow_into_heavy_tick_and_status_file(
+        self, tmp_path, monkeypatch,
+    ):
+        import xskill._workers as workers_mod
+        from xskill.utils.status_file import PROFILE_STATUS_FILE, read_status_file
+
+        monkeypatch.setattr(workers_mod, "XSKILL_HOME", tmp_path, raising=False)
+        monkeypatch.setattr(
+            "xskill.config.XSKILL_HOME", tmp_path, raising=False,
+        )
+        monkeypatch.setattr(
+            "xskill.config.load_config",
+            lambda: {
+                "server": {
+                    "vector_sync_batch_limit": 77,
+                    "recommend_heavy_memory_budget_mb": 333,
+                },
+            },
+        )
+        monkeypatch.setattr(
+            "xskill.team.server.engine_factory.build_recommend_engine",
+            lambda config: object(),
+        )
+        monkeypatch.setattr(workers_mod, "run_profile_refresh_once", lambda engine: 0)
+
+        captured = {}
+
+        def fake_heavy_tick(*, engine, vector_sync_batch_limit, memory_budget_mb):
+            captured["batch_limit"] = vector_sync_batch_limit
+            captured["memory_budget_mb"] = memory_budget_mb
+            return {
+                "vector": {
+                    "upserted": 3, "deleted": 1, "skipped": 2,
+                    "mode": "full", "reason": "bootstrap", "remaining": 5,
+                    "budget_aborted": False,
+                },
+                "recommends": 4,
+                "index_kind": "memory",
+                "rss_peak_mb": 42.5,
+            }
+
+        monkeypatch.setattr(
+            "xskill.recommend.heavy_worker.run_recommend_heavy_once",
+            fake_heavy_tick,
+        )
+
+        rc = workers_mod.run_recommend_heavy_once()
+        assert rc == 0
+        assert captured == {"batch_limit": 77, "memory_budget_mb": 333.0}
+
+        status = read_status_file(tmp_path / PROFILE_STATUS_FILE)
+        assert status["ok"] is True
+        stats = status["stats"]
+        assert stats["vector_upserted"] == 3
+        assert stats["vector_deleted"] == 1
+        assert stats["vector_skipped"] == 2
+        assert stats["vector_mode"] == "full"
+        assert stats["vector_reason"] == "bootstrap"
+        assert stats["vector_remaining"] == 5
+        assert stats["vector_budget_aborted"] is False
+        assert stats["recommends"] == 4
+        assert stats["index_kind"] == "memory"
+        assert stats["rss_peak_mb"] == 42.5

--- a/tests/test_recommend_heavy_worker.py
+++ b/tests/test_recommend_heavy_worker.py
@@ -209,3 +209,152 @@ class TestWorkersWiring:
         assert stats["recommends"] == 4
         assert stats["index_kind"] == "memory"
         assert stats["rss_peak_mb"] == 42.5
+
+
+# ─────────────────────────────────────────────────────────────────
+# PR #338 code review（tiammomo）复现的问题：内存预算检查漏洞、
+# 推荐结果不能用不完整索引覆盖
+# ─────────────────────────────────────────────────────────────────
+
+class TestMemoryBudgetReviewFinding:
+    def test_tiny_budget_small_batch_still_aborts(self, tmp_path):
+        """review 复现：memory_budget_mb=1、批量 10 条。旧的检查步长是
+        20，10 条的批次永远凑不到一次检查点，budget 形同虚设，10 条会
+        被全部处理。"""
+        db = tmp_path / "registry.db"
+        from xskill.pipeline.registry import get_connection
+        get_connection(db).close()
+        for i in range(10):
+            _store_row(db, f"native:k{i}", f"desc-{i}")
+        seed_full_catalog_vector_sweep(db_path=db, existing_index_keys=set())
+        assert count_catalog_vector_dirty(db_path=db) == 10
+
+        index = MemorySkillVectorIndex(dim=DEFAULT_DIM)
+        stats = _drain_full_sweep_batch(
+            db_path=db, index=index,
+            embed=lambda text: fake_embed(text, DEFAULT_DIM),
+            limit=10, force_upsert=False,
+            memory_budget_mb=1.0,  # 任何真实进程的 RSS 都会超过 1 MiB
+        )
+        assert stats["budget_aborted"] is True
+        assert stats["upserted"] == 0  # 一条都不该处理
+        assert count_catalog_vector_dirty(db_path=db) == 10  # 全部留给下一轮
+
+
+class TestRecommendsGatingIntegration:
+    """`run_recommend_heavy_once` 按 `_recommends_safe_to_recompute` 门禁
+    决定要不要用这一轮的索引重算推荐——不安全时不调用
+    `process_dirty_recommends`，已有推荐槽保持原样。
+
+    ``open_skill_vector_index``/``fake_embed``/``MemorySkillVectorIndex`` 是
+    ``run_recommend_heavy_once`` 内部局部 import 的，要在它们的源模块
+    （``skill_vector_store``）打 monkeypatch 才生效，不能打在
+    ``heavy_worker`` 模块对象上；``run_vector_sync``/``process_dirty_recommends``/
+    ``_embed_fn_from_engine`` 是同一个模块里定义的函数，直接打在
+    ``heavy_worker`` 模块对象上即可。
+    """
+
+    def _patch_open_index(self, monkeypatch):
+        monkeypatch.setattr(
+            "xskill.recommend.skill_vector_store.open_skill_vector_index",
+            lambda *_a, **_kw: MemorySkillVectorIndex(dim=DEFAULT_DIM),
+        )
+
+    def test_recommends_computed_when_incremental(self, monkeypatch):
+        import xskill.recommend.heavy_worker as hw
+
+        calls = {"process": 0}
+        monkeypatch.setattr(
+            hw, "run_vector_sync",
+            lambda **_kw: {"upserted": 0, "deleted": 0, "mode": "incremental", "reason": ""},
+        )
+        monkeypatch.setattr(
+            hw, "process_dirty_recommends",
+            lambda **_kw: calls.__setitem__("process", calls["process"] + 1) or 3,
+        )
+        monkeypatch.setattr(hw, "_embed_fn_from_engine", lambda engine: None)
+        self._patch_open_index(monkeypatch)
+
+        result = hw.run_recommend_heavy_once(
+            engine=object(), db_path="/tmp/unused-db",
+        )
+        assert calls["process"] == 1
+        assert result["recommends"] == 3
+        assert result["recommends_deferred"] is False
+
+    def test_recommends_deferred_when_full_sweep_in_progress(self, monkeypatch):
+        import xskill.recommend.heavy_worker as hw
+
+        calls = {"process": 0}
+        monkeypatch.setattr(
+            hw, "run_vector_sync",
+            lambda **_kw: {
+                "upserted": 2, "deleted": 0, "mode": "full", "reason": "bootstrap",
+                "remaining": 5,
+            },
+        )
+        monkeypatch.setattr(
+            hw, "process_dirty_recommends",
+            lambda **_kw: calls.__setitem__("process", calls["process"] + 1) or 99,
+        )
+        monkeypatch.setattr(hw, "_embed_fn_from_engine", lambda engine: None)
+        self._patch_open_index(monkeypatch)
+
+        result = hw.run_recommend_heavy_once(
+            engine=object(), db_path="/tmp/unused-db",
+        )
+        assert calls["process"] == 0  # 没调用——索引还不完整，不能拿它覆盖已有推荐
+        assert result["recommends"] == 0
+        assert result["recommends_deferred"] is True
+
+    def test_recommends_computed_when_full_sweep_completes_this_round(self, monkeypatch):
+        import xskill.recommend.heavy_worker as hw
+
+        calls = {"process": 0}
+        monkeypatch.setattr(
+            hw, "run_vector_sync",
+            lambda **_kw: {
+                "upserted": 2, "deleted": 0, "mode": "full", "reason": "bootstrap",
+                "remaining": 0,  # 持久索引：追平即完整，可信
+            },
+        )
+        monkeypatch.setattr(
+            hw, "process_dirty_recommends",
+            lambda **_kw: calls.__setitem__("process", calls["process"] + 1) or 7,
+        )
+        monkeypatch.setattr(hw, "_embed_fn_from_engine", lambda engine: None)
+        # memory_index 显式传入 → ephemeral_index=False（当成可复用/持久对待）。
+        result = hw.run_recommend_heavy_once(
+            engine=object(), db_path="/tmp/unused-db",
+            memory_index=MemorySkillVectorIndex(dim=DEFAULT_DIM),
+        )
+        assert calls["process"] == 1
+        assert result["recommends"] == 7
+        assert result["recommends_deferred"] is False
+
+    def test_recommends_not_computed_ephemeral_multi_round_tail(self, monkeypatch):
+        """无持久索引、多轮播种的尾轮：remaining 归零但这轮没有
+        total_indexable（不是本轮播种+消化完的），内存索引只有这轮那一小
+        批，不能信。"""
+        import xskill.recommend.heavy_worker as hw
+
+        calls = {"process": 0}
+        monkeypatch.setattr(
+            hw, "run_vector_sync",
+            lambda **_kw: {
+                "upserted": 2, "deleted": 0, "mode": "full", "reason": "ephemeral",
+                "remaining": 0,
+            },
+        )
+        monkeypatch.setattr(
+            hw, "process_dirty_recommends",
+            lambda **_kw: calls.__setitem__("process", calls["process"] + 1) or 1,
+        )
+        monkeypatch.setattr(hw, "_embed_fn_from_engine", lambda engine: None)
+        self._patch_open_index(monkeypatch)
+
+        result = hw.run_recommend_heavy_once(
+            engine=object(), db_path="/tmp/unused-db",
+        )
+        assert calls["process"] == 0
+        assert result["recommends_deferred"] is True

--- a/tests/test_recommend_heavy_worker.py
+++ b/tests/test_recommend_heavy_worker.py
@@ -217,10 +217,16 @@ class TestWorkersWiring:
 # ─────────────────────────────────────────────────────────────────
 
 class TestMemoryBudgetReviewFinding:
-    def test_tiny_budget_small_batch_still_aborts(self, tmp_path):
+    def test_tiny_budget_small_batch_still_aborts(self, tmp_path, monkeypatch):
         """review 复现：memory_budget_mb=1、批量 10 条。旧的检查步长是
         20，10 条的批次永远凑不到一次检查点，budget 形同虚设，10 条会
-        被全部处理。"""
+        被全部处理。
+
+        ``current_rss_mb`` 打桩成固定值而不是依赖真实 RSS——``current_rss_mb``
+        在 Windows 上没有 ``resource`` 模块，恒为 0.0，用真实 RSS 断言在
+        Windows CI 上必然失败；同文件里 ``TestMemoryBudget`` 的两个既有测试
+        已经是这个打桩写法。
+        """
         db = tmp_path / "registry.db"
         from xskill.pipeline.registry import get_connection
         get_connection(db).close()
@@ -229,12 +235,15 @@ class TestMemoryBudgetReviewFinding:
         seed_full_catalog_vector_sweep(db_path=db, existing_index_keys=set())
         assert count_catalog_vector_dirty(db_path=db) == 10
 
+        monkeypatch.setattr(
+            "xskill.recommend.heavy_worker.current_rss_mb", lambda: 9999.0,
+        )
         index = MemorySkillVectorIndex(dim=DEFAULT_DIM)
         stats = _drain_full_sweep_batch(
             db_path=db, index=index,
             embed=lambda text: fake_embed(text, DEFAULT_DIM),
             limit=10, force_upsert=False,
-            memory_budget_mb=1.0,  # 任何真实进程的 RSS 都会超过 1 MiB
+            memory_budget_mb=1.0,
         )
         assert stats["budget_aborted"] is True
         assert stats["upserted"] == 0  # 一条都不该处理

--- a/tests/test_scatter_materialize.py
+++ b/tests/test_scatter_materialize.py
@@ -199,7 +199,14 @@ class _FakeEngine:
         return SimpleNamespace(changed=True, cancelled=False, embed_items=1)
 
 
+@pytest.mark.flaky(reruns=3, reruns_delay=1)
 def test_service_event_trigger_submits_both_methods(tmp_path):
+    # 033d6b1 去掉过这个标记，当时修的是投递环节的固定 sleep(0.05)；这次
+    # CI 复现的超时点在更早的 wait_idle(timeout=3)（issue #328 review 修复
+    # 推送时，windows-latest 上连同下面 test_scatter_failure_does_not_block_
+    # profile_completion 一起超时），和同一子系统里另一个 profile-refresh
+    # 测试在无关提交上也曾偶发超时的情况一致，是 Windows runner 负载下的
+    # 环境性抖动，不是这两个测试各自的逻辑问题。
     engine = _FakeEngine(tmp_path / "team_profile.db")
     service = ProfileRefreshService(engine, workers=1, queue_size=4)
     recorder = _RecorderScatter()
@@ -217,10 +224,15 @@ def test_service_event_trigger_submits_both_methods(tmp_path):
         assert service.stop(timeout=3)
 
 
+@pytest.mark.flaky(reruns=3, reruns_delay=1)
 def test_scatter_failure_does_not_block_profile_completion(tmp_path):
     """issue #328 回归：散点子系统本就在独立线程/进程池里跑，画像刷新的
     完成条件（``wait_idle``）只看画像 worker 状态，不等散点——即便散点
-    每次都报错，画像刷新仍应正常收尾（对应 /sync 仍能读到已算好的槽）。"""
+    每次都报错，画像刷新仍应正常收尾（对应 /sync 仍能读到已算好的槽）。
+
+    ``wait_idle(timeout=3)`` 在 windows-latest 上和上面
+    ``test_service_event_trigger_submits_both_methods`` 同一次 CI 里一起
+    超时过，是同一类 runner 负载下的环境性抖动，见那个测试上的标记说明。"""
     engine = _FakeEngine(tmp_path / "team_profile.db")
     service = ProfileRefreshService(engine, workers=1, queue_size=4)
 

--- a/tests/test_scatter_materialize.py
+++ b/tests/test_scatter_materialize.py
@@ -217,6 +217,29 @@ def test_service_event_trigger_submits_both_methods(tmp_path):
         assert service.stop(timeout=3)
 
 
+def test_scatter_failure_does_not_block_profile_completion(tmp_path):
+    """issue #328 回归：散点子系统本就在独立线程/进程池里跑，画像刷新的
+    完成条件（``wait_idle``）只看画像 worker 状态，不等散点——即便散点
+    每次都报错，画像刷新仍应正常收尾（对应 /sync 仍能读到已算好的槽）。"""
+    engine = _FakeEngine(tmp_path / "team_profile.db")
+    service = ProfileRefreshService(engine, workers=1, queue_size=4)
+
+    def _always_raises(_user_key, _method):
+        raise RuntimeError("boom: scatter always fails in this test")
+
+    service._recompute_scatter = _always_raises
+    try:
+        assert service.request("client-x")
+        # wait_idle 只等画像 worker，不等散点派发线程；即便散点必炸，这里
+        # 也不应该超时或抛出。
+        assert service.wait_idle(timeout=3)
+        assert engine.calls == ["client-x"]
+        # 派发线程仍然存活、没有被未捕获异常打挂。
+        assert service._scatter_thread is None or service._scatter_thread.is_alive()
+    finally:
+        assert service.stop(timeout=3)
+
+
 def test_service_submit_scatter_dedup(tmp_path):
     engine = _FakeEngine(tmp_path / "team_profile.db")
     service = ProfileRefreshService(engine, workers=1, queue_size=4, autostart=False)

--- a/tests/test_skill_vector_incremental.py
+++ b/tests/test_skill_vector_incremental.py
@@ -640,6 +640,65 @@ class TestSweepSeededMarkerReviewFindings:
         for i in range(5):
             assert embedded_with[f"d{i}"] == "C"
 
+    def test_persistent_index_replacement_mid_sweep_reseeds_everything(
+        self, registry_db, tmp_path, monkeypatch,
+    ):
+        """持久索引文件在多轮 sweep 中途被替换时，新索引必须重新播种。
+
+        模型算法和维度没有变化，只有数据库 inode 变化；旧逻辑使用不含
+        索引 identity 的稳定 sweep key，会让新索引只消费旧队列剩余项，
+        随后错误提交为已追平。
+        """
+        from xskill.recommend.heavy_worker import run_recommend_heavy_once
+
+        for i in range(5):
+            _store_catalog(
+                registry_db, _catalog_row(f"native:k{i}", f"d{i}"), mark=False,
+            )
+
+        class PersistentIndex:
+            def __init__(self, db_path):
+                self.db_path = db_path
+                self.inner = CountingIndex()
+
+            def __getattr__(self, name):
+                return getattr(self.inner, name)
+
+        vector_db = tmp_path / "vectors.db"
+        vector_db.write_bytes(b"old-index")
+        old_index = PersistentIndex(vector_db)
+        new_index = PersistentIndex(vector_db)
+        indexes = iter((old_index, new_index))
+        monkeypatch.setattr(
+            "xskill.recommend.skill_vector_store.open_skill_vector_index",
+            lambda *_args, **_kwargs: next(indexes),
+        )
+
+        first = run_recommend_heavy_once(
+            engine=SimpleNamespace(embed_client=None),
+            db_path=registry_db,
+            vector_db_path=vector_db,
+            vector_sync_batch_limit=2,
+            mark_catalog_dirty=False,
+        )
+        assert first["vector"]["remaining"] == 3
+        assert old_index.list_keys() == {"native:k0", "native:k1"}
+
+        replacement = tmp_path / "replacement.db"
+        replacement.write_bytes(b"new-index")
+        replacement.replace(vector_db)
+        second = run_recommend_heavy_once(
+            engine=SimpleNamespace(embed_client=None),
+            db_path=registry_db,
+            vector_db_path=vector_db,
+            vector_sync_batch_limit=10,
+            mark_catalog_dirty=False,
+        )
+
+        assert second["vector"]["remaining"] == 0
+        assert second["vector"]["upserted"] == 5
+        assert new_index.list_keys() == {f"native:k{i}" for i in range(5)}
+
     def test_sweep_marker_cleared_on_completion_allows_next_periodic_seed(
         self, registry_db,
     ):

--- a/tests/test_skill_vector_incremental.py
+++ b/tests/test_skill_vector_incremental.py
@@ -546,3 +546,170 @@ class TestFullSweepBatching:
         assert stats["reason"] == "ephemeral"
         assert stats["upserted"] == 1
         assert embeds == ["alpha"]
+
+
+class TestSweepSeededMarkerReviewFindings:
+    """PR #338 code review（tiammomo）里复现的三个跨轮状态问题的回归测试。"""
+
+    def test_organic_dirty_item_does_not_block_full_seeding(self, registry_db):
+        """review 复现：3 条 catalog，bootstrap 前只有 k0 有机标脏。旧逻辑
+        「脏表非空就不播种」会把这当成「已经播种过」，k1/k2 永远进不了
+        索引，还会误把这轮标记成对账完成。"""
+        _store_catalog(registry_db, _catalog_row("native:k0", "d0"))  # mark=True，有机脏项
+        _store_catalog(registry_db, _catalog_row("native:k1", "d1"), mark=False)
+        _store_catalog(registry_db, _catalog_row("native:k2", "d2"), mark=False)
+        index = CountingIndex()
+
+        stats = run_vector_sync(
+            db_path=registry_db, index=index,
+            embed=lambda text: fake_embed(text, DEFAULT_DIM),
+            model_fingerprint="test:model-a:8", now=100.0, limit=256,
+        )
+        assert stats["mode"] == "full"
+        assert stats["remaining"] == 0
+        # 三条全部进了索引，不是只有有机标脏的那一条。
+        assert index.list_keys() == {"native:k0", "native:k1", "native:k2"}
+
+    def test_organic_dirty_item_does_not_block_multi_round_seeding(self, registry_db):
+        """同上，但目录更大、limit 更小，确认播种在多轮场景下同样不受
+        有机脏项影响——只播种一次，后续轮次正常消化剩余积压。"""
+        _store_catalog(registry_db, _catalog_row("native:k0", "d0"))  # 有机脏项
+        for i in range(1, 5):
+            _store_catalog(registry_db, _catalog_row(f"native:k{i}", f"d{i}"), mark=False)
+        index = CountingIndex()
+
+        r1 = run_vector_sync(
+            db_path=registry_db, index=index,
+            embed=lambda text: fake_embed(text, DEFAULT_DIM),
+            model_fingerprint="test:model-a:8", now=100.0, limit=2,
+        )
+        assert r1["mode"] == "full"
+        assert r1["remaining"] == 3  # 5 条播种，本轮处理 2 条
+
+        r2 = run_vector_sync(
+            db_path=registry_db, index=index,
+            embed=lambda text: fake_embed(text, DEFAULT_DIM),
+            model_fingerprint="test:model-a:8", now=101.0, limit=2,
+        )
+        assert r2["remaining"] == 1
+        # 第二轮没有重新播种（否则 remaining 会跳回接近 5，而不是继续下降）。
+
+        r3 = run_vector_sync(
+            db_path=registry_db, index=index,
+            embed=lambda text: fake_embed(text, DEFAULT_DIM),
+            model_fingerprint="test:model-a:8", now=102.0, limit=2,
+        )
+        assert r3["remaining"] == 0
+        assert index.list_keys() == {f"native:k{i}" for i in range(5)}
+
+    def test_model_change_mid_sweep_reseeds_and_reembeds_everything(self, registry_db):
+        """review 复现：sweep 从模型 B 开始，处理 2 条后模型切到 C，剩余
+        条目用 C embed。旧逻辑不会因为指纹变化而重新播种，导致 k0/k1
+        停留在 B 向量、水位却记成 C，形成混合模型索引。"""
+        for i in range(5):
+            _store_catalog(registry_db, _catalog_row(f"native:k{i}", f"d{i}"), mark=False)
+        index = CountingIndex()
+
+        embedded_with = {}
+
+        def embed_b(text):
+            embedded_with[text] = "B"
+            return fake_embed(f"B:{text}", DEFAULT_DIM)
+
+        def embed_c(text):
+            embedded_with[text] = "C"
+            return fake_embed(f"C:{text}", DEFAULT_DIM)
+
+        r1 = run_vector_sync(
+            db_path=registry_db, index=index, embed=embed_b,
+            model_fingerprint="test:model-b:8", now=100.0, limit=2,
+        )
+        assert r1["remaining"] == 3
+        assert index.calls["upsert"] == 2
+
+        # 模型切到 C，sweep 还没追平；应重新播种，之前在 B 下已处理的
+        # 也要用 C 重新 embed，不能停留在 B 向量。
+        r2 = run_vector_sync(
+            db_path=registry_db, index=index, embed=embed_c,
+            model_fingerprint="test:model-c:8", now=101.0, limit=10,
+        )
+        assert r2["reason"] == "model_changed"
+        assert r2["remaining"] == 0
+        # 全部 5 条这一轮都要用 C 重新处理（3 条剩余 + 2 条被重新播种）。
+        assert r2["upserted"] == 5
+        for i in range(5):
+            assert embedded_with[f"d{i}"] == "C"
+
+    def test_sweep_marker_cleared_on_completion_allows_next_periodic_seed(
+        self, registry_db,
+    ):
+        """追平后播种标记要清掉——不然下一次同指纹的周期性对账（内容真的
+        变了）会被误判成「已经播种过」而跳过。"""
+        _store_catalog(registry_db, _catalog_row("native:k0", "d0"), mark=False)
+        index = CountingIndex()
+        first = run_vector_sync(
+            db_path=registry_db, index=index,
+            embed=lambda text: fake_embed(text, DEFAULT_DIM),
+            model_fingerprint="test:model-a:8", now=100.0, limit=256,
+        )
+        assert first["remaining"] == 0
+
+        from xskill.recommend.vector_dirty import get_sweep_seeded_fingerprint
+        assert get_sweep_seeded_fingerprint(db_path=registry_db) == ""
+
+        # 内容真的变了 + 到了周期性对账窗口：应该能重新播种并处理。
+        _store_catalog(registry_db, _catalog_row("native:k1", "d1"), mark=False)
+        second = run_vector_sync(
+            db_path=registry_db, index=index,
+            embed=lambda text: fake_embed(text, DEFAULT_DIM),
+            model_fingerprint="test:model-a:8",
+            now=100.0 + VECTOR_RECONCILE_INTERVAL_SECONDS, limit=256,
+        )
+        assert second["reason"] == "periodic"
+        assert "native:k1" in index.list_keys()
+
+
+class TestRecommendsSafeToRecompute:
+    """review 复现：全量对账没追平/内存兜底只覆盖当前批次时，不能拿这
+    份不完整的索引重算并覆盖已有推荐结果。"""
+
+    def test_incremental_always_safe(self):
+        from xskill.recommend.heavy_worker import _recommends_safe_to_recompute
+        assert _recommends_safe_to_recompute(
+            {"mode": "incremental", "remaining": 0}, ephemeral_index=True,
+        )
+        assert _recommends_safe_to_recompute(
+            {"mode": "incremental", "remaining": 0}, ephemeral_index=False,
+        )
+
+    def test_full_sweep_in_progress_is_never_safe(self):
+        from xskill.recommend.heavy_worker import _recommends_safe_to_recompute
+        assert not _recommends_safe_to_recompute(
+            {"mode": "full", "remaining": 3}, ephemeral_index=False,
+        )
+        assert not _recommends_safe_to_recompute(
+            {"mode": "full", "remaining": 3}, ephemeral_index=True,
+        )
+
+    def test_full_sweep_done_persistent_index_is_safe(self):
+        from xskill.recommend.heavy_worker import _recommends_safe_to_recompute
+        assert _recommends_safe_to_recompute(
+            {"mode": "full", "remaining": 0}, ephemeral_index=False,
+        )
+
+    def test_full_sweep_done_ephemeral_single_round_is_safe(self):
+        """整份可索引目录一次就在这批里播种+处理完（total_indexable 有值）
+        ——这一轮内存里的索引确实是完整的。"""
+        from xskill.recommend.heavy_worker import _recommends_safe_to_recompute
+        assert _recommends_safe_to_recompute(
+            {"mode": "full", "remaining": 0, "total_indexable": 3},
+            ephemeral_index=True,
+        )
+
+    def test_full_sweep_done_ephemeral_multi_round_tail_is_not_safe(self):
+        """多轮播种的尾轮：remaining 归零了，但这轮没有播种（没有
+        total_indexable），内存里的索引只有这一轮那一小批，不是全量。"""
+        from xskill.recommend.heavy_worker import _recommends_safe_to_recompute
+        assert not _recommends_safe_to_recompute(
+            {"mode": "full", "remaining": 0}, ephemeral_index=True,
+        )

--- a/tests/test_skill_vector_incremental.py
+++ b/tests/test_skill_vector_incremental.py
@@ -109,7 +109,6 @@ def _store_catalog(db: Path, row: dict, *, mark: bool = True) -> None:
 def _sync(db: Path, index, *, model: str = "model-a", now: float = 100.0, embed=None):
     return run_vector_sync(
         db_path=db,
-        vector_db_path=db.parent / "vectors.db",
         index=index,
         embed=embed or (lambda text: fake_embed(text, DEFAULT_DIM)),
         model_fingerprint=f"test:{model}:{DEFAULT_DIM}",
@@ -418,3 +417,132 @@ def test_milvus_dimension_change_recreates_projection(monkeypatch):
         if _args and _args[0] == "vector"
     ]
     assert vector_fields[0]["dim"] == DEFAULT_DIM
+
+
+# ─────────────────────────────────────────────────────────────────
+# 全量对账分批（issue #328）：没有积压时播种，之后按 limit 分批消费，
+# 大目录天然拆成多轮；持久索引（这里用可跨调用复用的内存索引模拟）
+# 跨轮次真正累积覆盖，进度通过 remaining 字段体现。
+# ─────────────────────────────────────────────────────────────────
+
+def _store_many(db: Path, n: int, *, prefix: str = "native:k") -> None:
+    for i in range(n):
+        _store_catalog(
+            db, _catalog_row(f"{prefix}{i}", f"desc-{i}"), mark=False,
+        )
+
+
+class TestFullSweepBatching:
+    def test_large_catalog_spreads_across_multiple_rounds(self, registry_db):
+        """25 条、每轮 limit=10：分 3 轮才追平，期间索引跨轮累积覆盖。"""
+        _store_many(registry_db, 25)
+        index = CountingIndex()
+
+        r1 = run_vector_sync(
+            db_path=registry_db, index=index,
+            embed=lambda text: fake_embed(text, DEFAULT_DIM),
+            model_fingerprint="test:model-a:8", now=100.0, limit=10,
+        )
+        assert r1["mode"] == "full"
+        assert r1["reason"] == "bootstrap"
+        assert r1["upserted"] == 10
+        assert r1["remaining"] == 15
+        assert len(index.list_keys()) == 10
+
+        r2 = run_vector_sync(
+            db_path=registry_db, index=index,
+            embed=lambda text: fake_embed(text, DEFAULT_DIM),
+            model_fingerprint="test:model-a:8", now=101.0, limit=10,
+        )
+        assert r2["mode"] == "full"
+        assert r2["remaining"] == 5
+        assert len(index.list_keys()) == 20
+
+        r3 = run_vector_sync(
+            db_path=registry_db, index=index,
+            embed=lambda text: fake_embed(text, DEFAULT_DIM),
+            model_fingerprint="test:model-a:8", now=102.0, limit=10,
+        )
+        assert r3["mode"] == "full"
+        assert r3["remaining"] == 0
+        assert len(index.list_keys()) == 25
+
+        # 追平之后再来一轮：不再是「full」，纯增量且没有任何积压。
+        r4 = run_vector_sync(
+            db_path=registry_db, index=index,
+            embed=lambda text: fake_embed(text, DEFAULT_DIM),
+            model_fingerprint="test:model-a:8", now=103.0, limit=10,
+        )
+        assert r4["mode"] == "incremental"
+        assert r4["upserted"] == 0
+
+    def test_mid_sweep_does_not_reseed_and_lose_progress(self, registry_db):
+        """还在消化上一次播种的积压时，再次触发 full 原因不应该重新播种
+        （否则已经清掉的 key 会被重新标脏，进度被抹掉，永远追不平）。"""
+        _store_many(registry_db, 12)
+        index = CountingIndex()
+
+        run_vector_sync(
+            db_path=registry_db, index=index,
+            embed=lambda text: fake_embed(text, DEFAULT_DIM),
+            model_fingerprint="test:model-a:8", now=100.0, limit=5,
+        )
+        from xskill.recommend.vector_dirty import count_catalog_vector_dirty
+        assert count_catalog_vector_dirty(db_path=registry_db) == 7
+
+        # 第二轮：queue 里还有 7 条积压，不应该被重新播种成 12 条。
+        run_vector_sync(
+            db_path=registry_db, index=index,
+            embed=lambda text: fake_embed(text, DEFAULT_DIM),
+            model_fingerprint="test:model-a:8", now=101.0, limit=5,
+        )
+        assert count_catalog_vector_dirty(db_path=registry_db) == 2
+
+        run_vector_sync(
+            db_path=registry_db, index=index,
+            embed=lambda text: fake_embed(text, DEFAULT_DIM),
+            model_fingerprint="test:model-a:8", now=102.0, limit=5,
+        )
+        assert count_catalog_vector_dirty(db_path=registry_db) == 0
+        assert len(index.list_keys()) == 12
+
+    def test_sweep_deletes_stale_keys_no_longer_indexable(self, registry_db):
+        """索引里有、但 catalog 里已经不可索引（被删）的 key 会被播种成
+        delete 并在消费时清掉——和旧的全量对账行为一致。"""
+        index = CountingIndex()
+        index.upsert(
+            "native:gone", fake_embed("gone", DEFAULT_DIM),
+            content_sha="gone", source="native", name="gone",
+        )
+        _store_catalog(registry_db, _catalog_row("native:alpha", "alpha"), mark=False)
+
+        stats = run_vector_sync(
+            db_path=registry_db, index=index,
+            embed=lambda text: fake_embed(text, DEFAULT_DIM),
+            model_fingerprint="test:model-a:8", now=100.0, limit=256,
+        )
+        assert stats["deleted"] == 1
+        assert stats["remaining"] == 0
+        assert index.get("native:gone") is None
+        assert index.get("native:alpha") is not None
+
+    def test_ephemeral_reason_force_upserts_without_reuse(self, registry_db):
+        """ephemeral（无持久索引）强制重新 embed，即便 content_sha 没变——
+        旧向量可能是别的模型算的，复用会用错模型的向量。"""
+        index = CountingIndex()
+        row = _catalog_row("native:alpha", "alpha")
+        _store_catalog(registry_db, row, mark=False)
+        index.upsert(
+            row["catalog_key"], fake_embed("alpha", DEFAULT_DIM),
+            content_sha=row["content_sha"], source=row["source"], name=row["name"],
+        )
+        embeds = []
+        stats = run_vector_sync(
+            db_path=registry_db, index=index,
+            embed=lambda text: embeds.append(text) or fake_embed(text, DEFAULT_DIM),
+            model_fingerprint="test:model-a:8", now=100.0, limit=256,
+            force_full=True,
+        )
+        assert stats["reason"] == "ephemeral"
+        assert stats["upserted"] == 1
+        assert embeds == ["alpha"]


### PR DESCRIPTION
## Summary

修复 #328：team server 上万级 `skills_catalog` 时，`recommend-heavy` worker 一轮能把峰值 RSS 冲到 ~6 GiB，把 15 GiB 内存的机器打到近 OOM。根因是没装/开不了持久向量索引（Milvus Lite）时，`run_vector_sync` 每轮都在内存里从零全量重建：全表 catalog 行、全量向量、引擎同时活在同一个堆里，跑完才释放。

按 issue 讨论里确认的方向实现：全量对账允许被拉长成很多轮才追平（进度写日志），并顺带做了 numpy 预分配的空间优化。

## Changes

**一、全量对账改走持久脏表分批消费**（`src/xskill/recommend/heavy_worker.py`、`vector_dirty.py`）

`catalog_vector_dirty` 这张表以前只服务纯增量场景；现在 bootstrap / model_changed / periodic / ephemeral 触发的全量对账也复用它：

- 没有积压时播种一次：把当前可索引的 `catalog_key` 标脏。播种查询只读 `catalog_key`/`content_sha`/`source`/`distributable` 四个窄列（`content_sha` 非空即代表有正文，见 `catalog_store.py` 的写入逻辑），**不读 description 正文**，万级目录下这一步只占用几百 KB，不是 GB 级。
- 之后每次调用只处理至多 `limit`（默认 256，可配）条，天然把「一次性全量重建」拆成多轮。持久索引（Milvus Lite）的分批结果落在同一个 db 文件里，跨轮次真正累积覆盖；没有持久索引时每轮的索引对象随子进程退出丢弃，多轮**只保证内存峰值有界**，不保证检索覆盖率跨轮累积——这是没有持久存储时物理上做不到的，代码注释里写清楚了，不假装这是「渐进追平」。
- 复用已有的 content_sha 判等优化：内容没变的行跳过或复用旧向量，不是每条都重新付 embedding 成本；只有 `model_changed`/`ephemeral`（旧向量可能是别的模型算的）才强制重新 embed。
- 稳态（没有触发全量对账时）行为完全不变，仍然是「只处理真正变化的 key，空闲轮次不扫描索引」——这条既有性能契约（`PERFORMANCE_CONTRACTS.md`）没有回归。

移除了不再使用的一次性全量对账实现（`run_vector_reconcile`、`_full_apply_fence`），行为并入新的分批消费路径，没有外部调用方依赖它们。

**二、MemorySkillVectorIndex：字典套 Python list → 预分配 numpy 矩阵**（`skill_vector_store.py`）

内部存储改成一块预分配的二维 `float64` 矩阵 + 空闲槽位表：

- 省掉 Python float 装箱的空间（每个元素一个独立对象 vs 数组里连续的 8 字节）。
- `search()` 不再逐行把 list 转成 numpy 数组再算余弦，而是对整块矩阵一次性做向量化的归一化和矩阵乘法，用 `argpartition` 取 top-k 而不是对全量排序。
- 新增 `reserve(n)`：已知最终规模时提前把容量开够，避免边写边翻倍拷贝；`reconcile_catalog_to_index` 批量写入前会调用它。
- 对外接口不变（`upsert`/`delete`/`get`/`list_keys`/`search`），`_rows` 保留一个只读兼容属性给既有测试的内部状态断言用。

**三、单轮内存预算**（`heavy_worker.py`）

`resource.getrusage(...).ru_maxrss` 采集峰值 RSS（Linux 是 KiB、macOS 是字节，统一换算成 MiB）。全量对账批处理循环里每处理 20 行查一次；超预算就停止这一批剩下的行——已处理的部分正常生效（该清的脏项已经清了），没处理到的留在脏表里，下一轮接着来。

**四、配置与可观测性**（`config.py`、`_workers.py`）

新增 `server.vector_sync_batch_limit`（默认 256）和 `server.recommend_heavy_memory_budget_mb`（默认 1024，对 16 GiB 主机安全）。状态文件（`PROFILE_STATUS_FILE`）补充字段：`index_kind`（milvus/memory）、`rss_peak_mb`、`vector_mode`/`vector_reason`、`vector_remaining`（还剩多少 catalog_key 没追平）、`vector_total_indexable`（刚播种时的可索引总数）、`vector_budget_aborted`。

**五、散点隔离回归测试**（`tests/test_scatter_materialize.py`）

散点计算（t-SNE/UMAP）本就在独立线程/进程池里跑，`ProfileRefreshService.wait_idle()` 的完成条件只看画像 worker 状态、不等散点——这一点通过读代码确认成立（`_scatter_dispatch_loop` 把 `_recompute_scatter` 包在 `try/except` 里，异常只记日志不传播）。补了一条回归测试固定这个行为：散点每次必炸，画像刷新仍能正常收尾。

## Test plan

- [x] `make test` passes（2442 passed / 10 skipped）
- [x] Added/updated unit tests for the change：
  - `tests/test_memory_vector_index.py`（新增 15 例）：容量增长/`reserve`、删除后槽位复用、维度校验、`search` 正确性（含 exclude_keys、top_k 超候选数、全零向量、空索引）、千行规模混合增删查往返。
  - `tests/test_skill_vector_incremental.py`（新增 4 例）：25 行目录 limit=10 分 3 轮追平且跨轮累积、mid-sweep 不重复播种（防止进度被抹掉）、播种时正确标记「索引里有但 catalog 里已不可索引」的 key 为待删除、`ephemeral` 原因强制重新 embed 不复用旧向量。既有 14 例全部保持通过，未改预期行为。
  - `tests/test_recommend_heavy_worker.py`（新增 14 例）：`recommend_heavy_config` 校验、`current_rss_mb` 冒烟、内存预算超限批内提前中止（已处理部分生效、未处理留给下一轮）、无预算配置永不中止、`_workers.run_recommend_heavy_once` 到 `heavy_worker.run_recommend_heavy_once` 的配置接线与状态文件字段。
  - `tests/test_scatter_materialize.py`（新增 1 例）：散点必炸不阻塞画像刷新完成。
- [x] Manually verified the affected user flow，含一次更正：最初用 `fake_embed`（8 维玩具向量）模拟 10000 行 catalog、无持久索引、`limit=256`，测得峰值 RSS 约 50 MiB——维度不真实，会掩盖存储结构优化的真实贡献，数字本身没有代表性。补了两组更接近真实embedding 维度（1536）的测量：
  - **分批的贡献是结构性的**：同样 10000 行、dim=1536、新的 numpy 存储，不分批（一次性处理全部 10000 行）峰值 149 MiB；分批（`limit=256`）后峰值稳定在约 55 MiB，40 轮追平。分批把「随 catalog 行数线性增长」的那部分内存从 O(10000) 压到 O(256)，是防止未来 catalog 继续变大时重演本次事故的关键——不管单条向量本身多大，同时在内存里的行数都被限死在 `limit`。
  - **numpy 预分配存储是独立的二次收益**：单独隔离测量（同为 10000 行、dim=1536，不分批，只换存储结构）——旧的「字典套 Python list」峰值 631 MiB，新的预分配 numpy 矩阵峰值 149 MiB，约 **4.2 倍**，来自省掉 Python float 装箱开销。
  - 两者相乘，分批 + numpy 存储相对「旧存储 + 不分批」的组合，行数相关内存量级缩小约 150 倍，是现场 ~6 GiB 峰值能压下来的主要原因；本地模拟仍不含真实远程 embedding API 的网络/客户端开销，数字仅供量级参考，不是生产环境的精确预测。

## Linked issues

Closes #328

