### PR TITLE
fix(e2e): 为不可用的软件包镜像增加官方源回退

### DIFF
--- a/tests/docker_e2e/rig/Dockerfile
+++ b/tests/docker_e2e/rig/Dockerfile
@@ -12,15 +12,22 @@ USER root
 
 # host 是阿里云 SG，到 deb.debian.org/Fastly 实测 stall 在 9.6MB Packages 列表
 # （多次 Ign 重试，apt 30 分钟跑不完）；阿里云内网 mirror.cloud.aliyuncs.com 实
-# 测 6 MB/s。这是**内网**链路、不是清华那种外网大陆 mirror，所以这里专门换源。
-RUN sed -i 's|http://deb.debian.org|http://mirrors.cloud.aliyuncs.com|g' \
-        /etc/apt/sources.list.d/debian.sources
-
-# 系统工具：git/curl/jq 给探针脚本用；rsync 给 entrypoint 拷 pre_state；
-# build-essential 给某些 wheel 有 native dep 的场景兜底。
-RUN apt-get update && apt-get install -y --no-install-recommends \
-        git curl jq rsync build-essential \
-    && rm -rf /var/lib/apt/lists/*
+# 测 6 MB/s。这是**内网**链路、不是清华那种外网大陆 mirror，所以优先换源；
+# 内网源不可用时恢复 Debian 官方源，避免一次 502 阻断整个 E2E。
+ARG XSKILL_APT_MIRROR=http://mirrors.cloud.aliyuncs.com
+RUN set -eu; \
+    sed -i "s|http://deb.debian.org|${XSKILL_APT_MIRROR}|g" \
+        /etc/apt/sources.list.d/debian.sources; \
+    if ! apt-get update; then \
+        echo "APT mirror unavailable; falling back to deb.debian.org" >&2; \
+        rm -rf /var/lib/apt/lists/*; \
+        sed -i "s|${XSKILL_APT_MIRROR}|http://deb.debian.org|g" \
+            /etc/apt/sources.list.d/debian.sources; \
+        apt-get update; \
+    fi; \
+    apt-get install -y --no-install-recommends \
+        git curl jq rsync build-essential; \
+    rm -rf /var/lib/apt/lists/*
 
 # 测试用户：非 root 跑 daemon，模拟真用户安装。
 RUN useradd -m -s /bin/bash xtest
@@ -28,19 +35,27 @@ WORKDIR /home/xtest
 
 # host 是阿里云 SG，pypi.org / files.pythonhosted.org 实测 fetch metadata 阶段
 # Read timed out（rec'd 0 bytes 后挂死）；阿里云内网 pypi mirror 16 MB/s。
-# 同 apt 的逻辑：这是内网链路、不是清华那种外网大陆 mirror，仍合规。
-ENV PIP_INDEX_URL=http://mirrors.cloud.aliyuncs.com/pypi/simple/ \
-    PIP_TRUSTED_HOST=mirrors.cloud.aliyuncs.com \
+# 同 apt 的逻辑：优先内网源，失败时仅对当前安装命令回退官方 HTTPS 源。
+ARG XSKILL_PIP_INDEX_URL=http://mirrors.cloud.aliyuncs.com/pypi/simple/
+ARG XSKILL_PIP_TRUSTED_HOST=mirrors.cloud.aliyuncs.com
+ENV PIP_INDEX_URL=${XSKILL_PIP_INDEX_URL} \
+    PIP_TRUSTED_HOST=${XSKILL_PIP_TRUSTED_HOST} \
     PIP_DEFAULT_TIMEOUT=120 \
     PIP_RETRIES=3
 
 # 探针工具 + uvicorn/fastapi（_fake_llm_server.py 依赖）
-RUN pip install --no-cache-dir httpx pyyaml fastapi 'uvicorn[standard]'
+RUN pip install --no-cache-dir httpx pyyaml fastapi 'uvicorn[standard]' \
+    || PIP_INDEX_URL=https://pypi.org/simple \
+        PIP_TRUSTED_HOST= \
+        pip install --no-cache-dir httpx pyyaml fastapi 'uvicorn[standard]'
 
 # wheel 通过 build context 注入 —— rig/build.sh 会把 dist/*.whl 拷进来。
 # 这里不写死文件名（版本号会变），用通配后 pip install。
 COPY ./dist /tmp/xskill_dist
-RUN pip install --no-cache-dir --pre /tmp/xskill_dist/*.whl \
+RUN (pip install --no-cache-dir --pre /tmp/xskill_dist/*.whl \
+    || PIP_INDEX_URL=https://pypi.org/simple \
+        PIP_TRUSTED_HOST= \
+        pip install --no-cache-dir --pre /tmp/xskill_dist/*.whl) \
     && rm -rf /tmp/xskill_dist
 
 # rig 内部脚本 + 复用 tests/_fake_llm_server.py 当 scenario 的假 LLM 后端


### PR DESCRIPTION
## Summary

Docker E2E rig 原先将 APT 和 pip 固定到单一阿里云镜像，镜像返回 502 或缺少依赖时会在测试场景开始前直接终止构建。

本 PR 保留阿里云镜像作为快速首选源，同时为 APT 和 pip 增加官方源回退，并确保 PyPI 回退继续执行正常 TLS 校验。

## Changes

- 将 APT 与 pip 首选源提取为可覆盖的 Docker build arguments。
- `apt-get update` 失败后清理不完整索引、恢复 Debian 官方源并重试一次。
- 探针依赖安装和 xskill wheel 依赖解析失败时，分别回退至 PyPI 官方 HTTPS 索引。
- 官方 PyPI 回退清空继承的 `PIP_TRUSTED_HOST`，不绕过证书校验。
- 双源均失败时保留原有非零退出行为。

## Test plan

- [ ] `make test` passes
- [ ] Added/updated unit tests for the change
- [x] `make e2e` passes (if the change touches ingestion / install / daemon)
- [x] Manually verified the affected user flow

- 真实 Docker 构建中，阿里云 APT 源返回 502 后成功切回 Debian 官方源并完成安装。
- 阿里云 Python 镜像无法提供 `httptools` 时成功切回 PyPI 官方 HTTPS 索引并完成安装。
- `make e2e` 全部 2 个场景通过。
- `git diff --check` 通过。

## Linked issues

Closes #343
