### PR TITLE
fix(reverse-sync): 透传失败原因并展示当前故障

### DIFF
--- a/src/xskill/agents/user_edit_absorb_agent.py
+++ b/src/xskill/agents/user_edit_absorb_agent.py
@@ -286,6 +286,24 @@ class ReverseSyncStatus(str, Enum):
     FAILED = "failed"
 
 
+@dataclass(frozen=True)
+class ReverseSyncResult:
+    """copy 安装回流结果；失败时保留可稳定展示的错误类型。"""
+
+    status: ReverseSyncStatus
+    error_type: str | None = None
+
+    def __post_init__(self) -> None:
+        if self.status == ReverseSyncStatus.FAILED:
+            if not (
+                isinstance(self.error_type, str)
+                and self.error_type.startswith("REVERSE_SYNC_")
+            ):
+                raise ValueError("failed reverse sync requires error_type")
+        elif self.error_type is not None:
+            raise ValueError("successful reverse sync cannot have error_type")
+
+
 class _DestEditStatus(str, Enum):
     NO_EDIT = "no_edit"
     RECENT_EDIT = "recent_edit"
@@ -318,12 +336,31 @@ def _reverse_sync_path_hash(path: Path) -> str:
     ).hexdigest()[:16]
 
 
-def _log_reverse_sync_failure(dest_dir: Path, error_type: str) -> None:
-    logger.warning(
-        "reverse sync failed path_hash=%s error_type=%s",
-        _reverse_sync_path_hash(dest_dir),
-        error_type,
+def _log_reverse_sync_failure(
+    dest_dir: Path, error_type: str, *, source_dir: Path | None = None,
+) -> None:
+    if source_dir is None:
+        logger.warning(
+            "reverse sync failed path_hash=%s error_type=%s",
+            _reverse_sync_path_hash(dest_dir),
+            error_type,
+        )
+    else:
+        logger.warning(
+            "reverse sync failed skill=%r path_hash=%s error_type=%s",
+            source_dir.name,
+            _reverse_sync_path_hash(dest_dir),
+            error_type,
+        )
+
+
+def _reverse_sync_failure(
+    dest_dir: Path, source_dir: Path, error_type: str,
+) -> ReverseSyncResult:
+    _log_reverse_sync_failure(
+        dest_dir, error_type, source_dir=source_dir,
     )
+    return ReverseSyncResult(ReverseSyncStatus.FAILED, error_type)
 
 
 def _log_reverse_transaction_failure(
@@ -1307,19 +1344,20 @@ def _commit_reverse_transaction(
         return False
 
 
-def reverse_sync_copy_dest(
+def reverse_sync_copy_dest_result(
     dest_dir: Path, source_dir: Path,
     *,
     exclude: frozenset[str] = _DEFAULT_REVERSE_SYNC_EXCLUDE,
     quiet_seconds: int = USER_EDIT_QUIET_SECONDS,
-) -> ReverseSyncStatus:
+) -> ReverseSyncResult:
     """通用 copy-mode 回流：把 dest 用户改灌回 source。
 
     任何 ``install_dir`` 走到 copy 路径的生态都能用（openclaw / ngagent /
     其它落到 copy fallback 的）。``exclude`` 默认只排 ``.git``；调用方
     可以加更多（如 openclaw 兼容路径加 ``_OPENCLAW_INSTALL_META``）。
 
-    返回 :class:`ReverseSyncStatus`，明确区分无修改、仍在编辑、同步成功和失败。
+    返回 :class:`ReverseSyncResult`，明确区分无修改、仍在编辑、同步成功和失败，
+    并在失败时保留稳定的 ``error_type`` 供调用方展示和记录。
 
     流程：
     1. ``has_pending_dest_edit`` 检查（dest 有改且静默 ≥quiet_seconds）
@@ -1355,10 +1393,9 @@ def reverse_sync_copy_dest(
                 or _is_reparse_point(source_stat)
                 or not _recover_pending_reverse_transaction(source_dir)
             ):
-                _log_reverse_sync_failure(
-                    dest_dir, "REVERSE_SYNC_RECOVERY_FAILED",
+                return _reverse_sync_failure(
+                    dest_dir, source_dir, "REVERSE_SYNC_RECOVERY_FAILED",
                 )
-                return ReverseSyncStatus.FAILED
 
             full_exclude = frozenset(exclude)
             assessment = _dest_edit_status(
@@ -1367,24 +1404,22 @@ def reverse_sync_copy_dest(
                 exclude=full_exclude,
             )
             if assessment.status == _DestEditStatus.FAILED:
-                _log_reverse_sync_failure(
-                    dest_dir, "REVERSE_SYNC_STATE_FAILED",
+                return _reverse_sync_failure(
+                    dest_dir, source_dir, "REVERSE_SYNC_STATE_FAILED",
                 )
-                return ReverseSyncStatus.FAILED
             if (
                 assessment.status == _DestEditStatus.NO_EDIT
                 and not assessment.files
             ):
-                return ReverseSyncStatus.NO_EDIT
+                return ReverseSyncResult(ReverseSyncStatus.NO_EDIT)
             try:
                 baseline_fingerprints = read_copy_install_baseline(
                     dest_dir,
                 )
             except Exception:  # pylint: disable=broad-exception-caught
-                _log_reverse_sync_failure(
-                    dest_dir, "REVERSE_SYNC_BASELINE_FAILED",
+                return _reverse_sync_failure(
+                    dest_dir, source_dir, "REVERSE_SYNC_BASELINE_FAILED",
                 )
-                return ReverseSyncStatus.FAILED
             candidate_files: list[tuple[_SafeDestFile, str]] = []
             for file_info in assessment.files:
                 dest_hash = _hash_verified_file(
@@ -1395,14 +1430,14 @@ def reverse_sync_copy_dest(
                 ):
                     candidate_files.append((file_info, dest_hash))
             if not candidate_files:
-                return ReverseSyncStatus.NO_EDIT
+                return ReverseSyncResult(ReverseSyncStatus.NO_EDIT)
             last_change_time = max(
                 max(file_info.mtime_ns, file_info.ctime_ns)
                 / 1_000_000_000
                 for file_info, _ in candidate_files
             )
             if time.time() - last_change_time < quiet_seconds:
-                return ReverseSyncStatus.RECENT_EDIT
+                return ReverseSyncResult(ReverseSyncStatus.RECENT_EDIT)
 
             changed_files: list[
                 tuple[_SafeDestFile, str, str | None]
@@ -1441,16 +1476,17 @@ def reverse_sync_copy_dest(
                         else None
                     )
                     if normalized_source_hash != baseline_hash:
-                        _log_reverse_sync_failure(
-                            dest_dir, "REVERSE_SYNC_CONTENT_CONFLICT",
+                        return _reverse_sync_failure(
+                            dest_dir,
+                            source_dir,
+                            "REVERSE_SYNC_CONTENT_CONFLICT",
                         )
-                        return ReverseSyncStatus.FAILED
                 if source_hash != dest_hash:
                     changed_files.append(
                         (file_info, dest_hash, source_hash),
                     )
             if not changed_files:
-                return ReverseSyncStatus.NO_EDIT
+                return ReverseSyncResult(ReverseSyncStatus.NO_EDIT)
 
             manifest_path, data_dir, manifest = (
                 _create_reverse_transaction(source_dir)
@@ -1515,12 +1551,11 @@ def reverse_sync_copy_dest(
                 dest_dir, full_exclude,
             )
             if not rescan_ok:
-                _log_reverse_sync_failure(
-                    dest_dir, "REVERSE_SYNC_RESCAN_FAILED",
+                return _reverse_sync_failure(
+                    dest_dir, source_dir, "REVERSE_SYNC_RESCAN_FAILED",
                 )
-                return ReverseSyncStatus.FAILED
             if rescanned_files != assessment.files:
-                return ReverseSyncStatus.RECENT_EDIT
+                return ReverseSyncResult(ReverseSyncStatus.RECENT_EDIT)
 
             if not _commit_reverse_transaction(
                 source_dir,
@@ -1531,20 +1566,47 @@ def reverse_sync_copy_dest(
                 rollback_ok = _recover_pending_reverse_transaction(
                     source_dir,
                 )
-                _log_reverse_sync_failure(
+                return _reverse_sync_failure(
                     dest_dir,
+                    source_dir,
                     (
                         "REVERSE_SYNC_COMMIT_FAILED"
                         if rollback_ok
                         else "REVERSE_SYNC_ROLLBACK_FAILED"
                     ),
                 )
-                return ReverseSyncStatus.FAILED
     except Exception:  # pylint: disable=broad-exception-caught
-        _log_reverse_sync_failure(dest_dir, "REVERSE_SYNC_STAGE_FAILED")
-        return ReverseSyncStatus.FAILED
+        return _reverse_sync_failure(
+            dest_dir, source_dir, "REVERSE_SYNC_STAGE_FAILED",
+        )
 
-    return ReverseSyncStatus.SYNCED
+    return ReverseSyncResult(ReverseSyncStatus.SYNCED)
+
+
+def reverse_sync_copy_dest(
+    dest_dir: Path, source_dir: Path,
+    *,
+    exclude: frozenset[str] = _DEFAULT_REVERSE_SYNC_EXCLUDE,
+    quiet_seconds: int = USER_EDIT_QUIET_SECONDS,
+) -> ReverseSyncStatus:
+    """兼容旧调用方的状态 API；详细失败原因用 result 版本读取。"""
+    return reverse_sync_copy_dest_result(
+        dest_dir,
+        source_dir,
+        exclude=exclude,
+        quiet_seconds=quiet_seconds,
+    ).status
+
+
+def reverse_sync_openclaw_dest_result(
+    dest_dir: Path, source_dir: Path,
+    *, quiet_seconds: int = USER_EDIT_QUIET_SECONDS,
+) -> ReverseSyncResult:
+    """OpenClaw 兼容入口的详细结果版本。"""
+    return reverse_sync_copy_dest_result(
+        dest_dir, source_dir,
+        quiet_seconds=quiet_seconds,
+    )
 
 
 def reverse_sync_openclaw_dest(

--- a/src/xskill/dashboard/pipeline_live.py
+++ b/src/xskill/dashboard/pipeline_live.py
@@ -111,6 +111,10 @@ def pipeline_live(db_path: Optional[Path]) -> dict:
         "started_at": stats.get("started_at"),
         "heartbeat_at": stats.get("heartbeat_at"),
         "llm": stats.get("llm") or {},
+        "reverse_sync": stats.get("reverse_sync") or {
+            "failed": 0,
+            "failures": [],
+        },
         "pending_atoms": int(cluster.get("pending_atoms") or 0),
         "pools": pools,
     }

--- a/src/xskill/dashboard/router.py
+++ b/src/xskill/dashboard/router.py
@@ -408,6 +408,15 @@ def build_dashboard_router(db_path: Optional[Path] = None, *,
                 for seat in pool.get("seats") or []
             ]
             pool["queue"] = []
+        reverse_sync = live.get("reverse_sync") or {}
+        reverse_sync["failures"] = [
+            {
+                "ecosystem": failure.get("ecosystem"),
+                "error_type": failure.get("error_type"),
+            }
+            for failure in reverse_sync.get("failures") or []
+            if isinstance(failure, dict)
+        ]
         return live
 
     @sensitive_router.get("/api/v1/dashboard/pipeline/log")

--- a/src/xskill/dashboard/static/app.js
+++ b/src/xskill/dashboard/static/app.js
@@ -1294,6 +1294,12 @@ function pmRenderBubbles() {
   html += `<div class="pm-bubble ring-1 ring-slate-200"><span class="k">模型请求</span><span class="v">${llm.inflight || 0}</span></div>`;
   if (quotaWait > 0) html += `<div class="pm-bubble warn ring-1 ring-slate-200"><span class="pm-dot"></span><span class="k">配额排队</span><span class="v">${quotaWait}</span></div>`;
   html += `<div class="pm-bubble ring-1 ring-slate-200"><span class="k">未归类原子</span><span class="v">${d.pending_atoms || 0}</span></div>`;
+  const reverseSync = d.reverse_sync || {};
+  const reverseFailures = Array.isArray(reverseSync.failures) ? reverseSync.failures : [];
+  if (reverseFailures.length > 0) {
+    const detail = reverseFailures.map(f => `${f.skill || '未知技能'} · ${f.ecosystem || '未知生态'} · ${f.error_type || 'REVERSE_SYNC_FAILED'}`).join('\n');
+    html += `<div class="pm-bubble bad ring-1 ring-slate-200" title="${esc(detail)}"><span class="pm-dot"></span><span class="k">回流受阻</span><span class="v">${reverseFailures.length}</span></div>`;
+  }
   if (failed > 0) html += `<div class="pm-bubble bad ring-1 ring-slate-200"><span class="pm-dot"></span><span class="k">异常</span><span class="v">${failed}</span></div>`;
   for (const p of PM_POOLS) {
     const pool = d.pools[p.key] || {};

--- a/src/xskill/ecosystems/_fallback.py
+++ b/src/xskill/ecosystems/_fallback.py
@@ -177,12 +177,17 @@ def _maybe_reverse_sync_before_overwrite(
     if meta is not None and meta.get("mode") != "copy":
         raise InstallSafetyError("REVERSE_SYNC_STATE_FAILED") from None
     # 延迟 import 避免 _fallback ↔ user_edit_absorb_agent 循环
-    from xskill.agents.user_edit_absorb_agent import reverse_sync_copy_dest
-    reverse_status = reverse_sync_copy_dest(dest, source)
+    from xskill.agents.user_edit_absorb_agent import (
+        reverse_sync_copy_dest_result,
+    )
+    reverse_result = reverse_sync_copy_dest_result(dest, source)
+    reverse_status = reverse_result.status
     if reverse_status == ReverseSyncStatus.RECENT_EDIT:
         raise InstallSafetyError("REVERSE_SYNC_RECENT_EDIT") from None
     if reverse_status == ReverseSyncStatus.FAILED:
-        raise InstallSafetyError("REVERSE_SYNC_FAILED") from None
+        raise InstallSafetyError(
+            reverse_result.error_type or "REVERSE_SYNC_FAILED",
+        ) from None
     return reverse_status
 
 

--- a/src/xskill/ecosystems/openclaw.py
+++ b/src/xskill/ecosystems/openclaw.py
@@ -117,13 +117,18 @@ def install_to_openclaw(
     if dest.is_dir() and not dest.is_symlink():
         from xskill.agents.user_edit_absorb_agent import (
             ReverseSyncStatus,
-            reverse_sync_openclaw_dest,
+            reverse_sync_openclaw_dest_result,
         )
-        reverse_status = reverse_sync_openclaw_dest(dest, skill_path)
+        reverse_result = reverse_sync_openclaw_dest_result(
+            dest, skill_path,
+        )
+        reverse_status = reverse_result.status
         if reverse_status == ReverseSyncStatus.RECENT_EDIT:
             raise InstallSafetyError("REVERSE_SYNC_RECENT_EDIT") from None
         if reverse_status == ReverseSyncStatus.FAILED:
-            raise InstallSafetyError("REVERSE_SYNC_FAILED") from None
+            raise InstallSafetyError(
+                reverse_result.error_type or "REVERSE_SYNC_FAILED",
+            ) from None
 
     # 强制 copy + auto_reset 一站式：
     # 1. ``_maybe_reverse_sync_before_overwrite`` —— 二次回流保护（默认

--- a/src/xskill/pipeline/runner.py
+++ b/src/xskill/pipeline/runner.py
@@ -25,7 +25,6 @@ from __future__ import annotations
 
 import asyncio
 import contextlib
-import hashlib
 import logging
 import os
 import threading
@@ -134,6 +133,9 @@ class DirectoryWatcher:
             Path(install_history_path) if install_history_path
             else xskill_state_root / "install_history.jsonl"
         )
+        # 只保存当前仍未恢复的回流失败；用 copy-on-write 让状态上报线程读取
+        # 稳定快照，也避免每轮轮询向 install_history 重复追加同一故障。
+        self._reverse_sync_failures: dict[str, str] = {}
         # 冷启动批量 flush：rebuild 写 COLD_START 文件后，watcher 等流水线空闲再
         # 做一次 SkillEdit 扫描；这是 XSkill 状态，不能跟生态 home_root 混用。
         from xskill.pipeline.cold_start import ColdStartSignal
@@ -309,6 +311,7 @@ class DirectoryWatcher:
     def agent_worker_status(self):
         from xskill.utils.rate_limit import request_limiter_status
 
+        reverse_sync_failures = self._reverse_sync_failures
         return {
             "pid": os.getpid(),
             "started_at": self._started_at,
@@ -338,6 +341,19 @@ class DirectoryWatcher:
                 "running_batches": len(self.cluster_futures),
             },
             "cluster_write_queue": self.cluster_write_queue.status,
+            "reverse_sync": {
+                "failed": len(reverse_sync_failures),
+                "failures": [
+                    {
+                        "skill": skill,
+                        "ecosystem": "openclaw",
+                        "error_type": error_type,
+                    }
+                    for skill, error_type in sorted(
+                        reverse_sync_failures.items(),
+                    )
+                ],
+            },
             "llm": request_limiter_status("llm"),
             "embedding": request_limiter_status("embedding"),
         }
@@ -1351,6 +1367,25 @@ class DirectoryWatcher:
                 skill, agent,
             )
 
+    def _update_reverse_sync_failure(
+        self, *, skill: str, error_type: str | None,
+    ) -> bool:
+        """更新当前回流故障快照，返回故障是否发生了状态迁移。"""
+        current = self._reverse_sync_failures
+        if error_type is None:
+            if skill not in current:
+                return False
+            updated = dict(current)
+            updated.pop(skill, None)
+            self._reverse_sync_failures = updated
+            return True
+        if current.get(skill) == error_type:
+            return False
+        updated = dict(current)
+        updated[skill] = error_type
+        self._reverse_sync_failures = updated
+        return True
+
     def _install_skill_to_cc(self, skill_path):
         """Backward-compat thin wrapper for ``_install_skill_to_all_detected``.
 
@@ -1373,7 +1408,7 @@ class DirectoryWatcher:
             ReverseSyncStatus,
             UserEditAbsorbAgent,
             detect_user_edits,
-            reverse_sync_openclaw_dest,
+            reverse_sync_openclaw_dest_result,
         )
         from xskill.agents import agent_tools
         target_root = self._resolve_target_root()
@@ -1388,59 +1423,101 @@ class DirectoryWatcher:
             usage_ledger=self.usage_ledger,
             registry_db_path=self.db_path,
         )
-        for d in sorted(self.skill_dir.iterdir()):
-            if not d.is_dir() or d.name.startswith("."):
-                continue
+        skill_paths = [
+            d for d in sorted(self.skill_dir.iterdir())
+            if d.is_dir() and not d.name.startswith(".")
+        ]
+        active_skill_names = {d.name for d in skill_paths}
+        for stale_skill in (
+            set(self._reverse_sync_failures).difference(active_skill_names)
+        ):
+            self._update_reverse_sync_failure(
+                skill=stale_skill, error_type=None,
+            )
+        for d in skill_paths:
             try:
                 # openclaw 回流（dest → source）— 没装 openclaw / dest 不存在
-                # / dest 没改 → no-op。返回 True 意味着 source mtime 刚被 touch，
+                # / dest 没改 → no-op。返回 SYNCED 意味着 source 刚完成回流，
                 # 下面 detect_user_edits 会立刻看到 pending edit。
                 if target_root is not None:
                     dest_dir = target_root / ".agents" / "skills" / d.name
                     try:
-                        reverse_status = reverse_sync_openclaw_dest(
+                        reverse_result = reverse_sync_openclaw_dest_result(
                             dest_dir, d,
                         )
                     except Exception:
+                        error_type = "REVERSE_SYNC_UNEXPECTED"
                         logger.warning(
-                            "openclaw reverse sync stopped skill_id_hash=%s "
-                            "error_type=REVERSE_SYNC_UNEXPECTED",
-                            hashlib.sha256(
-                                d.name.encode("utf-8"),
-                            ).hexdigest()[:12],
+                            "reverse sync stopped skill=%r ecosystem=openclaw "
+                            "error_type=%s",
+                            d.name,
+                            error_type,
                         )
+                        if self._update_reverse_sync_failure(
+                            skill=d.name, error_type=error_type,
+                        ):
+                            self._record_install_fail(
+                                skill=d.name,
+                                agent="openclaw",
+                                reason=error_type,
+                            )
                         continue
+                    reverse_status = reverse_result.status
                     if reverse_status in {
                         ReverseSyncStatus.RECENT_EDIT,
                         ReverseSyncStatus.FAILED,
                     }:
-                        logger.warning(
-                            "openclaw reverse sync stopped "
-                            "skill_id_hash=%s error_type=%s",
-                            hashlib.sha256(
-                                d.name.encode("utf-8"),
-                            ).hexdigest()[:12],
-                            (
-                                "REVERSE_SYNC_RECENT_EDIT"
-                                if reverse_status
-                                == ReverseSyncStatus.RECENT_EDIT
-                                else "REVERSE_SYNC_FAILED"
-                            ),
+                        error_type = (
+                            "REVERSE_SYNC_RECENT_EDIT"
+                            if reverse_status == ReverseSyncStatus.RECENT_EDIT
+                            else (
+                                reverse_result.error_type
+                                or "REVERSE_SYNC_FAILED"
+                            )
                         )
+                        logger.warning(
+                            "reverse sync stopped skill=%r ecosystem=openclaw "
+                            "error_type=%s",
+                            d.name,
+                            error_type,
+                        )
+                        if reverse_status == ReverseSyncStatus.FAILED:
+                            if self._update_reverse_sync_failure(
+                                skill=d.name, error_type=error_type,
+                            ):
+                                self._record_install_fail(
+                                    skill=d.name,
+                                    agent="openclaw",
+                                    reason=error_type,
+                                )
+                        else:
+                            self._update_reverse_sync_failure(
+                                skill=d.name, error_type=None,
+                            )
                         continue
                     if reverse_status not in {
                         ReverseSyncStatus.NO_EDIT,
                         ReverseSyncStatus.SYNCED,
                     }:
+                        error_type = "REVERSE_SYNC_INVALID_STATUS"
                         logger.warning(
-                            "openclaw reverse sync stopped "
-                            "skill_id_hash=%s "
-                            "error_type=REVERSE_SYNC_INVALID_STATUS",
-                            hashlib.sha256(
-                                d.name.encode("utf-8"),
-                            ).hexdigest()[:12],
+                            "reverse sync stopped skill=%r ecosystem=openclaw "
+                            "error_type=%s",
+                            d.name,
+                            error_type,
                         )
+                        if self._update_reverse_sync_failure(
+                            skill=d.name, error_type=error_type,
+                        ):
+                            self._record_install_fail(
+                                skill=d.name,
+                                agent="openclaw",
+                                reason=error_type,
+                            )
                         continue
+                    self._update_reverse_sync_failure(
+                        skill=d.name, error_type=None,
+                    )
 
                 if not detect_user_edits(d):
                     continue

--- a/src/xskill/team/client/daemon.py
+++ b/src/xskill/team/client/daemon.py
@@ -48,6 +48,31 @@ from xskill.team.shared.protocol import (
 
 logger = logging.getLogger("xskill.team.client")
 
+_REVERSE_SYNC_ERROR_DETAILS = {
+    "REVERSE_SYNC_CONTENT_CONFLICT": (
+        "源目录与安装目录存在同文件双边修改，已保留现有安装目录"
+    ),
+    "REVERSE_SYNC_BASELINE_FAILED": (
+        "安装基线损坏或不可读，已保留现有安装目录"
+    ),
+    "REVERSE_SYNC_RECOVERY_FAILED": (
+        "上次用户修改回流事务恢复失败，已保留现有安装目录"
+    ),
+    "REVERSE_SYNC_ROLLBACK_FAILED": (
+        "用户修改回流回滚失败，已保留恢复数据和现有安装目录"
+    ),
+    "REVERSE_SYNC_STATE_FAILED": (
+        "安装目录状态无法安全确认，已保留现有安装目录"
+    ),
+}
+
+
+def _reverse_sync_error_detail(error_type: str) -> str:
+    return _REVERSE_SYNC_ERROR_DETAILS.get(
+        error_type,
+        "用户修改回流失败，已保留现有安装目录",
+    )
+
 
 def register_with_server(
     http, *,
@@ -363,7 +388,7 @@ class TeamClient:
         """
         from xskill.agents.user_edit_absorb_agent import (
             ReverseSyncStatus,
-            reverse_sync_openclaw_dest,
+            reverse_sync_openclaw_dest_result,
         )
 
         pushed = 0
@@ -374,32 +399,32 @@ class TeamClient:
             # openclaw 回流（dest → working copy）— 没装到 openclaw 时 no-op
             dest_dir = self.home_root / ".agents" / "skills" / repo_dir.name
             try:
-                reverse_status = reverse_sync_openclaw_dest(
+                reverse_result = reverse_sync_openclaw_dest_result(
                     dest_dir, repo_dir,
                 )
             except Exception:
                 logger.warning(
-                    "openclaw reverse sync stopped skill_id_hash=%s "
+                    "reverse sync stopped skill=%r ecosystem=openclaw "
                     "error_type=REVERSE_SYNC_UNEXPECTED",
-                    hashlib.sha256(
-                        repo_dir.name.encode("utf-8"),
-                    ).hexdigest()[:12],
+                    repo_dir.name,
                 )
                 continue
+            reverse_status = reverse_result.status
             if reverse_status in {
                 ReverseSyncStatus.RECENT_EDIT,
                 ReverseSyncStatus.FAILED,
             }:
                 logger.warning(
-                    "openclaw reverse sync stopped skill_id_hash=%s "
+                    "reverse sync stopped skill=%r ecosystem=openclaw "
                     "error_type=%s",
-                    hashlib.sha256(
-                        repo_dir.name.encode("utf-8"),
-                    ).hexdigest()[:12],
+                    repo_dir.name,
                     (
                         "REVERSE_SYNC_RECENT_EDIT"
                         if reverse_status == ReverseSyncStatus.RECENT_EDIT
-                        else "REVERSE_SYNC_FAILED"
+                        else (
+                            reverse_result.error_type
+                            or "REVERSE_SYNC_FAILED"
+                        )
                     ),
                 )
                 continue
@@ -408,11 +433,9 @@ class TeamClient:
                 ReverseSyncStatus.SYNCED,
             }:
                 logger.warning(
-                    "openclaw reverse sync stopped skill_id_hash=%s "
+                    "reverse sync stopped skill=%r ecosystem=openclaw "
                     "error_type=REVERSE_SYNC_INVALID_STATUS",
-                    hashlib.sha256(
-                        repo_dir.name.encode("utf-8"),
-                    ).hexdigest()[:12],
+                    repo_dir.name,
                 )
                 continue
 
@@ -986,8 +1009,8 @@ def install_skill_to_ecosystems(
                     error_code = "USER_EDIT_IN_PROGRESS"
                     error_detail = "检测到用户仍在编辑，已保留现有安装目录"
                 else:
-                    error_code = "REVERSE_SYNC_FAILED"
-                    error_detail = "用户修改回流失败，已保留现有安装目录"
+                    error_code = install_error.error_type
+                    error_detail = _reverse_sync_error_detail(error_code)
             elif isinstance(install_error, PermissionError):
                 error_code = "TARGET_PERMISSION_DENIED"
                 error_detail = "目标目录不可写，请检查目录权限"
@@ -1089,10 +1112,14 @@ def install_skill_to_ecosystems(
                 verification_error = (
                     "Git HEAD 校验失败，请检查 skill 仓库完整性"
                 )
-        if record.get("error_code") in {
-            "USER_EDIT_IN_PROGRESS",
-            "REVERSE_SYNC_FAILED",
-        }:
+        record_error_code = record.get("error_code")
+        if (
+            record_error_code == "USER_EDIT_IN_PROGRESS"
+            or (
+                isinstance(record_error_code, str)
+                and record_error_code.startswith("REVERSE_SYNC_")
+            )
+        ):
             target_is_current = False
         if target_is_current:
             record["status"] = "installed"

--- a/tests/test_dashboard_frontend_smoke.py
+++ b/tests/test_dashboard_frontend_smoke.py
@@ -182,6 +182,8 @@ def test_pipeline_log_scroll_is_sticky_not_forced():
         re.S,
     ) is None
     assert "pmLogKey.kind === kind && pmLogKey.name === name" in js
+    assert "回流受阻" in js
+    assert "reverse_sync" in js
     # 抽屉重渲染后恢复滚动
     assert "stickBottom ? newLog.scrollHeight : savedScroll" in js
 

--- a/tests/test_dashboard_pipeline_live.py
+++ b/tests/test_dashboard_pipeline_live.py
@@ -70,6 +70,14 @@ def _full_stats():
             "embed": {"workers": 2, "queued": 0, "completed": 9, "failed": 0},
         },
         "cluster": {"pending_atoms": 6, "claimed_atoms": 2, "running_batches": 1},
+        "reverse_sync": {
+            "failed": 1,
+            "failures": [{
+                "skill": "invoice-helper",
+                "ecosystem": "openclaw",
+                "error_type": "REVERSE_SYNC_CONTENT_CONFLICT",
+            }],
+        },
     }
 
 
@@ -89,6 +97,11 @@ def test_full_status_shapes_three_monitored_pools(tmp_path):
     assert body["pid"] == 1234
     assert body["pending_atoms"] == 6
     assert body["llm"]["inflight"] == 2
+    assert body["reverse_sync"]["failures"][0] == {
+        "skill": "invoice-helper",
+        "ecosystem": "openclaw",
+        "error_type": "REVERSE_SYNC_CONTENT_CONFLICT",
+    }
     assert set(body["pools"]) == {"split", "cluster", "edit", "generate"}
 
     split = body["pools"]["split"]
@@ -233,6 +246,10 @@ def test_live_endpoint_standalone_strips_task_identity(tmp_path):
     assert "task" not in seat
     assert body["pools"]["split"]["queue"] == []
     assert body["pools"]["split"]["queued"] == 1  # 计数仍在
+    assert body["reverse_sync"]["failures"] == [{
+        "ecosystem": "openclaw",
+        "error_type": "REVERSE_SYNC_CONTENT_CONFLICT",
+    }]
 
 
 def test_log_endpoint_only_on_sensitive_router(tmp_path):

--- a/tests/test_ecosystem_ngagent.py
+++ b/tests/test_ecosystem_ngagent.py
@@ -215,13 +215,15 @@ def test_install_to_ngagent_user_edit_round_trips(tmp_path, monkeypatch):
 
     # 让 reverse_sync 跳 quiet 检查（测试免等 3 分钟）
     from xskill.agents import user_edit_absorb_agent as ua
-    _real = ua.reverse_sync_copy_dest
+    _real = ua.reverse_sync_copy_dest_result
 
     def _force_quiet_zero(d, s, **kw):
         kw["quiet_seconds"] = 0
         return _real(d, s, **kw)
 
-    monkeypatch.setattr(ua, "reverse_sync_copy_dest", _force_quiet_zero)
+    monkeypatch.setattr(
+        ua, "reverse_sync_copy_dest_result", _force_quiet_zero,
+    )
 
     # 用户改 dest（mtime 比 installed_at 至少大 1 秒）
     _t.sleep(1.1)

--- a/tests/test_install_fallback_revsync.py
+++ b/tests/test_install_fallback_revsync.py
@@ -281,7 +281,7 @@ def test_auto_reset_reverse_sync_failure_preserves_destination(
     (dest / "SKILL.md").write_text(
         "UNSYNCED USER EDIT\n", encoding="utf-8",
     )
-    real_reverse_sync = user_absorb.reverse_sync_copy_dest
+    real_reverse_sync = user_absorb.reverse_sync_copy_dest_result
 
     def reverse_without_quiet_period(dest_dir, source_dir):
         return real_reverse_sync(
@@ -295,7 +295,7 @@ def test_auto_reset_reverse_sync_failure_preserves_destination(
 
     monkeypatch.setattr(
         user_absorb,
-        "reverse_sync_copy_dest",
+        "reverse_sync_copy_dest_result",
         reverse_without_quiet_period,
     )
     monkeypatch.setattr(
@@ -306,7 +306,7 @@ def test_auto_reset_reverse_sync_failure_preserves_destination(
         with pytest.raises(InstallSafetyError) as raised:
             install_dir(src, dest, force_mode="copy", auto_reset=True)
 
-    assert raised.value.error_type == "REVERSE_SYNC_FAILED"
+    assert raised.value.error_type == "REVERSE_SYNC_STAGE_FAILED"
     assert (dest / "SKILL.md").read_text(
         encoding="utf-8",
     ) == "UNSYNCED USER EDIT\n"
@@ -314,6 +314,26 @@ def test_auto_reset_reverse_sync_failure_preserves_destination(
     assert "reverse-secret" not in caplog.text
     assert "/root/private/reverse" not in caplog.text
     assert all(record.exc_info is None for record in caplog.records)
+
+
+def test_reverse_sync_result_preserves_content_conflict_reason(tmp_path):
+    """详细 API 透传底层原因，旧状态 API 仍保持兼容。"""
+    from xskill.agents import user_edit_absorb_agent as user_absorb
+
+    src = _build_real_skill_repo(tmp_path)
+    dest = tmp_path / "out" / "demo-skill"
+    dest.parent.mkdir(parents=True)
+    install_dir(src, dest, force_mode="copy")
+    time.sleep(1.1)
+    (src / "SKILL.md").write_text("SOURCE EDIT\n", encoding="utf-8")
+    (dest / "SKILL.md").write_text("DEST EDIT\n", encoding="utf-8")
+
+    result = user_absorb.reverse_sync_copy_dest_result(
+        dest, src, quiet_seconds=0,
+    )
+
+    assert result.status == user_absorb.ReverseSyncStatus.FAILED
+    assert result.error_type == "REVERSE_SYNC_CONTENT_CONFLICT"
 
 
 @pytest.mark.skipif(

--- a/tests/test_openclaw_adapter.py
+++ b/tests/test_openclaw_adapter.py
@@ -428,9 +428,9 @@ class TestInstallToOpenClawProtectsPendingDestEdits:
         dest_md = install_to_openclaw(sk, target_root=home)
 
         # 让 reverse_sync 跳过静默检查（测试用，免等 3 分钟）
-        from xskill.agents.user_edit_absorb_agent import reverse_sync_openclaw_dest as _orig
+        from xskill.agents.user_edit_absorb_agent import reverse_sync_openclaw_dest_result as _orig
         monkeypatch.setattr(
-            "xskill.agents.user_edit_absorb_agent.reverse_sync_openclaw_dest",
+            "xskill.agents.user_edit_absorb_agent.reverse_sync_openclaw_dest_result",
             lambda d, s, **_k: _orig(d, s, quiet_seconds=0),
         )
 

--- a/tests/test_search_cli_output.py
+++ b/tests/test_search_cli_output.py
@@ -1031,6 +1031,40 @@ def test_recent_auxiliary_edit_remains_safe_install_failure(
     ) == "USER EDIT IN PROGRESS\n"
 
 
+def test_reverse_sync_failure_reason_is_visible_in_install_result(
+    tmp_path, monkeypatch,
+):
+    from xskill.ecosystems.installation import InstallSafetyError
+    from xskill.skill.git import init_skill_repo_on_baby
+    from xskill.team.client.daemon import install_skill_to_ecosystems
+
+    repo_dir = tmp_path / "conflicted-skill"
+    init_skill_repo_on_baby(
+        str(repo_dir), "conflicted-skill", "reverse sync conflict test",
+    )
+    home = tmp_path / "home"
+
+    def fail_with_conflict(*_args, **_kwargs):
+        raise InstallSafetyError("REVERSE_SYNC_CONTENT_CONFLICT")
+
+    monkeypatch.setattr(
+        "xskill.ecosystems.install_to_openclaw",
+        fail_with_conflict,
+    )
+
+    records = install_skill_to_ecosystems(
+        repo_dir,
+        home_root=home,
+        ecosystems=["openclaw"],
+    )
+
+    assert records[0]["status"] == "failed"
+    assert records[0]["error_code"] == "REVERSE_SYNC_CONTENT_CONFLICT"
+    assert records[0]["error"] == (
+        "源目录与安装目录存在同文件双边修改，已保留现有安装目录"
+    )
+
+
 def test_damaged_metadata_is_not_reported_installed(
     tmp_path, monkeypatch, caplog,
 ):
@@ -1140,6 +1174,7 @@ def test_runner_stops_absorb_after_reverse_sync_failure(
     tmp_path, monkeypatch,
 ):
     from xskill.agents import user_edit_absorb_agent as user_absorb
+    from xskill.ecosystems._history import InstallHistory
     from xskill.pipeline.runner import DirectoryWatcher
 
     skill_dir = tmp_path / "skills"
@@ -1149,11 +1184,15 @@ def test_runner_stops_absorb_after_reverse_sync_failure(
     watcher = DirectoryWatcher(
         skill_dir=skill_dir,
         home_root=tmp_path / "home",
+        install_history_path=tmp_path / "install-history.jsonl",
     )
     monkeypatch.setattr(
         user_absorb,
-        "reverse_sync_openclaw_dest",
-        lambda *_args, **_kwargs: user_absorb.ReverseSyncStatus.FAILED,
+        "reverse_sync_openclaw_dest_result",
+        lambda *_args, **_kwargs: user_absorb.ReverseSyncResult(
+            user_absorb.ReverseSyncStatus.FAILED,
+            "REVERSE_SYNC_CONTENT_CONFLICT",
+        ),
     )
 
     def fail_if_detection_runs(*_args, **_kwargs):
@@ -1165,6 +1204,78 @@ def test_runner_stops_absorb_after_reverse_sync_failure(
     monkeypatch.setattr(watcher, "_factory", lambda: object())
 
     watcher._check_user_edits()
+
+    assert watcher.agent_worker_status["reverse_sync"] == {
+        "failed": 1,
+        "failures": [{
+            "skill": "failed-reverse",
+            "ecosystem": "openclaw",
+            "error_type": "REVERSE_SYNC_CONTENT_CONFLICT",
+        }],
+    }
+    failure = InstallHistory(watcher.install_history_path).fail_records()[-1]
+    assert {
+        key: failure[key]
+        for key in ("action", "skill", "agent", "reason")
+    } == {
+        "action": "fail",
+        "skill": "failed-reverse",
+        "agent": "openclaw",
+        "reason": "REVERSE_SYNC_CONTENT_CONFLICT",
+    }
+
+
+def test_runner_records_same_reverse_sync_failure_once_and_clears(
+    tmp_path, monkeypatch,
+):
+    from xskill.agents import user_edit_absorb_agent as user_absorb
+    from xskill.ecosystems._history import InstallHistory
+    from xskill.pipeline.runner import DirectoryWatcher
+
+    skill_dir = tmp_path / "skills"
+    skill_path = skill_dir / "failed-reverse"
+    skill_path.mkdir(parents=True)
+    (skill_path / "SKILL.md").write_text("body\n", encoding="utf-8")
+    watcher = DirectoryWatcher(
+        skill_dir=skill_dir,
+        home_root=tmp_path / "home",
+        install_history_path=tmp_path / "install-history.jsonl",
+    )
+    reverse_results = iter([
+        user_absorb.ReverseSyncResult(
+            user_absorb.ReverseSyncStatus.FAILED,
+            "REVERSE_SYNC_BASELINE_FAILED",
+        ),
+        user_absorb.ReverseSyncResult(
+            user_absorb.ReverseSyncStatus.FAILED,
+            "REVERSE_SYNC_BASELINE_FAILED",
+        ),
+        user_absorb.ReverseSyncResult(
+            user_absorb.ReverseSyncStatus.NO_EDIT,
+        ),
+    ])
+    monkeypatch.setattr(
+        user_absorb,
+        "reverse_sync_openclaw_dest_result",
+        lambda *_args, **_kwargs: next(reverse_results),
+    )
+    monkeypatch.setattr(
+        user_absorb, "detect_user_edits", lambda *_args, **_kwargs: False,
+    )
+    monkeypatch.setattr(watcher, "_factory", lambda: object())
+
+    watcher._check_user_edits()
+    watcher._check_user_edits()
+    watcher._check_user_edits()
+
+    failures = InstallHistory(watcher.install_history_path).fail_records()
+    assert [record["reason"] for record in failures] == [
+        "REVERSE_SYNC_BASELINE_FAILED",
+    ]
+    assert watcher.agent_worker_status["reverse_sync"] == {
+        "failed": 0,
+        "failures": [],
+    }
 
 
 def test_link_modes_do_not_read_install_metadata(monkeypatch):

--- a/tests/test_team_client.py
+++ b/tests/test_team_client.py
@@ -130,8 +130,11 @@ def test_push_user_edits_stops_after_reverse_sync_failure(
     tc.reconcile_skill_sides(manifest)
     monkeypatch.setattr(
         user_absorb,
-        "reverse_sync_openclaw_dest",
-        lambda *_args, **_kwargs: user_absorb.ReverseSyncStatus.FAILED,
+        "reverse_sync_openclaw_dest_result",
+        lambda *_args, **_kwargs: user_absorb.ReverseSyncResult(
+            user_absorb.ReverseSyncStatus.FAILED,
+            "REVERSE_SYNC_CONTENT_CONFLICT",
+        ),
     )
 
     def fail_if_git_status_runs(*_args, **_kwargs):


### PR DESCRIPTION
## Summary

本 PR 继续推进 #203，在不破坏旧状态 API 的前提下，把 copy reverse-sync 的具体失败原因透传到安装调用方、standalone 状态与看板。
正常回流路径不增加文件扫描或哈希，重复故障仅在状态迁移时写一次历史，避免轮询写放大。

## Changes

- 新增 `ReverseSyncResult` 与详细结果 API，保留 `reverse_sync_copy_dest` 和 `reverse_sync_openclaw_dest` 的原有返回语义。
- 让 fallback、OpenClaw、team client 与安装结果保留内容冲突、基线读取失败、恢复失败等具体错误码和安全中文提示。
- 在 standalone worker 中维护当前回流故障快照，在 install history 中按状态迁移去重记录，并在恢复或 skill 删除后清理状态。
- 在流水线看板展示“回流受阻”数量与 skill、生态、错误类型，同时对公网只读实例剥离 skill 名。
- 补充 API 兼容、错误透传、故障去重与恢复、看板展示和公网脱敏回归测试。

## Test plan

- [x] `uv run pytest tests --ignore=tests/docker_e2e --ignore=tests/live -q`：2465 passed, 9 skipped
- [x] Added/updated unit tests for the change
- [x] Python 3.9 定向兼容测试：6 passed
- [x] `tests/docker_e2e/run.sh all`：2 scenarios passed
- [x] 改动文件 Ruff 检查通过

## Linked issues

Refs #203
