### PR TITLE
fix(cli): init 可跳过连接，空 token 不再失败

### DIFF
--- a/src/xskill/cli.py
+++ b/src/xskill/cli.py
@@ -204,6 +204,81 @@ def _print_init_next_steps(connected: bool) -> None:
     print("  xskill serve --server")
 
 
+def _print_init_connect_guide(*, address: str = "") -> None:
+    print("token 向你们的 server 管理员要，他们执行 xskill serve --server 时会打印。")
+    print("不要用网上搜到的公共地址。")
+    if address:
+        print("补 token 后再连：")
+        print(f"  xskill connect {address} --token <token> --name <工号>")
+    else:
+        print("以后要连，再跑：")
+        print("  xskill connect <host:port> --token <token> --name <工号>")
+    print("也可以自己起一台：")
+    print("  xskill serve --server")
+
+
+def _init_connect_args(args, address: str, token: str, name: str | None):
+    return argparse.Namespace(
+        address=address,
+        token=token,
+        label=getattr(args, "label", "") or "",
+        name=name,
+        use_proxy=bool(getattr(args, "use_proxy", False)),
+        foreground=False,
+        no_auto_update=bool(getattr(args, "no_auto_update", False)),
+        no_skill=True,
+        target_root=getattr(args, "target_root", None),
+    )
+
+
+def _offer_optional_connect(args, connected: bool) -> None:
+    """交互式可选连团队。回车或空 token 都算跳过，不让 init 失败。"""
+    if connected or args.yes:
+        _print_init_next_steps(connected)
+        return
+    print("连团队 server 是可选的。现在可以跳过，本机 traj search 已经能用。")
+    print("  回车 / skip：先不连")
+    print("  1：现在连接（要管理员给的地址和 token）")
+    print("  2：看自己起团队服务的命令")
+    choice = input("选择：").strip().lower()
+    if choice in ("", "0", "skip", "n", "no", "none", "later"):
+        print("已跳过连接。本机检索：")
+        print("  xskill traj search <词>")
+        print("  xskill traj read <traj_id>")
+        _print_init_connect_guide()
+        return
+    if choice in ("2", "serve", "server"):
+        print("自己起团队服务：")
+        print("  xskill serve --server")
+        print("启动后终端会打印 join token。本机或同事再：")
+        print("  xskill connect <host:port> --token <刚打印的 token> --name <工号>")
+        print("不要用网上搜到的公共地址。")
+        print("本机检索现在就能用：xskill traj search <词>")
+        return
+    if choice not in ("1", "c", "connect", "y", "yes"):
+        print("未识别的选项，已按跳过连接处理。")
+        print("本机检索：xskill traj search <词>")
+        _print_init_connect_guide()
+        return
+    address = input("server 地址 host:port（回车=跳过连接）：").strip()
+    if not address:
+        print("没有填写地址，已跳过连接。")
+        _print_init_connect_guide()
+        return
+    token = input("join token（回车=跳过；向 server 管理员要）：").strip()
+    if not token:
+        print("没有填写 token，已跳过连接。")
+        _print_init_connect_guide(address=address)
+        return
+    name = input("工号 / 用户 ID（回车可后补）：").strip() or None
+    print(f"正在连接 {address} …")
+    code = cmd_connect(_init_connect_args(args, address, token, name))
+    if code != 0:
+        print("连接没有成功。本机引导已经完成，可以先用：")
+        print("  xskill traj search <词>")
+        print("连上后再跑 connect。")
+
+
 def _choose_helper_ecosystems(args, detections: list[dict], interactive: bool) -> list[str]:
     names = [str(row["ecosystem"]) for row in detections]
     selected = [str(item) for item in (getattr(args, "harness", None) or []) if item]
@@ -240,7 +315,8 @@ def _choose_helper_ecosystems(args, detections: list[dict], interactive: bool) -
 def cmd_init(args) -> int:
     """本机引导：扫描 harness、转换轨迹、可选装 /xskill-helper。
 
-    不要求 connect。``--yes`` 无头：全量扫描并把 helper 装到已扫到的 harness。
+    不要求 connect。交互时可选连团队，回车或空 token 都跳过并给出后续命令。
+    ``--yes`` 无头：全量扫描并把 helper 装到已扫到的 harness，不询问连接。
     """
     from pathlib import Path
 
@@ -277,7 +353,7 @@ def cmd_init(args) -> int:
         print("本机检索：xskill traj search <词>    读原文：xskill traj read <id>")
 
     if args.no_skill:
-        _print_init_next_steps(connected)
+        _offer_optional_connect(args, connected)
         return 0
 
     chosen = _choose_helper_ecosystems(args, detections, interactive)
@@ -285,7 +361,7 @@ def cmd_init(args) -> int:
         install_bundled_xskill_guide(target_root=home, ecosystems=chosen)
     elif detections:
         print("未安装 /xskill-helper。以后可再跑 xskill init，或 xskill connect 后自动装。")
-    _print_init_next_steps(connected)
+    _offer_optional_connect(args, connected)
     return 0
 
 
@@ -2888,7 +2964,7 @@ def build_parser() -> argparse.ArgumentParser:
 
     p_init = sub.add_parser(
         "init",
-        help="本机引导：扫描 harness、转换轨迹、可选装 /xskill-helper",
+        help="本机引导：扫描 harness、转换轨迹、可选装 /xskill-helper；连团队可跳过",
     )
     p_init.add_argument("-y", "--yes", action="store_true",
                         help="非交互：扫描全部，并把 helper 装到已扫到的 harness")

--- a/src/xskill/data/skill/xskill-helper/SKILL.md
+++ b/src/xskill/data/skill/xskill-helper/SKILL.md
@@ -54,8 +54,10 @@ and install `/xskill-helper` into all of them. `--no-skill` skips the
 guide. `--skills-only` only installs the guide. `--force` rescans even if
 the local index already exists.
 
-Remind the user they can later join a remote team server for shared Skills
-and teammate trajectories, or run a standalone team server themselves:
+Interactive `xskill init` then asks whether to join a team server. Enter,
+skip, or an empty address/token all leave the machine usable locally. Do
+not treat a skipped connect as failure. If they want to connect later, or
+run a standalone team server:
 
 ```bash
 xskill connect <host:port> --token <token> --name <user-id>

--- a/tests/test_cli_init.py
+++ b/tests/test_cli_init.py
@@ -159,3 +159,125 @@ def test_force_passed_to_ensure(detections, install_recorder, monkeypatch):
 
     assert code == 0
     assert seen[0]["force"] is True
+
+
+def _patch_init_common(monkeypatch, detections):
+    monkeypatch.setattr(
+        "xskill.ecosystems.detect_known_ecosystems",
+        lambda home_root=None: detections,
+    )
+    monkeypatch.setattr(
+        "xskill.config.get_team_client_state_path",
+        lambda: Path("/nonexistent/team_client.json"),
+    )
+    monkeypatch.setattr(
+        "xskill.ecosystems.local_bootstrap.ensure_local_sessions",
+        lambda **kwargs: {"ran": False, "reason": "already"},
+    )
+
+
+def test_interactive_skip_connect_is_success(
+        detections, install_recorder, monkeypatch, capsys):
+    _patch_init_common(monkeypatch, detections)
+    monkeypatch.setattr("builtins.input", lambda _prompt="": "")
+
+    code = cli.cmd_init(_args(yes=False, no_skill=True))
+
+    assert code == 0
+    captured = capsys.readouterr()
+    assert "已跳过连接" in captured.out
+    assert "xskill traj search" in captured.out
+    assert "xskill connect" in captured.out
+    assert "xskill serve --server" in captured.out
+    assert "缺少" not in captured.err
+    assert "必须带 --token" not in captured.err
+
+
+def test_interactive_empty_token_skips_connect(
+        detections, install_recorder, monkeypatch, capsys):
+    _patch_init_common(monkeypatch, detections)
+    answers = iter(["1", "hub.example.invalid", ""])
+    monkeypatch.setattr("builtins.input", lambda _prompt="": next(answers))
+    called = []
+    monkeypatch.setattr(
+        "xskill.cli.cmd_connect",
+        lambda args: called.append(args) or 0,
+    )
+
+    code = cli.cmd_init(_args(yes=False, no_skill=True))
+
+    assert code == 0
+    assert called == []
+    out = capsys.readouterr().out
+    assert "没有填写 token，已跳过连接" in out
+    assert "xskill connect hub.example.invalid --token <token>" in out
+
+
+def test_interactive_empty_address_skips_connect(
+        detections, install_recorder, monkeypatch, capsys):
+    _patch_init_common(monkeypatch, detections)
+    answers = iter(["1", ""])
+    monkeypatch.setattr("builtins.input", lambda _prompt="": next(answers))
+    called = []
+    monkeypatch.setattr(
+        "xskill.cli.cmd_connect",
+        lambda args: called.append(args) or 0,
+    )
+
+    code = cli.cmd_init(_args(yes=False, no_skill=True))
+
+    assert code == 0
+    assert called == []
+    assert "没有填写地址，已跳过连接" in capsys.readouterr().out
+
+
+def test_interactive_serve_option_does_not_connect(
+        detections, install_recorder, monkeypatch, capsys):
+    _patch_init_common(monkeypatch, detections)
+    monkeypatch.setattr("builtins.input", lambda _prompt="": "2")
+    called = []
+    monkeypatch.setattr(
+        "xskill.cli.cmd_connect",
+        lambda args: called.append(args) or 0,
+    )
+
+    code = cli.cmd_init(_args(yes=False, no_skill=True))
+
+    assert code == 0
+    assert called == []
+    out = capsys.readouterr().out
+    assert "xskill serve --server" in out
+    assert "不要用网上搜到的公共地址" in out
+
+
+def test_interactive_connect_when_both_filled(
+        detections, install_recorder, monkeypatch):
+    _patch_init_common(monkeypatch, detections)
+    answers = iter(["1", "10.0.0.2:8000", "tok-1", "u42"])
+    monkeypatch.setattr("builtins.input", lambda _prompt="": next(answers))
+    called = []
+    monkeypatch.setattr(
+        "xskill.cli.cmd_connect",
+        lambda args: called.append(args) or 0,
+    )
+
+    code = cli.cmd_init(_args(yes=False, no_skill=True))
+
+    assert code == 0
+    assert len(called) == 1
+    assert called[0].address == "10.0.0.2:8000"
+    assert called[0].token == "tok-1"
+    assert called[0].name == "u42"
+
+
+def test_interactive_failed_connect_still_succeeds_init(
+        detections, install_recorder, monkeypatch, capsys):
+    _patch_init_common(monkeypatch, detections)
+    answers = iter(["1", "10.0.0.2:8000", "bad", ""])
+    monkeypatch.setattr("builtins.input", lambda _prompt="": next(answers))
+    monkeypatch.setattr("xskill.cli.cmd_connect", lambda args: 2)
+
+    code = cli.cmd_init(_args(yes=False, no_skill=True))
+
+    assert code == 0
+    assert "本机引导已经完成" in capsys.readouterr().out


### PR DESCRIPTION
## Summary
- `xskill init` 把连团队当成可选项：回车、skip、空地址或空 token 都完成本机引导，给出 traj search / 以后 connect / 自己 serve 的命令，不再报「缺少 --token」退出。
- 选 1 且地址和 token 都填了才真正 connect；连接失败也不让 init 本身失败。

## Test plan
- [x] tests/test_cli_init.py

Made with [Cursor](https://cursor.com)