### PR TITLE
test(algorithms): 建立真实模型 Atom 拆分与路由离线回放

### DIFF
--- a/scripts/bench/algorithm_replay/README.md
+++ b/scripts/bench/algorithm_replay/README.md
@@ -16,14 +16,26 @@ python -m scripts.bench.algorithm_replay.evaluate \
   scripts/bench/algorithm_replay/fixtures/baseline_v2.json
 ```
 
-使用 `--format json` 可以输出机器可读报告。测试会把两份报告与入仓的 `*.report.json` 快照比较，因此 schema 和指标定义的变化必须作为可见 diff 接受 review。
+运行真实 Qwen v3 基线：
+
+```bash
+python -m scripts.bench.algorithm_replay.evaluate scripts/bench/algorithm_replay/fixtures/qwen38_baseline_v3.json
+```
+
+验证隐私安全的录制源：
+
+```bash
+python -c 'import json; from pathlib import Path; from scripts.bench.algorithm_replay.record import validate_source_suite; validate_source_suite(json.loads(Path("scripts/bench/algorithm_replay/fixtures/qwen38_baseline_v3.json").read_text()))'
+```
+
+使用 `--format json` 可以输出机器可读报告。测试会把 v1 和 v2 报告与入仓的 `*.report.json` 快照比较，并锁定 v3 的报告哈希和阶段来源，因此 schema 和指标定义的变化必须作为可见 diff 接受 review。
 
 ## Fixture 契约
 
-- `schema_version`：支持 `1` 和 `2`，未知版本会直接失败。
+- `schema_version`：支持 `1`、`2` 和 `3`，未知版本会直接失败。
 - `metric_config.routing_recall_k`：Recall@K 使用的候选截断。
 - `metric_config.atom_alignment_min_iou`：把预测对齐到 gold Atom 时，重复和路由指标要求的最小区间 IoU。
-- `run_manifest`：这份录制预测对应的仓库 revision、模型、Harness、prompt fingerprint、seed、生成参数、token 数、费用和生成时间。
+- `run_manifest`：v1 和 v2 录制预测对应的仓库 revision、模型、Harness、prompt fingerprint、seed、生成参数、token 数、费用和生成时间。
 - `skill_catalog`：本套件里唯一合法的路由标签。
 - `cases`：可按行寻址的合成轨迹、人工标注的 gold Atom，以及不可变的预测 Atom；`line_count` 必须与 `source_lines` 完全一致。
 
@@ -33,11 +45,79 @@ gold 区间不得重叠；预测区间可以重叠，因为重叠本身就是被
 
 `scorable_ranges` 标出覆盖率和重叠率使用的源行。
 
-入仓 fixture 都是合成数据，满足隐私约束。模型名是 `recorded-fixture`：它们只校验评测器契约，不代表当前线上模型效果。
+入仓轨迹都是满足隐私约束的合成数据。
 
-prompt fingerprint 哈希的是字面哨兵串，因为这份合成预测没有使用模型 prompt。
+v1 和 v2 fixture 使用模型名 `recorded-fixture`，只校验评测器契约，不代表当前线上模型效果。
 
-真实离线实验应替换运行清单和 prediction，并保持所选 schema。
+它们的 prompt fingerprint 哈希字面哨兵串，因为这些合成预测没有调用模型。
+
+v3 fixture 记录一次本地 `qwen3.8-27b-ud-iq3-xxs` 通过 llama.cpp OpenAI-compatible endpoint 的运行，包括每个阶段实测的 token 用量、生成时间和配置为零的本地推理费用。
+
+这六个小样本只验证录制和回放链路；其中只有一个正边界且没有路由错误，因此不足以支持模型质量或分数相关性的结论。
+
+## Schema v3 阶段来源
+
+schema v3 用 `stage_manifests` 下唯一的 `split` 和 `route` 两项替代含糊的全局 `run_manifest`。
+
+每个阶段分别记录模型、Harness、prompt fingerprint、算法版本、seed、生成参数、实测输入、输出与缓存 token、估算费用、价格来源、调用次数、生成时间、时间戳和仓库 revision。
+
+两个阶段必须使用相同的仓库 revision，拆分算法版本必须与每条候选边界记录一致。
+
+每个预测 Atom 都必须记录 `weight_scores`，每个最终 Skill 恰好对应一个 1 到 10 的严格整数分数，未采用的候选 Skill 不得出现分数。
+
+schema v1 和 v2 继续受支持，已有入仓报告保持字节级不变。
+
+## 录制真实模型运行
+
+录制器只读取命令行显式提供的 source 和 config 路径，不会发现 `~/.xskill`、coding-agent 历史目录或用户工作区。
+
+入仓 Qwen v3 fixture 包含六个隐私安全的合成 case，覆盖新目标、继续执行、用户纠正、失败重试、近重复请求和一个 Atom 支撑多个 Skills。
+
+fixture 保留 `source_schema_version`、`scenario` 和 `candidate_lines`，因此同一文件可以继续作为录制源，模型预测与人工 gold 标注仍位于不同字段。
+
+运行 `python -m scripts.bench.algorithm_replay.record SOURCE.json OUTPUT.json --config CONFIG.yaml` 可以调用配置中的 split 和 cluster 后端并写出通过校验的 schema v3 套件。
+
+该命令只使用 xskill 的常规运行依赖，并要求 OpenAI-compatible chat-completions endpoint 支持 JSON 输出且返回 prompt 和 completion token 用量。
+
+本地 llama.cpp Qwen endpoint 可以使用如下显式临时配置：
+
+```yaml
+llm:
+  base_url: http://127.0.0.1:8000/v1
+  model: qwen3.8-27b-ud-iq3-xxs
+  max_tokens: 4096
+  temperature: 0.0
+  extra_body:
+    chat_template_kwargs:
+      enable_thinking: false
+llm_agents:
+  split: {}
+  cluster: {}
+pricing:
+  qwen3.8-27b-ud-iq3-xxs:
+    input_per_1m: 0.0
+    output_per_1m: 0.0
+```
+
+使用 `read -rsp "Replay API key: " XSKILL_REPLAY_API_KEY && export XSKILL_REPLAY_API_KEY` 可以在不把凭据写进配置或 shell history 的情况下准备环境变量。
+
+运行 `python -m scripts.bench.algorithm_replay.record scripts/bench/algorithm_replay/fixtures/qwen38_baseline_v3.json /tmp/qwen38-baseline-v3.json --config /tmp/qwen38-replay.yaml --api-key-env XSKILL_REPLAY_API_KEY --harness llama.cpp-openai-compatible` 可以录制新的输出。
+
+模型 endpoint 离线后仍可运行 `python -m scripts.bench.algorithm_replay.evaluate /tmp/qwen38-baseline-v3.json --format json` 复现报告。
+
+录制器对每条轨迹单独调用 split 以匹配 TaskAgent 的隔离边界，再按照当前 cluster batch size 对完整 case 做有界批量路由。
+
+录制器只要求模型返回语义边界选择、intent、summary、路由标签和关系权重。
+
+xskill 在路由前确定性分配 Atom id、从采用的起点推导半开区间并把采用的候选映射到 Atom。
+
+不合法的 split 输出会在路由前失败，因此无效的第一阶段不会继续消耗路由模型请求。
+
+输出文件已存在时必须显式传入 `--overwrite` 才允许覆盖。
+
+套件只保存结构化模型内容和实测用量，不持久化隐藏推理、endpoint URL 或 API key。
+
+生成的 JSON 必须在入仓前进行隐私检查，并使用普通 evaluator 生成报告；真实模型调用不进入常规 CI。
 
 ## Version 2 候选边界契约
 

--- a/scripts/bench/algorithm_replay/evaluate.py
+++ b/scripts/bench/algorithm_replay/evaluate.py
@@ -11,6 +11,7 @@ import argparse
 import bisect
 import hashlib
 import json
+import math
 import re
 from collections import Counter
 from collections.abc import Iterable
@@ -19,8 +20,8 @@ from typing import Any
 
 from scripts.bench.evaluate import pk, prf, score_case, window_diff
 
-LATEST_SCHEMA_VERSION = 2
-SUPPORTED_SCHEMA_VERSIONS = {1, LATEST_SCHEMA_VERSION}
+LATEST_SCHEMA_VERSION = 3
+SUPPORTED_SCHEMA_VERSIONS = {1, 2, LATEST_SCHEMA_VERSION}
 SUPPORTED_LANGUAGES = {"en", "zh"}
 _SHA256_RE = re.compile(r"^sha256:[0-9a-f]{64}$")
 _CODE_SPAN_RE = re.compile(r"`[^`]*`")
@@ -77,6 +78,7 @@ def _validate_atoms(
     skill_catalog: set[str],
     context: str,
     require_non_overlapping: bool,
+    require_weight_scores: bool = False,
 ) -> None:
     if not isinstance(atoms, list):
         raise ReplayValidationError(f"{context}: expected a list")
@@ -114,6 +116,43 @@ def _validate_atoms(
             if len(set(labels)) != len(labels):
                 raise ReplayValidationError(
                     f"{atom_context}.{field}: duplicate labels are not allowed"
+                )
+        if require_weight_scores:
+            weight_scores = _require(atom, "weight_scores", list, atom_context)
+            if not weight_scores:
+                raise ReplayValidationError(
+                    f"{atom_context}.weight_scores must not be empty"
+                )
+            weighted_skills: list[str] = []
+            for weight_index, item in enumerate(weight_scores):
+                weight_context = f"{atom_context}.weight_scores[{weight_index}]"
+                if not isinstance(item, dict):
+                    raise ReplayValidationError(
+                        f"{weight_context}: expected an object"
+                    )
+                skill = _require(item, "skill", str, weight_context)
+                if not skill or skill not in skill_catalog:
+                    raise ReplayValidationError(
+                        f"{weight_context}.skill: unknown skill label {skill!r}"
+                    )
+                weightscore = _require(item, "weightscore", int, weight_context)
+                if not 1 <= weightscore <= 10:
+                    raise ReplayValidationError(
+                        f"{weight_context}.weightscore must satisfy 1 <= value <= 10"
+                    )
+                weighted_skills.append(skill)
+            if len(set(weighted_skills)) != len(weighted_skills):
+                raise ReplayValidationError(
+                    f"{atom_context}.weight_scores contains duplicate skills"
+                )
+            if set(weighted_skills) != set(skills):
+                raise ReplayValidationError(
+                    f"{atom_context}.weight_scores must match the final skills set; "
+                    f"skills={sorted(skills)}, weighted={sorted(weighted_skills)}"
+                )
+            if not set(skills).issubset(candidates):
+                raise ReplayValidationError(
+                    f"{atom_context}.skills must be present in ordered candidates"
                 )
     if require_non_overlapping:
         ordered = sorted(ranges)
@@ -205,6 +244,99 @@ def _validate_boundary_candidates(
         )
 
 
+def _validate_manifest(
+    manifest: Any, *, context: str, require_stage_fields: bool = False
+) -> None:
+    if not isinstance(manifest, dict):
+        raise ReplayValidationError(f"{context}: expected an object")
+    for key in (
+        "repository_revision",
+        "model",
+        "harness",
+        "prompt_fingerprint",
+        "generated_at",
+    ):
+        value = _require(manifest, key, str, context)
+        if not value:
+            raise ReplayValidationError(f"{context}.{key} must not be empty")
+    if not _SHA256_RE.fullmatch(manifest["prompt_fingerprint"]):
+        raise ReplayValidationError(
+            f"{context}.prompt_fingerprint must be sha256:<64 lowercase hex>"
+        )
+    for key in ("seed", "input_tokens", "output_tokens"):
+        value = _require(manifest, key, int, context)
+        if value < 0:
+            raise ReplayValidationError(f"{context}.{key} must be >= 0")
+    cost = manifest.get("cost_usd")
+    if (
+        isinstance(cost, bool)
+        or not isinstance(cost, (int, float))
+        or not math.isfinite(float(cost))
+        or cost < 0
+    ):
+        raise ReplayValidationError(f"{context}.cost_usd must be a number >= 0")
+    generation_config = _require(manifest, "generation_config", dict, context)
+    temperature = generation_config.get("temperature")
+    if (
+        isinstance(temperature, bool)
+        or not isinstance(temperature, (int, float))
+        or not math.isfinite(float(temperature))
+        or temperature < 0
+    ):
+        raise ReplayValidationError(
+            f"{context}.generation_config.temperature must be a number >= 0"
+        )
+    top_p = generation_config.get("top_p")
+    if (
+        isinstance(top_p, bool)
+        or not isinstance(top_p, (int, float))
+        or not math.isfinite(float(top_p))
+        or not 0 < top_p <= 1
+    ):
+        raise ReplayValidationError(
+            f"{context}.generation_config.top_p must satisfy 0 < top_p <= 1"
+        )
+    max_output_tokens = generation_config.get("max_output_tokens")
+    if (
+        isinstance(max_output_tokens, bool)
+        or not isinstance(max_output_tokens, int)
+        or max_output_tokens <= 0
+    ):
+        raise ReplayValidationError(
+            f"{context}.generation_config.max_output_tokens must be an int > 0"
+        )
+    if not require_stage_fields:
+        return
+    algorithm_version = _require(manifest, "algorithm_version", str, context)
+    if not algorithm_version:
+        raise ReplayValidationError(
+            f"{context}.algorithm_version must not be empty"
+        )
+    calls = _require(manifest, "calls", int, context)
+    if calls <= 0:
+        raise ReplayValidationError(f"{context}.calls must be > 0")
+    cache_read_tokens = _require(manifest, "cache_read_tokens", int, context)
+    if cache_read_tokens < 0:
+        raise ReplayValidationError(f"{context}.cache_read_tokens must be >= 0")
+    if cache_read_tokens > manifest["input_tokens"]:
+        raise ReplayValidationError(
+            f"{context}.cache_read_tokens must not exceed input_tokens"
+        )
+    price_source = _require(manifest, "price_source", str, context)
+    if not price_source:
+        raise ReplayValidationError(f"{context}.price_source must not be empty")
+    generation_seconds = manifest.get("generation_seconds")
+    if (
+        isinstance(generation_seconds, bool)
+        or not isinstance(generation_seconds, (int, float))
+        or not math.isfinite(float(generation_seconds))
+        or generation_seconds < 0
+    ):
+        raise ReplayValidationError(
+            f"{context}.generation_seconds must be a number >= 0"
+        )
+
+
 def validate_suite(suite: Any) -> None:
     """Fail loudly on malformed or unsupported replay data."""
     if not isinstance(suite, dict):
@@ -252,56 +384,35 @@ def validate_suite(suite: Any) -> None:
                 "suite.metric_config.boundary_score_thresholds must be strictly increasing"
             )
 
-    manifest = _require(suite, "run_manifest", dict, "suite")
-    for key in (
-        "repository_revision",
-        "model",
-        "harness",
-        "prompt_fingerprint",
-        "generated_at",
-    ):
-        _require(manifest, key, str, "suite.run_manifest")
-    if not _SHA256_RE.fullmatch(manifest["prompt_fingerprint"]):
-        raise ReplayValidationError(
-            "suite.run_manifest.prompt_fingerprint must be sha256:<64 lowercase hex>"
+    if version < 3:
+        _validate_manifest(
+            _require(suite, "run_manifest", dict, "suite"),
+            context="suite.run_manifest",
         )
-    for key in ("seed", "input_tokens", "output_tokens"):
-        value = _require(manifest, key, int, "suite.run_manifest")
-        if value < 0:
-            raise ReplayValidationError(f"suite.run_manifest.{key} must be >= 0")
-    cost = manifest.get("cost_usd")
-    if isinstance(cost, bool) or not isinstance(cost, (int, float)) or cost < 0:
-        raise ReplayValidationError("suite.run_manifest.cost_usd must be a number >= 0")
-    generation_config = _require(
-        manifest, "generation_config", dict, "suite.run_manifest"
-    )
-    temperature = generation_config.get("temperature")
-    if (
-        isinstance(temperature, bool)
-        or not isinstance(temperature, (int, float))
-        or temperature < 0
-    ):
-        raise ReplayValidationError(
-            "suite.run_manifest.generation_config.temperature must be a number >= 0"
-        )
-    top_p = generation_config.get("top_p")
-    if (
-        isinstance(top_p, bool)
-        or not isinstance(top_p, (int, float))
-        or not 0 < top_p <= 1
-    ):
-        raise ReplayValidationError(
-            "suite.run_manifest.generation_config.top_p must satisfy 0 < top_p <= 1"
-        )
-    max_output_tokens = generation_config.get("max_output_tokens")
-    if (
-        isinstance(max_output_tokens, bool)
-        or not isinstance(max_output_tokens, int)
-        or max_output_tokens <= 0
-    ):
-        raise ReplayValidationError(
-            "suite.run_manifest.generation_config.max_output_tokens must be an int > 0"
-        )
+    else:
+        if "run_manifest" in suite:
+            raise ReplayValidationError(
+                "suite.run_manifest is not allowed in schema v3; use stage_manifests"
+            )
+        stage_manifests = _require(suite, "stage_manifests", dict, "suite")
+        if set(stage_manifests) != {"split", "route"}:
+            raise ReplayValidationError(
+                "suite.stage_manifests must contain exactly split and route"
+            )
+        for stage in ("split", "route"):
+            _validate_manifest(
+                stage_manifests[stage],
+                context=f"suite.stage_manifests.{stage}",
+                require_stage_fields=True,
+            )
+        revisions = {
+            stage_manifests[stage]["repository_revision"]
+            for stage in ("split", "route")
+        }
+        if len(revisions) != 1:
+            raise ReplayValidationError(
+                "suite.stage_manifests must use one repository_revision"
+            )
 
     catalog_raw = _require(suite, "skill_catalog", list, "suite")
     if any(not isinstance(label, str) or not label for label in catalog_raw):
@@ -367,6 +478,7 @@ def validate_suite(suite: Any) -> None:
             skill_catalog=skill_catalog,
             context=f"{context}.predicted_atoms",
             require_non_overlapping=False,
+            require_weight_scores=version >= 3,
         )
         if version >= 2:
             boundary_candidates = _require(
@@ -385,6 +497,13 @@ def validate_suite(suite: Any) -> None:
         raise ReplayValidationError(
             "suite.boundary_candidates must contain exactly one algorithm_version"
         )
+    if version >= 3:
+        boundary_version = next(iter(boundary_algorithm_versions))
+        split_version = suite["stage_manifests"]["split"]["algorithm_version"]
+        if boundary_version != split_version:
+            raise ReplayValidationError(
+                "suite boundary algorithm_version must match the split manifest"
+            )
 
 
 def _range_set(ranges: Iterable[tuple[int, int]]) -> set[int]:
@@ -795,19 +914,29 @@ def evaluate_suite(suite: dict[str, Any]) -> dict[str, Any]:
     report = {
         "schema_version": suite["schema_version"],
         "suite_id": suite["suite_id"],
-        "run_manifest": suite["run_manifest"],
-        "metric_config": suite["metric_config"],
-        "metrics": {
-            **_public_metrics(
-                _merge_counts(
-                    case_counts, include_boundary_scores=include_boundary_scores
-                ),
-                boundary_score_thresholds,
-            ),
-            "routing_macro": _macro_prf(case_counts),
-        },
-        "cases": cases,
     }
+    if suite["schema_version"] >= 3:
+        report["stage_manifests"] = suite["stage_manifests"]
+        report["route_algorithm_version"] = suite["stage_manifests"]["route"][
+            "algorithm_version"
+        ]
+    else:
+        report["run_manifest"] = suite["run_manifest"]
+    report.update(
+        {
+            "metric_config": suite["metric_config"],
+            "metrics": {
+                **_public_metrics(
+                    _merge_counts(
+                        case_counts, include_boundary_scores=include_boundary_scores
+                    ),
+                    boundary_score_thresholds,
+                ),
+                "routing_macro": _macro_prf(case_counts),
+            },
+            "cases": cases,
+        }
+    )
     if include_boundary_scores:
         report["boundary_algorithm_version"] = next(
             iter(
@@ -828,9 +957,14 @@ def render_text(report: dict[str, Any]) -> str:
     metrics = report["metrics"]
     boundary = metrics["boundary"]
     routing = metrics["routing_micro"]
+    revision = (
+        report["stage_manifests"]["split"]["repository_revision"]
+        if "stage_manifests" in report
+        else report["run_manifest"]["repository_revision"]
+    )
     lines = [
         f"suite: {report['suite_id']}",
-        f"revision: {report['run_manifest']['repository_revision']}",
+        f"revision: {revision}",
         (
             "boundary: "
             f"P={boundary['precision']:.3f} "

--- a/scripts/bench/algorithm_replay/evaluate.py
+++ b/scripts/bench/algorithm_replay/evaluate.py
@@ -22,6 +22,7 @@ from scripts.bench.evaluate import pk, prf, score_case, window_diff
 
 LATEST_SCHEMA_VERSION = 3
 SUPPORTED_SCHEMA_VERSIONS = {1, 2, LATEST_SCHEMA_VERSION}
+SOURCE_SCHEMA_VERSION = 1
 SUPPORTED_LANGUAGES = {"en", "zh"}
 _SHA256_RE = re.compile(r"^sha256:[0-9a-f]{64}$")
 _CODE_SPAN_RE = re.compile(r"`[^`]*`")
@@ -390,6 +391,12 @@ def validate_suite(suite: Any) -> None:
             context="suite.run_manifest",
         )
     else:
+        source_version = _require(suite, "source_schema_version", int, "suite")
+        if source_version != SOURCE_SCHEMA_VERSION:
+            raise ReplayValidationError(
+                "suite.source_schema_version: "
+                f"supported={SOURCE_SCHEMA_VERSION}, got={source_version}"
+            )
         if "run_manifest" in suite:
             raise ReplayValidationError(
                 "suite.run_manifest is not allowed in schema v3; use stage_manifests"

--- a/scripts/bench/algorithm_replay/fixtures/qwen38_baseline_v3.json
+++ b/scripts/bench/algorithm_replay/fixtures/qwen38_baseline_v3.json
@@ -1,0 +1,543 @@
+{
+  "schema_version": 3,
+  "source_schema_version": 1,
+  "suite_id": "real-model-atom-replay-v1",
+  "metric_config": {
+    "routing_recall_k": 3,
+    "atom_alignment_min_iou": 0.5,
+    "boundary_score_thresholds": [
+      0.0,
+      0.5,
+      0.8
+    ]
+  },
+  "stage_manifests": {
+    "split": {
+      "algorithm_version": "offline-boundary-ranker-v1",
+      "repository_revision": "b1e08786becab32b2c1289f20e59b42a6c243789",
+      "model": "qwen3.8-27b-ud-iq3-xxs",
+      "harness": "llama.cpp-openai-compatible",
+      "prompt_fingerprint": "sha256:b081eb02a42815c619fbd1ade5001bcc818e63138428ce26a2828983af758557",
+      "generated_at": "2026-08-29T09:53:26.799239Z",
+      "seed": 0,
+      "calls": 6,
+      "input_tokens": 2138,
+      "output_tokens": 908,
+      "cache_read_tokens": 0,
+      "cost_usd": 0.0,
+      "price_source": "config",
+      "generation_seconds": 48.733034,
+      "generation_config": {
+        "temperature": 0.0,
+        "top_p": 1.0,
+        "max_output_tokens": 4096
+      }
+    },
+    "route": {
+      "algorithm_version": "offline-skill-router-v1",
+      "repository_revision": "b1e08786becab32b2c1289f20e59b42a6c243789",
+      "model": "qwen3.8-27b-ud-iq3-xxs",
+      "harness": "llama.cpp-openai-compatible",
+      "prompt_fingerprint": "sha256:4df79e48924c07aab68d6e2aba463a707894670fbba75e41dc83da7adc546bf6",
+      "generated_at": "2026-08-29T09:53:26.799239Z",
+      "seed": 0,
+      "calls": 1,
+      "input_tokens": 1249,
+      "output_tokens": 400,
+      "cache_read_tokens": 0,
+      "cost_usd": 0.0,
+      "price_source": "config",
+      "generation_seconds": 10.937016,
+      "generation_config": {
+        "temperature": 0.0,
+        "top_p": 1.0,
+        "max_output_tokens": 4096
+      }
+    }
+  },
+  "skill_catalog": [
+    "api-validation",
+    "documentation-maintenance",
+    "flaky-test-debugging",
+    "python-file-grouping",
+    "python-testing",
+    "regression-testing",
+    "spreadsheet-export",
+    "sqlite-migration",
+    "sqlite-validation"
+  ],
+  "cases": [
+    {
+      "case_id": "zh-new-goal",
+      "scenario": "new_goal",
+      "expected_language": "zh",
+      "line_count": 8,
+      "source_lines": [
+        "user: 请迁移 SQLite 表结构。",
+        "assistant: 我会先检查旧表。",
+        "tool: 旧表使用单列主键。",
+        "assistant: 字段和历史数据已经迁移。",
+        "user: 现在验证迁移后的约束和索引。",
+        "assistant: 我会执行结构检查。",
+        "tool: 联合主键和索引符合预期。",
+        "assistant: 验证完成。"
+      ],
+      "scorable_ranges": [
+        [
+          1,
+          9
+        ]
+      ],
+      "candidate_lines": [
+        5
+      ],
+      "gold_atoms": [
+        {
+          "id": "gold-zh-new-goal-migrate",
+          "start_line": 1,
+          "end_line": 5,
+          "intent": "迁移 SQLite 表结构",
+          "summary": "检查旧表并完成无损迁移。",
+          "skills": [
+            "sqlite-migration"
+          ],
+          "candidates": [
+            "sqlite-migration",
+            "sqlite-validation"
+          ]
+        },
+        {
+          "id": "gold-zh-new-goal-validate",
+          "start_line": 5,
+          "end_line": 9,
+          "intent": "验证 SQLite 迁移结果",
+          "summary": "检查迁移后的联合主键和索引。",
+          "skills": [
+            "sqlite-validation"
+          ],
+          "candidates": [
+            "sqlite-validation",
+            "sqlite-migration"
+          ]
+        }
+      ],
+      "predicted_atoms": [
+        {
+          "id": "pred-zh-new-goal-0001",
+          "start_line": 1,
+          "end_line": 5,
+          "intent": "迁移 SQLite 表结构",
+          "summary": "执行 SQLite 表结构迁移并处理字段与历史数据。",
+          "skills": [
+            "sqlite-migration"
+          ],
+          "candidates": [
+            "sqlite-migration",
+            "sqlite-validation"
+          ],
+          "weight_scores": [
+            {
+              "skill": "sqlite-migration",
+              "weightscore": 10
+            }
+          ]
+        },
+        {
+          "id": "pred-zh-new-goal-0002",
+          "start_line": 5,
+          "end_line": 9,
+          "intent": "验证迁移后的约束和索引",
+          "summary": "检查迁移后数据库的约束与索引是否符合预期。",
+          "skills": [
+            "sqlite-validation"
+          ],
+          "candidates": [
+            "sqlite-validation",
+            "sqlite-migration"
+          ],
+          "weight_scores": [
+            {
+              "skill": "sqlite-validation",
+              "weightscore": 10
+            }
+          ]
+        }
+      ],
+      "boundary_candidates": [
+        {
+          "line": 5,
+          "boundary_score": 0.95,
+          "algorithm_version": "offline-boundary-ranker-v1",
+          "selected": true,
+          "predicted_atom_id": "pred-zh-new-goal-0002"
+        }
+      ]
+    },
+    {
+      "case_id": "en-continuation",
+      "scenario": "continuation",
+      "expected_language": "en",
+      "line_count": 8,
+      "source_lines": [
+        "user: Group the Python files by purpose.",
+        "assistant: I will inspect the modules.",
+        "tool: The package contains API and CLI modules.",
+        "assistant: I will keep those categories separate.",
+        "user: Put tests beside the matching category.",
+        "assistant: I will include tests in the same grouping.",
+        "tool: All files now have a category.",
+        "assistant: The grouping task is complete."
+      ],
+      "scorable_ranges": [
+        [
+          1,
+          9
+        ]
+      ],
+      "candidate_lines": [
+        5
+      ],
+      "gold_atoms": [
+        {
+          "id": "gold-en-continuation",
+          "start_line": 1,
+          "end_line": 9,
+          "intent": "Group Python files by purpose",
+          "summary": "Group modules and their matching tests in one task.",
+          "skills": [
+            "python-file-grouping"
+          ],
+          "candidates": [
+            "python-file-grouping",
+            "python-testing"
+          ]
+        }
+      ],
+      "predicted_atoms": [
+        {
+          "id": "pred-en-continuation-0001",
+          "start_line": 1,
+          "end_line": 9,
+          "intent": "Group Python files by purpose and include tests in the matching category",
+          "summary": "The user requested grouping Python files by purpose and placing tests beside their matching categories. The assistant inspected the modules, identified API and CLI categories, and completed the grouping with tests included.",
+          "skills": [
+            "python-file-grouping"
+          ],
+          "candidates": [
+            "python-file-grouping",
+            "python-testing"
+          ],
+          "weight_scores": [
+            {
+              "skill": "python-file-grouping",
+              "weightscore": 10
+            }
+          ]
+        }
+      ],
+      "boundary_candidates": [
+        {
+          "line": 5,
+          "boundary_score": 0.1,
+          "algorithm_version": "offline-boundary-ranker-v1",
+          "selected": false,
+          "predicted_atom_id": null
+        }
+      ]
+    },
+    {
+      "case_id": "zh-correction",
+      "scenario": "user_correction",
+      "expected_language": "zh",
+      "line_count": 8,
+      "source_lines": [
+        "user: 把汇总结果导出为 CSV。",
+        "assistant: 我会生成 CSV 文件。",
+        "tool: 已准备表头和数据行。",
+        "assistant: 正在写入输出文件。",
+        "user: 更正一下，不要 CSV，请导出成 XLSX。",
+        "assistant: 我会保留同一份数据并改用 XLSX。",
+        "tool: 工作簿和格式已经生成。",
+        "assistant: XLSX 文件已完成。"
+      ],
+      "scorable_ranges": [
+        [
+          1,
+          9
+        ]
+      ],
+      "candidate_lines": [
+        5
+      ],
+      "gold_atoms": [
+        {
+          "id": "gold-zh-correction",
+          "start_line": 1,
+          "end_line": 9,
+          "intent": "导出汇总结果",
+          "summary": "用户将输出格式从 CSV 更正为 XLSX，最终生成工作簿。",
+          "skills": [
+            "spreadsheet-export"
+          ],
+          "candidates": [
+            "spreadsheet-export",
+            "python-file-grouping"
+          ]
+        }
+      ],
+      "predicted_atoms": [
+        {
+          "id": "pred-zh-correction-0001",
+          "start_line": 1,
+          "end_line": 9,
+          "intent": "导出汇总结果为 XLSX 文件",
+          "summary": "用户最初要求导出 CSV，随后更正为导出 XLSX，助手最终完成了 XLSX 文件的生成。",
+          "skills": [
+            "spreadsheet-export"
+          ],
+          "candidates": [
+            "spreadsheet-export"
+          ],
+          "weight_scores": [
+            {
+              "skill": "spreadsheet-export",
+              "weightscore": 10
+            }
+          ]
+        }
+      ],
+      "boundary_candidates": [
+        {
+          "line": 5,
+          "boundary_score": 0.1,
+          "algorithm_version": "offline-boundary-ranker-v1",
+          "selected": false,
+          "predicted_atom_id": null
+        }
+      ]
+    },
+    {
+      "case_id": "en-retry",
+      "scenario": "failed_retry",
+      "expected_language": "en",
+      "line_count": 8,
+      "source_lines": [
+        "user: Fix the intermittent concurrency test.",
+        "assistant: I will reproduce the timing failure.",
+        "tool: The first run timed out while waiting for the worker.",
+        "assistant: I found a missing synchronization signal.",
+        "user: Retry after adding the synchronization.",
+        "assistant: I will rerun the same test with the fix.",
+        "tool: The test passed repeatedly.",
+        "assistant: The concurrency failure is fixed."
+      ],
+      "scorable_ranges": [
+        [
+          1,
+          9
+        ]
+      ],
+      "candidate_lines": [
+        5
+      ],
+      "gold_atoms": [
+        {
+          "id": "gold-en-retry",
+          "start_line": 1,
+          "end_line": 9,
+          "intent": "Fix an intermittent concurrency test",
+          "summary": "Reproduce the timeout, add synchronization, and retry the same test.",
+          "skills": [
+            "flaky-test-debugging"
+          ],
+          "candidates": [
+            "flaky-test-debugging",
+            "regression-testing"
+          ]
+        }
+      ],
+      "predicted_atoms": [
+        {
+          "id": "pred-en-retry-0001",
+          "start_line": 1,
+          "end_line": 9,
+          "intent": "Fix intermittent concurrency test",
+          "summary": "The user requested a fix for an intermittent concurrency test. The assistant reproduced the timing failure, identified a missing synchronization signal, and after the user requested a retry with the fix, the test passed repeatedly, confirming the concurrency failure was resolved.",
+          "skills": [
+            "flaky-test-debugging"
+          ],
+          "candidates": [
+            "flaky-test-debugging",
+            "python-testing"
+          ],
+          "weight_scores": [
+            {
+              "skill": "flaky-test-debugging",
+              "weightscore": 10
+            }
+          ]
+        }
+      ],
+      "boundary_candidates": [
+        {
+          "line": 5,
+          "boundary_score": 0.1,
+          "algorithm_version": "offline-boundary-ranker-v1",
+          "selected": false,
+          "predicted_atom_id": null
+        }
+      ]
+    },
+    {
+      "case_id": "zh-near-duplicate",
+      "scenario": "near_duplicate_request",
+      "expected_language": "zh",
+      "line_count": 8,
+      "source_lines": [
+        "user: 更新 README 里的安装说明。",
+        "assistant: 我会核对当前安装命令。",
+        "tool: 文档仍引用旧版本命令。",
+        "assistant: 我正在替换旧示例。",
+        "user: 对，就是把新的安装命令补到 README。",
+        "assistant: 我会继续完成同一处文档更新。",
+        "tool: 新命令和验证步骤已经写入。",
+        "assistant: README 已更新。"
+      ],
+      "scorable_ranges": [
+        [
+          1,
+          9
+        ]
+      ],
+      "candidate_lines": [
+        5
+      ],
+      "gold_atoms": [
+        {
+          "id": "gold-zh-near-duplicate",
+          "start_line": 1,
+          "end_line": 9,
+          "intent": "更新 README 安装说明",
+          "summary": "将旧安装示例替换为新的安装命令和验证步骤。",
+          "skills": [
+            "documentation-maintenance"
+          ],
+          "candidates": [
+            "documentation-maintenance",
+            "python-file-grouping"
+          ]
+        }
+      ],
+      "predicted_atoms": [
+        {
+          "id": "pred-zh-near-duplicate-0001",
+          "start_line": 1,
+          "end_line": 9,
+          "intent": "更新 README 安装说明",
+          "summary": "用户要求更新 README 中的安装说明，助手核对并替换旧命令，最终完成文档更新。",
+          "skills": [
+            "documentation-maintenance"
+          ],
+          "candidates": [
+            "documentation-maintenance"
+          ],
+          "weight_scores": [
+            {
+              "skill": "documentation-maintenance",
+              "weightscore": 10
+            }
+          ]
+        }
+      ],
+      "boundary_candidates": [
+        {
+          "line": 5,
+          "boundary_score": 0.1,
+          "algorithm_version": "offline-boundary-ranker-v1",
+          "selected": false,
+          "predicted_atom_id": null
+        }
+      ]
+    },
+    {
+      "case_id": "en-multi-skill",
+      "scenario": "multi_skill",
+      "expected_language": "en",
+      "line_count": 8,
+      "source_lines": [
+        "user: Reject empty API payloads and add regression coverage.",
+        "assistant: I will inspect the request validator and tests.",
+        "tool: Empty and whitespace payloads currently pass validation.",
+        "assistant: I will reject both forms at the write boundary.",
+        "user: Include tests for empty strings and whitespace-only strings.",
+        "assistant: I will cover both invalid inputs in the same change.",
+        "tool: The validator and regression tests now pass.",
+        "assistant: Validation and coverage are complete."
+      ],
+      "scorable_ranges": [
+        [
+          1,
+          9
+        ]
+      ],
+      "candidate_lines": [
+        5
+      ],
+      "gold_atoms": [
+        {
+          "id": "gold-en-multi-skill",
+          "start_line": 1,
+          "end_line": 9,
+          "intent": "Reject empty API payloads with regression coverage",
+          "summary": "Add input validation and tests for empty and whitespace-only payloads.",
+          "skills": [
+            "api-validation",
+            "regression-testing"
+          ],
+          "candidates": [
+            "api-validation",
+            "regression-testing",
+            "flaky-test-debugging"
+          ]
+        }
+      ],
+      "predicted_atoms": [
+        {
+          "id": "pred-en-multi-skill-0001",
+          "start_line": 1,
+          "end_line": 9,
+          "intent": "Reject empty API payloads and add regression coverage",
+          "summary": "Update the request validator to reject empty and whitespace-only payloads and add corresponding regression tests.",
+          "skills": [
+            "api-validation",
+            "regression-testing"
+          ],
+          "candidates": [
+            "api-validation",
+            "regression-testing",
+            "python-testing"
+          ],
+          "weight_scores": [
+            {
+              "skill": "api-validation",
+              "weightscore": 10
+            },
+            {
+              "skill": "regression-testing",
+              "weightscore": 9
+            }
+          ]
+        }
+      ],
+      "boundary_candidates": [
+        {
+          "line": 5,
+          "boundary_score": 0.1,
+          "algorithm_version": "offline-boundary-ranker-v1",
+          "selected": false,
+          "predicted_atom_id": null
+        }
+      ]
+    }
+  ]
+}

--- a/scripts/bench/algorithm_replay/record.py
+++ b/scripts/bench/algorithm_replay/record.py
@@ -1,0 +1,970 @@
+"""Record real model outputs for the deterministic Atom replay evaluator.
+
+The recorder is deliberately opt-in: it reads only the source JSON and config path
+provided on the command line.  It never discovers local trajectories or writes to
+xskill's runtime stores.  Normal CI evaluates the committed output without calling
+the model again.
+"""
+
+from __future__ import annotations
+
+import argparse
+import hashlib
+import json
+import math
+import os
+import subprocess
+import time
+from collections.abc import Callable
+from copy import deepcopy
+from dataclasses import dataclass
+from datetime import datetime, timezone
+from pathlib import Path
+from tempfile import NamedTemporaryFile
+from typing import Any
+
+import yaml
+
+from scripts.bench.algorithm_replay.evaluate import (
+    ReplayValidationError,
+    evaluate_suite,
+    render_text,
+    validate_suite,
+)
+from xskill.agents.agno_factory import resolve_agent_llm_config
+from xskill.usage import cost_usd, extract_usage, load_price_table
+from xskill.utils.llm import LLMClient
+
+SOURCE_SCHEMA_VERSION = 1
+DEFAULT_SPLIT_ALGORITHM_VERSION = "offline-boundary-ranker-v1"
+DEFAULT_ROUTE_ALGORITHM_VERSION = "offline-skill-router-v1"
+
+SPLIT_SYSTEM_PROMPT = """You are an offline evaluator for xskill Atom boundaries.
+Return one JSON object and no prose.
+Score every supplied candidate line from 0 to 1 as an uncalibrated boundary ranking signal.
+Select boundaries that begin a new reusable user goal, not continuations, corrections, or retries of the same goal.
+Line numbers are the exact 1-based positions in source_lines.
+For every scorable range, emit non-overlapping predicted atoms that cover the complete range in order.
+Emit one Atom start at every scorable range start and every selected candidate line, with no other Atom starts.
+Use the expected source language for intent and summary.
+The recorder derives half-open end_line values and assigns stable Atom ids and candidate mappings; do not emit those fields.
+Do not emit skills, hidden reasoning, markdown fences, or fields not requested."""
+
+ROUTE_SYSTEM_PROMPT = """You are an offline evaluator for xskill Atom-to-Skills routing.
+Return one JSON object and no prose.
+For every supplied predicted atom, rank unique candidate skills from the supplied catalog and select one or more final skills.
+Every final skill must occur in the ordered candidates and have one strict integer weightscore from 1 to 10.
+The weight_scores skill set must equal the final skills set exactly; do not score unselected candidates.
+Preserve valid one-Atom-to-many-Skills relationships.
+Do not change atom ids, ranges, intent, or summary.
+Do not emit hidden reasoning, markdown fences, or fields not requested."""
+
+SPLIT_OUTPUT_INSTRUCTION = "Return {cases:[{case_id,boundary_candidates:[{line,boundary_score,selected}],predicted_atoms:[{start_line,intent,summary}]}]}. Include every candidate line exactly once."
+ROUTE_OUTPUT_INSTRUCTION = "Return {cases:[{case_id,atoms:[{id,skills,candidates,weight_scores:[{skill,weightscore}]}]}]}. Include every atom exactly once."
+
+
+@dataclass(frozen=True)
+class ModelCallResult:
+    """One measured OpenAI-compatible model response."""
+
+    content: str
+    input_tokens: int
+    output_tokens: int
+    cache_read_tokens: int
+    cost_usd: float
+    price_source: str
+    generation_seconds: float
+    calls: int = 1
+
+
+ModelCaller = Callable[
+    [str, dict[str, Any], str, str, int, float, Any], ModelCallResult
+]
+
+
+def _read_json(path: Path) -> dict[str, Any]:
+    try:
+        payload = json.loads(path.read_text(encoding="utf-8"))
+    except json.JSONDecodeError as error:
+        raise ReplayValidationError(f"invalid JSON in {path}: {error}") from error
+    if not isinstance(payload, dict):
+        raise ReplayValidationError(f"{path}: expected a JSON object")
+    return payload
+
+
+def _dummy_stage_manifest(algorithm_version: str) -> dict[str, Any]:
+    return {
+        "algorithm_version": algorithm_version,
+        "repository_revision": "source-validation",
+        "model": "source-validation",
+        "harness": "offline-source-validator",
+        "prompt_fingerprint": "sha256:" + "0" * 64,
+        "generated_at": "1970-01-01T00:00:00Z",
+        "seed": 0,
+        "calls": 1,
+        "input_tokens": 0,
+        "output_tokens": 0,
+        "cache_read_tokens": 0,
+        "cost_usd": 0.0,
+        "price_source": "not-applicable",
+        "generation_seconds": 0.0,
+        "generation_config": {
+            "temperature": 0.0,
+            "top_p": 1.0,
+            "max_output_tokens": 1,
+        },
+    }
+
+
+def validate_source_suite(source: Any) -> None:
+    """Validate gold data and explicit candidate lines without model calls."""
+    if not isinstance(source, dict):
+        raise ReplayValidationError("source: expected an object")
+    if source.get("source_schema_version") != SOURCE_SCHEMA_VERSION:
+        raise ReplayValidationError(
+            "source.source_schema_version: supported=1, "
+            f"got={source.get('source_schema_version')!r}"
+        )
+    catalog = source.get("skill_catalog")
+    if not isinstance(catalog, list) or not catalog:
+        raise ReplayValidationError("source.skill_catalog must be a non-empty list")
+    cases = source.get("cases")
+    if not isinstance(cases, list) or not cases:
+        raise ReplayValidationError("source.cases must be a non-empty list")
+
+    placeholder_cases: list[dict[str, Any]] = []
+    for case_index, case in enumerate(cases):
+        context = f"source.cases[{case_index}]"
+        if not isinstance(case, dict):
+            raise ReplayValidationError(f"{context}: expected an object")
+        candidate_lines = case.get("candidate_lines")
+        if not isinstance(candidate_lines, list):
+            raise ReplayValidationError(f"{context}.candidate_lines: expected a list")
+        if any(
+            isinstance(line, bool) or not isinstance(line, int)
+            for line in candidate_lines
+        ):
+            raise ReplayValidationError(
+                f"{context}.candidate_lines must contain integers"
+            )
+        if len(set(candidate_lines)) != len(candidate_lines):
+            raise ReplayValidationError(
+                f"{context}.candidate_lines contains duplicate lines"
+            )
+
+        gold_atoms = deepcopy(case.get("gold_atoms"))
+        if not isinstance(gold_atoms, list):
+            raise ReplayValidationError(f"{context}.gold_atoms: expected a list")
+        scorable_starts = {
+            value[0]
+            for value in case.get("scorable_ranges", [])
+            if isinstance(value, list) and len(value) == 2
+        }
+        gold_by_start = {
+            atom.get("start_line"): atom
+            for atom in gold_atoms
+            if isinstance(atom, dict) and atom.get("start_line") not in scorable_starts
+        }
+        missing_candidate_lines = set(gold_by_start) - set(candidate_lines)
+        if missing_candidate_lines:
+            raise ReplayValidationError(
+                f"{context}.candidate_lines misses gold boundaries "
+                f"{sorted(missing_candidate_lines)}"
+            )
+
+        predicted_atoms = deepcopy(gold_atoms)
+        for atom in predicted_atoms:
+            atom["weight_scores"] = [
+                {"skill": skill, "weightscore": 10} for skill in atom.get("skills", [])
+            ]
+        boundary_candidates = []
+        for line in candidate_lines:
+            selected_atom = gold_by_start.get(line)
+            boundary_candidates.append(
+                {
+                    "line": line,
+                    "boundary_score": 1.0 if selected_atom else 0.0,
+                    "algorithm_version": "source-validation",
+                    "selected": selected_atom is not None,
+                    "predicted_atom_id": selected_atom.get("id")
+                    if selected_atom
+                    else None,
+                }
+            )
+        placeholder = deepcopy(case)
+        placeholder.pop("candidate_lines", None)
+        placeholder["predicted_atoms"] = predicted_atoms
+        placeholder["boundary_candidates"] = boundary_candidates
+        placeholder_cases.append(placeholder)
+
+    validate_suite(
+        {
+            "schema_version": 3,
+            "suite_id": source.get("suite_id"),
+            "metric_config": source.get("metric_config"),
+            "stage_manifests": {
+                "split": _dummy_stage_manifest("source-validation"),
+                "route": _dummy_stage_manifest("source-route-validation"),
+            },
+            "skill_catalog": source.get("skill_catalog"),
+            "cases": placeholder_cases,
+        }
+    )
+
+
+def _prompt_fingerprint(system_prompt: str, output_instruction: str) -> str:
+    prompt_contract = f"{system_prompt}\n{output_instruction}"
+    digest = hashlib.sha256(prompt_contract.encode("utf-8")).hexdigest()
+    return f"sha256:{digest}"
+
+
+def _json_prompt(instruction: str, payload: dict[str, Any]) -> str:
+    return (
+        instruction
+        + "\nINPUT_JSON:\n"
+        + json.dumps(payload, ensure_ascii=False, sort_keys=True, separators=(",", ":"))
+    )
+
+
+def _split_prompt(source: dict[str, Any]) -> str:
+    cases = [
+        {
+            "case_id": case["case_id"],
+            "expected_language": case["expected_language"],
+            "source_lines": case["source_lines"],
+            "scorable_ranges": case["scorable_ranges"],
+            "candidate_lines": case["candidate_lines"],
+        }
+        for case in source["cases"]
+    ]
+    return _json_prompt(
+        SPLIT_OUTPUT_INSTRUCTION,
+        {"cases": cases},
+    )
+
+
+def _route_prompt(source: dict[str, Any], split_cases: list[dict[str, Any]]) -> str:
+    return _json_prompt(
+        ROUTE_OUTPUT_INSTRUCTION,
+        {
+            "skill_catalog": source["skill_catalog"],
+            "cases": [
+                {
+                    "case_id": case["case_id"],
+                    "source_lines": source_case["source_lines"],
+                    "predicted_atoms": case["predicted_atoms"],
+                }
+                for case, source_case in zip(split_cases, source["cases"])
+            ],
+        },
+    )
+
+
+def _parse_json_response(content: str, *, stage: str) -> dict[str, Any]:
+    if not isinstance(content, str) or not content.strip():
+        raise ReplayValidationError(f"{stage} model returned empty content")
+    text = content.strip()
+    if text.startswith("```"):
+        lines = text.splitlines()
+        if len(lines) >= 3 and lines[-1].strip() == "```":
+            text = "\n".join(lines[1:-1])
+            if text.lstrip().startswith("json"):
+                text = text.lstrip()[4:].lstrip("\r\n")
+    try:
+        payload = json.loads(text)
+    except json.JSONDecodeError as error:
+        raise ReplayValidationError(
+            f"{stage} model returned invalid JSON: {error}"
+        ) from error
+    if not isinstance(payload, dict):
+        raise ReplayValidationError(f"{stage} model response must be an object")
+    return payload
+
+
+def _default_model_caller(
+    stage: str,
+    llm_config: dict[str, Any],
+    system_prompt: str,
+    prompt: str,
+    seed: int,
+    top_p: float,
+    price_table: Any,
+) -> ModelCallResult:
+    model = llm_config.get("model")
+    if not isinstance(model, str) or not model:
+        raise ValueError(f"llm_agents.{stage}.model is required")
+    if not llm_config.get("base_url"):
+        raise ValueError(f"llm_agents.{stage}.base_url is required")
+    if not llm_config.get("api_key"):
+        raise ValueError(f"llm_agents.{stage}.api_key is required")
+    client = LLMClient.from_config(llm_config)._get_client()
+    request = {
+        "model": model,
+        "messages": [
+            {"role": "system", "content": system_prompt},
+            {"role": "user", "content": prompt},
+        ],
+        "max_tokens": int(llm_config.get("max_tokens", 10000)),
+        "temperature": float(llm_config.get("temperature", 0.0)),
+        "top_p": top_p,
+        "seed": seed,
+        "response_format": {"type": "json_object"},
+    }
+    if llm_config.get("extra_body"):
+        request["extra_body"] = llm_config["extra_body"]
+    started = time.perf_counter()
+    response = client.chat.completions.create(**request)
+    elapsed = time.perf_counter() - started
+    if not response.choices:
+        raise ReplayValidationError(f"{stage} model returned no choices")
+    content = response.choices[0].message.content
+    usage = extract_usage(response)
+    if usage.prompt is None or usage.completion is None:
+        raise ReplayValidationError(
+            f"{stage} model response did not report input/output tokens"
+        )
+    price, price_source = price_table.resolve(model)
+    estimated_cost = cost_usd(usage, price)
+    if estimated_cost is None:
+        raise ReplayValidationError(f"{stage} model cost could not be calculated")
+    return ModelCallResult(
+        content=content or "",
+        input_tokens=usage.prompt,
+        output_tokens=usage.completion,
+        cache_read_tokens=usage.cache_hit or 0,
+        cost_usd=estimated_cost,
+        price_source=price_source,
+        generation_seconds=elapsed,
+    )
+
+
+def _merge_call_results(results: list[ModelCallResult]) -> ModelCallResult:
+    if not results:
+        raise ValueError("at least one model call result is required")
+    price_sources = {result.price_source for result in results}
+    return ModelCallResult(
+        content="",
+        input_tokens=sum(result.input_tokens for result in results),
+        output_tokens=sum(result.output_tokens for result in results),
+        cache_read_tokens=sum(result.cache_read_tokens for result in results),
+        cost_usd=sum(result.cost_usd for result in results),
+        price_source=(
+            next(iter(price_sources)) if len(price_sources) == 1 else "mixed"
+        ),
+        generation_seconds=sum(result.generation_seconds for result in results),
+        calls=sum(result.calls for result in results),
+    )
+
+
+def _ordered_cases(
+    response: dict[str, Any], source: dict[str, Any], *, stage: str
+) -> list[dict[str, Any]]:
+    cases = response.get("cases")
+    if not isinstance(cases, list):
+        raise ReplayValidationError(f"{stage}.cases must be a list")
+    by_id: dict[str, dict[str, Any]] = {}
+    for index, case in enumerate(cases):
+        if not isinstance(case, dict) or not isinstance(case.get("case_id"), str):
+            raise ReplayValidationError(f"{stage}.cases[{index}] has invalid case_id")
+        case_id = case["case_id"]
+        if case_id in by_id:
+            raise ReplayValidationError(f"{stage}.cases has duplicate {case_id!r}")
+        by_id[case_id] = case
+    expected = [case["case_id"] for case in source["cases"]]
+    if set(by_id) != set(expected):
+        raise ReplayValidationError(
+            f"{stage}.cases ids differ: expected={expected}, got={sorted(by_id)}"
+        )
+    return [by_id[case_id] for case_id in expected]
+
+
+def _prepare_split_cases(
+    response: dict[str, Any],
+    source: dict[str, Any],
+    *,
+    algorithm_version: str,
+) -> list[dict[str, Any]]:
+    ordered = _ordered_cases(response, source, stage="split")
+    prepared: list[dict[str, Any]] = []
+    for source_case, case in zip(source["cases"], ordered):
+        candidates = case.get("boundary_candidates")
+        atoms = case.get("predicted_atoms")
+        if not isinstance(candidates, list) or not isinstance(atoms, list):
+            raise ReplayValidationError(
+                f"split case {case['case_id']!r} must contain candidate and Atom lists"
+            )
+        candidates_by_line: dict[int, dict[str, Any]] = {}
+        for candidate_index, candidate in enumerate(candidates):
+            if not isinstance(candidate, dict):
+                raise ReplayValidationError(
+                    f"split case {case['case_id']!r} candidate {candidate_index} "
+                    "must be an object"
+                )
+            line = candidate.get("line")
+            if isinstance(line, bool) or not isinstance(line, int):
+                raise ReplayValidationError(
+                    f"split case {case['case_id']!r} candidate line must be an integer"
+                )
+            if line in candidates_by_line:
+                raise ReplayValidationError(
+                    f"split case {case['case_id']!r} contains duplicate candidate lines"
+                )
+            candidates_by_line[line] = candidate
+        if set(candidates_by_line) != set(source_case["candidate_lines"]):
+            raise ReplayValidationError(
+                f"split case {case['case_id']!r} must score every candidate line once"
+            )
+        normalized_candidates = []
+        for line in source_case["candidate_lines"]:
+            candidate = candidates_by_line[line]
+            normalized = {
+                "line": line,
+                "boundary_score": candidate.get("boundary_score"),
+                "algorithm_version": algorithm_version,
+                "selected": candidate.get("selected"),
+                "predicted_atom_id": None,
+            }
+            normalized_candidates.append(normalized)
+        atoms_by_start: dict[int, dict[str, Any]] = {}
+        for atom in atoms:
+            if not isinstance(atom, dict):
+                raise ReplayValidationError(
+                    f"split case {case['case_id']!r} contains a non-object Atom"
+                )
+            start_line = atom.get("start_line")
+            if isinstance(start_line, bool) or not isinstance(start_line, int):
+                raise ReplayValidationError(
+                    f"split case {case['case_id']!r} Atom start_line must be an integer"
+                )
+            if start_line in atoms_by_start:
+                raise ReplayValidationError(
+                    f"split case {case['case_id']!r} duplicates Atom start {start_line}"
+                )
+            atoms_by_start[start_line] = atom
+        selected_starts = {
+            candidate["line"]
+            for candidate in normalized_candidates
+            if candidate["selected"] is True
+        }
+        forced_starts = {item[0] for item in source_case["scorable_ranges"]}
+        expected_starts = forced_starts | selected_starts
+        if set(atoms_by_start) != expected_starts:
+            raise ReplayValidationError(
+                f"split case {case['case_id']!r} Atom starts differ: "
+                f"expected={sorted(expected_starts)}, got={sorted(atoms_by_start)}"
+            )
+        normalized_atoms = []
+        atom_index = 1
+        for range_start, range_end in source_case["scorable_ranges"]:
+            starts = sorted(
+                start for start in expected_starts if range_start <= start < range_end
+            )
+            for start_index, start_line in enumerate(starts):
+                atom = atoms_by_start[start_line]
+                end_line = (
+                    starts[start_index + 1]
+                    if start_index + 1 < len(starts)
+                    else range_end
+                )
+                normalized_atoms.append(
+                    {
+                        "id": f"pred-{case['case_id']}-{atom_index:04d}",
+                        "start_line": start_line,
+                        "end_line": end_line,
+                        "intent": atom.get("intent"),
+                        "summary": atom.get("summary"),
+                    }
+                )
+                atom_index += 1
+        normalized_by_start = {atom["start_line"]: atom for atom in normalized_atoms}
+        for candidate in normalized_candidates:
+            if candidate["selected"] is not True:
+                continue
+            candidate["predicted_atom_id"] = normalized_by_start[candidate["line"]][
+                "id"
+            ]
+        prepared.append(
+            {
+                "case_id": case["case_id"],
+                "boundary_candidates": normalized_candidates,
+                "predicted_atoms": normalized_atoms,
+            }
+        )
+    return prepared
+
+
+def _apply_route_cases(
+    response: dict[str, Any],
+    source: dict[str, Any],
+    split_cases: list[dict[str, Any]],
+) -> None:
+    ordered = _ordered_cases(response, source, stage="route")
+    for route_case, split_case in zip(ordered, split_cases):
+        route_atoms = route_case.get("atoms")
+        if not isinstance(route_atoms, list):
+            raise ReplayValidationError(
+                f"route case {route_case['case_id']!r}.atoms must be a list"
+            )
+        route_by_id: dict[str, dict[str, Any]] = {}
+        for atom in route_atoms:
+            if not isinstance(atom, dict) or not isinstance(atom.get("id"), str):
+                raise ReplayValidationError(
+                    f"route case {route_case['case_id']!r} contains an invalid Atom"
+                )
+            if atom["id"] in route_by_id:
+                raise ReplayValidationError(
+                    f"route case {route_case['case_id']!r} duplicates Atom {atom['id']!r}"
+                )
+            route_by_id[atom["id"]] = atom
+        expected_ids = [atom["id"] for atom in split_case["predicted_atoms"]]
+        if set(route_by_id) != set(expected_ids):
+            raise ReplayValidationError(
+                f"route case {route_case['case_id']!r} Atom ids differ from split output"
+            )
+        for atom in split_case["predicted_atoms"]:
+            routed = route_by_id[atom["id"]]
+            atom["skills"] = routed.get("skills")
+            atom["candidates"] = routed.get("candidates")
+            atom["weight_scores"] = routed.get("weight_scores")
+
+
+def _route_batches(
+    source: dict[str, Any],
+    split_cases: list[dict[str, Any]],
+    *,
+    batch_size: int,
+) -> list[tuple[dict[str, Any], list[dict[str, Any]]]]:
+    """Group complete cases without exceeding the production Atom batch size."""
+    if (
+        isinstance(batch_size, bool)
+        or not isinstance(batch_size, int)
+        or batch_size <= 0
+    ):
+        raise ValueError("cluster batch_size must be a positive integer")
+    source_by_id = {case["case_id"]: case for case in source["cases"]}
+    batches = []
+    current_cases: list[dict[str, Any]] = []
+    current_sources: list[dict[str, Any]] = []
+    current_atoms = 0
+    for split_case in split_cases:
+        atom_count = len(split_case["predicted_atoms"])
+        if atom_count > batch_size:
+            raise ReplayValidationError(
+                f"route case {split_case['case_id']!r} has {atom_count} Atoms, "
+                f"exceeding cluster batch_size={batch_size}"
+            )
+        if current_cases and current_atoms + atom_count > batch_size:
+            batches.append(({**source, "cases": current_sources}, current_cases))
+            current_cases = []
+            current_sources = []
+            current_atoms = 0
+        current_cases.append(split_case)
+        current_sources.append(source_by_id[split_case["case_id"]])
+        current_atoms += atom_count
+    if current_cases:
+        batches.append(({**source, "cases": current_sources}, current_cases))
+    return batches
+
+
+def _route_batch_size(config: dict[str, Any]) -> int:
+    """Validate the production routing batch size before spending model tokens."""
+    agent_worker = config.get("agent_worker") or {}
+    if not isinstance(agent_worker, dict):
+        raise TypeError("agent_worker must be a mapping")
+    worker_pools = agent_worker.get("pools") or {}
+    if not isinstance(worker_pools, dict):
+        raise TypeError("agent_worker.pools must be a mapping")
+    cluster_pool = worker_pools.get("cluster") or {}
+    if not isinstance(cluster_pool, dict):
+        raise TypeError("agent_worker.pools.cluster must be a mapping")
+    batch_size = cluster_pool.get("batch_size", 8)
+    if (
+        isinstance(batch_size, bool)
+        or not isinstance(batch_size, int)
+        or batch_size <= 0
+    ):
+        raise ValueError("cluster batch_size must be a positive integer")
+    return batch_size
+
+
+def _validate_split_before_route(
+    source: dict[str, Any],
+    split_cases: list[dict[str, Any]],
+    *,
+    algorithm_version: str,
+) -> None:
+    """Reject malformed split output before spending a routing model call."""
+    placeholder_skill = source["skill_catalog"][0]
+    source_by_id = {case["case_id"]: case for case in source["cases"]}
+    cases = []
+    for split_case in split_cases:
+        source_case = source_by_id[split_case["case_id"]]
+        predicted_atoms = deepcopy(split_case["predicted_atoms"])
+        for atom in predicted_atoms:
+            atom["skills"] = [placeholder_skill]
+            atom["candidates"] = [placeholder_skill]
+            atom["weight_scores"] = [{"skill": placeholder_skill, "weightscore": 1}]
+        cases.append(
+            {
+                "case_id": source_case["case_id"],
+                "expected_language": source_case["expected_language"],
+                "line_count": source_case["line_count"],
+                "source_lines": source_case["source_lines"],
+                "scorable_ranges": source_case["scorable_ranges"],
+                "gold_atoms": source_case["gold_atoms"],
+                "predicted_atoms": predicted_atoms,
+                "boundary_candidates": split_case["boundary_candidates"],
+            }
+        )
+    validate_suite(
+        {
+            "schema_version": 3,
+            "suite_id": source["suite_id"],
+            "metric_config": source["metric_config"],
+            "stage_manifests": {
+                "split": _dummy_stage_manifest(algorithm_version),
+                "route": _dummy_stage_manifest("pre-route-validation"),
+            },
+            "skill_catalog": source["skill_catalog"],
+            "cases": cases,
+        }
+    )
+
+
+def _recorded_cases(
+    source: dict[str, Any], predicted_cases: list[dict[str, Any]]
+) -> list[dict[str, Any]]:
+    source_by_id = {case["case_id"]: case for case in source["cases"]}
+    cases = []
+    for predicted in predicted_cases:
+        source_case = source_by_id[predicted["case_id"]]
+        cases.append(
+            {
+                "case_id": source_case["case_id"],
+                "scenario": source_case.get("scenario"),
+                "expected_language": source_case["expected_language"],
+                "line_count": source_case["line_count"],
+                "source_lines": source_case["source_lines"],
+                "scorable_ranges": source_case["scorable_ranges"],
+                "candidate_lines": source_case["candidate_lines"],
+                "gold_atoms": source_case["gold_atoms"],
+                "predicted_atoms": predicted["predicted_atoms"],
+                "boundary_candidates": predicted["boundary_candidates"],
+            }
+        )
+    return cases
+
+
+def _validate_route_batch(
+    source: dict[str, Any],
+    predicted_cases: list[dict[str, Any]],
+    *,
+    split_algorithm_version: str,
+    route_algorithm_version: str,
+) -> None:
+    """Reject one malformed route batch before spending the next model call."""
+    validate_suite(
+        {
+            "schema_version": 3,
+            "suite_id": source["suite_id"],
+            "metric_config": source["metric_config"],
+            "stage_manifests": {
+                "split": _dummy_stage_manifest(split_algorithm_version),
+                "route": _dummy_stage_manifest(route_algorithm_version),
+            },
+            "skill_catalog": source["skill_catalog"],
+            "cases": _recorded_cases(source, predicted_cases),
+        }
+    )
+
+
+def _stage_manifest(
+    *,
+    algorithm_version: str,
+    repository_revision: str,
+    harness: str,
+    llm_config: dict[str, Any],
+    prompt_fingerprint: str,
+    generated_at: str,
+    seed: int,
+    top_p: float,
+    result: ModelCallResult,
+) -> dict[str, Any]:
+    return {
+        "algorithm_version": algorithm_version,
+        "repository_revision": repository_revision,
+        "model": llm_config["model"],
+        "harness": harness,
+        "prompt_fingerprint": prompt_fingerprint,
+        "generated_at": generated_at,
+        "seed": seed,
+        "calls": result.calls,
+        "input_tokens": result.input_tokens,
+        "output_tokens": result.output_tokens,
+        "cache_read_tokens": result.cache_read_tokens,
+        "cost_usd": round(result.cost_usd, 9),
+        "price_source": result.price_source,
+        "generation_seconds": round(result.generation_seconds, 6),
+        "generation_config": {
+            "temperature": float(llm_config.get("temperature", 0.0)),
+            "top_p": top_p,
+            "max_output_tokens": int(llm_config.get("max_tokens", 10000)),
+        },
+    }
+
+
+def record_suite(
+    source: dict[str, Any],
+    config: dict[str, Any],
+    *,
+    repository_revision: str,
+    harness: str = "xskill-openai-compatible",
+    split_algorithm_version: str = DEFAULT_SPLIT_ALGORITHM_VERSION,
+    route_algorithm_version: str = DEFAULT_ROUTE_ALGORITHM_VERSION,
+    seed: int = 0,
+    top_p: float = 1.0,
+    generated_at: str | None = None,
+    model_caller: ModelCaller = _default_model_caller,
+) -> dict[str, Any]:
+    """Call split and route models once each and return a validated v3 suite."""
+    validate_source_suite(source)
+    if isinstance(seed, bool) or not isinstance(seed, int) or seed < 0:
+        raise ValueError("seed must be a non-negative integer")
+    if (
+        isinstance(top_p, bool)
+        or not isinstance(top_p, (int, float))
+        or not 0 < top_p <= 1
+    ):
+        raise ValueError("top_p must satisfy 0 < top_p <= 1")
+    for field, value in (
+        ("repository_revision", repository_revision),
+        ("harness", harness),
+        ("split_algorithm_version", split_algorithm_version),
+        ("route_algorithm_version", route_algorithm_version),
+    ):
+        if not isinstance(value, str) or not value:
+            raise ValueError(f"{field} must be a non-empty string")
+    if generated_at is not None and (
+        not isinstance(generated_at, str) or not generated_at
+    ):
+        raise ValueError("generated_at must be a non-empty string when supplied")
+
+    split_config = resolve_agent_llm_config(config, "split")
+    route_config = resolve_agent_llm_config(config, "cluster")
+    for stage, stage_config in (("split", split_config), ("route", route_config)):
+        for field in ("base_url", "model", "api_key"):
+            if not isinstance(stage_config.get(field), str) or not stage_config[field]:
+                raise ValueError(f"{stage} LLM configuration requires {field}")
+        temperature = stage_config.get("temperature", 0.0)
+        if (
+            isinstance(temperature, bool)
+            or not isinstance(temperature, (int, float))
+            or not math.isfinite(float(temperature))
+            or temperature < 0
+        ):
+            raise ValueError(f"{stage} LLM temperature must be a number >= 0")
+        max_tokens = stage_config.get("max_tokens", 10000)
+        if (
+            isinstance(max_tokens, bool)
+            or not isinstance(max_tokens, int)
+            or max_tokens <= 0
+        ):
+            raise ValueError(f"{stage} LLM max_tokens must be a positive integer")
+        extra_body = stage_config.get("extra_body")
+        if extra_body is not None and not isinstance(extra_body, dict):
+            raise TypeError(f"{stage} LLM extra_body must be a mapping")
+    route_batch_size = _route_batch_size(config)
+    price_table = load_price_table(config.get("pricing"))
+    timestamp = generated_at or datetime.now(timezone.utc).isoformat().replace(
+        "+00:00", "Z"
+    )
+
+    split_cases = []
+    split_results = []
+    for source_case in source["cases"]:
+        case_source = {**source, "cases": [source_case]}
+        split_result = model_caller(
+            "split",
+            split_config,
+            SPLIT_SYSTEM_PROMPT,
+            _split_prompt(case_source),
+            seed,
+            float(top_p),
+            price_table,
+        )
+        split_payload = _parse_json_response(split_result.content, stage="split")
+        prepared = _prepare_split_cases(
+            split_payload,
+            case_source,
+            algorithm_version=split_algorithm_version,
+        )
+        _validate_split_before_route(
+            case_source,
+            prepared,
+            algorithm_version=split_algorithm_version,
+        )
+        split_cases.extend(prepared)
+        split_results.append(split_result)
+    split_result = _merge_call_results(split_results)
+    _validate_split_before_route(
+        source, split_cases, algorithm_version=split_algorithm_version
+    )
+
+    route_results = []
+    for source_batch, split_batch in _route_batches(
+        source, split_cases, batch_size=route_batch_size
+    ):
+        route_result = model_caller(
+            "route",
+            route_config,
+            ROUTE_SYSTEM_PROMPT,
+            _route_prompt(source_batch, split_batch),
+            seed,
+            float(top_p),
+            price_table,
+        )
+        route_payload = _parse_json_response(route_result.content, stage="route")
+        _apply_route_cases(route_payload, source_batch, split_batch)
+        _validate_route_batch(
+            source_batch,
+            split_batch,
+            split_algorithm_version=split_algorithm_version,
+            route_algorithm_version=route_algorithm_version,
+        )
+        route_results.append(route_result)
+    route_result = _merge_call_results(route_results)
+
+    suite = {
+        "schema_version": 3,
+        "source_schema_version": source["source_schema_version"],
+        "suite_id": source["suite_id"],
+        "metric_config": source["metric_config"],
+        "stage_manifests": {
+            "split": _stage_manifest(
+                algorithm_version=split_algorithm_version,
+                repository_revision=repository_revision,
+                harness=harness,
+                llm_config=split_config,
+                prompt_fingerprint=_prompt_fingerprint(
+                    SPLIT_SYSTEM_PROMPT, SPLIT_OUTPUT_INSTRUCTION
+                ),
+                generated_at=timestamp,
+                seed=seed,
+                top_p=float(top_p),
+                result=split_result,
+            ),
+            "route": _stage_manifest(
+                algorithm_version=route_algorithm_version,
+                repository_revision=repository_revision,
+                harness=harness,
+                llm_config=route_config,
+                prompt_fingerprint=_prompt_fingerprint(
+                    ROUTE_SYSTEM_PROMPT, ROUTE_OUTPUT_INSTRUCTION
+                ),
+                generated_at=timestamp,
+                seed=seed,
+                top_p=float(top_p),
+                result=route_result,
+            ),
+        },
+        "skill_catalog": source["skill_catalog"],
+        "cases": _recorded_cases(source, split_cases),
+    }
+    validate_suite(suite)
+    return suite
+
+
+def _write_json(path: Path, payload: dict[str, Any], *, overwrite: bool) -> None:
+    path = Path(path)
+    if path.exists() and not overwrite:
+        raise FileExistsError(f"output already exists: {path}; pass --overwrite")
+    path.parent.mkdir(parents=True, exist_ok=True)
+    serialized = json.dumps(payload, ensure_ascii=False, indent=2) + "\n"
+    with NamedTemporaryFile(
+        "w", encoding="utf-8", dir=path.parent, delete=False
+    ) as handle:
+        temporary = Path(handle.name)
+        handle.write(serialized)
+        handle.flush()
+        os.fsync(handle.fileno())
+    os.replace(temporary, path)
+
+
+def _git_revision() -> str:
+    return subprocess.run(
+        ["git", "rev-parse", "HEAD"],
+        check=True,
+        capture_output=True,
+        text=True,
+    ).stdout.strip()
+
+
+def _parser() -> argparse.ArgumentParser:
+    parser = argparse.ArgumentParser(
+        description="Record real model output for xskill Atom replay."
+    )
+    parser.add_argument("source", type=Path, help="Explicit privacy-safe source JSON")
+    parser.add_argument("output", type=Path, help="New recorded replay JSON")
+    parser.add_argument("--config", required=True, type=Path, help="xskill YAML config")
+    parser.add_argument(
+        "--api-key-env",
+        help="Read the API key from this environment variable without persisting it",
+    )
+    parser.add_argument("--harness", default="xskill-openai-compatible")
+    parser.add_argument(
+        "--split-algorithm-version", default=DEFAULT_SPLIT_ALGORITHM_VERSION
+    )
+    parser.add_argument(
+        "--route-algorithm-version", default=DEFAULT_ROUTE_ALGORITHM_VERSION
+    )
+    parser.add_argument("--seed", type=int, default=0)
+    parser.add_argument("--top-p", type=float, default=1.0)
+    parser.add_argument("--overwrite", action="store_true")
+    return parser
+
+
+def main(argv: list[str] | None = None) -> int:
+    args = _parser().parse_args(argv)
+    if args.output.exists() and not args.overwrite:
+        raise FileExistsError(f"output already exists: {args.output}; pass --overwrite")
+    source = _read_json(args.source)
+    config_payload = yaml.safe_load(args.config.read_text(encoding="utf-8")) or {}
+    if not isinstance(config_payload, dict):
+        raise TypeError(f"{args.config}: expected a YAML mapping")
+    if args.api_key_env:
+        api_key = os.environ.get(args.api_key_env)
+        if not api_key:
+            raise ValueError(
+                f"API key environment variable is empty: {args.api_key_env}"
+            )
+        llm_config = config_payload.setdefault("llm", {})
+        if not isinstance(llm_config, dict):
+            raise ValueError("llm must be a YAML mapping")
+        llm_config["api_key"] = api_key
+        stage_configs = config_payload.get("llm_agents") or {}
+        if not isinstance(stage_configs, dict):
+            raise ValueError("llm_agents must be a YAML mapping")
+        for stage in ("split", "cluster"):
+            stage_config = stage_configs.get(stage)
+            if stage_config is not None:
+                if not isinstance(stage_config, dict):
+                    raise ValueError(f"llm_agents.{stage} must be a YAML mapping")
+                stage_config["api_key"] = api_key
+    suite = record_suite(
+        source,
+        config_payload,
+        repository_revision=_git_revision(),
+        harness=args.harness,
+        split_algorithm_version=args.split_algorithm_version,
+        route_algorithm_version=args.route_algorithm_version,
+        seed=args.seed,
+        top_p=args.top_p,
+    )
+    _write_json(args.output, suite, overwrite=args.overwrite)
+    print(render_text(evaluate_suite(suite)))
+    print(f"recorded_suite={args.output}")
+    return 0
+
+
+if __name__ == "__main__":  # pragma: no cover
+    raise SystemExit(main())

--- a/scripts/bench/algorithm_replay/record.py
+++ b/scripts/bench/algorithm_replay/record.py
@@ -27,6 +27,7 @@ import yaml
 
 from scripts.bench.algorithm_replay.evaluate import (
     ReplayValidationError,
+    SOURCE_SCHEMA_VERSION,
     evaluate_suite,
     render_text,
     validate_suite,
@@ -35,7 +36,6 @@ from xskill.agents.agno_factory import resolve_agent_llm_config
 from xskill.usage import cost_usd, extract_usage, load_price_table
 from xskill.utils.llm import LLMClient
 
-SOURCE_SCHEMA_VERSION = 1
 DEFAULT_SPLIT_ALGORITHM_VERSION = "offline-boundary-ranker-v1"
 DEFAULT_ROUTE_ALGORITHM_VERSION = "offline-skill-router-v1"
 
@@ -120,7 +120,12 @@ def validate_source_suite(source: Any) -> None:
     """Validate gold data and explicit candidate lines without model calls."""
     if not isinstance(source, dict):
         raise ReplayValidationError("source: expected an object")
-    if source.get("source_schema_version") != SOURCE_SCHEMA_VERSION:
+    source_version = source.get("source_schema_version")
+    if (
+        isinstance(source_version, bool)
+        or not isinstance(source_version, int)
+        or source_version != SOURCE_SCHEMA_VERSION
+    ):
         raise ReplayValidationError(
             "source.source_schema_version: supported=1, "
             f"got={source.get('source_schema_version')!r}"
@@ -200,6 +205,7 @@ def validate_source_suite(source: Any) -> None:
     validate_suite(
         {
             "schema_version": 3,
+            "source_schema_version": source["source_schema_version"],
             "suite_id": source.get("suite_id"),
             "metric_config": source.get("metric_config"),
             "stage_manifests": {
@@ -619,6 +625,7 @@ def _validate_split_before_route(
     validate_suite(
         {
             "schema_version": 3,
+            "source_schema_version": source["source_schema_version"],
             "suite_id": source["suite_id"],
             "metric_config": source["metric_config"],
             "stage_manifests": {
@@ -666,6 +673,7 @@ def _validate_route_batch(
     validate_suite(
         {
             "schema_version": 3,
+            "source_schema_version": source["source_schema_version"],
             "suite_id": source["suite_id"],
             "metric_config": source["metric_config"],
             "stage_manifests": {

--- a/tests/test_algorithm_replay.py
+++ b/tests/test_algorithm_replay.py
@@ -190,9 +190,9 @@ def test_source_line_count_mismatch_fails_loudly():
 
 def test_unsupported_schema_version_fails_loudly():
     suite = load_suite(BASELINE_PATH)
-    suite["schema_version"] = 3
+    suite["schema_version"] = 4
 
-    with pytest.raises(ReplayValidationError, match=r"supported=\[1, 2\], got=3"):
+    with pytest.raises(ReplayValidationError, match=r"supported=\[1, 2, 3\], got=4"):
         validate_suite(suite)
 
 
@@ -282,3 +282,18 @@ def test_cli_renders_text_and_json(capsys):
     assert main([str(BASELINE_PATH), "--format", "json"]) == 0
     json_output = json.loads(capsys.readouterr().out)
     assert json_output == evaluate_suite(load_suite(BASELINE_PATH))
+
+
+@pytest.mark.parametrize(
+    ("fixture_path", "report_path"),
+    [
+        (BASELINE_PATH, REPORT_PATH),
+        (BOUNDARY_SCORE_PATH, BOUNDARY_SCORE_REPORT_PATH),
+    ],
+)
+def test_existing_json_cli_output_remains_byte_for_byte_stable(
+    fixture_path, report_path, capsys
+):
+    assert main([str(fixture_path), "--format", "json"]) == 0
+
+    assert capsys.readouterr().out == report_path.read_text(encoding="utf-8")

--- a/tests/test_algorithm_replay_record.py
+++ b/tests/test_algorithm_replay_record.py
@@ -161,6 +161,24 @@ def test_record_source_fixture_is_privacy_safe_and_valid():
     }
 
 
+@pytest.mark.parametrize("source_version", [True, "1", 1.0, 2])
+def test_source_schema_version_requires_the_exact_integer(source_version):
+    source = _source()
+    source["source_schema_version"] = source_version
+
+    with pytest.raises(ReplayValidationError, match="source_schema_version"):
+        validate_source_suite(source)
+
+
+@pytest.mark.parametrize("source_version", [True, "1", 1.0, 2])
+def test_recorded_v3_schema_version_requires_the_exact_integer(source_version):
+    suite = _source()
+    suite["source_schema_version"] = source_version
+
+    with pytest.raises(ReplayValidationError, match="source_schema_version"):
+        validate_suite(suite)
+
+
 def test_checked_in_qwen_recording_replays_with_stable_provenance():
     suite = _source()
 

--- a/tests/test_algorithm_replay_record.py
+++ b/tests/test_algorithm_replay_record.py
@@ -1,0 +1,411 @@
+"""Real-model recorder contracts without network calls."""
+
+from __future__ import annotations
+
+import json
+from copy import deepcopy
+from pathlib import Path
+
+import pytest
+
+from scripts.bench.algorithm_replay.evaluate import (
+    ReplayValidationError,
+    evaluate_suite,
+    validate_suite,
+)
+from scripts.bench.algorithm_replay.record import (
+    ModelCallResult,
+    _write_json,
+    main,
+    record_suite,
+    validate_source_suite,
+)
+
+FIXTURE_DIR = (
+    Path(__file__).parent.parent / "scripts" / "bench" / "algorithm_replay" / "fixtures"
+)
+SOURCE_PATH = FIXTURE_DIR / "qwen38_baseline_v3.json"
+
+pytestmark = pytest.mark.algorithm_replay
+
+
+def _source() -> dict:
+    return json.loads(SOURCE_PATH.read_text(encoding="utf-8"))
+
+
+def _split_payload(source: dict) -> dict:
+    cases = []
+    for case in source["cases"]:
+        atoms = []
+        for gold in case["gold_atoms"]:
+            atoms.append(
+                {
+                    "start_line": gold["start_line"],
+                    "intent": gold["intent"],
+                    "summary": gold["summary"],
+                }
+            )
+        gold_by_start = {
+            gold["start_line"]: gold
+            for gold in case["gold_atoms"]
+            if gold["start_line"] not in {item[0] for item in case["scorable_ranges"]}
+        }
+        candidates = []
+        for line in case["candidate_lines"]:
+            gold = gold_by_start.get(line)
+            candidates.append(
+                {
+                    "line": line,
+                    "boundary_score": 0.9 if gold else 0.2,
+                    "selected": gold is not None,
+                }
+            )
+        cases.append(
+            {
+                "case_id": case["case_id"],
+                "boundary_candidates": candidates,
+                "predicted_atoms": atoms,
+            }
+        )
+    return {"cases": cases}
+
+
+def _route_payload(source: dict, split_payload: dict) -> dict:
+    source_by_id = {case["case_id"]: case for case in source["cases"]}
+    cases = []
+    for split_case in split_payload["cases"]:
+        source_case = source_by_id[split_case["case_id"]]
+        atoms = []
+        for atom_index, (_predicted, gold) in enumerate(
+            zip(split_case["predicted_atoms"], source_case["gold_atoms"]),
+            start=1,
+        ):
+            atoms.append(
+                {
+                    "id": f"pred-{split_case['case_id']}-{atom_index:04d}",
+                    "skills": gold["skills"],
+                    "candidates": gold["candidates"],
+                    "weight_scores": [
+                        {"skill": skill, "weightscore": 8} for skill in gold["skills"]
+                    ],
+                }
+            )
+        cases.append({"case_id": split_case["case_id"], "atoms": atoms})
+    return {"cases": cases}
+
+
+def _config() -> dict:
+    return {
+        "llm": {
+            "base_url": "http://model.invalid/v1",
+            "model": "base-model",
+            "api_key": "test-secret",
+            "max_tokens": 2048,
+            "temperature": 0.0,
+        },
+        "llm_agents": {
+            "split": {"model": "split-model"},
+            "cluster": {"model": "route-model"},
+        },
+        "pricing": {
+            "split-model": {"input_per_1m": 0.0, "output_per_1m": 0.0},
+            "route-model": {"input_per_1m": 0.0, "output_per_1m": 0.0},
+        },
+    }
+
+
+def _caller_for(source: dict, *, broken_route_score: bool = False):
+    split_payload = _split_payload(source)
+    route_payload = _route_payload(source, split_payload)
+    if broken_route_score:
+        route_payload["cases"][0]["atoms"][0]["weight_scores"][0]["weightscore"] = "8"
+
+    def call(stage, _config, _system, prompt, _seed, _top_p, _prices):
+        prompt_input = json.loads(prompt.split("INPUT_JSON:\n", 1)[1])
+        case_ids = {case["case_id"] for case in prompt_input["cases"]}
+        full_payload = split_payload if stage == "split" else route_payload
+        payload = {
+            "cases": [
+                case for case in full_payload["cases"] if case["case_id"] in case_ids
+            ]
+        }
+        return ModelCallResult(
+            content=json.dumps(payload, ensure_ascii=False),
+            input_tokens=100 if stage == "split" else 80,
+            output_tokens=40 if stage == "split" else 30,
+            cache_read_tokens=10,
+            cost_usd=0.0,
+            price_source="config",
+            generation_seconds=0.25,
+        )
+
+    return call
+
+
+def test_record_source_fixture_is_privacy_safe_and_valid():
+    source = _source()
+
+    validate_source_suite(source)
+
+    serialized = SOURCE_PATH.read_text(encoding="utf-8")
+    assert "api_key" not in serialized
+    assert "DESKTOP-" not in serialized
+    assert "/home/" not in serialized
+    assert {case["scenario"] for case in source["cases"]} == {
+        "new_goal",
+        "continuation",
+        "user_correction",
+        "failed_retry",
+        "near_duplicate_request",
+        "multi_skill",
+    }
+
+
+def test_checked_in_qwen_recording_replays_with_stable_provenance():
+    suite = _source()
+
+    validate_suite(suite)
+    report = evaluate_suite(suite)
+
+    assert report["report_sha256"] == (
+        "babf67f9295f04fb26bdb5bb23dad4854788d41a9ae15d25b7d9e45e2fa072ed"
+    )
+    assert suite["stage_manifests"]["split"]["calls"] == 6
+    assert suite["stage_manifests"]["route"]["calls"] == 1
+    assert suite["stage_manifests"]["split"]["input_tokens"] == 2138
+    assert suite["stage_manifests"]["split"]["output_tokens"] == 908
+    assert suite["stage_manifests"]["route"]["input_tokens"] == 1249
+    assert suite["stage_manifests"]["route"]["output_tokens"] == 400
+    assert report["metrics"]["boundary"]["f1"] == 1.0
+    assert report["metrics"]["coverage"] == 1.0
+    assert report["metrics"]["routing_micro"]["f1"] == 1.0
+    assert report["metrics"]["multi_skill_relation_retention"] == 1.0
+    assert (
+        report["metrics"]["routing_error_association"]["low_score_error_auroc"] is None
+    )
+
+
+def test_record_suite_keeps_stage_provenance_and_replays_offline():
+    source = _source()
+    calls = []
+    caller = _caller_for(source)
+
+    def recording_caller(*args):
+        calls.append(args[0])
+        return caller(*args)
+
+    suite = record_suite(
+        source,
+        _config(),
+        repository_revision="abc123",
+        generated_at="2026-08-28T00:00:00Z",
+        model_caller=recording_caller,
+    )
+
+    validate_suite(suite)
+    report = evaluate_suite(suite)
+    assert suite["schema_version"] == 3
+    assert suite["source_schema_version"] == 1
+    assert "run_manifest" not in suite
+    assert suite["cases"][0]["scenario"] == "new_goal"
+    assert suite["cases"][0]["candidate_lines"] == [5]
+    assert suite["stage_manifests"]["split"]["model"] == "split-model"
+    assert suite["stage_manifests"]["route"]["model"] == "route-model"
+    assert suite["stage_manifests"]["split"]["input_tokens"] == 600
+    assert suite["stage_manifests"]["route"]["output_tokens"] == 30
+    assert suite["stage_manifests"]["split"]["calls"] == len(source["cases"])
+    assert suite["stage_manifests"]["route"]["calls"] == 1
+    assert calls == ["split"] * len(source["cases"]) + ["route"]
+    assert "api_key" not in json.dumps(suite)
+    assert "base_url" not in json.dumps(suite)
+    assert report["boundary_algorithm_version"] == "offline-boundary-ranker-v1"
+    assert report["route_algorithm_version"] == "offline-skill-router-v1"
+    assert report["metrics"]["boundary"]["f1"] == 1.0
+    assert report["metrics"]["routing_micro"]["f1"] == 1.0
+    assert report["metrics"]["multi_skill_relation_retention"] == 1.0
+
+
+def test_record_suite_rejects_missing_candidate_output_before_routing():
+    source = _source()
+    split_payload = _split_payload(source)
+    split_payload["cases"][0]["boundary_candidates"].clear()
+    calls = []
+
+    def caller(stage, _config, _system, _prompt, _seed, _top_p, _prices):
+        calls.append(stage)
+        return ModelCallResult(
+            content=json.dumps({"cases": [split_payload["cases"][0]]}),
+            input_tokens=1,
+            output_tokens=1,
+            cache_read_tokens=0,
+            cost_usd=0.0,
+            price_source="config",
+            generation_seconds=0.0,
+        )
+
+    with pytest.raises(ReplayValidationError, match="score every candidate line"):
+        record_suite(
+            source,
+            _config(),
+            repository_revision="abc123",
+            model_caller=caller,
+        )
+    assert calls == ["split"]
+
+
+def test_record_suite_rejects_non_integer_candidate_line_cleanly():
+    source = _source()
+    split_payload = _split_payload(source)
+    split_payload["cases"][0]["boundary_candidates"][0]["line"] = [5]
+
+    def caller(_stage, _config, _system, _prompt, _seed, _top_p, _prices):
+        return ModelCallResult(
+            content=json.dumps({"cases": [split_payload["cases"][0]]}),
+            input_tokens=1,
+            output_tokens=1,
+            cache_read_tokens=0,
+            cost_usd=0.0,
+            price_source="config",
+            generation_seconds=0.0,
+        )
+
+    with pytest.raises(
+        ReplayValidationError, match="candidate line must be an integer"
+    ):
+        record_suite(
+            source,
+            _config(),
+            repository_revision="abc123",
+            model_caller=caller,
+        )
+
+
+def test_record_suite_rejects_string_weightscore_without_coercion():
+    source = _source()
+
+    with pytest.raises(ReplayValidationError, match=r"weight_scores\[0\]\.weightscore"):
+        record_suite(
+            source,
+            _config(),
+            repository_revision="abc123",
+            model_caller=_caller_for(source, broken_route_score=True),
+        )
+
+
+def test_v3_rejects_stage_algorithm_mismatch():
+    source = _source()
+    suite = record_suite(
+        source,
+        _config(),
+        repository_revision="abc123",
+        model_caller=_caller_for(source),
+    )
+    broken = deepcopy(suite)
+    broken["stage_manifests"]["split"]["algorithm_version"] = "other-split"
+
+    with pytest.raises(ReplayValidationError, match="match the split manifest"):
+        validate_suite(broken)
+
+
+def test_v3_rejects_ambiguous_legacy_run_manifest():
+    source = _source()
+    suite = record_suite(
+        source,
+        _config(),
+        repository_revision="abc123",
+        model_caller=_caller_for(source),
+    )
+    suite["run_manifest"] = deepcopy(suite["stage_manifests"]["split"])
+
+    with pytest.raises(ReplayValidationError, match="not allowed in schema v3"):
+        validate_suite(suite)
+
+
+def test_route_calls_follow_configured_atom_batch_size():
+    source = _source()
+    config = _config()
+    config["agent_worker"] = {"pools": {"cluster": {"batch_size": 2}}}
+    calls = []
+    caller = _caller_for(source)
+
+    def recording_caller(*args):
+        calls.append(args[0])
+        return caller(*args)
+
+    suite = record_suite(
+        source,
+        config,
+        repository_revision="abc123",
+        model_caller=recording_caller,
+    )
+
+    assert suite["stage_manifests"]["route"]["calls"] == 4
+    assert calls.count("route") == 4
+
+
+def test_invalid_first_route_batch_stops_later_model_calls():
+    source = _source()
+    config = _config()
+    config["agent_worker"] = {"pools": {"cluster": {"batch_size": 2}}}
+    calls = []
+    caller = _caller_for(source, broken_route_score=True)
+
+    def recording_caller(*args):
+        calls.append(args[0])
+        return caller(*args)
+
+    with pytest.raises(ReplayValidationError, match="weightscore"):
+        record_suite(
+            source,
+            config,
+            repository_revision="abc123",
+            model_caller=recording_caller,
+        )
+
+    assert calls == ["split"] * len(source["cases"]) + ["route"]
+
+
+def test_invalid_route_batch_size_fails_before_model_calls():
+    source = _source()
+    config = _config()
+    config["agent_worker"] = {"pools": {"cluster": {"batch_size": 0}}}
+    calls = []
+
+    def caller(*args):
+        calls.append(args[0])
+        return _caller_for(source)(*args)
+
+    with pytest.raises(ValueError, match="batch_size must be a positive integer"):
+        record_suite(
+            source,
+            config,
+            repository_revision="abc123",
+            model_caller=caller,
+        )
+
+    assert calls == []
+
+
+def test_recorder_does_not_overwrite_without_explicit_flag(tmp_path):
+    output = tmp_path / "recorded.json"
+    _write_json(output, {"first": True}, overwrite=False)
+
+    with pytest.raises(FileExistsError, match="pass --overwrite"):
+        _write_json(output, {"second": True}, overwrite=False)
+
+    assert json.loads(output.read_text(encoding="utf-8")) == {"first": True}
+
+
+def test_cli_rejects_existing_output_before_reading_config(tmp_path):
+    output = tmp_path / "recorded.json"
+    _write_json(output, {"first": True}, overwrite=False)
+
+    with pytest.raises(FileExistsError, match="pass --overwrite"):
+        main(
+            [
+                str(SOURCE_PATH),
+                str(output),
+                "--config",
+                str(tmp_path / "missing.yaml"),
+            ]
+        )


### PR DESCRIPTION
## Summary

为 Atom 拆分与路由离线回放增加真实模型录制命令，并提交一份本地 Qwen 3.8 生成的隐私安全 fixture。

普通 CI 只回放固定 fixture，不调用模型；TaskAgent、TaskClusterAgent、生产状态机和线上评分语义没有变化。

## Changes

- 增加 schema v3，以独立的 `split` 和 `route` manifests 记录模型、Harness、prompt fingerprint、算法版本、生成参数、token、费用、调用次数和耗时，并保持 v1/v2 报告字节级不变。
- 增加显式 opt-in 录制器，只读取调用者指定的 source、config 和 output，不扫描用户工作区，并由 xskill 确定性分配 Atom id、半开区间和候选映射。
- 在每个阶段和 route batch 后做严格校验，拒绝字符串 `weightscore`、未知 Skill、错误 Atom 映射、非有限数值和含糊的双 manifest，并在失败时停止后续模型调用。
- 入仓一份包含新目标、继续、纠正、重试、近重复和多 Skill 关系的 Qwen 3.8 合成回放，实测为 6 次 split、1 次 route、3387 input tokens、1308 output tokens 和零配置本地费用。
- 补充中文录制、隐私检查和离线复现文档，并明确六个小样本不能用于宣称模型质量或分数相关性。

## Test plan

- [x] `make test` passes（2751 passed, 9 skipped）
- [x] Added/updated unit tests for the change（42 个算法回放专项测试通过）
- [ ] `make e2e` passes (if the change touches ingestion / install / daemon)（不涉及 ingestion、install 或 daemon）
- [x] Manually verified the affected user flow（本地 Qwen 3.8 真实复录；结构化输出与前次运行一致，仅 revision、时间戳和耗时变化）

补充检查：Ruff 通过，Python 3.9 `py_compile` 通过，fixture 隐私扫描通过，提交已使用 SSH 签名。

## Linked issues

Closes #374


## 给外人看的背景（真实模型 Atom 拆分与路由回放是什么）

下面按给第三方看的问题单来写：每个词第一次出现都会说明它是什么。代码位置只是提示，不是必须先读完整个仓库才能看懂。

### 这是什么

XSkill 平时学技能，先把人在编码助手里做过的事收成轨迹。轨迹就是一份按时间排好的对话记录。下一步要把轨迹切成更小的片段，再决定每个片段该进哪些技能。

Atom 是轨迹里意图相对单一的一小段。拆分就是把一条完整轨迹切成一段段 Atom：哪里该切开、哪里该连着，由模型提议语义边界，再由确定性代码写成区间。确定性的意思是：同样的输入再跑一遍，编号和区间不会因为采样而变。

路由就是决定某个 Atom 该进哪个 Skill。Skill 是后来写给助手用的说明书。一个 Atom 可以对应多个 Skill，每对关系还有一个叫 weightscore 的整数权重。

本 PR 是 Q1 评测链的第一张。Q1 评测链是后面要一块块补齐的离线评测工作，用来回答拆分、成图、形成技能这些步骤各自有没有效。这一张只做一件事：让拆分和路由能先被真实模型跑一遍并记下来，以后再按这份固定结果离线复算。

录制就是：维护者在本机显式打开命令，对着指定样本调用模型，把结构化输出和用量写进文件。回放就是：以后只读这份已经写好的文件，算出指标报告，不再访问模型、向量库或网络。这份写好的固定输入输出包，评测里叫 fixture。

入仓的是一份本地 Qwen 3.8 合成小样本，用来把录制和回放链路跑通。合成的意思是：轨迹是为评测编的脱敏材料，不是用户现网会话。六个小样本不能用来宣称模型质量，也不能用来宣称「拆分方法已经有效」。

### 用户侧和评测侧实际发生了什么

用户日常写代码时，生产里的拆分代理（TaskAgent）和归类代理（TaskClusterAgent）仍按原样跑。本 PR 不改这两个代理，不改生产状态机，也不改线上评分。用户电脑上不会因为合入这张补丁就多一次模型调用。现网是格力内网那套正在给人用的服务；Agent 接触不到现网，合进仓库也不等于现网已经换成这份拆分。

评测侧才用到本 PR。维护者如果要重新采一份真实模型结果，必须自己准备脱敏样本、配置和输出路径，再跑录制命令。命令只读调用者写明的 source、config 和 output，不会去扫 `~/.xskill`、助手历史目录或用户工作区。

普通 CI（持续集成，也就是每次提交后自动跑的那组检查）不做录制。它只回放入仓的 fixture，检查约定和指标还能复现。CI 不调用大模型，不调 embedding，不连向量库，也不走编码助手命令行。

入仓的这一份是本地 Qwen 3.8 小样本：6 次拆分调用、1 次路由调用。实测大约 3387 个输入 token、1308 个输出 token。token 是模型计费用的文本用量单位。本地费用按配置记成零。六个样本覆盖新目标、继续、纠正、重试、近重复和一个 Atom 对应多个 Skill，但其中只有一个正边界、没有路由错误。这只够证明录制和回放链路能走通，不能用来宣称模型质量，也不能用来宣称边界分数和路由对错相关。

### 文件和录制长什么样

回放目录在 `scripts/bench/algorithm_replay/`。旧的 v1、v2 fixture 还在，模型名写的是 `recorded-fixture`。那是合成预测，用来锁评测器约定，不是某次真实模型运行。它们的 token、费用、耗时都是零。

本 PR 新入仓的是 `fixtures/qwen38_baseline_v3.json`。它用 schema v3。schema 就是这份 JSON 必须长什么样的约定。v3 不再用一份含糊的全局运行记录，而是在 `stage_manifests` 里分别记 `split` 和 `route`：模型名、Harness、prompt fingerprint、算法版本、随机种子、生成参数、token、费用、调用次数、耗时、时间戳、仓库 revision。Harness 是这次推理跑在哪套外壳上，这份写的是 `llama.cpp-openai-compatible`。prompt fingerprint 是提示词的哈希，用来对上「当时喂给模型的是哪一版提示」，不是把提示词原文再抄一遍。两个阶段必须用同一个仓库 revision。

每个 case 里有合成轨迹行、人工 gold Atom，以及模型当时给出的预测 Atom。gold 是人标的正确答案，和模型输出分字段存放，避免把标注和预测糊在一起。预测 Atom 还带 `weight_scores`。区间从第 1 行起算，写成半开区间 `[start_line, end_line)`：起点算进去，终点不算。Atom 编号、半开区间和候选映射由 xskill 确定性分配。模型只回语义边界、意图、摘要、路由标签和关系权重。

录制命令是 `python -m scripts.bench.algorithm_replay.record`。它对每条轨迹单独做一次拆分，再按当前归类批量大小做一次有界路由。某一阶段输出不合法就停，不会继续消耗后面的模型调用。套件不保存隐藏思维链、接口地址或 API key。输出文件已存在时必须加 `--overwrite` 才覆盖。

回放命令是 `python -m scripts.bench.algorithm_replay.evaluate`，对着同一份 JSON 就能出报告。v1、v2 的入仓报告保持字节级不变。

### 合本 PR 之前缺了什么

#373 已经给离线回放加上了候选边界分数和阈值分析，但 v2 基线仍是合成的 `recorded-fixture`。那只能证明表格、校验和指标实现是对的，不能说明真实拆分模型会给出什么样的候选排序，也不能说明低边界分数是不是更容易对应路由错误。

如果有人手改一份 JSON 冒充真实运行，模型、路由、提示词、Harness 和算法版本容易糊在同一个全局记录里，后面实验对不上账。#374 要的就是：显式录制、分阶段记账、CI 只回放、生产流水线不动。本 PR 是那张问题单的实现。

### 本 PR 具体改哪

评测器支持 schema v3，拆分和路由各有一份运行清单，并拒绝 v3 再带一份全局运行记录。v1、v2 继续能评，旧报告字节不变。

新增录制器 `scripts/bench/algorithm_replay/record.py`。它是显式打开的：路径都由调用者指定，默认不发现本机轨迹。每个阶段和每次路由批量之后做严格校验。字符串形式的 weightscore、未知 Skill、错误 Atom 映射、非有限数值、含糊的双清单，都会失败。

入仓一份本地 Qwen 3.8 合成回放，并在 README 里写清怎么录、怎么做隐私检查、怎么离线复现，以及这六个小样本不能当质量结论。

测试锁住录制校验和 v3 回放。普通 CI 仍只跑 evaluate，不跑真实模型。生产 TaskAgent、TaskClusterAgent、状态机和线上评分都不动。

### 不要和什么搞混

不要把它和现网拆分搞混。现网拆分是格力内网生产流水线里 TaskAgent 正在做的事。本 PR 不改 TaskAgent，不改 TaskClusterAgent，不改生产状态机，不改 `ux_score` 和 `weightscore` 的线上语义。`ux_score` 是现有技能好不好的分数。合进仓库不等于现网已经换成这份拆分。

不要把它和 #377 搞混。#377 才隔离原始输入和评分器：给后面的 Formation 评测把原始会话和标准答案拆开，避免评分端看见不该看见的标注。Formation 是后面「怎么形成 Skill」那条评测。本 PR 还是拆分加路由的回放账本，不管原始输入和评分器分家。

不要把它和 #379、#385 搞混。#379 测的是 Task Graph 结构。Task Graph 是架在主路上面的一层任务图，用来把相关 Atom 收成更大的任务，并和「整段会话当任务」「每个 Atom 当任务」比较。#385 才测下游方法效果：同样的任务上，按会话、按 Atom、按任务图去形成 Skill，会不会真的更好。本 PR 不画任务图，也不比较这些形成方法。

也不要把入仓的 Qwen 小样本当成「方法已经有效」。合成轨迹、六个 case、一次本地小模型运行，只能证明链路可复现。正边界太少、没有路由错误，分数相关性和模型质量都不能从这里下结论。后面要更大、更隔离的评测，才轮到 #377、#379、#385。

### 怎么算这段背景对齐了

能说出 Atom 是轨迹里切出来的一小段，拆分是切这段，路由是把这段标到哪些 Skill。能说出录制是本机显式调模型写文件，回放是 CI 只读这份 fixture、不再调模型。能说出合本 PR 之前只有合成 v2，现在多了分阶段记账的真实模型 v3，但生产代理和现网拆分都没改。能把本 PR 和后面的 #377、#379、#385 分开：这里不管原始输入和评分器隔离，不管任务图结构，不管下游方法是否更有效。能说出六个合成小样本不能用来宣称模型质量或方法已经有效。
