### PR TITLE
fix(test): search BM25 补丁跟上 #313 的路径解析

### DIFF
--- a/tests/test_search_local_fallback.py
+++ b/tests/test_search_local_fallback.py
@@ -43,7 +43,9 @@ def local_skill_dir(tmp_path, monkeypatch) -> Path:
     skill_dir = tmp_path / "skill"
     skill_dir.mkdir()
     import xskill.config as config_module
-    monkeypatch.setattr(config_module, "get_skill_dir", lambda: skill_dir)
+    monkeypatch.setattr(
+        config_module, "resolve_local_skill_dir", lambda **_kw: skill_dir,
+    )
     return skill_dir
 
 
@@ -165,11 +167,12 @@ def test_local_bm25_survives_missing_config(monkeypatch, capsys, tmp_path):
     import xskill.config as config_module
     from xskill import runtime
 
-    def _raise_missing_config():
+    def _raise_missing_config(*_a, **_k):
         raise FileNotFoundError("xskill config not found")
 
     monkeypatch.setattr(runtime, "read_status", lambda: {"running": False})
-    monkeypatch.setattr(config_module, "get_skill_dir", _raise_missing_config)
+    # 完整 get_config 会因缺 llm 等字段失败；search 只窥视 skill_dir。
+    monkeypatch.setattr(config_module, "get_config", _raise_missing_config)
     monkeypatch.setattr(config_module, "XSKILL_HOME", tmp_path)
     _write_skill(tmp_path / "skill", "copy-align", "处理前端文案对齐任务")
     rc = cli._cmd_search_local(_args())


### PR DESCRIPTION
Follow-up to #313

本地 search 已改走 `resolve_local_skill_dir`。测试里无参 `lambda` 补丁 `get_skill_dir` 会 TypeError，py3.11 / py3.12 各红 5 条。

## Summary
- fixture 改补 `resolve_local_skill_dir`
- 缺配置用例改为断言不走 `get_config`，用默认 `XSKILL_HOME/skill` 兜底

## Test plan
- [x] tests/test_search_local_fallback.py 9 passed

Made with [Cursor](https://cursor.com)