### PR TITLE
perf(generate): append wiki log without rewriting history

### DIFF
--- a/src/xskill/agents/llm_wiki.py
+++ b/src/xskill/agents/llm_wiki.py
@@ -359,10 +359,18 @@ def wiki_log(entry: str) -> str:
     stamp = datetime.now(timezone.utc).strftime("%Y-%m-%dT%H:%M:%SZ")
     line = f"## [{stamp}] {text}\n"
     log = root / "log.md"
-    prev = log.read_text(encoding="utf-8") if log.is_file() else "# log\n\n"
-    if not prev.endswith("\n"):
-        prev += "\n"
-    log.write_text(prev + line, encoding="utf-8")
+    if not log.is_file():
+        log.write_text("# log\n\n", encoding="utf-8")
+    with log.open("rb") as handle:
+        handle.seek(0, 2)
+        size = handle.tell()
+        if size:
+            handle.seek(-1, 2)
+            prefix = "" if handle.read(1) == b"\n" else "\n"
+        else:
+            prefix = "\n"
+    with log.open("a", encoding="utf-8") as handle:
+        handle.write(prefix + line)
     return f"ok appended log.md chars={len(line)}"
 
 

--- a/tests/PERFORMANCE_CONTRACTS.md
+++ b/tests/PERFORMANCE_CONTRACTS.md
@@ -6,7 +6,7 @@
 pytest tests/ --ignore=tests/e2e --ignore=tests/bdd -m performance_contract
 ```
 
-规模符号：`S` 为技能数，`C` 为客户端或 watch_dir 数，`T` 为轨迹数，`A` 为 Atom 数，`B` 为 Cluster batch 数，`K` 为单个 Atom 关联的技能数，`D` 为当前脏记录数。
+规模符号：`S` 为技能数，`C` 为客户端或 watch_dir 数，`T` 为轨迹数，`A` 为 Atom 数，`B` 为 Cluster batch 数，`K` 为单个 Atom 关联的技能数，`D` 为当前脏记录数，`H` 为已有 Wiki 日志大小。
 
 | 热路径 | 规模 | 当前实现 | 回归上限 | 契约测试 |
 |---|---:|---|---|---|
@@ -19,5 +19,6 @@ pytest tests/ --ignore=tests/e2e --ignore=tests/bdd -m performance_contract
 | 多技能 pending 投影 | K | 写入和读取 O(K) | 保留全部 Atom–Skill 关系 | `test_atom_candidate_pending.py::test_backfill_and_dashboard_keep_multi_skill_pending_associations` |
 | Skill 向量同步 | S | 稳态 O(D) | 只更新脏技能且空闲轮次不扫描索引 | `test_skill_vector_incremental.py::test_idle_tick_does_not_scan_vector_index`、`test_skill_vector_incremental.py::test_one_dirty_skill_only_updates_that_key` |
 | Atom 向量同步 | A | 增量更新 O(A_delta) | 不读取历史 JSON，embedding 批次大小有界 | `test_atom_vector_projection.py::test_incremental_add_reads_no_historical_json`、`test_atom_vector_projection.py::test_embedding_batches_have_a_fixed_memory_bound` |
+| Generate Wiki 日志追加 | H | 单次追加相对历史大小为 O(1) | 不完整读取或重写已有 `log.md` | `test_llm_wiki.py::test_wiki_log_appends_without_rewriting_history` |
 
 低频 reconcile 和显式 rebuild 允许 O(S)、O(C + T) 或 O(A) 全量工作，用于修复外部写入和旧版本数据；这些慢路径必须由间隔、版本变化或显式操作触发，不能进入每轮稳态轮询。

--- a/tests/test_llm_wiki.py
+++ b/tests/test_llm_wiki.py
@@ -2,6 +2,8 @@ from __future__ import annotations
 
 from pathlib import Path
 
+import pytest
+
 from xskill.agents import agent_tools
 from xskill.agents.llm_wiki import (
     AFTER_COMPACT_EMPTY_HINT,
@@ -41,6 +43,59 @@ def test_wiki_roundtrip_and_search(tmp_path: Path):
     assert "pages/survey.md" in hits
     assert logged.startswith("ok appended")
     assert "看完一批会话" in (root / "log.md").read_text(encoding="utf-8")
+
+
+@pytest.mark.performance_contract
+def test_wiki_log_appends_without_rewriting_history(tmp_path: Path, monkeypatch):
+    root = seed_generate_wiki(tmp_path / "wiki")
+    log = root / "log.md"
+    log.write_text("existing history", encoding="utf-8")
+    ctx = agent_tools.create_agent_tool_context(
+        skill_dir=tmp_path / "skill",
+        wiki_root=root,
+    )
+    (tmp_path / "skill").mkdir()
+    original_read_text = Path.read_text
+    original_write_text = Path.write_text
+
+    def reject_full_read(path, *args, **kwargs):
+        if path == log:
+            raise AssertionError("wiki_log must not read the complete history")
+        return original_read_text(path, *args, **kwargs)
+
+    def reject_rewrite(path, *args, **kwargs):
+        if path == log:
+            raise AssertionError("wiki_log must append instead of rewriting history")
+        return original_write_text(path, *args, **kwargs)
+
+    monkeypatch.setattr(Path, "read_text", reject_full_read)
+    monkeypatch.setattr(Path, "write_text", reject_rewrite)
+    with agent_tools.use_agent_tool_context(ctx):
+        result = wiki_log.entrypoint(entry="continue from here")
+
+    content = original_read_text(log, encoding="utf-8")
+    assert result.startswith("ok appended")
+    assert content.startswith("existing history\n## [")
+    assert content.endswith("] continue from here\n")
+
+
+def test_wiki_log_recreates_missing_log(tmp_path: Path):
+    root = seed_generate_wiki(tmp_path / "wiki")
+    log = root / "log.md"
+    log.unlink()
+    ctx = agent_tools.create_agent_tool_context(
+        skill_dir=tmp_path / "skill",
+        wiki_root=root,
+    )
+    (tmp_path / "skill").mkdir()
+
+    with agent_tools.use_agent_tool_context(ctx):
+        result = wiki_log.entrypoint(entry="start again")
+
+    assert result.startswith("ok appended")
+    content = log.read_text(encoding="utf-8")
+    assert content.startswith("# log\n\n## [")
+    assert content.endswith("] start again\n")
 
 
 def test_wiki_edit_append_and_replace(tmp_path: Path):


### PR DESCRIPTION
## Summary

`wiki_log` 现在只读取日志尾部状态并追加当前记录，不再为每条进度重读和重写完整历史，使单次追加相对已有日志大小保持 O(1)。

## Changes

- 使用尾字节检查保留原有换行格式，并通过追加模式写入新记录。
- 保留缺失 `log.md` 时自动写入 `# log` 种子内容的行为。
- 增加确定性性能契约，禁止完整读取或重写已有日志，并记录到性能契约清单。

## Test plan

- [x] `make test` passes（2718 passed, 9 skipped）
- [x] Added/updated unit tests for the change（68 个相关测试通过，12 个性能契约测试通过）
- [ ] `make e2e` passes (if the change touches ingestion / install / daemon)（不适用，本 PR 只修改 Generate Wiki 文件追加）
- [x] Manually verified the affected user flow（2 MB 历史日志连续追加 1000 次约 0.024 秒）

## Linked issues

Closes #368

## 给外人看的背景（Generate Wiki 进度日志怎么追加）

下面按给第三方看的问题单来写：每个词第一次出现都会说明它是什么。代码位置只是提示，不是必须先读完整个仓库才能看懂。

### 这是什么

XSkill 平时是从编码轨迹里自动蒸馏技能的。另有一条用户主动发起的命令：

```
xskill generate "定向指令"
```

用户用一句话描述想要的技能。系统立刻起一个生成代理（GenerateAgent），按这句话去读轨迹、读已有技能、写出技能文件。生成代理跑的时间可能很长，对话会被压缩：旧的大段工具结果会收起来，模型只留下摘要。压缩之后，代理还得知道自己刚才干到哪一步。

为此，Generate 有一份会话证据 wiki。wiki 就是这次生成任务自己的笔记本，写在磁盘上，压缩后还能再读回来。笔记本里有几页固定页面，其中一页叫 `log.md`：按时间一行一行记下「已精读多少条、下一步搜什么」这类交接信息。

`wiki_log` 是只给生成代理用的工具：往 `log.md` 追加一行带时间戳的进度。它和 `wiki_write` 不同。`wiki_write` 是整页覆盖；`wiki_log` 只追加流水，不覆盖已有记录。本 PR 不改 Generate 命令本身，也不改技能怎么写，只改 `wiki_log` 往磁盘上写这一行的方式。

### 用户侧实际发生了什么

用户在已经连上团队 server 的客户端上敲 `xskill generate "……"`。终端会阻塞，并实时打出代理的思维过程和工具调用。那份流式输出走的是生成代理自己的运行日志，不是 `log.md`。

代理在 server 上干活时，每读完一批轨迹，会用 `wiki_log` 记一行。`log.md` 会越来越长。一次生成里可能追加很多次。用户一般不会去翻这份文件；它主要是给压缩之后的代理自己看的。

文件还不存在时，先写入种子内容 `# log`，再追加第一条进度。种子就是文件开头那一行标题，用来标明这是进度日志，不是空文件。已有文件则应只在末尾加一行，形如：

```
## [2026-08-31T07:00:00Z] 已精读 15 条，下一步搜发票核对
```

### 合本 PR 之前缺了什么

每次调用都把整份 `log.md` 读进内存，再把「旧全文加上新一行」整文件写回去。日志越长，单次追加越慢。记 M 次、每次新行长度差不多时，累计读写最坏会按次数的平方涨，并反复分配内存、反复写已经不会变的旧行。

结果对不对不受影响：时间戳、换行、缺文件时写种子，这些语义本来就有。缺的是：单次追加相对已有日志大小 H 应当是常数时间，也就是 O(1)，不要随着 H 变大而整份重读重写。这个问题在更早的 PR #339 评审里已经记下，后来单独开了 #368。

### 本 PR 具体改哪

改的是 `src/xskill/agents/llm_wiki.py` 里的 `wiki_log`。

文件不存在时，仍先写入 `# log` 种子。文件已经在时，不再 `read_text()` 读全文，也不再 `write_text()` 整份覆盖。只打开文件，看最后一个字节是不是换行；缺换行就先补一个，然后用追加模式写入当前这一行。

性能契约清单里加了一条：Generate Wiki 日志追加相对历史大小 H 为 O(1)，禁止完整读取或重写已有 `log.md`。性能契约就是一组确定性测试，锁住「不许走慢路径」，不用墙上时钟当门槛。对应测试会在调用 `wiki_log` 时拦截对这份 `log.md` 的整文件读和整文件写。缺文件再创建的路径另有回归测试。

手工对照：一份约 2 MB 的历史日志连续追加 1000 次，大约 0.024 秒。这组数字只说明「不再跟历史一起膨胀」，不是跨机器的承诺。

### 不要和什么搞混

不要和 #393 搞混。#393 修的是 Codex 原始会话文件怎么采集进来。Codex 是 OpenAI 的命令行编码助手；rollout 是它自己记下的原始会话文件。本 PR 不读、不改任何 rollout。

不要和 #394 搞混。#394 把 Task Graph 默认打开。Task Graph 是架在「会话切成片段、再写成技能」这条主路上面的一层任务图。本 PR 不碰那层图，也不改拆分、归类、编辑这些自动流水线。

也不要把 `log.md` 当成用户终端里看到的那份生成运行日志，或当成后来写给助手用的 Skill。Skill 是技能说明书；`log.md` 只是这一次 Generate 任务内部的进度流水。更不要把它理解成现网已经改过了。真正的现网在格力内网。写这段说明的 Agent 进不去那张内网，也接触不到现网看板。这张补丁只改 Generate 写 wiki 日志的方式，合进主干之后，要等现网侧自己升级才会生效。

### 怎么算这段背景对齐了

能说出 `wiki_log` 是 Generate 往自己的会话证据 wiki 里记进度，不是采集 Codex，也不是画 Task Graph。能说出合之前每次都整份读再整份写，合之后只看末尾有没有换行再追加。能说出缺 `log.md` 时仍先写 `# log` 种子。能说出这不改现网、不改用户怎么敲 generate、也不改技能正文怎么写。
