### PR TITLE
fix(generate): honor traj_search context without rg

### DIFF
--- a/src/xskill/agents/traj_tools.py
+++ b/src/xskill/agents/traj_tools.py
@@ -367,10 +367,31 @@ def _rg(args: list[str], timeout: int) -> str:
     return completed.stdout if completed.returncode <= 1 else ""
 
 
+def _format_search_hit(
+    path: Path, hit_line: int, snippet: str, count: int, context: int,
+) -> str:
+    """检索命中：默认一行摘要；context>0 时带前后文，命中行标星。"""
+    mark = f"（共命中 {count} 处）" if count > 1 else ""
+    if context <= 0:
+        return f"{path.stem}\tL{hit_line}: {_one_line(snippet, 100)}{mark}"
+    try:
+        lines = path.read_text(encoding="utf-8", errors="replace").splitlines()
+    except OSError:
+        lines = []
+    start = max(1, hit_line - context)
+    end = min(len(lines), hit_line + context) if lines else hit_line
+    rows = [f"{path.stem}{mark}"]
+    for number in range(start, end + 1):
+        tag = "*" if number == hit_line else " "
+        text = lines[number - 1] if 0 <= number - 1 < len(lines) else ""
+        rows.append(f"  L{number}{tag} {_one_line(text, 90)}")
+    return "\n".join(rows)
+
+
 def _search_by_query(query: str, take: int, context: int = 0) -> str:
     roots = _traj_roots()
     if not shutil.which("rg"):
-        return _search_by_query_python(query, take, roots)
+        return _search_by_query_python(query, take, roots, context)
     # 一遍 rg -c 同时拿命中文件与每文件命中处数
     counts: dict[Path, int] = {}
     for root in roots:
@@ -405,27 +426,16 @@ def _search_by_query(query: str, take: int, context: int = 0) -> str:
     for path in shown:
         args = ["rg", "-n", "--no-heading", "--color", "never", "--smart-case",
                 "-m", "1", "-e", query, str(path)]
-        if context > 0:
-            args[1:1] = ["-C", str(context)]
         out = _rg(args, 10)
         lines = [ln for ln in out.splitlines() if ln.strip()]
-        total = counts.get(path, 1)
-        mark = f"（共命中 {total} 处）" if total > 1 else ""
-        if context <= 0:
-            first = lines[0] if lines else "1:"
-            lineno, _, content = first.partition(":")
-            rows.append(f"{path.stem}\tL{lineno}: {_one_line(content, 100)}{mark}")
-            continue
-        block: list[str] = [f"{path.stem}{mark}"]
-        for raw in lines:
-            # rg 上下文行用 '-' 分隔，命中行用 ':'
-            for sep in (":", "-"):
-                lineno, found, content = raw.partition(sep)
-                if found and lineno.isdigit():
-                    tag = "*" if sep == ":" else " "
-                    block.append(f"  L{lineno}{tag} {_one_line(content, 90)}")
-                    break
-        rows.append("\n".join(block))
+        first = lines[0] if lines else "1:"
+        lineno, _, content = first.partition(":")
+        hit_line = int(lineno) if lineno.isdigit() else 1
+        rows.append(
+            _format_search_hit(
+                path, hit_line, content, counts.get(path, 1), context,
+            )
+        )
     head = (
         f"query={query!r} 命中 {len(hits)} 条不同轨迹，展示 {len(shown)} 条"
         f"（同名前缀已错开）。看内容用 traj_cards，一次最多 {CARDS_MAX} 个 id。"
@@ -437,7 +447,9 @@ def _search_by_query(query: str, take: int, context: int = 0) -> str:
     return head + "\n" + "\n".join(rows)
 
 
-def _search_by_query_python(query: str, take: int, roots: list[Path]) -> str:
+def _search_by_query_python(
+    query: str, take: int, roots: list[Path], context: int = 0,
+) -> str:
     needle = query.lower()
     hits: list[tuple[Path, int, str, int]] = []
     for path in _traj_files():
@@ -462,8 +474,7 @@ def _search_by_query_python(query: str, take: int, roots: list[Path]) -> str:
         if path not in lookup:
             continue
         number, line, count = lookup[path]
-        mark = f"（共命中 {count} 处）" if count > 1 else ""
-        rows.append(f"{path.stem}\tL{number}: {_one_line(line, 100)}{mark}")
+        rows.append(_format_search_hit(path, number, line, count, context))
     leftover = len(hits) - len(rows)
     head = (
         f"query={query!r} 命中 {len(hits)} 条不同轨迹，展示 {len(rows)} 条"

--- a/tests/test_agent_tools_explore.py
+++ b/tests/test_agent_tools_explore.py
@@ -100,8 +100,9 @@ class TestGrepFiles:
         )
 
         assert out.startswith("engine: ")
-        assert f"{corpus_dir}/traj_a.md:2:" in out
-        assert f"{corpus_dir}/traj_a.md-1-" in out
+        hit = corpus_dir / "traj_a.md"
+        assert f"{hit}:2:" in out
+        assert f"{hit}-1-" in out
         assert "context: before=2 after=2" in out
 
     def test_sensitive_files_filtered_from_hits(self, tmp_path, monkeypatch):
@@ -186,8 +187,9 @@ class TestGrepFiles:
             "DOCKER_RESTART", path=str(corpus_dir), before=0, after=0,
         )
 
-        assert f"{corpus_dir}/traj_a.md:2:" in out
-        assert f"{corpus_dir}/traj_a.md-1-" not in out
+        hit = corpus_dir / "traj_a.md"
+        assert f"{hit}:2:" in out
+        assert f"{hit}-1-" not in out
 
 
 class TestSkillReadTree:

--- a/tests/test_traj_tools.py
+++ b/tests/test_traj_tools.py
@@ -139,6 +139,16 @@ def test_search_hit_counts_and_context(tmp_path: Path):
     assert "我应该先定位循环" in ctx_hits
 
 
+def test_search_context_without_rg(tmp_path: Path, monkeypatch):
+    """CI 没有 rg，必须走逐行回退且仍尊重 context。"""
+    monkeypatch.setattr("xskill.agents.traj_tools.shutil.which", lambda _name: None)
+    with agent_tools.use_agent_tool_context(_ctx(tmp_path)):
+        ctx_hits = traj_search.entrypoint(query="重试循环", context=2)
+    assert "无 rg" in ctx_hits
+    assert "L31*" in ctx_hits
+    assert "我应该先定位循环" in ctx_hits
+
+
 def test_card_keeps_questions_and_drops_tool_output(tmp_path: Path):
     with agent_tools.use_agent_tool_context(_ctx(tmp_path)):
         batch = traj_cards.entrypoint(


### PR DESCRIPTION
## Summary
- #366 已合入 main，但 ut+it 全红：CI 没有 ripgrep，`traj_search` 的逐行回退丢掉了 `context` 和命中行星号，`test_search_hit_counts_and_context` 断言 `L31*` 失败。
- 回退路径与 rg 路径共用同一套命中渲染；补一条强制无 rg 的测试，避免本机有 rg 时漏掉这条回归。
- Windows 上 `grep_files` 测试写死了 `/`，和原生路径对不上，改成用 `Path` 拼接。

## Test plan
- [x] `pytest tests/test_traj_tools.py tests/test_agent_tools_explore.py tests/test_traj_browse.py tests/test_traj_search.py`
- [ ] 等本 PR 的 ut+it 矩阵变绿


Made with [Cursor](https://cursor.com)