### PR TITLE
fix(ci): 兼容 Agno 3.0 metrics 导入路径

### DIFF
--- a/tests/test_usage.py
+++ b/tests/test_usage.py
@@ -36,7 +36,7 @@ def test_extract_usage_missing_usage():
 
 def _agno_response(**metrics_kwargs):
     """构造真实 agno ModelResponse —— agent LLM 记账点的实际传入形态。"""
-    from agno.models.metrics import MessageMetrics
+    from agno.metrics import MessageMetrics
     from agno.models.response import ModelResponse
 
     resp = ModelResponse()


### PR DESCRIPTION
## Summary

Agno 3.0 移除了 `agno.models.metrics` 旧兼容模块，导致当前 main 的全部 `ut+it` 任务在用量测试中失败。

本 PR 将测试夹具切换到 Agno 2.9 和 3.0 均支持的规范导入路径，不锁定旧依赖，也不修改生产用量计算行为。

## Changes

- 将 `MessageMetrics` 的导入从 `agno.models.metrics` 改为 `agno.metrics`。
- 保留现有真实 Agno `ModelResponse.response_usage` 覆盖范围。

## Test plan

- [ ] `make test` passes
- [x] Added/updated unit tests for the change
- [ ] `make e2e` passes (if the change touches ingestion / install / daemon)
- [x] Manually verified the affected user flow

- Agno 2.9.0：`pytest tests/test_usage.py -q`，24 passed。
- Agno 3.0.0：`pytest tests/test_usage.py -q`，24 passed。
- Agno 3.0.0：`ruff check tests/test_usage.py` 通过。
- Python 3.9：修改文件的 `py_compile` 检查通过。
- Agno 3.0.0 全量测试中，用量测试的 4 个稳定失败均已消失；结果为 2413 passed、10 skipped、1 failed，剩余失败是未改动的 `test_real_edit_is_true` 时间戳断言，单独重跑通过。

## Linked issues

Closes #341
