### PR TITLE
fix(agents): 新任务清理遗留的 Skill 写入授权

### DIFF
--- a/src/xskill/agents/agent_tools.py
+++ b/src/xskill/agents/agent_tools.py
@@ -276,6 +276,9 @@ class AgentToolConfig:
                 Path(spill_root) if spill_root is not None else None
             ),
             usage_ledger=usage_ledger,
+            cluster_batch_ids=frozenset(),
+            skill_edit_skill_name=None,
+            skill_edit_batch_ids=(),
         ))
 
     def configure_atom_task(
@@ -293,6 +296,9 @@ class AgentToolConfig:
                 Path(spill_root) if spill_root is not None else None
             ),
             usage_ledger=usage_ledger,
+            cluster_batch_ids=frozenset(),
+            skill_edit_skill_name=None,
+            skill_edit_batch_ids=(),
         ))
 
     def snapshot(self) -> dict:

--- a/tests/test_agent_tool_context_isolation.py
+++ b/tests/test_agent_tool_context_isolation.py
@@ -522,6 +522,43 @@ def test_configured_context_uses_only_its_spill_root_without_workspace(
     assert roots == [spill_root.resolve()]
 
 
+@pytest.mark.parametrize(
+    "initialize",
+    [
+        lambda root: agent_tools.init_skill_authoring_tool_context(
+            root, root, {},
+        ),
+        lambda root: agent_tools.init_atom_task_tool_context(
+            skill_dir=root,
+            atom_store=None,
+            default_traj_root=root,
+        ),
+    ],
+    ids=["skill-authoring", "atom-task"],
+)
+def test_compat_initializers_clear_previous_turn_write_authority(
+    tmp_path, initialize,
+):
+    previous = agent_tools.create_agent_tool_context(
+        skill_dir=tmp_path / "previous",
+        cluster_batch_ids=["previous-atom"],
+        skill_edit_skill_name="previous-skill",
+        skill_edit_batch_ids=["previous-atom"],
+    )
+    token = agent_tools.bind_agent_tool_context(previous)
+    try:
+        current_root = tmp_path / "current"
+        initialize(current_root)
+
+        current = agent_tools.current_agent_tool_context()
+        assert current.cluster_batch_ids == frozenset()
+        assert current.skill_edit_skill_name is None
+        assert current.skill_edit_batch_ids == ()
+        assert agent_tools.agent_tool_config.writable_skill_dir == current_root
+    finally:
+        agent_tools.reset_agent_tool_context(token)
+
+
 def test_long_context_spills_are_instance_isolated_and_never_use_shared_tmp(
     tmp_path,
 ):


### PR DESCRIPTION
## 变更说明

修复 #355。

兼容初始化入口开始新任务时，现在会清理上一轮的 `cluster_batch_ids`、`skill_edit_skill_name` 和 `skill_edit_batch_ids`。

同一任务内 `new_skill_folder()` 钉住写入目标的行为保持不变，只有下一次显式初始化任务时才清除。

新增两个入口的回归测试，验证上一轮写入目标与批次授权不会进入下一轮，且新任务的写入根正确。

## 验证

`tests/test_agent_tool_context_isolation.py`、`tests/test_skill_tools_atom.py`、`tests/test_skill_tools_dotgit_guard.py` 与 `tests/test_write_file_skill_dir_paths.py` 联合运行：74 passed。

修复前同一顺序稳定出现 7 个失败，修复后全部通过。

代码保持 Python 3.9 兼容。