### PR TITLE
fix(reverse-sync): 安全修复存量 copy 安装基线

### DIFF
--- a/src/xskill/cli.py
+++ b/src/xskill/cli.py
@@ -1951,6 +1951,100 @@ def cmd_rebuild(args, _xskill) -> int:
     return 0
 
 
+def cmd_repair_baselines(args) -> int:
+    """审计并安全重算已有 copy 安装基线。"""
+    import hashlib
+    import json as _json
+    from pathlib import Path
+
+    from xskill.ecosystems.install_ledger import get_default_ledger
+    from xskill.ecosystems.installation import (
+        CopyBaselineRepairStatus,
+        repair_copy_install_baseline,
+    )
+
+    try:
+        installs = get_default_ledger().list_active_install_targets(
+            mode="copy", skill_name=args.skill,
+        )
+    except Exception as ledger_error:  # noqa: BLE001
+        logger.error(
+            "copy baseline repair ledger read failed error_type=%s",
+            type(ledger_error).__name__,
+        )
+        print("error: 无法读取本机安装账本", file=sys.stderr)
+        return 1
+
+    results: list[dict[str, str]] = []
+    for install in installs:
+        dest_key = install.get("dest_key")
+        skill_name = install.get("skill_name")
+        if not isinstance(dest_key, str) or not isinstance(skill_name, str):
+            results.append({
+                "skill": (
+                    skill_name
+                    if isinstance(skill_name, str)
+                    else "<invalid>"
+                ),
+                "target_id": "",
+                "status": CopyBaselineRepairStatus.INVALID.value,
+            })
+            continue
+        status = repair_copy_install_baseline(
+            Path(dest_key), apply=not args.dry_run,
+        )
+        results.append({
+            "skill": skill_name,
+            "target_id": hashlib.sha256(
+                dest_key.encode("utf-8", errors="surrogatepass"),
+            ).hexdigest()[:16],
+            "status": status.value,
+        })
+
+    counts = {
+        status.value: sum(
+            result["status"] == status.value for result in results
+        )
+        for status in CopyBaselineRepairStatus
+    }
+    if args.json:
+        print(_json.dumps(
+            {
+                "dry_run": bool(args.dry_run),
+                "counts": counts,
+                "results": results,
+            },
+            ensure_ascii=False,
+            indent=2,
+        ))
+    elif not results:
+        print("没有匹配的 active copy 安装。")
+    else:
+        labels = {
+            CopyBaselineRepairStatus.CURRENT.value: "无需修复",
+            CopyBaselineRepairStatus.REPAIRABLE.value: "可安全修复",
+            CopyBaselineRepairStatus.REPAIRED.value: "已修复",
+            CopyBaselineRepairStatus.DIVERGED.value: "已跳过：source 与安装副本存在分叉",
+            CopyBaselineRepairStatus.INVALID.value: "已跳过：安装身份或元数据无效",
+            CopyBaselineRepairStatus.CONCURRENT.value: "已跳过：安装在检查期间发生换代",
+            CopyBaselineRepairStatus.FAILED.value: "修复失败：文件在检查期间变化或不可安全读取",
+        }
+        for result in results:
+            print(
+                f"{result['skill']} [{result['target_id']}]: "
+                f"{labels[result['status']]}"
+            )
+
+    safe_statuses = {
+        CopyBaselineRepairStatus.CURRENT.value,
+        CopyBaselineRepairStatus.REPAIRABLE.value,
+        CopyBaselineRepairStatus.REPAIRED.value,
+    }
+    return 0 if all(
+        result["status"] in safe_statuses for result in results
+    ) else 1
+
+
 # ═══════════════════════════════════════════════════════════════
 # argparse
 # ═══════════════════════════════════════════════════════════════
@@ -2184,6 +2278,22 @@ def build_parser() -> argparse.ArgumentParser:
         help="跳过'daemon 模型≠config 模型'护栏，用当前运行的模型重跑",
     )
 
+    p_repair_baselines = sub.add_parser(
+        "repair-baselines",
+        help="安全审计并重算历史 copy 安装基线",
+    )
+    p_repair_baselines.add_argument(
+        "--skill", default=None,
+        help="只处理指定 skill 名（默认处理全部 active copy 安装）",
+    )
+    p_repair_baselines.add_argument(
+        "--dry-run", action="store_true",
+        help="只审计并报告可修复项，不写安装账本",
+    )
+    p_repair_baselines.add_argument(
+        "--json", action="store_true", help="机读 JSON 输出",
+    )
+
     return p
 
 
@@ -2275,6 +2385,8 @@ def main() -> int:
         return cmd_read(args, None)
     if args.command == "rebuild":
         return cmd_rebuild(args, None)
+    if args.command == "repair-baselines":
+        return cmd_repair_baselines(args)
 
     # team 客户端的 `registry list`：本机是 client（有 team_client.json）且没有
     # standalone 数据（watch_dirs 为空）时，改走现算视图。放在 config/facade

--- a/src/xskill/ecosystems/__init__.py
+++ b/src/xskill/ecosystems/__init__.py
@@ -128,6 +128,7 @@ from xskill.ecosystems.ngagent import (
 )
 from xskill.ecosystems.installation import (
     COPY_INSTALL_MARKER_NAME,
+    CopyBaselineRepairStatus,
     GitHeadError,
     InstallSafetyError,
     InstallMode,
@@ -143,6 +144,7 @@ from xskill.ecosystems.installation import (
     read_install_metadata,
     read_install_metadata_file,
     read_skill_head_sha,
+    repair_copy_install_baseline,
     write_install_metadata,
 )
 from xskill.ecosystems.install_ledger import (
@@ -185,7 +187,8 @@ __all__ = [
     "TraeIngester", "detect_trae_record",
     "make_openclaw_canary_flip_hook",
     "adapt_trajectory", "submit_trajectory", "generate_traj_id",
-    "COPY_INSTALL_MARKER_NAME", "GitHeadError", "InstallMode",
+    "COPY_INSTALL_MARKER_NAME", "CopyBaselineRepairStatus",
+    "GitHeadError", "InstallMode",
     "InstallSafetyError",
     "InstallationMetadataError",
     "copy_install_identity_matches", "copy_install_is_current",
@@ -194,6 +197,7 @@ __all__ = [
     "is_link_or_junction", "read_install_metadata",
     "read_copy_install_baseline",
     "read_install_metadata_file", "read_skill_head_sha",
+    "repair_copy_install_baseline",
     "link_install_metadata_is_current",
     "write_install_metadata",
     "InstallLedger", "get_default_ledger", "remove_owned_dest",

--- a/src/xskill/ecosystems/install_ledger.py
+++ b/src/xskill/ecosystems/install_ledger.py
@@ -177,6 +177,33 @@ class InstallLedger(_SqliteStore):
         finally:
             conn.close()
 
+    def list_active_install_targets(
+        self,
+        *,
+        mode: str | None = None,
+        skill_name: str | None = None,
+    ) -> list[dict[str, str]]:
+        """轻量返回稳定排序的 active 安装目标，不解析基线 JSON。"""
+        clauses = ["status='active'"]
+        parameters: list[str] = []
+        if mode is not None:
+            clauses.append("mode=?")
+            parameters.append(mode)
+        if skill_name is not None:
+            clauses.append("skill_name=?")
+            parameters.append(skill_name)
+        conn = self._conn()
+        try:
+            rows = conn.execute(
+                "SELECT dest_key, skill_name FROM installations WHERE "
+                + " AND ".join(clauses)
+                + " ORDER BY skill_name, dest_key",
+                tuple(parameters),
+            ).fetchall()
+            return [dict(row) for row in rows]
+        finally:
+            conn.close()
+
     def record_install(
         self,
         dest: Path | str,
@@ -280,6 +307,53 @@ class InstallLedger(_SqliteStore):
             )
             conn.commit()
             return cur.rowcount > 0
+        except Exception:
+            conn.rollback()
+            raise
+        finally:
+            conn.close()
+
+    def compare_and_swap_copy_baseline(
+        self,
+        dest: Path | str,
+        *,
+        expected_generation: int,
+        expected_installation_id: str,
+        expected_baseline_identity: str,
+        file_fingerprints: dict[str, str],
+        baseline_identity: str,
+    ) -> bool:
+        """在安装世代与旧基线均未变化时更新 active copy 基线。"""
+        key = dest_key(dest)
+        fp_json = json.dumps(
+            file_fingerprints, ensure_ascii=False, sort_keys=True,
+        )
+        conn = self._conn()
+        try:
+            cur = conn.execute(
+                """
+                UPDATE installations
+                SET file_fingerprints_json=?, baseline_identity=?
+                WHERE dest_key=? AND status='active' AND mode='copy'
+                  AND generation=? AND installation_id=?
+                  AND baseline_identity=?
+                  AND NOT EXISTS (
+                      SELECT 1 FROM removal_jobs
+                      WHERE removal_jobs.dest_key=installations.dest_key
+                        AND state IN ('pending', 'deleting')
+                  )
+                """,
+                (
+                    fp_json,
+                    baseline_identity,
+                    key,
+                    expected_generation,
+                    expected_installation_id,
+                    expected_baseline_identity,
+                ),
+            )
+            conn.commit()
+            return cur.rowcount == 1
         except Exception:
             conn.rollback()
             raise

--- a/src/xskill/ecosystems/installation.py
+++ b/src/xskill/ecosystems/installation.py
@@ -14,6 +14,7 @@ import secrets
 import stat
 import tempfile
 import time
+from enum import Enum
 from operator import attrgetter
 from pathlib import Path
 from typing import Literal, NoReturn
@@ -66,6 +67,18 @@ class InstallSafetyError(RuntimeError):
     def __init__(self, error_type: str):
         self.error_type = error_type
         super().__init__("安装安全检查失败，已保留现有目标目录")
+
+
+class CopyBaselineRepairStatus(str, Enum):
+    """显式 copy 基线审计/修复的无歧义结果。"""
+
+    CURRENT = "current"
+    REPAIRABLE = "repairable"
+    REPAIRED = "repaired"
+    DIVERGED = "diverged"
+    INVALID = "invalid"
+    CONCURRENT = "concurrent"
+    FAILED = "failed"
 
 
 def _path_hash(path: Path) -> str:
@@ -726,7 +739,12 @@ def _hash_verified_copy_file(
             os.close(directory_descriptor)
 
 
-def _safe_copy_file_fingerprints(dest: Path) -> dict[str, str]:
+def _safe_copy_file_fingerprints(
+    dest: Path,
+    *,
+    exclude_root_names: frozenset[str] = frozenset(),
+    exclude_root_prefixes: tuple[str, ...] = (),
+) -> dict[str, str]:
     fingerprints: dict[str, str] = {}
     pending_directories: list[tuple[Path, Path]] = [(dest, Path())]
     root_stat = dest.lstat()
@@ -749,7 +767,14 @@ def _safe_copy_file_fingerprints(dest: Path) -> dict[str, str]:
                 relative_path = relative_directory / entry.name
                 if (
                     relative_directory == Path()
-                    and entry.name == COPY_INSTALL_MARKER_NAME
+                    and (
+                        entry.name == COPY_INSTALL_MARKER_NAME
+                        or entry.name in exclude_root_names
+                        or any(
+                            entry.name.startswith(prefix)
+                            for prefix in exclude_root_prefixes
+                        )
+                    )
                 ):
                     continue
                 # Windows 的 DirEntry.stat() 可能直接使用 WIN32_FIND_DATA
@@ -1104,6 +1129,181 @@ def refresh_copy_install_baseline(dest: Path) -> bool:
         file_fingerprints=file_fingerprints,
         baseline_identity=baseline_identity,
     )
+
+
+_COPY_REPAIR_SOURCE_EXCLUDE = frozenset({
+    ".git",
+    ".xskill-install-meta.json",
+})
+
+
+def _copy_repair_source_fingerprints(root: Path) -> dict[str, str]:
+    return _safe_copy_file_fingerprints(
+        root,
+        exclude_root_names=_COPY_REPAIR_SOURCE_EXCLUDE,
+        exclude_root_prefixes=(_INSTALL_META_PREFIX,),
+    )
+
+
+def _copy_repair_dest_user_fingerprints(
+    fingerprints: dict[str, str],
+) -> dict[str, str]:
+    return {
+        relative_name: file_hash
+        for relative_name, file_hash in fingerprints.items()
+        if relative_name.partition("/")[0]
+        not in _COPY_REPAIR_SOURCE_EXCLUDE
+    }
+
+
+def repair_copy_install_baseline(
+    dest: Path,
+    *,
+    apply: bool = True,
+) -> CopyBaselineRepairStatus:
+    """仅在 source 与 copy dest 完全一致时安全重算一条存量基线。
+
+    该入口不会用当前 dest 无条件覆盖账本：任何待回流用户编辑、source 前进、
+    特殊文件、身份不匹配或并发安装换代都会拒绝。写入使用安装世代、安装 ID
+    与旧基线身份做 CAS；写后复核若发现外部竞态，则尽力回滚旧基线。
+    """
+    from xskill.ecosystems.install_ledger import get_default_ledger
+    from xskill.skill.git import skill_repo_lock
+
+    dest = Path(dest)
+    ledger = get_default_ledger()
+    try:
+        metadata = ledger.read_install(dest)
+        if metadata is None:
+            return CopyBaselineRepairStatus.INVALID
+        metadata = _validate_metadata(metadata, dest)
+    except (InstallationMetadataError, OSError, ValueError):
+        return CopyBaselineRepairStatus.INVALID
+    raw_source = metadata.get("source")
+    old_fingerprints = metadata.get("file_fingerprints")
+    old_baseline_identity = metadata.get("baseline_identity")
+    generation = metadata.get("generation")
+    installation_id = metadata.get("installation_id")
+    if (
+        metadata.get("mode") != "copy"
+        or not isinstance(raw_source, str)
+        or not Path(raw_source).is_absolute()
+        or not isinstance(old_fingerprints, dict)
+        or not isinstance(old_baseline_identity, str)
+        or isinstance(generation, bool)
+        or not isinstance(generation, int)
+        or not isinstance(installation_id, str)
+        or not copy_install_identity_matches(
+            dest, Path(raw_source), metadata=metadata,
+        )
+    ):
+        return CopyBaselineRepairStatus.INVALID
+    source = Path(raw_source)
+    baseline_written = False
+    new_baseline_identity = ""
+    try:
+        with skill_repo_lock(source, use_git_write_limit=False):
+            dest_fingerprints = _safe_copy_file_fingerprints(dest)
+            new_baseline_identity = _copy_baseline_identity(
+                dest_fingerprints,
+            )
+            if (
+                dest_fingerprints == old_fingerprints
+                and new_baseline_identity == old_baseline_identity
+            ):
+                return CopyBaselineRepairStatus.CURRENT
+            source_user_fingerprints = _copy_repair_source_fingerprints(
+                source,
+            )
+            dest_user_fingerprints = (
+                _copy_repair_dest_user_fingerprints(dest_fingerprints)
+            )
+            if (
+                "SKILL.md" not in source_user_fingerprints
+                or "SKILL.md" not in dest_user_fingerprints
+            ):
+                return CopyBaselineRepairStatus.INVALID
+            if source_user_fingerprints != dest_user_fingerprints:
+                return CopyBaselineRepairStatus.DIVERGED
+            if not apply:
+                return CopyBaselineRepairStatus.REPAIRABLE
+            if not ledger.compare_and_swap_copy_baseline(
+                dest,
+                expected_generation=generation,
+                expected_installation_id=installation_id,
+                expected_baseline_identity=old_baseline_identity,
+                file_fingerprints=dest_fingerprints,
+                baseline_identity=new_baseline_identity,
+            ):
+                return CopyBaselineRepairStatus.CONCURRENT
+            baseline_written = True
+            verified_dest = _safe_copy_file_fingerprints(dest)
+            verified_source_user = _copy_repair_source_fingerprints(
+                source,
+            )
+            verified_dest_user = _copy_repair_dest_user_fingerprints(
+                verified_dest,
+            )
+            current_metadata = ledger.read_install(dest)
+            ledger_still_matches = (
+                current_metadata is not None
+                and current_metadata.get("generation") == generation
+                and current_metadata.get("installation_id")
+                == installation_id
+                and current_metadata.get("baseline_identity")
+                == new_baseline_identity
+            )
+            if not ledger_still_matches:
+                baseline_written = False
+                return CopyBaselineRepairStatus.CONCURRENT
+            if (
+                verified_dest == dest_fingerprints
+                and verified_source_user == source_user_fingerprints
+                and verified_dest_user == dest_user_fingerprints
+            ):
+                baseline_written = False
+                return CopyBaselineRepairStatus.REPAIRED
+            rolled_back = ledger.compare_and_swap_copy_baseline(
+                dest,
+                expected_generation=generation,
+                expected_installation_id=installation_id,
+                expected_baseline_identity=new_baseline_identity,
+                file_fingerprints=old_fingerprints,
+                baseline_identity=old_baseline_identity,
+            )
+            baseline_written = not rolled_back
+            return (
+                CopyBaselineRepairStatus.FAILED
+                if rolled_back
+                else CopyBaselineRepairStatus.CONCURRENT
+            )
+    except Exception as repair_error:  # pylint: disable=broad-exception-caught
+        rollback_ok = False
+        if baseline_written:
+            try:
+                rollback_ok = ledger.compare_and_swap_copy_baseline(
+                    dest,
+                    expected_generation=generation,
+                    expected_installation_id=installation_id,
+                    expected_baseline_identity=new_baseline_identity,
+                    file_fingerprints=old_fingerprints,
+                    baseline_identity=old_baseline_identity,
+                )
+            except Exception as rollback_error:  # pylint: disable=broad-exception-caught
+                logger.error(
+                    "copy baseline repair rollback failed path_hash=%s "
+                    "error_type=%s",
+                    _path_hash(dest),
+                    type(rollback_error).__name__,
+                )
+        logger.warning(
+            "copy baseline repair failed path_hash=%s error_type=%s "
+            "rollback_ok=%s",
+            _path_hash(dest),
+            type(repair_error).__name__,
+            rollback_ok,
+        )
+        return CopyBaselineRepairStatus.FAILED
 
 
 def is_link_or_junction(path: Path) -> bool:

--- a/tests/test_copy_baseline_repair.py
+++ b/tests/test_copy_baseline_repair.py
@@ -7,7 +7,7 @@ import sys
 from pathlib import Path
 
 from xskill import cli
-from xskill.ecosystems.install_ledger import get_default_ledger
+from xskill.ecosystems.install_ledger import dest_key, get_default_ledger
 from xskill.ecosystems.installation import (
     CopyBaselineRepairStatus,
     read_install_metadata,
@@ -286,7 +286,7 @@ def test_active_target_listing_does_not_decode_baseline_json(tmp_path):
         conn.execute(
             "UPDATE installations SET file_fingerprints_json=? "
             "WHERE dest_key=?",
-            ("not-json", str(dest)),
+            ("not-json", dest_key(dest)),
         )
         conn.commit()
     finally:
@@ -296,7 +296,7 @@ def test_active_target_listing_does_not_decode_baseline_json(tmp_path):
         mode="copy", skill_name="demo",
     )
 
-    assert targets == [{"dest_key": str(dest), "skill_name": "demo"}]
+    assert targets == [{"dest_key": dest_key(dest), "skill_name": "demo"}]
 
 
 def test_copy_baseline_cas_rejects_reinstalled_generation(tmp_path):

--- a/tests/test_copy_baseline_repair.py
+++ b/tests/test_copy_baseline_repair.py
@@ -1,0 +1,321 @@
+"""存量 copy 安装基线的安全审计与修复回归。"""
+from __future__ import annotations
+
+import hashlib
+import json
+import sys
+from pathlib import Path
+
+from xskill import cli
+from xskill.ecosystems.install_ledger import get_default_ledger
+from xskill.ecosystems.installation import (
+    CopyBaselineRepairStatus,
+    read_install_metadata,
+    repair_copy_install_baseline,
+    write_install_metadata,
+)
+
+
+def _installed_copy(tmp_path: Path, name: str = "demo") -> tuple[Path, Path]:
+    source = tmp_path / "source" / name
+    dest = tmp_path / "ecosystem" / name
+    source.mkdir(parents=True)
+    dest.mkdir(parents=True)
+    content = b"---\r\nname: demo\r\ndescription: test\r\n---\r\nbody\r\n"
+    (source / "SKILL.md").write_bytes(content)
+    (dest / "SKILL.md").write_bytes(content)
+    write_install_metadata(dest, source, "copy")
+    return source, dest
+
+
+def _replace_with_blob_lf_baseline(dest: Path) -> dict[str, str]:
+    legacy = {
+        "SKILL.md": hashlib.sha256(
+            b"---\nname: demo\ndescription: test\n---\nbody\n",
+        ).hexdigest(),
+    }
+    identity = hashlib.sha256(json.dumps(
+        legacy,
+        ensure_ascii=False,
+        separators=(",", ":"),
+        sort_keys=True,
+    ).encode("utf-8")).hexdigest()
+    assert get_default_ledger().update_copy_baseline(
+        dest,
+        file_fingerprints=legacy,
+        baseline_identity=identity,
+    )
+    return legacy
+
+
+def test_repair_copy_baseline_heals_matching_legacy_bytes(tmp_path):
+    source, dest = _installed_copy(tmp_path)
+    legacy = _replace_with_blob_lf_baseline(dest)
+    before = read_install_metadata(dest)
+    assert before is not None
+
+    status = repair_copy_install_baseline(dest)
+
+    assert status == CopyBaselineRepairStatus.REPAIRED
+    after = read_install_metadata(dest)
+    assert after is not None
+    assert after["file_fingerprints"] != legacy
+    assert after["file_fingerprints"]["SKILL.md"] == hashlib.sha256(
+        (source / "SKILL.md").read_bytes(),
+    ).hexdigest()
+    assert after["generation"] == before["generation"]
+    assert after["installation_id"] == before["installation_id"]
+
+
+def test_repair_copy_baseline_dry_run_does_not_write(tmp_path):
+    _source, dest = _installed_copy(tmp_path)
+    legacy = _replace_with_blob_lf_baseline(dest)
+
+    status = repair_copy_install_baseline(dest, apply=False)
+
+    assert status == CopyBaselineRepairStatus.REPAIRABLE
+    after = read_install_metadata(dest)
+    assert after is not None
+    assert after["file_fingerprints"] == legacy
+
+
+def test_current_copy_baseline_only_scans_dest_once(
+    tmp_path, monkeypatch,
+):
+    from xskill.ecosystems import installation
+
+    source, dest = _installed_copy(tmp_path)
+    real_scan = installation._safe_copy_file_fingerprints
+    scanned_roots: list[Path] = []
+
+    def count_scan(root, **kwargs):
+        scanned_roots.append(Path(root))
+        return real_scan(root, **kwargs)
+
+    monkeypatch.setattr(
+        installation, "_safe_copy_file_fingerprints", count_scan,
+    )
+
+    status = repair_copy_install_baseline(dest)
+
+    assert status == CopyBaselineRepairStatus.CURRENT
+    assert scanned_roots == [dest]
+    assert source not in scanned_roots
+
+
+def test_repair_copy_baseline_uses_two_stable_tree_passes(
+    tmp_path, monkeypatch,
+):
+    from xskill.ecosystems import installation
+
+    source, dest = _installed_copy(tmp_path)
+    _replace_with_blob_lf_baseline(dest)
+    real_scan = installation._safe_copy_file_fingerprints
+    scanned_roots: list[Path] = []
+
+    def count_scan(root, **kwargs):
+        scanned_roots.append(Path(root))
+        return real_scan(root, **kwargs)
+
+    monkeypatch.setattr(
+        installation, "_safe_copy_file_fingerprints", count_scan,
+    )
+
+    status = repair_copy_install_baseline(dest)
+
+    assert status == CopyBaselineRepairStatus.REPAIRED
+    assert scanned_roots.count(dest) == 2
+    assert scanned_roots.count(source) == 2
+
+
+def test_repair_copy_baseline_refuses_pending_dest_edit(tmp_path):
+    _source, dest = _installed_copy(tmp_path)
+    legacy = _replace_with_blob_lf_baseline(dest)
+    (dest / "SKILL.md").write_bytes(b"user edit\r\n")
+
+    status = repair_copy_install_baseline(dest)
+
+    assert status == CopyBaselineRepairStatus.DIVERGED
+    after = read_install_metadata(dest)
+    assert after is not None
+    assert after["file_fingerprints"] == legacy
+
+
+def test_repair_copy_baseline_refuses_source_advance(tmp_path):
+    source, dest = _installed_copy(tmp_path)
+    legacy = _replace_with_blob_lf_baseline(dest)
+    (source / "SKILL.md").write_bytes(b"source v2\r\n")
+
+    status = repair_copy_install_baseline(dest)
+
+    assert status == CopyBaselineRepairStatus.DIVERGED
+    after = read_install_metadata(dest)
+    assert after is not None
+    assert after["file_fingerprints"] == legacy
+
+
+def test_repair_copy_baseline_refuses_missing_skill_entrypoint(tmp_path):
+    source, dest = _installed_copy(tmp_path)
+    legacy = _replace_with_blob_lf_baseline(dest)
+    (source / "SKILL.md").unlink()
+    (dest / "SKILL.md").unlink()
+
+    status = repair_copy_install_baseline(dest)
+
+    assert status == CopyBaselineRepairStatus.INVALID
+    after = read_install_metadata(dest)
+    assert after is not None
+    assert after["file_fingerprints"] == legacy
+
+
+def test_repair_copy_baseline_refuses_open_removal(tmp_path):
+    _source, dest = _installed_copy(tmp_path)
+    legacy = _replace_with_blob_lf_baseline(dest)
+    ledger = get_default_ledger()
+    assert ledger.begin_removal(dest) is not None
+
+    status = repair_copy_install_baseline(dest)
+
+    assert status == CopyBaselineRepairStatus.CONCURRENT
+    after = read_install_metadata(dest)
+    assert after is not None
+    assert after["file_fingerprints"] == legacy
+
+
+def test_repair_copy_baseline_rolls_back_dest_race(
+    tmp_path, monkeypatch,
+):
+    from xskill.ecosystems import installation
+
+    _source, dest = _installed_copy(tmp_path)
+    legacy = _replace_with_blob_lf_baseline(dest)
+    real_scan = installation._safe_copy_file_fingerprints
+    full_dest_scans = 0
+
+    def race_scan(root, **kwargs):
+        nonlocal full_dest_scans
+        if Path(root) == dest and not kwargs:
+            full_dest_scans += 1
+            if full_dest_scans == 2:
+                (dest / "SKILL.md").write_bytes(b"racing edit\r\n")
+        return real_scan(root, **kwargs)
+
+    monkeypatch.setattr(
+        installation, "_safe_copy_file_fingerprints", race_scan,
+    )
+
+    status = repair_copy_install_baseline(dest)
+
+    assert status == CopyBaselineRepairStatus.FAILED
+    after = read_install_metadata(dest)
+    assert after is not None
+    assert after["file_fingerprints"] == legacy
+
+
+def test_repair_copy_baseline_reports_concurrent_reinstall(
+    tmp_path, monkeypatch,
+):
+    source, dest = _installed_copy(tmp_path)
+    _replace_with_blob_lf_baseline(dest)
+    ledger = get_default_ledger()
+    real_swap = ledger.compare_and_swap_copy_baseline
+    swap_calls = 0
+
+    def reinstall_after_swap(*args, **kwargs):
+        nonlocal swap_calls
+        swapped = real_swap(*args, **kwargs)
+        swap_calls += 1
+        if swapped and swap_calls == 1:
+            write_install_metadata(dest, source, "copy")
+        return swapped
+
+    monkeypatch.setattr(
+        ledger, "compare_and_swap_copy_baseline", reinstall_after_swap,
+    )
+
+    status = repair_copy_install_baseline(dest)
+
+    assert status == CopyBaselineRepairStatus.CONCURRENT
+    current = read_install_metadata(dest)
+    assert current is not None
+    assert current["file_fingerprints"]["SKILL.md"] == hashlib.sha256(
+        (dest / "SKILL.md").read_bytes(),
+    ).hexdigest()
+
+
+def test_repair_baselines_cli_reports_safe_dry_run(tmp_path, capsys):
+    _source, dest = _installed_copy(tmp_path)
+    _replace_with_blob_lf_baseline(dest)
+    args = cli.build_parser().parse_args([
+        "repair-baselines", "--skill", "demo", "--dry-run", "--json",
+    ])
+
+    return_code = cli.cmd_repair_baselines(args)
+
+    payload = json.loads(capsys.readouterr().out)
+    assert return_code == 0
+    assert payload["dry_run"] is True
+    assert payload["counts"]["repairable"] == 1
+    assert payload["results"][0]["skill"] == "demo"
+    after = read_install_metadata(dest)
+    assert after is not None
+    assert after["file_fingerprints"]["SKILL.md"] != hashlib.sha256(
+        (dest / "SKILL.md").read_bytes(),
+    ).hexdigest()
+
+
+def test_repair_baselines_cli_main_does_not_require_config(
+    monkeypatch, capsys,
+):
+    monkeypatch.setattr(
+        sys, "argv", ["xskill", "repair-baselines", "--json"],
+    )
+
+    return_code = cli.main()
+
+    payload = json.loads(capsys.readouterr().out)
+    assert return_code == 0
+    assert payload["results"] == []
+
+
+def test_active_target_listing_does_not_decode_baseline_json(tmp_path):
+    _source, dest = _installed_copy(tmp_path)
+    ledger = get_default_ledger()
+    conn = ledger._conn()
+    try:
+        conn.execute(
+            "UPDATE installations SET file_fingerprints_json=? "
+            "WHERE dest_key=?",
+            ("not-json", str(dest)),
+        )
+        conn.commit()
+    finally:
+        conn.close()
+
+    targets = ledger.list_active_install_targets(
+        mode="copy", skill_name="demo",
+    )
+
+    assert targets == [{"dest_key": str(dest), "skill_name": "demo"}]
+
+
+def test_copy_baseline_cas_rejects_reinstalled_generation(tmp_path):
+    source, dest = _installed_copy(tmp_path)
+    ledger = get_default_ledger()
+    before = read_install_metadata(dest)
+    assert before is not None
+    write_install_metadata(dest, source, "copy")
+    current = read_install_metadata(dest)
+    assert current is not None
+
+    updated = ledger.compare_and_swap_copy_baseline(
+        dest,
+        expected_generation=before["generation"],
+        expected_installation_id=before["installation_id"],
+        expected_baseline_identity=before["baseline_identity"],
+        file_fingerprints=before["file_fingerprints"],
+        baseline_identity=before["baseline_identity"],
+    )
+
+    assert updated is False
+    assert read_install_metadata(dest) == current


### PR DESCRIPTION
## Summary

本 PR 继续推进 #203，为历史 copy 安装提供显式、可审计的 baseline 修复命令。
修复只在 source 与安装副本的用户可见内容完全一致时更新账本，不会把待回流用户编辑或 source 前进误写成新基线。

## Changes

- 新增 `xskill repair-baselines`，支持 `--skill`、`--dry-run` 与 `--json`。
- 轻量枚举 active copy 目标，不预先读取和解析全部 baseline JSON。
- 使用 source/dest 双向指纹一致性、`SKILL.md` 入口、安装身份和文件安全检查决定是否允许修复。
- 使用 generation、installation_id、旧 baseline 与开放卸装事务条件进行 CAS，写后再次复核，竞态时回滚或报告 concurrent。
- 输出 skill、隐私安全的 target_id 和结构化状态，不暴露本机路径。
- 增加历史 LF blob/CRLF copy、自定义编辑、source 前进、文件竞态、并发重装、开放卸装、损坏入口、扫描次数和 CLI 回归测试。

## Test plan

- [x] `make test` passes
- [x] Added/updated unit tests for the change
- [x] `make e2e` passes (if the change touches ingestion / install / daemon)
- [ ] Manually verified the affected user flow（为避免触碰真实用户目录，本 PR 使用隔离的 CLI 集成测试覆盖 `--dry-run`、skill 筛选、JSON 输出和无 config 启动路径）

验证结果：Python 3.11 全量测试为 2475 passed、10 skipped；Python 3.9 新增用例为 14 passed；安装与 reverse-sync 聚焦测试为 68 passed。
Docker E2E 的 `runtime_ecosystem_detect` 与 `runtime_openclaw_detect` 两个场景均通过。
改动范围 Ruff 与 `git diff --check` 通过；项目现有 lint baseline 未因本 PR 增加告警。

## Linked issues

Refs #203
