### PR TITLE
feat(generate): session preview cards and wiki read-plan

### DIFF
--- a/src/xskill/agents/agent_tools.py
+++ b/src/xskill/agents/agent_tools.py
@@ -94,6 +94,7 @@ class AgentToolContext:
     registry_db_path: Path | None = None
     extra_read_roots: tuple[Path, ...] = ()
     generate_user_id: str | None = None
+    wiki_root: Path | None = None
     blocked_read_roots: tuple[Path, ...] = ()
 
     def __post_init__(self) -> None:
@@ -110,6 +111,8 @@ class AgentToolContext:
             )
         extra = tuple(Path(p) for p in (self.extra_read_roots or ()))
         object.__setattr__(self, "extra_read_roots", extra)
+        if self.wiki_root is not None:
+            object.__setattr__(self, "wiki_root", Path(self.wiki_root))
         blocked = tuple(Path(p) for p in (self.blocked_read_roots or ()))
         object.__setattr__(self, "blocked_read_roots", blocked)
 
@@ -141,6 +144,7 @@ def create_agent_tool_context(
     registry_db_path=None,
     extra_read_roots=(),
     generate_user_id=None,
+    wiki_root=None,
     blocked_read_roots=(),
 ) -> AgentToolContext:
     """Create an immutable context without changing the current task."""
@@ -180,6 +184,7 @@ def create_agent_tool_context(
         generate_user_id=(
             str(generate_user_id) if generate_user_id else None
         ),
+        wiki_root=Path(wiki_root) if wiki_root is not None else None,
         blocked_read_roots=tuple(
             Path(p) for p in (blocked_read_roots or ())
         ),
@@ -322,6 +327,7 @@ class AgentToolConfig:
             "registry_db_path": current.registry_db_path,
             "extra_read_roots": current.extra_read_roots,
             "generate_user_id": current.generate_user_id,
+            "wiki_root": current.wiki_root,
             "blocked_read_roots": current.blocked_read_roots,
         }
 
@@ -343,6 +349,7 @@ class AgentToolConfig:
             registry_db_path=snapshot.get("registry_db_path"),
             extra_read_roots=snapshot.get("extra_read_roots") or (),
             generate_user_id=snapshot.get("generate_user_id"),
+            wiki_root=snapshot.get("wiki_root"),
             blocked_read_roots=snapshot.get("blocked_read_roots") or (),
         ))
         if not snapshot.get("configured", True):
@@ -611,6 +618,75 @@ def _mark_file_read(path: Path) -> None:
         _read_file_ledger().add(str(path.resolve()))
     except OSError:
         logger.debug("mark_file_read failed for %s", path, exc_info=True)
+
+
+_TRAJ_STEM = re.compile(r"^traj_[A-Za-z0-9_-]+$")
+_MIN_GENERATE_TRAJ_READS = 10
+_SESSION_DIR_MARKERS = frozenset({"team_trajectories", "sessions"})
+
+
+def _is_generate_mode() -> bool:
+    ctx = current_agent_tool_context()
+    return bool(ctx.generate_user_id or ctx.wiki_root)
+
+
+def generate_read_traj_ids() -> list[str]:
+    """本趟 read_file 真正打开过的不同 traj_* stem。看过卡片的不算。"""
+    ids: list[str] = []
+    seen: set[str] = set()
+    for raw in sorted(_read_file_ledger()):
+        name = Path(raw).name
+        if not (name.endswith(".md") or name.endswith(".json")):
+            continue
+        stem = Path(name).stem
+        if not _TRAJ_STEM.match(stem) or stem in seen:
+            continue
+        seen.add(stem)
+        ids.append(stem)
+    return ids
+
+
+def _generate_commit_read_gate() -> str | None:
+    if not _is_generate_mode():
+        return None
+    ids = generate_read_traj_ids()
+    if len(ids) >= _MIN_GENERATE_TRAJ_READS:
+        return None
+    shown = ", ".join(ids) if ids else "(none)"
+    return (
+        f"error: commit_generate_main 需要本趟 read_file 精读至少 "
+        f"{_MIN_GENERATE_TRAJ_READS} 条不同轨迹，当前 {len(ids)} 条: {shown}。"
+        "只看过 session_card 的 id 不算。继续按 read-plan 精读后再 commit。"
+    )
+
+
+def _is_generate_session_dir_scan(path: Path) -> bool:
+    """Generate 禁止对会话目录做 list_files 或整目录 grep。单文件可以。"""
+    if not _is_generate_mode():
+        return False
+    try:
+        resolved = path.resolve()
+    except OSError:
+        resolved = path
+    if resolved.is_file():
+        return False
+    if any(part in _SESSION_DIR_MARKERS for part in resolved.parts):
+        return True
+    ctx = current_agent_tool_context()
+    root = ctx.default_traj_root
+    if root is None:
+        return False
+    try:
+        traj = Path(root).resolve()
+    except OSError:
+        traj = Path(root)
+    if resolved == traj:
+        return True
+    try:
+        resolved.relative_to(traj)
+    except ValueError:
+        return False
+    return True
 
 
 def _file_was_read(path: Path) -> bool:
@@ -1171,6 +1247,9 @@ def commit_generate_main(skill_name: str, message: str) -> str:
     """
     from xskill.skill.git import commit_generate_to_main_branch
 
+    gated = _generate_commit_read_gate()
+    if gated is not None:
+        return gated
     skill_dir = agent_tool_config.atom_skill_dir or agent_tool_config.skill_dir
     if skill_dir is None:
         return "error: skill directory is not configured"
@@ -1951,6 +2030,11 @@ def list_files(path: str) -> str:
         return f"error: list_files restricted to {allowed_block} (tried: {path})"
     if _is_blocked_read_path(target_directory):
         return _onhold_block_message(target_directory)
+    if _is_generate_session_dir_scan(target_directory):
+        return (
+            "error: Generate 看会话请用 list_sessions / session_cards，"
+            "不要 list_files 扫轨迹目录。"
+        )
     if not target_directory.is_dir():
         return f"error: not a directory: {path}"
     entries = sorted(target_directory.iterdir())
@@ -1985,6 +2069,11 @@ def grep_files(pattern: str, path: str = "", glob: str = "",
         return f"error: grep_files restricted to {allowed_block} (tried: {path})"
     if _is_blocked_read_path(search_root):
         return _onhold_block_message(search_root)
+    if _is_generate_session_dir_scan(search_root):
+        return (
+            "error: Generate 不要对会话目录做全文 grep。"
+            "对单条轨迹文件可以 grep；扫面用 list_sessions。"
+        )
     if not search_root.exists():
         return f"error: path not found ({path})"
 

--- a/src/xskill/agents/context_budget.py
+++ b/src/xskill/agents/context_budget.py
@@ -71,10 +71,14 @@ CJK_TOKENS_PER_CHAR_BY_FAMILY = {
 _TRIMMABLE_TOOLS = (
     "look", "readfile", "read_file", "atom_task_read", "read_traj", "skill_read",
     "grep_files", "list_files", "edit",
+    "list_sessions", "session_card", "session_cards",
+    "wiki_read", "wiki_status", "wiki_search",
 )
 _SPILLABLE_TOOLS = (
     "readfile", "read_file", "atom_task_read", "read_traj", "skill_read",
     "grep_files", "edit",
+    "list_sessions", "session_card", "session_cards",
+    "wiki_read", "wiki_search",
 )
 _TRIM_MARK = "[…look 旧结果已剪裁,需要可重新 look…]"
 _COMPACT_MARK = "[compacted_agent_memory]"
@@ -948,7 +952,23 @@ def _compact_history_in_place(
             new_messages.append(msg)
             kept_new_ids.add(id(msg))
     messages[:] = new_messages
+    _maybe_apply_generate_compact_hint(messages)
     return True
+
+
+def _maybe_apply_generate_compact_hint(messages: list) -> None:
+    """Generate 压缩成功后另塞一条短 hint，不写进 SYSTEM_PROMPT。"""
+    try:
+        from xskill.agents.agent_tools import current_agent_tool_context
+
+        ctx = current_agent_tool_context()
+        if not getattr(ctx, "wiki_root", None) and not getattr(ctx, "generate_user_id", None):
+            return
+        from xskill.agents.llm_wiki import apply_after_compact_hint
+
+        apply_after_compact_hint(messages)
+    except Exception:  # noqa: BLE001 — hint must not abort compact
+        logger.debug("generate compact hint skipped", exc_info=True)
 
 
 def _response_text(resp: Any, assistant_message: Any | None = None) -> str:

--- a/src/xskill/agents/generate_agent.py
+++ b/src/xskill/agents/generate_agent.py
@@ -1,8 +1,8 @@
 """GenerateAgent —— 用户点名、直接写主干的 skill 生成代理。
 
 和 SkillEditAgent 同类（Agno + 同一套工具上下文），但由
-``xskill generate`` 启动，不靠候选缓冲攒分。读轨迹靠 list/grep/read；
-写完用 ``commit_generate_main`` 落到 main。
+``xskill generate`` 启动，不靠候选缓冲攒分。读轨迹先预览卡再精读，
+进度写进磁盘 wiki；写完用 ``commit_generate_main`` 落到 main。
 """
 from __future__ import annotations
 
@@ -39,8 +39,28 @@ scripts/ 下放可执行脚本、在 references/ 下放长参考材料。价值�
 
 {read_roots_block}
 
-用 list_files 摸清结构，用 grep_files 按关键词搜索，用 read_file 按行精读。
-看某个已有 skill 的现状用 skill_read。
+# 怎么读轨迹（省上下文，先预览再精读）
+
+会话很多，禁止 list_files 或 grep_files 去扫 team_trajectories、sessions。
+那会把几百个文件名和命中行倒进上下文，上一轮就是这样烧掉一百多万 token，
+却只精读了几条。
+
+session_card / session_cards 只是预览，很省上下文：
+- 有用户 query 和行号 L
+- 有截断的 toolcall 参数（command、path 等收短）
+- 没有 tool result，没有完整回传，没有原始 json
+看过卡片只知道「大概在干什么、该从哪一行精读」，不算读懂这条轨迹。
+不要把只看过卡片的 traj_id 写进 survey，也不要写进 SKILL.md 的依据。
+
+步骤（箭头串起来）：
+
+扫面→预览卡→写计划→精读⇄更新wiki→写skill（卡片只预览；commit 至少 10 条）
+
+精读和更新 wiki 可以小循环几轮：读一批 → 改 read-plan 状态 → 把要点写入 survey → 把做法或坑写入 knowledge → 页顶更新「必要信息是否读完」。必要信息未读完就继续按计划精读，不要急着 new_skill_folder。
+
+list_sessions 翻页；session_cards 一次最多 10 条。立刻写 read-plan（默认至少计划 20 条，commit 至少精读 10 条）。按卡片 path 和 L 做 read_file。压缩后先读 plan、survey、knowledge，只补未读，不准重扫目录。依据只引用精读过的 traj_id。
+
+知识一旦写进 SKILL.md，同一手 wiki_write knowledge，把「已入 skill」改成是，并注明章节。commit 前再 wiki_read 核对：必要信息已读完，且入 skill 的知识都有标注。
 
 # 怎么改文件
 
@@ -80,14 +100,14 @@ edit 前必须先读过该文件，否则工具会报错。
 
 # 可用工具
 
-- list_files(path)：目录条目过多时完整列表写入 spill 文件，用 read_file 按行翻页。
+- list_sessions(offset=0, limit=60, query="")：会话目录，一行一条，不是正文
+- session_card(traj_id) / session_cards(traj_ids)：预览卡，一次最多 10 条，不算精读
+- wiki_status / wiki_read / wiki_write / wiki_search / wiki_log
+- list_files(path)：只列 skill 目录或 spill。会话目录用 list_sessions
 - grep_files(pattern, path="", glob="", max_results=100)
-- read_file(path, offset=1, limit=200)
+- read_file(path, offset=1, limit=200)：精读。会话请带卡片上的 path 和 L
 - skill_read(skill_name)
-- write_file(path, content) — 仅新文件或 stub 整篇重写
-- edit(path, old_string, new_string) — 改已读过的已有文件（含本趟刚生成的）
-- new_skill_folder(skill_name, description)
-- commit_generate_main(skill_name, message)
+- write_file / edit / new_skill_folder / commit_generate_main
 """
 
 
@@ -146,7 +166,17 @@ class GenerateAgent:
             name_hint=_name_hint(preferred_names),
             read_roots_block=_read_roots_block(list(self.extra_read_roots)),
         )
+        from xskill.agents import llm_wiki, session_catalog
+
         tools = [
+            session_catalog.list_sessions,
+            session_catalog.session_card,
+            session_catalog.session_cards,
+            llm_wiki.wiki_status,
+            llm_wiki.wiki_read,
+            llm_wiki.wiki_write,
+            llm_wiki.wiki_search,
+            llm_wiki.wiki_log,
             agent_tools.list_files,
             agent_tools.grep_files,
             agent_tools.read_file,

--- a/src/xskill/agents/llm_wiki.py
+++ b/src/xskill/agents/llm_wiki.py
@@ -1,0 +1,267 @@
+"""Generate 磁盘 wiki：读计划、精读要点、知识沉淀。压缩后还能读回来。
+
+只给 GenerateAgent 挂工具。SkillEdit / TaskAgent 不导入、不注册。
+"""
+from __future__ import annotations
+
+import re
+from datetime import datetime, timezone
+from pathlib import Path
+
+from agno.tools import tool
+
+_SAFE_PAGE = re.compile(r"^[A-Za-z0-9_./-]+$")
+
+AFTER_COMPACT_HINT = (
+    "上下文刚被压缩。先 wiki_status，再 wiki_read pages/read-plan.md、"
+    "pages/survey.md、pages/knowledge.md。"
+    "只精读计划里还没读的 traj_id，不要再 list_files 扫会话目录。"
+)
+_COMPACT_HINT_MARK = "上下文刚被压缩"
+
+
+def apply_after_compact_hint(messages) -> None:
+    """compact 成功后塞一条短 hint：先读 wiki，只补未读计划。"""
+    if not messages:
+        return
+    for msg in messages:
+        content = getattr(msg, "content", None)
+        if content is None and isinstance(msg, dict):
+            content = msg.get("content")
+        if _COMPACT_HINT_MARK in str(content or ""):
+            return
+    try:
+        from xskill.agents.context_budget import _new_user_message
+
+        messages.append(_new_user_message(messages[0], AFTER_COMPACT_HINT))
+        return
+    except Exception:  # noqa: BLE001 — compact hint must not abort generate
+        pass
+    try:
+        from agno.models.message import Message
+
+        messages.append(Message(role="user", content=AFTER_COMPACT_HINT))
+    except Exception:  # noqa: BLE001
+        messages.append({"role": "user", "content": AFTER_COMPACT_HINT})
+
+
+_SCHEMA = """# Generate 会话证据 wiki
+
+raw 是会话文件（只读）；wiki 是本目录（模型写）。
+
+页面：
+- pages/read-plan.md：待读、在读、已读、跳过。页顶写必要信息是否读完、还缺什么。
+- pages/survey.md：真正 read_file 精读过的 traj_id 和要点。看过卡片不要写进来。
+- pages/knowledge.md：做法或坑。列：知识、来源 traj_id、已入 skill、skill 段落。
+
+压缩之后：wiki_status → 读 read-plan、survey、knowledge → 只补计划里还没读的 id。
+"""
+
+_INDEX = """# index
+
+- [SCHEMA.md](SCHEMA.md)
+- [pages/read-plan.md](pages/read-plan.md)
+- [pages/survey.md](pages/survey.md)
+- [pages/knowledge.md](pages/knowledge.md)
+- [log.md](log.md)
+"""
+
+_READ_PLAN = """# read-plan
+
+必要信息：未读完
+还缺什么：还没写计划
+
+| 状态 | traj_id | 起始行 | 原因 |
+|---|---|---|---|
+"""
+
+_SURVEY = """# survey
+
+只写 read_file 精读过的 traj_id。看过卡片不算。
+
+| traj_id | 要点 |
+|---|---|
+"""
+
+_KNOWLEDGE = """# knowledge
+
+知识写进 SKILL.md 的同一手，必须把「已入 skill」改成是，并注明章节。
+
+| 知识 | 来源 traj_id | 已入 skill | skill 段落 |
+|---|---|---|---|
+"""
+
+
+def seed_generate_wiki(root: Path) -> Path:
+    """建 wiki 骨架。已有页不覆盖，同一 job_id 重跑可恢复。"""
+    root = Path(root)
+    root.mkdir(parents=True, exist_ok=True)
+    (root / "pages").mkdir(exist_ok=True)
+    files = {
+        "SCHEMA.md": _SCHEMA,
+        "index.md": _INDEX,
+        "log.md": "# log\n\n",
+        "pages/read-plan.md": _READ_PLAN,
+        "pages/survey.md": _SURVEY,
+        "pages/knowledge.md": _KNOWLEDGE,
+    }
+    for rel, text in files.items():
+        path = root / rel
+        if not path.is_file():
+            path.write_text(text, encoding="utf-8")
+    return root
+
+
+def _wiki_root() -> Path | str:
+    from xskill.agents.agent_tools import current_agent_tool_context
+
+    ctx = current_agent_tool_context()
+    raw = getattr(ctx, "wiki_root", None)
+    if raw is None:
+        return "error: 当前 Generate 上下文没有 wiki_root"
+    root = Path(raw).expanduser()
+    try:
+        root = root.resolve()
+    except OSError:
+        pass
+    if not root.is_dir():
+        return f"error: wiki 根不存在: {root}"
+    return root
+
+
+def _resolve_page(root: Path, rel: str) -> Path | str:
+    rel = (rel or "").strip().lstrip("/")
+    if not rel:
+        return "error: path 为空"
+    if rel.endswith("/"):
+        return "error: path 必须是文件"
+    if not _SAFE_PAGE.match(rel) or ".." in rel.split("/"):
+        return "error: path 只允许相对 wiki 根，例如 index.md 或 pages/read-plan.md"
+    if not rel.endswith(".md"):
+        rel += ".md"
+    path = (root / rel).resolve()
+    try:
+        path.relative_to(root)
+    except ValueError:
+        return "error: path 越出 wiki 根"
+    if path.is_symlink():
+        return "error: path 越出 wiki 根"
+    return path
+
+
+@tool(name="wiki_status")
+def wiki_status() -> str:
+    """看 wiki 有哪些页。压缩之后应先调这个，再读 read-plan、survey、knowledge。"""
+    root = _wiki_root()
+    if isinstance(root, str):
+        return root
+    pages = sorted(
+        p.relative_to(root).as_posix() for p in root.rglob("*.md") if p.is_file()
+    )
+    index = root / "index.md"
+    head = ""
+    if index.is_file():
+        head = "\n".join(index.read_text(encoding="utf-8").splitlines()[:40])
+    return (
+        f"wiki_root={root}\npages={len(pages)}\n"
+        + "\n".join(f"- {name}" for name in pages)
+        + ("\n\n# index.md (head)\n" + head if head else "")
+    )
+
+
+@tool(name="wiki_read")
+def wiki_read(path: str) -> str:
+    """读 wiki 里的一页。先 pages/read-plan.md，再 survey、knowledge。"""
+    root = _wiki_root()
+    if isinstance(root, str):
+        return root
+    target = _resolve_page(root, path)
+    if isinstance(target, str):
+        return target
+    if not target.is_file():
+        return f"error: 没有这一页: {target.relative_to(root)}"
+    return f"path={target.relative_to(root)}\n\n{target.read_text(encoding='utf-8')}"
+
+
+@tool(name="wiki_write")
+def wiki_write(path: str, content: str) -> str:
+    """新建或覆盖 wiki 页。知识写入 SKILL.md 的同一手要改 knowledge 的「已入 skill」。"""
+    root = _wiki_root()
+    if isinstance(root, str):
+        return root
+    target = _resolve_page(root, path)
+    if isinstance(target, str):
+        return target
+    text = (content or "").strip()
+    if not text:
+        return "error: content 为空"
+    if len(text) > 40_000:
+        return "error: 单页不要超过 40000 字"
+    target.parent.mkdir(parents=True, exist_ok=True)
+    existed = target.is_file()
+    target.write_text(text + ("" if text.endswith("\n") else "\n"), encoding="utf-8")
+    rel = target.relative_to(root).as_posix()
+    _touch_index(root, rel, created=not existed)
+    return f"ok {'updated' if existed else 'created'} {rel} chars={len(text)}"
+
+
+@tool(name="wiki_search")
+def wiki_search(pattern: str, max_results: int = 40) -> str:
+    """在 wiki 里用正则搜，找回已经写过的 traj_id。"""
+    root = _wiki_root()
+    if isinstance(root, str):
+        return root
+    pat = (pattern or "").strip()
+    if not pat:
+        return "error: pattern 为空"
+    try:
+        cre = re.compile(pat, re.I)
+    except re.error as exc:
+        return f"error: 非法正则: {exc}"
+    take = max(1, min(int(max_results or 40), 80))
+    hits: list[str] = []
+    for path in sorted(root.rglob("*.md")):
+        try:
+            lines = path.read_text(encoding="utf-8").splitlines()
+        except OSError:
+            continue
+        rel = path.relative_to(root).as_posix()
+        for i, line in enumerate(lines, 1):
+            if cre.search(line):
+                hits.append(f"{rel}:{i}:{line[:200]}")
+                if len(hits) >= take:
+                    return "\n".join(hits)
+    return "\n".join(hits) if hits else f"(no hits for {pat!r})"
+
+
+@tool(name="wiki_log")
+def wiki_log(entry: str) -> str:
+    """往 log.md 追加一条时间线。"""
+    root = _wiki_root()
+    if isinstance(root, str):
+        return root
+    text = (entry or "").strip()
+    if not text:
+        return "error: entry 为空"
+    stamp = datetime.now(timezone.utc).strftime("%Y-%m-%dT%H:%M:%SZ")
+    line = f"## [{stamp}] {text}\n"
+    log = root / "log.md"
+    prev = log.read_text(encoding="utf-8") if log.is_file() else "# log\n\n"
+    if not prev.endswith("\n"):
+        prev += "\n"
+    log.write_text(prev + line, encoding="utf-8")
+    return f"ok appended log.md chars={len(line)}"
+
+
+def _touch_index(root: Path, rel: str, *, created: bool) -> None:
+    if rel in {"index.md", "log.md", "SCHEMA.md"} or not created:
+        return
+    index = root / "index.md"
+    if not index.is_file():
+        return
+    text = index.read_text(encoding="utf-8")
+    if f"]({rel})" in text:
+        return
+    if not text.endswith("\n"):
+        text += "\n"
+    index.write_text(text + f"- [{rel}]({rel})\n", encoding="utf-8")

--- a/src/xskill/agents/session_catalog.py
+++ b/src/xskill/agents/session_catalog.py
@@ -1,0 +1,453 @@
+"""Generate 用的会话预览：目录一行一条，卡片只帮选读点。
+
+只给 GenerateAgent 挂工具。SkillEdit / TaskAgent 不导入、不注册。
+卡片不是精读：没有 tool result、没有完整回传、不倒原始 json。
+"""
+from __future__ import annotations
+
+import json
+import re
+from pathlib import Path
+from typing import Any
+
+from agno.tools import tool
+
+_TRAJ_FILE = re.compile(r"^traj_[A-Za-z0-9_-]+\.(json|md)$")
+_TOOL_USE_MARK = re.compile(r"\[tool_use:\s*([A-Za-z0-9._-]+)\s*([^\]]*)\]")
+_USER_QUERY = re.compile(
+    r"<user_query>\s*(.*?)\s*</user_query>",
+    re.DOTALL,
+)
+_QUERY_SNIP = 160
+_PARAM_SNIP = 80
+_LISTING_PEEK_BYTES = 16_384
+_CARD_PEEK_BYTES = 200_000
+_CARD_CHAR_BUDGET = 2000
+_MAX_CARD_TOOLS = 12
+_SCAN_MAX_FILES = 2000
+_TOOL_PARAM_KEYS = (
+    "command", "file_path", "path", "pattern", "query", "glob", "url",
+    "target_file", "relative_workspace_path",
+)
+
+
+def _one_line(text: str, limit: int) -> str:
+    cleaned = re.sub(r"\s+", " ", (text or "").strip())
+    if len(cleaned) <= limit:
+        return cleaned
+    return cleaned[: limit - 1] + "…"
+
+
+def _secret_scrub(text: str) -> str:
+    text = re.sub(r"(sk-[A-Za-z0-9_-]{8,})", "sk-[REDACTED]", text)
+    text = re.sub(
+        r"(?i)(api[_-]?key|token|password)\s*[:=]\s*\S+",
+        r"\1=[REDACTED]",
+        text,
+    )
+    return text
+
+
+def _session_roots() -> list[Path]:
+    from xskill.agents.agent_tools import (
+        _is_blocked_read_path,
+        current_agent_tool_context,
+    )
+
+    ctx = current_agent_tool_context()
+    roots: list[Path] = []
+    seen: set[str] = set()
+    skip: set[str] = set()
+    if ctx.wiki_root is not None:
+        try:
+            skip.add(str(Path(ctx.wiki_root).resolve()))
+        except OSError:
+            skip.add(str(Path(ctx.wiki_root)))
+    candidates: list[Path] = []
+    if ctx.default_traj_root is not None:
+        candidates.append(Path(ctx.default_traj_root))
+    candidates.extend(Path(p) for p in (ctx.extra_read_roots or ()))
+    for raw in candidates:
+        try:
+            path = raw.resolve()
+        except OSError:
+            path = raw
+        key = str(path)
+        if key in seen or key in skip or _is_blocked_read_path(path):
+            continue
+        seen.add(key)
+        roots.append(path)
+    return roots
+
+
+def _iter_traj_files(roots: list[Path]) -> list[Path]:
+    from xskill.agents.agent_tools import _is_blocked_read_path
+
+    found: list[Path] = []
+    seen: set[str] = set()
+    for root in roots:
+        if not root.exists():
+            continue
+        candidates: list[Path] = []
+        if root.is_file():
+            candidates.append(root)
+        else:
+            try:
+                for path in root.rglob("traj_*.*"):
+                    if len(candidates) >= _SCAN_MAX_FILES:
+                        break
+                    if path.suffix not in {".json", ".md"}:
+                        continue
+                    if not _TRAJ_FILE.match(path.name):
+                        continue
+                    if path.is_file():
+                        candidates.append(path)
+            except OSError:
+                continue
+        for path in candidates:
+            try:
+                resolved = path.resolve()
+            except OSError:
+                resolved = path
+            key = str(resolved)
+            if key in seen or _is_blocked_read_path(resolved):
+                continue
+            seen.add(key)
+            found.append(resolved)
+            if len(found) >= _SCAN_MAX_FILES:
+                break
+        if len(found) >= _SCAN_MAX_FILES:
+            break
+    return _prefer_md_per_stem(found)
+
+
+def _prefer_md_per_stem(paths: list[Path]) -> list[Path]:
+    """同一 traj_id 只留一条。优先 md，方便卡片上的 L 对上 read_file。"""
+    ordered: list[str] = []
+    by_stem: dict[str, Path] = {}
+    for path in paths:
+        stem = path.stem
+        if stem not in by_stem:
+            by_stem[stem] = path
+            ordered.append(stem)
+        elif path.suffix == ".md":
+            by_stem[stem] = path
+    return [by_stem[stem] for stem in ordered]
+
+
+def _read_prefix(path: Path, max_bytes: int) -> str:
+    try:
+        with path.open("r", encoding="utf-8", errors="replace") as handle:
+            return handle.read(max_bytes)
+    except OSError:
+        return ""
+
+
+def _heading_spans(text: str) -> list[tuple[str, int, int]]:
+    lines = text.splitlines()
+    heads: list[tuple[str, int]] = []
+    for index, line in enumerate(lines):
+        if line.startswith("## "):
+            heads.append((line[3:].strip(), index + 1))
+    spans: list[tuple[str, int, int]] = []
+    for index, (heading, start) in enumerate(heads):
+        end = heads[index + 1][1] if index + 1 < len(heads) else len(lines) + 1
+        spans.append((heading, start, end))
+    return spans
+
+
+def _section_body(text: str, start: int, end: int) -> str:
+    lines = text.splitlines()
+    return "\n".join(lines[start - 1 : end - 1])
+
+
+def _query_from_text(text: str) -> tuple[str, int | None]:
+    for heading, start, end in _heading_spans(text):
+        if heading.lower() != "initial query":
+            continue
+        body = _section_body(text, start, end)
+        match = _USER_QUERY.search(body)
+        snippet = match.group(1) if match else body
+        line = start
+        if match:
+            prefix = body[: match.start()]
+            line = start + prefix.count("\n")
+        return _one_line(_secret_scrub(snippet), _QUERY_SNIP), line
+    match = _USER_QUERY.search(text)
+    if match:
+        line = text[: match.start()].count("\n") + 1
+        return _one_line(_secret_scrub(match.group(1)), _QUERY_SNIP), line
+    if "# query" in text:
+        after = text.split("# query", 1)[1]
+        snippet = after.split("#", 1)[0]
+        line = text.split("# query", 1)[0].count("\n") + 1
+        return _one_line(_secret_scrub(snippet), _QUERY_SNIP), line
+    for heading, start, end in _heading_spans(text):
+        if heading.lower() != "user":
+            continue
+        body = _section_body(text, start, end)
+        match = _USER_QUERY.search(body)
+        snippet = match.group(1) if match else body
+        return _one_line(_secret_scrub(snippet), _QUERY_SNIP), start
+    return "", None
+
+
+def _tools_from_text(text: str) -> list[str]:
+    names: list[str] = []
+    seen: set[str] = set()
+    for match in _TOOL_USE_MARK.finditer(text):
+        name = match.group(1)
+        if name in seen:
+            continue
+        seen.add(name)
+        names.append(name)
+        if len(names) >= 12:
+            break
+    return names
+
+
+def _tool_lines_from_md(text: str) -> list[str]:
+    rows: list[str] = []
+    for index, line in enumerate(text.splitlines(), 1):
+        match = _TOOL_USE_MARK.search(line)
+        if not match:
+            continue
+        name = match.group(1)
+        params = _one_line(_secret_scrub(match.group(2) or ""), _PARAM_SNIP)
+        rows.append(f"- L{index} {name} {params}".rstrip())
+        if len(rows) >= _MAX_CARD_TOOLS:
+            break
+    return rows
+
+
+def _format_tool_params(inp: Any) -> str:
+    if isinstance(inp, dict):
+        keys = [k for k in _TOOL_PARAM_KEYS if k in inp and inp[k] not in (None, "")]
+        for key in inp:
+            if str(key).startswith("_") or key in keys:
+                continue
+            if inp[key] in (None, ""):
+                continue
+            keys.append(key)
+            if len(keys) >= 4:
+                break
+        parts = [
+            f"{key}={_one_line(_secret_scrub(str(inp[key])), _PARAM_SNIP)}"
+            for key in keys
+        ]
+        return " ".join(parts)
+    if inp in (None, ""):
+        return ""
+    return _one_line(_secret_scrub(str(inp)), _PARAM_SNIP)
+
+
+def _peek_json_meta(path: Path) -> dict[str, Any]:
+    raw = _read_prefix(path, _LISTING_PEEK_BYTES)
+    item: dict[str, Any] = {"source": "json", "query": "", "tools": []}
+    try:
+        size = path.stat().st_size
+        obj = json.loads(
+            path.read_text(encoding="utf-8") if size <= 80_000 else raw
+        )
+    except (OSError, json.JSONDecodeError, ValueError):
+        return item
+    if not isinstance(obj, dict):
+        return item
+    item["source"] = str(obj.get("source") or obj.get("category") or "json")
+    item["query"] = _one_line(_secret_scrub(str(obj.get("query") or "")), _QUERY_SNIP)
+    tools = [str(x) for x in (obj.get("tool_names") or []) if x]
+    timeline = obj.get("timeline") or []
+    if not tools and isinstance(timeline, list):
+        found: list[str] = []
+        for ev in timeline:
+            if not isinstance(ev, dict):
+                continue
+            if ev.get("tool"):
+                found.append(str(ev.get("tool")))
+            for extra in ev.get("tools") or []:
+                if isinstance(extra, dict) and extra.get("tool"):
+                    found.append(str(extra.get("tool")))
+        tools = list(dict.fromkeys(found))
+    item["tools"] = tools[:12]
+    if not item["query"] and isinstance(timeline, list):
+        for ev in timeline:
+            if not isinstance(ev, dict):
+                continue
+            if str(ev.get("role") or "") != "user":
+                continue
+            item["query"] = _one_line(
+                _secret_scrub(str(ev.get("content") or ev.get("text") or "")),
+                _QUERY_SNIP,
+            )
+            break
+    return item
+
+
+def _tool_lines_from_json(path: Path) -> list[str]:
+    try:
+        if path.stat().st_size > 400_000:
+            return []
+        obj = json.loads(path.read_text(encoding="utf-8"))
+    except (OSError, json.JSONDecodeError):
+        return []
+    if not isinstance(obj, dict):
+        return []
+    timeline = obj.get("timeline") or []
+    if not isinstance(timeline, list):
+        return []
+    rows: list[str] = []
+    for ev in timeline:
+        if not isinstance(ev, dict):
+            continue
+        role = str(ev.get("role") or ev.get("type") or "")
+        if role in {"tool_output", "tool_result"}:
+            continue
+        extras = ev.get("tools") if isinstance(ev.get("tools"), list) else []
+        if role in {"tool_call", "tool_use"}:
+            extras = extras or [ev]
+        for item in extras:
+            if not isinstance(item, dict):
+                continue
+            name = str(item.get("tool") or item.get("name") or ev.get("tool") or "tool")
+            params = _format_tool_params(item.get("input") or item.get("arguments"))
+            rows.append(f"- {name} {params}".rstrip())
+            if len(rows) >= _MAX_CARD_TOOLS:
+                return rows
+    return rows
+
+
+def _listing_item(path: Path) -> dict[str, Any]:
+    item: dict[str, Any] = {
+        "traj_id": path.stem,
+        "path": str(path),
+        "source": "markdown" if path.suffix == ".md" else "json",
+        "query": "",
+        "tools": [],
+    }
+    if path.suffix == ".json":
+        item.update(_peek_json_meta(path))
+        item["traj_id"] = path.stem
+        return item
+    text = _read_prefix(path, _LISTING_PEEK_BYTES)
+    query, _line = _query_from_text(text)
+    item["query"] = query
+    item["tools"] = _tools_from_text(text)
+    item["source"] = "markdown"
+    for line in text.splitlines()[:40]:
+        if line.startswith("source:"):
+            item["source"] = line.split(":", 1)[1].strip() or item["source"]
+    return item
+
+
+def render_session_card(path: Path) -> str:
+    traj_id = path.stem
+    text = _read_prefix(path, _CARD_PEEK_BYTES)
+    query, query_line = _query_from_text(text)
+    tools = _tools_from_text(text)
+    tool_rows = _tool_lines_from_md(text)
+    source = "markdown" if path.suffix == ".md" else "json"
+    if path.suffix == ".json":
+        meta = _peek_json_meta(path)
+        source = str(meta.get("source") or source)
+        query = query or str(meta.get("query") or "")
+        tools = tools or list(meta.get("tools") or [])
+        if not tool_rows:
+            tool_rows = _tool_lines_from_json(path)
+    query_line_txt = f" L{query_line}" if query_line else ""
+    body = [
+        f"traj_id: {traj_id}",
+        f"source: {source}",
+        f"path: {path}",
+        f"query{query_line_txt}: {query or '(empty)'}",
+        "preview: 卡片只预览，不算读懂。精读用 read_file(path, offset=L)。",
+        "toolcalls:",
+    ]
+    if tool_rows:
+        body.extend(tool_rows)
+    else:
+        body.append("- (no toolcall on card)")
+    if tools:
+        body.append("tools: " + ", ".join(tools))
+    text_out = "\n".join(body) + "\n"
+    if len(text_out) > _CARD_CHAR_BUDGET:
+        text_out = text_out[: _CARD_CHAR_BUDGET - 20] + "\n…[card truncated]\n"
+    return text_out
+
+
+def _find_by_id(traj_id: str) -> Path | None:
+    tid = (traj_id or "").strip()
+    if not tid:
+        return None
+    for path in _iter_traj_files(_session_roots()):
+        if path.stem == tid:
+            return path
+    return None
+
+
+@tool(name="list_sessions")
+def list_sessions(offset: int = 0, limit: int = 60, query: str = "") -> str:
+    """列出会话目录：id、来源、工具名、query 一行。这是扫面，不是正文，不算精读。"""
+    files = _iter_traj_files(_session_roots())
+    items = [_listing_item(path) for path in files]
+    needle = (query or "").strip().lower()
+    if needle:
+        items = [
+            item
+            for item in items
+            if needle in " ".join(
+                [
+                    str(item.get("traj_id") or ""),
+                    str(item.get("source") or ""),
+                    str(item.get("query") or ""),
+                    " ".join(item.get("tools") or []),
+                ]
+            ).lower()
+        ]
+    try:
+        start = max(0, int(offset))
+        take = max(1, min(int(limit), 80))
+    except (TypeError, ValueError):
+        return "error: offset/limit 必须是整数"
+    page = items[start : start + take]
+    lines = [
+        f"total={len(files)} matched={len(items)} showing={len(page)} offset={start}",
+        "这是目录，不是正文。预览用 session_card / session_cards（一次最多 10 条）。",
+    ]
+    for item in page:
+        tools = ",".join(item.get("tools") or []) or "-"
+        lines.append(
+            f"{item.get('traj_id')}\tsource={item.get('source')}\t"
+            f"tools={tools}\tquery={item.get('query')}"
+        )
+    if start + take < len(items):
+        lines.append(
+            f"continue: list_sessions(offset={start + take}, limit={take}, query={query!r})"
+        )
+    return "\n".join(lines)
+
+
+@tool(name="session_card")
+def session_card(traj_id: str) -> str:
+    """一条预览卡：query+行号、截断 toolcall、path。没有 tool result，不算精读。"""
+    tid = (traj_id or "").strip()
+    if not tid:
+        return "error: traj_id 为空"
+    if "/" in tid or "\\" in tid or tid.endswith(".md") or tid.endswith(".json"):
+        return "error: traj_id 只要 id 本身，不要带路径或后缀"
+    path = _find_by_id(tid)
+    if path is None:
+        return f"error: 找不到会话 {tid}。先 list_sessions。"
+    return f"traj_id={tid}\n\n{render_session_card(path)}"
+
+
+@tool(name="session_cards")
+def session_cards(traj_ids: str) -> str:
+    """一次最多 10 条预览卡。traj_ids 用逗号或空白分开。看过卡片仍不算精读。"""
+    raw = (traj_ids or "").replace(",", " ").split()
+    ids = [x.strip() for x in raw if x.strip()]
+    if not ids:
+        return "error: traj_ids 为空"
+    if len(ids) > 10:
+        return f"error: 一次最多 10 条，这次给了 {len(ids)}。拆成多次。"
+    chunks = [session_card.entrypoint(traj_id=tid) for tid in ids]
+    return f"batch={len(ids)}\n\n" + "\n\n----\n\n".join(chunks)

--- a/src/xskill/team/server/generate_jobs.py
+++ b/src/xskill/team/server/generate_jobs.py
@@ -22,6 +22,21 @@ def _job_dir(logs_dir: Path, user_id: str) -> Path:
     return path
 
 
+def prepare_generate_wiki(logs_dir: Path, user_id: str, job_id: str) -> Path:
+    """按 job 建 wiki。已有页不覆盖，同一 job_id 重跑可恢复。"""
+    from xskill.agents.llm_wiki import seed_generate_wiki
+
+    root = (
+        Path(logs_dir)
+        / "agents"
+        / "generate_agents"
+        / user_id
+        / "wiki"
+        / job_id
+    )
+    return seed_generate_wiki(root)
+
+
 def jobs_root(logs_dir: Path) -> Path:
     """web 进程与 agent-worker 共用的入队目录（与 logs 同级）。"""
     return Path(logs_dir).expanduser().resolve().parent / "generate_jobs"
@@ -504,6 +519,9 @@ def _run_generate_job_body(
     )
     extra_roots = exclude_blocked_read_roots(extra_roots, blocked_roots)
     logs_dir = Path(logs_dir) if logs_dir is not None else get_logs_dir()
+    wiki_root = prepare_generate_wiki(logs_dir, job["user_id"], job["job_id"])
+    extra_roots = list(extra_roots)
+    extra_roots.append(wiki_root)
     spill_root = (
         logs_dir / "agents" / "generate_agents" / job["user_id"] / "spill" / job["job_id"]
     )
@@ -519,6 +537,7 @@ def _run_generate_job_body(
         spill_root=spill_root,
         extra_read_roots=tuple(extra_roots),
         generate_user_id=job["user_id"],
+        wiki_root=wiki_root,
         registry_db_path=resolved_db,
         blocked_read_roots=blocked_roots,
     )

--- a/tests/test_generate_command.py
+++ b/tests/test_generate_command.py
@@ -98,6 +98,22 @@ def test_generate_prompt_teaches_edit_not_full_rewrite():
     assert "不要整文件 write_file" in SYSTEM_PROMPT
     assert "刚 write_file 过的脚本" in SYSTEM_PROMPT
     assert "write_file 只用于" in SYSTEM_PROMPT
+    assert "预览" in SYSTEM_PROMPT
+    assert "不算读懂" in SYSTEM_PROMPT
+    assert "read-plan" in SYSTEM_PROMPT
+    assert "精读⇄更新wiki" in SYSTEM_PROMPT
+    assert "必要信息" in SYSTEM_PROMPT
+    assert "已入 skill" in SYSTEM_PROMPT
+    assert "list_sessions" in SYSTEM_PROMPT
+    assert "用 list_files 摸清结构" not in SYSTEM_PROMPT
+
+
+def _seed_traj_reads(root: Path, n: int) -> None:
+    root.mkdir(parents=True, exist_ok=True)
+    for i in range(n):
+        path = root / f"traj_seed_{i:02d}.md"
+        path.write_text(f"body {i}\n", encoding="utf-8")
+        agent_tools._mark_file_read(path)
 
 
 def test_generate_agent_registers_edit_tool(tmp_path: Path):
@@ -131,6 +147,12 @@ def test_generate_agent_registers_edit_tool(tmp_path: Path):
         agent.run(instruction="改一下发票 skill", user_id="alice", job_id="j1")
     assert "edit" in captured["tools"]
     assert "write_file" in captured["tools"]
+    assert "list_sessions" in captured["tools"]
+    assert "session_card" in captured["tools"]
+    assert "session_cards" in captured["tools"]
+    assert "wiki_status" in captured["tools"]
+    assert "wiki_read" in captured["tools"]
+    assert "wiki_write" in captured["tools"]
 
 
 def test_generate_new_folder_then_edit_relative_skill_md(tmp_path: Path):
@@ -202,6 +224,7 @@ def test_generate_read_roots_include_traj_not_parent_secrets(tmp_path: Path):
 def test_commit_generate_main_tool_prefixes_user(tmp_path: Path):
     skill_dir, ctx = _bind_skill_ctx(tmp_path)
     with agent_tools.use_agent_tool_context(ctx):
+        _seed_traj_reads(tmp_path / "trajs", 10)
         result = _call_tool(
             agent_tools.commit_generate_main,
             skill_name="fresh-skill",
@@ -211,6 +234,91 @@ def test_commit_generate_main_tool_prefixes_user(tmp_path: Path):
     repo = skill_dir / "fresh-skill"
     assert current_branch(str(repo)) == "main"
     assert agent_tools.generate_committed_skills() == ["fresh-skill"]
+
+
+def test_commit_generate_main_requires_ten_traj_reads(tmp_path: Path):
+    skill_dir, ctx = _bind_skill_ctx(tmp_path)
+    with agent_tools.use_agent_tool_context(ctx):
+        _seed_traj_reads(tmp_path / "trajs", 9)
+        denied = _call_tool(
+            agent_tools.commit_generate_main,
+            skill_name="fresh-skill",
+            message="too few",
+        )
+        assert denied.startswith("error:")
+        assert "9" in denied
+        _seed_traj_reads(tmp_path / "trajs", 10)
+        ok = _call_tool(
+            agent_tools.commit_generate_main,
+            skill_name="fresh-skill",
+            message="enough",
+        )
+    assert ok.startswith("committed to main: fresh-skill")
+
+
+def test_session_card_does_not_count_as_traj_read(tmp_path: Path):
+    from xskill.agents import session_catalog
+
+    sessions = tmp_path / "team_trajectories" / "clients" / "alice" / "sessions"
+    sessions.mkdir(parents=True)
+    (sessions / "traj_card_only.md").write_text(
+        "## Initial Query\n\npreview only\n\n"
+        "## Assistant\n[tool_use: Read path=/tmp/a.py]\n",
+        encoding="utf-8",
+    )
+    skill_dir = tmp_path / "skill"
+    skill_dir.mkdir()
+    ctx = agent_tools.create_agent_tool_context(
+        skill_dir=skill_dir,
+        atom_skill_dir=skill_dir,
+        default_traj_root=tmp_path / "team_trajectories",
+        extra_read_roots=(tmp_path / "team_trajectories",),
+        generate_user_id="alice",
+    )
+    agent_tools.reset_generate_session()
+    with agent_tools.use_agent_tool_context(ctx):
+        card = _call_tool(session_catalog.session_card, traj_id="traj_card_only")
+        assert "preview only" in card
+        assert agent_tools.generate_read_traj_ids() == []
+        denied = _call_tool(
+            agent_tools.commit_generate_main,
+            skill_name="fresh-skill",
+            message="card only",
+        )
+    assert denied.startswith("error:")
+    assert "(none)" in denied
+
+
+def test_generate_blocks_list_and_grep_on_session_dir(tmp_path: Path):
+    skill_dir = tmp_path / "skill"
+    skill_dir.mkdir()
+    sessions = tmp_path / "team_trajectories" / "clients" / "alice" / "sessions"
+    sessions.mkdir(parents=True)
+    traj = sessions / "traj_1.md"
+    traj.write_text("invoice workflow\n", encoding="utf-8")
+    ctx = agent_tools.create_agent_tool_context(
+        skill_dir=skill_dir,
+        extra_read_roots=(skill_dir, tmp_path / "team_trajectories"),
+        generate_user_id="alice",
+    )
+    with agent_tools.use_agent_tool_context(ctx):
+        listing = _call_tool(
+            agent_tools.list_files, str(tmp_path / "team_trajectories"),
+        )
+        grep_dir = _call_tool(
+            agent_tools.grep_files,
+            pattern="invoice",
+            path=str(tmp_path / "team_trajectories"),
+        )
+        grep_file = _call_tool(
+            agent_tools.grep_files,
+            pattern="invoice",
+            path=str(traj),
+        )
+    assert listing.startswith("error:")
+    assert "list_sessions" in listing
+    assert grep_dir.startswith("error:")
+    assert "invoice workflow" in grep_file
 
 
 def test_pin_generated_skills(tmp_path: Path):

--- a/tests/test_llm_wiki.py
+++ b/tests/test_llm_wiki.py
@@ -1,0 +1,89 @@
+"""Generate wiki：seed 出 read-plan 与 knowledge；越出 wiki 根要拦住。"""
+from __future__ import annotations
+
+from pathlib import Path
+
+from xskill.agents import agent_tools, llm_wiki
+from xskill.team.server.generate_jobs import prepare_generate_wiki
+
+
+def _call(tool, *args, **kwargs):
+    entrypoint = tool if callable(tool) else getattr(tool, "entrypoint")
+    return entrypoint(*args, **kwargs)
+
+
+def _ctx(tmp_path: Path, wiki: Path):
+    skill_dir = tmp_path / "skill"
+    skill_dir.mkdir(exist_ok=True)
+    return agent_tools.create_agent_tool_context(
+        skill_dir=skill_dir,
+        wiki_root=wiki,
+        generate_user_id="alice",
+        extra_read_roots=(wiki,),
+    )
+
+
+def test_seed_writes_read_plan_and_knowledge(tmp_path: Path):
+    root = llm_wiki.seed_generate_wiki(tmp_path / "wiki")
+    plan = (root / "pages" / "read-plan.md").read_text(encoding="utf-8")
+    knowledge = (root / "pages" / "knowledge.md").read_text(encoding="utf-8")
+    survey = (root / "pages" / "survey.md").read_text(encoding="utf-8")
+    assert "必要信息" in plan
+    assert "未读完" in plan
+    assert "待读" in plan or "状态" in plan
+    assert "已入 skill" in knowledge
+    assert "来源 traj_id" in knowledge
+    assert "read_file" in survey
+    old = plan
+    (root / "pages" / "read-plan.md").write_text("KEEP_ME\n", encoding="utf-8")
+    llm_wiki.seed_generate_wiki(root)
+    assert (root / "pages" / "read-plan.md").read_text(encoding="utf-8") == "KEEP_ME\n"
+    assert old != "KEEP_ME\n"
+
+
+def test_wiki_path_escape_blocked(tmp_path: Path):
+    wiki = llm_wiki.seed_generate_wiki(tmp_path / "wiki")
+    secret = tmp_path / "secret.md"
+    secret.write_text("do not leak\n", encoding="utf-8")
+    ctx = _ctx(tmp_path, wiki)
+    with agent_tools.use_agent_tool_context(ctx):
+        escaped = _call(llm_wiki.wiki_read, path="../secret.md")
+        dotted = _call(llm_wiki.wiki_write, path="pages/../../secret.md", content="x")
+        ok = _call(llm_wiki.wiki_read, path="pages/read-plan.md")
+    assert escaped.startswith("error:")
+    assert "do not leak" not in escaped
+    assert dotted.startswith("error:")
+    assert "必要信息" in ok
+
+
+def test_wiki_symlink_escape_blocked(tmp_path: Path):
+    wiki = llm_wiki.seed_generate_wiki(tmp_path / "wiki")
+    outside = tmp_path / "outside.md"
+    outside.write_text("outside-secret\n", encoding="utf-8")
+    link = wiki / "pages" / "leak.md"
+    link.symlink_to(outside)
+    ctx = _ctx(tmp_path, wiki)
+    with agent_tools.use_agent_tool_context(ctx):
+        denied = _call(llm_wiki.wiki_read, path="pages/leak.md")
+    assert denied.startswith("error:")
+    assert "outside-secret" not in denied
+
+
+def test_prepare_generate_wiki_does_not_overwrite(tmp_path: Path):
+    logs = tmp_path / "logs"
+    root = prepare_generate_wiki(logs, "alice", "job1")
+    plan = root / "pages" / "read-plan.md"
+    plan.write_text("ALREADY_WRITTEN\n", encoding="utf-8")
+    again = prepare_generate_wiki(logs, "alice", "job1")
+    assert again == root
+    assert plan.read_text(encoding="utf-8") == "ALREADY_WRITTEN\n"
+
+
+def test_after_compact_hint_mentions_plan(tmp_path: Path):
+    messages = [{"role": "user", "content": "start"}]
+    llm_wiki.apply_after_compact_hint(messages)
+    assert any("上下文刚被压缩" in str(m.get("content")) for m in messages)
+    assert any("read-plan.md" in str(m.get("content")) for m in messages)
+    before = len(messages)
+    llm_wiki.apply_after_compact_hint(messages)
+    assert len(messages) == before

--- a/tests/test_session_catalog.py
+++ b/tests/test_session_catalog.py
@@ -1,0 +1,89 @@
+"""会话预览卡：目录不含正文；卡片有 query、path、L、截断 toolcall，没有 tool result。"""
+from __future__ import annotations
+
+from pathlib import Path
+
+from xskill.agents import agent_tools, session_catalog
+
+
+def _call(tool, *args, **kwargs):
+    entrypoint = tool if callable(tool) else getattr(tool, "entrypoint")
+    return entrypoint(*args, **kwargs)
+
+
+def _bind(tmp_path: Path):
+    sessions = tmp_path / "team_trajectories" / "clients" / "alice" / "sessions"
+    sessions.mkdir(parents=True)
+    long_cmd = "echo start " + ("y" * 40) + " UNIQUE_CMD_TAIL_SHOULD_TRUNCATE"
+    (sessions / "traj_demo_one.md").write_text(
+        "# Cursor Agent Trajectory\n"
+        "\n"
+        "## Initial Query\n"
+        "\n"
+        "<user_query>\n"
+        "please check the invoice workflow\n"
+        "</user_query>\n"
+        "\n"
+        "## Assistant\n"
+        "I will look around.\n"
+        f"[tool_use: Shell command={long_cmd}]\n"
+        "\n"
+        "## Tool Result\n"
+        "UNIQUE_TOOL_RESULT_SHOULD_NOT_APPEAR\n"
+        "FULL_BODY_PARAGRAPH_ONLY_IN_TRAJ\n",
+        encoding="utf-8",
+    )
+    (sessions / "traj_demo_two.md").write_text(
+        "## Initial Query\n\nfix the login form\n\n"
+        "## Assistant\n[tool_use: Read path=/tmp/login.py]\n",
+        encoding="utf-8",
+    )
+    skill_dir = tmp_path / "skill"
+    skill_dir.mkdir()
+    ctx = agent_tools.create_agent_tool_context(
+        skill_dir=skill_dir,
+        default_traj_root=tmp_path / "team_trajectories",
+        extra_read_roots=(tmp_path / "team_trajectories",),
+        generate_user_id="alice",
+    )
+    return ctx
+
+
+def test_list_sessions_has_no_traj_body(tmp_path: Path):
+    ctx = _bind(tmp_path)
+    with agent_tools.use_agent_tool_context(ctx):
+        listing = _call(session_catalog.list_sessions)
+    assert "traj_demo_one" in listing
+    assert "invoice workflow" in listing
+    assert "FULL_BODY_PARAGRAPH_ONLY_IN_TRAJ" not in listing
+    assert "UNIQUE_TOOL_RESULT_SHOULD_NOT_APPEAR" not in listing
+
+
+def test_session_card_has_query_path_line_and_truncated_toolcall(tmp_path: Path):
+    ctx = _bind(tmp_path)
+    with agent_tools.use_agent_tool_context(ctx):
+        card = _call(session_catalog.session_card, traj_id="traj_demo_one")
+    assert "invoice workflow" in card
+    assert "traj_demo_one.md" in card
+    assert "path:" in card
+    assert "L" in card
+    assert "Shell" in card
+    assert "echo start" in card
+    assert "UNIQUE_CMD_TAIL_SHOULD_TRUNCATE" not in card
+    assert "UNIQUE_TOOL_RESULT_SHOULD_NOT_APPEAR" not in card
+
+
+def test_session_cards_max_ten(tmp_path: Path):
+    ctx = _bind(tmp_path)
+    ids = ",".join(f"traj_{i:02d}" for i in range(11))
+    with agent_tools.use_agent_tool_context(ctx):
+        err = _call(session_catalog.session_cards, traj_ids=ids)
+        ok = _call(
+            session_catalog.session_cards,
+            traj_ids="traj_demo_one traj_demo_two",
+        )
+    assert err.startswith("error:")
+    assert "10" in err
+    assert "batch=2" in ok
+    assert "traj_demo_one" in ok
+    assert "traj_demo_two" in ok


### PR DESCRIPTION
## Summary
- Generate 读轨迹改成扫面、预览卡、写 read-plan，再精读并更新 wiki。卡片只有 query、行号、截断 toolcall、path，没有 tool result；看过卡片不算读懂。
- `commit_generate_main` 只数本趟 `read_file` 过的不同 `traj_*`，少于 10 条直接失败。会话目录禁止 `list_files` 和整目录 `grep_files`。
- 从今天 main 重写，没有整段搬 #339。不修 Cursor 适配器截断 tool_use。

## Test plan
- [x] `tests/test_session_catalog.py`：目录不含正文；卡片有 query、path、L、截断 toolcall；一次最多 10 条
- [x] `tests/test_llm_wiki.py`：seed 出 read-plan 与 knowledge；越出 wiki 根拦住
- [x] `tests/test_generate_command.py`：提示词含预览、精读⇄更新wiki、必要信息、已入 skill；9 条失败、10 条通过；只看卡片不计入
- [x] `tests/test_generate_onhold.py` 仍过


Made with [Cursor](https://cursor.com)