### PR TITLE
docs: add v0.7.0 release notes to README news

### DIFF
--- a/README.en.md
+++ b/README.en.md
@@ -244,6 +244,7 @@ Standalone readiness: `xskill traj search` works out of the box after `pip insta
 
 ## 📰 News
 
+- **2026-08-27** `v0.7.0`: Generate reads trajectories with traj_search, traj_cards, atom_search, and read_traj, and can append to the wiki incrementally; `xskill init` can skip joining a team and will not disconnect an existing client.
 - **2026-08-17** `v0.6.32a1`: Newest trajectories are split and clustered first; admins can hot-change pool seats and LLM weights; generate waiting for an LLM slot always goes first; imported skills that already meet SkillEdit triggers take an edit seat before distilled ones.
 - **2026-08-14** `v0.6.31`: `xskill rebuild --force` no longer dies on a non-empty `.git/objects` directory; a full rebuild keeps skills brought in with `xskill import` and only wipes distilled ones.
 - **2026-08-14** `v0.6.30`: Team `xskill import` pins the skill onto the initiator's recommendation list; the skills library shows a hollow star to pin into your feed, plus whether a skill is already pushed or pinned; imported skills appear in the library list immediately.

--- a/README.md
+++ b/README.md
@@ -348,6 +348,7 @@ skillhub:
 
 
 ## 📰 动态
+- **2026-08-27** `v0.7.0`：Generate 读轨迹改为 traj_search、traj_cards、atom_search、read_traj，wiki 可增量记进度；`xskill init` 可跳过连接，已连接用户再跑不会断连。
 - **2026-08-17** `v0.6.32a1`：流水线按新轨迹先拆先归；看板可热改席位和配额比，不重启 agent-worker；有 generate 在等大模型时硬优先；已达触发条件的 import 技能优先占编辑座。
 - **2026-08-14** `v0.6.31`：`xskill rebuild --force` 不再因 `.git/objects` 非空中断；全量 rebuild 会留下 `xskill import` 纳入的技能，只清蒸馏产物。
 - **2026-08-14** `v0.6.30`：team `xskill import` 后钉到发起人推荐列表；技能库登录后可点空心星 pin 进自己的推荐流，并标出推给我、已钉状态；import 后技能立即出现在技能库清单。

--- a/README.zh-CN.md
+++ b/README.zh-CN.md
@@ -21,6 +21,7 @@
 
 ## 动态
 
+- **2026-08-27** — `v0.7.0`：Generate 读轨迹改为 traj_search、traj_cards、atom_search、read_traj，wiki 可增量记进度；`xskill init` 可跳过连接，已连接用户再跑不会断连。详见 [Release notes](https://github.com/SkillNerds/xskill/releases/tag/v0.7.0)。
 - **2026-08-17** — `v0.6.32a1`：流水线按新轨迹先拆先归；看板可热改席位和配额比；generate 等大模型时硬优先；已达触发条件的 import 技能优先占编辑座。详见 [Release notes](https://github.com/SkillNerds/xskill/releases/tag/v0.6.32a1)。
 - **2026-08-14** — `v0.6.31`：`xskill rebuild --force` 不再因 `.git/objects` 非空中断；全量 rebuild 会留下 `xskill import` 纳入的技能。详见 [Release notes](https://github.com/SkillNerds/xskill/releases/tag/v0.6.31)。
 - **2026-08-14** — `v0.6.30`：team `xskill import` 后钉到发起人推荐列表；技能库登录后可点空心星 pin 进自己的推荐流，并标出推给我、已钉状态。详见 [Release notes](https://github.com/SkillNerds/xskill/releases/tag/v0.6.30)。


### PR DESCRIPTION
## Summary
- 三份 README 动态补上正式版 v0.7.0。

## Test plan
- [x] 仅文档

Made with [Cursor](https://cursor.com)