### PR TITLE
fix(local-init): 兼容 Cursor Agent 嵌套轨迹，--local 能搜到

### DIFF
--- a/src/xskill/ecosystems/_shared.py
+++ b/src/xskill/ecosystems/_shared.py
@@ -870,6 +870,8 @@ class JsonlIngester:
 
     def run_once(self) -> list[dict]:
         """单轮扫盘 + 桥接（常驻 worker 每轮调用，source 唯一）。"""
+        if self.target_traj_dir is not None and not self._seen:
+            self._seen = _scan_seen_sessions(self.target_traj_dir)
         submitted = self.scan_and_bridge(
             target_traj_dir=self.target_traj_dir,
             home_root=self.home_root,
@@ -1024,6 +1026,7 @@ class JsonlIngester:
             result = submit_trajectory(
                 content=content,
                 format=self.spec.adapter_format,
+                metadata={"session_id": sid},
                 traj_id=traj_id,
                 traj_dir=target_traj_dir,
             )

--- a/src/xskill/ecosystems/_shared.py
+++ b/src/xskill/ecosystems/_shared.py
@@ -196,7 +196,9 @@ _KNOWN_ECOSYSTEMS: list[dict] = [
     },
     {
         "id": "cursor",
-        # Cursor 写 <home>/.cursor/projects/<encoded-cwd>/agent-transcripts/<sid>.jsonl
+        # Cursor Agent 写
+        # <home>/.cursor/projects/<encoded-cwd>/agent-transcripts/<sid>/<sid>.jsonl
+        # （旧布局是同目录下扁平的 <sid>.jsonl）
         "source_subpath": ".cursor/projects",
         "bridge_subpath": ".xskill/cursor_sessions",
         "source_kind": "dir",

--- a/src/xskill/ecosystems/cursor.py
+++ b/src/xskill/ecosystems/cursor.py
@@ -157,6 +157,24 @@ _CURSOR_TOOL_KEYS = (
     "target_file", "relative_workspace_path",
 )
 
+_CURSOR_USER_QUERY_RE = re.compile(
+    r"<user_query>\s*(.*?)\s*</user_query>",
+    re.DOTALL,
+)
+
+
+def _cursor_visible_user_text(text: str, limit: int = 4000) -> str:
+    """Cursor Agent 常把整份 skill 内联在 user 消息前，真正的问话在
+    ``<user_query>`` 里。截断前先抽出这段，否则 ``traj search --local``
+    只能扫到 skill 正文。
+    """
+    match = _CURSOR_USER_QUERY_RE.search(text)
+    if match:
+        query = " ".join(match.group(1).split()).strip()
+        if query:
+            return query[:limit]
+    return text[:limit]
+
 
 def _cursor_tool_snip(inp: dict[str, Any], limit: int = 160) -> str:
     """把工具入参收成短串，写进 md / timeline，给后面的卡片用。"""
@@ -260,11 +278,15 @@ def _adapt_cursor_transcripts_jsonl(content: str, metadata: dict) -> tuple[str, 
         if not body:
             continue
 
-        if role == "user" and not first_user_query:
-            first_user_query = body[:500]
+        if role == "user":
+            visible = _cursor_visible_user_text(body)
+            if not first_user_query:
+                first_user_query = visible[:500]
+        else:
+            visible = body[:2000]
 
         entry = {
-            "t": t, "role": role, "content": body[:2000],
+            "t": t, "role": role, "content": visible,
         }
         if pending_tools:
             entry["tools"] = pending_tools

--- a/src/xskill/ecosystems/cursor.py
+++ b/src/xskill/ecosystems/cursor.py
@@ -315,8 +315,9 @@ def ingest_cursor_sessions(
 ) -> list[dict]:
     """Bridge Cursor agent-transcripts JSONLs into xskill's trajectory directory.
 
-    Scans ``<home_root>/.cursor/projects/<encoded-cwd>/agent-transcripts/*.jsonl``
-    and submits any session whose stem is not in ``seen_sessions`` as a new
+    Scans ``<home_root>/.cursor/projects/<encoded-cwd>/agent-transcripts/``
+    for both ``<sid>.jsonl`` and ``<sid>/<sid>.jsonl``, and submits any
+    session whose stem is not in ``seen_sessions`` as a new
     trajectory under ``target_traj_dir`` using the
     ``cursor_transcripts_jsonl`` adapter.
     """

--- a/src/xskill/ecosystems/local_bootstrap.py
+++ b/src/xskill/ecosystems/local_bootstrap.py
@@ -126,6 +126,92 @@ def _local_corpus_empty(home_root: Path) -> bool:
     return True
 
 
+def _jsonl_spec_for(eco: str):
+    from xskill.ecosystems import (
+        CC_SPEC,
+        CODEX_SPEC,
+        CURSOR_SPEC,
+        DSH_SPEC,
+        NGA3_SPEC,
+        OPENCLAW_SPEC,
+    )
+
+    specs = {
+        "claude_code": CC_SPEC,
+        "codex": CODEX_SPEC,
+        "nga3": NGA3_SPEC,
+        "cursor": CURSOR_SPEC,
+        "openclaw": OPENCLAW_SPEC,
+        "deepseek_harness": DSH_SPEC,
+    }
+    return specs.get(eco)
+
+
+def _bridge_index_empty(bridge: Path) -> bool:
+    from xskill.traj_search import session_index_count
+
+    return session_index_count(Path(bridge)) <= 0
+
+
+def _jsonl_needs_ingest(eco: str, home_root: Path, bridge: Path) -> bool:
+    spec = _jsonl_spec_for(eco)
+    if spec is None:
+        return _bridge_index_empty(bridge)
+    glob = spec.sessions_glob
+    root = spec.sessions_path(home_root)
+    if not glob or not root.is_dir():
+        return False
+    source_n = 0
+    for _path in root.glob(glob):
+        source_n += 1
+        if source_n == 1 and _bridge_index_empty(bridge):
+            return True
+    if source_n == 0:
+        return False
+    from xskill.traj_search import session_index_count
+
+    return session_index_count(Path(bridge)) < source_n
+
+
+def pending_local_ingest_ecosystems(home_root: Path) -> list[str]:
+    """源里已有会话、对应 ``*_sessions`` 还缺可检索条目的 harness。"""
+    from xskill.ecosystems import detect_known_ecosystems
+
+    pending: list[str] = []
+    for detection in detect_known_ecosystems(home_root=home_root):
+        eco = str(detection["ecosystem"])
+        if not _jsonl_needs_ingest(eco, home_root, Path(detection["bridge"])):
+            continue
+        pending.append(eco)
+    return pending
+
+
+def _merge_harness_names(old: list | None, new: list | None) -> list[str]:
+    merged: list[str] = []
+    seen: set[str] = set()
+    for raw in list(old or []) + list(new or []):
+        name = str(raw)
+        if not name or name in seen:
+            continue
+        seen.add(name)
+        merged.append(name)
+    return merged
+
+
+def _merge_init_state(old: dict | None, report: dict) -> dict:
+    bridged = dict((old or {}).get("bridged") or {})
+    bridged.update(report.get("bridged") or {})
+    return {
+        "version": 1,
+        "harnesses": _merge_harness_names(
+            (old or {}).get("harnesses"),
+            report.get("harnesses"),
+        ),
+        "bridged": bridged,
+        "updated_at": datetime.now(timezone.utc).isoformat(),
+    }
+
+
 def ingest_detected_sessions_once(
     home_root: Path | str | None = None,
     ecosystems: list[str] | None = None,
@@ -176,7 +262,9 @@ def ensure_local_sessions(
 ) -> dict[str, Any]:
     """确保本机具备可检索的会话数据与索引。
 
-    若已完成初始化且索引有效则自动跳过；在首次运行或强制指定 force 时重新扫描并生成。
+    已初始化且每个已探测到的 harness 都有索引时跳过。某个 harness 的源
+    目录里已经有会话、对应 ``*_sessions`` 仍是空的（例如 Cursor Agent
+    嵌套 JSONL 第一次被旧 glob 漏掉），只补扫这些空档，不必 ``--force``。
     """
     if skip_if_server:
         from xskill.runtime import role
@@ -185,20 +273,22 @@ def ensure_local_sessions(
 
     root = Path(home_root).expanduser().resolve() if home_root else Path.home()
     state = load_local_init_state(root)
-    if state is not None and not force and not _local_corpus_empty(root):
-        return {
-            "ran": False,
-            "reason": "already",
-            "harnesses": list(state.get("harnesses") or []),
-        }
+    ecosystems: list[str] | None = None
+    reason = "scanned"
+    if state is not None and not force:
+        pending = pending_local_ingest_ecosystems(root)
+        if pending:
+            ecosystems = pending
+            reason = "filled_empty"
+        elif not _local_corpus_empty(root):
+            return {
+                "ran": False,
+                "reason": "already",
+                "harnesses": list(state.get("harnesses") or []),
+            }
 
-    report = ingest_detected_sessions_once(home_root=root)
-    payload = {
-        "version": 1,
-        "harnesses": report["harnesses"],
-        "bridged": report["bridged"],
-        "updated_at": datetime.now(timezone.utc).isoformat(),
-    }
+    report = ingest_detected_sessions_once(home_root=root, ecosystems=ecosystems)
+    payload = _merge_init_state(state, report)
     state_path = local_init_state_path(root)
     state_path.parent.mkdir(parents=True, exist_ok=True)
     state_path.write_text(
@@ -206,6 +296,6 @@ def ensure_local_sessions(
         encoding="utf-8",
     )
     report["ran"] = True
-    report["reason"] = "scanned"
+    report["reason"] = reason
     report["state_path"] = str(state_path)
     return report

--- a/src/xskill/ecosystems/local_bootstrap.py
+++ b/src/xskill/ecosystems/local_bootstrap.py
@@ -156,21 +156,26 @@ def _bridge_index_empty(bridge: Path) -> bool:
 def _jsonl_needs_ingest(eco: str, home_root: Path, bridge: Path) -> bool:
     spec = _jsonl_spec_for(eco)
     if spec is None:
-        return _bridge_index_empty(bridge)
+        # OpenCode / ngagent / Trae 不是 JSONL。空库也会被探测到，
+        # 不能只看 bridge 空就 pending，否则 --local 每次重扫。
+        return False
     glob = spec.sessions_glob
     root = spec.sessions_path(home_root)
     if not glob or not root.is_dir():
         return False
-    source_n = 0
-    for _path in root.glob(glob):
-        source_n += 1
-        if source_n == 1 and _bridge_index_empty(bridge):
+    source_ids: set[str] = set()
+    for path in root.glob(glob):
+        sid = spec.session_id_from_path(path)
+        if not sid:
+            continue
+        source_ids.add(sid)
+        if len(source_ids) == 1 and _bridge_index_empty(bridge):
             return True
-    if source_n == 0:
+    if not source_ids:
         return False
     from xskill.traj_search import session_index_count
 
-    return session_index_count(Path(bridge)) < source_n
+    return session_index_count(Path(bridge)) < len(source_ids)
 
 
 def pending_local_ingest_ecosystems(home_root: Path) -> list[str]:

--- a/tests/test_cursor_adapter.py
+++ b/tests/test_cursor_adapter.py
@@ -132,6 +132,22 @@ class TestCursorAdapter:
         assert meta["total_turns"] == 0
         assert meta["tool_names"] == []
 
+    def test_adapter_keeps_user_query_after_inlined_skill(self):
+        dump = "SKILL " + ("x" * 3000)
+        text = (
+            f"<manually_attached_skills>\n{dump}\n</manually_attached_skills>\n"
+            "<timestamp>Friday, Aug 28, 2026</timestamp>\n"
+            "<user_query>\n问题第215号给出这样一个问题单\n</user_query>"
+        )
+        raw = json.dumps({
+            "role": "user",
+            "message": {"content": [{"type": "text", "text": text}]},
+        })
+        md, meta = adapt_trajectory(raw + "\n", "cursor_transcripts_jsonl")
+        assert "问题第215号给出这样一个问题单" in md
+        assert meta["query"] == "问题第215号给出这样一个问题单"
+        assert "xxxxx" not in md
+
     def test_adapter_skips_malformed_lines(self):
         bad = "{not json\n" + json.dumps({
             "role": "user", "message": {"content": [{"type": "text", "text": "ok"}]},
@@ -197,6 +213,20 @@ class TestIngestCursorSessions:
             "traj_cursor_c-proj-A_aaaa1111",
             "traj_cursor_c-proj-B_bbbb2222",
         }
+
+    def test_run_once_restores_seen_and_is_idempotent(self, tmp_path, fixture_content):
+        _place_fixture_in_cursor_home(tmp_path, fixture_content)
+        target = tmp_path / "traj"
+        first = JsonlIngester(
+            CURSOR_SPEC, target_traj_dir=target, home_root=tmp_path,
+            settle_seconds=0.0,
+        ).run_once()
+        assert len(first) == 1
+        second = JsonlIngester(
+            CURSOR_SPEC, target_traj_dir=target, home_root=tmp_path,
+            settle_seconds=0.0,
+        ).run_once()
+        assert second == []
 
     def test_ingest_finds_nested_transcript_layout(self, tmp_path, fixture_content):
         transcripts = (

--- a/tests/test_local_bootstrap.py
+++ b/tests/test_local_bootstrap.py
@@ -1,8 +1,37 @@
 """本机未 connect 时扫描 harness、转轨迹、建索引。"""
 from __future__ import annotations
 
+import json
+from pathlib import Path
+
 from xskill.ecosystems import local_bootstrap as lb
 from xskill.traj_search import upsert_session_file
+
+_CURSOR_FIXTURE = (
+    Path(__file__).parent / "fixtures" / "cursor" / "sample_transcript.jsonl"
+)
+
+
+def _write_nested_cursor_transcript(home: Path, body: str | None = None) -> Path:
+    nested = (
+        home / ".cursor" / "projects" / "home-admin"
+        / "agent-transcripts" / "sid-aaaa-bbbb"
+    )
+    nested.mkdir(parents=True)
+    path = nested / "sid-aaaa-bbbb.jsonl"
+    path.write_text(
+        body if body is not None else _CURSOR_FIXTURE.read_text(encoding="utf-8"),
+        encoding="utf-8",
+    )
+    return path
+
+
+def _index_existing_cc(home: Path) -> None:
+    sessions = home / ".xskill" / "cc_sessions"
+    sessions.mkdir(parents=True)
+    md = sessions / "traj_cc_demo.md"
+    md.write_text("# t\n\n## User\n\nhello cc\n", encoding="utf-8")
+    upsert_session_file(sessions, md)
 
 
 def test_ensure_skips_on_server_role(tmp_path, monkeypatch):
@@ -126,3 +155,65 @@ def test_local_traj_search_bootstraps_once(monkeypatch):
 
     assert code == 0
     assert boot == [True]
+
+
+def test_pending_skips_cursor_without_transcripts(tmp_path):
+    (tmp_path / ".cursor" / "projects").mkdir(parents=True)
+    assert lb.pending_local_ingest_ecosystems(tmp_path) == []
+
+
+def test_pending_includes_nested_cursor_when_bridge_empty(tmp_path):
+    _write_nested_cursor_transcript(tmp_path)
+    assert lb.pending_local_ingest_ecosystems(tmp_path) == ["cursor"]
+
+
+def test_pending_includes_cursor_when_source_outnumbers_index(tmp_path):
+    _write_nested_cursor_transcript(tmp_path)
+    extra = (
+        tmp_path / ".cursor" / "projects" / "home-admin"
+        / "agent-transcripts" / "sid-cccc-dddd"
+    )
+    extra.mkdir(parents=True)
+    (extra / "sid-cccc-dddd.jsonl").write_text(
+        _CURSOR_FIXTURE.read_text(encoding="utf-8"), encoding="utf-8",
+    )
+    sessions = tmp_path / ".xskill" / "cursor_sessions"
+    sessions.mkdir(parents=True)
+    md = sessions / "traj_cursor_home-admin_sid-aaaa.md"
+    md.write_text("# Cursor Agent Trajectory\n\n## User\n\nhello\n", encoding="utf-8")
+    upsert_session_file(sessions, md)
+    assert lb.pending_local_ingest_ecosystems(tmp_path) == ["cursor"]
+
+
+def test_ensure_fills_empty_cursor_when_other_harness_indexed(tmp_path):
+    _write_nested_cursor_transcript(tmp_path)
+    _index_existing_cc(tmp_path)
+    (tmp_path / ".xskill" / "local_init.json").write_text(
+        json.dumps({
+            "version": 1,
+            "harnesses": ["claude_code", "cursor"],
+            "bridged": {"claude_code": 1, "cursor": 0},
+        }),
+        encoding="utf-8",
+    )
+
+    report = lb.ensure_local_sessions(home_root=tmp_path, skip_if_server=False)
+
+    assert report["ran"] is True
+    assert report["reason"] == "filled_empty"
+    assert report["bridged"].get("cursor", 0) >= 1
+    assert "claude_code" not in report["bridged"]
+    cursor_mds = list((tmp_path / ".xskill" / "cursor_sessions").glob("traj_cursor_*.md"))
+    assert cursor_mds
+    assert "Fix the bug in foo.py" in cursor_mds[0].read_text(encoding="utf-8")
+
+    state = lb.load_local_init_state(tmp_path)
+    assert state is not None
+    assert "claude_code" in state["harnesses"]
+    assert "cursor" in state["harnesses"]
+    assert state["bridged"]["claude_code"] == 1
+    assert state["bridged"]["cursor"] >= 1
+
+    second = lb.ensure_local_sessions(home_root=tmp_path, skip_if_server=False)
+    assert second["ran"] is False
+    assert second["reason"] == "already"

--- a/tests/test_local_bootstrap.py
+++ b/tests/test_local_bootstrap.py
@@ -2,6 +2,7 @@
 from __future__ import annotations
 
 import json
+import sqlite3
 from pathlib import Path
 
 from xskill.ecosystems import local_bootstrap as lb
@@ -24,6 +25,31 @@ def _write_nested_cursor_transcript(home: Path, body: str | None = None) -> Path
         encoding="utf-8",
     )
     return path
+
+
+def _write_flat_and_nested_cursor_same_sid(home: Path) -> None:
+    body = _CURSOR_FIXTURE.read_text(encoding="utf-8")
+    transcripts = (
+        home / ".cursor" / "projects" / "home-admin" / "agent-transcripts"
+    )
+    transcripts.mkdir(parents=True)
+    (transcripts / "sid-aaaa-bbbb.jsonl").write_text(body, encoding="utf-8")
+    nested = transcripts / "sid-aaaa-bbbb"
+    nested.mkdir()
+    (nested / "sid-aaaa-bbbb.jsonl").write_text(body, encoding="utf-8")
+
+
+def _write_empty_opencode_db(home: Path) -> None:
+    db = home / ".local" / "share" / "opencode" / "opencode.db"
+    db.parent.mkdir(parents=True)
+    conn = sqlite3.connect(db)
+    try:
+        conn.execute(
+            "CREATE TABLE session (id TEXT PRIMARY KEY, time_updated INTEGER)"
+        )
+        conn.commit()
+    finally:
+        conn.close()
 
 
 def _index_existing_cc(home: Path) -> None:
@@ -214,6 +240,51 @@ def test_ensure_fills_empty_cursor_when_other_harness_indexed(tmp_path):
     assert state["bridged"]["claude_code"] == 1
     assert state["bridged"]["cursor"] >= 1
 
+    second = lb.ensure_local_sessions(home_root=tmp_path, skip_if_server=False)
+    assert second["ran"] is False
+    assert second["reason"] == "already"
+
+
+def test_same_cursor_sid_flat_and_nested_is_not_pending_after_one_bridge(tmp_path):
+    _write_flat_and_nested_cursor_same_sid(tmp_path)
+    _index_existing_cc(tmp_path)
+    (tmp_path / ".xskill" / "local_init.json").write_text(
+        json.dumps({
+            "version": 1,
+            "harnesses": ["claude_code", "cursor"],
+            "bridged": {"claude_code": 1, "cursor": 0},
+        }),
+        encoding="utf-8",
+    )
+
+    first = lb.ensure_local_sessions(home_root=tmp_path, skip_if_server=False)
+    assert first["ran"] is True
+    assert first["reason"] == "filled_empty"
+    assert first["bridged"].get("cursor", 0) == 1
+    assert lb.pending_local_ingest_ecosystems(tmp_path) == []
+
+    second = lb.ensure_local_sessions(home_root=tmp_path, skip_if_server=False)
+    assert second["ran"] is False
+    assert second["reason"] == "already"
+    assert second.get("bridged") is None
+
+
+def test_empty_opencode_db_does_not_repeat_ingest(tmp_path):
+    _write_empty_opencode_db(tmp_path)
+    _index_existing_cc(tmp_path)
+    (tmp_path / ".xskill" / "local_init.json").write_text(
+        json.dumps({
+            "version": 1,
+            "harnesses": ["claude_code", "opencode"],
+            "bridged": {"claude_code": 1, "opencode": 0},
+        }),
+        encoding="utf-8",
+    )
+
+    assert lb.pending_local_ingest_ecosystems(tmp_path) == []
+    first = lb.ensure_local_sessions(home_root=tmp_path, skip_if_server=False)
+    assert first["ran"] is False
+    assert first["reason"] == "already"
     second = lb.ensure_local_sessions(home_root=tmp_path, skip_if_server=False)
     assert second["ran"] is False
     assert second["reason"] == "already"


### PR DESCRIPTION
本机 Cursor Agent 的会话在 `~/.cursor/projects/<encoded-cwd>/agent-transcripts/<sid>/<sid>.jsonl`。适配器已经能读这种嵌套 JSONL，但 `ensure_local_sessions` 只要任意一个 `*_sessions` 有索引就整段跳过。第一次扫描若把 Cursor 记成 0 条，之后 `--local` 再也不会补扫，`cursor_sessions` 一直空着。

## 这是什么

XSkill 会把各 harness 的一次会话收成一份 `traj_*.md`。本机检索是 `xskill traj search --local`，读 `~/.xskill/*_sessions`。

Cursor Agent（Cursor 自带的这个 agent，包括命令行里跑的那一份）把正文写成 JSONL。每一行是 `role` 加 `message.content`（`text` / `tool_use`）。会话 id 在文件名，项目名在 `agent-transcripts` 的上一级目录。旧布局是同目录下扁平的 `<sid>.jsonl`，两种都认。

Cursor 下发技能走目前最常见的 Agent Skills 协议：每个技能一个目录，里面有 `SKILL.md`，装到 `~/.cursor/skills/<名>/`。本 PR 不新做第二套 ecosystem id，也不读桌面 IDE 的 `store.db`，也不扫只有元数据的 `acp-sessions`。

## 用户怎么用

```
xskill traj search --local "会话里的一句话"
xskill traj search --local --cards "同一句话"
xskill traj read --local traj_cursor_<项目slug>_<sid前8位>
```

已经装过、别的 harness 已有索引、Cursor 档仍是空的：第一次 `--local` 会只补扫 Cursor，不必 `xskill init --force`。源文件数多于已索引数时也会再扫一轮（settle 期内跳过的会话，过后再搜能补上）。

## 改了什么

- `ensure_local_sessions` 按 harness 判断空档 / 源多索引少，只补扫这些，并合并写回 `local_init.json`
- Cursor 探测注释和 ingest 文档改成嵌套 `<sid>/<sid>.jsonl`
- 抽出 `<user_query>`，避免内联 skill 把原话截掉
- 回归：别的 harness 已有索引时仍会写出 `traj_cursor_*.md`；只有空的 `~/.cursor/projects` 不会每次重扫

## 时序

写法对齐 #357：人、CLI、磁盘、team server 各画一次。Cursor 走的是目前最常见的 Agent Skills 协议：每个技能一个目录，里面有 `SKILL.md`，装在 `~/.cursor/skills/<名>/`。本机已经能看到这条布局（`~/.cursor/skills` 下现有技能是指向 xskill 工作副本或 downloaded_skills 的 symlink；`install_to_cursor` 在隔离 home 里也会写出同一条路径）。

### 轨迹收集（本机）

Cursor Agent 先把会话写成 JSONL。`xskill traj search --local` 或 `xskill init` 发现 `cursor_sessions` 空着、或源文件比索引多，就只补扫 Cursor，不必 `--force`。

```mermaid
sequenceDiagram
    participant Agent as Cursor Agent
    participant JSONL as agent-transcripts
    actor User as 用户
    participant CLI as xskill CLI
    participant Init as 本机初始化
    participant Disk as cursor_sessions

    Agent->>JSONL: 写下 sid 目录里的 jsonl
    User->>CLI: xskill traj search --local 一句话
    CLI->>Init: 空档或源多于索引则补扫
    Init->>JSONL: 扫扁平和嵌套两种布局
    Init->>Disk: 写出 traj_cursor 并建索引
    CLI->>Disk: 全文检索
    Disk-->>CLI: traj_id 与命中行
    CLI-->>User: 命中 traj_cursor
```

### 轨迹上传（已 connect）

本机桥好的 `traj_*.md` 由 connect 守护进程静默一段时间后再传。上传前脱敏。team server 按 harness=cursor 收下。`--local` 不走这条。

```mermaid
sequenceDiagram
    participant Disk as cursor_sessions
    participant Daemon as connect 守护进程
    participant API as team server

    Daemon->>Disk: 取出已静默的 traj
    Daemon->>Daemon: 脱敏
    Daemon->>API: POST /api/v1/team/upload
    Note over API: harness 记为 cursor
    API-->>Daemon: accepted 列表
    Daemon->>Daemon: 记下已上传
```

### Skill 下发

守护进程每轮先 sync 再拉 bundle，然后 `install_to_cursor`。Cursor 认的是 Agent Skills 目录协议，和 Claude Code 那套 `SKILL.md` 同形，只是根目录换成 `~/.cursor/skills`。symlink 能建就用 symlink，更新即时可见。

```mermaid
sequenceDiagram
    participant Daemon as connect 守护进程
    participant API as team server
    participant Repo as 本机 skill 副本
    participant Cursor as Cursor skills 目录

    Daemon->>API: GET /api/v1/team/sync
    API-->>Daemon: slots 名称与 sha
    Daemon->>API: GET skill bundle
    API-->>Daemon: bundle
    Daemon->>Repo: 落到 working copy
    Daemon->>Cursor: install_to_cursor
    Note over Cursor: ~/.cursor/skills/名/SKILL.md
```

`xskill download`、`xskill init` 装 `/xskill-helper` 也走同一条 `install_to_cursor`，不是另做一套 Cursor 专用格式。

### Skill 上传

`xskill upload` 把本地技能目录打成 zip，落到该用户在 SkillHub 的分享区。这不是 `import`（import 进自有仓主干）。队友之后 `xskill search` 能搜到；下一轮 sync 再按上面的下发图装进 Cursor。

```mermaid
sequenceDiagram
    actor User as 用户
    participant CLI as xskill CLI
    participant API as team server
    participant Hub as SkillHub

    User->>CLI: xskill upload 技能目录
    CLI->>CLI: 校验 SKILL.md 并打 zip
    CLI->>API: POST /api/v1/team/skill_hub/upload
    API->>Hub: 落入该用户的分享目录
    API-->>CLI: skill_id
    CLI-->>User: 队友可 search 到
```


## Test plan

- [x] `pytest tests/test_local_bootstrap.py tests/test_cursor_adapter.py`
- [x] 单测：嵌套 JSONL、空 projects 不 pending、源文件多于索引会再扫、补扫后幂等
- [x] 本机安装后 `xskill traj search --local` 能命中 `traj_cursor_home-admin_f2ab876f` 以及另外几条原话
- [x] `install_to_cursor` 在隔离 home 写出 `~/.cursor/skills/<名>/SKILL.md`（symlink）；本机 `~/.cursor/skills` 已是同一协议

Closes #370
