### PR TITLE
fix(reverse-sync): 容忍历史基线的换行符差异

### DIFF
--- a/src/xskill/agents/user_edit_absorb_agent.py
+++ b/src/xskill/agents/user_edit_absorb_agent.py
@@ -18,8 +18,9 @@
 """
 from __future__ import annotations
 
-import json
+import codecs
 import hashlib
+import json
 import logging
 import os
 import secrets
@@ -680,9 +681,12 @@ def _copy_verified_file_to_stage(
 
 
 def _hash_verified_file(
-    root: Path, file_info: _SafeDestFile,
+    root: Path,
+    file_info: _SafeDestFile,
+    *,
+    normalize_utf8_newlines: bool = False,
 ) -> str:
-    """在目录锚点下 nofollow 读取并校验一个普通文件的内容摘要。"""
+    """安全读取文件并返回摘要；非文本的换行规范化摘要为空字符串。"""
     open_flags = os.O_RDONLY
     open_flags |= getattr(os, "O_BINARY", 0)
     open_flags |= getattr(os, "O_NOFOLLOW", 0)
@@ -761,11 +765,50 @@ def _hash_verified_file(
         if os.name != "nt":
             os.set_blocking(file_descriptor, True)
         digest = hashlib.sha256()
-        while True:
-            file_chunk = os.read(file_descriptor, 1024 * 1024)
-            if not file_chunk:
-                break
-            digest.update(file_chunk)
+        pending_cr = False
+        is_text = True
+        if not normalize_utf8_newlines:
+            while True:
+                file_chunk = os.read(file_descriptor, 1024 * 1024)
+                if not file_chunk:
+                    break
+                digest.update(file_chunk)
+        else:
+            def raw_chunks():
+                while True:
+                    file_chunk = os.read(file_descriptor, 1024 * 1024)
+                    if not file_chunk:
+                        break
+                    yield file_chunk
+
+            try:
+                decoded_chunks = codecs.iterdecode(
+                    raw_chunks(), "utf-8", errors="strict",
+                )
+                for decoded_chunk in decoded_chunks:
+                    if "\x00" in decoded_chunk:
+                        is_text = False
+                        break
+                    if pending_cr:
+                        digest.update(b"\n")
+                        if decoded_chunk.startswith("\n"):
+                            decoded_chunk = decoded_chunk[1:]
+                        pending_cr = False
+                    if decoded_chunk.endswith("\r"):
+                        decoded_chunk = decoded_chunk[:-1]
+                        pending_cr = True
+                    digest.update(
+                        decoded_chunk.replace("\r\n", "\n")
+                        .replace("\r", "\n")
+                        .encode("utf-8"),
+                    )
+            except UnicodeDecodeError:
+                is_text = False
+            if not is_text:
+                while os.read(file_descriptor, 1024 * 1024):
+                    pass
+            elif pending_cr:
+                digest.update(b"\n")
         final_stat = os.fstat(file_descriptor)
         if (
             final_stat.st_dev,
@@ -783,7 +826,7 @@ def _hash_verified_file(
             opened_stat.st_ctime_ns,
         ):
             raise OSError("file changed while reading")
-        return digest.hexdigest()
+        return digest.hexdigest() if is_text else ""
     finally:
         os.close(file_descriptor)
         for directory_descriptor in reversed(opened_directories):
@@ -1385,10 +1428,23 @@ def reverse_sync_copy_dest(
                     and source_hash != baseline_hash
                     and source_hash != dest_hash
                 ):
-                    _log_reverse_sync_failure(
-                        dest_dir, "REVERSE_SYNC_CONTENT_CONFLICT",
+                    # 历史孤儿基线可能按 Git blob 的 LF 字节计算，而 Windows
+                    # worktree 是 CRLF。只在将要报冲突时补做一次 UTF-8 换行
+                    # 规范化比较；二进制仍严格按字节冲突，正常轮询没有额外 IO。
+                    normalized_source_hash = (
+                        _hash_verified_file(
+                            source_dir,
+                            source_file_info,
+                            normalize_utf8_newlines=True,
+                        )
+                        if source_file_info is not None
+                        else None
                     )
-                    return ReverseSyncStatus.FAILED
+                    if normalized_source_hash != baseline_hash:
+                        _log_reverse_sync_failure(
+                            dest_dir, "REVERSE_SYNC_CONTENT_CONFLICT",
+                        )
+                        return ReverseSyncStatus.FAILED
                 if source_hash != dest_hash:
                     changed_files.append(
                         (file_info, dest_hash, source_hash),

--- a/tests/test_install_fallback_revsync.py
+++ b/tests/test_install_fallback_revsync.py
@@ -19,7 +19,6 @@ import os
 import sys
 import time
 from pathlib import Path
-from unittest.mock import Mock
 
 import pytest
 
@@ -150,6 +149,58 @@ def test_reverse_sync_rejects_three_way_content_conflict(tmp_path):
     assert (dest / "SKILL.md").read_text(
         encoding="utf-8",
     ) == "dest v2\n"
+
+
+def test_reverse_sync_keeps_binary_newline_differences_as_conflict(tmp_path):
+    """二进制内容即使只差 CRLF，也不能绕过逐字节三方冲突。"""
+    from xskill.agents import user_edit_absorb_agent as user_absorb
+
+    src = _build_real_skill_repo(tmp_path)
+    binary_source = src / "references" / "sample.bin"
+    binary_source.parent.mkdir()
+    binary_source.write_bytes(b"baseline\n\x00payload")
+    dest = tmp_path / "out" / "demo-skill"
+    dest.parent.mkdir(parents=True)
+    install_dir(src, dest, force_mode="copy")
+    binary_source.write_bytes(b"baseline\r\n\x00payload")
+    (dest / "references" / "sample.bin").write_bytes(
+        b"dest-edit\r\n\x00payload",
+    )
+
+    assert user_absorb.reverse_sync_copy_dest(
+        dest, src, quiet_seconds=0,
+    ) == user_absorb.ReverseSyncStatus.FAILED
+    assert binary_source.read_bytes() == b"baseline\r\n\x00payload"
+
+
+def test_reverse_sync_skips_newline_fallback_on_normal_dest_edit(
+    tmp_path, monkeypatch,
+):
+    """源文件仍精确匹配基线时，不增加换行规范化读取。"""
+    from xskill.agents import user_edit_absorb_agent as user_absorb
+
+    src = _build_real_skill_repo(tmp_path)
+    dest = tmp_path / "out" / "demo-skill"
+    dest.parent.mkdir(parents=True)
+    install_dir(src, dest, force_mode="copy")
+    (dest / "SKILL.md").write_text("dest edit\n", encoding="utf-8")
+    original_hash = user_absorb._hash_verified_file
+    normalized_hash_calls = 0
+
+    def count_normalized_hash(*args, **kwargs):
+        nonlocal normalized_hash_calls
+        if kwargs.get("normalize_utf8_newlines"):
+            normalized_hash_calls += 1
+        return original_hash(*args, **kwargs)
+
+    monkeypatch.setattr(
+        user_absorb, "_hash_verified_file", count_normalized_hash,
+    )
+
+    assert user_absorb.reverse_sync_copy_dest(
+        dest, src, quiet_seconds=0,
+    ) == user_absorb.ReverseSyncStatus.SYNCED
+    assert normalized_hash_calls == 0
 
 
 def test_reverse_sync_detects_edit_with_restored_mtime(tmp_path):

--- a/tests/test_orphan_adoption.py
+++ b/tests/test_orphan_adoption.py
@@ -223,6 +223,39 @@ def test_revsync_orphan_backports_when_worktree_has_crlf(tmp_path):
     assert (src / "SKILL.md").read_bytes() == b"v2-user-edit\r\n"
 
 
+def test_revsync_orphan_backports_crlf_edit_after_source_head_advances(
+    tmp_path,
+):
+    """HEAD 前进后，blob LF 基线不应把 worktree CRLF 误判为源侧修改。"""
+    src, install_sha = _git_source(tmp_path, {"SKILL.md": "v1\n"})
+    (src / "notes.md").write_text("source-only\n", encoding="utf-8")
+    repo = porcelain.open_repo(str(src))
+    try:
+        porcelain.add(repo, paths=["notes.md"])
+        porcelain.commit(
+            repo,
+            message=b"advance source head",
+            author=b"t <t@example.com>",
+            committer=b"t <t@example.com>",
+        )
+    finally:
+        repo.close()
+    (src / "SKILL.md").write_bytes(b"v1\r\n")
+    dest = _orphan_dest(
+        tmp_path, {"SKILL.md": "v1\r\n"}, install_sha,
+    )
+    (dest / "SKILL.md").write_bytes(b"v2-user-edit\r\n")
+
+    status = reverse_sync_copy_dest(
+        dest, src,
+        exclude=_REVSYNC_EXCLUDE,
+        quiet_seconds=0,
+    )
+
+    assert status == ReverseSyncStatus.SYNCED
+    assert (src / "SKILL.md").read_bytes() == b"v2-user-edit\r\n"
+
+
 def test_revsync_orphan_unedited_is_no_edit(tmp_path):
     src, sha = _git_source(tmp_path, {"SKILL.md": "v1\n"})
     dest = _orphan_dest(tmp_path, {"SKILL.md": "v1\n"}, sha)


### PR DESCRIPTION
## Summary

本 PR 完成 #203 的第一阶段：当历史 copy 安装基线按 Git blob 的 LF 字节计算、而 Windows 工作区使用 CRLF 时，reverse-sync 在判定内容冲突前按需补做一次换行规范化比较，避免把 dest 单边用户编辑误判成 source/dest 双边分叉。

## Changes

- 在现有 nofollow 安全读取与文件身份复核路径上增加可选的 UTF-8 换行规范化摘要，保留跨读取块的 CRLF 处理。
- 规范化只在三方比较原本即将返回 `REVERSE_SYNC_CONTENT_CONFLICT` 时触发，普通轮询与正常 dest 单边编辑不增加额外文件读取。
- 非法 UTF-8 或包含 NUL 的文件继续严格按原始字节判定冲突，不对二进制内容放宽覆盖保护。
- 增加“安装提交已落后 + blob LF + worktree CRLF + dest 真实编辑”的端到端回归，并覆盖二进制安全边界与正常路径 I/O 契约。

## Test plan

- [x] `make test` passes
- [x] Added/updated unit tests for the change
- [x] `make e2e` passes (if the change touches ingestion / install / daemon)
- [ ] Manually verified the affected user flow

验证结果：Python 3.11 完整 `make test` 为 2423 passed、9 skipped；`tests/test_orphan_adoption.py` 与 `tests/test_install_fallback_revsync.py` 共 43 项通过；Docker E2E 的 `runtime_ecosystem_detect` 与 `runtime_openclaw_detect` 两个场景均通过；Ruff 和 `git diff --check` 通过。

完整测试首轮出现一次 `tests/test_canary_rotation.py::TestDetectUserEditsRegression::test_pending_edit_and_quiet_is_true` 文件时间判定失败；该测试随后连续 6 次通过，第二轮完整测试也通过。此处不标记为已知 flaky，仅记录本地验证事实，交由当前 head 的 PR CI 继续做跨平台确认。

## Linked issues

Refs #203
