### PR TITLE
feat(agents): 支持分阶段 LLM backend 配置

### DIFF
--- a/README.en.md
+++ b/README.en.md
@@ -102,6 +102,23 @@ embedding:
   dim:      0
 ```
 
+The `llm` block is the shared default. If you already have a config, you can leave it as-is.
+
+Want a different model or endpoint for split, cluster, or edit? Add an optional `llm_agents` block. You can skip it entirely. Any stage or field you leave out falls back to `llm_skill` (if you have one), then to `llm`. `xskill generate` still uses `llm` and `llm_skill` only. After changing these, just restart `xskill serve`.
+
+```yaml
+# optional — leave this out and all three stages keep using `llm` above
+llm_agents:
+  split:
+    model: qwen-plus
+  cluster:
+    model: deepseek-v4-flash
+  edit:
+    base_url: http://localhost:8000/v1
+    model: local-skill-editor
+    api_key: local
+```
+
 Run `xskill serve` again — it auto-detects every supported agent on your machine and starts watching. To backfill an archive of older trajectories:
 
 ```bash

--- a/README.md
+++ b/README.md
@@ -172,6 +172,23 @@ embedding:
   dim:      0
 ```
 
+上面这一段 `llm` 就是大家共用的默认模型。已经在用的配置不用改，继续这样写完全没问题。
+
+如果你想给流水线里的拆分、聚类、编辑各自换一个模型或地址，可以再加一段可选的 `llm_agents`。不写也没关系。某个阶段或某个字段没写的话，会先看看有没有 `llm_skill`，再回到 `llm`。`xskill generate` 还是用 `llm` 和 `llm_skill`，不会去读 `llm_agents`。改完这几段之后重启一下 `xskill serve` 就好。
+
+```yaml
+# 可选。不写这段的话，三个阶段都继续用上面的 llm
+llm_agents:
+  split:
+    model: qwen-plus
+  cluster:
+    model: deepseek-v4-flash
+  edit:
+    base_url: http://localhost:8000/v1
+    model: local-skill-editor
+    api_key: local
+```
+
 再跑一次 `xskill serve`, 它会自动识别你机器上每一个受支持的 agent 并开始运行，收集agent的轨迹并将skill推送到对应的harness下。
 
 > [!NOTE]

--- a/README.zh-CN.md
+++ b/README.zh-CN.md
@@ -67,6 +67,23 @@ embedding:
   dim:      0
 ```
 
+上面这一段 `llm` 就是大家共用的默认模型。已经在用的配置不用改，继续这样写完全没问题。
+
+如果你想给流水线里的拆分、聚类、编辑各自换一个模型或地址，可以再加一段可选的 `llm_agents`。不写也没关系。某个阶段或某个字段没写的话，会先看看有没有 `llm_skill`，再回到 `llm`。`xskill generate` 还是用 `llm` 和 `llm_skill`，不会去读 `llm_agents`。改完这几段之后重启一下 `xskill serve` 就好。
+
+```yaml
+# 可选。不写这段的话，三个阶段都继续用上面的 llm
+llm_agents:
+  split:
+    model: qwen-plus
+  cluster:
+    model: deepseek-v4-flash
+  edit:
+    base_url: http://localhost:8000/v1
+    model: local-skill-editor
+    api_key: local
+```
+
 再跑一次 `xskill serve`，它会自动扫机器上装好的所有 agent（Claude Code、Codex、OpenCode、OpenClaw、Cursor、Trae）开始监听。如果还有一份历史轨迹归档想一起吃进来：
 
 ```bash

--- a/skills/using-xskill/references/installation.md
+++ b/skills/using-xskill/references/installation.md
@@ -25,6 +25,28 @@ embedding:
   dim:      0
 ```
 
+The `llm` block is the shared default. If you already have a config, you can
+leave it as-is.
+
+Want a different model or endpoint for split, cluster, or edit? Add an optional
+`llm_agents` block. You can skip it entirely. Any stage or field you leave out
+falls back to `llm_skill` (if you have one), then to `llm`. `xskill generate`
+still uses `llm` and `llm_skill` only. After changing these, just restart
+`xskill serve`.
+
+```yaml
+# optional — leave this out and all three stages keep using `llm` above
+llm_agents:
+  split:
+    model: qwen-plus
+  cluster:
+    model: deepseek-v4-flash
+  edit:
+    base_url: http://localhost:8000/v1
+    model: local-skill-editor
+    api_key: local
+```
+
 Run `xskill serve` again — it auto-detects every supported agent on the machine and
 starts watching. To backfill an archive of old trajectories:
 

--- a/src/xskill/agents/agno_factory.py
+++ b/src/xskill/agents/agno_factory.py
@@ -25,6 +25,8 @@ from xskill.utils.llm import ssl_verify
 
 logger = logging.getLogger("xskill.agno_factory")
 
+AGENT_LLM_STAGES = frozenset(("split", "cluster", "edit"))
+
 
 def _discard_log(*args, **kwargs) -> None:
     del args, kwargs
@@ -372,8 +374,51 @@ def _wrap_with_trace(model):
     return model
 
 
+def resolve_agent_llm_config(config: dict, stage: str | None = None) -> dict:
+    """Resolve one Agno agent's effective LLM configuration.
+
+    ``llm`` and ``llm_skill`` keep their existing inheritance contract.  An
+    optional ``llm_agents.<stage>`` mapping is the final partial override, so
+    old configurations produce byte-for-byte equivalent effective values while
+    split, cluster, and edit can opt into different endpoints or models.
+    """
+    if stage is not None and stage not in AGENT_LLM_STAGES:
+        raise ValueError(
+            f"agent LLM stage must be one of {sorted(AGENT_LLM_STAGES)!r}, "
+            f"got {stage!r}"
+        )
+
+    base_cfg = config.get("llm", {}) or {}
+    skill_cfg = config.get("llm_skill", {}) or {}
+    llm_cfg = {
+        **base_cfg,
+        **{key: value for key, value in skill_cfg.items() if value},
+    }
+    if stage is not None:
+        stage_cfg = ((config.get("llm_agents", {}) or {}).get(stage, {}) or {})
+        stage_override = {
+            key: value
+            for key, value in stage_cfg.items()
+            if value not in (None, "")
+        }
+        stage_rate_limit = stage_override.pop("rate_limit", None)
+        llm_cfg.update(stage_override)
+        if stage_rate_limit:
+            llm_cfg["rate_limit"] = {
+                **(llm_cfg.get("rate_limit", {}) or {}),
+                **stage_rate_limit,
+            }
+
+    pool_cfg = (config.get("agent_worker", {}) or {}).get("pools", {}) or {}
+    llm_cfg["_pool_weights"] = {
+        name: int((pool_cfg.get(name, {}) or {}).get("llm_weight", 1))
+        for name in ("split", "cluster", "edit")
+    }
+    return llm_cfg
+
+
 def make_default_factory(
-    config: dict, *, usage_ledger=None, spill_root=None,
+    config: dict, *, stage: str | None = None, usage_ledger=None, spill_root=None,
 ) -> Callable[..., Any]:
     """生产环境的 agno Agent 工厂。
 
@@ -381,19 +426,12 @@ def make_default_factory(
     匹配 ``TaskClusterAgent`` / ``SkillEditAgent`` / ``process_atom_task``
     对 ``agno_agent_factory`` 的契约。
 
-    LLM 配置：优先 ``config['llm_skill']``（质量敏感的 cluster/edit），缺
-    项 fall back 到 ``config['llm']``。这与旧 ``run_agent`` 的行为一致。
+    LLM 配置：先按现有契约从 ``llm`` 合并 ``llm_skill``，再应用可选的
+    ``llm_agents.<stage>`` 局部覆盖。未传 ``stage`` 或未配置覆盖时与旧行为一致。
     """
     from agno.agent import Agent
 
-    base_cfg = config.get("llm", {}) or {}
-    override_cfg = config.get("llm_skill", {}) or {}
-    llm_cfg = {**base_cfg, **{k: v for k, v in override_cfg.items() if v}}
-    pool_cfg = (config.get("agent_worker", {}) or {}).get("pools", {}) or {}
-    llm_cfg["_pool_weights"] = {
-        name: int((pool_cfg.get(name, {}) or {}).get("llm_weight", 1))
-        for name in ("split", "cluster", "edit")
-    }
+    llm_cfg = resolve_agent_llm_config(config, stage)
 
     def factory(*, instructions, tools, **kwargs):
         model = build_chat_model(

--- a/src/xskill/config.py
+++ b/src/xskill/config.py
@@ -113,8 +113,9 @@ llm:
     # token_burst: 20000 # optional token burst capacity (separate from requests)
   # See docs/adr/0001-rate-limit-diy-not-litellm.md for the design rationale.
 
-# Optional per-agent partial overrides. Missing fields inherit llm_skill first,
-# then llm, so leaving this block commented preserves the existing behavior.
+# Optional. Give split, cluster, or edit their own model or endpoint if you want.
+# Anything you leave out falls back to llm_skill, then llm. Leave this commented
+# and your existing config keeps working as before.
 # llm_agents:
 #   split:
 #     model: qwen-plus

--- a/src/xskill/config.py
+++ b/src/xskill/config.py
@@ -113,6 +113,18 @@ llm:
     # token_burst: 20000 # optional token burst capacity (separate from requests)
   # See docs/adr/0001-rate-limit-diy-not-litellm.md for the design rationale.
 
+# Optional per-agent partial overrides. Missing fields inherit llm_skill first,
+# then llm, so leaving this block commented preserves the existing behavior.
+# llm_agents:
+#   split:
+#     model: qwen-plus
+#   cluster:
+#     model: deepseek-v4-flash
+#   edit:
+#     base_url: http://localhost:8000/v1
+#     model: local-skill-editor
+#     api_key: local
+
 # ===== Embedding (vector retrieval) =====
 # Any OpenAI-compatible embeddings endpoint. dim: 0 auto-probes on first call.
 #
@@ -477,6 +489,42 @@ def normalize_runtime_config(config_data: dict) -> dict:
                     skill_rate.setdefault("token_burst", skill_burst)
             llm_skill["rate_limit"] = skill_rate
         runtime_config["llm_skill"] = llm_skill
+
+    llm_agents = runtime_config.get("llm_agents")
+    if llm_agents is not None:
+        if not isinstance(llm_agents, dict):
+            raise ValueError("llm_agents 必须是 mapping")
+        unknown_stages = set(llm_agents) - {"split", "cluster", "edit"}
+        if unknown_stages:
+            raise ValueError(
+                f"llm_agents 包含未知阶段: {sorted(unknown_stages)!r}"
+            )
+        normalized_agents: dict[str, dict] = {}
+        for stage, stage_value in llm_agents.items():
+            if not isinstance(stage_value, dict):
+                raise ValueError(f"llm_agents.{stage} 必须是 mapping")
+            stage_cfg = dict(stage_value)
+            if "rate_limit" in stage_cfg:
+                stage_rate = stage_cfg.get("rate_limit")
+                if stage_rate is None:
+                    stage_rate = {}
+                if not isinstance(stage_rate, dict):
+                    raise ValueError(
+                        f"llm_agents.{stage}.rate_limit 必须是 mapping"
+                    )
+                stage_rate = dict(stage_rate)
+                stage_burst = stage_rate.pop("burst", None)
+                if stage_burst is not None:
+                    stage_burst = _positive_int(
+                        stage_burst,
+                        f"llm_agents.{stage}.rate_limit.burst",
+                    )
+                    stage_rate.setdefault("request_burst", stage_burst)
+                    if "tpm" in stage_rate:
+                        stage_rate.setdefault("token_burst", stage_burst)
+                stage_cfg["rate_limit"] = stage_rate
+            normalized_agents[stage] = stage_cfg
+        runtime_config["llm_agents"] = normalized_agents
 
     embedding = runtime_config.get("embedding") or {}
     if not isinstance(embedding, dict):

--- a/src/xskill/dashboard/console.py
+++ b/src/xskill/dashboard/console.py
@@ -643,7 +643,7 @@ class PipelinePoolPatch(BaseModel):
 # llm/embedding/agent_worker/watcher 涉及进程级资源，改动需重启 serve。
 HOT_RELOAD_SECTIONS = ("dashboard", "canary", "recommend", "skillhub")
 RESTART_SECTIONS = (
-    "llm", "llm_skill", "embedding", "watcher", "agent_worker", "team",
+    "llm", "llm_skill", "llm_agents", "embedding", "watcher", "agent_worker", "team",
 )
 # team 段整体是重启域(join_token/路径/registry 接线),但这几个子键是纯调优数字,
 # 由 api.live_manifest_tuning() 每请求现取 → 改它们不需要重启。只有改到 team

--- a/src/xskill/pipeline/runner.py
+++ b/src/xskill/pipeline/runner.py
@@ -72,6 +72,28 @@ _ACTION_STATUS = {
     "error": "error",
 }
 
+def _agent_context_llm_config(
+    config: dict, stage: str, *, inherit_skill: bool,
+) -> dict:
+    """Resolve settings read by an Agent outside the model factory.
+
+    SkillEdit historically inherited non-empty ``llm_skill`` values, including
+    explicit ``False`` and ``0``; TaskCluster historically read only ``llm``.
+    Keep those contracts while applying the new explicit stage override last.
+    """
+    result = dict(config.get("llm", {}) or {})
+    sections = []
+    if inherit_skill:
+        sections.append(config.get("llm_skill", {}) or {})
+    sections.append(((config.get("llm_agents", {}) or {}).get(stage, {}) or {}))
+    for section in sections:
+        result.update({
+            key: value for key, value in section.items()
+            if value not in (None, "")
+        })
+    return result
+
+
 def _install_thread_event_loop() -> None:
     """给工作线程装一个事件循环（Python 3.9 兼容）。
 
@@ -857,7 +879,7 @@ class DirectoryWatcher:
         if not actionable_skills:
             return
 
-        factory = self._factory()
+        factory = self._factory("edit")
         # store 选哪个：edit agent 工具 (atom_task_read/read_traj) 需要 store +
         # traj_root 才能读到 atom 原文。单机只有一个 watch_dir（cc_sessions）。
         # team-CS server 下有 N 个 watch_dir（每个 client 上传轨迹注册成一个 wd，
@@ -913,16 +935,9 @@ class DirectoryWatcher:
 
         actionable_skills.sort(key=_skill_edit_sort_key)
 
-        base_llm_cfg = self.config.get("llm", {}) or {}
-        skill_llm_override = self.config.get("llm_skill", {}) or {}
-        skill_llm_cfg = {
-            **base_llm_cfg,
-            **{
-                key: value
-                for key, value in skill_llm_override.items()
-                if value not in (None, "")
-            },
-        }
+        skill_llm_cfg = _agent_context_llm_config(
+            self.config, "edit", inherit_skill=True,
+        )
 
         def _run_one(d):
             """在 pool 工作线程里跑单个 skill 的 maybe_run；返回 (d, promoted)。
@@ -2838,18 +2853,21 @@ class DirectoryWatcher:
             self._store_cache[key] = AtomTaskStore(root=Path(dir_path))
         return self._store_cache[key]
 
-    def _factory(self):
+    def _factory(self, stage: str | None = None):
         """返回 agno agent 工厂；优先 inject 的，否则用默认 deepseek 工厂。"""
         if self.agno_agent_factory is not None:
             return self.agno_agent_factory
         from xskill.agents.agno_factory import make_default_factory
         if not hasattr(self, "_default_factory_cache"):
-            self._default_factory_cache = make_default_factory(
+            self._default_factory_cache = {}
+        if stage not in self._default_factory_cache:
+            self._default_factory_cache[stage] = make_default_factory(
                 self.config,
+                stage=stage,
                 usage_ledger=self.usage_ledger,
                 spill_root=self.spill_root,
             )
-        return self._default_factory_cache
+        return self._default_factory_cache[stage]
 
     # ───────────────────────────────────────────────────────────
     # 任务执行函数（在线程池中运行）
@@ -2929,7 +2947,7 @@ class DirectoryWatcher:
             with scope_context:
                 with agent_tools.use_agent_tool_context(tool_context):
                     atoms = TaskAgent(
-                        agno_agent_factory=self._factory(),
+                        agno_agent_factory=self._factory("split"),
                         store=store,
                         traj_root=dir_path,
                         skill_dir=self.skill_dir,
@@ -3103,7 +3121,7 @@ class DirectoryWatcher:
         if not stores:
             raise RuntimeError("cluster batch has no active AtomTaskStore")
         store = stores[0] if len(stores) == 1 else MultiAtomTaskStore(stores)
-        factory = self._factory()
+        factory = self._factory("cluster")
         return process_atom_batch(
             atom_ids=atom_ids,
             config=self.config,
@@ -3633,7 +3651,9 @@ def _process_atom_task_bound(*, atom_id: str, config: dict,
     cluster = TaskClusterAgent(
         skill_dir=skill_dir, store=store,
         agno_agent_factory=agno_agent_factory,
-        llm_cfg=config.get("llm", {}),
+        llm_cfg=_agent_context_llm_config(
+            config, "cluster", inherit_skill=False,
+        ),
         logs_dir=logs_dir,
         db_path=db_path,
         tools=[
@@ -3771,7 +3791,9 @@ def _process_atom_batch_bound(*, atom_ids: list[str], config: dict,
     cluster = TaskClusterAgent(
         skill_dir=skill_dir, store=store,
         agno_agent_factory=agno_agent_factory,
-        llm_cfg=config.get("llm", {}),
+        llm_cfg=_agent_context_llm_config(
+            config, "cluster", inherit_skill=False,
+        ),
         logs_dir=logs_dir,
         db_path=db_path,
         tools=[

--- a/tests/test_agent_llm_backends.py
+++ b/tests/test_agent_llm_backends.py
@@ -1,0 +1,167 @@
+"""Per-agent LLM backend resolution and watcher factory routing."""
+
+from __future__ import annotations
+
+from pathlib import Path
+
+import pytest
+
+from xskill.agents.agno_factory import resolve_agent_llm_config
+from xskill.config import normalize_runtime_config
+from xskill.pipeline.runner import DirectoryWatcher, _agent_context_llm_config
+
+
+def _config() -> dict:
+    return {
+        "llm": {
+            "base_url": "https://base.example.test/v1",
+            "model": "base-model",
+            "api_key": "base-key",
+            "max_tokens": 1000,
+            "rate_limit": {"rpm": 60, "request_burst": 10, "max_inflight": 4},
+        },
+        "llm_skill": {
+            "model": "skill-model",
+            "max_tokens": 2000,
+            "enable_spill": False,
+        },
+        "llm_agents": {
+            "split": {
+                "base_url": "https://split.example.test/v1",
+                "model": "split-model",
+                "rate_limit": {"rpm": 30},
+            },
+            "cluster": {"model": "cluster-model"},
+            "edit": {"max_tokens": 4000, "temperature": 0.0},
+        },
+        "agent_worker": {
+            "pools": {
+                "split": {"llm_weight": 6},
+                "cluster": {"llm_weight": 3},
+                "edit": {"llm_weight": 1},
+            },
+        },
+    }
+
+
+def test_stage_overrides_are_isolated_and_inherit_legacy_config():
+    config = _config()
+
+    split = resolve_agent_llm_config(config, "split")
+    cluster = resolve_agent_llm_config(config, "cluster")
+    edit = resolve_agent_llm_config(config, "edit")
+
+    assert split["base_url"] == "https://split.example.test/v1"
+    assert split["model"] == "split-model"
+    assert split["api_key"] == "base-key"
+    assert split["max_tokens"] == 2000
+    assert split["rate_limit"] == {
+        "rpm": 30,
+        "request_burst": 10,
+        "max_inflight": 4,
+    }
+    assert cluster["base_url"] == "https://base.example.test/v1"
+    assert cluster["model"] == "cluster-model"
+    assert edit["model"] == "skill-model"
+    assert edit["max_tokens"] == 4000
+    assert edit["temperature"] == 0.0
+    assert split["_pool_weights"] == {"split": 6, "cluster": 3, "edit": 1}
+
+
+def test_missing_stage_config_preserves_legacy_effective_values():
+    config = _config()
+    config.pop("llm_agents")
+
+    legacy = resolve_agent_llm_config(config)
+
+    for stage in ("split", "cluster", "edit"):
+        assert resolve_agent_llm_config(config, stage) == legacy
+
+
+def test_resolver_does_not_mutate_user_config():
+    config = _config()
+
+    resolve_agent_llm_config(config, "split")["model"] = "changed"
+
+    assert config["llm_agents"]["split"]["model"] == "split-model"
+    assert "_pool_weights" not in config["llm"]
+
+
+def test_agent_context_config_preserves_stage_specific_legacy_inheritance():
+    config = _config()
+    config["llm"]["enable_spill"] = True
+
+    edit = _agent_context_llm_config(config, "edit", inherit_skill=True)
+    cluster = _agent_context_llm_config(config, "cluster", inherit_skill=False)
+
+    assert edit["enable_spill"] is False
+    assert edit["temperature"] == 0.0
+    assert cluster["enable_spill"] is True
+    assert cluster["model"] == "cluster-model"
+
+
+def test_unknown_stage_is_rejected():
+    with pytest.raises(ValueError, match="agent LLM stage"):
+        resolve_agent_llm_config(_config(), "generate")
+
+
+@pytest.mark.parametrize(
+    ("config", "message"),
+    [
+        ({"llm_agents": []}, "llm_agents 必须是 mapping"),
+        ({"llm_agents": {"split": "model"}}, "llm_agents.split 必须是 mapping"),
+        ({"llm_agents": {"judge": {}}}, "llm_agents 包含未知阶段"),
+        (
+            {"llm_agents": {"edit": {"rate_limit": []}}},
+            "llm_agents.edit.rate_limit 必须是 mapping",
+        ),
+    ],
+)
+def test_runtime_config_rejects_invalid_agent_overrides(config, message):
+    with pytest.raises(ValueError, match=message):
+        normalize_runtime_config({**config, "llm": {}, "embedding": {}})
+
+
+def test_runtime_config_normalizes_stage_burst_without_filling_other_limits():
+    effective = normalize_runtime_config({
+        "llm": {},
+        "embedding": {},
+        "llm_agents": {
+            "cluster": {"rate_limit": {"rpm": 30, "tpm": 6000, "burst": 5}},
+        },
+    })
+
+    assert effective["llm_agents"]["cluster"]["rate_limit"] == {
+        "rpm": 30,
+        "tpm": 6000,
+        "request_burst": 5,
+        "token_burst": 5,
+    }
+
+
+def test_watcher_caches_one_factory_per_stage(monkeypatch, tmp_path):
+    calls: list[str | None] = []
+
+    def fake_make_default_factory(config, *, stage, usage_ledger, spill_root):
+        del config, usage_ledger, spill_root
+        calls.append(stage)
+        return object()
+
+    monkeypatch.setattr(
+        "xskill.agents.agno_factory.make_default_factory",
+        fake_make_default_factory,
+    )
+    watcher = object.__new__(DirectoryWatcher)
+    watcher.agno_agent_factory = None
+    watcher.config = _config()
+    watcher.usage_ledger = object()
+    watcher.spill_root = Path(tmp_path)
+
+    split = watcher._factory("split")
+    cluster = watcher._factory("cluster")
+    edit = watcher._factory("edit")
+
+    assert watcher._factory("split") is split
+    assert watcher._factory("cluster") is cluster
+    assert watcher._factory("edit") is edit
+    assert calls == ["split", "cluster", "edit"]


### PR DESCRIPTION
## Summary

支持为 split、cluster 和 edit 三个 Agent 阶段分别覆盖 LLM backend 配置，并在未配置时保持现有行为。

继承顺序为 `llm` → 现有 `llm_skill` 有效值 → `llm_agents.<stage>` 显式覆盖，本 PR 提供配置回退但不实现请求失败后的 provider 自动故障切换。

## Changes

- 增加 `llm_agents.split`、`llm_agents.cluster` 和 `llm_agents.edit` 配置、校验与模板示例。
- 为 TaskAgent、TaskClusterAgent 和 SkillEditAgent 选择对应阶段 factory，并按阶段惰性缓存。
- 合并分阶段 `rate_limit` 子项，避免只覆盖 RPM 时丢失继承的 burst 或 inflight 配置。
- 保留 SkillEdit 与 TaskCluster 读取 context 配置时原有的 falsy 值和继承语义。
- 将 `llm_agents` 标记为 Dashboard 的重启配置域，并增加兼容性、隔离、校验和缓存测试。

## Test plan

- [x] 全量单测通过：`2472 passed, 10 skipped`
- [x] 分阶段配置聚焦回归通过：`71 passed`
- [x] Ruff 检查通过
- [ ] `make e2e` passes (not applicable: no ingestion / install / daemon behavior changes)

## Linked issues

Refs #327
