### PR TITLE
test(algorithms): 建立 Logical Task 与 Attempt 离线回放基线

### DIFF
--- a/scripts/bench/task_graph_replay/README.md
+++ b/scripts/bench/task_graph_replay/README.md
@@ -1,0 +1,49 @@
+# Logical Task 与 Task Attempt 离线回放
+
+这套基线评估固定的 Logical Task、Task Attempt 和用量归因结果，常规测试不会调用 LLM、Embedding 服务、外部 Harness 或网络。
+
+运行入仓基线：
+
+```bash
+python -m scripts.bench.task_graph_replay.evaluate scripts/bench/task_graph_replay/fixtures/baseline_v1.json
+```
+
+使用 `--format json` 可以输出机器可读报告，测试会将结果与 `baseline_v1.report.json` 比较，因此指标定义变化必须作为可见 diff 接受 review。
+
+## Fixture 契约
+
+根对象包含版本号、指标配置、运行清单和多个脱敏 case。
+
+每个 case 使用稳定的 TaskScope、带 Session 和半开行区间的 Atom 标注、gold 结果、recorded prediction 以及两个 usage plane 的原始事件。
+
+gold 与 prediction 采用便于人工标注的紧凑格式，评测器会先将两者编译为生产代码的 `TaskGraphGeneration`，再由正式模型检查 Atom 主归属唯一性、Task 与 Attempt 关系、证据范围、DAG 和用量分配不变量。
+
+Attempt 可以记录 model、Harness、Skill 版本和稳定 run id，这些字段会进入正式 `EvidenceRange` 与 `execution_identity`，但不会被混入 Task 身份。
+
+入仓 fixture 完全由合成数据构成，`recorded-fixture` 只表示固定评测输入，不代表任一在线模型的效果。
+
+prompt fingerprint 对应字面量 `no-model-prompt:synthetic-logical-task-baseline-v1`，因为这份合成 prediction 没有使用模型 prompt。
+
+真实离线实验应替换运行清单和 prediction，并保持同一 schema，从而记录仓库 revision、模型、Harness、prompt fingerprint、seed 和生成时间。
+
+## 指标定义
+
+Task 聚合同时报告 pairwise precision/recall/F1 与 B³ precision/recall/F1，缺失的 prediction membership 按该 Atom 的单例预测处理。
+
+Task relation 和 Attempt relation 先基于 Atom 支持集与 EvidenceRange 对齐，再合并计算 micro 指标、relation type macro-F1 和逐类型指标。
+
+Attempt detection 统计漏掉与多出的执行尝试，Attempt outcome 同时报告 accuracy、macro-F1 和逐 outcome 指标。
+
+membership 与 Attempt outcome confidence 分别报告 Brier score、ECE 和 confidence coverage，未提供 confidence 的样本保留在 coverage 分母中但不伪造概率。
+
+evidence coverage 统计 gold EvidenceRange 中被对齐 prediction 覆盖的比例。
+
+execution 与 xskill_processing 分开检查 fraction、Token 和 cost 守恒，并独立统计 measured、estimated、unavailable、shared 和 unattributed 情况。
+
+`shared_fraction` 与 `unattributed_fraction` 是各 usage event 分配比例的算术平均，因此始终位于 `[0, 1]`，而不是跨事件直接相加的质量占比。
+
+case 错误输出明确区分误拆分、误合并、缺失或多余关系、Attempt 缺失或多出、outcome 错误及归因不守恒。
+
+固定 fixture 有意保留少量已知错误，以证明 evaluator 能发现回归信号而不是把 prediction 与 gold 硬编码为相同结果。
+
+在维护者评审代表性真实基线前，不应把具体模型质量分数设为阻塞阈值，但 schema、正式模型不变量、指标算法和 snapshot 一致性应保持阻塞。

--- a/scripts/bench/task_graph_replay/README.md
+++ b/scripts/bench/task_graph_replay/README.md
@@ -28,9 +28,9 @@ prompt fingerprint 对应字面量 `no-model-prompt:synthetic-logical-task-basel
 
 ## 指标定义
 
-Task 聚合同时报告 pairwise precision/recall/F1 与 B³ precision/recall/F1，缺失的 prediction membership 按该 Atom 的单例预测处理。
+Task 聚合同时报告 pairwise precision/recall/F1 与 B³ precision/recall/F1，缺失的 prediction membership 按该 Atom 的单例预测处理，并由独立的 membership detection 与 confidence coverage 统计漏归属。
 
-Task relation 和 Attempt relation 先基于 Atom 支持集与 EvidenceRange 对齐，再合并计算 micro 指标、relation type macro-F1 和逐类型指标。
+Task relation 和 Attempt relation 先基于 Atom 支持集与 EvidenceRange 对齐，再合并计算 micro 指标、relation type macro-F1 和逐类型指标；`parent(A, B)` 与 `subtask(B, A)` 会规范化为同一条 parent → child 语义边。
 
 Attempt detection 统计漏掉与多出的执行尝试，Attempt outcome 同时报告 accuracy、macro-F1 和逐 outcome 指标。
 
@@ -38,11 +38,15 @@ membership 与 Attempt outcome confidence 分别报告 Brier score、ECE 和 con
 
 evidence coverage 统计 gold EvidenceRange 中被对齐 prediction 覆盖的比例。
 
-execution 与 xskill_processing 分开检查 fraction、Token 和 cost 守恒，并独立统计 measured、estimated、unavailable、shared 和 unattributed 情况。
+execution attribution 分别检查 model、Harness、Skills 和 execution identity 的 coverage 与 accuracy，版本字段只用于执行归因，不参与 Logical Task 身份。
+
+execution 与 xskill_processing 分开检查 fraction、prompt、completion、total、cache-read Token 和 cost 守恒，并独立统计 measured、estimated、unavailable、shared 和 unattributed 情况。
 
 `shared_fraction` 与 `unattributed_fraction` 是各 usage event 分配比例的算术平均，因此始终位于 `[0, 1]`，而不是跨事件直接相加的质量占比。
 
-case 错误输出明确区分误拆分、误合并、缺失或多余关系、Attempt 缺失或多出、outcome 错误及归因不守恒。
+pairwise 计数基于 gold/pred contingency 线性累计，不再物化所有 Atom 对；错误总数保持精确，每份报告最多保留 100 条确定性错误样本。
+
+case 错误输出明确区分误拆分、误合并、membership 缺失或多出、关系缺失或多出、Attempt 缺失或多出、outcome 错误、执行版本归因错误及用量不守恒。
 
 固定 fixture 有意保留少量已知错误，以证明 evaluator 能发现回归信号而不是把 prediction 与 gold 硬编码为相同结果。
 

--- a/scripts/bench/task_graph_replay/__init__.py
+++ b/scripts/bench/task_graph_replay/__init__.py
@@ -1,0 +1,1 @@
+"""Deterministic Logical Task and Task Attempt replay benchmark."""

--- a/scripts/bench/task_graph_replay/evaluate.py
+++ b/scripts/bench/task_graph_replay/evaluate.py
@@ -1,0 +1,1179 @@
+"""Evaluate recorded Logical Task graphs without model or network calls."""
+
+from __future__ import annotations
+
+import argparse
+import hashlib
+import itertools
+import json
+import math
+import re
+from collections import defaultdict
+from collections.abc import Iterable
+from pathlib import Path
+from typing import Any
+
+from scripts.bench.evaluate import prf
+from xskill.tasks.models import (
+    MEASUREMENT_QUALITIES,
+    AtomRef,
+    AttemptRelation,
+    DecisionRecord,
+    EvidenceRange,
+    LogicalTask,
+    SessionRef,
+    TaskAtomMembership,
+    TaskAttempt,
+    TaskGraphGeneration,
+    TaskRelation,
+    UsageAllocation,
+    stable_ref_key,
+)
+
+SCHEMA_VERSION = 1
+USAGE_PLANES = frozenset(("execution", "xskill_processing"))
+_SHA256_RE = re.compile(r"^sha256:[0-9a-f]{64}$")
+
+
+class TaskReplayValidationError(ValueError):
+    """Raised when a replay fixture violates its versioned contract."""
+
+
+def _require(mapping: dict[str, Any], key: str, expected: type, context: str) -> Any:
+    if key not in mapping:
+        raise TaskReplayValidationError(f"{context}: missing required field {key!r}")
+    value = mapping[key]
+    if expected is int and isinstance(value, bool):
+        raise TaskReplayValidationError(f"{context}.{key}: expected int, got bool")
+    if not isinstance(value, expected):
+        raise TaskReplayValidationError(
+            f"{context}.{key}: expected {expected.__name__}, got {type(value).__name__}"
+        )
+    return value
+
+
+def _non_negative_number(value: Any, context: str, *, optional: bool = False):
+    if value is None and optional:
+        return None
+    if isinstance(value, bool) or not isinstance(value, (int, float)):
+        raise TaskReplayValidationError(f"{context}: expected a non-negative number")
+    if not math.isfinite(float(value)) or value < 0:
+        raise TaskReplayValidationError(f"{context}: expected a non-negative number")
+    return value
+
+
+def _compile_generation_unchecked(
+    case: dict[str, Any],
+    side_name: str,
+    context: str,
+) -> TaskGraphGeneration:
+    """Compile concise annotations into the production Task Graph contract."""
+    side = _require(case, side_name, dict, context)
+    tenant_id = str(case.get("tenant_id") or "tenant-fixture")
+    task_scope_id = str(case.get("task_scope_id") or case["case_id"])
+    atoms = _require(case, "atoms", list, context)
+    atom_refs = {}
+    atom_specs = {}
+    for index, atom in enumerate(atoms):
+        atom_context = f"{context}.atoms[{index}]"
+        if not isinstance(atom, dict):
+            raise TaskReplayValidationError(f"{atom_context}: expected an object")
+        atom_id = _require(atom, "atom_id", str, atom_context)
+        if not atom_id or atom_id in atom_refs:
+            raise TaskReplayValidationError(
+                f"{atom_context}: empty or duplicate atom_id"
+            )
+        traj_id = _require(atom, "traj_id", str, atom_context)
+        start = _require(atom, "start", int, atom_context)
+        end = _require(atom, "end", int, atom_context)
+        if start < 0 or end <= start:
+            raise TaskReplayValidationError(f"{atom_context}: invalid half-open range")
+        atom_refs[atom_id] = AtomRef(
+            tenant_id, task_scope_id, "source-fixture", traj_id, atom_id
+        )
+        atom_specs[atom_id] = atom
+
+    membership_specs = _require(side, "memberships", list, f"{context}.{side_name}")
+    memberships = []
+    task_ids = set()
+    for index, membership in enumerate(membership_specs):
+        item_context = f"{context}.{side_name}.memberships[{index}]"
+        if not isinstance(membership, dict):
+            raise TaskReplayValidationError(f"{item_context}: expected an object")
+        atom_id = _require(membership, "atom_id", str, item_context)
+        task_id = _require(membership, "task_id", str, item_context)
+        if atom_id not in atom_refs:
+            raise TaskReplayValidationError(f"{item_context}: unknown atom_id")
+        task_ids.add(task_id)
+        memberships.append(
+            TaskAtomMembership(
+                f"membership-{side_name}-{index}",
+                task_id,
+                atom_refs[atom_id],
+                str(membership.get("role") or "primary"),
+                membership.get("confidence"),
+                str(membership.get("decision") or "confirmed"),
+                "recorded-fixture",
+                "baseline-v1",
+                (f"evidence-{atom_id}",),
+                "2026-08-25T00:00:00Z",
+            )
+        )
+
+    attempts = []
+    attempt_specs = _require(side, "attempts", list, f"{context}.{side_name}")
+    for index, attempt in enumerate(attempt_specs):
+        item_context = f"{context}.{side_name}.attempts[{index}]"
+        if not isinstance(attempt, dict):
+            raise TaskReplayValidationError(f"{item_context}: expected an object")
+        attempt_id = _require(attempt, "attempt_id", str, item_context)
+        task_id = _require(attempt, "task_id", str, item_context)
+        outcome = _require(attempt, "outcome", str, item_context)
+        atom_ids = _require(attempt, "atom_ids", list, item_context)
+        task_ids.add(task_id)
+        evidence_ranges = []
+        for atom_id in atom_ids:
+            if atom_id not in atom_refs:
+                raise TaskReplayValidationError(
+                    f"{item_context}: unknown evidence Atom"
+                )
+            atom_ref = atom_refs[atom_id]
+            atom = atom_specs[atom_id]
+            session_ref = SessionRef(
+                atom_ref.tenant_id,
+                atom_ref.task_scope_id,
+                atom_ref.source_scope_id,
+                atom_ref.traj_id,
+            )
+            content_hash = hashlib.sha256(
+                f"{case['case_id']}:{atom_id}".encode()
+            ).hexdigest()
+            evidence_ranges.append(
+                EvidenceRange(
+                    f"evidence-{atom_id}",
+                    session_ref,
+                    "trajectory_line",
+                    atom["start"],
+                    atom["end"],
+                    f"sha256:{content_hash}",
+                    atom_hash=f"sha256:{content_hash}",
+                    atom_ref=atom_ref,
+                    model=dict(attempt.get("model") or {}),
+                    harness=dict(attempt.get("harness") or {}),
+                    skills=tuple(attempt.get("skills") or ()),
+                )
+            )
+        evidence_ids = tuple(item.evidence_id for item in evidence_ranges)
+        decision = DecisionRecord(
+            f"decision-{side_name}-{attempt_id}",
+            "outcome",
+            outcome,
+            attempt.get("confidence"),
+            "confirmed",
+            "recorded-fixture",
+            "baseline-v1",
+            evidence_ids,
+            "2026-08-25T00:00:00Z",
+        )
+        lifecycle = str(attempt.get("lifecycle") or "finished")
+        attempts.append(
+            TaskAttempt(
+                attempt_id,
+                task_id,
+                "2026-08-25T00:00:00Z",
+                None if lifecycle == "running" else "2026-08-25T00:01:00Z",
+                lifecycle,
+                outcome,
+                str(attempt.get("verification") or "unverified"),
+                str(attempt.get("user_disposition") or "unknown"),
+                tuple(evidence_ranges),
+                decisions=(decision,),
+                execution_identity=dict(attempt.get("execution_identity") or {}),
+            )
+        )
+
+    relation_specs = _require(side, "task_relations", list, f"{context}.{side_name}")
+    relations = []
+    for index, relation in enumerate(relation_specs):
+        item_context = f"{context}.{side_name}.task_relations[{index}]"
+        source = _require(relation, "from_task_id", str, item_context)
+        target = _require(relation, "to_task_id", str, item_context)
+        task_ids.update((source, target))
+        relations.append(
+            TaskRelation(
+                f"task-relation-{side_name}-{index}",
+                source,
+                target,
+                _require(relation, "relation_type", str, item_context),
+                relation.get("confidence"),
+                str(relation.get("decision") or "confirmed"),
+                "recorded-fixture",
+                "baseline-v1",
+                (),
+                "2026-08-25T00:00:00Z",
+            )
+        )
+    attempt_relations = []
+    for index, relation in enumerate(
+        _require(side, "attempt_relations", list, f"{context}.{side_name}")
+    ):
+        item_context = f"{context}.{side_name}.attempt_relations[{index}]"
+        attempt_relations.append(
+            AttemptRelation(
+                f"attempt-relation-{side_name}-{index}",
+                _require(relation, "from_attempt_id", str, item_context),
+                _require(relation, "to_attempt_id", str, item_context),
+                _require(relation, "relation_type", str, item_context),
+                relation.get("confidence"),
+                str(relation.get("decision") or "confirmed"),
+                "recorded-fixture",
+                "baseline-v1",
+                (),
+                "2026-08-25T00:00:00Z",
+            )
+        )
+
+    attempts_by_task: dict[str, list[TaskAttempt]] = defaultdict(list)
+    for attempt in attempts:
+        attempts_by_task[attempt.task_id].append(attempt)
+    task_states = side.get("task_states") or {}
+    tasks = []
+    confirmed_counts = defaultdict(int)
+    for membership in memberships:
+        if (
+            membership.role == "primary"
+            and membership.decision == "confirmed"
+            and not membership.stale
+        ):
+            confirmed_counts[membership.task_id] += 1
+    for task_id in sorted(task_ids):
+        state = task_states.get(task_id) or {}
+        task_attempts = attempts_by_task.get(task_id, [])
+        last_outcome = task_attempts[-1].outcome if task_attempts else "unknown"
+        lifecycle = str(
+            state.get("lifecycle")
+            or (
+                "blocked"
+                if last_outcome == "blocked"
+                else "open"
+                if last_outcome == "unknown"
+                else "closed"
+            )
+        )
+        outcome = str(
+            state.get("outcome")
+            or ("unknown" if lifecycle in {"open", "blocked"} else last_outcome)
+        )
+        tasks.append(
+            LogicalTask(
+                task_id,
+                f"Fixture {task_id}",
+                f"Synthetic {task_id}",
+                "2026-08-25T00:00:00Z",
+                lifecycle=lifecycle,
+                outcome=outcome,
+                tombstoned=confirmed_counts[task_id] == 0,
+            )
+        )
+
+    allocations = []
+    for item in side.get("usage_allocations") or ():
+        try:
+            allocations.append(UsageAllocation.from_dict(item))
+        except (TypeError, ValueError) as error:
+            raise TaskReplayValidationError(
+                f"{context}.{side_name}.usage_allocations: {error}"
+            ) from error
+    return TaskGraphGeneration(
+        f"generation-{case['case_id']}-{side_name}",
+        tenant_id,
+        task_scope_id,
+        f"sha256:source-{case['case_id']}",
+        {"name": "recorded-fixture", "version": "1"},
+        0,
+        "2026-08-25T00:00:00Z",
+        tuple(tasks),
+        tuple(memberships),
+        tuple(relations),
+        tuple(attempts),
+        tuple(attempt_relations),
+        tuple(allocations),
+    )
+
+
+def _compile_generation(
+    case: dict[str, Any],
+    side_name: str,
+    context: str,
+) -> TaskGraphGeneration:
+    try:
+        return _compile_generation_unchecked(case, side_name, context)
+    except TaskReplayValidationError:
+        raise
+    except (KeyError, TypeError, ValueError) as error:
+        raise TaskReplayValidationError(f"{context}.{side_name}: {error}") from error
+
+
+def _confirmed_atom_assignment(graph: TaskGraphGeneration) -> dict[str, str]:
+    return {
+        stable_ref_key(item.atom_ref): item.task_id
+        for item in graph.memberships
+        if item.role == "primary" and item.decision == "confirmed" and not item.stale
+    }
+
+
+def _validate_gold(graph: TaskGraphGeneration, context: str) -> None:
+    if any(task.tombstoned for task in graph.tasks):
+        raise TaskReplayValidationError(f"{context}: gold Tasks must be live")
+    assignment = _confirmed_atom_assignment(graph)
+    if not assignment:
+        raise TaskReplayValidationError(
+            f"{context}: gold needs confirmed primary Atom memberships"
+        )
+    if any(
+        item.role != "primary" or item.decision != "confirmed" or item.stale
+        for item in graph.memberships
+    ):
+        raise TaskReplayValidationError(
+            f"{context}: gold memberships must be live confirmed primary facts"
+        )
+    if any(item.decision != "confirmed" or item.stale for item in graph.relations):
+        raise TaskReplayValidationError(
+            f"{context}: gold Task relations must be live confirmed facts"
+        )
+    if any(item.decision != "confirmed" for item in graph.attempt_relations):
+        raise TaskReplayValidationError(
+            f"{context}: gold Attempt relations must be confirmed facts"
+        )
+
+
+def _validate_usage(
+    case: dict[str, Any], prediction: TaskGraphGeneration, context: str
+):
+    events = _require(case, "usage_events", list, context)
+    event_by_key: dict[tuple[str, str], dict] = {}
+    for index, event in enumerate(events):
+        item_context = f"{context}.usage_events[{index}]"
+        if not isinstance(event, dict):
+            raise TaskReplayValidationError(f"{item_context}: expected an object")
+        event_id = _require(event, "usage_event_id", str, item_context)
+        plane = _require(event, "usage_plane", str, item_context)
+        quality = _require(event, "measurement_quality", str, item_context)
+        key = plane, event_id
+        if not event_id or plane not in USAGE_PLANES or key in event_by_key:
+            raise TaskReplayValidationError(
+                f"{item_context}: invalid or duplicate identity"
+            )
+        if quality not in MEASUREMENT_QUALITIES:
+            raise TaskReplayValidationError(
+                f"{item_context}: invalid measurement_quality"
+            )
+        numeric_values = []
+        for name in ("prompt_tokens", "completion_tokens", "total_tokens"):
+            value = event.get(name)
+            if value is not None and (
+                isinstance(value, bool) or not isinstance(value, int)
+            ):
+                raise TaskReplayValidationError(f"{item_context}.{name}: expected int")
+            numeric_values.append(
+                _non_negative_number(value, f"{item_context}.{name}", optional=True)
+            )
+        numeric_values.append(
+            _non_negative_number(
+                event.get("cost_usd"), f"{item_context}.cost_usd", optional=True
+            )
+        )
+        if quality == "unavailable" and any(
+            value is not None for value in numeric_values
+        ):
+            raise TaskReplayValidationError(
+                f"{item_context}: unavailable usage cannot contain numeric values"
+            )
+        if quality != "unavailable" and all(value is None for value in numeric_values):
+            raise TaskReplayValidationError(
+                f"{item_context}: measured or estimated usage needs a value"
+            )
+        event_by_key[key] = event
+    for allocation in prediction.usage_allocations:
+        key = allocation.usage_plane, allocation.usage_event_id
+        if key not in event_by_key:
+            raise TaskReplayValidationError(
+                f"{context}.prediction: allocation references unknown usage event {key!r}"
+            )
+    return event_by_key
+
+
+def validate_suite(suite: Any) -> None:
+    if not isinstance(suite, dict):
+        raise TaskReplayValidationError("suite: expected an object")
+    version = _require(suite, "schema_version", int, "suite")
+    if version != SCHEMA_VERSION:
+        raise TaskReplayValidationError(
+            f"suite.schema_version: supported={SCHEMA_VERSION}, got={version}"
+        )
+    _require(suite, "suite_id", str, "suite")
+    config = _require(suite, "metric_config", dict, "suite")
+    bins = _require(config, "ece_bins", int, "suite.metric_config")
+    if bins <= 0:
+        raise TaskReplayValidationError("suite.metric_config.ece_bins must be > 0")
+    tolerance = _non_negative_number(
+        config.get("usage_numeric_tolerance"),
+        "suite.metric_config.usage_numeric_tolerance",
+    )
+    if tolerance > 1:
+        raise TaskReplayValidationError(
+            "suite.metric_config.usage_numeric_tolerance must be <= 1"
+        )
+    manifest = _require(suite, "run_manifest", dict, "suite")
+    for key in (
+        "repository_revision",
+        "model",
+        "harness",
+        "prompt_fingerprint",
+        "generated_at",
+    ):
+        _require(manifest, key, str, "suite.run_manifest")
+    if not _SHA256_RE.fullmatch(manifest["prompt_fingerprint"]):
+        raise TaskReplayValidationError(
+            "suite.run_manifest.prompt_fingerprint must be sha256:<64 lowercase hex>"
+        )
+    if _require(manifest, "seed", int, "suite.run_manifest") < 0:
+        raise TaskReplayValidationError("suite.run_manifest.seed must be >= 0")
+    cases = _require(suite, "cases", list, "suite")
+    if not cases:
+        raise TaskReplayValidationError("suite.cases must not be empty")
+    seen_case_ids = set()
+    for index, case in enumerate(cases):
+        context = f"suite.cases[{index}]"
+        if not isinstance(case, dict):
+            raise TaskReplayValidationError(f"{context}: expected an object")
+        case_id = _require(case, "case_id", str, context)
+        if not case_id or case_id in seen_case_ids:
+            raise TaskReplayValidationError(f"{context}.case_id: empty or duplicate")
+        seen_case_ids.add(case_id)
+        gold = _compile_generation(case, "gold", context)
+        prediction = _compile_generation(case, "prediction", context)
+        _validate_gold(gold, f"{context}.gold")
+        expected_atoms = {
+            stable_ref_key(
+                AtomRef(
+                    gold.tenant_id,
+                    gold.task_scope_id,
+                    "source-fixture",
+                    atom["traj_id"],
+                    atom["atom_id"],
+                )
+            )
+            for atom in case["atoms"]
+        }
+        if set(_confirmed_atom_assignment(gold)) != expected_atoms:
+            raise TaskReplayValidationError(
+                f"{context}.gold: every annotated Atom needs one confirmed membership"
+            )
+        _validate_usage(case, prediction, context)
+
+
+def load_suite(path: Path | str) -> dict[str, Any]:
+    suite_path = Path(path)
+    try:
+        suite = json.loads(suite_path.read_text(encoding="utf-8"))
+    except json.JSONDecodeError as error:
+        raise TaskReplayValidationError(
+            f"invalid JSON in {suite_path}: {error}"
+        ) from error
+    validate_suite(suite)
+    return suite
+
+
+def _clusters(graph: TaskGraphGeneration) -> tuple[dict[str, set[str]], dict[str, str]]:
+    clusters: dict[str, set[str]] = defaultdict(set)
+    assignment = _confirmed_atom_assignment(graph)
+    for atom_key, task_id in assignment.items():
+        clusters[task_id].add(atom_key)
+    return dict(clusters), assignment
+
+
+def _pairs(clusters: dict[str, set[str]]) -> set[tuple[str, str]]:
+    return {
+        tuple(sorted(pair))
+        for atoms in clusters.values()
+        for pair in itertools.combinations(sorted(atoms), 2)
+    }
+
+
+def _prf(gold: set[Any], predicted: set[Any]) -> dict[str, float | int]:
+    true_positive = len(gold & predicted)
+    false_positive = len(predicted - gold)
+    false_negative = len(gold - predicted)
+    precision, recall, f1 = prf(true_positive, false_positive, false_negative)
+    return {
+        "true_positive": true_positive,
+        "false_positive": false_positive,
+        "false_negative": false_negative,
+        "precision": round(precision, 6),
+        "recall": round(recall, 6),
+        "f1": round(f1, 6),
+    }
+
+
+def _safe_ratio(numerator: float, denominator: float, *, empty: float = 1.0) -> float:
+    return round(numerator / denominator, 6) if denominator else empty
+
+
+def _grouping_counts(gold: TaskGraphGeneration, prediction: TaskGraphGeneration):
+    gold_clusters, gold_assignment = _clusters(gold)
+    predicted_clusters, predicted_assignment = _clusters(prediction)
+    b3_precision_sum = 0.0
+    b3_recall_sum = 0.0
+    for atom_key, gold_task in gold_assignment.items():
+        gold_cluster = gold_clusters[gold_task]
+        predicted_task = predicted_assignment.get(atom_key)
+        predicted_cluster = (
+            predicted_clusters[predicted_task] if predicted_task else {atom_key}
+        )
+        overlap = len(gold_cluster & predicted_cluster)
+        b3_precision_sum += overlap / len(predicted_cluster)
+        b3_recall_sum += overlap / len(gold_cluster)
+    gold_pairs = _pairs(gold_clusters)
+    predicted_pairs = _pairs(predicted_clusters)
+    return {
+        "gold_pairs": gold_pairs,
+        "predicted_pairs": predicted_pairs,
+        "b3_precision_sum": b3_precision_sum,
+        "b3_recall_sum": b3_recall_sum,
+        "atom_count": len(gold_assignment),
+        "false_splits": sorted(gold_pairs - predicted_pairs),
+        "false_merges": sorted(predicted_pairs - gold_pairs),
+    }
+
+
+def _public_grouping(counts: dict[str, Any]) -> dict[str, Any]:
+    pairwise = _prf(counts["gold_pairs"], counts["predicted_pairs"])
+    precision = _safe_ratio(counts["b3_precision_sum"], counts["atom_count"])
+    recall = _safe_ratio(counts["b3_recall_sum"], counts["atom_count"])
+    f1 = 2 * precision * recall / (precision + recall) if precision + recall else 0.0
+    return {
+        "pairwise": pairwise,
+        "b3": {"precision": precision, "recall": recall, "f1": round(f1, 6)},
+    }
+
+
+def _jaccard(left: set[str], right: set[str]) -> float:
+    union = left | right
+    return len(left & right) / len(union) if union else 0.0
+
+
+def _task_relations(graph: TaskGraphGeneration) -> set[tuple[str, tuple, tuple]]:
+    clusters, _ = _clusters(graph)
+    result = set()
+    for relation in graph.relations:
+        if relation.decision != "confirmed" or relation.stale:
+            continue
+        source = tuple(sorted(clusters.get(relation.from_task_id, ())))
+        target = tuple(sorted(clusters.get(relation.to_task_id, ())))
+        if not source:
+            source = (f"__empty__:{relation.from_task_id}",)
+        if not target:
+            target = (f"__empty__:{relation.to_task_id}",)
+        result.add((f"task:{relation.relation_type}", source, target))
+    return result
+
+
+def _evidence_ids(attempt: TaskAttempt) -> set[str]:
+    return {item.evidence_id for item in attempt.evidence_ranges if not item.stale}
+
+
+def _align_attempts(
+    gold: TaskGraphGeneration,
+    prediction: TaskGraphGeneration,
+) -> dict[str, str]:
+    gold_clusters, _ = _clusters(gold)
+    predicted_clusters, _ = _clusters(prediction)
+    candidates = []
+    for predicted_attempt in prediction.attempts:
+        for gold_attempt in gold.attempts:
+            evidence_score = _jaccard(
+                _evidence_ids(predicted_attempt), _evidence_ids(gold_attempt)
+            )
+            if evidence_score == 0:
+                continue
+            task_score = _jaccard(
+                predicted_clusters.get(predicted_attempt.task_id, set()),
+                gold_clusters.get(gold_attempt.task_id, set()),
+            )
+            candidates.append(
+                (
+                    -(0.8 * evidence_score + 0.2 * task_score),
+                    predicted_attempt.attempt_id,
+                    gold_attempt.attempt_id,
+                )
+            )
+    alignment = {}
+    used_predicted = set()
+    used_gold = set()
+    for _score, predicted_id, gold_id in sorted(candidates):
+        if predicted_id in used_predicted or gold_id in used_gold:
+            continue
+        alignment[predicted_id] = gold_id
+        used_predicted.add(predicted_id)
+        used_gold.add(gold_id)
+    return alignment
+
+
+def _attempt_relations(
+    graph: TaskGraphGeneration,
+    alignment: dict[str, str] | None = None,
+) -> set[tuple[str, str, str]]:
+    result = set()
+    for relation in graph.attempt_relations:
+        if relation.decision != "confirmed":
+            continue
+        source = relation.from_attempt_id
+        target = relation.to_attempt_id
+        if alignment is not None:
+            source = alignment.get(source, f"__pred__:{source}")
+            target = alignment.get(target, f"__pred__:{target}")
+        result.add((f"attempt:{relation.relation_type}", source, target))
+    return result
+
+
+def _macro_metrics(gold: set[tuple], predicted: set[tuple]) -> dict[str, Any]:
+    labels = sorted({item[0] for item in gold | predicted})
+    by_type = {
+        label: _prf(
+            {item for item in gold if item[0] == label},
+            {item for item in predicted if item[0] == label},
+        )
+        for label in labels
+    }
+    macro = {
+        metric: _safe_ratio(
+            sum(float(by_type[label][metric]) for label in labels), len(labels)
+        )
+        for metric in ("precision", "recall", "f1")
+    }
+    return {"micro": _prf(gold, predicted), "macro": macro, "by_type": by_type}
+
+
+def _attempt_counts(
+    gold: TaskGraphGeneration,
+    prediction: TaskGraphGeneration,
+    alignment: dict[str, str],
+) -> dict[str, Any]:
+    gold_by_id = {item.attempt_id: item for item in gold.attempts}
+    predicted_by_id = {item.attempt_id: item for item in prediction.attempts}
+    inverse = {gold_id: predicted_id for predicted_id, gold_id in alignment.items()}
+    predicted_outcomes = {}
+    correct = 0
+    evidence_matches = 0
+    evidence_total = 0
+    errors = []
+    for gold_id, gold_attempt in gold_by_id.items():
+        gold_evidence = _evidence_ids(gold_attempt)
+        evidence_total += len(gold_evidence)
+        predicted_id = inverse.get(gold_id)
+        if predicted_id is None:
+            errors.append({"type": "attempt_missing", "attempt_id": gold_id})
+            continue
+        predicted_attempt = predicted_by_id[predicted_id]
+        evidence_matches += len(gold_evidence & _evidence_ids(predicted_attempt))
+        predicted_outcomes[gold_id] = predicted_attempt.outcome
+        if predicted_attempt.outcome == gold_attempt.outcome:
+            correct += 1
+        else:
+            errors.append(
+                {
+                    "type": "attempt_outcome_mismatch",
+                    "attempt_id": gold_id,
+                    "gold": gold_attempt.outcome,
+                    "predicted": predicted_attempt.outcome,
+                }
+            )
+    spurious = sorted(set(predicted_by_id) - set(alignment))
+    errors.extend(
+        {"type": "attempt_spurious", "attempt_id": attempt_id}
+        for attempt_id in spurious
+    )
+    labels = sorted(
+        {item.outcome for item in gold.attempts}
+        | {item.outcome for item in prediction.attempts}
+    )
+    by_outcome_counts = {}
+    by_outcome = {}
+    for label in labels:
+        true_positive = sum(
+            predicted_outcomes.get(gold_id) == label and item.outcome == label
+            for gold_id, item in gold_by_id.items()
+        )
+        false_negative = sum(
+            item.outcome == label and predicted_outcomes.get(gold_id) != label
+            for gold_id, item in gold_by_id.items()
+        )
+        false_positive = sum(
+            outcome == label and gold_by_id[gold_id].outcome != label
+            for gold_id, outcome in predicted_outcomes.items()
+        ) + sum(predicted_by_id[attempt_id].outcome == label for attempt_id in spurious)
+        precision, recall, f1 = prf(true_positive, false_positive, false_negative)
+        by_outcome_counts[label] = (true_positive, false_positive, false_negative)
+        by_outcome[label] = {
+            "precision": round(precision, 6),
+            "recall": round(recall, 6),
+            "f1": round(f1, 6),
+        }
+    return {
+        "gold_ids": set(gold_by_id),
+        "predicted_detection_ids": set(alignment.values())
+        | {f"__pred__:{attempt_id}" for attempt_id in spurious},
+        "gold_count": len(gold_by_id),
+        "correct": correct,
+        "by_outcome_counts": by_outcome_counts,
+        "by_outcome": by_outcome,
+        "macro_f1": _safe_ratio(
+            sum(item["f1"] for item in by_outcome.values()), len(by_outcome)
+        ),
+        "evidence_matches": evidence_matches,
+        "evidence_total": evidence_total,
+        "errors": errors,
+    }
+
+
+def _calibration(samples: list[tuple[float, int]], bins: int) -> dict[str, Any]:
+    if not samples:
+        return {"count": 0, "brier": None, "ece": None}
+    brier = sum((probability - target) ** 2 for probability, target in samples) / len(
+        samples
+    )
+    grouped: dict[int, list[tuple[float, int]]] = defaultdict(list)
+    for probability, target in samples:
+        grouped[min(int(probability * bins), bins - 1)].append((probability, target))
+    ece = sum(
+        len(values)
+        / len(samples)
+        * abs(
+            sum(item[0] for item in values) / len(values)
+            - sum(item[1] for item in values) / len(values)
+        )
+        for values in grouped.values()
+    )
+    return {"count": len(samples), "brier": round(brier, 6), "ece": round(ece, 6)}
+
+
+def _membership_calibration(
+    gold: TaskGraphGeneration,
+    prediction: TaskGraphGeneration,
+) -> tuple[list[tuple[float, int]], int]:
+    gold_assignment = _confirmed_atom_assignment(gold)
+    gold_clusters, _ = _clusters(gold)
+    predicted_clusters, _ = _clusters(prediction)
+    task_alignment = {}
+    for task_id, atoms in predicted_clusters.items():
+        ranked = sorted(
+            (
+                (_jaccard(atoms, gold_atoms), gold_id)
+                for gold_id, gold_atoms in gold_clusters.items()
+            ),
+            key=lambda item: (-item[0], item[1]),
+        )
+        task_alignment[task_id] = ranked[0][1] if ranked and ranked[0][0] else None
+    samples = []
+    total = 0
+    for membership in prediction.memberships:
+        if membership.stale or membership.role != "primary":
+            continue
+        total += 1
+        if membership.confidence is None:
+            continue
+        target = int(
+            task_alignment.get(membership.task_id)
+            == gold_assignment.get(stable_ref_key(membership.atom_ref))
+        )
+        samples.append((membership.confidence, target))
+    return samples, total
+
+
+def _outcome_confidence(attempt: TaskAttempt) -> float | None:
+    decisions = [
+        item
+        for item in attempt.decisions
+        if item.dimension == "outcome" and item.value == attempt.outcome
+    ]
+    if not decisions:
+        return None
+    return max(
+        decisions, key=lambda item: (item.observed_at, item.decision_id)
+    ).confidence
+
+
+def _outcome_calibration(
+    gold: TaskGraphGeneration,
+    prediction: TaskGraphGeneration,
+    alignment: dict[str, str],
+) -> tuple[list[tuple[float, int]], int, int]:
+    gold_by_id = {item.attempt_id: item for item in gold.attempts}
+    samples = []
+    covered_gold = set()
+    for attempt in prediction.attempts:
+        confidence = _outcome_confidence(attempt)
+        if confidence is None:
+            continue
+        gold_id = alignment.get(attempt.attempt_id)
+        if gold_id is not None:
+            covered_gold.add(gold_id)
+        target = int(
+            gold_id is not None and attempt.outcome == gold_by_id[gold_id].outcome
+        )
+        samples.append((confidence, target))
+    return samples, len(gold_by_id), len(covered_gold)
+
+
+def _usage_counts(
+    events: dict[tuple[str, str], dict],
+    prediction: TaskGraphGeneration,
+    tolerance: float,
+):
+    allocations_by_key: dict[tuple[str, str], list] = defaultdict(list)
+    for allocation in prediction.usage_allocations:
+        allocations_by_key[(allocation.usage_plane, allocation.usage_event_id)].append(
+            allocation
+        )
+    planes = {
+        plane: {
+            "events": 0,
+            "conserved_events": 0,
+            "measured_events": 0,
+            "estimated_events": 0,
+            "unavailable_events": 0,
+            "raw_total_tokens": 0,
+            "allocated_total_tokens": 0,
+            "raw_cost_usd": 0.0,
+            "allocated_cost_usd": 0.0,
+            "unattributed_fraction": 0.0,
+            "shared_fraction": 0.0,
+        }
+        for plane in sorted(USAGE_PLANES)
+    }
+    errors = []
+    for key, event in events.items():
+        plane, event_id = key
+        counts = planes[plane]
+        counts["events"] += 1
+        counts[f"{event['measurement_quality']}_events"] += 1
+        allocations = allocations_by_key.get(key, [])
+        fraction_sum = sum(item.fraction for item in allocations)
+        counts["unattributed_fraction"] += sum(
+            item.fraction
+            for item in allocations
+            if item.allocation_mode == "unattributed"
+        )
+        counts["shared_fraction"] += sum(
+            item.fraction for item in allocations if item.allocation_mode == "shared"
+        )
+        conserved = abs(fraction_sum - 1.0) <= tolerance
+        raw_tokens = event.get("total_tokens")
+        allocated_tokens = sum(
+            item.total_tokens for item in allocations if item.total_tokens is not None
+        )
+        raw_cost = event.get("cost_usd")
+        allocated_cost = sum(
+            float(item.cost_usd) for item in allocations if item.cost_usd is not None
+        )
+        if raw_tokens is not None:
+            counts["raw_total_tokens"] += raw_tokens
+            counts["allocated_total_tokens"] += allocated_tokens
+            conserved = conserved and allocated_tokens == raw_tokens
+        if raw_cost is not None:
+            counts["raw_cost_usd"] += float(raw_cost)
+            counts["allocated_cost_usd"] += allocated_cost
+            conserved = conserved and abs(allocated_cost - float(raw_cost)) <= tolerance
+        if conserved:
+            counts["conserved_events"] += 1
+        else:
+            errors.append(
+                {
+                    "type": "usage_not_conserved",
+                    "usage_plane": plane,
+                    "usage_event_id": event_id,
+                    "fraction_sum": round(fraction_sum, 9),
+                    "token_delta": (
+                        None if raw_tokens is None else allocated_tokens - raw_tokens
+                    ),
+                    "cost_delta": (
+                        None
+                        if raw_cost is None
+                        else round(allocated_cost - raw_cost, 9)
+                    ),
+                }
+            )
+    return planes, errors
+
+
+def _case_counts(case: dict, config: dict) -> dict[str, Any]:
+    gold = _compile_generation(case, "gold", "case")
+    prediction = _compile_generation(case, "prediction", "case")
+    grouping = _grouping_counts(gold, prediction)
+    alignment = _align_attempts(gold, prediction)
+    gold_relations = _task_relations(gold) | _attempt_relations(gold)
+    predicted_relations = _task_relations(prediction) | _attempt_relations(
+        prediction, alignment
+    )
+    attempts = _attempt_counts(gold, prediction, alignment)
+    membership_samples, membership_total = _membership_calibration(gold, prediction)
+    outcome_samples, outcome_total, outcome_covered = _outcome_calibration(
+        gold, prediction, alignment
+    )
+    usage_events = _validate_usage(case, prediction, "case")
+    usage, usage_errors = _usage_counts(
+        usage_events, prediction, config["usage_numeric_tolerance"]
+    )
+    errors = [
+        {"type": "task_false_split", "atom_keys": list(pair)}
+        for pair in grouping["false_splits"]
+    ] + [
+        {"type": "task_false_merge", "atom_keys": list(pair)}
+        for pair in grouping["false_merges"]
+    ]
+    errors.extend(
+        {"type": "relation_missing", "relation": list(item)}
+        for item in sorted(gold_relations - predicted_relations)
+    )
+    errors.extend(
+        {"type": "relation_spurious", "relation": list(item)}
+        for item in sorted(predicted_relations - gold_relations)
+    )
+    errors.extend(attempts["errors"])
+    errors.extend(usage_errors)
+    return {
+        "grouping": grouping,
+        "gold_relations": gold_relations,
+        "predicted_relations": predicted_relations,
+        "attempts": attempts,
+        "membership_samples": membership_samples,
+        "membership_total": membership_total,
+        "outcome_samples": outcome_samples,
+        "outcome_total": outcome_total,
+        "outcome_covered": outcome_covered,
+        "usage": usage,
+        "errors": errors,
+    }
+
+
+def _public_metrics(counts: dict[str, Any], bins: int) -> dict[str, Any]:
+    attempts = counts["attempts"]
+    membership = _calibration(counts["membership_samples"], bins)
+    membership["coverage"] = _safe_ratio(
+        membership["count"], counts["membership_total"], empty=0.0
+    )
+    outcome = _calibration(counts["outcome_samples"], bins)
+    outcome["coverage"] = _safe_ratio(
+        counts["outcome_covered"], counts["outcome_total"], empty=0.0
+    )
+    usage = {}
+    for plane, values in counts["usage"].items():
+        public = dict(values)
+        event_count = public["events"]
+        public["conservation_rate"] = _safe_ratio(
+            public.pop("conserved_events"), event_count
+        )
+        public["unattributed_fraction"] = _safe_ratio(
+            public["unattributed_fraction"], event_count, empty=0.0
+        )
+        public["shared_fraction"] = _safe_ratio(
+            public["shared_fraction"], event_count, empty=0.0
+        )
+        for name in (
+            "events",
+            "measured_events",
+            "estimated_events",
+            "unavailable_events",
+            "raw_total_tokens",
+            "allocated_total_tokens",
+        ):
+            public[name] = int(public[name])
+        for name in (
+            "raw_cost_usd",
+            "allocated_cost_usd",
+            "unattributed_fraction",
+            "shared_fraction",
+        ):
+            public[name] = round(public[name], 9)
+        usage[plane] = public
+    return {
+        "task_grouping": _public_grouping(counts["grouping"]),
+        "relations": _macro_metrics(
+            counts["gold_relations"], counts["predicted_relations"]
+        ),
+        "attempt_detection": _prf(
+            attempts["gold_ids"], attempts["predicted_detection_ids"]
+        ),
+        "attempt_outcome": {
+            "accuracy": _safe_ratio(attempts["correct"], attempts["gold_count"]),
+            "macro_f1": attempts["macro_f1"],
+            "by_outcome": attempts["by_outcome"],
+        },
+        "confidence": {"membership": membership, "attempt_outcome": outcome},
+        "evidence_coverage": _safe_ratio(
+            attempts["evidence_matches"], attempts["evidence_total"], empty=0.0
+        ),
+        "usage": usage,
+    }
+
+
+def _prefix_relation(item: tuple, prefix: str) -> tuple:
+    label, source, target = item
+    if isinstance(source, tuple):
+        return (
+            label,
+            tuple(prefix + atom_key for atom_key in source),
+            tuple(prefix + atom_key for atom_key in target),
+        )
+    return label, prefix + source, prefix + target
+
+
+def _merge_counts(case_counts: Iterable[dict[str, Any]]) -> dict[str, Any]:
+    merged = {
+        "grouping": {
+            "gold_pairs": set(),
+            "predicted_pairs": set(),
+            "b3_precision_sum": 0.0,
+            "b3_recall_sum": 0.0,
+            "atom_count": 0,
+        },
+        "gold_relations": set(),
+        "predicted_relations": set(),
+        "attempts": {
+            "gold_ids": set(),
+            "predicted_detection_ids": set(),
+            "gold_count": 0,
+            "correct": 0,
+            "by_outcome_counts": defaultdict(lambda: [0, 0, 0]),
+            "evidence_matches": 0,
+            "evidence_total": 0,
+        },
+        "membership_samples": [],
+        "membership_total": 0,
+        "outcome_samples": [],
+        "outcome_total": 0,
+        "outcome_covered": 0,
+        "usage": {plane: defaultdict(float) for plane in sorted(USAGE_PLANES)},
+        "errors": [],
+    }
+    for index, counts in enumerate(case_counts):
+        prefix = f"case-{index}:"
+        grouping = counts["grouping"]
+        for key in ("gold_pairs", "predicted_pairs"):
+            merged["grouping"][key].update(
+                (prefix + left, prefix + right) for left, right in grouping[key]
+            )
+        for key in ("b3_precision_sum", "b3_recall_sum", "atom_count"):
+            merged["grouping"][key] += grouping[key]
+        for key in ("gold_relations", "predicted_relations"):
+            merged[key].update(_prefix_relation(item, prefix) for item in counts[key])
+        attempts = counts["attempts"]
+        for key in ("gold_ids", "predicted_detection_ids"):
+            merged["attempts"][key].update(prefix + item for item in attempts[key])
+        for key in ("gold_count", "correct", "evidence_matches", "evidence_total"):
+            merged["attempts"][key] += attempts[key]
+        for label, values in attempts["by_outcome_counts"].items():
+            for value_index, value in enumerate(values):
+                merged["attempts"]["by_outcome_counts"][label][value_index] += value
+        for key in ("membership_samples", "outcome_samples"):
+            merged[key].extend(counts[key])
+        for key in ("membership_total", "outcome_total", "outcome_covered"):
+            merged[key] += counts[key]
+        for plane, values in counts["usage"].items():
+            for key, value in values.items():
+                merged["usage"][plane][key] += value
+        merged["errors"].extend(
+            {"case_index": index, **error} for error in counts["errors"]
+        )
+    by_outcome = {}
+    for label, values in merged["attempts"]["by_outcome_counts"].items():
+        precision, recall, f1 = prf(*values)
+        by_outcome[label] = {
+            "precision": round(precision, 6),
+            "recall": round(recall, 6),
+            "f1": round(f1, 6),
+        }
+    merged["attempts"]["by_outcome"] = by_outcome
+    merged["attempts"]["macro_f1"] = _safe_ratio(
+        sum(item["f1"] for item in by_outcome.values()), len(by_outcome)
+    )
+    return merged
+
+
+def evaluate_suite(suite: dict[str, Any]) -> dict[str, Any]:
+    validate_suite(suite)
+    config = suite["metric_config"]
+    counts = [_case_counts(case, config) for case in suite["cases"]]
+    merged = _merge_counts(counts)
+    report = {
+        "schema_version": SCHEMA_VERSION,
+        "suite_id": suite["suite_id"],
+        "run_manifest": suite["run_manifest"],
+        "metric_config": config,
+        "metrics": _public_metrics(merged, config["ece_bins"]),
+        "error_count": len(merged["errors"]),
+        "cases": [
+            {
+                "case_id": case["case_id"],
+                "metrics": _public_metrics(case_count, config["ece_bins"]),
+                "errors": case_count["errors"],
+            }
+            for case, case_count in zip(suite["cases"], counts)
+        ],
+    }
+    report = json.loads(json.dumps(report, ensure_ascii=False, sort_keys=True))
+    canonical = json.dumps(report, ensure_ascii=False, sort_keys=True).encode("utf-8")
+    report["report_sha256"] = hashlib.sha256(canonical).hexdigest()
+    return report
+
+
+def render_text(report: dict[str, Any]) -> str:
+    metrics = report["metrics"]
+    grouping = metrics["task_grouping"]
+    return "\n".join(
+        (
+            f"suite: {report['suite_id']}",
+            f"revision: {report['run_manifest']['repository_revision']}",
+            (
+                f"task_pairwise_f1={grouping['pairwise']['f1']:.3f} "
+                f"b3_f1={grouping['b3']['f1']:.3f}"
+            ),
+            f"relation_macro_f1={metrics['relations']['macro']['f1']:.3f}",
+            f"attempt_outcome_accuracy={metrics['attempt_outcome']['accuracy']:.3f}",
+            f"evidence_coverage={metrics['evidence_coverage']:.3f}",
+            (
+                f"usage_execution_conservation="
+                f"{metrics['usage']['execution']['conservation_rate']:.3f}"
+            ),
+            (
+                f"usage_processing_conservation="
+                f"{metrics['usage']['xskill_processing']['conservation_rate']:.3f}"
+            ),
+            f"errors={report['error_count']}",
+            f"report_sha256={report['report_sha256']}",
+        )
+    )
+
+
+def _parser() -> argparse.ArgumentParser:
+    parser = argparse.ArgumentParser(
+        description="Evaluate a recorded xskill Logical Task/Attempt replay suite."
+    )
+    parser.add_argument("suite", type=Path, help="Path to the versioned replay JSON")
+    parser.add_argument("--format", choices=("text", "json"), default="text")
+    return parser
+
+
+def main(argv: list[str] | None = None) -> int:
+    args = _parser().parse_args(argv)
+    report = evaluate_suite(load_suite(args.suite))
+    if args.format == "json":
+        print(json.dumps(report, ensure_ascii=False, indent=2, sort_keys=True))
+    else:
+        print(render_text(report))
+    return 0
+
+
+if __name__ == "__main__":
+    raise SystemExit(main())

--- a/scripts/bench/task_graph_replay/evaluate.py
+++ b/scripts/bench/task_graph_replay/evaluate.py
@@ -4,7 +4,6 @@ from __future__ import annotations
 
 import argparse
 import hashlib
-import itertools
 import json
 import math
 import re
@@ -32,6 +31,14 @@ from xskill.tasks.models import (
 
 SCHEMA_VERSION = 1
 USAGE_PLANES = frozenset(("execution", "xskill_processing"))
+TOKEN_FIELDS = (
+    "prompt_tokens",
+    "completion_tokens",
+    "total_tokens",
+    "cache_read_tokens",
+)
+ATTRIBUTION_FIELDS = ("model", "harness", "skills", "execution_identity")
+ERROR_EXAMPLE_LIMIT = 100
 _SHA256_RE = re.compile(r"^sha256:[0-9a-f]{64}$")
 
 
@@ -369,7 +376,7 @@ def _validate_usage(
                 f"{item_context}: invalid measurement_quality"
             )
         numeric_values = []
-        for name in ("prompt_tokens", "completion_tokens", "total_tokens"):
+        for name in TOKEN_FIELDS:
             value = event.get(name)
             if value is not None and (
                 isinstance(value, bool) or not isinstance(value, int)
@@ -493,18 +500,40 @@ def _clusters(graph: TaskGraphGeneration) -> tuple[dict[str, set[str]], dict[str
     return dict(clusters), assignment
 
 
-def _pairs(clusters: dict[str, set[str]]) -> set[tuple[str, str]]:
-    return {
-        tuple(sorted(pair))
-        for atoms in clusters.values()
-        for pair in itertools.combinations(sorted(atoms), 2)
-    }
+def _pair_count(clusters: dict[str, set[str]]) -> int:
+    return sum(len(atoms) * (len(atoms) - 1) // 2 for atoms in clusters.values())
 
 
-def _prf(gold: set[Any], predicted: set[Any]) -> dict[str, float | int]:
-    true_positive = len(gold & predicted)
-    false_positive = len(predicted - gold)
-    false_negative = len(gold - predicted)
+def _pair_error_examples(
+    primary_clusters: dict[str, set[str]],
+    secondary_assignment: dict[str, str],
+    *,
+    limit: int = ERROR_EXAMPLE_LIMIT,
+) -> list[tuple[str, str]]:
+    """Return bounded cross-partition pair examples without materializing all pairs."""
+    examples: list[tuple[str, str]] = []
+    for cluster_id in sorted(primary_clusters):
+        groups: dict[str, list[str]] = defaultdict(list)
+        for atom_key in sorted(primary_clusters[cluster_id]):
+            secondary_id = secondary_assignment.get(atom_key)
+            group_id = secondary_id or f"__missing__:{atom_key}"
+            groups[group_id].append(atom_key)
+        ordered_groups = [groups[group_id] for group_id in sorted(groups)]
+        for left_index, left_group in enumerate(ordered_groups):
+            for right_group in ordered_groups[left_index + 1 :]:
+                for left in left_group:
+                    for right in right_group:
+                        examples.append(tuple(sorted((left, right))))
+                        if len(examples) >= limit:
+                            return sorted(examples)
+    return sorted(examples)
+
+
+def _prf_counts(
+    true_positive: int,
+    false_positive: int,
+    false_negative: int,
+) -> dict[str, float | int]:
     precision, recall, f1 = prf(true_positive, false_positive, false_negative)
     return {
         "true_positive": true_positive,
@@ -514,6 +543,14 @@ def _prf(gold: set[Any], predicted: set[Any]) -> dict[str, float | int]:
         "recall": round(recall, 6),
         "f1": round(f1, 6),
     }
+
+
+def _prf(gold: set[Any], predicted: set[Any]) -> dict[str, float | int]:
+    return _prf_counts(
+        len(gold & predicted),
+        len(predicted - gold),
+        len(gold - predicted),
+    )
 
 
 def _safe_ratio(numerator: float, denominator: float, *, empty: float = 1.0) -> float:
@@ -534,21 +571,45 @@ def _grouping_counts(gold: TaskGraphGeneration, prediction: TaskGraphGeneration)
         overlap = len(gold_cluster & predicted_cluster)
         b3_precision_sum += overlap / len(predicted_cluster)
         b3_recall_sum += overlap / len(gold_cluster)
-    gold_pairs = _pairs(gold_clusters)
-    predicted_pairs = _pairs(predicted_clusters)
+    contingency: dict[tuple[str, str], int] = defaultdict(int)
+    for atom_key, gold_task in gold_assignment.items():
+        predicted_task = predicted_assignment.get(atom_key)
+        if predicted_task is not None:
+            contingency[(gold_task, predicted_task)] += 1
+    true_positive_pairs = sum(
+        count * (count - 1) // 2 for count in contingency.values()
+    )
+    gold_pairs = _pair_count(gold_clusters)
+    predicted_pairs = _pair_count(predicted_clusters)
+    false_split_count = gold_pairs - true_positive_pairs
+    false_merge_count = predicted_pairs - true_positive_pairs
     return {
-        "gold_pairs": gold_pairs,
-        "predicted_pairs": predicted_pairs,
+        "gold_pair_count": gold_pairs,
+        "predicted_pair_count": predicted_pairs,
+        "true_positive_pair_count": true_positive_pairs,
         "b3_precision_sum": b3_precision_sum,
         "b3_recall_sum": b3_recall_sum,
         "atom_count": len(gold_assignment),
-        "false_splits": sorted(gold_pairs - predicted_pairs),
-        "false_merges": sorted(predicted_pairs - gold_pairs),
+        "false_split_count": false_split_count,
+        "false_merge_count": false_merge_count,
+        "false_splits": _pair_error_examples(
+            gold_clusters,
+            predicted_assignment,
+        ),
+        "false_merges": _pair_error_examples(
+            predicted_clusters,
+            gold_assignment,
+        ),
     }
 
 
 def _public_grouping(counts: dict[str, Any]) -> dict[str, Any]:
-    pairwise = _prf(counts["gold_pairs"], counts["predicted_pairs"])
+    true_positive = counts["true_positive_pair_count"]
+    pairwise = _prf_counts(
+        true_positive,
+        counts["predicted_pair_count"] - true_positive,
+        counts["gold_pair_count"] - true_positive,
+    )
     precision = _safe_ratio(counts["b3_precision_sum"], counts["atom_count"])
     recall = _safe_ratio(counts["b3_recall_sum"], counts["atom_count"])
     f1 = 2 * precision * recall / (precision + recall) if precision + recall else 0.0
@@ -569,13 +630,19 @@ def _task_relations(graph: TaskGraphGeneration) -> set[tuple[str, tuple, tuple]]
     for relation in graph.relations:
         if relation.decision != "confirmed" or relation.stale:
             continue
-        source = tuple(sorted(clusters.get(relation.from_task_id, ())))
-        target = tuple(sorted(clusters.get(relation.to_task_id, ())))
+        source_id = relation.from_task_id
+        target_id = relation.to_task_id
+        relation_type = relation.relation_type
+        if relation_type == "subtask":
+            source_id, target_id = target_id, source_id
+            relation_type = "parent"
+        source = tuple(sorted(clusters.get(source_id, ())))
+        target = tuple(sorted(clusters.get(target_id, ())))
         if not source:
-            source = (f"__empty__:{relation.from_task_id}",)
+            source = (f"__empty__:{source_id}",)
         if not target:
-            target = (f"__empty__:{relation.to_task_id}",)
-        result.add((f"task:{relation.relation_type}", source, target))
+            target = (f"__empty__:{target_id}",)
+        result.add((f"task:{relation_type}", source, target))
     return result
 
 
@@ -761,7 +828,7 @@ def _calibration(samples: list[tuple[float, int]], bins: int) -> dict[str, Any]:
 def _membership_calibration(
     gold: TaskGraphGeneration,
     prediction: TaskGraphGeneration,
-) -> tuple[list[tuple[float, int]], int]:
+) -> tuple[list[tuple[float, int]], int, int]:
     gold_assignment = _confirmed_atom_assignment(gold)
     gold_clusters, _ = _clusters(gold)
     predicted_clusters, _ = _clusters(prediction)
@@ -776,19 +843,36 @@ def _membership_calibration(
         )
         task_alignment[task_id] = ranked[0][1] if ranked and ranked[0][0] else None
     samples = []
-    total = 0
+    covered_gold = set()
     for membership in prediction.memberships:
         if membership.stale or membership.role != "primary":
             continue
-        total += 1
         if membership.confidence is None:
             continue
+        atom_key = stable_ref_key(membership.atom_ref)
+        if atom_key in gold_assignment:
+            covered_gold.add(atom_key)
         target = int(
-            task_alignment.get(membership.task_id)
-            == gold_assignment.get(stable_ref_key(membership.atom_ref))
+            task_alignment.get(membership.task_id) == gold_assignment.get(atom_key)
         )
         samples.append((membership.confidence, target))
-    return samples, total
+    return samples, len(gold_assignment), len(covered_gold)
+
+
+def _membership_counts(
+    gold: TaskGraphGeneration,
+    prediction: TaskGraphGeneration,
+) -> dict[str, Any]:
+    gold_atoms = set(_confirmed_atom_assignment(gold))
+    predicted_atoms = set(_confirmed_atom_assignment(prediction))
+    missing = sorted(gold_atoms - predicted_atoms)
+    spurious = sorted(predicted_atoms - gold_atoms)
+    return {
+        "gold_atoms": gold_atoms,
+        "predicted_atoms": predicted_atoms,
+        "missing": missing,
+        "spurious": spurious,
+    }
 
 
 def _outcome_confidence(attempt: TaskAttempt) -> float | None:
@@ -826,6 +910,91 @@ def _outcome_calibration(
     return samples, len(gold_by_id), len(covered_gold)
 
 
+def _canonical_value(value: Any) -> str:
+    return json.dumps(value, ensure_ascii=False, sort_keys=True, separators=(",", ":"))
+
+
+def _attempt_attribution(attempt: TaskAttempt, field: str) -> tuple[str, ...]:
+    if field == "execution_identity":
+        return (
+            (_canonical_value(attempt.execution_identity),)
+            if attempt.execution_identity
+            else ()
+        )
+    values = []
+    for evidence in sorted(
+        attempt.evidence_ranges,
+        key=lambda item: item.evidence_id,
+    ):
+        if evidence.stale:
+            continue
+        if field == "skills":
+            value = [
+                json.loads(item)
+                for item in sorted(_canonical_value(item) for item in evidence.skills)
+            ]
+        else:
+            value = getattr(evidence, field)
+        if value:
+            values.append(
+                _canonical_value(
+                    {
+                        "evidence_id": evidence.evidence_id,
+                        "value": value,
+                    }
+                )
+            )
+    return tuple(values)
+
+
+def _public_attribution(value: tuple[str, ...]) -> list[Any]:
+    return [json.loads(item) for item in value]
+
+
+def _execution_attribution_counts(
+    gold: TaskGraphGeneration,
+    prediction: TaskGraphGeneration,
+    alignment: dict[str, str],
+) -> tuple[dict[str, dict[str, int]], list[dict[str, Any]]]:
+    predicted_by_id = {item.attempt_id: item for item in prediction.attempts}
+    inverse = {gold_id: predicted_id for predicted_id, gold_id in alignment.items()}
+    counts = {
+        field: {"expected": 0, "present": 0, "correct": 0}
+        for field in ATTRIBUTION_FIELDS
+    }
+    errors = []
+    for gold_attempt in gold.attempts:
+        predicted_id = inverse.get(gold_attempt.attempt_id)
+        predicted_attempt = (
+            predicted_by_id.get(predicted_id) if predicted_id is not None else None
+        )
+        for field in ATTRIBUTION_FIELDS:
+            expected = _attempt_attribution(gold_attempt, field)
+            if not expected:
+                continue
+            counts[field]["expected"] += 1
+            actual = (
+                _attempt_attribution(predicted_attempt, field)
+                if predicted_attempt is not None
+                else ()
+            )
+            if actual:
+                counts[field]["present"] += 1
+            if actual == expected:
+                counts[field]["correct"] += 1
+                continue
+            errors.append(
+                {
+                    "type": "execution_attribution_mismatch",
+                    "attempt_id": gold_attempt.attempt_id,
+                    "field": field,
+                    "gold": _public_attribution(expected),
+                    "predicted": _public_attribution(actual),
+                }
+            )
+    return counts, errors
+
+
 def _usage_counts(
     events: dict[tuple[str, str], dict],
     prediction: TaskGraphGeneration,
@@ -843,8 +1012,8 @@ def _usage_counts(
             "measured_events": 0,
             "estimated_events": 0,
             "unavailable_events": 0,
-            "raw_total_tokens": 0,
-            "allocated_total_tokens": 0,
+            **{f"raw_{field}": 0 for field in TOKEN_FIELDS},
+            **{f"allocated_{field}": 0 for field in TOKEN_FIELDS},
             "raw_cost_usd": 0.0,
             "allocated_cost_usd": 0.0,
             "unattributed_fraction": 0.0,
@@ -869,18 +1038,25 @@ def _usage_counts(
             item.fraction for item in allocations if item.allocation_mode == "shared"
         )
         conserved = abs(fraction_sum - 1.0) <= tolerance
-        raw_tokens = event.get("total_tokens")
-        allocated_tokens = sum(
-            item.total_tokens for item in allocations if item.total_tokens is not None
-        )
+        token_deltas = {}
+        for field in TOKEN_FIELDS:
+            raw_value = event.get(field)
+            allocated_value = sum(
+                getattr(item, field)
+                for item in allocations
+                if getattr(item, field) is not None
+            )
+            if raw_value is None:
+                token_deltas[field] = None
+                continue
+            counts[f"raw_{field}"] += raw_value
+            counts[f"allocated_{field}"] += allocated_value
+            token_deltas[field] = allocated_value - raw_value
+            conserved = conserved and allocated_value == raw_value
         raw_cost = event.get("cost_usd")
         allocated_cost = sum(
             float(item.cost_usd) for item in allocations if item.cost_usd is not None
         )
-        if raw_tokens is not None:
-            counts["raw_total_tokens"] += raw_tokens
-            counts["allocated_total_tokens"] += allocated_tokens
-            conserved = conserved and allocated_tokens == raw_tokens
         if raw_cost is not None:
             counts["raw_cost_usd"] += float(raw_cost)
             counts["allocated_cost_usd"] += allocated_cost
@@ -894,9 +1070,7 @@ def _usage_counts(
                     "usage_plane": plane,
                     "usage_event_id": event_id,
                     "fraction_sum": round(fraction_sum, 9),
-                    "token_delta": (
-                        None if raw_tokens is None else allocated_tokens - raw_tokens
-                    ),
+                    "token_deltas": token_deltas,
                     "cost_delta": (
                         None
                         if raw_cost is None
@@ -917,8 +1091,14 @@ def _case_counts(case: dict, config: dict) -> dict[str, Any]:
         prediction, alignment
     )
     attempts = _attempt_counts(gold, prediction, alignment)
-    membership_samples, membership_total = _membership_calibration(gold, prediction)
+    memberships = _membership_counts(gold, prediction)
+    membership_samples, membership_total, membership_covered = _membership_calibration(
+        gold, prediction
+    )
     outcome_samples, outcome_total, outcome_covered = _outcome_calibration(
+        gold, prediction, alignment
+    )
+    attribution, attribution_errors = _execution_attribution_counts(
         gold, prediction, alignment
     )
     usage_events = _validate_usage(case, prediction, "case")
@@ -940,20 +1120,44 @@ def _case_counts(case: dict, config: dict) -> dict[str, Any]:
         {"type": "relation_spurious", "relation": list(item)}
         for item in sorted(predicted_relations - gold_relations)
     )
+    errors.extend(
+        {"type": "membership_missing", "atom_key": atom_key}
+        for atom_key in memberships["missing"]
+    )
+    errors.extend(
+        {"type": "membership_spurious", "atom_key": atom_key}
+        for atom_key in memberships["spurious"]
+    )
     errors.extend(attempts["errors"])
+    errors.extend(attribution_errors)
     errors.extend(usage_errors)
+    error_count = (
+        grouping["false_split_count"]
+        + grouping["false_merge_count"]
+        + len(gold_relations - predicted_relations)
+        + len(predicted_relations - gold_relations)
+        + len(memberships["missing"])
+        + len(memberships["spurious"])
+        + len(attempts["errors"])
+        + len(attribution_errors)
+        + len(usage_errors)
+    )
     return {
         "grouping": grouping,
+        "memberships": memberships,
         "gold_relations": gold_relations,
         "predicted_relations": predicted_relations,
         "attempts": attempts,
+        "attribution": attribution,
         "membership_samples": membership_samples,
         "membership_total": membership_total,
+        "membership_covered": membership_covered,
         "outcome_samples": outcome_samples,
         "outcome_total": outcome_total,
         "outcome_covered": outcome_covered,
         "usage": usage,
-        "errors": errors,
+        "error_count": error_count,
+        "errors": errors[:ERROR_EXAMPLE_LIMIT],
     }
 
 
@@ -961,7 +1165,7 @@ def _public_metrics(counts: dict[str, Any], bins: int) -> dict[str, Any]:
     attempts = counts["attempts"]
     membership = _calibration(counts["membership_samples"], bins)
     membership["coverage"] = _safe_ratio(
-        membership["count"], counts["membership_total"], empty=0.0
+        counts["membership_covered"], counts["membership_total"], empty=0.0
     )
     outcome = _calibration(counts["outcome_samples"], bins)
     outcome["coverage"] = _safe_ratio(
@@ -985,8 +1189,8 @@ def _public_metrics(counts: dict[str, Any], bins: int) -> dict[str, Any]:
             "measured_events",
             "estimated_events",
             "unavailable_events",
-            "raw_total_tokens",
-            "allocated_total_tokens",
+            *(f"raw_{field}" for field in TOKEN_FIELDS),
+            *(f"allocated_{field}" for field in TOKEN_FIELDS),
         ):
             public[name] = int(public[name])
         for name in (
@@ -997,8 +1201,22 @@ def _public_metrics(counts: dict[str, Any], bins: int) -> dict[str, Any]:
         ):
             public[name] = round(public[name], 9)
         usage[plane] = public
+    attribution = {}
+    for field, values in counts["attribution"].items():
+        expected = values["expected"]
+        attribution[field] = {
+            "expected": int(expected),
+            "present": int(values["present"]),
+            "correct": int(values["correct"]),
+            "coverage": _safe_ratio(values["present"], expected, empty=0.0),
+            "accuracy": _safe_ratio(values["correct"], expected, empty=0.0),
+        }
     return {
         "task_grouping": _public_grouping(counts["grouping"]),
+        "membership_detection": _prf(
+            counts["memberships"]["gold_atoms"],
+            counts["memberships"]["predicted_atoms"],
+        ),
         "relations": _macro_metrics(
             counts["gold_relations"], counts["predicted_relations"]
         ),
@@ -1011,6 +1229,7 @@ def _public_metrics(counts: dict[str, Any], bins: int) -> dict[str, Any]:
             "by_outcome": attempts["by_outcome"],
         },
         "confidence": {"membership": membership, "attempt_outcome": outcome},
+        "execution_attribution": attribution,
         "evidence_coverage": _safe_ratio(
             attempts["evidence_matches"], attempts["evidence_total"], empty=0.0
         ),
@@ -1032,12 +1251,14 @@ def _prefix_relation(item: tuple, prefix: str) -> tuple:
 def _merge_counts(case_counts: Iterable[dict[str, Any]]) -> dict[str, Any]:
     merged = {
         "grouping": {
-            "gold_pairs": set(),
-            "predicted_pairs": set(),
+            "gold_pair_count": 0,
+            "predicted_pair_count": 0,
+            "true_positive_pair_count": 0,
             "b3_precision_sum": 0.0,
             "b3_recall_sum": 0.0,
             "atom_count": 0,
         },
+        "memberships": {"gold_atoms": set(), "predicted_atoms": set()},
         "gold_relations": set(),
         "predicted_relations": set(),
         "attempts": {
@@ -1051,21 +1272,34 @@ def _merge_counts(case_counts: Iterable[dict[str, Any]]) -> dict[str, Any]:
         },
         "membership_samples": [],
         "membership_total": 0,
+        "membership_covered": 0,
         "outcome_samples": [],
         "outcome_total": 0,
         "outcome_covered": 0,
+        "attribution": {
+            field: {"expected": 0, "present": 0, "correct": 0}
+            for field in ATTRIBUTION_FIELDS
+        },
         "usage": {plane: defaultdict(float) for plane in sorted(USAGE_PLANES)},
+        "error_count": 0,
         "errors": [],
     }
     for index, counts in enumerate(case_counts):
         prefix = f"case-{index}:"
         grouping = counts["grouping"]
-        for key in ("gold_pairs", "predicted_pairs"):
-            merged["grouping"][key].update(
-                (prefix + left, prefix + right) for left, right in grouping[key]
-            )
-        for key in ("b3_precision_sum", "b3_recall_sum", "atom_count"):
+        for key in (
+            "gold_pair_count",
+            "predicted_pair_count",
+            "true_positive_pair_count",
+            "b3_precision_sum",
+            "b3_recall_sum",
+            "atom_count",
+        ):
             merged["grouping"][key] += grouping[key]
+        for key in ("gold_atoms", "predicted_atoms"):
+            merged["memberships"][key].update(
+                prefix + atom_key for atom_key in counts["memberships"][key]
+            )
         for key in ("gold_relations", "predicted_relations"):
             merged[key].update(_prefix_relation(item, prefix) for item in counts[key])
         attempts = counts["attempts"]
@@ -1078,14 +1312,25 @@ def _merge_counts(case_counts: Iterable[dict[str, Any]]) -> dict[str, Any]:
                 merged["attempts"]["by_outcome_counts"][label][value_index] += value
         for key in ("membership_samples", "outcome_samples"):
             merged[key].extend(counts[key])
-        for key in ("membership_total", "outcome_total", "outcome_covered"):
+        for key in (
+            "membership_total",
+            "membership_covered",
+            "outcome_total",
+            "outcome_covered",
+        ):
             merged[key] += counts[key]
+        for field, values in counts["attribution"].items():
+            for key, value in values.items():
+                merged["attribution"][field][key] += value
         for plane, values in counts["usage"].items():
             for key, value in values.items():
                 merged["usage"][plane][key] += value
-        merged["errors"].extend(
-            {"case_index": index, **error} for error in counts["errors"]
-        )
+        merged["error_count"] += counts["error_count"]
+        remaining = ERROR_EXAMPLE_LIMIT - len(merged["errors"])
+        if remaining > 0:
+            merged["errors"].extend(
+                {"case_index": index, **error} for error in counts["errors"][:remaining]
+            )
     by_outcome = {}
     for label, values in merged["attempts"]["by_outcome_counts"].items():
         precision, recall, f1 = prf(*values)
@@ -1112,11 +1357,16 @@ def evaluate_suite(suite: dict[str, Any]) -> dict[str, Any]:
         "run_manifest": suite["run_manifest"],
         "metric_config": config,
         "metrics": _public_metrics(merged, config["ece_bins"]),
-        "error_count": len(merged["errors"]),
+        "error_count": merged["error_count"],
+        "error_examples_truncated": merged["error_count"] > len(merged["errors"]),
         "cases": [
             {
                 "case_id": case["case_id"],
                 "metrics": _public_metrics(case_count, config["ece_bins"]),
+                "error_count": case_count["error_count"],
+                "error_examples_truncated": (
+                    case_count["error_count"] > len(case_count["errors"])
+                ),
                 "errors": case_count["errors"],
             }
             for case, case_count in zip(suite["cases"], counts)
@@ -1139,8 +1389,13 @@ def render_text(report: dict[str, Any]) -> str:
                 f"task_pairwise_f1={grouping['pairwise']['f1']:.3f} "
                 f"b3_f1={grouping['b3']['f1']:.3f}"
             ),
+            f"membership_f1={metrics['membership_detection']['f1']:.3f}",
             f"relation_macro_f1={metrics['relations']['macro']['f1']:.3f}",
             f"attempt_outcome_accuracy={metrics['attempt_outcome']['accuracy']:.3f}",
+            (
+                "model_attribution_accuracy="
+                f"{metrics['execution_attribution']['model']['accuracy']:.3f}"
+            ),
             f"evidence_coverage={metrics['evidence_coverage']:.3f}",
             (
                 f"usage_execution_conservation="

--- a/scripts/bench/task_graph_replay/fixtures/baseline_v1.json
+++ b/scripts/bench/task_graph_replay/fixtures/baseline_v1.json
@@ -1,0 +1,279 @@
+{
+  "schema_version": 1,
+  "suite_id": "logical-task-attempt-baseline-v1",
+  "metric_config": {"ece_bins": 5, "usage_numeric_tolerance": 1e-09},
+  "run_manifest": {
+    "repository_revision": "14f8f27d173e443e631248f873d158b2c34dc8d5",
+    "model": "recorded-fixture",
+    "harness": "offline-replay",
+    "prompt_fingerprint": "sha256:3565cbdfde8bf0bf0aa8043f18dfb8db69d8e829e7831175b0875b60848834f1",
+    "seed": 0,
+    "generated_at": "2026-08-25T00:00:00Z"
+  },
+  "cases": [
+    {
+      "case_id": "single-task-cross-session-attempt",
+      "task_scope_id": "scope-cross-session",
+      "atoms": [
+        {"atom_id": "atom-a1", "traj_id": "traj-1", "start": 1, "end": 6},
+        {"atom_id": "atom-a2", "traj_id": "traj-2", "start": 1, "end": 6}
+      ],
+      "gold": {
+        "memberships": [
+          {"atom_id": "atom-a1", "task_id": "gold-task-a"},
+          {"atom_id": "atom-a2", "task_id": "gold-task-a"}
+        ],
+        "task_relations": [],
+        "attempts": [
+          {"attempt_id": "gold-attempt-a", "task_id": "gold-task-a", "outcome": "succeeded", "atom_ids": ["atom-a1", "atom-a2"]}
+        ],
+        "attempt_relations": []
+      },
+      "prediction": {
+        "memberships": [
+          {"atom_id": "atom-a1", "task_id": "pred-task-a", "confidence": 0.95},
+          {"atom_id": "atom-a2", "task_id": "pred-task-a", "confidence": 0.9}
+        ],
+        "task_relations": [],
+        "attempts": [
+          {"attempt_id": "pred-attempt-a", "task_id": "pred-task-a", "outcome": "succeeded", "confidence": 0.9, "atom_ids": ["atom-a1", "atom-a2"], "model": {"provider": "fixture", "model": "model-v2"}, "harness": {"name": "codex", "version": "0.2"}, "skills": [{"name": "fixture-skill", "version": "v2"}], "execution_identity": {"run_id": "run-a"}}
+        ],
+        "attempt_relations": [],
+        "usage_allocations": [
+          {"allocation_id": "alloc-a-exec", "usage_event_id": "usage-a-exec", "usage_plane": "execution", "allocation_mode": "direct", "fraction": 1.0, "task_id": "pred-task-a", "attempt_id": "pred-attempt-a", "total_tokens": 100, "cost_usd": 0.01, "method": "fixture", "method_version": "1"},
+          {"allocation_id": "alloc-a-process", "usage_event_id": "usage-a-process", "usage_plane": "xskill_processing", "allocation_mode": "direct", "fraction": 1.0, "task_id": "pred-task-a", "processing_step": "task_linker", "total_tokens": 20, "cost_usd": 0.002, "method": "fixture", "method_version": "1"}
+        ]
+      },
+      "usage_events": [
+        {"usage_event_id": "usage-a-exec", "usage_plane": "execution", "measurement_quality": "measured", "total_tokens": 100, "cost_usd": 0.01},
+        {"usage_event_id": "usage-a-process", "usage_plane": "xskill_processing", "measurement_quality": "measured", "total_tokens": 20, "cost_usd": 0.002}
+      ]
+    },
+    {
+      "case_id": "a-b-a-and-attempt-over-split",
+      "task_scope_id": "scope-a-b-a",
+      "atoms": [
+        {"atom_id": "atom-a1", "traj_id": "traj-1", "start": 1, "end": 6},
+        {"atom_id": "atom-b1", "traj_id": "traj-1", "start": 11, "end": 16},
+        {"atom_id": "atom-a2", "traj_id": "traj-1", "start": 21, "end": 26}
+      ],
+      "gold": {
+        "memberships": [
+          {"atom_id": "atom-a1", "task_id": "gold-task-a"},
+          {"atom_id": "atom-b1", "task_id": "gold-task-b"},
+          {"atom_id": "atom-a2", "task_id": "gold-task-a"}
+        ],
+        "task_relations": [],
+        "attempts": [
+          {"attempt_id": "gold-attempt-a", "task_id": "gold-task-a", "outcome": "succeeded", "atom_ids": ["atom-a1", "atom-a2"]},
+          {"attempt_id": "gold-attempt-b", "task_id": "gold-task-b", "outcome": "succeeded", "atom_ids": ["atom-b1"]}
+        ],
+        "attempt_relations": []
+      },
+      "prediction": {
+        "memberships": [
+          {"atom_id": "atom-a1", "task_id": "pred-task-a", "confidence": 0.9},
+          {"atom_id": "atom-b1", "task_id": "pred-task-b", "confidence": 0.9},
+          {"atom_id": "atom-a2", "task_id": "pred-task-a2", "confidence": 0.55},
+          {"atom_id": "atom-a2", "task_id": "pred-task-a", "decision": "proposed", "confidence": 0.45}
+        ],
+        "task_relations": [],
+        "attempts": [
+          {"attempt_id": "pred-attempt-a1", "task_id": "pred-task-a", "outcome": "succeeded", "confidence": 0.8, "atom_ids": ["atom-a1"]},
+          {"attempt_id": "pred-attempt-b", "task_id": "pred-task-b", "outcome": "succeeded", "confidence": 0.9, "atom_ids": ["atom-b1"]},
+          {"attempt_id": "pred-attempt-a2", "task_id": "pred-task-a2", "outcome": "succeeded", "confidence": 0.6, "atom_ids": ["atom-a2"]}
+        ],
+        "attempt_relations": [],
+        "usage_allocations": [
+          {"allocation_id": "alloc-b-exec-a", "usage_event_id": "usage-b-exec", "usage_plane": "execution", "allocation_mode": "shared", "fraction": 0.5, "task_id": "pred-task-a", "attempt_id": "pred-attempt-a1", "total_tokens": 60, "cost_usd": 0.006, "method": "fixture", "method_version": "1"},
+          {"allocation_id": "alloc-b-exec-b", "usage_event_id": "usage-b-exec", "usage_plane": "execution", "allocation_mode": "shared", "fraction": 0.5, "task_id": "pred-task-b", "attempt_id": "pred-attempt-b", "total_tokens": 60, "cost_usd": 0.006, "method": "fixture", "method_version": "1"}
+        ]
+      },
+      "usage_events": [
+        {"usage_event_id": "usage-b-exec", "usage_plane": "execution", "measurement_quality": "measured", "total_tokens": 120, "cost_usd": 0.012}
+      ]
+    },
+    {
+      "case_id": "retry-with-outcome-mismatch",
+      "task_scope_id": "scope-retry",
+      "atoms": [
+        {"atom_id": "atom-c1", "traj_id": "traj-1", "start": 1, "end": 6},
+        {"atom_id": "atom-c2", "traj_id": "traj-1", "start": 11, "end": 16}
+      ],
+      "gold": {
+        "memberships": [
+          {"atom_id": "atom-c1", "task_id": "gold-task-c"},
+          {"atom_id": "atom-c2", "task_id": "gold-task-c"}
+        ],
+        "task_relations": [],
+        "attempts": [
+          {"attempt_id": "gold-attempt-c1", "task_id": "gold-task-c", "outcome": "failed", "atom_ids": ["atom-c1"]},
+          {"attempt_id": "gold-attempt-c2", "task_id": "gold-task-c", "outcome": "succeeded", "atom_ids": ["atom-c2"]}
+        ],
+        "attempt_relations": [
+          {"from_attempt_id": "gold-attempt-c2", "to_attempt_id": "gold-attempt-c1", "relation_type": "retry_of"}
+        ]
+      },
+      "prediction": {
+        "memberships": [
+          {"atom_id": "atom-c1", "task_id": "pred-task-c", "confidence": 0.9},
+          {"atom_id": "atom-c2", "task_id": "pred-task-c", "confidence": 0.85}
+        ],
+        "task_relations": [],
+        "attempts": [
+          {"attempt_id": "pred-attempt-c1", "task_id": "pred-task-c", "outcome": "failed", "confidence": 0.85, "atom_ids": ["atom-c1"]},
+          {"attempt_id": "pred-attempt-c2", "task_id": "pred-task-c", "outcome": "partially_succeeded", "confidence": 0.7, "atom_ids": ["atom-c2"]}
+        ],
+        "attempt_relations": [
+          {"from_attempt_id": "pred-attempt-c2", "to_attempt_id": "pred-attempt-c1", "relation_type": "retry_of", "confidence": 0.8}
+        ],
+        "usage_allocations": [
+          {"allocation_id": "alloc-c-exec-1", "usage_event_id": "usage-c-exec", "usage_plane": "execution", "allocation_mode": "shared", "fraction": 0.5, "task_id": "pred-task-c", "attempt_id": "pred-attempt-c1", "total_tokens": 60, "cost_usd": 0.006, "method": "fixture", "method_version": "1"},
+          {"allocation_id": "alloc-c-exec-2", "usage_event_id": "usage-c-exec", "usage_plane": "execution", "allocation_mode": "shared", "fraction": 0.5, "task_id": "pred-task-c", "attempt_id": "pred-attempt-c2", "total_tokens": 60, "cost_usd": 0.006, "method": "fixture", "method_version": "1"},
+          {"allocation_id": "alloc-c-process", "usage_event_id": "usage-c-process", "usage_plane": "xskill_processing", "allocation_mode": "direct", "fraction": 1.0, "task_id": "pred-task-c", "processing_step": "task_linker", "total_tokens": 30, "cost_usd": 0.003, "method": "fixture", "method_version": "1"}
+        ]
+      },
+      "usage_events": [
+        {"usage_event_id": "usage-c-exec", "usage_plane": "execution", "measurement_quality": "measured", "total_tokens": 120, "cost_usd": 0.012},
+        {"usage_event_id": "usage-c-process", "usage_plane": "xskill_processing", "measurement_quality": "estimated", "total_tokens": 30, "cost_usd": 0.003}
+      ]
+    },
+    {
+      "case_id": "parent-subtask-and-unavailable-usage",
+      "task_scope_id": "scope-parent",
+      "atoms": [
+        {"atom_id": "atom-parent", "traj_id": "traj-1", "start": 1, "end": 6},
+        {"atom_id": "atom-child", "traj_id": "traj-1", "start": 11, "end": 16},
+        {"atom_id": "atom-grandchild", "traj_id": "traj-1", "start": 21, "end": 26}
+      ],
+      "gold": {
+        "memberships": [
+          {"atom_id": "atom-parent", "task_id": "gold-parent"},
+          {"atom_id": "atom-child", "task_id": "gold-child"},
+          {"atom_id": "atom-grandchild", "task_id": "gold-grandchild"}
+        ],
+        "task_relations": [
+          {"from_task_id": "gold-parent", "to_task_id": "gold-child", "relation_type": "parent"},
+          {"from_task_id": "gold-grandchild", "to_task_id": "gold-child", "relation_type": "subtask"}
+        ],
+        "attempts": [
+          {"attempt_id": "gold-attempt-parent", "task_id": "gold-parent", "outcome": "succeeded", "atom_ids": ["atom-parent"]},
+          {"attempt_id": "gold-attempt-child", "task_id": "gold-child", "outcome": "succeeded", "atom_ids": ["atom-child"]},
+          {"attempt_id": "gold-attempt-grandchild", "task_id": "gold-grandchild", "outcome": "succeeded", "atom_ids": ["atom-grandchild"]}
+        ],
+        "attempt_relations": []
+      },
+      "prediction": {
+        "memberships": [
+          {"atom_id": "atom-parent", "task_id": "pred-parent", "confidence": 0.8},
+          {"atom_id": "atom-child", "task_id": "pred-child", "confidence": 0.75},
+          {"atom_id": "atom-grandchild", "task_id": "pred-grandchild", "confidence": 0.85},
+          {"atom_id": "atom-parent", "task_id": "pred-child", "decision": "proposed", "confidence": 0.2}
+        ],
+        "task_relations": [
+          {"from_task_id": "pred-parent", "to_task_id": "pred-child", "relation_type": "depends_on", "confidence": 0.6},
+          {"from_task_id": "pred-grandchild", "to_task_id": "pred-child", "relation_type": "subtask", "confidence": 0.85}
+        ],
+        "attempts": [
+          {"attempt_id": "pred-attempt-parent", "task_id": "pred-parent", "outcome": "succeeded", "confidence": 0.8, "atom_ids": ["atom-parent"]},
+          {"attempt_id": "pred-attempt-child", "task_id": "pred-child", "outcome": "succeeded", "confidence": 0.8, "atom_ids": ["atom-child"]},
+          {"attempt_id": "pred-attempt-grandchild", "task_id": "pred-grandchild", "outcome": "succeeded", "confidence": 0.85, "atom_ids": ["atom-grandchild"]}
+        ],
+        "attempt_relations": [],
+        "usage_allocations": [
+          {"allocation_id": "alloc-d-exec", "usage_event_id": "usage-d-exec", "usage_plane": "execution", "allocation_mode": "unattributed", "fraction": 1.0, "method": "fixture", "method_version": "1"},
+          {"allocation_id": "alloc-d-process-direct", "usage_event_id": "usage-d-process", "usage_plane": "xskill_processing", "allocation_mode": "direct", "fraction": 0.8, "task_id": "pred-parent", "processing_step": "task_linker", "total_tokens": 8, "cost_usd": 0.0008, "method": "fixture", "method_version": "1"},
+          {"allocation_id": "alloc-d-process-rest", "usage_event_id": "usage-d-process", "usage_plane": "xskill_processing", "allocation_mode": "unattributed", "fraction": 0.2, "total_tokens": 2, "cost_usd": 0.0002, "method": "fixture", "method_version": "1"}
+        ]
+      },
+      "usage_events": [
+        {"usage_event_id": "usage-d-exec", "usage_plane": "execution", "measurement_quality": "unavailable", "total_tokens": null, "cost_usd": null},
+        {"usage_event_id": "usage-d-process", "usage_plane": "xskill_processing", "measurement_quality": "measured", "total_tokens": 10, "cost_usd": 0.001}
+      ]
+    },
+    {
+      "case_id": "continuation-correction-and-version-change",
+      "task_scope_id": "scope-continuation-correction",
+      "atoms": [
+        {"atom_id": "atom-e1", "traj_id": "traj-1", "start": 1, "end": 6},
+        {"atom_id": "atom-e2", "traj_id": "traj-2", "start": 1, "end": 6},
+        {"atom_id": "atom-e3", "traj_id": "traj-2", "start": 11, "end": 16}
+      ],
+      "gold": {
+        "memberships": [
+          {"atom_id": "atom-e1", "task_id": "gold-task-e"},
+          {"atom_id": "atom-e2", "task_id": "gold-task-e"},
+          {"atom_id": "atom-e3", "task_id": "gold-task-e"}
+        ],
+        "task_relations": [],
+        "attempts": [
+          {"attempt_id": "gold-attempt-e1", "task_id": "gold-task-e", "outcome": "blocked", "atom_ids": ["atom-e1"]},
+          {"attempt_id": "gold-attempt-e2", "task_id": "gold-task-e", "outcome": "failed", "atom_ids": ["atom-e2"]},
+          {"attempt_id": "gold-attempt-e3", "task_id": "gold-task-e", "outcome": "succeeded", "atom_ids": ["atom-e3"]}
+        ],
+        "attempt_relations": [
+          {"from_attempt_id": "gold-attempt-e2", "to_attempt_id": "gold-attempt-e1", "relation_type": "continuation_of"},
+          {"from_attempt_id": "gold-attempt-e3", "to_attempt_id": "gold-attempt-e2", "relation_type": "correction_of"}
+        ]
+      },
+      "prediction": {
+        "memberships": [
+          {"atom_id": "atom-e1", "task_id": "pred-task-e", "confidence": 0.8},
+          {"atom_id": "atom-e2", "task_id": "pred-task-e", "confidence": 0.85},
+          {"atom_id": "atom-e3", "task_id": "pred-task-e", "confidence": 0.9}
+        ],
+        "task_relations": [],
+        "attempts": [
+          {"attempt_id": "pred-attempt-e1", "task_id": "pred-task-e", "outcome": "blocked", "confidence": 0.8, "atom_ids": ["atom-e1"], "model": {"provider": "fixture-a", "model": "model-a"}, "harness": {"name": "codex", "version": "0.1"}, "skills": [{"name": "fixture-skill", "version": "v1"}]},
+          {"attempt_id": "pred-attempt-e2", "task_id": "pred-task-e", "outcome": "failed", "confidence": 0.8, "atom_ids": ["atom-e2"], "model": {"provider": "fixture-b", "model": "model-b"}, "harness": {"name": "dsh", "version": "0.2"}, "skills": [{"name": "fixture-skill", "version": "v2"}]},
+          {"attempt_id": "pred-attempt-e3", "task_id": "pred-task-e", "outcome": "succeeded", "confidence": 0.9, "atom_ids": ["atom-e3"], "model": {"provider": "fixture-b", "model": "model-b"}, "harness": {"name": "dsh", "version": "0.3"}, "skills": [{"name": "fixture-skill", "version": "v3"}]}
+        ],
+        "attempt_relations": [
+          {"from_attempt_id": "pred-attempt-e2", "to_attempt_id": "pred-attempt-e1", "relation_type": "continuation_of", "confidence": 0.8},
+          {"from_attempt_id": "pred-attempt-e3", "to_attempt_id": "pred-attempt-e2", "relation_type": "supersedes", "confidence": 0.6}
+        ],
+        "usage_allocations": []
+      },
+      "usage_events": []
+    },
+    {
+      "case_id": "terminal-states-and-cross-session-negative",
+      "task_scope_id": "scope-terminal",
+      "atoms": [
+        {"atom_id": "atom-cancelled", "traj_id": "traj-1", "start": 1, "end": 6},
+        {"atom_id": "atom-blocked", "traj_id": "traj-2", "start": 1, "end": 6},
+        {"atom_id": "atom-partial", "traj_id": "traj-3", "start": 1, "end": 6}
+      ],
+      "gold": {
+        "memberships": [
+          {"atom_id": "atom-cancelled", "task_id": "task-cancelled"},
+          {"atom_id": "atom-blocked", "task_id": "task-blocked"},
+          {"atom_id": "atom-partial", "task_id": "task-partial"}
+        ],
+        "task_relations": [],
+        "attempts": [
+          {"attempt_id": "gold-attempt-cancelled", "task_id": "task-cancelled", "outcome": "cancelled", "atom_ids": ["atom-cancelled"], "user_disposition": "cancelled"},
+          {"attempt_id": "gold-attempt-blocked", "task_id": "task-blocked", "outcome": "blocked", "atom_ids": ["atom-blocked"]},
+          {"attempt_id": "gold-attempt-partial", "task_id": "task-partial", "outcome": "partially_succeeded", "atom_ids": ["atom-partial"]}
+        ],
+        "attempt_relations": []
+      },
+      "prediction": {
+        "memberships": [
+          {"atom_id": "atom-cancelled", "task_id": "pred-cancelled", "confidence": 0.8},
+          {"atom_id": "atom-blocked", "task_id": "pred-blocked", "confidence": 0.8},
+          {"atom_id": "atom-partial", "task_id": "pred-partial", "confidence": 0.8}
+        ],
+        "task_relations": [],
+        "attempts": [
+          {"attempt_id": "pred-attempt-cancelled", "task_id": "pred-cancelled", "outcome": "cancelled", "confidence": 0.8, "atom_ids": ["atom-cancelled"], "user_disposition": "cancelled"},
+          {"attempt_id": "pred-attempt-blocked", "task_id": "pred-blocked", "outcome": "blocked", "confidence": 0.8, "atom_ids": ["atom-blocked"]},
+          {"attempt_id": "pred-attempt-partial", "task_id": "pred-partial", "outcome": "partially_succeeded", "confidence": 0.8, "atom_ids": ["atom-partial"]}
+        ],
+        "attempt_relations": [],
+        "usage_allocations": []
+      },
+      "usage_events": []
+    }
+  ]
+}

--- a/scripts/bench/task_graph_replay/fixtures/baseline_v1.json
+++ b/scripts/bench/task_graph_replay/fixtures/baseline_v1.json
@@ -25,7 +25,7 @@
         ],
         "task_relations": [],
         "attempts": [
-          {"attempt_id": "gold-attempt-a", "task_id": "gold-task-a", "outcome": "succeeded", "atom_ids": ["atom-a1", "atom-a2"]}
+          {"attempt_id": "gold-attempt-a", "task_id": "gold-task-a", "outcome": "succeeded", "atom_ids": ["atom-a1", "atom-a2"], "model": {"provider": "fixture", "model": "model-v2"}, "harness": {"name": "codex", "version": "0.2"}, "skills": [{"name": "fixture-skill", "version": "v2"}], "execution_identity": {"run_id": "run-a"}}
         ],
         "attempt_relations": []
       },
@@ -40,13 +40,13 @@
         ],
         "attempt_relations": [],
         "usage_allocations": [
-          {"allocation_id": "alloc-a-exec", "usage_event_id": "usage-a-exec", "usage_plane": "execution", "allocation_mode": "direct", "fraction": 1.0, "task_id": "pred-task-a", "attempt_id": "pred-attempt-a", "total_tokens": 100, "cost_usd": 0.01, "method": "fixture", "method_version": "1"},
-          {"allocation_id": "alloc-a-process", "usage_event_id": "usage-a-process", "usage_plane": "xskill_processing", "allocation_mode": "direct", "fraction": 1.0, "task_id": "pred-task-a", "processing_step": "task_linker", "total_tokens": 20, "cost_usd": 0.002, "method": "fixture", "method_version": "1"}
+          {"allocation_id": "alloc-a-exec", "usage_event_id": "usage-a-exec", "usage_plane": "execution", "allocation_mode": "direct", "fraction": 1.0, "task_id": "pred-task-a", "attempt_id": "pred-attempt-a", "prompt_tokens": 80, "completion_tokens": 20, "total_tokens": 100, "cache_read_tokens": 60, "cost_usd": 0.01, "method": "fixture", "method_version": "1"},
+          {"allocation_id": "alloc-a-process", "usage_event_id": "usage-a-process", "usage_plane": "xskill_processing", "allocation_mode": "direct", "fraction": 1.0, "task_id": "pred-task-a", "processing_step": "task_linker", "prompt_tokens": 15, "completion_tokens": 5, "total_tokens": 20, "cache_read_tokens": 0, "cost_usd": 0.002, "method": "fixture", "method_version": "1"}
         ]
       },
       "usage_events": [
-        {"usage_event_id": "usage-a-exec", "usage_plane": "execution", "measurement_quality": "measured", "total_tokens": 100, "cost_usd": 0.01},
-        {"usage_event_id": "usage-a-process", "usage_plane": "xskill_processing", "measurement_quality": "measured", "total_tokens": 20, "cost_usd": 0.002}
+        {"usage_event_id": "usage-a-exec", "usage_plane": "execution", "measurement_quality": "measured", "prompt_tokens": 80, "completion_tokens": 20, "total_tokens": 100, "cache_read_tokens": 60, "cost_usd": 0.01},
+        {"usage_event_id": "usage-a-process", "usage_plane": "xskill_processing", "measurement_quality": "measured", "prompt_tokens": 15, "completion_tokens": 5, "total_tokens": 20, "cache_read_tokens": 0, "cost_usd": 0.002}
       ]
     },
     {
@@ -85,12 +85,12 @@
         ],
         "attempt_relations": [],
         "usage_allocations": [
-          {"allocation_id": "alloc-b-exec-a", "usage_event_id": "usage-b-exec", "usage_plane": "execution", "allocation_mode": "shared", "fraction": 0.5, "task_id": "pred-task-a", "attempt_id": "pred-attempt-a1", "total_tokens": 60, "cost_usd": 0.006, "method": "fixture", "method_version": "1"},
-          {"allocation_id": "alloc-b-exec-b", "usage_event_id": "usage-b-exec", "usage_plane": "execution", "allocation_mode": "shared", "fraction": 0.5, "task_id": "pred-task-b", "attempt_id": "pred-attempt-b", "total_tokens": 60, "cost_usd": 0.006, "method": "fixture", "method_version": "1"}
+          {"allocation_id": "alloc-b-exec-a", "usage_event_id": "usage-b-exec", "usage_plane": "execution", "allocation_mode": "shared", "fraction": 0.5, "task_id": "pred-task-a", "attempt_id": "pred-attempt-a1", "prompt_tokens": 45, "completion_tokens": 15, "total_tokens": 60, "cache_read_tokens": 20, "cost_usd": 0.006, "method": "fixture", "method_version": "1"},
+          {"allocation_id": "alloc-b-exec-b", "usage_event_id": "usage-b-exec", "usage_plane": "execution", "allocation_mode": "shared", "fraction": 0.5, "task_id": "pred-task-b", "attempt_id": "pred-attempt-b", "prompt_tokens": 45, "completion_tokens": 15, "total_tokens": 60, "cache_read_tokens": 20, "cost_usd": 0.006, "method": "fixture", "method_version": "1"}
         ]
       },
       "usage_events": [
-        {"usage_event_id": "usage-b-exec", "usage_plane": "execution", "measurement_quality": "measured", "total_tokens": 120, "cost_usd": 0.012}
+        {"usage_event_id": "usage-b-exec", "usage_plane": "execution", "measurement_quality": "measured", "prompt_tokens": 90, "completion_tokens": 30, "total_tokens": 120, "cache_read_tokens": 40, "cost_usd": 0.012}
       ]
     },
     {
@@ -128,14 +128,14 @@
           {"from_attempt_id": "pred-attempt-c2", "to_attempt_id": "pred-attempt-c1", "relation_type": "retry_of", "confidence": 0.8}
         ],
         "usage_allocations": [
-          {"allocation_id": "alloc-c-exec-1", "usage_event_id": "usage-c-exec", "usage_plane": "execution", "allocation_mode": "shared", "fraction": 0.5, "task_id": "pred-task-c", "attempt_id": "pred-attempt-c1", "total_tokens": 60, "cost_usd": 0.006, "method": "fixture", "method_version": "1"},
-          {"allocation_id": "alloc-c-exec-2", "usage_event_id": "usage-c-exec", "usage_plane": "execution", "allocation_mode": "shared", "fraction": 0.5, "task_id": "pred-task-c", "attempt_id": "pred-attempt-c2", "total_tokens": 60, "cost_usd": 0.006, "method": "fixture", "method_version": "1"},
-          {"allocation_id": "alloc-c-process", "usage_event_id": "usage-c-process", "usage_plane": "xskill_processing", "allocation_mode": "direct", "fraction": 1.0, "task_id": "pred-task-c", "processing_step": "task_linker", "total_tokens": 30, "cost_usd": 0.003, "method": "fixture", "method_version": "1"}
+          {"allocation_id": "alloc-c-exec-1", "usage_event_id": "usage-c-exec", "usage_plane": "execution", "allocation_mode": "shared", "fraction": 0.5, "task_id": "pred-task-c", "attempt_id": "pred-attempt-c1", "prompt_tokens": 40, "completion_tokens": 20, "total_tokens": 60, "cache_read_tokens": 15, "cost_usd": 0.006, "method": "fixture", "method_version": "1"},
+          {"allocation_id": "alloc-c-exec-2", "usage_event_id": "usage-c-exec", "usage_plane": "execution", "allocation_mode": "shared", "fraction": 0.5, "task_id": "pred-task-c", "attempt_id": "pred-attempt-c2", "prompt_tokens": 40, "completion_tokens": 20, "total_tokens": 60, "cache_read_tokens": 15, "cost_usd": 0.006, "method": "fixture", "method_version": "1"},
+          {"allocation_id": "alloc-c-process", "usage_event_id": "usage-c-process", "usage_plane": "xskill_processing", "allocation_mode": "direct", "fraction": 1.0, "task_id": "pred-task-c", "processing_step": "task_linker", "prompt_tokens": 20, "completion_tokens": 10, "total_tokens": 30, "cache_read_tokens": 0, "cost_usd": 0.003, "method": "fixture", "method_version": "1"}
         ]
       },
       "usage_events": [
-        {"usage_event_id": "usage-c-exec", "usage_plane": "execution", "measurement_quality": "measured", "total_tokens": 120, "cost_usd": 0.012},
-        {"usage_event_id": "usage-c-process", "usage_plane": "xskill_processing", "measurement_quality": "estimated", "total_tokens": 30, "cost_usd": 0.003}
+        {"usage_event_id": "usage-c-exec", "usage_plane": "execution", "measurement_quality": "measured", "prompt_tokens": 80, "completion_tokens": 40, "total_tokens": 120, "cache_read_tokens": 30, "cost_usd": 0.012},
+        {"usage_event_id": "usage-c-process", "usage_plane": "xskill_processing", "measurement_quality": "estimated", "prompt_tokens": 20, "completion_tokens": 10, "total_tokens": 30, "cache_read_tokens": 0, "cost_usd": 0.003}
       ]
     },
     {
@@ -182,13 +182,13 @@
         "attempt_relations": [],
         "usage_allocations": [
           {"allocation_id": "alloc-d-exec", "usage_event_id": "usage-d-exec", "usage_plane": "execution", "allocation_mode": "unattributed", "fraction": 1.0, "method": "fixture", "method_version": "1"},
-          {"allocation_id": "alloc-d-process-direct", "usage_event_id": "usage-d-process", "usage_plane": "xskill_processing", "allocation_mode": "direct", "fraction": 0.8, "task_id": "pred-parent", "processing_step": "task_linker", "total_tokens": 8, "cost_usd": 0.0008, "method": "fixture", "method_version": "1"},
-          {"allocation_id": "alloc-d-process-rest", "usage_event_id": "usage-d-process", "usage_plane": "xskill_processing", "allocation_mode": "unattributed", "fraction": 0.2, "total_tokens": 2, "cost_usd": 0.0002, "method": "fixture", "method_version": "1"}
+          {"allocation_id": "alloc-d-process-direct", "usage_event_id": "usage-d-process", "usage_plane": "xskill_processing", "allocation_mode": "direct", "fraction": 0.8, "task_id": "pred-parent", "processing_step": "task_linker", "prompt_tokens": 6, "completion_tokens": 2, "total_tokens": 8, "cache_read_tokens": 3, "cost_usd": 0.0008, "method": "fixture", "method_version": "1"},
+          {"allocation_id": "alloc-d-process-rest", "usage_event_id": "usage-d-process", "usage_plane": "xskill_processing", "allocation_mode": "unattributed", "fraction": 0.2, "prompt_tokens": 2, "completion_tokens": 0, "total_tokens": 2, "cache_read_tokens": 1, "cost_usd": 0.0002, "method": "fixture", "method_version": "1"}
         ]
       },
       "usage_events": [
-        {"usage_event_id": "usage-d-exec", "usage_plane": "execution", "measurement_quality": "unavailable", "total_tokens": null, "cost_usd": null},
-        {"usage_event_id": "usage-d-process", "usage_plane": "xskill_processing", "measurement_quality": "measured", "total_tokens": 10, "cost_usd": 0.001}
+        {"usage_event_id": "usage-d-exec", "usage_plane": "execution", "measurement_quality": "unavailable", "prompt_tokens": null, "completion_tokens": null, "total_tokens": null, "cache_read_tokens": null, "cost_usd": null},
+        {"usage_event_id": "usage-d-process", "usage_plane": "xskill_processing", "measurement_quality": "measured", "prompt_tokens": 8, "completion_tokens": 2, "total_tokens": 10, "cache_read_tokens": 4, "cost_usd": 0.001}
       ]
     },
     {
@@ -207,9 +207,9 @@
         ],
         "task_relations": [],
         "attempts": [
-          {"attempt_id": "gold-attempt-e1", "task_id": "gold-task-e", "outcome": "blocked", "atom_ids": ["atom-e1"]},
-          {"attempt_id": "gold-attempt-e2", "task_id": "gold-task-e", "outcome": "failed", "atom_ids": ["atom-e2"]},
-          {"attempt_id": "gold-attempt-e3", "task_id": "gold-task-e", "outcome": "succeeded", "atom_ids": ["atom-e3"]}
+          {"attempt_id": "gold-attempt-e1", "task_id": "gold-task-e", "outcome": "blocked", "atom_ids": ["atom-e1"], "model": {"provider": "fixture-a", "model": "model-a"}, "harness": {"name": "codex", "version": "0.1"}, "skills": [{"name": "fixture-skill", "version": "v1"}], "execution_identity": {"run_id": "run-e1"}},
+          {"attempt_id": "gold-attempt-e2", "task_id": "gold-task-e", "outcome": "failed", "atom_ids": ["atom-e2"], "model": {"provider": "fixture-b", "model": "model-b"}, "harness": {"name": "dsh", "version": "0.2"}, "skills": [{"name": "fixture-skill", "version": "v2"}], "execution_identity": {"run_id": "run-e2"}},
+          {"attempt_id": "gold-attempt-e3", "task_id": "gold-task-e", "outcome": "succeeded", "atom_ids": ["atom-e3"], "model": {"provider": "fixture-b", "model": "model-b"}, "harness": {"name": "dsh", "version": "0.3"}, "skills": [{"name": "fixture-skill", "version": "v3"}], "execution_identity": {"run_id": "run-e3"}}
         ],
         "attempt_relations": [
           {"from_attempt_id": "gold-attempt-e2", "to_attempt_id": "gold-attempt-e1", "relation_type": "continuation_of"},
@@ -224,9 +224,9 @@
         ],
         "task_relations": [],
         "attempts": [
-          {"attempt_id": "pred-attempt-e1", "task_id": "pred-task-e", "outcome": "blocked", "confidence": 0.8, "atom_ids": ["atom-e1"], "model": {"provider": "fixture-a", "model": "model-a"}, "harness": {"name": "codex", "version": "0.1"}, "skills": [{"name": "fixture-skill", "version": "v1"}]},
-          {"attempt_id": "pred-attempt-e2", "task_id": "pred-task-e", "outcome": "failed", "confidence": 0.8, "atom_ids": ["atom-e2"], "model": {"provider": "fixture-b", "model": "model-b"}, "harness": {"name": "dsh", "version": "0.2"}, "skills": [{"name": "fixture-skill", "version": "v2"}]},
-          {"attempt_id": "pred-attempt-e3", "task_id": "pred-task-e", "outcome": "succeeded", "confidence": 0.9, "atom_ids": ["atom-e3"], "model": {"provider": "fixture-b", "model": "model-b"}, "harness": {"name": "dsh", "version": "0.3"}, "skills": [{"name": "fixture-skill", "version": "v3"}]}
+          {"attempt_id": "pred-attempt-e1", "task_id": "pred-task-e", "outcome": "blocked", "confidence": 0.8, "atom_ids": ["atom-e1"], "model": {"provider": "fixture-a", "model": "model-a"}, "harness": {"name": "codex", "version": "0.1"}, "skills": [{"name": "fixture-skill", "version": "v1"}], "execution_identity": {"run_id": "run-e1"}},
+          {"attempt_id": "pred-attempt-e2", "task_id": "pred-task-e", "outcome": "failed", "confidence": 0.8, "atom_ids": ["atom-e2"], "model": {"provider": "fixture-b", "model": "model-b"}, "harness": {"name": "dsh", "version": "0.2"}, "skills": [{"name": "fixture-skill", "version": "v2"}], "execution_identity": {"run_id": "run-e2"}},
+          {"attempt_id": "pred-attempt-e3", "task_id": "pred-task-e", "outcome": "succeeded", "confidence": 0.9, "atom_ids": ["atom-e3"], "model": {"provider": "fixture-b", "model": "model-b"}, "harness": {"name": "dsh", "version": "0.3"}, "skills": [{"name": "fixture-skill", "version": "v3"}], "execution_identity": {"run_id": "run-e3"}}
         ],
         "attempt_relations": [
           {"from_attempt_id": "pred-attempt-e2", "to_attempt_id": "pred-attempt-e1", "relation_type": "continuation_of", "confidence": 0.8},

--- a/scripts/bench/task_graph_replay/fixtures/baseline_v1.report.json
+++ b/scripts/bench/task_graph_replay/fixtures/baseline_v1.report.json
@@ -1,0 +1,936 @@
+{
+  "cases": [
+    {
+      "case_id": "single-task-cross-session-attempt",
+      "errors": [],
+      "metrics": {
+        "attempt_detection": {
+          "f1": 1.0,
+          "false_negative": 0,
+          "false_positive": 0,
+          "precision": 1.0,
+          "recall": 1.0,
+          "true_positive": 1
+        },
+        "attempt_outcome": {
+          "accuracy": 1.0,
+          "by_outcome": {
+            "succeeded": {
+              "f1": 1.0,
+              "precision": 1.0,
+              "recall": 1.0
+            }
+          },
+          "macro_f1": 1.0
+        },
+        "confidence": {
+          "attempt_outcome": {
+            "brier": 0.01,
+            "count": 1,
+            "coverage": 1.0,
+            "ece": 0.1
+          },
+          "membership": {
+            "brier": 0.00625,
+            "count": 2,
+            "coverage": 1.0,
+            "ece": 0.075
+          }
+        },
+        "evidence_coverage": 1.0,
+        "relations": {
+          "by_type": {},
+          "macro": {
+            "f1": 1.0,
+            "precision": 1.0,
+            "recall": 1.0
+          },
+          "micro": {
+            "f1": 1.0,
+            "false_negative": 0,
+            "false_positive": 0,
+            "precision": 1.0,
+            "recall": 1.0,
+            "true_positive": 0
+          }
+        },
+        "task_grouping": {
+          "b3": {
+            "f1": 1.0,
+            "precision": 1.0,
+            "recall": 1.0
+          },
+          "pairwise": {
+            "f1": 1.0,
+            "false_negative": 0,
+            "false_positive": 0,
+            "precision": 1.0,
+            "recall": 1.0,
+            "true_positive": 1
+          }
+        },
+        "usage": {
+          "execution": {
+            "allocated_cost_usd": 0.01,
+            "allocated_total_tokens": 100,
+            "conservation_rate": 1.0,
+            "estimated_events": 0,
+            "events": 1,
+            "measured_events": 1,
+            "raw_cost_usd": 0.01,
+            "raw_total_tokens": 100,
+            "shared_fraction": 0.0,
+            "unattributed_fraction": 0.0,
+            "unavailable_events": 0
+          },
+          "xskill_processing": {
+            "allocated_cost_usd": 0.002,
+            "allocated_total_tokens": 20,
+            "conservation_rate": 1.0,
+            "estimated_events": 0,
+            "events": 1,
+            "measured_events": 1,
+            "raw_cost_usd": 0.002,
+            "raw_total_tokens": 20,
+            "shared_fraction": 0.0,
+            "unattributed_fraction": 0.0,
+            "unavailable_events": 0
+          }
+        }
+      }
+    },
+    {
+      "case_id": "a-b-a-and-attempt-over-split",
+      "errors": [
+        {
+          "atom_keys": [
+            "tenant-fixture\u001fscope-a-b-a\u001fsource-fixture\u001ftraj-1\u001fatom-a1",
+            "tenant-fixture\u001fscope-a-b-a\u001fsource-fixture\u001ftraj-1\u001fatom-a2"
+          ],
+          "type": "task_false_split"
+        },
+        {
+          "attempt_id": "pred-attempt-a2",
+          "type": "attempt_spurious"
+        }
+      ],
+      "metrics": {
+        "attempt_detection": {
+          "f1": 0.8,
+          "false_negative": 0,
+          "false_positive": 1,
+          "precision": 0.666667,
+          "recall": 1.0,
+          "true_positive": 2
+        },
+        "attempt_outcome": {
+          "accuracy": 1.0,
+          "by_outcome": {
+            "succeeded": {
+              "f1": 0.8,
+              "precision": 0.666667,
+              "recall": 1.0
+            }
+          },
+          "macro_f1": 0.8
+        },
+        "confidence": {
+          "attempt_outcome": {
+            "brier": 0.136667,
+            "count": 3,
+            "coverage": 1.0,
+            "ece": 0.3
+          },
+          "membership": {
+            "brier": 0.13125,
+            "count": 4,
+            "coverage": 1.0,
+            "ece": 0.3
+          }
+        },
+        "evidence_coverage": 0.666667,
+        "relations": {
+          "by_type": {},
+          "macro": {
+            "f1": 1.0,
+            "precision": 1.0,
+            "recall": 1.0
+          },
+          "micro": {
+            "f1": 1.0,
+            "false_negative": 0,
+            "false_positive": 0,
+            "precision": 1.0,
+            "recall": 1.0,
+            "true_positive": 0
+          }
+        },
+        "task_grouping": {
+          "b3": {
+            "f1": 0.8,
+            "precision": 1.0,
+            "recall": 0.666667
+          },
+          "pairwise": {
+            "f1": 0.0,
+            "false_negative": 1,
+            "false_positive": 0,
+            "precision": 0.0,
+            "recall": 0.0,
+            "true_positive": 0
+          }
+        },
+        "usage": {
+          "execution": {
+            "allocated_cost_usd": 0.012,
+            "allocated_total_tokens": 120,
+            "conservation_rate": 1.0,
+            "estimated_events": 0,
+            "events": 1,
+            "measured_events": 1,
+            "raw_cost_usd": 0.012,
+            "raw_total_tokens": 120,
+            "shared_fraction": 1.0,
+            "unattributed_fraction": 0.0,
+            "unavailable_events": 0
+          },
+          "xskill_processing": {
+            "allocated_cost_usd": 0.0,
+            "allocated_total_tokens": 0,
+            "conservation_rate": 1.0,
+            "estimated_events": 0,
+            "events": 0,
+            "measured_events": 0,
+            "raw_cost_usd": 0.0,
+            "raw_total_tokens": 0,
+            "shared_fraction": 0.0,
+            "unattributed_fraction": 0.0,
+            "unavailable_events": 0
+          }
+        }
+      }
+    },
+    {
+      "case_id": "retry-with-outcome-mismatch",
+      "errors": [
+        {
+          "attempt_id": "gold-attempt-c2",
+          "gold": "succeeded",
+          "predicted": "partially_succeeded",
+          "type": "attempt_outcome_mismatch"
+        }
+      ],
+      "metrics": {
+        "attempt_detection": {
+          "f1": 1.0,
+          "false_negative": 0,
+          "false_positive": 0,
+          "precision": 1.0,
+          "recall": 1.0,
+          "true_positive": 2
+        },
+        "attempt_outcome": {
+          "accuracy": 0.5,
+          "by_outcome": {
+            "failed": {
+              "f1": 1.0,
+              "precision": 1.0,
+              "recall": 1.0
+            },
+            "partially_succeeded": {
+              "f1": 0.0,
+              "precision": 0.0,
+              "recall": 0.0
+            },
+            "succeeded": {
+              "f1": 0.0,
+              "precision": 0.0,
+              "recall": 0.0
+            }
+          },
+          "macro_f1": 0.333333
+        },
+        "confidence": {
+          "attempt_outcome": {
+            "brier": 0.25625,
+            "count": 2,
+            "coverage": 1.0,
+            "ece": 0.425
+          },
+          "membership": {
+            "brier": 0.01625,
+            "count": 2,
+            "coverage": 1.0,
+            "ece": 0.125
+          }
+        },
+        "evidence_coverage": 1.0,
+        "relations": {
+          "by_type": {
+            "attempt:retry_of": {
+              "f1": 1.0,
+              "false_negative": 0,
+              "false_positive": 0,
+              "precision": 1.0,
+              "recall": 1.0,
+              "true_positive": 1
+            }
+          },
+          "macro": {
+            "f1": 1.0,
+            "precision": 1.0,
+            "recall": 1.0
+          },
+          "micro": {
+            "f1": 1.0,
+            "false_negative": 0,
+            "false_positive": 0,
+            "precision": 1.0,
+            "recall": 1.0,
+            "true_positive": 1
+          }
+        },
+        "task_grouping": {
+          "b3": {
+            "f1": 1.0,
+            "precision": 1.0,
+            "recall": 1.0
+          },
+          "pairwise": {
+            "f1": 1.0,
+            "false_negative": 0,
+            "false_positive": 0,
+            "precision": 1.0,
+            "recall": 1.0,
+            "true_positive": 1
+          }
+        },
+        "usage": {
+          "execution": {
+            "allocated_cost_usd": 0.012,
+            "allocated_total_tokens": 120,
+            "conservation_rate": 1.0,
+            "estimated_events": 0,
+            "events": 1,
+            "measured_events": 1,
+            "raw_cost_usd": 0.012,
+            "raw_total_tokens": 120,
+            "shared_fraction": 1.0,
+            "unattributed_fraction": 0.0,
+            "unavailable_events": 0
+          },
+          "xskill_processing": {
+            "allocated_cost_usd": 0.003,
+            "allocated_total_tokens": 30,
+            "conservation_rate": 1.0,
+            "estimated_events": 1,
+            "events": 1,
+            "measured_events": 0,
+            "raw_cost_usd": 0.003,
+            "raw_total_tokens": 30,
+            "shared_fraction": 0.0,
+            "unattributed_fraction": 0.0,
+            "unavailable_events": 0
+          }
+        }
+      }
+    },
+    {
+      "case_id": "parent-subtask-and-unavailable-usage",
+      "errors": [
+        {
+          "relation": [
+            "task:parent",
+            [
+              "tenant-fixture\u001fscope-parent\u001fsource-fixture\u001ftraj-1\u001fatom-parent"
+            ],
+            [
+              "tenant-fixture\u001fscope-parent\u001fsource-fixture\u001ftraj-1\u001fatom-child"
+            ]
+          ],
+          "type": "relation_missing"
+        },
+        {
+          "relation": [
+            "task:depends_on",
+            [
+              "tenant-fixture\u001fscope-parent\u001fsource-fixture\u001ftraj-1\u001fatom-parent"
+            ],
+            [
+              "tenant-fixture\u001fscope-parent\u001fsource-fixture\u001ftraj-1\u001fatom-child"
+            ]
+          ],
+          "type": "relation_spurious"
+        }
+      ],
+      "metrics": {
+        "attempt_detection": {
+          "f1": 1.0,
+          "false_negative": 0,
+          "false_positive": 0,
+          "precision": 1.0,
+          "recall": 1.0,
+          "true_positive": 3
+        },
+        "attempt_outcome": {
+          "accuracy": 1.0,
+          "by_outcome": {
+            "succeeded": {
+              "f1": 1.0,
+              "precision": 1.0,
+              "recall": 1.0
+            }
+          },
+          "macro_f1": 1.0
+        },
+        "confidence": {
+          "attempt_outcome": {
+            "brier": 0.034167,
+            "count": 3,
+            "coverage": 1.0,
+            "ece": 0.183333
+          },
+          "membership": {
+            "brier": 0.04125,
+            "count": 4,
+            "coverage": 1.0,
+            "ece": 0.2
+          }
+        },
+        "evidence_coverage": 1.0,
+        "relations": {
+          "by_type": {
+            "task:depends_on": {
+              "f1": 0.0,
+              "false_negative": 0,
+              "false_positive": 1,
+              "precision": 0.0,
+              "recall": 0.0,
+              "true_positive": 0
+            },
+            "task:parent": {
+              "f1": 0.0,
+              "false_negative": 1,
+              "false_positive": 0,
+              "precision": 0.0,
+              "recall": 0.0,
+              "true_positive": 0
+            },
+            "task:subtask": {
+              "f1": 1.0,
+              "false_negative": 0,
+              "false_positive": 0,
+              "precision": 1.0,
+              "recall": 1.0,
+              "true_positive": 1
+            }
+          },
+          "macro": {
+            "f1": 0.333333,
+            "precision": 0.333333,
+            "recall": 0.333333
+          },
+          "micro": {
+            "f1": 0.5,
+            "false_negative": 1,
+            "false_positive": 1,
+            "precision": 0.5,
+            "recall": 0.5,
+            "true_positive": 1
+          }
+        },
+        "task_grouping": {
+          "b3": {
+            "f1": 1.0,
+            "precision": 1.0,
+            "recall": 1.0
+          },
+          "pairwise": {
+            "f1": 1.0,
+            "false_negative": 0,
+            "false_positive": 0,
+            "precision": 1.0,
+            "recall": 1.0,
+            "true_positive": 0
+          }
+        },
+        "usage": {
+          "execution": {
+            "allocated_cost_usd": 0.0,
+            "allocated_total_tokens": 0,
+            "conservation_rate": 1.0,
+            "estimated_events": 0,
+            "events": 1,
+            "measured_events": 0,
+            "raw_cost_usd": 0.0,
+            "raw_total_tokens": 0,
+            "shared_fraction": 0.0,
+            "unattributed_fraction": 1.0,
+            "unavailable_events": 1
+          },
+          "xskill_processing": {
+            "allocated_cost_usd": 0.001,
+            "allocated_total_tokens": 10,
+            "conservation_rate": 1.0,
+            "estimated_events": 0,
+            "events": 1,
+            "measured_events": 1,
+            "raw_cost_usd": 0.001,
+            "raw_total_tokens": 10,
+            "shared_fraction": 0.0,
+            "unattributed_fraction": 0.2,
+            "unavailable_events": 0
+          }
+        }
+      }
+    },
+    {
+      "case_id": "continuation-correction-and-version-change",
+      "errors": [
+        {
+          "relation": [
+            "attempt:correction_of",
+            "gold-attempt-e3",
+            "gold-attempt-e2"
+          ],
+          "type": "relation_missing"
+        },
+        {
+          "relation": [
+            "attempt:supersedes",
+            "gold-attempt-e3",
+            "gold-attempt-e2"
+          ],
+          "type": "relation_spurious"
+        }
+      ],
+      "metrics": {
+        "attempt_detection": {
+          "f1": 1.0,
+          "false_negative": 0,
+          "false_positive": 0,
+          "precision": 1.0,
+          "recall": 1.0,
+          "true_positive": 3
+        },
+        "attempt_outcome": {
+          "accuracy": 1.0,
+          "by_outcome": {
+            "blocked": {
+              "f1": 1.0,
+              "precision": 1.0,
+              "recall": 1.0
+            },
+            "failed": {
+              "f1": 1.0,
+              "precision": 1.0,
+              "recall": 1.0
+            },
+            "succeeded": {
+              "f1": 1.0,
+              "precision": 1.0,
+              "recall": 1.0
+            }
+          },
+          "macro_f1": 1.0
+        },
+        "confidence": {
+          "attempt_outcome": {
+            "brier": 0.03,
+            "count": 3,
+            "coverage": 1.0,
+            "ece": 0.166667
+          },
+          "membership": {
+            "brier": 0.024167,
+            "count": 3,
+            "coverage": 1.0,
+            "ece": 0.15
+          }
+        },
+        "evidence_coverage": 1.0,
+        "relations": {
+          "by_type": {
+            "attempt:continuation_of": {
+              "f1": 1.0,
+              "false_negative": 0,
+              "false_positive": 0,
+              "precision": 1.0,
+              "recall": 1.0,
+              "true_positive": 1
+            },
+            "attempt:correction_of": {
+              "f1": 0.0,
+              "false_negative": 1,
+              "false_positive": 0,
+              "precision": 0.0,
+              "recall": 0.0,
+              "true_positive": 0
+            },
+            "attempt:supersedes": {
+              "f1": 0.0,
+              "false_negative": 0,
+              "false_positive": 1,
+              "precision": 0.0,
+              "recall": 0.0,
+              "true_positive": 0
+            }
+          },
+          "macro": {
+            "f1": 0.333333,
+            "precision": 0.333333,
+            "recall": 0.333333
+          },
+          "micro": {
+            "f1": 0.5,
+            "false_negative": 1,
+            "false_positive": 1,
+            "precision": 0.5,
+            "recall": 0.5,
+            "true_positive": 1
+          }
+        },
+        "task_grouping": {
+          "b3": {
+            "f1": 1.0,
+            "precision": 1.0,
+            "recall": 1.0
+          },
+          "pairwise": {
+            "f1": 1.0,
+            "false_negative": 0,
+            "false_positive": 0,
+            "precision": 1.0,
+            "recall": 1.0,
+            "true_positive": 3
+          }
+        },
+        "usage": {
+          "execution": {
+            "allocated_cost_usd": 0.0,
+            "allocated_total_tokens": 0,
+            "conservation_rate": 1.0,
+            "estimated_events": 0,
+            "events": 0,
+            "measured_events": 0,
+            "raw_cost_usd": 0.0,
+            "raw_total_tokens": 0,
+            "shared_fraction": 0.0,
+            "unattributed_fraction": 0.0,
+            "unavailable_events": 0
+          },
+          "xskill_processing": {
+            "allocated_cost_usd": 0.0,
+            "allocated_total_tokens": 0,
+            "conservation_rate": 1.0,
+            "estimated_events": 0,
+            "events": 0,
+            "measured_events": 0,
+            "raw_cost_usd": 0.0,
+            "raw_total_tokens": 0,
+            "shared_fraction": 0.0,
+            "unattributed_fraction": 0.0,
+            "unavailable_events": 0
+          }
+        }
+      }
+    },
+    {
+      "case_id": "terminal-states-and-cross-session-negative",
+      "errors": [],
+      "metrics": {
+        "attempt_detection": {
+          "f1": 1.0,
+          "false_negative": 0,
+          "false_positive": 0,
+          "precision": 1.0,
+          "recall": 1.0,
+          "true_positive": 3
+        },
+        "attempt_outcome": {
+          "accuracy": 1.0,
+          "by_outcome": {
+            "blocked": {
+              "f1": 1.0,
+              "precision": 1.0,
+              "recall": 1.0
+            },
+            "cancelled": {
+              "f1": 1.0,
+              "precision": 1.0,
+              "recall": 1.0
+            },
+            "partially_succeeded": {
+              "f1": 1.0,
+              "precision": 1.0,
+              "recall": 1.0
+            }
+          },
+          "macro_f1": 1.0
+        },
+        "confidence": {
+          "attempt_outcome": {
+            "brier": 0.04,
+            "count": 3,
+            "coverage": 1.0,
+            "ece": 0.2
+          },
+          "membership": {
+            "brier": 0.04,
+            "count": 3,
+            "coverage": 1.0,
+            "ece": 0.2
+          }
+        },
+        "evidence_coverage": 1.0,
+        "relations": {
+          "by_type": {},
+          "macro": {
+            "f1": 1.0,
+            "precision": 1.0,
+            "recall": 1.0
+          },
+          "micro": {
+            "f1": 1.0,
+            "false_negative": 0,
+            "false_positive": 0,
+            "precision": 1.0,
+            "recall": 1.0,
+            "true_positive": 0
+          }
+        },
+        "task_grouping": {
+          "b3": {
+            "f1": 1.0,
+            "precision": 1.0,
+            "recall": 1.0
+          },
+          "pairwise": {
+            "f1": 1.0,
+            "false_negative": 0,
+            "false_positive": 0,
+            "precision": 1.0,
+            "recall": 1.0,
+            "true_positive": 0
+          }
+        },
+        "usage": {
+          "execution": {
+            "allocated_cost_usd": 0.0,
+            "allocated_total_tokens": 0,
+            "conservation_rate": 1.0,
+            "estimated_events": 0,
+            "events": 0,
+            "measured_events": 0,
+            "raw_cost_usd": 0.0,
+            "raw_total_tokens": 0,
+            "shared_fraction": 0.0,
+            "unattributed_fraction": 0.0,
+            "unavailable_events": 0
+          },
+          "xskill_processing": {
+            "allocated_cost_usd": 0.0,
+            "allocated_total_tokens": 0,
+            "conservation_rate": 1.0,
+            "estimated_events": 0,
+            "events": 0,
+            "measured_events": 0,
+            "raw_cost_usd": 0.0,
+            "raw_total_tokens": 0,
+            "shared_fraction": 0.0,
+            "unattributed_fraction": 0.0,
+            "unavailable_events": 0
+          }
+        }
+      }
+    }
+  ],
+  "error_count": 7,
+  "metric_config": {
+    "ece_bins": 5,
+    "usage_numeric_tolerance": 1e-09
+  },
+  "metrics": {
+    "attempt_detection": {
+      "f1": 0.965517,
+      "false_negative": 0,
+      "false_positive": 1,
+      "precision": 0.933333,
+      "recall": 1.0,
+      "true_positive": 14
+    },
+    "attempt_outcome": {
+      "accuracy": 0.928571,
+      "by_outcome": {
+        "blocked": {
+          "f1": 1.0,
+          "precision": 1.0,
+          "recall": 1.0
+        },
+        "cancelled": {
+          "f1": 1.0,
+          "precision": 1.0,
+          "recall": 1.0
+        },
+        "failed": {
+          "f1": 1.0,
+          "precision": 1.0,
+          "recall": 1.0
+        },
+        "partially_succeeded": {
+          "f1": 0.666667,
+          "precision": 0.5,
+          "recall": 1.0
+        },
+        "succeeded": {
+          "f1": 0.875,
+          "precision": 0.875,
+          "recall": 0.875
+        }
+      },
+      "macro_f1": 0.908333
+    },
+    "confidence": {
+      "attempt_outcome": {
+        "brier": 0.083,
+        "count": 15,
+        "coverage": 1.0,
+        "ece": 0.233333
+      },
+      "membership": {
+        "brier": 0.051528,
+        "count": 18,
+        "coverage": 1.0,
+        "ece": 0.191667
+      }
+    },
+    "evidence_coverage": 0.9375,
+    "relations": {
+      "by_type": {
+        "attempt:continuation_of": {
+          "f1": 1.0,
+          "false_negative": 0,
+          "false_positive": 0,
+          "precision": 1.0,
+          "recall": 1.0,
+          "true_positive": 1
+        },
+        "attempt:correction_of": {
+          "f1": 0.0,
+          "false_negative": 1,
+          "false_positive": 0,
+          "precision": 0.0,
+          "recall": 0.0,
+          "true_positive": 0
+        },
+        "attempt:retry_of": {
+          "f1": 1.0,
+          "false_negative": 0,
+          "false_positive": 0,
+          "precision": 1.0,
+          "recall": 1.0,
+          "true_positive": 1
+        },
+        "attempt:supersedes": {
+          "f1": 0.0,
+          "false_negative": 0,
+          "false_positive": 1,
+          "precision": 0.0,
+          "recall": 0.0,
+          "true_positive": 0
+        },
+        "task:depends_on": {
+          "f1": 0.0,
+          "false_negative": 0,
+          "false_positive": 1,
+          "precision": 0.0,
+          "recall": 0.0,
+          "true_positive": 0
+        },
+        "task:parent": {
+          "f1": 0.0,
+          "false_negative": 1,
+          "false_positive": 0,
+          "precision": 0.0,
+          "recall": 0.0,
+          "true_positive": 0
+        },
+        "task:subtask": {
+          "f1": 1.0,
+          "false_negative": 0,
+          "false_positive": 0,
+          "precision": 1.0,
+          "recall": 1.0,
+          "true_positive": 1
+        }
+      },
+      "macro": {
+        "f1": 0.428571,
+        "precision": 0.428571,
+        "recall": 0.428571
+      },
+      "micro": {
+        "f1": 0.6,
+        "false_negative": 2,
+        "false_positive": 2,
+        "precision": 0.6,
+        "recall": 0.6,
+        "true_positive": 3
+      }
+    },
+    "task_grouping": {
+      "b3": {
+        "f1": 0.967742,
+        "precision": 1.0,
+        "recall": 0.9375
+      },
+      "pairwise": {
+        "f1": 0.909091,
+        "false_negative": 1,
+        "false_positive": 0,
+        "precision": 1.0,
+        "recall": 0.833333,
+        "true_positive": 5
+      }
+    },
+    "usage": {
+      "execution": {
+        "allocated_cost_usd": 0.034,
+        "allocated_total_tokens": 340,
+        "conservation_rate": 1.0,
+        "estimated_events": 0,
+        "events": 4,
+        "measured_events": 3,
+        "raw_cost_usd": 0.034,
+        "raw_total_tokens": 340,
+        "shared_fraction": 0.5,
+        "unattributed_fraction": 0.25,
+        "unavailable_events": 1
+      },
+      "xskill_processing": {
+        "allocated_cost_usd": 0.006,
+        "allocated_total_tokens": 60,
+        "conservation_rate": 1.0,
+        "estimated_events": 1,
+        "events": 3,
+        "measured_events": 2,
+        "raw_cost_usd": 0.006,
+        "raw_total_tokens": 60,
+        "shared_fraction": 0.0,
+        "unattributed_fraction": 0.066667,
+        "unavailable_events": 0
+      }
+    }
+  },
+  "report_sha256": "8d485521fc06647ec457345e7f21d802b3175e3c0a3ca9f82ad37c7728b1c9ef",
+  "run_manifest": {
+    "generated_at": "2026-08-25T00:00:00Z",
+    "harness": "offline-replay",
+    "model": "recorded-fixture",
+    "prompt_fingerprint": "sha256:3565cbdfde8bf0bf0aa8043f18dfb8db69d8e829e7831175b0875b60848834f1",
+    "repository_revision": "14f8f27d173e443e631248f873d158b2c34dc8d5",
+    "seed": 0
+  },
+  "schema_version": 1,
+  "suite_id": "logical-task-attempt-baseline-v1"
+}

--- a/scripts/bench/task_graph_replay/fixtures/baseline_v1.report.json
+++ b/scripts/bench/task_graph_replay/fixtures/baseline_v1.report.json
@@ -2,6 +2,8 @@
   "cases": [
     {
       "case_id": "single-task-cross-session-attempt",
+      "error_count": 0,
+      "error_examples_truncated": false,
       "errors": [],
       "metrics": {
         "attempt_detection": {
@@ -38,6 +40,44 @@
           }
         },
         "evidence_coverage": 1.0,
+        "execution_attribution": {
+          "execution_identity": {
+            "accuracy": 1.0,
+            "correct": 1,
+            "coverage": 1.0,
+            "expected": 1,
+            "present": 1
+          },
+          "harness": {
+            "accuracy": 1.0,
+            "correct": 1,
+            "coverage": 1.0,
+            "expected": 1,
+            "present": 1
+          },
+          "model": {
+            "accuracy": 1.0,
+            "correct": 1,
+            "coverage": 1.0,
+            "expected": 1,
+            "present": 1
+          },
+          "skills": {
+            "accuracy": 1.0,
+            "correct": 1,
+            "coverage": 1.0,
+            "expected": 1,
+            "present": 1
+          }
+        },
+        "membership_detection": {
+          "f1": 1.0,
+          "false_negative": 0,
+          "false_positive": 0,
+          "precision": 1.0,
+          "recall": 1.0,
+          "true_positive": 2
+        },
         "relations": {
           "by_type": {},
           "macro": {
@@ -71,26 +111,38 @@
         },
         "usage": {
           "execution": {
+            "allocated_cache_read_tokens": 60,
+            "allocated_completion_tokens": 20,
             "allocated_cost_usd": 0.01,
+            "allocated_prompt_tokens": 80,
             "allocated_total_tokens": 100,
             "conservation_rate": 1.0,
             "estimated_events": 0,
             "events": 1,
             "measured_events": 1,
+            "raw_cache_read_tokens": 60,
+            "raw_completion_tokens": 20,
             "raw_cost_usd": 0.01,
+            "raw_prompt_tokens": 80,
             "raw_total_tokens": 100,
             "shared_fraction": 0.0,
             "unattributed_fraction": 0.0,
             "unavailable_events": 0
           },
           "xskill_processing": {
+            "allocated_cache_read_tokens": 0,
+            "allocated_completion_tokens": 5,
             "allocated_cost_usd": 0.002,
+            "allocated_prompt_tokens": 15,
             "allocated_total_tokens": 20,
             "conservation_rate": 1.0,
             "estimated_events": 0,
             "events": 1,
             "measured_events": 1,
+            "raw_cache_read_tokens": 0,
+            "raw_completion_tokens": 5,
             "raw_cost_usd": 0.002,
+            "raw_prompt_tokens": 15,
             "raw_total_tokens": 20,
             "shared_fraction": 0.0,
             "unattributed_fraction": 0.0,
@@ -101,6 +153,8 @@
     },
     {
       "case_id": "a-b-a-and-attempt-over-split",
+      "error_count": 2,
+      "error_examples_truncated": false,
       "errors": [
         {
           "atom_keys": [
@@ -149,6 +203,44 @@
           }
         },
         "evidence_coverage": 0.666667,
+        "execution_attribution": {
+          "execution_identity": {
+            "accuracy": 0.0,
+            "correct": 0,
+            "coverage": 0.0,
+            "expected": 0,
+            "present": 0
+          },
+          "harness": {
+            "accuracy": 0.0,
+            "correct": 0,
+            "coverage": 0.0,
+            "expected": 0,
+            "present": 0
+          },
+          "model": {
+            "accuracy": 0.0,
+            "correct": 0,
+            "coverage": 0.0,
+            "expected": 0,
+            "present": 0
+          },
+          "skills": {
+            "accuracy": 0.0,
+            "correct": 0,
+            "coverage": 0.0,
+            "expected": 0,
+            "present": 0
+          }
+        },
+        "membership_detection": {
+          "f1": 1.0,
+          "false_negative": 0,
+          "false_positive": 0,
+          "precision": 1.0,
+          "recall": 1.0,
+          "true_positive": 3
+        },
         "relations": {
           "by_type": {},
           "macro": {
@@ -182,26 +274,38 @@
         },
         "usage": {
           "execution": {
+            "allocated_cache_read_tokens": 40,
+            "allocated_completion_tokens": 30,
             "allocated_cost_usd": 0.012,
+            "allocated_prompt_tokens": 90,
             "allocated_total_tokens": 120,
             "conservation_rate": 1.0,
             "estimated_events": 0,
             "events": 1,
             "measured_events": 1,
+            "raw_cache_read_tokens": 40,
+            "raw_completion_tokens": 30,
             "raw_cost_usd": 0.012,
+            "raw_prompt_tokens": 90,
             "raw_total_tokens": 120,
             "shared_fraction": 1.0,
             "unattributed_fraction": 0.0,
             "unavailable_events": 0
           },
           "xskill_processing": {
+            "allocated_cache_read_tokens": 0,
+            "allocated_completion_tokens": 0,
             "allocated_cost_usd": 0.0,
+            "allocated_prompt_tokens": 0,
             "allocated_total_tokens": 0,
             "conservation_rate": 1.0,
             "estimated_events": 0,
             "events": 0,
             "measured_events": 0,
+            "raw_cache_read_tokens": 0,
+            "raw_completion_tokens": 0,
             "raw_cost_usd": 0.0,
+            "raw_prompt_tokens": 0,
             "raw_total_tokens": 0,
             "shared_fraction": 0.0,
             "unattributed_fraction": 0.0,
@@ -212,6 +316,8 @@
     },
     {
       "case_id": "retry-with-outcome-mismatch",
+      "error_count": 1,
+      "error_examples_truncated": false,
       "errors": [
         {
           "attempt_id": "gold-attempt-c2",
@@ -265,6 +371,44 @@
           }
         },
         "evidence_coverage": 1.0,
+        "execution_attribution": {
+          "execution_identity": {
+            "accuracy": 0.0,
+            "correct": 0,
+            "coverage": 0.0,
+            "expected": 0,
+            "present": 0
+          },
+          "harness": {
+            "accuracy": 0.0,
+            "correct": 0,
+            "coverage": 0.0,
+            "expected": 0,
+            "present": 0
+          },
+          "model": {
+            "accuracy": 0.0,
+            "correct": 0,
+            "coverage": 0.0,
+            "expected": 0,
+            "present": 0
+          },
+          "skills": {
+            "accuracy": 0.0,
+            "correct": 0,
+            "coverage": 0.0,
+            "expected": 0,
+            "present": 0
+          }
+        },
+        "membership_detection": {
+          "f1": 1.0,
+          "false_negative": 0,
+          "false_positive": 0,
+          "precision": 1.0,
+          "recall": 1.0,
+          "true_positive": 2
+        },
         "relations": {
           "by_type": {
             "attempt:retry_of": {
@@ -307,26 +451,38 @@
         },
         "usage": {
           "execution": {
+            "allocated_cache_read_tokens": 30,
+            "allocated_completion_tokens": 40,
             "allocated_cost_usd": 0.012,
+            "allocated_prompt_tokens": 80,
             "allocated_total_tokens": 120,
             "conservation_rate": 1.0,
             "estimated_events": 0,
             "events": 1,
             "measured_events": 1,
+            "raw_cache_read_tokens": 30,
+            "raw_completion_tokens": 40,
             "raw_cost_usd": 0.012,
+            "raw_prompt_tokens": 80,
             "raw_total_tokens": 120,
             "shared_fraction": 1.0,
             "unattributed_fraction": 0.0,
             "unavailable_events": 0
           },
           "xskill_processing": {
+            "allocated_cache_read_tokens": 0,
+            "allocated_completion_tokens": 10,
             "allocated_cost_usd": 0.003,
+            "allocated_prompt_tokens": 20,
             "allocated_total_tokens": 30,
             "conservation_rate": 1.0,
             "estimated_events": 1,
             "events": 1,
             "measured_events": 0,
+            "raw_cache_read_tokens": 0,
+            "raw_completion_tokens": 10,
             "raw_cost_usd": 0.003,
+            "raw_prompt_tokens": 20,
             "raw_total_tokens": 30,
             "shared_fraction": 0.0,
             "unattributed_fraction": 0.0,
@@ -337,6 +493,8 @@
     },
     {
       "case_id": "parent-subtask-and-unavailable-usage",
+      "error_count": 2,
+      "error_examples_truncated": false,
       "errors": [
         {
           "relation": [
@@ -398,6 +556,44 @@
           }
         },
         "evidence_coverage": 1.0,
+        "execution_attribution": {
+          "execution_identity": {
+            "accuracy": 0.0,
+            "correct": 0,
+            "coverage": 0.0,
+            "expected": 0,
+            "present": 0
+          },
+          "harness": {
+            "accuracy": 0.0,
+            "correct": 0,
+            "coverage": 0.0,
+            "expected": 0,
+            "present": 0
+          },
+          "model": {
+            "accuracy": 0.0,
+            "correct": 0,
+            "coverage": 0.0,
+            "expected": 0,
+            "present": 0
+          },
+          "skills": {
+            "accuracy": 0.0,
+            "correct": 0,
+            "coverage": 0.0,
+            "expected": 0,
+            "present": 0
+          }
+        },
+        "membership_detection": {
+          "f1": 1.0,
+          "false_negative": 0,
+          "false_positive": 0,
+          "precision": 1.0,
+          "recall": 1.0,
+          "true_positive": 3
+        },
         "relations": {
           "by_type": {
             "task:depends_on": {
@@ -409,26 +605,18 @@
               "true_positive": 0
             },
             "task:parent": {
-              "f1": 0.0,
+              "f1": 0.666667,
               "false_negative": 1,
               "false_positive": 0,
-              "precision": 0.0,
-              "recall": 0.0,
-              "true_positive": 0
-            },
-            "task:subtask": {
-              "f1": 1.0,
-              "false_negative": 0,
-              "false_positive": 0,
               "precision": 1.0,
-              "recall": 1.0,
+              "recall": 0.5,
               "true_positive": 1
             }
           },
           "macro": {
-            "f1": 0.333333,
-            "precision": 0.333333,
-            "recall": 0.333333
+            "f1": 0.333334,
+            "precision": 0.5,
+            "recall": 0.25
           },
           "micro": {
             "f1": 0.5,
@@ -456,26 +644,38 @@
         },
         "usage": {
           "execution": {
+            "allocated_cache_read_tokens": 0,
+            "allocated_completion_tokens": 0,
             "allocated_cost_usd": 0.0,
+            "allocated_prompt_tokens": 0,
             "allocated_total_tokens": 0,
             "conservation_rate": 1.0,
             "estimated_events": 0,
             "events": 1,
             "measured_events": 0,
+            "raw_cache_read_tokens": 0,
+            "raw_completion_tokens": 0,
             "raw_cost_usd": 0.0,
+            "raw_prompt_tokens": 0,
             "raw_total_tokens": 0,
             "shared_fraction": 0.0,
             "unattributed_fraction": 1.0,
             "unavailable_events": 1
           },
           "xskill_processing": {
+            "allocated_cache_read_tokens": 4,
+            "allocated_completion_tokens": 2,
             "allocated_cost_usd": 0.001,
+            "allocated_prompt_tokens": 8,
             "allocated_total_tokens": 10,
             "conservation_rate": 1.0,
             "estimated_events": 0,
             "events": 1,
             "measured_events": 1,
+            "raw_cache_read_tokens": 4,
+            "raw_completion_tokens": 2,
             "raw_cost_usd": 0.001,
+            "raw_prompt_tokens": 8,
             "raw_total_tokens": 10,
             "shared_fraction": 0.0,
             "unattributed_fraction": 0.2,
@@ -486,6 +686,8 @@
     },
     {
       "case_id": "continuation-correction-and-version-change",
+      "error_count": 2,
+      "error_examples_truncated": false,
       "errors": [
         {
           "relation": [
@@ -549,6 +751,44 @@
           }
         },
         "evidence_coverage": 1.0,
+        "execution_attribution": {
+          "execution_identity": {
+            "accuracy": 1.0,
+            "correct": 3,
+            "coverage": 1.0,
+            "expected": 3,
+            "present": 3
+          },
+          "harness": {
+            "accuracy": 1.0,
+            "correct": 3,
+            "coverage": 1.0,
+            "expected": 3,
+            "present": 3
+          },
+          "model": {
+            "accuracy": 1.0,
+            "correct": 3,
+            "coverage": 1.0,
+            "expected": 3,
+            "present": 3
+          },
+          "skills": {
+            "accuracy": 1.0,
+            "correct": 3,
+            "coverage": 1.0,
+            "expected": 3,
+            "present": 3
+          }
+        },
+        "membership_detection": {
+          "f1": 1.0,
+          "false_negative": 0,
+          "false_positive": 0,
+          "precision": 1.0,
+          "recall": 1.0,
+          "true_positive": 3
+        },
         "relations": {
           "by_type": {
             "attempt:continuation_of": {
@@ -607,26 +847,38 @@
         },
         "usage": {
           "execution": {
+            "allocated_cache_read_tokens": 0,
+            "allocated_completion_tokens": 0,
             "allocated_cost_usd": 0.0,
+            "allocated_prompt_tokens": 0,
             "allocated_total_tokens": 0,
             "conservation_rate": 1.0,
             "estimated_events": 0,
             "events": 0,
             "measured_events": 0,
+            "raw_cache_read_tokens": 0,
+            "raw_completion_tokens": 0,
             "raw_cost_usd": 0.0,
+            "raw_prompt_tokens": 0,
             "raw_total_tokens": 0,
             "shared_fraction": 0.0,
             "unattributed_fraction": 0.0,
             "unavailable_events": 0
           },
           "xskill_processing": {
+            "allocated_cache_read_tokens": 0,
+            "allocated_completion_tokens": 0,
             "allocated_cost_usd": 0.0,
+            "allocated_prompt_tokens": 0,
             "allocated_total_tokens": 0,
             "conservation_rate": 1.0,
             "estimated_events": 0,
             "events": 0,
             "measured_events": 0,
+            "raw_cache_read_tokens": 0,
+            "raw_completion_tokens": 0,
             "raw_cost_usd": 0.0,
+            "raw_prompt_tokens": 0,
             "raw_total_tokens": 0,
             "shared_fraction": 0.0,
             "unattributed_fraction": 0.0,
@@ -637,6 +889,8 @@
     },
     {
       "case_id": "terminal-states-and-cross-session-negative",
+      "error_count": 0,
+      "error_examples_truncated": false,
       "errors": [],
       "metrics": {
         "attempt_detection": {
@@ -683,6 +937,44 @@
           }
         },
         "evidence_coverage": 1.0,
+        "execution_attribution": {
+          "execution_identity": {
+            "accuracy": 0.0,
+            "correct": 0,
+            "coverage": 0.0,
+            "expected": 0,
+            "present": 0
+          },
+          "harness": {
+            "accuracy": 0.0,
+            "correct": 0,
+            "coverage": 0.0,
+            "expected": 0,
+            "present": 0
+          },
+          "model": {
+            "accuracy": 0.0,
+            "correct": 0,
+            "coverage": 0.0,
+            "expected": 0,
+            "present": 0
+          },
+          "skills": {
+            "accuracy": 0.0,
+            "correct": 0,
+            "coverage": 0.0,
+            "expected": 0,
+            "present": 0
+          }
+        },
+        "membership_detection": {
+          "f1": 1.0,
+          "false_negative": 0,
+          "false_positive": 0,
+          "precision": 1.0,
+          "recall": 1.0,
+          "true_positive": 3
+        },
         "relations": {
           "by_type": {},
           "macro": {
@@ -716,26 +1008,38 @@
         },
         "usage": {
           "execution": {
+            "allocated_cache_read_tokens": 0,
+            "allocated_completion_tokens": 0,
             "allocated_cost_usd": 0.0,
+            "allocated_prompt_tokens": 0,
             "allocated_total_tokens": 0,
             "conservation_rate": 1.0,
             "estimated_events": 0,
             "events": 0,
             "measured_events": 0,
+            "raw_cache_read_tokens": 0,
+            "raw_completion_tokens": 0,
             "raw_cost_usd": 0.0,
+            "raw_prompt_tokens": 0,
             "raw_total_tokens": 0,
             "shared_fraction": 0.0,
             "unattributed_fraction": 0.0,
             "unavailable_events": 0
           },
           "xskill_processing": {
+            "allocated_cache_read_tokens": 0,
+            "allocated_completion_tokens": 0,
             "allocated_cost_usd": 0.0,
+            "allocated_prompt_tokens": 0,
             "allocated_total_tokens": 0,
             "conservation_rate": 1.0,
             "estimated_events": 0,
             "events": 0,
             "measured_events": 0,
+            "raw_cache_read_tokens": 0,
+            "raw_completion_tokens": 0,
             "raw_cost_usd": 0.0,
+            "raw_prompt_tokens": 0,
             "raw_total_tokens": 0,
             "shared_fraction": 0.0,
             "unattributed_fraction": 0.0,
@@ -746,6 +1050,7 @@
     }
   ],
   "error_count": 7,
+  "error_examples_truncated": false,
   "metric_config": {
     "ece_bins": 5,
     "usage_numeric_tolerance": 1e-09
@@ -805,6 +1110,44 @@
       }
     },
     "evidence_coverage": 0.9375,
+    "execution_attribution": {
+      "execution_identity": {
+        "accuracy": 1.0,
+        "correct": 4,
+        "coverage": 1.0,
+        "expected": 4,
+        "present": 4
+      },
+      "harness": {
+        "accuracy": 1.0,
+        "correct": 4,
+        "coverage": 1.0,
+        "expected": 4,
+        "present": 4
+      },
+      "model": {
+        "accuracy": 1.0,
+        "correct": 4,
+        "coverage": 1.0,
+        "expected": 4,
+        "present": 4
+      },
+      "skills": {
+        "accuracy": 1.0,
+        "correct": 4,
+        "coverage": 1.0,
+        "expected": 4,
+        "present": 4
+      }
+    },
+    "membership_detection": {
+      "f1": 1.0,
+      "false_negative": 0,
+      "false_positive": 0,
+      "precision": 1.0,
+      "recall": 1.0,
+      "true_positive": 16
+    },
     "relations": {
       "by_type": {
         "attempt:continuation_of": {
@@ -848,26 +1191,18 @@
           "true_positive": 0
         },
         "task:parent": {
-          "f1": 0.0,
+          "f1": 0.666667,
           "false_negative": 1,
           "false_positive": 0,
-          "precision": 0.0,
-          "recall": 0.0,
-          "true_positive": 0
-        },
-        "task:subtask": {
-          "f1": 1.0,
-          "false_negative": 0,
-          "false_positive": 0,
           "precision": 1.0,
-          "recall": 1.0,
+          "recall": 0.5,
           "true_positive": 1
         }
       },
       "macro": {
-        "f1": 0.428571,
-        "precision": 0.428571,
-        "recall": 0.428571
+        "f1": 0.444444,
+        "precision": 0.5,
+        "recall": 0.416667
       },
       "micro": {
         "f1": 0.6,
@@ -895,26 +1230,38 @@
     },
     "usage": {
       "execution": {
+        "allocated_cache_read_tokens": 130,
+        "allocated_completion_tokens": 90,
         "allocated_cost_usd": 0.034,
+        "allocated_prompt_tokens": 250,
         "allocated_total_tokens": 340,
         "conservation_rate": 1.0,
         "estimated_events": 0,
         "events": 4,
         "measured_events": 3,
+        "raw_cache_read_tokens": 130,
+        "raw_completion_tokens": 90,
         "raw_cost_usd": 0.034,
+        "raw_prompt_tokens": 250,
         "raw_total_tokens": 340,
         "shared_fraction": 0.5,
         "unattributed_fraction": 0.25,
         "unavailable_events": 1
       },
       "xskill_processing": {
+        "allocated_cache_read_tokens": 4,
+        "allocated_completion_tokens": 17,
         "allocated_cost_usd": 0.006,
+        "allocated_prompt_tokens": 43,
         "allocated_total_tokens": 60,
         "conservation_rate": 1.0,
         "estimated_events": 1,
         "events": 3,
         "measured_events": 2,
+        "raw_cache_read_tokens": 4,
+        "raw_completion_tokens": 17,
         "raw_cost_usd": 0.006,
+        "raw_prompt_tokens": 43,
         "raw_total_tokens": 60,
         "shared_fraction": 0.0,
         "unattributed_fraction": 0.066667,
@@ -922,7 +1269,7 @@
       }
     }
   },
-  "report_sha256": "8d485521fc06647ec457345e7f21d802b3175e3c0a3ca9f82ad37c7728b1c9ef",
+  "report_sha256": "94d911dd303172d46a8fc5d6104da55b67c79d51a16ea2aa087a993c337f978e",
   "run_manifest": {
     "generated_at": "2026-08-25T00:00:00Z",
     "harness": "offline-replay",

--- a/tests/test_task_graph_replay.py
+++ b/tests/test_task_graph_replay.py
@@ -1,0 +1,146 @@
+"""Contracts for the deterministic Logical Task and Attempt replay."""
+
+from __future__ import annotations
+
+import json
+from copy import deepcopy
+from pathlib import Path
+
+import pytest
+
+from scripts.bench.task_graph_replay.evaluate import (
+    TaskReplayValidationError,
+    evaluate_suite,
+    load_suite,
+    main,
+    render_text,
+    validate_suite,
+)
+
+FIXTURE_DIR = (
+    Path(__file__).parent.parent
+    / "scripts"
+    / "bench"
+    / "task_graph_replay"
+    / "fixtures"
+)
+BASELINE_PATH = FIXTURE_DIR / "baseline_v1.json"
+REPORT_PATH = FIXTURE_DIR / "baseline_v1.report.json"
+
+
+pytestmark = pytest.mark.algorithm_replay
+
+
+def test_baseline_report_matches_checked_in_snapshot():
+    report = evaluate_suite(load_suite(BASELINE_PATH))
+
+    assert report == json.loads(REPORT_PATH.read_text(encoding="utf-8"))
+
+
+def test_baseline_exposes_expected_regression_signals():
+    report = evaluate_suite(load_suite(BASELINE_PATH))
+    metrics = report["metrics"]
+
+    assert metrics["task_grouping"]["pairwise"]["f1"] < 1.0
+    assert metrics["task_grouping"]["b3"]["f1"] < 1.0
+    assert metrics["relations"]["macro"]["f1"] < 1.0
+    assert set(metrics["relations"]["by_type"]) >= {
+        "task:parent",
+        "task:subtask",
+        "attempt:continuation_of",
+        "attempt:correction_of",
+        "attempt:retry_of",
+    }
+    assert metrics["attempt_detection"]["precision"] < 1.0
+    assert metrics["attempt_outcome"]["accuracy"] < 1.0
+    assert metrics["confidence"]["membership"]["brier"] > 0.0
+    assert metrics["confidence"]["attempt_outcome"]["ece"] > 0.0
+    assert metrics["evidence_coverage"] < 1.0
+    assert metrics["usage"]["execution"]["conservation_rate"] == 1.0
+    assert metrics["usage"]["xskill_processing"]["conservation_rate"] == 1.0
+    assert metrics["usage"]["execution"]["shared_fraction"] > 0.0
+    assert metrics["usage"]["execution"]["unattributed_fraction"] > 0.0
+    assert metrics["usage"]["execution"]["unavailable_events"] == 1
+    assert metrics["usage"]["xskill_processing"]["estimated_events"] == 1
+    assert report["error_count"] > 0
+
+
+def test_valid_false_merge_reduces_pairwise_precision():
+    suite = load_suite(BASELINE_PATH)
+    case = suite["cases"][1]
+    case["prediction"]["memberships"][1]["task_id"] = "pred-task-a"
+    case["prediction"]["attempts"][1]["task_id"] = "pred-task-a"
+    case["prediction"]["usage_allocations"][1]["task_id"] = "pred-task-a"
+
+    metrics = evaluate_suite(suite)["cases"][1]["metrics"]
+
+    assert metrics["task_grouping"]["pairwise"]["precision"] < 1.0
+
+
+def test_numeric_usage_imbalance_is_reported_without_hiding_the_event():
+    suite = load_suite(BASELINE_PATH)
+    allocation = suite["cases"][2]["prediction"]["usage_allocations"][0]
+    allocation["total_tokens"] = 59
+
+    case = evaluate_suite(suite)["cases"][2]
+
+    assert case["metrics"]["usage"]["execution"]["conservation_rate"] == 0.0
+    assert any(error["type"] == "usage_not_conserved" for error in case["errors"])
+
+
+def test_multiple_confirmed_primary_memberships_use_production_invariant():
+    suite = load_suite(BASELINE_PATH)
+    broken = deepcopy(suite)
+    broken["cases"][1]["prediction"]["memberships"][3]["decision"] = "confirmed"
+
+    with pytest.raises(
+        TaskReplayValidationError,
+        match="at most one confirmed primary membership",
+    ):
+        validate_suite(broken)
+
+
+def test_unknown_usage_event_fails_loudly():
+    suite = load_suite(BASELINE_PATH)
+    suite["cases"][0]["prediction"]["usage_allocations"][0]["usage_event_id"] = (
+        "missing-event"
+    )
+
+    with pytest.raises(TaskReplayValidationError, match="unknown usage event"):
+        validate_suite(suite)
+
+
+def test_out_of_range_confidence_fails_loudly():
+    suite = load_suite(BASELINE_PATH)
+    suite["cases"][0]["prediction"]["memberships"][0]["confidence"] = 1.1
+
+    with pytest.raises(TaskReplayValidationError, match=r"within \[0, 1\]"):
+        validate_suite(suite)
+
+
+def test_missing_gold_atom_membership_fails_loudly():
+    suite = load_suite(BASELINE_PATH)
+    suite["cases"][0]["gold"]["memberships"].pop()
+
+    with pytest.raises(TaskReplayValidationError, match="every annotated Atom"):
+        validate_suite(suite)
+
+
+def test_unsupported_schema_version_fails_loudly():
+    suite = load_suite(BASELINE_PATH)
+    suite["schema_version"] = 2
+
+    with pytest.raises(TaskReplayValidationError, match="supported=1, got=2"):
+        validate_suite(suite)
+
+
+def test_cli_renders_text_and_json(capsys):
+    assert main([str(BASELINE_PATH)]) == 0
+    assert capsys.readouterr().out == (
+        render_text(evaluate_suite(load_suite(BASELINE_PATH))) + "\n"
+    )
+
+    assert main([str(BASELINE_PATH), "--format", "json"]) == 0
+    assert json.loads(capsys.readouterr().out) == evaluate_suite(
+        load_suite(BASELINE_PATH)
+    )

--- a/tests/test_task_graph_replay.py
+++ b/tests/test_task_graph_replay.py
@@ -9,6 +9,7 @@ from pathlib import Path
 import pytest
 
 from scripts.bench.task_graph_replay.evaluate import (
+    ERROR_EXAMPLE_LIMIT,
     TaskReplayValidationError,
     evaluate_suite,
     load_suite,
@@ -46,15 +47,19 @@ def test_baseline_exposes_expected_regression_signals():
     assert metrics["relations"]["macro"]["f1"] < 1.0
     assert set(metrics["relations"]["by_type"]) >= {
         "task:parent",
-        "task:subtask",
         "attempt:continuation_of",
         "attempt:correction_of",
         "attempt:retry_of",
     }
     assert metrics["attempt_detection"]["precision"] < 1.0
+    assert metrics["membership_detection"]["f1"] == 1.0
     assert metrics["attempt_outcome"]["accuracy"] < 1.0
     assert metrics["confidence"]["membership"]["brier"] > 0.0
     assert metrics["confidence"]["attempt_outcome"]["ece"] > 0.0
+    assert all(
+        values["accuracy"] == 1.0 and values["coverage"] == 1.0
+        for values in metrics["execution_attribution"].values()
+    )
     assert metrics["evidence_coverage"] < 1.0
     assert metrics["usage"]["execution"]["conservation_rate"] == 1.0
     assert metrics["usage"]["xskill_processing"]["conservation_rate"] == 1.0
@@ -86,6 +91,124 @@ def test_numeric_usage_imbalance_is_reported_without_hiding_the_event():
 
     assert case["metrics"]["usage"]["execution"]["conservation_rate"] == 0.0
     assert any(error["type"] == "usage_not_conserved" for error in case["errors"])
+
+
+@pytest.mark.parametrize(
+    "field",
+    ["prompt_tokens", "completion_tokens", "total_tokens", "cache_read_tokens"],
+)
+def test_each_token_component_participates_in_conservation(field):
+    suite = load_suite(BASELINE_PATH)
+    allocation = suite["cases"][0]["prediction"]["usage_allocations"][0]
+    allocation[field] -= 1
+
+    case = evaluate_suite(suite)["cases"][0]
+
+    assert case["metrics"]["usage"]["execution"]["conservation_rate"] == 0.0
+    error = next(
+        error for error in case["errors"] if error["type"] == "usage_not_conserved"
+    )
+    assert error["token_deltas"][field] == -1
+
+
+def test_missing_singleton_membership_reduces_detection_and_confidence_coverage():
+    suite = load_suite(BASELINE_PATH)
+    suite["cases"][5]["prediction"]["memberships"].pop(0)
+
+    case = evaluate_suite(suite)["cases"][5]
+
+    assert case["metrics"]["task_grouping"]["b3"]["f1"] == 1.0
+    assert case["metrics"]["membership_detection"]["recall"] == 0.666667
+    assert case["metrics"]["confidence"]["membership"]["coverage"] == 0.666667
+    assert any(error["type"] == "membership_missing" for error in case["errors"])
+
+
+def test_parent_and_inverse_subtask_are_the_same_semantic_relation():
+    suite = load_suite(BASELINE_PATH)
+    suite["cases"][3]["prediction"]["task_relations"][0] = {
+        "from_task_id": "pred-child",
+        "to_task_id": "pred-parent",
+        "relation_type": "subtask",
+        "confidence": 0.9,
+    }
+
+    case = evaluate_suite(suite)["cases"][3]
+
+    assert case["metrics"]["relations"]["micro"]["f1"] == 1.0
+    assert not any(error["type"].startswith("relation_") for error in case["errors"])
+
+
+@pytest.mark.parametrize("field", ["model", "harness", "skills", "execution_identity"])
+def test_execution_attribution_changes_are_reported(field):
+    suite = load_suite(BASELINE_PATH)
+    attempt = suite["cases"][4]["prediction"]["attempts"][0]
+    attempt[field] = (
+        [{"name": "different", "version": "v9"}]
+        if field == "skills"
+        else {"name": "different", "version": "v9"}
+    )
+
+    case = evaluate_suite(suite)["cases"][4]
+
+    assert case["metrics"]["execution_attribution"][field]["accuracy"] < 1.0
+    assert any(
+        error["type"] == "execution_attribution_mismatch" and error["field"] == field
+        for error in case["errors"]
+    )
+
+
+def test_large_false_split_keeps_exact_count_and_bounds_error_examples():
+    suite = load_suite(BASELINE_PATH)
+    atom_count = 150
+    suite["cases"] = [
+        {
+            "case_id": "bounded-pair-errors",
+            "atoms": [
+                {
+                    "atom_id": f"atom-{index}",
+                    "traj_id": f"traj-{index}",
+                    "start": 1,
+                    "end": 2,
+                }
+                for index in range(atom_count)
+            ],
+            "gold": {
+                "memberships": [
+                    {"atom_id": f"atom-{index}", "task_id": "gold-task"}
+                    for index in range(atom_count)
+                ],
+                "task_relations": [],
+                "attempts": [],
+                "attempt_relations": [],
+            },
+            "prediction": {
+                "memberships": [
+                    {
+                        "atom_id": f"atom-{index}",
+                        "task_id": f"pred-task-{index}",
+                        "confidence": 0.9,
+                    }
+                    for index in range(atom_count)
+                ],
+                "task_relations": [],
+                "attempts": [],
+                "attempt_relations": [],
+                "usage_allocations": [],
+            },
+            "usage_events": [],
+        }
+    ]
+
+    report = evaluate_suite(suite)
+    expected_pairs = atom_count * (atom_count - 1) // 2
+
+    assert (
+        report["metrics"]["task_grouping"]["pairwise"]["false_negative"]
+        == expected_pairs
+    )
+    assert report["error_count"] == expected_pairs
+    assert len(report["cases"][0]["errors"]) == ERROR_EXAMPLE_LIMIT
+    assert report["cases"][0]["error_examples_truncated"] is True
 
 
 def test_multiple_confirmed_primary_memberships_use_production_invariant():


### PR DESCRIPTION
## Summary

为 Logical Task、Task Attempt、关系、终态、置信度、执行版本和双平面用量归因建立固定离线回放基线。

评测输入会先编译为生产代码的 `TaskGraphGeneration` 并执行正式不变量校验，本 PR 不修改生产拆分、关联、Registry 或 Dashboard 行为。

## Changes

- 增加 6 组脱敏固定 case，覆盖跨 Session、A → B → A、重试、继续、纠正、父子与子任务关系、取消、阻塞、部分完成以及模型、Harness、Skill 版本变化。
- 增加 Task pairwise/B³、membership detection、relation micro/macro-F1、Attempt detection/outcome、Brier/ECE、evidence coverage 和 execution attribution 指标。
- 将 `parent(A, B)` 与 `subtask(B, A)` 规范化为同一语义关系，并独立暴露缺失 membership 和置信度覆盖率。
- 分开统计 `execution` 与 `xskill_processing`，检查 prompt、completion、total、cache-read Token、fraction 和 cost 守恒。
- 使用 contingency 线性累计替代 O(n²) Atom 对物化，保持精确错误总数并将错误样例限制为 100 条。
- 增加逐 case 错误输出、机器可读 snapshot、运行说明和 fail-loud schema/不变量测试。

## Test plan

- [x] 完整单元测试通过：`2482 passed, 10 skipped`。
- [x] 聚焦测试通过：`58 passed`。
- [x] Ruff 规则与格式检查通过。
- [x] 10,000 Atom 极端误拆分回放在 1.42 秒、约 84 MiB 峰值内完成，精确统计 49,995,000 个错误对并只保留 100 条样例。
- [ ] `make e2e` passes（不适用：本 PR 不修改 ingestion、install 或 daemon 行为）。

## Linked issues

Closes #325
