### PR TITLE
fix(team): 同机隔离在配置异常时 fail closed 并修复遗留母本软链

### DIFF
--- a/src/xskill/config.py
+++ b/src/xskill/config.py
@@ -1220,7 +1220,11 @@ def get_team_server_state_path(*, xskill_home: Optional[Path] = None) -> Path:
     return Path(xskill_home).expanduser().resolve() / "team_server.json"
 
 
-def _peek_state_config(xskill_home: Optional[Path] = None) -> dict:
+def _peek_state_config(
+    xskill_home: Optional[Path] = None,
+    *,
+    strict: bool = False,
+) -> dict:
     """只读 state_root/config.yaml，不经 ``get_config()``。
 
     瘦客户端没有 llm.api_key，``get_config()`` 会抛 KeyError。同机隔离只需要
@@ -1234,14 +1238,29 @@ def _peek_state_config(xskill_home: Optional[Path] = None) -> dict:
         return {}
     try:
         data = yaml.safe_load(cfg_file.read_text(encoding="utf-8")) or {}
-    except Exception:
+    except Exception as config_error:
+        if strict:
+            raise ValueError(
+                "state config cannot be read safely"
+            ) from config_error
         return {}
-    return data if isinstance(data, dict) else {}
+    if isinstance(data, dict):
+        return data
+    if strict:
+        raise ValueError("state config must be a mapping")
+    return {}
 
 
-def resolve_local_skill_dir(*, xskill_home: Optional[Path] = None) -> Path:
+def resolve_local_skill_dir(
+    *,
+    xskill_home: Optional[Path] = None,
+    strict_config: bool = False,
+) -> Path:
     """本机 skill 仓路径：走 ``get_skill_dir``，不要求完整 config。"""
-    return get_skill_dir(_peek_state_config(xskill_home), xskill_home=xskill_home)
+    return get_skill_dir(
+        _peek_state_config(xskill_home, strict=strict_config),
+        xskill_home=xskill_home,
+    )
 
 
 def get_team_client_working_dir(*, xskill_home: Optional[Path] = None) -> Path:
@@ -1284,10 +1303,18 @@ def is_team_server_canonical_skill_dir(
         return False
     try:
         req_key = _norm_path_key(skill_dir)
-        canon_key = _norm_path_key(resolve_local_skill_dir(xskill_home=xskill_home))
+        canon_key = _norm_path_key(resolve_local_skill_dir(
+            xskill_home=xskill_home,
+            strict_config=True,
+        ))
         return req_key == canon_key
-    except (OSError, RuntimeError, ValueError):
-        return False
+    except (OSError, RuntimeError, ValueError) as config_error:
+        logger.error(
+            "team server canonical skill dir is uncertain; failing closed "
+            "error_type=%s",
+            type(config_error).__name__,
+        )
+        return True
 
 
 def resolve_team_client_skill_dir(

--- a/src/xskill/team/client/daemon.py
+++ b/src/xskill/team/client/daemon.py
@@ -304,8 +304,17 @@ class TeamClient:
             display_name=display_name, source_path=source_path,
         )
 
-    def _install_to_ecosystems(self, repo_dir: Path) -> None:
-        install_skill_to_ecosystems(repo_dir, home_root=self.home_root)
+    def _install_to_ecosystems(
+        self,
+        repo_dir: Path,
+        *,
+        ecosystems: list[str] | tuple[str, ...] | None = None,
+    ) -> None:
+        install_skill_to_ecosystems(
+            repo_dir,
+            home_root=self.home_root,
+            ecosystems=ecosystems,
+        )
 
     def reconcile_downloaded_skills(self) -> int:
         """刷新显式下载项；持久下载不占 search LRU，随服务端版本继续更新。"""
@@ -569,12 +578,28 @@ class TeamClient:
             )
         # 上面的 working-copy 驱动清理看不见"工作副本已被 out-of-band 删除、生态
         # link 却还在"的孤儿；按生态目录反向再收一遍。
-        self._reap_orphaned_ecosystem_links(keep)
+        reinstall = self._reap_orphaned_ecosystem_links(keep)
+        for skill_name, ecosystems in sorted(reinstall.items()):
+            repo_dir = self.skill_dir / skill_name
+            if not repo_dir.is_dir():
+                logger.warning(
+                    "kept server link repair skipped missing working copy "
+                    "skill_id_hash=%s",
+                    hashlib.sha256(
+                        skill_name.encode("utf-8"),
+                    ).hexdigest()[:12],
+                )
+                continue
+            self._install_to_ecosystems(
+                repo_dir, ecosystems=sorted(ecosystems),
+            )
         # copy 孤儿（有老 meta、无账本或卸装拒删）同样逃出 working-copy 驱动清理；
         # 推荐流 delta 必须能清掉，否则 .agents 只增不减。
         self._reap_orphan_copy_dests(keep)
 
-    def _reap_orphaned_ecosystem_links(self, keep: set[str]) -> None:
+    def _reap_orphaned_ecosystem_links(
+        self, keep: set[str],
+    ) -> dict[str, set[str]]:
         """扫生态 dest 根目录，收掉 manifest 已不含、且指向 xskill 工作副本根（或同机 Server 母本）的
         link/junction（含工作副本被删后留下的 dangling 孤儿，以及跨模式切换遗留的 Server 软链）。
 
@@ -589,17 +614,24 @@ class TeamClient:
         from xskill.config import (
             get_team_server_state_path, resolve_local_skill_dir,
         )
-        server_root_key = (
-            _source_path_key(resolve_local_skill_dir(xskill_home=self._xskill_home))
-            if get_team_server_state_path(xskill_home=self._xskill_home).is_file()
-            else None
-        )
-        for root in _ecosystem_skill_roots(self.home_root):
+        server_root_key = None
+        if get_team_server_state_path(xskill_home=self._xskill_home).is_file():
+            try:
+                server_root_key = _source_path_key(resolve_local_skill_dir(
+                    xskill_home=self._xskill_home,
+                    strict_config=True,
+                ))
+            except (OSError, RuntimeError, ValueError) as config_error:
+                logger.warning(
+                    "server skill link cleanup skipped uncertain canonical "
+                    "root error_type=%s",
+                    type(config_error).__name__,
+                )
+        reinstall: dict[str, set[str]] = {}
+        for root, ecosystem in _ecosystem_skill_root_installers(self.home_root):
             if not root.is_dir():
                 continue
             for entry in sorted(root.iterdir()):
-                if entry.name in keep:
-                    continue  # manifest 仍需要 → 保留（dangling 也留给 reconcile 重装）
                 # 只收 link/junction：真目录（手动建 skill）与 copy 安装一律不碰。
                 if not is_link_or_junction(entry):
                     continue
@@ -615,15 +647,20 @@ class TeamClient:
                         or entry_key.startswith(server_root_key + os.sep)
                     )
                 )
+                if entry.name in keep and not is_stale_server_link:
+                    continue  # 正常 Client link 与 dangling link 留给 reconcile
                 if not (is_client_link or is_stale_server_link):
                     continue  # link 不指向 xskill 工作副本根或服务端母本 → 第三方安装，跳过
                 if _remove_owned_install_target(
                     entry, Path(_source_path_key(entry)),
                 ):
+                    if entry.name in keep and is_stale_server_link:
+                        reinstall.setdefault(entry.name, set()).add(ecosystem)
                     logger.info(
                         "reaped orphaned ecosystem link target_hash=%s",
                         _target_path_hash(entry),
                     )
+        return reinstall
 
     def _reap_orphan_copy_dests(self, keep: set[str]) -> None:
         """收掉 manifest 已不含、带 dest 内老 install-meta 的 copy 真目录。
@@ -832,21 +869,32 @@ def _targets_for_ecosystem(ecosystem: str, skill_name: str,
     return roots.get(ecosystem, [])
 
 
-def _ecosystem_skill_roots(home_root: Path) -> list[Path]:
-    """所有安装器的 skill 目标根目录；不依赖生态当前是否仍可探测。"""
+def _ecosystem_skill_root_installers(
+    home_root: Path,
+) -> list[tuple[Path, str]]:
+    """安装目标根及其定向修复安装器；不依赖生态当前是否仍可探测。"""
     from xskill.ecosystems import (
         _agents_skills_path, _cc_skills_path, _cursor_skills_path,
         _nga3_skills_path, _ngagent_skills_path,
     )
 
     return [
-        _cc_skills_path(home_root),
-        _agents_skills_path(home_root),
-        _nga3_skills_path(home_root),
-        _ngagent_skills_path(home_root),
-        _cursor_skills_path(home_root),
-        home_root / ".trae-cn" / "skills",
-        home_root / ".trae" / "skills",
+        (_cc_skills_path(home_root), "claude_code"),
+        # Codex / OpenCode / OpenClaw 共用 .agents/skills；遗留 link 用
+        # symlink-first 的 Codex 安装器即可恢复为 Client 工作副本。
+        (_agents_skills_path(home_root), "codex"),
+        (_nga3_skills_path(home_root), "nga3"),
+        (_ngagent_skills_path(home_root), "ngagent"),
+        (_cursor_skills_path(home_root), "cursor"),
+        (home_root / ".trae-cn" / "skills", "trae"),
+        (home_root / ".trae" / "skills", "trae"),
+    ]
+
+
+def _ecosystem_skill_roots(home_root: Path) -> list[Path]:
+    """所有安装器的 skill 目标根目录；不依赖生态当前是否仍可探测。"""
+    return [
+        root for root, _ecosystem in _ecosystem_skill_root_installers(home_root)
     ]
 
 

--- a/tests/test_team_client.py
+++ b/tests/test_team_client.py
@@ -399,6 +399,84 @@ def test_cleanup_reaps_stale_server_ecosystem_links(tmp_path, monkeypatch):
     assert (canonical / "stale-skill").is_dir()
 
 
+def test_cleanup_fails_closed_when_server_config_becomes_malformed(tmp_path, monkeypatch):
+    """Server 后启动且配置损坏时，cleanup 不得删除自定义权威仓。"""
+    from xskill.team.shared.protocol import SyncResponse
+
+    xhome = tmp_path / ".xskill"
+    xhome.mkdir()
+    canonical = tmp_path / "company-skills"
+    server_skill = canonical / "server-only"
+    server_skill.mkdir(parents=True)
+    (server_skill / "SKILL.md").write_text("# keep\n", encoding="utf-8")
+    config = xhome / "config.yaml"
+    config.write_text(f"skill_dir: {canonical}\n", encoding="utf-8")
+    monkeypatch.setattr("xskill.config.XSKILL_HOME", xhome)
+
+    tc = TeamClient(
+        state=ClientState(
+            server_url="http://testserver", client_id="c", join_token="t",
+        ),
+        http=SimpleNamespace(),
+        skill_dir=canonical,
+        cursor_path=tmp_path / "cursor.json",
+        history_path=tmp_path / "history.jsonl",
+        home_root=tmp_path / "home",
+        min_change_interval=0,
+    )
+    (xhome / "team_server.json").write_text("{}", encoding="utf-8")
+    config.write_text("skill_dir: [", encoding="utf-8")
+
+    tc.cleanup(SyncResponse(slots=[], server_time=1.0))
+
+    assert tc.skill_dir == xhome / "client_skill"
+    assert server_skill.is_dir()
+
+
+def test_cleanup_repairs_kept_link_that_targets_server_repo(tmp_path, monkeypatch):
+    """清单保留项的旧 Server 软链要在同轮切回 Client 工作副本。"""
+    from xskill.team.shared.protocol import SkillSlot, SyncResponse
+
+    xhome = tmp_path / ".xskill"
+    canonical = xhome / "skill"
+    server_skill = canonical / "kept-skill"
+    server_skill.mkdir(parents=True)
+    (server_skill / "SKILL.md").write_text("# server\n", encoding="utf-8")
+    (xhome / "team_server.json").write_text("{}", encoding="utf-8")
+    monkeypatch.setattr("xskill.config.XSKILL_HOME", xhome)
+
+    client_skill = xhome / "client_skill" / "kept-skill"
+    client_skill.mkdir(parents=True)
+    (client_skill / "SKILL.md").write_text("# client\n", encoding="utf-8")
+    home_dir = tmp_path / "home"
+    cursor_skills = home_dir / ".cursor" / "skills"
+    cursor_skills.mkdir(parents=True)
+    link = cursor_skills / "kept-skill"
+    link.symlink_to(server_skill)
+
+    tc = TeamClient(
+        state=ClientState(
+            server_url="http://testserver", client_id="c", join_token="t",
+        ),
+        http=SimpleNamespace(),
+        skill_dir=canonical,
+        cursor_path=tmp_path / "cursor.json",
+        history_path=tmp_path / "history.jsonl",
+        home_root=home_dir,
+        min_change_interval=0,
+    )
+    manifest = SyncResponse(
+        slots=[SkillSlot(
+            skill_name="kept-skill", side="main", sha="abc", bucket="ranked",
+        )],
+        server_time=1.0,
+    )
+
+    tc.cleanup(manifest)
+
+    assert link.resolve() == client_skill.resolve()
+
+
 
 def test_cleanup_reaps_orphaned_ecosystem_links(server_app, tmp_path):
     """cleanup 按生态目录反向收孤儿 link:工作副本被 out-of-band 删除后残留、

--- a/tests/test_team_config.py
+++ b/tests/test_team_config.py
@@ -110,3 +110,19 @@ def test_resolve_team_client_skill_dir_respects_config_skill_dir(tmp_path, monke
     requested = C.resolve_local_skill_dir(xskill_home=xhome)
     assert C.resolve_team_client_skill_dir(requested, xskill_home=xhome) == xhome / "client_skill"
 
+
+def test_team_server_canonical_check_fails_closed_on_bad_config(tmp_path):
+    """Server 存在但权威仓配置不可判定时，破坏性 Client 操作必须保守拦截。"""
+    xhome = tmp_path / ".xskill"
+    xhome.mkdir()
+    requested = tmp_path / "company-skills"
+    requested.mkdir()
+    (xhome / "team_server.json").write_text("{}", encoding="utf-8")
+    (xhome / "config.yaml").write_text("skill_dir: [", encoding="utf-8")
+
+    assert C.is_team_server_canonical_skill_dir(
+        requested, xskill_home=xhome,
+    ) is True
+    assert C.resolve_team_client_skill_dir(
+        requested, xskill_home=xhome,
+    ) == xhome / "client_skill"


### PR DESCRIPTION
## Summary

#313 已将同机 Team Client 工作副本与 Server 权威 Skill 仓隔离，但配置读取异常和 manifest 保留项中的旧软链仍可能绕过安全边界。

本 PR 让权威目录无法可靠解析时 fail closed，并修复仍指向 Server 母本的遗留生态软链。

## Changes

- 为本地 `skill_dir` 解析增加严格模式，无法确认 Server 权威目录时拒绝危险 cleanup。
- 识别并摘除 manifest 保留项中仍指向 Server 母本的软链，再定向安装到 Client 工作副本。
- 保持正常 Client link、dangling link、第三方 link、手工目录和非保留孤儿清理的既有行为。
- 仅在确认发现遗留 Server link 时触发定向重装，正常轮询不增加安装调用。

## Test plan

- [ ] `make test` passes：当前环境缺少名为 `python3.11` 的可执行文件，命令在测试启动前退出。
- [x] 使用同一 pytest 参数运行完整 UT/IT：`2586 passed, 10 skipped`。
- [x] Team、配置和生态安装定向测试：`236 passed`。
- [x] Added/updated unit tests for the change。
- [ ] `make e2e` passes：定向连接生命周期 E2E 在当前非 WSL Linux 环境按条件跳过。
- [ ] Manually verified the affected user flow。

Ruff 在改动文件上报告 12 项，使用精确的 `main@d6a9717` 运行同一命令得到相同 12 项，因此没有把主分支存量清理捆入本 PR。

当前 head `6e911423b5361442f325f54793a5e692f66c8df8` 已合并最新 main，包含 #358 的跨任务写入授权清理。

## Linked issues

Closes #350

Refs #313
