### PR TITLE
test(algorithms): 建立 raw-only Formation 数据与评分隔离契约

### DIFF
--- a/scripts/bench/algorithm_replay/README.md
+++ b/scripts/bench/algorithm_replay/README.md
@@ -45,7 +45,11 @@ python -m scripts.bench.algorithm_replay.formation_data validate \
   scripts/bench/algorithm_replay/fixtures/formation_truth_v1.json
 ```
 
-truth suite 必须标注每个内部用户回合是 `split` 还是 `keep`，并记录 `new_goal`、`continue`、`clarify`、`correct`、`retry`、`abandon_or_return` 或 `uncertain` 边界类型。
+truth suite 必须标注每个内部用户回合是 `split` 还是 `keep`，并记录 `new_goal`、`continue`、`clarify`、`correct`、`retry`、`noise`、`abandon_or_return` 或 `uncertain` 边界类型。
+
+v1 只把大小写和左侧缩进均符合生产 `TaskAgent` 语法的 `## User` 与 `## Initial Query` 行视为结构化用户回合，正文中的小写标题和缩进代码不会成为候选边界。
+
+结构合法但被生产 F0 过滤的机器噪声回合仍保存在 scorer truth 中，并使用 `keep/noise` 作为硬负例，避免把当前算法过滤结果写成 Gold 事实。
 
 Gold Atom 必须从第一行连续无重叠地覆盖到 EOF，内部起点必须与 `split` 决策完全一致，所有证据行都必须落在所属 Atom 的原始范围内。
 

--- a/scripts/bench/algorithm_replay/README.md
+++ b/scripts/bench/algorithm_replay/README.md
@@ -18,6 +18,45 @@ python -m scripts.bench.algorithm_replay.evaluate \
 
 使用 `--format json` 可以输出机器可读报告。测试会把两份报告与入仓的 `*.report.json` 快照比较，因此 schema 和指标定义的变化必须作为可见 diff 接受 review。
 
+## Raw-only Formation 数据契约
+
+Formation 运行只能读取 raw suite，raw case 严格只包含不携带语义答案的 `case_id` 和原始 `raw_content`。
+
+`payload` 会把原始 case id 再映射成顺序无语义的 `case-000001` 形式，避免 `new-goal`、`retry` 等命名把场景答案泄漏给 Formation，原始映射只由 scorer 保留。
+
+数据集名称、固定 revision、来源地址和许可证保存在 raw suite 的 manifest 中，但 `payload` 子命令不会把 manifest 传给 Formation runner。
+
+Gold 边界、来源任务 ID、组合场景、证据引用、终态和学习资格保存在物理分离的 truth suite 中。
+
+`payload` 子命令的参数结构没有 truth 路径，因此产生 Formation 输入时不需要读取或发现评分文件。
+
+Formation runner 可以从原始内容构造全局目标地图并按需读取局部证据，不要求把完整 raw content 一次性塞进模型 Prompt。
+
+```bash
+python -m scripts.bench.algorithm_replay.formation_data payload \
+  scripts/bench/algorithm_replay/fixtures/formation_raw_v1.json
+```
+
+`validate` 子命令属于 scorer 侧，它使用 `raw_sha256` 把标注绑定到原始内容，并校验两个文件的 suite 和 case 集合完全一致。
+
+```bash
+python -m scripts.bench.algorithm_replay.formation_data validate \
+  scripts/bench/algorithm_replay/fixtures/formation_raw_v1.json \
+  scripts/bench/algorithm_replay/fixtures/formation_truth_v1.json
+```
+
+truth suite 必须标注每个内部用户回合是 `split` 还是 `keep`，并记录 `new_goal`、`continue`、`clarify`、`correct`、`retry`、`abandon_or_return` 或 `uncertain` 边界类型。
+
+Gold Atom 必须从第一行连续无重叠地覆盖到 EOF，内部起点必须与 `split` 决策完全一致，所有证据行都必须落在所属 Atom 的原始范围内。
+
+证据引用不能指向空行或 Markdown section header，非 `unknown` 终态必须至少引用一条 outcome、verification、user acceptance 或 user rejection 证据。
+
+每个 Gold Atom 分别记录 outcome、evidence completeness 和 learning eligibility，不能用 `ux_score` 或 `(atom_id, skill)` 的 `weightscore` 替代 Formation 质量。
+
+低价值、失败或不确定 Atom 仍保存在 truth 事实中，`learning_eligibility` 只控制下游是否学习，不能用来静默删除原始片段。
+
+当前两条隐私安全 fixture 只验证 raw/truth 隔离、标注 schema、范围和证据不变量，不代表真实模型或生产 Formation 的质量。
+
 ## Fixture 契约
 
 - `schema_version`：支持 `1` 和 `2`，未知版本会直接失败。

--- a/scripts/bench/algorithm_replay/fixtures/formation_raw_v1.json
+++ b/scripts/bench/algorithm_replay/fixtures/formation_raw_v1.json
@@ -1,0 +1,20 @@
+{
+  "raw_schema_version": 1,
+  "suite_id": "raw-only-formation-contract-v1",
+  "dataset_manifest": {
+    "dataset_id": "xskill-formation-contract-fixture",
+    "source_uri": "https://github.com/SkillNerds/xskill",
+    "revision": "v1",
+    "license": "MIT"
+  },
+  "cases": [
+    {
+      "case_id": "formation-001",
+      "raw_content": "<!-- xskill:harness=fixture -->\n## Initial Query\n请迁移 SQLite 表结构。\n## Assistant\n我会先检查现有表结构。\n## Tool\n旧表使用 atom_id 单列主键。\n## Assistant\n迁移已完成，历史记录全部保留。\n## User\n现在验证迁移后的约束和索引。\n## Assistant\n我会执行结构与查询计划检查。\n## Tool\n联合主键和目标索引均符合预期。\n## Assistant\n迁移结果验证完成。"
+    },
+    {
+      "case_id": "formation-002",
+      "raw_content": "<!-- xskill:harness=fixture -->\n## Initial Query\n请修复电子表格导出。\n## Assistant\n我会检查导出路径和列映射。\n## Tool\n现有实现遗漏了最后一列。\n## User\n导出的列顺序也要保持不变。\n## Assistant\n我会在同一修复中保留原有顺序。\n## Tool\n导出测试和列顺序检查均已通过。\n## Assistant\n导出问题已经修复并验证。"
+    }
+  ]
+}

--- a/scripts/bench/algorithm_replay/fixtures/formation_truth_v1.json
+++ b/scripts/bench/algorithm_replay/fixtures/formation_truth_v1.json
@@ -1,0 +1,106 @@
+{
+  "truth_schema_version": 1,
+  "annotation_schema_version": 1,
+  "suite_id": "raw-only-formation-contract-v1",
+  "cases": [
+    {
+      "case_id": "formation-001",
+      "raw_sha256": "sha256:1b3032cc399aefb23e377d3a4e84e1dc70b54b6f2f947d5fac3af6df88a45fa4",
+      "provenance": {
+        "source_ids": ["fixture-migration", "fixture-validation"],
+        "composition_scenario": "a_to_b"
+      },
+      "boundaries": [
+        {
+          "line": 10,
+          "decision": "split",
+          "type": "new_goal",
+          "ambiguous": false
+        }
+      ],
+      "gold_atoms": [
+        {
+          "id": "gold-formation-001-01",
+          "start_line": 1,
+          "end_line": 10,
+          "outcome_state": "completed",
+          "evidence": {
+            "goal": [3],
+            "action": [5],
+            "tool_feedback": [7],
+            "artifact_change": [],
+            "verification": [],
+            "outcome": [9],
+            "user_acceptance": [],
+            "user_rejection": []
+          },
+          "evidence_completeness": "partial",
+          "learning_eligibility": "uncertain",
+          "eligibility_reasons": [
+            "迁移动作可归因，但独立验证属于后续目标"
+          ]
+        },
+        {
+          "id": "gold-formation-001-02",
+          "start_line": 10,
+          "end_line": 18,
+          "outcome_state": "completed",
+          "evidence": {
+            "goal": [11],
+            "action": [13],
+            "tool_feedback": [15],
+            "artifact_change": [],
+            "verification": [15, 17],
+            "outcome": [17],
+            "user_acceptance": [],
+            "user_rejection": []
+          },
+          "evidence_completeness": "complete",
+          "learning_eligibility": "eligible",
+          "eligibility_reasons": [
+            "目标、检查动作和验证结果均可定位"
+          ]
+        }
+      ]
+    },
+    {
+      "case_id": "formation-002",
+      "raw_sha256": "sha256:7eaee300dfe299d0259e3f4f91c8f42e61f9dddc271c9d461bffaa8e7851894b",
+      "provenance": {
+        "source_ids": ["fixture-spreadsheet-export"],
+        "composition_scenario": "clarification"
+      },
+      "boundaries": [
+        {
+          "line": 8,
+          "decision": "keep",
+          "type": "clarify",
+          "ambiguous": false
+        }
+      ],
+      "gold_atoms": [
+        {
+          "id": "gold-formation-002-01",
+          "start_line": 1,
+          "end_line": 16,
+          "outcome_state": "completed",
+          "evidence": {
+            "goal": [3, 9],
+            "action": [5, 11],
+            "tool_feedback": [7, 13],
+            "artifact_change": [],
+            "verification": [13],
+            "outcome": [15],
+            "user_acceptance": [],
+            "user_rejection": []
+          },
+          "evidence_completeness": "complete",
+          "learning_eligibility": "eligible",
+          "eligibility_reasons": [
+            "补充要求属于同一导出目标，且结果已验证"
+          ]
+        }
+      ]
+    }
+  ]
+}

--- a/scripts/bench/algorithm_replay/formation_data.py
+++ b/scripts/bench/algorithm_replay/formation_data.py
@@ -1,0 +1,586 @@
+"""Raw-only Formation inputs and scorer-only truth contracts.
+
+The Formation-facing payload is built from the raw suite alone.  Gold boundaries,
+evidence annotations, outcomes, and learning eligibility live in a separate truth
+suite that is loaded only by the offline scorer.
+"""
+
+from __future__ import annotations
+
+import argparse
+import hashlib
+import json
+import re
+from pathlib import Path
+from typing import Any
+
+from scripts.bench.algorithm_replay.evaluate import ReplayValidationError
+
+RAW_SCHEMA_VERSION = 1
+TRUTH_SCHEMA_VERSION = 1
+ANNOTATION_SCHEMA_VERSION = 1
+
+_RAW_ROOT_KEYS = {
+    "raw_schema_version",
+    "suite_id",
+    "dataset_manifest",
+    "cases",
+}
+_RAW_MANIFEST_KEYS = {"dataset_id", "source_uri", "revision", "license"}
+_RAW_CASE_KEYS = {"case_id", "raw_content"}
+_TRUTH_ROOT_KEYS = {
+    "truth_schema_version",
+    "annotation_schema_version",
+    "suite_id",
+    "cases",
+}
+_TRUTH_CASE_KEYS = {
+    "case_id",
+    "raw_sha256",
+    "provenance",
+    "boundaries",
+    "gold_atoms",
+}
+_PROVENANCE_KEYS = {"source_ids", "composition_scenario"}
+_BOUNDARY_KEYS = {"line", "decision", "type", "ambiguous"}
+_ATOM_KEYS = {
+    "id",
+    "start_line",
+    "end_line",
+    "outcome_state",
+    "evidence",
+    "evidence_completeness",
+    "learning_eligibility",
+    "eligibility_reasons",
+}
+_EVIDENCE_TYPES = {
+    "goal",
+    "action",
+    "tool_feedback",
+    "artifact_change",
+    "verification",
+    "outcome",
+    "user_acceptance",
+    "user_rejection",
+}
+_BOUNDARY_DECISIONS = {"split", "keep"}
+_BOUNDARY_TYPES = {
+    "new_goal",
+    "continue",
+    "clarify",
+    "correct",
+    "retry",
+    "abandon_or_return",
+    "uncertain",
+}
+_OUTCOME_STATES = {"completed", "failed", "abandoned", "unknown"}
+_EVIDENCE_COMPLETENESS = {"complete", "partial", "minimal"}
+_LEARNING_ELIGIBILITY = {"eligible", "ineligible", "uncertain"}
+_COMPOSITION_SCENARIOS = {
+    "organic",
+    "a_to_b",
+    "a_to_b_to_a",
+    "continuation",
+    "clarification",
+    "correction",
+    "retry",
+    "abandon_or_return",
+    "similar_goal_hard_negative",
+    "missing_terminal",
+}
+_USER_HEADER_RE = re.compile(
+    r"^##\s+(?:User|Initial\s+Query)\b",
+    re.IGNORECASE,
+)
+_SECTION_HEADER_RE = re.compile(r"^##\s+\S+")
+
+
+def _error(path: str, message: str) -> ReplayValidationError:
+    return ReplayValidationError(f"{path}: {message}")
+
+
+def _expect_exact_keys(value: Any, expected: set[str], path: str) -> dict[str, Any]:
+    if not isinstance(value, dict):
+        raise _error(path, "expected an object")
+    actual = set(value)
+    if actual != expected:
+        missing = sorted(expected - actual)
+        extra = sorted(actual - expected)
+        raise _error(path, f"keys mismatch; missing={missing}, extra={extra}")
+    return value
+
+
+def _expect_non_empty_string(value: Any, path: str) -> str:
+    if not isinstance(value, str) or not value.strip():
+        raise _error(path, "expected a non-empty string")
+    return value
+
+
+def _expect_strict_int(value: Any, path: str) -> int:
+    if isinstance(value, bool) or not isinstance(value, int):
+        raise _error(path, "expected an integer")
+    return value
+
+
+def _expect_bool(value: Any, path: str) -> bool:
+    if not isinstance(value, bool):
+        raise _error(path, "expected a boolean")
+    return value
+
+
+def _expect_enum(value: Any, choices: set[str], path: str) -> str:
+    if not isinstance(value, str) or value not in choices:
+        raise _error(path, f"expected one of {sorted(choices)}, got {value!r}")
+    return value
+
+
+def _read_json(path: str | Path) -> dict[str, Any]:
+    source_path = Path(path)
+    try:
+        value = json.loads(source_path.read_text(encoding="utf-8"))
+    except json.JSONDecodeError as error:
+        raise ReplayValidationError(
+            f"invalid JSON in {source_path}: {error}"
+        ) from error
+    if not isinstance(value, dict):
+        raise ReplayValidationError(f"{source_path}: expected a JSON object")
+    return value
+
+
+def raw_content_sha256(raw_content: str) -> str:
+    """Return the stable hash used to bind hidden truth to one raw session."""
+    digest = hashlib.sha256(raw_content.encode("utf-8")).hexdigest()
+    return f"sha256:{digest}"
+
+
+def _raw_lines(raw_content: str) -> list[str]:
+    return raw_content.splitlines()
+
+
+def _user_header_lines(raw_content: str) -> list[int]:
+    return [
+        line_number
+        for line_number, line in enumerate(_raw_lines(raw_content), start=1)
+        if _USER_HEADER_RE.match(line.strip())
+    ]
+
+
+def validate_raw_suite(source: Any) -> None:
+    """Validate data that may be exposed to the Formation algorithm."""
+    root = _expect_exact_keys(source, _RAW_ROOT_KEYS, "raw")
+    if root["raw_schema_version"] != RAW_SCHEMA_VERSION:
+        raise _error(
+            "raw.raw_schema_version",
+            f"supported={RAW_SCHEMA_VERSION}, got={root['raw_schema_version']!r}",
+        )
+    _expect_non_empty_string(root["suite_id"], "raw.suite_id")
+    manifest = _expect_exact_keys(
+        root["dataset_manifest"],
+        _RAW_MANIFEST_KEYS,
+        "raw.dataset_manifest",
+    )
+    for key in sorted(_RAW_MANIFEST_KEYS):
+        _expect_non_empty_string(manifest[key], f"raw.dataset_manifest.{key}")
+
+    cases = root["cases"]
+    if not isinstance(cases, list) or not cases:
+        raise _error("raw.cases", "expected a non-empty list")
+    case_ids: set[str] = set()
+    for case_index, value in enumerate(cases):
+        path = f"raw.cases[{case_index}]"
+        case = _expect_exact_keys(value, _RAW_CASE_KEYS, path)
+        case_id = _expect_non_empty_string(case["case_id"], f"{path}.case_id")
+        if case_id in case_ids:
+            raise _error(f"{path}.case_id", f"duplicate case id {case_id!r}")
+        case_ids.add(case_id)
+        raw_content = _expect_non_empty_string(
+            case["raw_content"],
+            f"{path}.raw_content",
+        )
+        if not _user_header_lines(raw_content):
+            raise _error(
+                f"{path}.raw_content",
+                "expected at least one ## User or ## Initial Query header",
+            )
+
+
+def build_formation_payload(source: Any) -> dict[str, Any]:
+    """Build the complete Formation input without accepting truth data."""
+    validate_raw_suite(source)
+    return {
+        "cases": [
+            {
+                "case_id": f"case-{case_index:06d}",
+                "raw_content": case["raw_content"],
+            }
+            for case_index, case in enumerate(source["cases"], start=1)
+        ]
+    }
+
+
+def formation_case_id_map(source: Any) -> dict[str, str]:
+    """Return the scorer-side map from opaque payload ids to raw case ids."""
+    validate_raw_suite(source)
+    return {
+        f"case-{case_index:06d}": case["case_id"]
+        for case_index, case in enumerate(source["cases"], start=1)
+    }
+
+
+def _validate_boundary_annotations(
+    boundaries: Any,
+    *,
+    raw_content: str,
+    path: str,
+) -> dict[int, dict[str, Any]]:
+    if not isinstance(boundaries, list):
+        raise _error(path, "expected a list")
+    user_lines = _user_header_lines(raw_content)
+    candidate_lines = user_lines[1:]
+    by_line: dict[int, dict[str, Any]] = {}
+    for index, value in enumerate(boundaries):
+        boundary_path = f"{path}[{index}]"
+        boundary = _expect_exact_keys(value, _BOUNDARY_KEYS, boundary_path)
+        line = _expect_strict_int(boundary["line"], f"{boundary_path}.line")
+        if line not in candidate_lines:
+            raise _error(
+                f"{boundary_path}.line",
+                f"{line} is not an internal user-message header",
+            )
+        if line in by_line:
+            raise _error(f"{boundary_path}.line", f"duplicate line {line}")
+        _expect_enum(
+            boundary["decision"],
+            _BOUNDARY_DECISIONS,
+            f"{boundary_path}.decision",
+        )
+        _expect_enum(
+            boundary["type"],
+            _BOUNDARY_TYPES,
+            f"{boundary_path}.type",
+        )
+        decision = boundary["decision"]
+        boundary_type = boundary["type"]
+        if boundary_type == "new_goal" and decision != "split":
+            raise _error(
+                boundary_path,
+                "new_goal must use decision='split'",
+            )
+        if (
+            boundary_type in {"continue", "clarify", "correct", "retry"}
+            and decision != "keep"
+        ):
+            raise _error(
+                boundary_path,
+                f"{boundary_type} must use decision='keep'",
+            )
+        _expect_bool(boundary["ambiguous"], f"{boundary_path}.ambiguous")
+        if boundary_type == "uncertain" and not boundary["ambiguous"]:
+            raise _error(
+                boundary_path,
+                "uncertain boundary type requires ambiguous=true",
+            )
+        by_line[line] = boundary
+    if set(by_line) != set(candidate_lines):
+        missing = sorted(set(candidate_lines) - set(by_line))
+        extra = sorted(set(by_line) - set(candidate_lines))
+        raise _error(path, f"must label every candidate; missing={missing}, extra={extra}")
+    return by_line
+
+
+def _validate_evidence(
+    evidence: Any,
+    *,
+    raw_lines: list[str],
+    start_line: int,
+    end_line: int,
+    path: str,
+) -> dict[str, list[int]]:
+    evidence_map = _expect_exact_keys(evidence, _EVIDENCE_TYPES, path)
+    for evidence_type in sorted(_EVIDENCE_TYPES):
+        lines = evidence_map[evidence_type]
+        evidence_path = f"{path}.{evidence_type}"
+        if not isinstance(lines, list):
+            raise _error(evidence_path, "expected a list")
+        normalized: list[int] = []
+        for index, value in enumerate(lines):
+            line = _expect_strict_int(value, f"{evidence_path}[{index}]")
+            if not start_line <= line < end_line:
+                raise _error(
+                    f"{evidence_path}[{index}]",
+                    f"line {line} falls outside Atom range [{start_line}, {end_line})",
+                )
+            source_line = raw_lines[line - 1].strip()
+            if not source_line or _SECTION_HEADER_RE.match(source_line):
+                raise _error(
+                    f"{evidence_path}[{index}]",
+                    f"line {line} does not contain evidence content",
+                )
+            normalized.append(line)
+        if len(set(normalized)) != len(normalized):
+            raise _error(evidence_path, "contains duplicate line references")
+    if not evidence_map["goal"]:
+        raise _error(f"{path}.goal", "must contain at least one goal reference")
+    return evidence_map
+
+
+def _validate_gold_atoms(
+    atoms: Any,
+    *,
+    raw_content: str,
+    boundaries_by_line: dict[int, dict[str, Any]],
+    path: str,
+) -> None:
+    if not isinstance(atoms, list) or not atoms:
+        raise _error(path, "expected a non-empty list")
+    eof_line = len(_raw_lines(raw_content)) + 1
+    raw_lines = _raw_lines(raw_content)
+    user_lines = set(_user_header_lines(raw_content))
+    atom_ids: set[str] = set()
+    cursor = 1
+    internal_starts: set[int] = set()
+    for index, value in enumerate(atoms):
+        atom_path = f"{path}[{index}]"
+        atom = _expect_exact_keys(value, _ATOM_KEYS, atom_path)
+        atom_id = _expect_non_empty_string(atom["id"], f"{atom_path}.id")
+        if atom_id in atom_ids:
+            raise _error(f"{atom_path}.id", f"duplicate Atom id {atom_id!r}")
+        atom_ids.add(atom_id)
+        start_line = _expect_strict_int(
+            atom["start_line"],
+            f"{atom_path}.start_line",
+        )
+        end_line = _expect_strict_int(atom["end_line"], f"{atom_path}.end_line")
+        if start_line != cursor:
+            raise _error(
+                f"{atom_path}.start_line",
+                f"expected contiguous start {cursor}, got {start_line}",
+            )
+        if end_line <= start_line or end_line > eof_line:
+            raise _error(
+                f"{atom_path}.end_line",
+                f"expected {start_line} < end <= {eof_line}, got {end_line}",
+            )
+        if index and start_line not in user_lines:
+            raise _error(
+                f"{atom_path}.start_line",
+                "internal Atom must start at a user-message header",
+            )
+        if index:
+            internal_starts.add(start_line)
+        _expect_enum(
+            atom["outcome_state"],
+            _OUTCOME_STATES,
+            f"{atom_path}.outcome_state",
+        )
+        evidence = _validate_evidence(
+            atom["evidence"],
+            raw_lines=raw_lines,
+            start_line=start_line,
+            end_line=end_line,
+            path=f"{atom_path}.evidence",
+        )
+        completeness = _expect_enum(
+            atom["evidence_completeness"],
+            _EVIDENCE_COMPLETENESS,
+            f"{atom_path}.evidence_completeness",
+        )
+        if completeness == "complete":
+            terminal = (
+                evidence["verification"]
+                or evidence["user_acceptance"]
+                or evidence["user_rejection"]
+            )
+            if not evidence["action"] or not terminal:
+                raise _error(
+                    f"{atom_path}.evidence_completeness",
+                    "complete evidence requires action and terminal references",
+                )
+        outcome_state = atom["outcome_state"]
+        observable_outcome = (
+            evidence["outcome"]
+            or evidence["verification"]
+            or evidence["user_acceptance"]
+            or evidence["user_rejection"]
+        )
+        if outcome_state != "unknown" and not observable_outcome:
+            raise _error(
+                f"{atom_path}.outcome_state",
+                "non-unknown outcome requires an outcome or terminal reference",
+            )
+        _expect_enum(
+            atom["learning_eligibility"],
+            _LEARNING_ELIGIBILITY,
+            f"{atom_path}.learning_eligibility",
+        )
+        reasons = atom["eligibility_reasons"]
+        if not isinstance(reasons, list) or not reasons:
+            raise _error(
+                f"{atom_path}.eligibility_reasons",
+                "expected a non-empty list",
+            )
+        for reason_index, reason in enumerate(reasons):
+            _expect_non_empty_string(
+                reason,
+                f"{atom_path}.eligibility_reasons[{reason_index}]",
+            )
+        cursor = end_line
+    if cursor != eof_line:
+        raise _error(path, f"Atoms end at {cursor}, expected EOF {eof_line}")
+    split_lines = {
+        line
+        for line, annotation in boundaries_by_line.items()
+        if annotation["decision"] == "split"
+    }
+    if internal_starts != split_lines:
+        raise _error(
+            path,
+            "internal Atom starts must equal split decisions; "
+            f"starts={sorted(internal_starts)}, splits={sorted(split_lines)}",
+        )
+
+
+def validate_truth_suite(truth: Any, raw_source: Any) -> None:
+    """Validate scorer-only annotations against an already validated raw suite."""
+    validate_raw_suite(raw_source)
+    root = _expect_exact_keys(truth, _TRUTH_ROOT_KEYS, "truth")
+    if root["truth_schema_version"] != TRUTH_SCHEMA_VERSION:
+        raise _error(
+            "truth.truth_schema_version",
+            f"supported={TRUTH_SCHEMA_VERSION}, got={root['truth_schema_version']!r}",
+        )
+    if root["annotation_schema_version"] != ANNOTATION_SCHEMA_VERSION:
+        raise _error(
+            "truth.annotation_schema_version",
+            "supported="
+            f"{ANNOTATION_SCHEMA_VERSION}, got={root['annotation_schema_version']!r}",
+        )
+    if root["suite_id"] != raw_source["suite_id"]:
+        raise _error("truth.suite_id", "does not match raw.suite_id")
+    cases = root["cases"]
+    if not isinstance(cases, list) or not cases:
+        raise _error("truth.cases", "expected a non-empty list")
+    raw_cases = {case["case_id"]: case for case in raw_source["cases"]}
+    truth_ids: set[str] = set()
+    for case_index, value in enumerate(cases):
+        path = f"truth.cases[{case_index}]"
+        case = _expect_exact_keys(value, _TRUTH_CASE_KEYS, path)
+        case_id = _expect_non_empty_string(case["case_id"], f"{path}.case_id")
+        if case_id in truth_ids:
+            raise _error(f"{path}.case_id", f"duplicate case id {case_id!r}")
+        truth_ids.add(case_id)
+        if case_id not in raw_cases:
+            raise _error(f"{path}.case_id", f"unknown raw case {case_id!r}")
+        raw_content = raw_cases[case_id]["raw_content"]
+        expected_hash = raw_content_sha256(raw_content)
+        if case["raw_sha256"] != expected_hash:
+            raise _error(
+                f"{path}.raw_sha256",
+                f"expected {expected_hash}, got {case['raw_sha256']!r}",
+            )
+        provenance = _expect_exact_keys(
+            case["provenance"],
+            _PROVENANCE_KEYS,
+            f"{path}.provenance",
+        )
+        source_ids = provenance["source_ids"]
+        if not isinstance(source_ids, list) or not source_ids:
+            raise _error(
+                f"{path}.provenance.source_ids",
+                "expected a non-empty list",
+            )
+        for source_index, source_id in enumerate(source_ids):
+            _expect_non_empty_string(
+                source_id,
+                f"{path}.provenance.source_ids[{source_index}]",
+            )
+        if len(set(source_ids)) != len(source_ids):
+            raise _error(
+                f"{path}.provenance.source_ids",
+                "contains duplicate source ids",
+            )
+        _expect_enum(
+            provenance["composition_scenario"],
+            _COMPOSITION_SCENARIOS,
+            f"{path}.provenance.composition_scenario",
+        )
+        boundaries = _validate_boundary_annotations(
+            case["boundaries"],
+            raw_content=raw_content,
+            path=f"{path}.boundaries",
+        )
+        _validate_gold_atoms(
+            case["gold_atoms"],
+            raw_content=raw_content,
+            boundaries_by_line=boundaries,
+            path=f"{path}.gold_atoms",
+        )
+    if truth_ids != set(raw_cases):
+        missing = sorted(set(raw_cases) - truth_ids)
+        extra = sorted(truth_ids - set(raw_cases))
+        raise _error(
+            "truth.cases",
+            f"case ids must match raw suite; missing={missing}, extra={extra}",
+        )
+
+
+def load_raw_suite(path: str | Path) -> dict[str, Any]:
+    """Read and validate a raw-only suite."""
+    source = _read_json(path)
+    validate_raw_suite(source)
+    return source
+
+
+def load_truth_suite(
+    path: str | Path,
+    *,
+    raw_source: Any,
+) -> dict[str, Any]:
+    """Read scorer-only truth and bind it to the exact raw suite."""
+    truth = _read_json(path)
+    validate_truth_suite(truth, raw_source)
+    return truth
+
+
+def _argument_parser() -> argparse.ArgumentParser:
+    parser = argparse.ArgumentParser(
+        description="Validate raw-only Formation data contracts.",
+    )
+    commands = parser.add_subparsers(dest="command", required=True)
+    payload = commands.add_parser(
+        "payload",
+        help="print the Formation input payload from a raw suite",
+    )
+    payload.add_argument("raw", type=Path)
+    validate = commands.add_parser(
+        "validate",
+        help="validate scorer truth against an exact raw suite",
+    )
+    validate.add_argument("raw", type=Path)
+    validate.add_argument("truth", type=Path)
+    return parser
+
+
+def main(argv: list[str] | None = None) -> int:
+    """Run raw payload generation or scorer-side pair validation."""
+    args = _argument_parser().parse_args(argv)
+    raw_source = load_raw_suite(args.raw)
+    if args.command == "payload":
+        print(json.dumps(build_formation_payload(raw_source), ensure_ascii=False))
+        return 0
+    truth = load_truth_suite(args.truth, raw_source=raw_source)
+    print(
+        json.dumps(
+            {
+                "status": "ok",
+                "suite_id": raw_source["suite_id"],
+                "case_count": len(truth["cases"]),
+            },
+            ensure_ascii=False,
+        )
+    )
+    return 0
+
+
+if __name__ == "__main__":
+    raise SystemExit(main())

--- a/scripts/bench/algorithm_replay/formation_data.py
+++ b/scripts/bench/algorithm_replay/formation_data.py
@@ -70,6 +70,7 @@ _BOUNDARY_TYPES = {
     "clarify",
     "correct",
     "retry",
+    "noise",
     "abandon_or_return",
     "uncertain",
 }
@@ -88,10 +89,6 @@ _COMPOSITION_SCENARIOS = {
     "similar_goal_hard_negative",
     "missing_terminal",
 }
-_USER_HEADER_RE = re.compile(
-    r"^##\s+(?:User|Initial\s+Query)\b",
-    re.IGNORECASE,
-)
 _SECTION_HEADER_RE = re.compile(r"^##\s+\S+")
 
 
@@ -157,21 +154,41 @@ def _raw_lines(raw_content: str) -> list[str]:
     return raw_content.splitlines()
 
 
+def _is_structural_user_header(line: str) -> bool:
+    """Match the canonical user-turn grammar without applying F0 filtering.
+
+    This intentionally mirrors ``TaskAgent._is_user_header`` for case and
+    indentation.  Canonical machine-noise turns remain scorer-side hard
+    negatives even when TaskAgent omits them from its prompt query map.
+    """
+    body = line.rstrip("\r\n").rstrip()
+    return (
+        body == "## User"
+        or body.startswith("## User ")
+        or body == "## Initial Query"
+        or body.startswith("## Initial Query ")
+    )
+
+
 def _user_header_lines(raw_content: str) -> list[int]:
     return [
         line_number
         for line_number, line in enumerate(_raw_lines(raw_content), start=1)
-        if _USER_HEADER_RE.match(line.strip())
+        if _is_structural_user_header(line)
     ]
 
 
 def validate_raw_suite(source: Any) -> None:
     """Validate data that may be exposed to the Formation algorithm."""
     root = _expect_exact_keys(source, _RAW_ROOT_KEYS, "raw")
-    if root["raw_schema_version"] != RAW_SCHEMA_VERSION:
+    raw_schema_version = _expect_strict_int(
+        root["raw_schema_version"],
+        "raw.raw_schema_version",
+    )
+    if raw_schema_version != RAW_SCHEMA_VERSION:
         raise _error(
             "raw.raw_schema_version",
-            f"supported={RAW_SCHEMA_VERSION}, got={root['raw_schema_version']!r}",
+            f"supported={RAW_SCHEMA_VERSION}, got={raw_schema_version!r}",
         )
     _expect_non_empty_string(root["suite_id"], "raw.suite_id")
     manifest = _expect_exact_keys(
@@ -267,7 +284,7 @@ def _validate_boundary_annotations(
                 "new_goal must use decision='split'",
             )
         if (
-            boundary_type in {"continue", "clarify", "correct", "retry"}
+            boundary_type in {"continue", "clarify", "correct", "retry", "noise"}
             and decision != "keep"
         ):
             raise _error(
@@ -444,16 +461,24 @@ def validate_truth_suite(truth: Any, raw_source: Any) -> None:
     """Validate scorer-only annotations against an already validated raw suite."""
     validate_raw_suite(raw_source)
     root = _expect_exact_keys(truth, _TRUTH_ROOT_KEYS, "truth")
-    if root["truth_schema_version"] != TRUTH_SCHEMA_VERSION:
+    truth_schema_version = _expect_strict_int(
+        root["truth_schema_version"],
+        "truth.truth_schema_version",
+    )
+    if truth_schema_version != TRUTH_SCHEMA_VERSION:
         raise _error(
             "truth.truth_schema_version",
-            f"supported={TRUTH_SCHEMA_VERSION}, got={root['truth_schema_version']!r}",
+            f"supported={TRUTH_SCHEMA_VERSION}, got={truth_schema_version!r}",
         )
-    if root["annotation_schema_version"] != ANNOTATION_SCHEMA_VERSION:
+    annotation_schema_version = _expect_strict_int(
+        root["annotation_schema_version"],
+        "truth.annotation_schema_version",
+    )
+    if annotation_schema_version != ANNOTATION_SCHEMA_VERSION:
         raise _error(
             "truth.annotation_schema_version",
             "supported="
-            f"{ANNOTATION_SCHEMA_VERSION}, got={root['annotation_schema_version']!r}",
+            f"{ANNOTATION_SCHEMA_VERSION}, got={annotation_schema_version!r}",
         )
     if root["suite_id"] != raw_source["suite_id"]:
         raise _error("truth.suite_id", "does not match raw.suite_id")

--- a/tests/test_formation_data_contract.py
+++ b/tests/test_formation_data_contract.py
@@ -1,0 +1,193 @@
+from __future__ import annotations
+
+import copy
+import json
+from pathlib import Path
+
+import pytest
+
+from scripts.bench.algorithm_replay.evaluate import ReplayValidationError
+from scripts.bench.algorithm_replay.formation_data import (
+    build_formation_payload,
+    formation_case_id_map,
+    load_raw_suite,
+    load_truth_suite,
+    main,
+    raw_content_sha256,
+    validate_raw_suite,
+    validate_truth_suite,
+)
+
+
+FIXTURES = Path("scripts/bench/algorithm_replay/fixtures")
+RAW_PATH = FIXTURES / "formation_raw_v1.json"
+TRUTH_PATH = FIXTURES / "formation_truth_v1.json"
+
+
+@pytest.fixture
+def raw_suite():
+    return json.loads(RAW_PATH.read_text(encoding="utf-8"))
+
+
+@pytest.fixture
+def truth_suite():
+    return json.loads(TRUTH_PATH.read_text(encoding="utf-8"))
+
+
+def test_checked_in_raw_and_truth_contracts_load_separately():
+    raw = load_raw_suite(RAW_PATH)
+    truth = load_truth_suite(TRUTH_PATH, raw_source=raw)
+
+    assert [case["case_id"] for case in raw["cases"]] == [
+        "formation-001",
+        "formation-002",
+    ]
+    assert [case["case_id"] for case in truth["cases"]] == [
+        "formation-001",
+        "formation-002",
+    ]
+
+
+def test_formation_payload_contains_only_opaque_id_and_raw_content(
+    raw_suite,
+    truth_suite,
+):
+    payload = build_formation_payload(raw_suite)
+    serialized = json.dumps(payload, ensure_ascii=False, sort_keys=True)
+
+    assert set(payload) == {"cases"}
+    assert all(set(case) == {"case_id", "raw_content"} for case in payload["cases"])
+    assert [case["case_id"] for case in payload["cases"]] == [
+        "case-000001",
+        "case-000002",
+    ]
+    assert formation_case_id_map(raw_suite) == {
+        "case-000001": "formation-001",
+        "case-000002": "formation-002",
+    }
+    assert "gold_atoms" not in serialized
+    assert "raw_sha256" not in serialized
+    assert "learning_eligibility" not in serialized
+    assert "formation-001" not in serialized
+    assert raw_suite["dataset_manifest"]["source_uri"] not in serialized
+    assert truth_suite["cases"][0]["gold_atoms"][0]["eligibility_reasons"][0] not in serialized
+
+
+def test_raw_contract_rejects_truth_fields(raw_suite):
+    raw_suite["cases"][0]["gold_atoms"] = []
+
+    with pytest.raises(ReplayValidationError, match=r"extra=\['gold_atoms'\]"):
+        validate_raw_suite(raw_suite)
+
+
+def test_truth_contract_rejects_raw_content(raw_suite, truth_suite):
+    truth_suite["cases"][0]["raw_content"] = raw_suite["cases"][0]["raw_content"]
+
+    with pytest.raises(ReplayValidationError, match=r"extra=\['raw_content'\]"):
+        validate_truth_suite(truth_suite, raw_suite)
+
+
+def test_truth_hash_binds_annotations_to_exact_raw_content(raw_suite, truth_suite):
+    raw_suite["cases"][0]["raw_content"] += "\n## Assistant\nlate mutation"
+
+    with pytest.raises(ReplayValidationError, match="raw_sha256"):
+        validate_truth_suite(truth_suite, raw_suite)
+
+
+def test_raw_content_hash_is_stable():
+    assert raw_content_sha256("a\nb") == (
+        "sha256:7e18f737311b2dc3b2f269dd78396b0351f14fb66efa879f768cb23181883c78"
+    )
+
+
+def test_truth_must_label_every_internal_user_boundary(raw_suite, truth_suite):
+    truth_suite["cases"][0]["boundaries"] = []
+
+    with pytest.raises(ReplayValidationError, match="must label every candidate"):
+        validate_truth_suite(truth_suite, raw_suite)
+
+
+def test_boundary_line_rejects_boolean(raw_suite, truth_suite):
+    truth_suite["cases"][0]["boundaries"][0]["line"] = True
+
+    with pytest.raises(ReplayValidationError, match="expected an integer"):
+        validate_truth_suite(truth_suite, raw_suite)
+
+
+def test_new_goal_cannot_be_annotated_as_keep(raw_suite, truth_suite):
+    truth_suite["cases"][0]["boundaries"][0]["decision"] = "keep"
+
+    with pytest.raises(ReplayValidationError, match="new_goal must use"):
+        validate_truth_suite(truth_suite, raw_suite)
+
+
+def test_uncertain_boundary_must_be_marked_ambiguous(raw_suite, truth_suite):
+    boundary = truth_suite["cases"][0]["boundaries"][0]
+    boundary["type"] = "uncertain"
+    boundary["ambiguous"] = False
+
+    with pytest.raises(ReplayValidationError, match="requires ambiguous=true"):
+        validate_truth_suite(truth_suite, raw_suite)
+
+
+def test_evidence_reference_must_stay_inside_its_atom(raw_suite, truth_suite):
+    truth_suite["cases"][0]["gold_atoms"][0]["evidence"]["goal"] = [11]
+
+    with pytest.raises(ReplayValidationError, match="outside Atom range"):
+        validate_truth_suite(truth_suite, raw_suite)
+
+
+def test_evidence_reference_cannot_point_to_a_section_header(raw_suite, truth_suite):
+    truth_suite["cases"][0]["gold_atoms"][0]["evidence"]["goal"] = [2]
+
+    with pytest.raises(ReplayValidationError, match="does not contain evidence content"):
+        validate_truth_suite(truth_suite, raw_suite)
+
+
+def test_complete_evidence_requires_action_and_terminal_reference(
+    raw_suite,
+    truth_suite,
+):
+    atom = truth_suite["cases"][1]["gold_atoms"][0]
+    atom["evidence"]["verification"] = []
+
+    with pytest.raises(ReplayValidationError, match="complete evidence requires"):
+        validate_truth_suite(truth_suite, raw_suite)
+
+
+def test_known_outcome_requires_observable_outcome_evidence(raw_suite, truth_suite):
+    atom = truth_suite["cases"][0]["gold_atoms"][0]
+    atom["evidence"]["outcome"] = []
+
+    with pytest.raises(ReplayValidationError, match="non-unknown outcome requires"):
+        validate_truth_suite(truth_suite, raw_suite)
+
+
+def test_atom_starts_must_match_split_decisions(raw_suite, truth_suite):
+    changed = copy.deepcopy(truth_suite)
+    changed["cases"][0]["boundaries"][0]["decision"] = "keep"
+    changed["cases"][0]["boundaries"][0]["type"] = "uncertain"
+    changed["cases"][0]["boundaries"][0]["ambiguous"] = True
+
+    with pytest.raises(ReplayValidationError, match="split decisions"):
+        validate_truth_suite(changed, raw_suite)
+
+
+def test_payload_cli_cannot_emit_scorer_truth(capsys):
+    assert main(["payload", str(RAW_PATH)]) == 0
+
+    payload = capsys.readouterr().out
+    assert "raw_content" in payload
+    assert "gold_atoms" not in payload
+    assert "learning_eligibility" not in payload
+
+
+def test_validate_cli_reports_bound_pair(capsys):
+    assert main(["validate", str(RAW_PATH), str(TRUTH_PATH)]) == 0
+
+    report = json.loads(capsys.readouterr().out)
+    assert report == {
+        "status": "ok",
+        "suite_id": "raw-only-formation-contract-v1",
+        "case_count": 2,
+    }

--- a/tests/test_formation_data_contract.py
+++ b/tests/test_formation_data_contract.py
@@ -8,6 +8,7 @@ import pytest
 
 from scripts.bench.algorithm_replay.evaluate import ReplayValidationError
 from scripts.bench.algorithm_replay.formation_data import (
+    _user_header_lines,
     build_formation_payload,
     formation_case_id_map,
     load_raw_suite,
@@ -17,6 +18,7 @@ from scripts.bench.algorithm_replay.formation_data import (
     validate_raw_suite,
     validate_truth_suite,
 )
+from xskill.agents.task_agent import _is_user_header as task_agent_is_user_header
 
 
 FIXTURES = Path("scripts/bench/algorithm_replay/fixtures")
@@ -100,6 +102,58 @@ def test_raw_content_hash_is_stable():
     )
 
 
+@pytest.mark.parametrize(
+    ("line", "expected"),
+    [
+        ("## User", True),
+        ("## User metadata", True),
+        ("## Initial Query", True),
+        ("## Initial Query metadata", True),
+        ("## user", False),
+        ("  ## User", False),
+        ("## User-guide", False),
+        ("## Initial query", False),
+    ],
+)
+def test_structural_user_header_grammar_matches_task_agent(line, expected):
+    assert bool(_user_header_lines(f"{line}\ncontent")) is expected
+    assert task_agent_is_user_header(line.rstrip()) is expected
+
+
+def test_machine_noise_turn_remains_a_scorer_hard_negative():
+    raw_content = (
+        "## Initial Query\ngoal\n## Assistant\ndone\n"
+        f"## User\n{'a' * 40}\n## Assistant\nignored"
+    )
+
+    assert _user_header_lines(raw_content) == [1, 5]
+
+
+@pytest.mark.parametrize("invalid_version", [True, 1.0, "1"])
+def test_raw_schema_version_requires_a_strict_integer(raw_suite, invalid_version):
+    raw_suite["raw_schema_version"] = invalid_version
+
+    with pytest.raises(ReplayValidationError, match="expected an integer"):
+        validate_raw_suite(raw_suite)
+
+
+@pytest.mark.parametrize(
+    "field",
+    ["truth_schema_version", "annotation_schema_version"],
+)
+@pytest.mark.parametrize("invalid_version", [True, 1.0, "1"])
+def test_truth_schema_versions_require_strict_integers(
+    raw_suite,
+    truth_suite,
+    field,
+    invalid_version,
+):
+    truth_suite[field] = invalid_version
+
+    with pytest.raises(ReplayValidationError, match="expected an integer"):
+        validate_truth_suite(truth_suite, raw_suite)
+
+
 def test_truth_must_label_every_internal_user_boundary(raw_suite, truth_suite):
     truth_suite["cases"][0]["boundaries"] = []
 
@@ -128,6 +182,32 @@ def test_uncertain_boundary_must_be_marked_ambiguous(raw_suite, truth_suite):
 
     with pytest.raises(ReplayValidationError, match="requires ambiguous=true"):
         validate_truth_suite(truth_suite, raw_suite)
+
+
+def test_noise_boundary_must_be_kept(raw_suite, truth_suite):
+    boundary = truth_suite["cases"][0]["boundaries"][0]
+    boundary["type"] = "noise"
+    boundary["decision"] = "split"
+
+    with pytest.raises(ReplayValidationError, match="noise must use decision='keep'"):
+        validate_truth_suite(truth_suite, raw_suite)
+
+
+def test_canonical_machine_noise_can_be_a_kept_hard_negative(
+    raw_suite,
+    truth_suite,
+):
+    raw_case = raw_suite["cases"][1]
+    raw_lines = raw_case["raw_content"].splitlines()
+    raw_lines[8] = "a" * 40
+    raw_case["raw_content"] = "\n".join(raw_lines)
+
+    truth_case = truth_suite["cases"][1]
+    truth_case["raw_sha256"] = raw_content_sha256(raw_case["raw_content"])
+    truth_case["boundaries"][0]["type"] = "noise"
+    truth_case["gold_atoms"][0]["evidence"]["goal"] = [3]
+
+    validate_truth_suite(truth_suite, raw_suite)
 
 
 def test_evidence_reference_must_stay_inside_its_atom(raw_suite, truth_suite):


### PR DESCRIPTION
## Summary

建立 raw-only Formation 数据契约，使 Formation runner 只能接收原始 Session，而 Gold 边界、来源任务、证据、终态和学习资格只由独立 scorer 读取。

本 PR 只增加离线评测 schema、验证器和 fixture，不修改生产 TaskAgent、AtomTask 或 Skill 行为。

## Changes

- 增加物理分离的 raw suite 与 truth suite，并使用严格字段白名单和固定 schema version。
- Formation payload 把原始 case id 映射为无语义顺序号，避免场景名称泄漏。
- Scorer 使用原文 SHA、suite id 和完整 case 集合绑定 truth，并保留隐藏来源与组合场景。
- 校验每个内部用户候选边界、连续 Atom 覆盖、split 决策、证据行归属、已知终态证据和学习资格字段。
- 固定 v1 结构化用户回合语法，将机器噪声作为 `keep/noise` 硬负例，并严格校验 schema version 类型。
- 增加两条隐私安全 fixture、37 个契约测试和 raw/scorer CLI 使用说明。

## Test plan

- [ ] `make test` passes
- [x] Added/updated unit tests for the change
- [ ] `make e2e` passes (if the change touches ingestion / install / daemon)
- [x] Manually verified the affected user flow

本机没有裸 `python3.11` 命令，因此未勾选字面命令 `make test`，使用同一 Makefile 目标 `make test PY=.venv/bin/python` 在 Python 3.14.6 上得到 `2772 passed, 10 skipped`。

聚焦测试 `python -m pytest tests/test_algorithm_replay.py tests/test_formation_data_contract.py -q` 得到 `64 passed`。

Ruff 聚焦检查通过。

手动运行 `formation_data payload` 确认输出只含无语义 case id 与原始内容，并运行 `formation_data validate` 确认两个 fixture case 通过哈希和标注不变量校验。

E2E 不适用，因为本 PR 不修改 ingestion、install、daemon 或生产流水线。

## Linked issues

Refs #327
Closes #376

## 给外人看的背景（raw-only 数据与打分隔离是什么）

下面按给第三方看的问题单来写：每个词第一次出现都会说明它是什么。代码位置只是提示，不是必须先读完整个仓库才能看懂。

### 这是什么

XSkill 平时学技能，走的是这条主路：先把一次连续对话收成 Session，再切成 Atom，Atom 进入候选，攒够了再写成 Skill。Session 就是一次连续对话。Atom 是里面意图相对单一的一小段。Skill 是后来写给助手用的说明书。

Q1 是后面那组评测：换一种方式去形成技能，会不会比只看整段 Session 或单个 Atom 更好。形成技能的那条被评测算法，这里叫 Formation。本 PR 还不跑 Formation，也不给它打效果分。它先把「算法能看见的输入」和「打分用的标准答案」拆开，免得后面一打分，分不清算法是自己看懂了对话，还是偷看了标注。

算法开跑时只能看 raw。raw 就是多轮对话原文：用户问、助手答、中间的工具行，按行排好。raw 里没有「这里该切开」，也没有「这段是标准 Atom」。

打分的程序叫 scorer。它只在事后打开另一份文件，叫 truth。truth 里才有人工标好的边界、gold atom 和 evidence。边界是「这一行用户话要不要切开」。gold atom 是人工认为正确的那段 Atom，用起止行号标在原文上。evidence 是「这句话为什么算目标、动作或结果」，也用原文行号指回去。

两份文件用 `raw_sha256` 钉在一起。这是原文的固定指纹：多一个字、少一行，指纹就变。truth 里记下的指纹必须和当前 raw 对上。有人改了对话还拿旧标注继续算，校验会拒绝，避免标准和原文对不上。

所以本 PR 不是数据集本身的效果实验。入仓的两条小样本只用来证明：算法侧读不到标注，打分侧能对上原文，行号落在所属片段里。不能拿它们宣称「这套数据上形成技能更好」，也不能当成 Q1 已经测出效果。

### 评测侧实际发生了什么

评测的人准备两份文件。一份是 `formation_raw_v1.json`，每个 case 只有编号和 `raw_content`。另一份是 `formation_truth_v1.json`，是同一批 case 的标注，不重复抄原文。

真正交给 Formation 的不是 raw 文件原样。命令 `formation_data payload` 只读 raw，打出更瘦的一包：原来的 `formation-001` 变成没有含义的 `case-000001`，`formation-002` 变成 `case-000002`。数据集名字、来源地址、许可证还留在 raw 文件的清单里，但这包输出里没有清单，命令行上也没有 truth 路径。Formation 即使想打开标准答案，这条命令也给不了。

scorer 用另一条命令 `formation_data validate`，同时打开 raw 和 truth。它先看两份是不是同一套（套件编号相同，case 集合对得上），再按原文算出 `raw_sha256`，和 truth 里记下的指纹比对。对不上就停，不许打分。

### 两份文件分别长什么样

第一份对话 `formation-001` 的 raw 按行长这样：

```
<!-- xskill:harness=fixture -->
## Initial Query
请迁移 SQLite 表结构。
## Assistant
我会先检查现有表结构。
## Tool
旧表使用 atom_id 单列主键。
## Assistant
迁移已完成，历史记录全部保留。
## User
现在验证迁移后的约束和索引。
## Assistant
我会执行结构与查询计划检查。
## Tool
联合主键和目标索引均符合预期。
## Assistant
迁移结果验证完成。
```

第 3 行是用户问「请迁移 SQLite 表结构。」第 5 行是助手答，第 7 行是工具回报。第 10 行出现下一条用户头 `## User`，第 11 行用户改口问「现在验证迁移后的约束和索引。」

truth 不抄这段正文。它只写：第 10 行标成 split，类型是 new_goal，意思是这里切开，前面是迁移，后面是验证。gold atom 有两条。第一条从第 1 行到第 10 行，第 10 行本身算下一段的开头，不算进上一段；目标证据指向第 3 行，动作在第 5 行，工具回报在第 7 行，结果在第 9 行。第二条从第 10 行接到文件末尾，目标证据指向第 11 行。

第二份 `formation-002` 用户先问「请修复电子表格导出。」后来又说「导出的列顺序也要保持不变。」truth 在第 8 行那条用户头上标成 keep，类型是 clarify：补充要求还是同一件事，不要切开。整段只标一个 gold atom。

算法那边看见的是换过号的 `case-000001`、`case-000002`，加上上面那些用户问、助手答、工具行。它看不见 split，看不见 gold atom，也看不见「这是从迁移接到验证」这类来源说明。

### 合本 PR 之前缺了什么

对照 #375。#375 是 Q1 评测链上更前面的一张：把真实模型的拆分和路由录下来，CI 只回放已经录好的结果，不调模型。那套回放文件里，源行、人工 gold Atom 和模型预测还在同一份 fixture 里。录制代码可以自己挑字段去拼提示词，但没有从文件结构上保证：形成技能的算法开跑时，手里绝对拿不到标准答案。

如果 case 名称写成 new-goal、retry 这种，或者边界、证据行号、终态、学习资格漏进 Formation 的输入，后面算出的分就可能是「算法看见了标注」，不是「算法只看了对话原文」。原文改过之后如果还用旧标注，分数也会打到已经对不上的对话上。本 PR 用指纹把标注钉在某一份原文上，就是为了挡住这件事。

### 本 PR 具体改哪

新增 `scripts/bench/algorithm_replay/formation_data.py`。`payload` 只从 raw 生成 Formation 输入；`validate` 只给 scorer 用，用来核对 raw 和 truth。

新增两条 fixture：`formation_raw_v1.json` 和 `formation_truth_v1.json`。raw 只允许编号和原文；truth 只允许指纹、来源、边界、gold atom。两边字段不能混放：raw 里出现 gold atom 会失败，truth 里出现原文也会失败。

`payload` 把原始编号映射成 `case-000001` 这种顺序号。原始编号和映射只留在 scorer 一侧。

校验会看：每个内部用户头都标了 split 还是 keep；gold atom 从第一行连续接到文件末尾，中间起点必须正好是标了 split 的那些行；证据行必须落在所属 atom 的原文范围内，不能指到空行或 `##` 标题行。结构合法、但生产现在会滤掉的机器噪声回合，仍可以留在 truth 里标成 keep，类型写 noise，当作打分时应当判成「不要在这里切开」的反面例子。不把当前生产过滤结果写成标准事实。

生产 TaskAgent、AtomTask、Skill 行为没有改。#375 那套已经入仓的回放 fixture 和报告也没有改。

### 不要和什么搞混

不要和 #375 搞混。#375 回答「模型跑过一次拆分和路由之后，分数能不能复现」。本 PR 回答「形成技能时能不能看见标准答案」。两张 PR 只在 `scripts/bench/algorithm_replay/README.md` 上碰头，其余文件分开。

不要和 #379、#385 搞混。#379 看的是任务图有没有把相关片段收对。#385 才问：用任务图去形成技能，会不会比只看整段 Session 或单个 Atom 更有效。本 PR 不产生那种效果分数。

也不要把它理解成改了现网拆分。Agent 接触不到格力内网现网。这张补丁只往仓库里加离线评测文件和校验脚本，合进 main 之后，现网侧不升级也不会多出任何线上行为。

### 怎么算这段背景对齐了

能说出 raw 是多轮对话原文，truth 是打分用的标准答案，两份不在同一个文件里。能举出 fixture 里的具体形状：用户问在哪一行，助手答和工具行在哪，第 10 行标 split 切成两条 gold atom，第 8 行标 keep 仍是一条。能说出 `raw_sha256` 是防原文和标注对不上，不是用来给技能打质量分。

能说出这不是数据集本身的效果实验：两条小样本只证明分开读和校验能跑通。

CI 现状：14 项通过。一次历史 Windows `ut+it`（windows-latest，Python 3.11）超时。审阅时请先重跑这一项，不要把这次历史超时先当成失败、据此拒绝合入。
