### PR TITLE
test(algorithms): 记录 Atom 候选边界分数并分析路由错误

### DIFF
--- a/scripts/bench/algorithm_replay/README.md
+++ b/scripts/bench/algorithm_replay/README.md
@@ -1,76 +1,95 @@
 # Atom splitting and routing replay
 
-This suite evaluates immutable, recorded algorithm outputs. It does not call an
-LLM, an embedding endpoint, Milvus, or a coding-agent CLI during normal tests.
+This suite evaluates immutable, recorded algorithm outputs.
 
-Run the checked-in baseline:
+It does not call an LLM, an embedding endpoint, Milvus, or a coding-agent CLI during normal tests.
 
-```bash
-python -m scripts.bench.algorithm_replay.evaluate \
-  scripts/bench/algorithm_replay/fixtures/baseline_v1.json
-```
+Run the checked-in v1 baseline with `python -m scripts.bench.algorithm_replay.evaluate scripts/bench/algorithm_replay/fixtures/baseline_v1.json`.
 
-Use `--format json` for a machine-readable report. The test suite compares that
-report with `baseline_v1.report.json`, so metric-definition changes are explicit
-and reviewable.
+Run the candidate-boundary v2 baseline with `python -m scripts.bench.algorithm_replay.evaluate scripts/bench/algorithm_replay/fixtures/baseline_v2.json`.
+
+Use `--format json` for a machine-readable report.
+
+The test suite compares both reports with their checked-in `*.report.json` snapshots, so schema and metric-definition changes are explicit and reviewable.
 
 ## Fixture contract
 
-The root object contains:
-
-- `schema_version`: currently `1`; unsupported versions fail loudly.
+- `schema_version`: versions `1` and `2` are supported, while unknown versions fail loudly.
 - `metric_config.routing_recall_k`: the candidate cutoff used by Recall@K.
-- `metric_config.atom_alignment_min_iou`: the minimum interval IoU used to
-  align a prediction with a gold Atom for duplicate and routing metrics.
-- `run_manifest`: repository revision, model, harness, prompt fingerprint, seed,
-  generation parameters, token counts, cost, and generation time for the
-  recorded predictions.
+- `metric_config.atom_alignment_min_iou`: the minimum interval IoU used to align a prediction with a gold Atom for duplicate and routing metrics.
+- `run_manifest`: the repository revision, model, harness, prompt fingerprint, seed, generation parameters, token counts, cost, and generation time for the recorded predictions.
 - `skill_catalog`: the only valid routing labels in the suite.
-- `cases`: a line-addressable synthetic trajectory, human-authored gold atoms,
-  and immutable predicted atoms. `line_count` must exactly match `source_lines`.
+- `cases`: line-addressable synthetic trajectories, human-authored gold Atoms, and immutable predicted Atoms whose `line_count` exactly matches `source_lines`.
 
-Atom ranges are 1-based half-open intervals `[start_line, end_line)`. Gold ranges
-must not overlap. Predicted ranges may overlap because overlap is a measured
-failure mode. `scorable_ranges` identifies the source lines used by coverage and
-overlap metrics.
+Atom ranges are 1-based half-open intervals `[start_line, end_line)`.
 
-The checked-in fixture is synthetic and privacy-safe. Its model name is
-`recorded-fixture`; it is an evaluator contract, not a claim about current online
-model quality. Its prompt fingerprint hashes the literal sentinel
-`no-model-prompt:synthetic-baseline-v1`, because no model prompt was used. A real
-offline run must replace the run manifest and prediction section while preserving
-the same schema.
+Gold ranges must not overlap, while predicted ranges may overlap because overlap is a measured failure mode.
+
+`scorable_ranges` identifies the source lines used by coverage and overlap metrics.
+
+The checked-in fixtures are synthetic and privacy-safe.
+
+Their model name is `recorded-fixture`; they validate evaluator contracts and do not claim current online model quality.
+
+The prompt fingerprints hash literal sentinel strings because no model prompt was used.
+
+A real offline run must replace the run manifest and prediction sections while preserving the selected schema.
+
+## Version 2 candidate-boundary contract
+
+Schema v2 retains every v1 field and adds `metric_config.boundary_score_thresholds` plus a `boundary_candidates` list to each case.
+
+Each candidate records an internal scorable `line`, a numeric `boundary_score` in `[0, 1]`, a non-empty `algorithm_version`, a `selected` boolean, and a `predicted_atom_id` when selected.
+
+A v2 suite must contain exactly one `algorithm_version`, and the report copies it to `boundary_algorithm_version` so aggregate scores from different rankers cannot be mixed silently.
+
+Candidate lines are unique within a case and cannot use the forced start of a scorable range.
+
+Every selected candidate must map to a predicted Atom that starts on the same line, and every predicted Atom that starts inside a scorable range must have exactly one selected candidate.
+
+A rejected candidate has `predicted_atom_id: null` because it did not produce an Atom.
+
+`boundary_score` is an uncalibrated ranking signal recorded for offline analysis.
+
+It is not a probability, production confidence field, `ux_score`, or `(atom_id, skill)` `weightscore`.
 
 ## Metric definitions
 
-- Boundary precision/recall/F1 compares exact internal Atom start lines. The
-  forced start of each scorable range is excluded. When both sides have no
-  internal boundary, all three values are `1.0`.
-- Pk and WindowDiff reuse the repository's existing, independently tested
-  `scripts/bench/evaluate.py` implementations. They expose near-miss and
-  over/under-segmentation behavior that exact boundary F1 cannot represent.
-- Coverage is the fraction of scorable lines covered by at least one predicted
-  Atom. Overlap rate counts repeated predicted coverage over the same denominator.
-- Duplicate rate aligns each prediction to the gold Atom with maximum interval
-  IoU at or above `atom_alignment_min_iou`, then counts additional predictions
-  aligned to an already matched gold Atom.
-- Language consistency detects the dominant script of `intent + summary` after
-  removing inline code and path-like tokens. An output with no detectable
-  natural language is a mismatch, not an excluded sample. Version 1 supports
-  English and Chinese fixtures only.
-- Routing micro precision/recall/F1 compares `(gold_atom_id, skill)` relations
-  after interval alignment. Macro precision/recall/F1 is the unweighted mean of
-  per-case scores. Recall@K uses each prediction's ordered `candidates` list.
-- Multi-Skill relation retention measures gold relations belonging to atoms with
-  more than one expected Skill. It prevents an optimization from collapsing a
-  valid one-to-many relation into one label.
+- Boundary precision/recall/F1 compares exact internal Atom start lines and excludes the forced start of each scorable range.
+- Pk and WindowDiff reuse the independently tested implementations in `scripts/bench/evaluate.py` to expose near-miss and over/under-segmentation behavior.
+- Coverage is the fraction of scorable lines covered by at least one predicted Atom, while overlap rate counts repeated predicted coverage over the same denominator.
+- Duplicate rate aligns each prediction to the gold Atom with maximum interval IoU at or above `atom_alignment_min_iou`, then counts additional predictions aligned to an already matched gold Atom.
+- Language consistency detects the dominant script of `intent + summary` after removing inline code and path-like tokens, and an output with no detectable natural language is a mismatch.
+- Routing micro precision/recall/F1 compares `(gold_atom_id, skill)` relations after interval alignment, while macro precision/recall/F1 is the unweighted mean of per-case scores.
+- Recall@K uses each prediction's ordered `candidates` list.
+- Multi-Skill relation retention measures gold relations belonging to Atoms with more than one expected Skill so a valid one-to-many relation cannot silently collapse to one label.
 
-Empty-set behavior follows the existing benchmark: precision/recall/F1 is `1.0`
-only when true-positive, false-positive, and false-negative counts are all zero.
-Duplicate and overlap rates are `0.0` when there is no applicable denominator;
-other vacuously satisfied ratios are `1.0`. An unknown detected language still
-has a denominator and therefore scores as a mismatch.
+When both sides have no internal boundary, boundary precision, recall, and F1 are `1.0`.
 
-Do not turn a metric into a blocking quality threshold until a maintainer has
-reviewed a representative recorded baseline. Deterministic schema and metric
-tests remain blocking regardless of model quality.
+Other empty-set behavior follows the existing benchmark: precision, recall, and F1 are `1.0` only when true-positive, false-positive, and false-negative counts are all zero; duplicate and overlap rates are `0.0` without an applicable denominator; other vacuously satisfied ratios are `1.0`.
+
+## Version 2 score analysis
+
+Candidate-boundary AUROC labels a candidate positive when its line is an exact internal gold boundary and computes rank discrimination with half credit for tied scores.
+
+A gold boundary that was never proposed cannot enter candidate AUROC and remains visible as a false negative in the existing boundary recall metric.
+
+AUROC is `null` when a case or aggregate contains only one label class because discrimination is undefined.
+
+Routing-error analysis includes only selected candidates because rejected candidates have no downstream Atom to route.
+
+The selected candidate's predicted Atom is aligned with the existing IoU rule, and routing is erroneous when the Atom is unmatched or its final `skills` set differs from the aligned gold Atom's complete `skills` set.
+
+`low_score_error_auroc` uses `1 - boundary_score` as the ranking signal, so a value above `0.5` means lower boundary scores tend to rank routing errors ahead of correct routes.
+
+For each fixed `boundary_score_thresholds` value, the report includes eligible and retained samples, retained coverage, routing errors, and routing error rate.
+
+Coverage and routing error rate are `null` when there are no eligible or retained samples, rather than claiming vacuous success.
+
+Candidate and routing AUROC each run in `O(n log n)`, and the threshold table runs in `O(n log n + t log n)` for `n` selected candidates and `t` thresholds.
+
+These metrics show association, not causation or probability calibration.
+
+Do not turn a score or metric into a blocking quality threshold until a maintainer has reviewed a representative recorded baseline.
+
+Deterministic schema and metric tests remain blocking regardless of model quality.

--- a/scripts/bench/algorithm_replay/README.md
+++ b/scripts/bench/algorithm_replay/README.md
@@ -1,95 +1,95 @@
-# Atom splitting and routing replay
+# Atom 拆分与路由离线回放
 
-This suite evaluates immutable, recorded algorithm outputs.
+这套基线评估已经录好、不可变的算法输出。常规测试不会调用 LLM、Embedding 服务、Milvus 或 coding-agent CLI。
 
-It does not call an LLM, an embedding endpoint, Milvus, or a coding-agent CLI during normal tests.
+运行入仓 v1 基线：
 
-Run the checked-in v1 baseline with `python -m scripts.bench.algorithm_replay.evaluate scripts/bench/algorithm_replay/fixtures/baseline_v1.json`.
+```bash
+python -m scripts.bench.algorithm_replay.evaluate \
+  scripts/bench/algorithm_replay/fixtures/baseline_v1.json
+```
 
-Run the candidate-boundary v2 baseline with `python -m scripts.bench.algorithm_replay.evaluate scripts/bench/algorithm_replay/fixtures/baseline_v2.json`.
+运行候选边界 v2 基线：
 
-Use `--format json` for a machine-readable report.
+```bash
+python -m scripts.bench.algorithm_replay.evaluate \
+  scripts/bench/algorithm_replay/fixtures/baseline_v2.json
+```
 
-The test suite compares both reports with their checked-in `*.report.json` snapshots, so schema and metric-definition changes are explicit and reviewable.
+使用 `--format json` 可以输出机器可读报告。测试会把两份报告与入仓的 `*.report.json` 快照比较，因此 schema 和指标定义的变化必须作为可见 diff 接受 review。
 
-## Fixture contract
+## Fixture 契约
 
-- `schema_version`: versions `1` and `2` are supported, while unknown versions fail loudly.
-- `metric_config.routing_recall_k`: the candidate cutoff used by Recall@K.
-- `metric_config.atom_alignment_min_iou`: the minimum interval IoU used to align a prediction with a gold Atom for duplicate and routing metrics.
-- `run_manifest`: the repository revision, model, harness, prompt fingerprint, seed, generation parameters, token counts, cost, and generation time for the recorded predictions.
-- `skill_catalog`: the only valid routing labels in the suite.
-- `cases`: line-addressable synthetic trajectories, human-authored gold Atoms, and immutable predicted Atoms whose `line_count` exactly matches `source_lines`.
+- `schema_version`：支持 `1` 和 `2`，未知版本会直接失败。
+- `metric_config.routing_recall_k`：Recall@K 使用的候选截断。
+- `metric_config.atom_alignment_min_iou`：把预测对齐到 gold Atom 时，重复和路由指标要求的最小区间 IoU。
+- `run_manifest`：这份录制预测对应的仓库 revision、模型、Harness、prompt fingerprint、seed、生成参数、token 数、费用和生成时间。
+- `skill_catalog`：本套件里唯一合法的路由标签。
+- `cases`：可按行寻址的合成轨迹、人工标注的 gold Atom，以及不可变的预测 Atom；`line_count` 必须与 `source_lines` 完全一致。
 
-Atom ranges are 1-based half-open intervals `[start_line, end_line)`.
+Atom 区间是 1-based 半开区间 `[start_line, end_line)`。
 
-Gold ranges must not overlap, while predicted ranges may overlap because overlap is a measured failure mode.
+gold 区间不得重叠；预测区间可以重叠，因为重叠本身就是被度量的失败模式。
 
-`scorable_ranges` identifies the source lines used by coverage and overlap metrics.
+`scorable_ranges` 标出覆盖率和重叠率使用的源行。
 
-The checked-in fixtures are synthetic and privacy-safe.
+入仓 fixture 都是合成数据，满足隐私约束。模型名是 `recorded-fixture`：它们只校验评测器契约，不代表当前线上模型效果。
 
-Their model name is `recorded-fixture`; they validate evaluator contracts and do not claim current online model quality.
+prompt fingerprint 哈希的是字面哨兵串，因为这份合成预测没有使用模型 prompt。
 
-The prompt fingerprints hash literal sentinel strings because no model prompt was used.
+真实离线实验应替换运行清单和 prediction，并保持所选 schema。
 
-A real offline run must replace the run manifest and prediction sections while preserving the selected schema.
+## Version 2 候选边界契约
 
-## Version 2 candidate-boundary contract
+schema v2 保留全部 v1 字段，并增加 `metric_config.boundary_score_thresholds`，以及每个 case 的 `boundary_candidates` 列表。
 
-Schema v2 retains every v1 field and adds `metric_config.boundary_score_thresholds` plus a `boundary_candidates` list to each case.
+每条候选记录一个内部可评分的 `line`、`[0, 1]` 内的数值 `boundary_score`、非空的 `algorithm_version`、布尔值 `selected`，以及被采用时的 `predicted_atom_id`。
 
-Each candidate records an internal scorable `line`, a numeric `boundary_score` in `[0, 1]`, a non-empty `algorithm_version`, a `selected` boolean, and a `predicted_atom_id` when selected.
+一份 v2 套件必须只有一个 `algorithm_version`。报告会把它抄到 `boundary_algorithm_version`，避免不同 ranker 的聚合分数被悄悄混在一起。
 
-A v2 suite must contain exactly one `algorithm_version`, and the report copies it to `boundary_algorithm_version` so aggregate scores from different rankers cannot be mixed silently.
+同一 case 里候选行号唯一，且不能使用可评分区间的被迫起点。
 
-Candidate lines are unique within a case and cannot use the forced start of a scorable range.
+每条被采用的候选必须映射到从同一行开始的预测 Atom；每个从可评分区间内起笔的预测 Atom 也必须恰好对应一条被采用的候选。
 
-Every selected candidate must map to a predicted Atom that starts on the same line, and every predicted Atom that starts inside a scorable range must have exactly one selected candidate.
+被拒绝的候选没有产出 Atom，因此 `predicted_atom_id` 为 `null`。
 
-A rejected candidate has `predicted_atom_id: null` because it did not produce an Atom.
+`boundary_score` 是录下来做离线分析的未校准排序信号。它不是概率，也不是生产置信度、`ux_score`，更不是 `(atom_id, skill)` 的 `weightscore`。
 
-`boundary_score` is an uncalibrated ranking signal recorded for offline analysis.
+## 指标定义
 
-It is not a probability, production confidence field, `ux_score`, or `(atom_id, skill)` `weightscore`.
+- 边界 precision/recall/F1 比较精确的内部 Atom 起始行，并排除每个可评分区间的被迫起点。
+- Pk 和 WindowDiff 复用 `scripts/bench/evaluate.py` 里已独立测试的实现，用来暴露近失以及过切、欠切。
+- Coverage 是至少被一个预测 Atom 覆盖的可评分行比例；overlap rate 用同一分母统计被重复覆盖的部分。
+- Duplicate rate 先按不低于 `atom_alignment_min_iou` 的最大区间 IoU，把每条预测对齐到 gold Atom，再统计对齐到已匹配 gold Atom 的额外预测。
+- Language consistency 在去掉行内代码和路径类 token 后，检测 `intent + summary` 的主导文字；没有可检测自然语言的输出算 mismatch。
+- 路由 micro precision/recall/F1 在区间对齐后比较 `(gold_atom_id, skill)` 关系；macro precision/recall/F1 是各 case 分数的不加权平均。
+- Recall@K 使用每条预测里排好序的 `candidates` 列表。
+- Multi-Skill relation retention 度量属于多个期望 Skill 的 gold 关系，避免合法的一对多关系被悄悄压成一个标签。
 
-## Metric definitions
+两边都没有内部边界时，边界 precision、recall、F1 为 `1.0`。
 
-- Boundary precision/recall/F1 compares exact internal Atom start lines and excludes the forced start of each scorable range.
-- Pk and WindowDiff reuse the independently tested implementations in `scripts/bench/evaluate.py` to expose near-miss and over/under-segmentation behavior.
-- Coverage is the fraction of scorable lines covered by at least one predicted Atom, while overlap rate counts repeated predicted coverage over the same denominator.
-- Duplicate rate aligns each prediction to the gold Atom with maximum interval IoU at or above `atom_alignment_min_iou`, then counts additional predictions aligned to an already matched gold Atom.
-- Language consistency detects the dominant script of `intent + summary` after removing inline code and path-like tokens, and an output with no detectable natural language is a mismatch.
-- Routing micro precision/recall/F1 compares `(gold_atom_id, skill)` relations after interval alignment, while macro precision/recall/F1 is the unweighted mean of per-case scores.
-- Recall@K uses each prediction's ordered `candidates` list.
-- Multi-Skill relation retention measures gold relations belonging to Atoms with more than one expected Skill so a valid one-to-many relation cannot silently collapse to one label.
+其余空集行为沿用现有 benchmark：只有 true-positive、false-positive、false-negative 都是零时，precision、recall、F1 才是 `1.0`；没有可用分母时，duplicate 和 overlap rate 为 `0.0`；其他平凡成立的比率是 `1.0`。
 
-When both sides have no internal boundary, boundary precision, recall, and F1 are `1.0`.
+## Version 2 分数分析
 
-Other empty-set behavior follows the existing benchmark: precision, recall, and F1 are `1.0` only when true-positive, false-positive, and false-negative counts are all zero; duplicate and overlap rates are `0.0` without an applicable denominator; other vacuously satisfied ratios are `1.0`.
+候选边界 AUROC 把落在精确内部 gold 边界上的候选标为正例，用排序判别力计分，并列分数记一半。
 
-## Version 2 score analysis
+从未被提出的 gold 边界不能进入候选 AUROC，仍会作为现有边界 recall 的假阴性出现。
 
-Candidate-boundary AUROC labels a candidate positive when its line is an exact internal gold boundary and computes rank discrimination with half credit for tied scores.
+某个 case 或聚合结果只有一个类别时，判别无定义，AUROC 为 `null`。
 
-A gold boundary that was never proposed cannot enter candidate AUROC and remains visible as a false negative in the existing boundary recall metric.
+路由错误分析只看被采用的候选，因为被拒绝的候选没有下游 Atom 可路由。
 
-AUROC is `null` when a case or aggregate contains only one label class because discrimination is undefined.
+被采用候选的预测 Atom 按现有 IoU 规则对齐。Atom 对不齐，或其最终 `skills` 集合与对齐后 gold Atom 的完整 `skills` 集合不同，就算路由错误。
 
-Routing-error analysis includes only selected candidates because rejected candidates have no downstream Atom to route.
+`low_score_error_auroc` 用 `1 - boundary_score` 做排序信号。大于 `0.5` 表示更低的边界分数倾向于把路由错误排在正确路由前面。
 
-The selected candidate's predicted Atom is aligned with the existing IoU rule, and routing is erroneous when the Atom is unmatched or its final `skills` set differs from the aligned gold Atom's complete `skills` set.
+对每个固定的 `boundary_score_thresholds` 值，报告给出合格样本、保留样本、保留覆盖率、路由错误数和路由错误率。
 
-`low_score_error_auroc` uses `1 - boundary_score` as the ranking signal, so a value above `0.5` means lower boundary scores tend to rank routing errors ahead of correct routes.
+没有合格样本或没有保留样本时，覆盖率和路由错误率为 `null`，不把空集写成成功。
 
-For each fixed `boundary_score_thresholds` value, the report includes eligible and retained samples, retained coverage, routing errors, and routing error rate.
+候选 AUROC 和路由 AUROC 各是 `O(n log n)`；阈值表是 `O(n log n + t log n)`，其中 `n` 是被采用的候选数，`t` 是阈值个数。
 
-Coverage and routing error rate are `null` when there are no eligible or retained samples, rather than claiming vacuous success.
+这些指标表示关联，不是因果，也不是概率校准。
 
-Candidate and routing AUROC each run in `O(n log n)`, and the threshold table runs in `O(n log n + t log n)` for `n` selected candidates and `t` thresholds.
-
-These metrics show association, not causation or probability calibration.
-
-Do not turn a score or metric into a blocking quality threshold until a maintainer has reviewed a representative recorded baseline.
-
-Deterministic schema and metric tests remain blocking regardless of model quality.
+在维护者评审过代表性录制基线之前，不要把某个分数或指标设成阻塞质量阈值。确定性的 schema 测试和指标测试无论模型质量如何都应保持阻塞。

--- a/scripts/bench/algorithm_replay/evaluate.py
+++ b/scripts/bench/algorithm_replay/evaluate.py
@@ -8,17 +8,19 @@ the fixture and scores that immutable prediction against human-authored gold dat
 from __future__ import annotations
 
 import argparse
+import bisect
 import hashlib
 import json
 import re
 from collections import Counter
+from collections.abc import Iterable
 from pathlib import Path
-from typing import Any, Iterable
+from typing import Any
 
 from scripts.bench.evaluate import pk, prf, score_case, window_diff
 
-
-SCHEMA_VERSION = 1
+LATEST_SCHEMA_VERSION = 2
+SUPPORTED_SCHEMA_VERSIONS = {1, LATEST_SCHEMA_VERSION}
 SUPPORTED_LANGUAGES = {"en", "zh"}
 _SHA256_RE = re.compile(r"^sha256:[0-9a-f]{64}$")
 _CODE_SPAN_RE = re.compile(r"`[^`]*`")
@@ -122,14 +124,96 @@ def _validate_atoms(
                 )
 
 
+def _validate_boundary_candidates(
+    candidates: Any,
+    *,
+    predicted_atoms: list[dict[str, Any]],
+    scorable_ranges: list[tuple[int, int]],
+    context: str,
+) -> None:
+    if not isinstance(candidates, list):
+        raise ReplayValidationError(f"{context}: expected a list")
+    predicted_by_id = {atom["id"]: atom for atom in predicted_atoms}
+    expected_predicted_ids = {
+        atom["id"]
+        for atom in predicted_atoms
+        if any(start < atom["start_line"] < end for start, end in scorable_ranges)
+    }
+    seen_lines: set[int] = set()
+    selected_predicted_ids: set[str] = set()
+    for index, candidate in enumerate(candidates):
+        candidate_context = f"{context}[{index}]"
+        if not isinstance(candidate, dict):
+            raise ReplayValidationError(f"{candidate_context}: expected an object")
+        line = _require(candidate, "line", int, candidate_context)
+        if not any(start < line < end for start, end in scorable_ranges):
+            raise ReplayValidationError(
+                f"{candidate_context}.line: expected an internal scorable line"
+            )
+        if line in seen_lines:
+            raise ReplayValidationError(
+                f"{candidate_context}.line: duplicate candidate line {line}"
+            )
+        seen_lines.add(line)
+        score = candidate.get("boundary_score")
+        if (
+            isinstance(score, bool)
+            or not isinstance(score, (int, float))
+            or not 0 <= score <= 1
+        ):
+            raise ReplayValidationError(
+                f"{candidate_context}.boundary_score must satisfy 0 <= value <= 1"
+            )
+        algorithm_version = _require(
+            candidate, "algorithm_version", str, candidate_context
+        )
+        if not algorithm_version:
+            raise ReplayValidationError(
+                f"{candidate_context}.algorithm_version must not be empty"
+            )
+        selected = _require(candidate, "selected", bool, candidate_context)
+        predicted_atom_id = candidate.get("predicted_atom_id")
+        if not selected:
+            if predicted_atom_id is not None:
+                raise ReplayValidationError(
+                    f"{candidate_context}.predicted_atom_id must be null when rejected"
+                )
+            continue
+        if not isinstance(predicted_atom_id, str) or not predicted_atom_id:
+            raise ReplayValidationError(
+                f"{candidate_context}.predicted_atom_id must identify a selected Atom"
+            )
+        if predicted_atom_id not in predicted_by_id:
+            raise ReplayValidationError(
+                f"{candidate_context}.predicted_atom_id: unknown Atom {predicted_atom_id!r}"
+            )
+        if predicted_by_id[predicted_atom_id]["start_line"] != line:
+            raise ReplayValidationError(
+                f"{candidate_context}: selected line must equal the Atom start line"
+            )
+        if predicted_atom_id in selected_predicted_ids:
+            raise ReplayValidationError(
+                f"{candidate_context}.predicted_atom_id: duplicate selected Atom"
+            )
+        selected_predicted_ids.add(predicted_atom_id)
+    if selected_predicted_ids != expected_predicted_ids:
+        missing = sorted(expected_predicted_ids - selected_predicted_ids)
+        unexpected = sorted(selected_predicted_ids - expected_predicted_ids)
+        raise ReplayValidationError(
+            f"{context}: selected candidate mappings do not match internal predicted "
+            f"Atoms; missing={missing}, unexpected={unexpected}"
+        )
+
+
 def validate_suite(suite: Any) -> None:
     """Fail loudly on malformed or unsupported replay data."""
     if not isinstance(suite, dict):
         raise ReplayValidationError("suite: expected an object")
     version = _require(suite, "schema_version", int, "suite")
-    if version != SCHEMA_VERSION:
+    if version not in SUPPORTED_SCHEMA_VERSIONS:
         raise ReplayValidationError(
-            f"suite.schema_version: supported={SCHEMA_VERSION}, got={version}"
+            "suite.schema_version: "
+            f"supported={sorted(SUPPORTED_SCHEMA_VERSIONS)}, got={version}"
         )
     _require(suite, "suite_id", str, "suite")
     config = _require(suite, "metric_config", dict, "suite")
@@ -145,6 +229,28 @@ def validate_suite(suite: Any) -> None:
         raise ReplayValidationError(
             "suite.metric_config.atom_alignment_min_iou must satisfy 0 < value <= 1"
         )
+    if version >= 2:
+        thresholds = _require(
+            config, "boundary_score_thresholds", list, "suite.metric_config"
+        )
+        if not thresholds:
+            raise ReplayValidationError(
+                "suite.metric_config.boundary_score_thresholds must not be empty"
+            )
+        if any(
+            isinstance(threshold, bool)
+            or not isinstance(threshold, (int, float))
+            or not 0 <= threshold <= 1
+            for threshold in thresholds
+        ):
+            raise ReplayValidationError(
+                "suite.metric_config.boundary_score_thresholds must contain numbers "
+                "satisfying 0 <= value <= 1"
+            )
+        if any(left >= right for left, right in zip(thresholds, thresholds[1:])):
+            raise ReplayValidationError(
+                "suite.metric_config.boundary_score_thresholds must be strictly increasing"
+            )
 
     manifest = _require(suite, "run_manifest", dict, "suite")
     for key in (
@@ -208,6 +314,7 @@ def validate_suite(suite: Any) -> None:
     if not cases:
         raise ReplayValidationError("suite.cases must not be empty")
     seen_case_ids: set[str] = set()
+    boundary_algorithm_versions: set[str] = set()
     for index, case in enumerate(cases):
         context = f"suite.cases[{index}]"
         if not isinstance(case, dict):
@@ -253,12 +360,30 @@ def validate_suite(suite: Any) -> None:
             context=f"{context}.gold_atoms",
             require_non_overlapping=True,
         )
+        predicted_atoms = _require(case, "predicted_atoms", list, context)
         _validate_atoms(
-            _require(case, "predicted_atoms", list, context),
+            predicted_atoms,
             line_count=line_count,
             skill_catalog=skill_catalog,
             context=f"{context}.predicted_atoms",
             require_non_overlapping=False,
+        )
+        if version >= 2:
+            boundary_candidates = _require(
+                case, "boundary_candidates", list, context
+            )
+            _validate_boundary_candidates(
+                boundary_candidates,
+                predicted_atoms=predicted_atoms,
+                scorable_ranges=parsed_ranges,
+                context=f"{context}.boundary_candidates",
+            )
+            boundary_algorithm_versions.update(
+                candidate["algorithm_version"] for candidate in boundary_candidates
+            )
+    if version >= 2 and len(boundary_algorithm_versions) != 1:
+        raise ReplayValidationError(
+            "suite.boundary_candidates must contain exactly one algorithm_version"
         )
 
 
@@ -324,6 +449,57 @@ def _prf(gold: set[Any], predicted: set[Any]) -> dict[str, float | int]:
     }
 
 
+def _binary_auroc(examples: list[tuple[float, bool]]) -> float | None:
+    positive_count = sum(label for _score, label in examples)
+    negative_count = len(examples) - positive_count
+    if not positive_count or not negative_count:
+        return None
+    ranked = sorted(examples, key=lambda item: item[0])
+    positive_rank_sum = 0.0
+    index = 0
+    while index < len(ranked):
+        group_end = index + 1
+        while group_end < len(ranked) and ranked[group_end][0] == ranked[index][0]:
+            group_end += 1
+        average_rank = ((index + 1) + group_end) / 2
+        positive_rank_sum += average_rank * sum(
+            label for _score, label in ranked[index:group_end]
+        )
+        index = group_end
+    area = positive_rank_sum - positive_count * (positive_count + 1) / 2
+    return round(area / (positive_count * negative_count), 6)
+
+
+def _routing_error_thresholds(
+    examples: list[tuple[float, bool]], thresholds: list[float]
+) -> list[dict[str, Any]]:
+    ordered = sorted(examples, key=lambda item: item[0])
+    scores = [score for score, _error in ordered]
+    prefix_errors = [0]
+    for _score, error in ordered:
+        prefix_errors.append(prefix_errors[-1] + int(error))
+    total = len(ordered)
+    total_errors = prefix_errors[-1]
+    results = []
+    for threshold in thresholds:
+        retained_start = bisect.bisect_left(scores, threshold)
+        retained = total - retained_start
+        errors = total_errors - prefix_errors[retained_start]
+        results.append(
+            {
+                "minimum_score": threshold,
+                "eligible": total,
+                "retained": retained,
+                "coverage": round(retained / total, 6) if total else None,
+                "routing_errors": errors,
+                "routing_error_rate": round(errors / retained, 6)
+                if retained
+                else None,
+            }
+        )
+    return results
+
+
 def detect_language(text: str) -> str:
     """Detect the dominant natural-language script for English/Chinese fixtures.
 
@@ -343,7 +519,11 @@ def detect_language(text: str) -> str:
 
 
 def _case_counts(
-    case: dict[str, Any], recall_k: int, alignment_min_iou: float
+    case: dict[str, Any],
+    recall_k: int,
+    alignment_min_iou: float,
+    *,
+    include_boundary_scores: bool,
 ) -> dict[str, Any]:
     gold_atoms = case["gold_atoms"]
     predicted_atoms = case["predicted_atoms"]
@@ -399,7 +579,7 @@ def _case_counts(
         for skill in atom["skills"]
     }
 
-    return {
+    counts = {
         "boundary_true_positive": boundary["tp"],
         "boundary_false_positive": boundary["fp"],
         "boundary_false_negative": boundary["fn"],
@@ -427,6 +607,27 @@ def _case_counts(
         "candidate_relations": candidate_relations,
         "multi_skill_gold": multi_skill_gold,
     }
+    if include_boundary_scores:
+        gold_by_id = {atom["id"]: atom for atom in gold_atoms}
+        predicted_by_id = {atom["id"]: atom for atom in predicted_atoms}
+        boundary_score_examples = []
+        routing_error_examples = []
+        for candidate in case["boundary_candidates"]:
+            score = float(candidate["boundary_score"])
+            boundary_score_examples.append(
+                (score, candidate["line"] in gold_boundaries)
+            )
+            if not candidate["selected"]:
+                continue
+            predicted = predicted_by_id[candidate["predicted_atom_id"]]
+            gold_id = alignment[predicted["id"]]
+            routing_error = gold_id is None or set(predicted["skills"]) != set(
+                gold_by_id[gold_id]["skills"]
+            )
+            routing_error_examples.append((score, routing_error))
+        counts["boundary_score_examples"] = boundary_score_examples
+        counts["routing_error_examples"] = routing_error_examples
+    return counts
 
 
 def _safe_ratio(numerator: int, denominator: int, *, empty: float = 1.0) -> float:
@@ -444,7 +645,9 @@ def _macro_prf(case_counts: list[dict[str, Any]]) -> dict[str, float]:
     }
 
 
-def _public_metrics(counts: dict[str, Any]) -> dict[str, Any]:
+def _public_metrics(
+    counts: dict[str, Any], boundary_score_thresholds: list[float] | None = None
+) -> dict[str, Any]:
     precision, recall, f1 = prf(
         counts["boundary_true_positive"],
         counts["boundary_false_positive"],
@@ -462,7 +665,7 @@ def _public_metrics(counts: dict[str, Any]) -> dict[str, Any]:
         ),
     }
     routing = _prf(counts["gold_relations"], counts["predicted_relations"])
-    return {
+    metrics = {
         "boundary": boundary,
         "segmentation": {
             "pk": round(
@@ -492,9 +695,33 @@ def _public_metrics(counts: dict[str, Any]) -> dict[str, Any]:
             len(counts["multi_skill_gold"]),
         ),
     }
+    if boundary_score_thresholds is not None:
+        boundary_examples = counts["boundary_score_examples"]
+        routing_examples = counts["routing_error_examples"]
+        positive_count = sum(label for _score, label in boundary_examples)
+        routing_error_count = sum(error for _score, error in routing_examples)
+        metrics["boundary_score"] = {
+            "candidates": len(boundary_examples),
+            "positive": positive_count,
+            "negative": len(boundary_examples) - positive_count,
+            "auroc": _binary_auroc(boundary_examples),
+        }
+        metrics["routing_error_association"] = {
+            "selected_candidates": len(routing_examples),
+            "routing_errors": routing_error_count,
+            "low_score_error_auroc": _binary_auroc(
+                [(1 - score, error) for score, error in routing_examples]
+            ),
+            "thresholds": _routing_error_thresholds(
+                routing_examples, boundary_score_thresholds
+            ),
+        }
+    return metrics
 
 
-def _merge_counts(all_counts: list[dict[str, Any]]) -> dict[str, Any]:
+def _merge_counts(
+    all_counts: list[dict[str, Any]], *, include_boundary_scores: bool
+) -> dict[str, Any]:
     merged: dict[str, Any] = {
         "boundary_true_positive": 0,
         "boundary_false_positive": 0,
@@ -521,11 +748,17 @@ def _merge_counts(all_counts: list[dict[str, Any]]) -> dict[str, Any]:
         "candidate_relations",
         "multi_skill_gold",
     }
+    if include_boundary_scores:
+        merged["boundary_score_examples"] = []
+        merged["routing_error_examples"] = []
+    list_keys = {"boundary_score_examples", "routing_error_examples"}
     for index, counts in enumerate(all_counts):
         prefix = f"case-{index}:"
         for key, value in counts.items():
             if key in set_keys:
                 merged[key].update((prefix, item) for item in value)
+            elif key in list_keys:
+                merged[key].extend(value)
             else:
                 merged[key] += value
     return merged
@@ -536,28 +769,55 @@ def evaluate_suite(suite: dict[str, Any]) -> dict[str, Any]:
     validate_suite(suite)
     recall_k = suite["metric_config"]["routing_recall_k"]
     alignment_min_iou = suite["metric_config"]["atom_alignment_min_iou"]
+    include_boundary_scores = suite["schema_version"] >= 2
+    boundary_score_thresholds = (
+        suite["metric_config"]["boundary_score_thresholds"]
+        if include_boundary_scores
+        else None
+    )
     case_counts = [
-        _case_counts(case, recall_k, alignment_min_iou) for case in suite["cases"]
+        _case_counts(
+            case,
+            recall_k,
+            alignment_min_iou,
+            include_boundary_scores=include_boundary_scores,
+        )
+        for case in suite["cases"]
     ]
     cases = [
         {
             "case_id": case["case_id"],
             "expected_language": case["expected_language"],
-            "metrics": _public_metrics(counts),
+            "metrics": _public_metrics(counts, boundary_score_thresholds),
         }
         for case, counts in zip(suite["cases"], case_counts)
     ]
     report = {
-        "schema_version": SCHEMA_VERSION,
+        "schema_version": suite["schema_version"],
         "suite_id": suite["suite_id"],
         "run_manifest": suite["run_manifest"],
         "metric_config": suite["metric_config"],
         "metrics": {
-            **_public_metrics(_merge_counts(case_counts)),
+            **_public_metrics(
+                _merge_counts(
+                    case_counts, include_boundary_scores=include_boundary_scores
+                ),
+                boundary_score_thresholds,
+            ),
             "routing_macro": _macro_prf(case_counts),
         },
         "cases": cases,
     }
+    if include_boundary_scores:
+        report["boundary_algorithm_version"] = next(
+            iter(
+                {
+                    candidate["algorithm_version"]
+                    for case in suite["cases"]
+                    for candidate in case["boundary_candidates"]
+                }
+            )
+        )
     canonical = json.dumps(report, ensure_ascii=False, sort_keys=True).encode("utf-8")
     report["report_sha256"] = hashlib.sha256(canonical).hexdigest()
     return report
@@ -568,35 +828,51 @@ def render_text(report: dict[str, Any]) -> str:
     metrics = report["metrics"]
     boundary = metrics["boundary"]
     routing = metrics["routing_micro"]
-    return "\n".join(
+    lines = [
+        f"suite: {report['suite_id']}",
+        f"revision: {report['run_manifest']['repository_revision']}",
         (
-            f"suite: {report['suite_id']}",
-            f"revision: {report['run_manifest']['repository_revision']}",
+            "boundary: "
+            f"P={boundary['precision']:.3f} "
+            f"R={boundary['recall']:.3f} F1={boundary['f1']:.3f}"
+        ),
+        (
+            f"coverage={metrics['coverage']:.3f} "
+            f"overlap={metrics['overlap_rate']:.3f} "
+            f"duplicates={metrics['duplicate_rate']:.3f}"
+        ),
+        f"language_consistency={metrics['language_consistency']:.3f}",
+        (
+            "routing: "
+            f"P={routing['precision']:.3f} "
+            f"R={routing['recall']:.3f} F1={routing['f1']:.3f}"
+        ),
+        (
+            f"routing_recall@{report['metric_config']['routing_recall_k']}="
+            f"{metrics['routing_recall_at_k']:.3f} "
+            f"multi_skill_retention="
+            f"{metrics['multi_skill_relation_retention']:.3f}"
+        ),
+    ]
+    if "boundary_score" in metrics:
+        score = metrics["boundary_score"]
+        association = metrics["routing_error_association"]
+        lines.extend(
             (
-                "boundary: "
-                f"P={boundary['precision']:.3f} "
-                f"R={boundary['recall']:.3f} F1={boundary['f1']:.3f}"
-            ),
-            (
-                f"coverage={metrics['coverage']:.3f} "
-                f"overlap={metrics['overlap_rate']:.3f} "
-                f"duplicates={metrics['duplicate_rate']:.3f}"
-            ),
-            f"language_consistency={metrics['language_consistency']:.3f}",
-            (
-                "routing: "
-                f"P={routing['precision']:.3f} "
-                f"R={routing['recall']:.3f} F1={routing['f1']:.3f}"
-            ),
-            (
-                f"routing_recall@{report['metric_config']['routing_recall_k']}="
-                f"{metrics['routing_recall_at_k']:.3f} "
-                f"multi_skill_retention="
-                f"{metrics['multi_skill_relation_retention']:.3f}"
-            ),
-            f"report_sha256={report['report_sha256']}",
+                (
+                    f"boundary_score: candidates={score['candidates']} "
+                    f"AUROC={score['auroc']}"
+                ),
+                (
+                    "routing_error_association: "
+                    f"selected={association['selected_candidates']} "
+                    f"errors={association['routing_errors']} "
+                    f"low_score_AUROC={association['low_score_error_auroc']}"
+                ),
+            )
         )
-    )
+    lines.append(f"report_sha256={report['report_sha256']}")
+    return "\n".join(lines)
 
 
 def _parser() -> argparse.ArgumentParser:

--- a/scripts/bench/algorithm_replay/fixtures/baseline_v2.json
+++ b/scripts/bench/algorithm_replay/fixtures/baseline_v2.json
@@ -1,0 +1,182 @@
+{
+  "schema_version": 2,
+  "suite_id": "atom-boundary-score-baseline-v2",
+  "metric_config": {
+    "routing_recall_k": 2,
+    "atom_alignment_min_iou": 0.5,
+    "boundary_score_thresholds": [0.0, 0.5, 0.8]
+  },
+  "run_manifest": {
+    "repository_revision": "0d7edff1ba136866badd00e06f0cb817dd7abb53",
+    "model": "recorded-fixture",
+    "harness": "offline-replay",
+    "prompt_fingerprint": "sha256:9e81d645fc03bcb0c1eed0a281f0032b2c16c79a2a99510b85910213107bd909",
+    "seed": 0,
+    "generation_config": {
+      "temperature": 0.0,
+      "top_p": 1.0,
+      "max_output_tokens": 1024
+    },
+    "input_tokens": 0,
+    "output_tokens": 0,
+    "cost_usd": 0.0,
+    "generated_at": "2026-08-28T00:00:00Z"
+  },
+  "skill_catalog": [
+    "python-file-grouping",
+    "python-file-utility-scripts",
+    "sqlite-migration",
+    "sqlite-validation"
+  ],
+  "cases": [
+    {
+      "case_id": "zh-correct-boundary-and-routing",
+      "expected_language": "zh",
+      "line_count": 8,
+      "source_lines": [
+        "user: 请迁移 SQLite 表结构。",
+        "assistant: 我会先检查旧表。",
+        "tool: 旧表使用单列主键。",
+        "assistant: 字段和历史数据已经迁移。",
+        "user: 现在验证迁移结果。",
+        "assistant: 我会检查联合主键。",
+        "tool: 约束和索引符合预期。",
+        "assistant: 迁移结果验证完成。"
+      ],
+      "scorable_ranges": [[1, 9]],
+      "gold_atoms": [
+        {
+          "id": "gold-zh-migrate",
+          "start_line": 1,
+          "end_line": 5,
+          "intent": "迁移 SQLite 表结构",
+          "summary": "检查旧表并完成无损迁移。",
+          "skills": ["sqlite-migration"],
+          "candidates": ["sqlite-migration", "sqlite-validation"]
+        },
+        {
+          "id": "gold-zh-validate",
+          "start_line": 5,
+          "end_line": 9,
+          "intent": "验证 SQLite 迁移结果",
+          "summary": "检查迁移后的约束和索引。",
+          "skills": ["sqlite-validation"],
+          "candidates": ["sqlite-validation", "sqlite-migration"]
+        }
+      ],
+      "predicted_atoms": [
+        {
+          "id": "pred-zh-migrate",
+          "start_line": 1,
+          "end_line": 5,
+          "intent": "迁移 SQLite 表结构",
+          "summary": "先完成旧表的无损迁移。",
+          "skills": ["sqlite-migration"],
+          "candidates": ["sqlite-migration", "sqlite-validation"]
+        },
+        {
+          "id": "pred-zh-validate",
+          "start_line": 5,
+          "end_line": 9,
+          "intent": "验证 SQLite 迁移结果",
+          "summary": "随后检查联合主键和索引。",
+          "skills": ["sqlite-validation"],
+          "candidates": ["sqlite-validation", "sqlite-migration"]
+        }
+      ],
+      "boundary_candidates": [
+        {
+          "line": 3,
+          "boundary_score": 0.3,
+          "selected": false,
+          "predicted_atom_id": null,
+          "algorithm_version": "synthetic-boundary-ranker-v1"
+        },
+        {
+          "line": 5,
+          "boundary_score": 0.8,
+          "selected": true,
+          "predicted_atom_id": "pred-zh-validate",
+          "algorithm_version": "synthetic-boundary-ranker-v1"
+        },
+        {
+          "line": 7,
+          "boundary_score": 0.8,
+          "selected": false,
+          "predicted_atom_id": null,
+          "algorithm_version": "synthetic-boundary-ranker-v1"
+        }
+      ]
+    },
+    {
+      "case_id": "en-false-boundary-and-routing-error",
+      "expected_language": "en",
+      "line_count": 8,
+      "source_lines": [
+        "user: Group the Python files by purpose.",
+        "assistant: I will inspect the modules.",
+        "tool: The package contains API and CLI modules.",
+        "assistant: I will keep those categories separate.",
+        "user: Put tests beside the matching category.",
+        "assistant: I will include tests in the same grouping.",
+        "tool: All files now have a category.",
+        "assistant: The grouping task is complete."
+      ],
+      "scorable_ranges": [[1, 9]],
+      "gold_atoms": [
+        {
+          "id": "gold-en-group",
+          "start_line": 1,
+          "end_line": 9,
+          "intent": "Group Python files by purpose",
+          "summary": "All turns refine one file-grouping task.",
+          "skills": ["python-file-grouping"],
+          "candidates": ["python-file-grouping", "python-file-utility-scripts"]
+        }
+      ],
+      "predicted_atoms": [
+        {
+          "id": "pred-en-group",
+          "start_line": 1,
+          "end_line": 5,
+          "intent": "Group Python modules",
+          "summary": "Group the package modules by purpose.",
+          "skills": ["python-file-grouping"],
+          "candidates": ["python-file-grouping", "python-file-utility-scripts"]
+        },
+        {
+          "id": "pred-en-helper",
+          "start_line": 5,
+          "end_line": 9,
+          "intent": "Create a Python file helper",
+          "summary": "Treat the follow-up as a separate utility task.",
+          "skills": ["python-file-utility-scripts"],
+          "candidates": ["python-file-utility-scripts", "python-file-grouping"]
+        }
+      ],
+      "boundary_candidates": [
+        {
+          "line": 3,
+          "boundary_score": 0.3,
+          "selected": false,
+          "predicted_atom_id": null,
+          "algorithm_version": "synthetic-boundary-ranker-v1"
+        },
+        {
+          "line": 5,
+          "boundary_score": 0.3,
+          "selected": true,
+          "predicted_atom_id": "pred-en-helper",
+          "algorithm_version": "synthetic-boundary-ranker-v1"
+        },
+        {
+          "line": 7,
+          "boundary_score": 0.1,
+          "selected": false,
+          "predicted_atom_id": null,
+          "algorithm_version": "synthetic-boundary-ranker-v1"
+        }
+      ]
+    }
+  ]
+}

--- a/scripts/bench/algorithm_replay/fixtures/baseline_v2.report.json
+++ b/scripts/bench/algorithm_replay/fixtures/baseline_v2.report.json
@@ -1,0 +1,244 @@
+{
+  "boundary_algorithm_version": "synthetic-boundary-ranker-v1",
+  "cases": [
+    {
+      "case_id": "zh-correct-boundary-and-routing",
+      "expected_language": "zh",
+      "metrics": {
+        "boundary": {
+          "exact_match": 1.0,
+          "f1": 1.0,
+          "false_negative": 0,
+          "false_positive": 0,
+          "precision": 1.0,
+          "recall": 1.0,
+          "true_positive": 1
+        },
+        "boundary_score": {
+          "auroc": 0.75,
+          "candidates": 3,
+          "negative": 2,
+          "positive": 1
+        },
+        "coverage": 1.0,
+        "duplicate_rate": 0.0,
+        "language_consistency": 1.0,
+        "multi_skill_relation_retention": 1.0,
+        "overlap_rate": 0.0,
+        "routing_error_association": {
+          "low_score_error_auroc": null,
+          "routing_errors": 0,
+          "selected_candidates": 1,
+          "thresholds": [
+            {
+              "coverage": 1.0,
+              "eligible": 1,
+              "minimum_score": 0.0,
+              "retained": 1,
+              "routing_error_rate": 0.0,
+              "routing_errors": 0
+            },
+            {
+              "coverage": 1.0,
+              "eligible": 1,
+              "minimum_score": 0.5,
+              "retained": 1,
+              "routing_error_rate": 0.0,
+              "routing_errors": 0
+            },
+            {
+              "coverage": 1.0,
+              "eligible": 1,
+              "minimum_score": 0.8,
+              "retained": 1,
+              "routing_error_rate": 0.0,
+              "routing_errors": 0
+            }
+          ]
+        },
+        "routing_micro": {
+          "f1": 1.0,
+          "false_negative": 0,
+          "false_positive": 0,
+          "precision": 1.0,
+          "recall": 1.0,
+          "true_positive": 2
+        },
+        "routing_recall_at_k": 1.0,
+        "segmentation": {
+          "pk": 0.0,
+          "window_diff": 0.0
+        }
+      }
+    },
+    {
+      "case_id": "en-false-boundary-and-routing-error",
+      "expected_language": "en",
+      "metrics": {
+        "boundary": {
+          "exact_match": 0.0,
+          "f1": 0.0,
+          "false_negative": 0,
+          "false_positive": 1,
+          "precision": 0.0,
+          "recall": 0.0,
+          "true_positive": 0
+        },
+        "boundary_score": {
+          "auroc": null,
+          "candidates": 3,
+          "negative": 3,
+          "positive": 0
+        },
+        "coverage": 1.0,
+        "duplicate_rate": 0.5,
+        "language_consistency": 1.0,
+        "multi_skill_relation_retention": 1.0,
+        "overlap_rate": 0.0,
+        "routing_error_association": {
+          "low_score_error_auroc": null,
+          "routing_errors": 1,
+          "selected_candidates": 1,
+          "thresholds": [
+            {
+              "coverage": 1.0,
+              "eligible": 1,
+              "minimum_score": 0.0,
+              "retained": 1,
+              "routing_error_rate": 1.0,
+              "routing_errors": 1
+            },
+            {
+              "coverage": 0.0,
+              "eligible": 1,
+              "minimum_score": 0.5,
+              "retained": 0,
+              "routing_error_rate": null,
+              "routing_errors": 0
+            },
+            {
+              "coverage": 0.0,
+              "eligible": 1,
+              "minimum_score": 0.8,
+              "retained": 0,
+              "routing_error_rate": null,
+              "routing_errors": 0
+            }
+          ]
+        },
+        "routing_micro": {
+          "f1": 0.666667,
+          "false_negative": 0,
+          "false_positive": 1,
+          "precision": 0.5,
+          "recall": 1.0,
+          "true_positive": 1
+        },
+        "routing_recall_at_k": 1.0,
+        "segmentation": {
+          "pk": 1.0,
+          "window_diff": 1.0
+        }
+      }
+    }
+  ],
+  "metric_config": {
+    "atom_alignment_min_iou": 0.5,
+    "boundary_score_thresholds": [
+      0.0,
+      0.5,
+      0.8
+    ],
+    "routing_recall_k": 2
+  },
+  "metrics": {
+    "boundary": {
+      "exact_match": 0.5,
+      "f1": 0.666667,
+      "false_negative": 0,
+      "false_positive": 1,
+      "precision": 0.5,
+      "recall": 1.0,
+      "true_positive": 1
+    },
+    "boundary_score": {
+      "auroc": 0.9,
+      "candidates": 6,
+      "negative": 5,
+      "positive": 1
+    },
+    "coverage": 1.0,
+    "duplicate_rate": 0.25,
+    "language_consistency": 1.0,
+    "multi_skill_relation_retention": 1.0,
+    "overlap_rate": 0.0,
+    "routing_error_association": {
+      "low_score_error_auroc": 1.0,
+      "routing_errors": 1,
+      "selected_candidates": 2,
+      "thresholds": [
+        {
+          "coverage": 1.0,
+          "eligible": 2,
+          "minimum_score": 0.0,
+          "retained": 2,
+          "routing_error_rate": 0.5,
+          "routing_errors": 1
+        },
+        {
+          "coverage": 0.5,
+          "eligible": 2,
+          "minimum_score": 0.5,
+          "retained": 1,
+          "routing_error_rate": 0.0,
+          "routing_errors": 0
+        },
+        {
+          "coverage": 0.5,
+          "eligible": 2,
+          "minimum_score": 0.8,
+          "retained": 1,
+          "routing_error_rate": 0.0,
+          "routing_errors": 0
+        }
+      ]
+    },
+    "routing_macro": {
+      "f1": 0.833333,
+      "precision": 0.75,
+      "recall": 1.0
+    },
+    "routing_micro": {
+      "f1": 0.857143,
+      "false_negative": 0,
+      "false_positive": 1,
+      "precision": 0.75,
+      "recall": 1.0,
+      "true_positive": 3
+    },
+    "routing_recall_at_k": 1.0,
+    "segmentation": {
+      "pk": 0.5,
+      "window_diff": 0.5
+    }
+  },
+  "report_sha256": "74b376480e5da0655a967bdbae86278ba24cd5fcc611a7815a5c42d5784e109e",
+  "run_manifest": {
+    "cost_usd": 0.0,
+    "generated_at": "2026-08-28T00:00:00Z",
+    "generation_config": {
+      "max_output_tokens": 1024,
+      "temperature": 0.0,
+      "top_p": 1.0
+    },
+    "harness": "offline-replay",
+    "input_tokens": 0,
+    "model": "recorded-fixture",
+    "output_tokens": 0,
+    "prompt_fingerprint": "sha256:9e81d645fc03bcb0c1eed0a281f0032b2c16c79a2a99510b85910213107bd909",
+    "repository_revision": "0d7edff1ba136866badd00e06f0cb817dd7abb53",
+    "seed": 0
+  },
+  "schema_version": 2,
+  "suite_id": "atom-boundary-score-baseline-v2"
+}

--- a/tests/test_algorithm_replay.py
+++ b/tests/test_algorithm_replay.py
@@ -18,12 +18,13 @@ from scripts.bench.algorithm_replay.evaluate import (
     validate_suite,
 )
 
-
 FIXTURE_DIR = (
     Path(__file__).parent.parent / "scripts" / "bench" / "algorithm_replay" / "fixtures"
 )
 BASELINE_PATH = FIXTURE_DIR / "baseline_v1.json"
 REPORT_PATH = FIXTURE_DIR / "baseline_v1.report.json"
+BOUNDARY_SCORE_PATH = FIXTURE_DIR / "baseline_v2.json"
+BOUNDARY_SCORE_REPORT_PATH = FIXTURE_DIR / "baseline_v2.report.json"
 
 
 pytestmark = pytest.mark.algorithm_replay
@@ -33,6 +34,71 @@ def test_baseline_report_matches_checked_in_snapshot():
     report = evaluate_suite(load_suite(BASELINE_PATH))
 
     assert report == json.loads(REPORT_PATH.read_text(encoding="utf-8"))
+
+
+def test_boundary_score_report_matches_checked_in_snapshot():
+    report = evaluate_suite(load_suite(BOUNDARY_SCORE_PATH))
+
+    assert report == json.loads(
+        BOUNDARY_SCORE_REPORT_PATH.read_text(encoding="utf-8")
+    )
+
+
+def test_boundary_scores_expose_routing_error_association():
+    report = evaluate_suite(load_suite(BOUNDARY_SCORE_PATH))
+    boundary_score = report["metrics"]["boundary_score"]
+    association = report["metrics"]["routing_error_association"]
+
+    assert report["boundary_algorithm_version"] == "synthetic-boundary-ranker-v1"
+    # The one positive boundary outranks four negatives and ties the fifth.
+    assert boundary_score == {
+        "candidates": 6,
+        "positive": 1,
+        "negative": 5,
+        "auroc": 0.9,
+    }
+    assert association["low_score_error_auroc"] == 1.0
+    assert association["thresholds"] == [
+        {
+            "minimum_score": 0.0,
+            "eligible": 2,
+            "retained": 2,
+            "coverage": 1.0,
+            "routing_errors": 1,
+            "routing_error_rate": 0.5,
+        },
+        {
+            "minimum_score": 0.5,
+            "eligible": 2,
+            "retained": 1,
+            "coverage": 0.5,
+            "routing_errors": 0,
+            "routing_error_rate": 0.0,
+        },
+        {
+            "minimum_score": 0.8,
+            "eligible": 2,
+            "retained": 1,
+            "coverage": 0.5,
+            "routing_errors": 0,
+            "routing_error_rate": 0.0,
+        },
+    ]
+    text_report = render_text(report)
+    assert "boundary_score: candidates=6 AUROC=0.9" in text_report
+    assert "selected=2 errors=1 low_score_AUROC=1.0" in text_report
+
+
+def test_one_class_boundary_or_routing_samples_have_no_auroc():
+    report = evaluate_suite(load_suite(BOUNDARY_SCORE_PATH))
+
+    assert report["cases"][1]["metrics"]["boundary_score"]["auroc"] is None
+    assert (
+        report["cases"][0]["metrics"]["routing_error_association"][
+            "low_score_error_auroc"
+        ]
+        is None
+    )
 
 
 def test_baseline_exposes_expected_regression_signals():
@@ -124,9 +190,65 @@ def test_source_line_count_mismatch_fails_loudly():
 
 def test_unsupported_schema_version_fails_loudly():
     suite = load_suite(BASELINE_PATH)
-    suite["schema_version"] = 2
+    suite["schema_version"] = 3
 
-    with pytest.raises(ReplayValidationError, match="supported=1, got=2"):
+    with pytest.raises(ReplayValidationError, match=r"supported=\[1, 2\], got=3"):
+        validate_suite(suite)
+
+
+@pytest.mark.parametrize("score", [True, -0.1, 1.1, "0.8"])
+def test_invalid_boundary_score_fails_loudly(score):
+    suite = load_suite(BOUNDARY_SCORE_PATH)
+    suite["cases"][0]["boundary_candidates"][0]["boundary_score"] = score
+
+    with pytest.raises(ReplayValidationError, match="boundary_score must satisfy"):
+        validate_suite(suite)
+
+
+def test_boundary_score_thresholds_must_be_strictly_increasing():
+    suite = load_suite(BOUNDARY_SCORE_PATH)
+    suite["metric_config"]["boundary_score_thresholds"] = [0.5, 0.5]
+
+    with pytest.raises(ReplayValidationError, match="strictly increasing"):
+        validate_suite(suite)
+
+
+def test_selected_boundary_must_map_to_matching_predicted_atom():
+    suite = load_suite(BOUNDARY_SCORE_PATH)
+    suite["cases"][0]["boundary_candidates"][1]["predicted_atom_id"] = (
+        "pred-zh-migrate"
+    )
+
+    with pytest.raises(ReplayValidationError, match="selected line must equal"):
+        validate_suite(suite)
+
+
+def test_every_internal_predicted_atom_requires_selected_candidate():
+    suite = load_suite(BOUNDARY_SCORE_PATH)
+    suite["cases"][0]["boundary_candidates"][1]["selected"] = False
+    suite["cases"][0]["boundary_candidates"][1]["predicted_atom_id"] = None
+
+    with pytest.raises(
+        ReplayValidationError, match=r"missing=\['pred-zh-validate'\]"
+    ):
+        validate_suite(suite)
+
+
+def test_rejected_boundary_cannot_map_to_predicted_atom():
+    suite = load_suite(BOUNDARY_SCORE_PATH)
+    suite["cases"][0]["boundary_candidates"][0]["predicted_atom_id"] = (
+        "pred-zh-migrate"
+    )
+
+    with pytest.raises(ReplayValidationError, match="must be null when rejected"):
+        validate_suite(suite)
+
+
+def test_boundary_scores_from_different_algorithm_versions_cannot_be_aggregated():
+    suite = load_suite(BOUNDARY_SCORE_PATH)
+    suite["cases"][1]["boundary_candidates"][0]["algorithm_version"] = "other-v2"
+
+    with pytest.raises(ReplayValidationError, match="exactly one algorithm_version"):
         validate_suite(suite)
 
 


### PR DESCRIPTION
## Summary

为 Atom 离线算法回放增加可版本化的候选边界分数和路由错误关联分析，使 #327 提出的“边界不确定性是否与下游路由错误相关”可以先用固定数据验证。

本 PR 只修改离线 replay 契约、指标、合成 fixture、文档和测试，不改变 TaskAgent、TaskClusterAgent、SkillEditAgent 或生产写入行为。

## Changes

- 增加 schema v2，同时继续支持 schema v1，并用原快照确认 v1 报告逐字不变。
- 为每个 case 增加 `boundary_candidates`，严格校验候选行、`boundary_score`、采用状态、`predicted_atom_id` 映射和单一 `algorithm_version`。
- 增加候选边界 AUROC、`low_score_error_auroc`，以及固定分数阈值下的保留覆盖率和路由错误率。
- AUROC 使用排序和并列平均秩，单类别或空样本返回 `null`，不把原始分数解释为概率或 production confidence。
- 增加两条脱敏合成轨迹和固定 v2 报告，覆盖正确与错误边界、采用与拒绝、路由正确与错误以及分数并列。
- 文档明确 `boundary_score` 与 `ux_score`、`weightscore` 的语义边界，并记录 `O(n log n)` 的评测复杂度。

## Test plan

- [x] `make test` passes（2727 passed, 10 skipped）
- [x] Added/updated unit tests for the change（27 passed）
- [ ] `make e2e` passes (if the change touches ingestion / install / daemon) — N/A，本 PR 不修改这些路径
- [x] Manually verified the affected user flow（Python 3.9 与 3.12 生成相同 v2 摘要；v1 JSON 与既有快照逐字一致；变更文件 Ruff 检查通过）

补充非门禁性能检查：10 万条候选和 101 个阈值的本地计算分别约为 0.010 秒与 0.009 秒。

## Linked issues

Closes #372

Refs #327
