### PR TITLE
test(tasks): benchmark Task linker structure against Session and Atom baselines

### DIFF
--- a/scripts/bench/task_graph_replay/README.md
+++ b/scripts/bench/task_graph_replay/README.md
@@ -10,6 +10,24 @@ python -m scripts.bench.task_graph_replay.evaluate scripts/bench/task_graph_repl
 
 使用 `--format json` 可以输出机器可读报告，测试会将结果与 `baseline_v1.report.json` 比较，因此指标定义变化必须作为可见 diff 接受 review。
 
+运行生产 linker 的结构评测：
+
+```bash
+python -m scripts.bench.task_graph_replay.evaluate_linker scripts/bench/task_graph_replay/fixtures/linker_structure_v1.json
+```
+
+这份结构评测直接调用当前 `BoundedTaskLinker`，同时计算 Session-as-Task、Atom-as-Task、Task Graph 自动结果和 oracle review upper bound 的 Task grouping 指标，并报告 proposed membership 的 precision、漏拆分对可恢复率、每 Atom 候选数、Attempt 数量和 Attempt relation F1。
+
+同一个结构 case 内的全部 Session 共享一个 TaskScope，`source_scope_id` 和 `traj_id` 仍保持独立，因此跨 Session case 检查的是 linker 在合法 TaskScope 内的关联能力，不会绕过租户、actor 或 workspace 隔离边界。
+
+一个 proposed membership 只有在目标 confirmed Task 的全部现存 Atom 都属于该 Atom 的 gold Task 时才计为 useful，避免把指向已误合并 Task 的危险候选算作正确候选。
+
+`oracle review upper bound` 只合并 gold 判定正确的 proposed membership，用于衡量当前候选集在理想审核下能恢复多少错误，它使用 gold 信息，不是自动算法分数，也不能作为线上效果宣称。
+
+Task grouping 通过 contingency table 线性累计，proposal 可恢复对按有界候选连接的 Task 对聚合，不物化全部 Atom pair。
+
+`linker_structure_v1.json` 是覆盖 A→B→A、跨 Session 显式/隐式延续、相似负例、新目标、重试、纠正和多 Skill Atom 的小规模合成结构 pilot；它用于锁定指标、风险和生产 linker 行为，不替代后续 50–100 个经人工复核的代表性离线样本。
+
 ## Fixture 契约
 
 根对象包含版本号、指标配置、运行清单和多个脱敏 case。

--- a/scripts/bench/task_graph_replay/README.md
+++ b/scripts/bench/task_graph_replay/README.md
@@ -16,15 +16,17 @@ python -m scripts.bench.task_graph_replay.evaluate scripts/bench/task_graph_repl
 python -m scripts.bench.task_graph_replay.evaluate_linker scripts/bench/task_graph_replay/fixtures/linker_structure_v1.json
 ```
 
-这份结构评测直接调用当前 `BoundedTaskLinker`，同时计算 Session-as-Task、Atom-as-Task、Task Graph 自动结果和 oracle review upper bound 的 Task grouping 指标，并报告 proposed membership 的 precision、漏拆分对可恢复率、每 Atom 候选数、Attempt 数量和 Attempt relation F1。
+这份结构评测直接调用当前 `BoundedTaskLinker`，同时计算 Session-as-Task、Atom-as-Task、Task Graph 自动结果和 oracle review upper bound 的 Task grouping 指标，并报告 proposed membership 的 precision、漏拆分对可恢复率、每 Atom 候选数、Attempt 数量和包含 evidence 端点的 Attempt relation F1。
 
 同一个结构 case 内的全部 Session 共享一个 TaskScope，`source_scope_id` 和 `traj_id` 仍保持独立，因此跨 Session case 检查的是 linker 在合法 TaskScope 内的关联能力，不会绕过租户、actor 或 workspace 隔离边界。
 
-一个 proposed membership 只有在目标 confirmed Task 的全部现存 Atom 都属于该 Atom 的 gold Task 时才计为 useful，避免把指向已误合并 Task 的危险候选算作正确候选。
+一个 proposed membership 只有在源和目标 confirmed Task 都是同一个 gold Task 的纯净片段时才计为 useful，避免把来自或指向已误合并 Task 的危险候选算作正确候选。
 
-`oracle review upper bound` 只合并 gold 判定正确的 proposed membership，用于衡量当前候选集在理想审核下能恢复多少错误，它使用 gold 信息，不是自动算法分数，也不能作为线上效果宣称。
+`oracle review upper bound` 只合并由 gold 判定为同一任务的纯净 Task 片段，用于衡量当前候选集在理想审核下能恢复多少错误，它使用 gold 信息，不是自动算法分数，也不能作为线上效果宣称。
 
-Task grouping 通过 contingency table 线性累计，proposal 可恢复对按有界候选连接的 Task 对聚合，不物化全部 Atom pair。
+Task grouping 通过 contingency table 线性累计，confirmed Task 的 gold 纯度只预计算一次，proposal 判断保持 O(Atom + proposal)，可恢复对直接取 oracle review 前后正确 pair 的差值，不物化全部 Atom pair。
+
+结构 fixture 的 Attempt relation 使用 `from_evidence` 和 `to_evidence` 记录 Atom id 与半开行区间，指标联合比较两个 evidence 端点、relation type 和 decision，并拒绝跨 gold Task 的关系。
 
 `linker_structure_v1.json` 是覆盖 A→B→A、跨 Session 显式/隐式延续、相似负例、新目标、重试、纠正和多 Skill Atom 的小规模合成结构 pilot；它用于锁定指标、风险和生产 linker 行为，不替代后续 50–100 个经人工复核的代表性离线样本。
 

--- a/scripts/bench/task_graph_replay/evaluate_linker.py
+++ b/scripts/bench/task_graph_replay/evaluate_linker.py
@@ -13,7 +13,12 @@ from typing import Any
 from xskill.pipeline.atom import AtomTask
 from xskill.tasks.evidence import ScopedAtomEvidence, ScopedTrajectoryEvidence
 from xskill.tasks.linker import BoundedTaskLinker
-from xskill.tasks.models import ATTEMPT_RELATION_TYPES, AtomRef, SessionRef
+from xskill.tasks.models import (
+    ATTEMPT_RELATION_TYPES,
+    AtomRef,
+    SessionRef,
+    TaskAttempt,
+)
 from xskill.tasks.scopes import ScopeIdentity
 
 SCHEMA_VERSION = 1
@@ -51,7 +56,9 @@ def validate_suite(suite: Any) -> None:
         raise LinkerReplayValidationError(
             f"suite.schema_version: supported={SCHEMA_VERSION}, got={version}"
         )
-    _require(suite, "suite_id", str, "suite")
+    suite_id = _require(suite, "suite_id", str, "suite")
+    if not suite_id.strip():
+        raise LinkerReplayValidationError("suite.suite_id: expected a non-empty string")
     manifest = _require(suite, "run_manifest", dict, "suite")
     for key in ("repository_revision", "generated_at", "fixture_kind"):
         if not _require(manifest, key, str, "suite.run_manifest"):
@@ -85,6 +92,7 @@ def validate_suite(suite: Any) -> None:
         if not sessions:
             raise LinkerReplayValidationError(f"{context}.sessions must not be empty")
         atom_ids: set[str] = set()
+        atom_ranges: dict[str, tuple[int, int]] = {}
         session_ids: set[tuple[str, str]] = set()
         for session_index, session in enumerate(sessions):
             session_context = f"{context}.sessions[{session_index}]"
@@ -109,6 +117,7 @@ def validate_suite(suite: Any) -> None:
                 raise LinkerReplayValidationError(
                     f"{session_context}.atoms must not be empty"
                 )
+            offset = 1
             for atom_index, atom in enumerate(atoms):
                 atom_context = f"{session_context}.atoms[{atom_index}]"
                 if not isinstance(atom, dict):
@@ -126,9 +135,13 @@ def validate_suite(suite: Any) -> None:
                         raise LinkerReplayValidationError(
                             f"{atom_context}.{key}: expected a non-empty string"
                         )
-                skills = atom.get("skills") or []
+                raw_segment = atom["raw_segment"]
+                span = max(1, len(raw_segment.splitlines()))
+                atom_ranges[atom_id] = (offset, offset + span)
+                offset += span
+                skills = atom.get("skills", [])
                 if not isinstance(skills, list) or not all(
-                    isinstance(skill, str) and skill for skill in skills
+                    isinstance(skill, str) and skill.strip() for skill in skills
                 ):
                     raise LinkerReplayValidationError(
                         f"{atom_context}.skills: expected non-empty strings"
@@ -174,6 +187,57 @@ def validate_suite(suite: Any) -> None:
             if decision not in ATTEMPT_DECISIONS:
                 raise LinkerReplayValidationError(
                     f"{relation_context}.decision: unsupported value {decision!r}"
+                )
+            endpoint_signatures = []
+            for endpoint in ("from_evidence", "to_evidence"):
+                evidence_specs = _require(relation, endpoint, list, relation_context)
+                if not evidence_specs:
+                    raise LinkerReplayValidationError(
+                        f"{relation_context}.{endpoint}: must not be empty"
+                    )
+                signature = []
+                for evidence_index, evidence in enumerate(evidence_specs):
+                    evidence_context = (
+                        f"{relation_context}.{endpoint}[{evidence_index}]"
+                    )
+                    if not isinstance(evidence, dict):
+                        raise LinkerReplayValidationError(
+                            f"{evidence_context}: expected an object"
+                        )
+                    atom_id = _require(evidence, "atom_id", str, evidence_context)
+                    start = _require(evidence, "start", int, evidence_context)
+                    end = _require(evidence, "end", int, evidence_context)
+                    if atom_id not in atom_ranges:
+                        raise LinkerReplayValidationError(
+                            f"{evidence_context}.atom_id: unknown Atom {atom_id!r}"
+                        )
+                    atom_start, atom_end = atom_ranges[atom_id]
+                    if not atom_start <= start < end <= atom_end:
+                        raise LinkerReplayValidationError(
+                            f"{evidence_context}: range must stay within "
+                            f"[{atom_start}, {atom_end})"
+                        )
+                    signature.append((atom_id, start, end))
+                if len(set(signature)) != len(signature):
+                    raise LinkerReplayValidationError(
+                        f"{relation_context}.{endpoint}: duplicate evidence range"
+                    )
+                endpoint_signatures.append(tuple(sorted(signature)))
+            if endpoint_signatures[0] == endpoint_signatures[1]:
+                raise LinkerReplayValidationError(
+                    f"{relation_context}: Attempt relation endpoints must differ"
+                )
+            endpoint_gold_tasks = [
+                {gold_by_atom[atom_id] for atom_id, _start, _end in signature}
+                for signature in endpoint_signatures
+            ]
+            if (
+                len(endpoint_gold_tasks[0]) != 1
+                or endpoint_gold_tasks[0] != endpoint_gold_tasks[1]
+            ):
+                raise LinkerReplayValidationError(
+                    f"{relation_context}: Attempt relation endpoints must belong "
+                    "to the same gold Task"
                 )
 
 
@@ -385,42 +449,23 @@ def _proposal_counts(
     confirmed_clusters: dict[str, set[str]] = defaultdict(set)
     for atom_id, task_id in confirmed.items():
         confirmed_clusters[task_id].add(atom_id)
+    cluster_gold_tasks: dict[str, set[str]] = defaultdict(set)
+    for atom_id, task_id in confirmed.items():
+        cluster_gold_tasks[task_id].add(gold[atom_id])
     proposals_by_atom: dict[str, list[str]] = defaultdict(list)
     useful_proposals = []
-    useful_proposers: dict[tuple[str, str], set[str]] = defaultdict(set)
     for atom_id, candidate_task_id in proposed:
         proposals_by_atom[atom_id].append(candidate_task_id)
         candidate_atoms = confirmed_clusters.get(candidate_task_id, set())
+        source_task_id = confirmed[atom_id]
+        expected_gold = {gold[atom_id]}
         if (
             candidate_atoms
             and atom_id not in candidate_atoms
-            and all(
-                gold[other_atom_id] == gold[atom_id]
-                for other_atom_id in candidate_atoms
-            )
+            and cluster_gold_tasks[source_task_id] == expected_gold
+            and cluster_gold_tasks[candidate_task_id] == expected_gold
         ):
             useful_proposals.append((atom_id, candidate_task_id))
-            useful_proposers[(confirmed[atom_id], candidate_task_id)].add(atom_id)
-    gold_sizes = Counter(gold.values())
-    contingency = Counter((gold[atom_id], confirmed[atom_id]) for atom_id in gold)
-    gold_pair_count = sum(count * (count - 1) // 2 for count in gold_sizes.values())
-    confirmed_gold_pair_count = sum(
-        count * (count - 1) // 2 for count in contingency.values()
-    )
-    false_split_pair_count = gold_pair_count - confirmed_gold_pair_count
-    recoverable_pair_count = 0
-    task_pairs = {
-        tuple(sorted((source_task_id, candidate_task_id)))
-        for source_task_id, candidate_task_id in useful_proposers
-    }
-    for left_task_id, right_task_id in task_pairs:
-        left_proposers = useful_proposers.get((left_task_id, right_task_id), set())
-        right_proposers = useful_proposers.get((right_task_id, left_task_id), set())
-        recoverable_pair_count += (
-            len(left_proposers) * len(confirmed_clusters[right_task_id])
-            + len(right_proposers) * len(confirmed_clusters[left_task_id])
-            - len(left_proposers) * len(right_proposers)
-        )
 
     parent = {task_id: task_id for task_id in set(confirmed.values())}
 
@@ -439,6 +484,14 @@ def _proposal_counts(
     for atom_id, candidate_task_id in set(useful_proposals):
         union(confirmed[atom_id], candidate_task_id)
     oracle_review = {atom_id: find(task_id) for atom_id, task_id in confirmed.items()}
+    confirmed_counts = _partition_counts(gold, confirmed)
+    oracle_counts = _partition_counts(gold, oracle_review)
+    false_split_pair_count = (
+        confirmed_counts["gold_pairs"] - confirmed_counts["true_positive_pairs"]
+    )
+    recoverable_pair_count = (
+        oracle_counts["true_positive_pairs"] - confirmed_counts["true_positive_pairs"]
+    )
     return (
         {
             "proposed": len(proposed),
@@ -485,6 +538,58 @@ def _relation_counts(expected: Counter, predicted: Counter) -> dict:
         "false_positive": predicted_total - true_positive,
         "false_negative": expected_total - true_positive,
     }
+
+
+def _attempt_support(attempt: TaskAttempt) -> tuple[tuple[str, int, int], ...]:
+    return tuple(
+        sorted(
+            (
+                evidence.atom_ref.atom_id,
+                evidence.start,
+                evidence.end,
+            )
+            for evidence in attempt.evidence_ranges
+            if evidence.atom_ref is not None and not evidence.stale
+        )
+    )
+
+
+def _fixture_relation_key(relation: dict[str, Any]) -> tuple:
+    def endpoint(name: str) -> tuple[tuple[str, int, int], ...]:
+        return tuple(
+            sorted(
+                (item["atom_id"], item["start"], item["end"]) for item in relation[name]
+            )
+        )
+
+    return (
+        endpoint("from_evidence"),
+        endpoint("to_evidence"),
+        relation["relation_type"],
+        relation["decision"],
+    )
+
+
+def _public_relation_keys(relations: Counter) -> list[dict[str, Any]]:
+    result = []
+    for from_evidence, to_evidence, relation_type, decision in sorted(
+        relations.elements()
+    ):
+        result.append(
+            {
+                "from_evidence": [
+                    {"atom_id": atom_id, "start": start, "end": end}
+                    for atom_id, start, end in from_evidence
+                ],
+                "to_evidence": [
+                    {"atom_id": atom_id, "start": start, "end": end}
+                    for atom_id, start, end in to_evidence
+                ],
+                "relation_type": relation_type,
+                "decision": decision,
+            }
+        )
+    return result
 
 
 def _public_relation(counts: dict) -> dict:
@@ -548,11 +653,19 @@ def _evaluate_case(
         for name, predicted in baselines.items()
     }
     expected_relations = Counter(
-        (relation["relation_type"], relation["decision"])
+        _fixture_relation_key(relation)
         for relation in case["expected_attempt_relations"]
     )
+    attempt_support_by_id = {
+        attempt.attempt_id: _attempt_support(attempt) for attempt in generation.attempts
+    }
     predicted_relations = Counter(
-        (relation.relation_type, relation.decision)
+        (
+            attempt_support_by_id[relation.from_attempt_id],
+            attempt_support_by_id[relation.to_attempt_id],
+            relation.relation_type,
+            relation.decision,
+        )
         for relation in generation.attempt_relations
     )
     relation_counts = _relation_counts(expected_relations, predicted_relations)
@@ -573,14 +686,8 @@ def _evaluate_case(
             "absolute_error": abs(attempt_count - expected_attempt_count),
         },
         "attempt_relations": _public_relation(relation_counts),
-        "expected_attempt_relation_types": sorted(
-            f"{relation_type}:{decision}"
-            for relation_type, decision in expected_relations.elements()
-        ),
-        "predicted_attempt_relation_types": sorted(
-            f"{relation_type}:{decision}"
-            for relation_type, decision in predicted_relations.elements()
-        ),
+        "expected_attempt_relations": _public_relation_keys(expected_relations),
+        "predicted_attempt_relations": _public_relation_keys(predicted_relations),
     }
     raw_counts = {
         "grouping": grouping_counts,

--- a/scripts/bench/task_graph_replay/evaluate_linker.py
+++ b/scripts/bench/task_graph_replay/evaluate_linker.py
@@ -1,0 +1,726 @@
+"""Evaluate the production Task linker against structural grouping baselines."""
+
+from __future__ import annotations
+
+import argparse
+import hashlib
+import json
+from collections import Counter, defaultdict
+from datetime import datetime, timedelta, timezone
+from pathlib import Path
+from typing import Any
+
+from xskill.pipeline.atom import AtomTask
+from xskill.tasks.evidence import ScopedAtomEvidence, ScopedTrajectoryEvidence
+from xskill.tasks.linker import BoundedTaskLinker
+from xskill.tasks.models import ATTEMPT_RELATION_TYPES, AtomRef, SessionRef
+from xskill.tasks.scopes import ScopeIdentity
+
+SCHEMA_VERSION = 1
+ATTEMPT_DECISIONS = frozenset(("confirmed", "proposed"))
+
+
+class LinkerReplayValidationError(ValueError):
+    """Raised when a structural linker fixture violates its contract."""
+
+
+def _require(mapping: dict[str, Any], key: str, expected: type, context: str) -> Any:
+    if key not in mapping:
+        raise LinkerReplayValidationError(f"{context}: missing required field {key!r}")
+    value = mapping[key]
+    if expected is int and isinstance(value, bool):
+        raise LinkerReplayValidationError(f"{context}.{key}: expected int, got bool")
+    if not isinstance(value, expected):
+        raise LinkerReplayValidationError(
+            f"{context}.{key}: expected {expected.__name__}, got {type(value).__name__}"
+        )
+    return value
+
+
+def _positive_integer(value: Any, context: str) -> int:
+    if isinstance(value, bool) or not isinstance(value, int) or value <= 0:
+        raise LinkerReplayValidationError(f"{context}: expected a positive integer")
+    return value
+
+
+def validate_suite(suite: Any) -> None:
+    if not isinstance(suite, dict):
+        raise LinkerReplayValidationError("suite: expected an object")
+    version = _require(suite, "schema_version", int, "suite")
+    if version != SCHEMA_VERSION:
+        raise LinkerReplayValidationError(
+            f"suite.schema_version: supported={SCHEMA_VERSION}, got={version}"
+        )
+    _require(suite, "suite_id", str, "suite")
+    manifest = _require(suite, "run_manifest", dict, "suite")
+    for key in ("repository_revision", "generated_at", "fixture_kind"):
+        if not _require(manifest, key, str, "suite.run_manifest"):
+            raise LinkerReplayValidationError(
+                f"suite.run_manifest.{key}: expected a non-empty string"
+            )
+    linker_config = _require(suite, "linker_config", dict, "suite")
+    expected_config_keys = {"top_k", "recent_k", "posting_cap"}
+    if set(linker_config) != expected_config_keys:
+        raise LinkerReplayValidationError(
+            f"suite.linker_config: expected exactly {sorted(expected_config_keys)!r}"
+        )
+    for key in ("top_k", "recent_k", "posting_cap"):
+        _positive_integer(
+            _require(linker_config, key, int, "suite.linker_config"),
+            f"suite.linker_config.{key}",
+        )
+    cases = _require(suite, "cases", list, "suite")
+    if not cases:
+        raise LinkerReplayValidationError("suite.cases must not be empty")
+    seen_case_ids: set[str] = set()
+    for case_index, case in enumerate(cases):
+        context = f"suite.cases[{case_index}]"
+        if not isinstance(case, dict):
+            raise LinkerReplayValidationError(f"{context}: expected an object")
+        case_id = _require(case, "case_id", str, context)
+        if not case_id or case_id in seen_case_ids:
+            raise LinkerReplayValidationError(f"{context}.case_id: empty or duplicate")
+        seen_case_ids.add(case_id)
+        sessions = _require(case, "sessions", list, context)
+        if not sessions:
+            raise LinkerReplayValidationError(f"{context}.sessions must not be empty")
+        atom_ids: set[str] = set()
+        session_ids: set[tuple[str, str]] = set()
+        for session_index, session in enumerate(sessions):
+            session_context = f"{context}.sessions[{session_index}]"
+            if not isinstance(session, dict):
+                raise LinkerReplayValidationError(
+                    f"{session_context}: expected an object"
+                )
+            source_scope_id = _require(session, "source_scope_id", str, session_context)
+            traj_id = _require(session, "traj_id", str, session_context)
+            if not source_scope_id or not traj_id:
+                raise LinkerReplayValidationError(
+                    f"{session_context}: source_scope_id and traj_id must be non-empty"
+                )
+            session_key = source_scope_id, traj_id
+            if session_key in session_ids:
+                raise LinkerReplayValidationError(
+                    f"{session_context}: duplicate source_scope_id/traj_id"
+                )
+            session_ids.add(session_key)
+            atoms = _require(session, "atoms", list, session_context)
+            if not atoms:
+                raise LinkerReplayValidationError(
+                    f"{session_context}.atoms must not be empty"
+                )
+            for atom_index, atom in enumerate(atoms):
+                atom_context = f"{session_context}.atoms[{atom_index}]"
+                if not isinstance(atom, dict):
+                    raise LinkerReplayValidationError(
+                        f"{atom_context}: expected an object"
+                    )
+                atom_id = _require(atom, "atom_id", str, atom_context)
+                if not atom_id or atom_id in atom_ids:
+                    raise LinkerReplayValidationError(
+                        f"{atom_context}.atom_id: empty or duplicate"
+                    )
+                atom_ids.add(atom_id)
+                for key in ("intent", "summary", "raw_segment"):
+                    if not _require(atom, key, str, atom_context):
+                        raise LinkerReplayValidationError(
+                            f"{atom_context}.{key}: expected a non-empty string"
+                        )
+                skills = atom.get("skills") or []
+                if not isinstance(skills, list) or not all(
+                    isinstance(skill, str) and skill for skill in skills
+                ):
+                    raise LinkerReplayValidationError(
+                        f"{atom_context}.skills: expected non-empty strings"
+                    )
+        gold = _require(case, "gold_memberships", list, context)
+        gold_by_atom: dict[str, str] = {}
+        for membership_index, membership in enumerate(gold):
+            membership_context = f"{context}.gold_memberships[{membership_index}]"
+            if not isinstance(membership, dict):
+                raise LinkerReplayValidationError(
+                    f"{membership_context}: expected an object"
+                )
+            atom_id = _require(membership, "atom_id", str, membership_context)
+            task_id = _require(membership, "task_id", str, membership_context)
+            if atom_id not in atom_ids or atom_id in gold_by_atom or not task_id:
+                raise LinkerReplayValidationError(
+                    f"{membership_context}: invalid Atom membership"
+                )
+            gold_by_atom[atom_id] = task_id
+        if set(gold_by_atom) != atom_ids:
+            raise LinkerReplayValidationError(
+                f"{context}.gold_memberships: every Atom needs one membership"
+            )
+        expected_attempts = _require(case, "expected_attempt_count", int, context)
+        if expected_attempts < 0:
+            raise LinkerReplayValidationError(
+                f"{context}.expected_attempt_count must be non-negative"
+            )
+        relations = _require(case, "expected_attempt_relations", list, context)
+        for relation_index, relation in enumerate(relations):
+            relation_context = f"{context}.expected_attempt_relations[{relation_index}]"
+            if not isinstance(relation, dict):
+                raise LinkerReplayValidationError(
+                    f"{relation_context}: expected an object"
+                )
+            relation_type = _require(relation, "relation_type", str, relation_context)
+            if relation_type not in ATTEMPT_RELATION_TYPES:
+                raise LinkerReplayValidationError(
+                    f"{relation_context}.relation_type: unsupported value "
+                    f"{relation_type!r}"
+                )
+            decision = _require(relation, "decision", str, relation_context)
+            if decision not in ATTEMPT_DECISIONS:
+                raise LinkerReplayValidationError(
+                    f"{relation_context}.decision: unsupported value {decision!r}"
+                )
+
+
+def load_suite(path: Path | str) -> dict[str, Any]:
+    suite_path = Path(path)
+    try:
+        suite = json.loads(suite_path.read_text(encoding="utf-8"))
+    except json.JSONDecodeError as error:
+        raise LinkerReplayValidationError(
+            f"invalid JSON in {suite_path}: {error}"
+        ) from error
+    validate_suite(suite)
+    return suite
+
+
+def _hash(value: Any) -> str:
+    payload = json.dumps(
+        value, ensure_ascii=False, sort_keys=True, separators=(",", ":")
+    ).encode("utf-8")
+    return hashlib.sha256(payload).hexdigest()
+
+
+def _compile_case(case: dict[str, Any], case_index: int):
+    tenant_id = "tenant-linker-replay"
+    task_scope_id = f"task-scope-{case['case_id']}"
+    scope = ScopeIdentity(
+        tenant_id=tenant_id,
+        task_scope_id=task_scope_id,
+        source_scope_id="source-placeholder",
+        actor_id="actor-linker-replay",
+        workspace_id=f"workspace-{case['case_id']}",
+    )
+    trajectories = []
+    session_assignment = {}
+    atom_ids = []
+    base_time = datetime(2026, 8, 30, tzinfo=timezone.utc) + timedelta(
+        minutes=case_index
+    )
+    for session_index, session in enumerate(case["sessions"]):
+        source_scope_id = session["source_scope_id"]
+        traj_id = session["traj_id"]
+        session_scope = ScopeIdentity(
+            tenant_id=scope.tenant_id,
+            task_scope_id=scope.task_scope_id,
+            source_scope_id=source_scope_id,
+            actor_id=scope.actor_id,
+            workspace_id=scope.workspace_id,
+        )
+        session_ref = SessionRef(
+            tenant_id=tenant_id,
+            task_scope_id=task_scope_id,
+            source_scope_id=source_scope_id,
+            traj_id=traj_id,
+        )
+        observed_at = (base_time + timedelta(seconds=session_index)).isoformat()
+        atom_specs = session["atoms"]
+        atoms = []
+        session_atom_ids = []
+        offset = 1
+        for atom_index, atom_spec in enumerate(atom_specs):
+            atom_id = atom_spec["atom_id"]
+            raw_segment = atom_spec["raw_segment"]
+            span = max(1, len(raw_segment.splitlines()))
+            atom = AtomTask(
+                atom_id=atom_id,
+                traj_id=traj_id,
+                offset_start=offset,
+                offset_end=offset + span,
+                intent=atom_spec["intent"],
+                summary=atom_spec["summary"],
+                used_skills=list(atom_spec.get("skills") or ()),
+                pre_atom_id=(
+                    atom_specs[atom_index - 1]["atom_id"] if atom_index > 0 else None
+                ),
+                post_atom_id=(
+                    atom_specs[atom_index + 1]["atom_id"]
+                    if atom_index + 1 < len(atom_specs)
+                    else None
+                ),
+                raw_segment=raw_segment,
+                source_model="recorded-fixture",
+            )
+            atom_ref = AtomRef(
+                tenant_id=tenant_id,
+                task_scope_id=task_scope_id,
+                source_scope_id=source_scope_id,
+                traj_id=traj_id,
+                atom_id=atom_id,
+            )
+            atoms.append(
+                ScopedAtomEvidence(
+                    atom=atom,
+                    atom_ref=atom_ref,
+                    atom_hash=_hash({"intent": atom.intent, "summary": atom.summary}),
+                    session_hash=_hash(
+                        {"source_scope_id": source_scope_id, "traj_id": traj_id}
+                    ),
+                    source_model={
+                        "provider": "fixture",
+                        "model_id": "recorded-fixture",
+                    },
+                    source_harness={"name": "offline-linker-replay"},
+                    observed_at=observed_at,
+                )
+            )
+            session_assignment[atom_id] = f"{source_scope_id}:{traj_id}"
+            atom_ids.append(atom_id)
+            session_atom_ids.append(atom_id)
+            offset += span
+        session_hash = _hash(
+            {
+                "source_scope_id": source_scope_id,
+                "traj_id": traj_id,
+                "atoms": session_atom_ids,
+            }
+        )
+        trajectories.append(
+            ScopedTrajectoryEvidence(
+                watch_dir_id=session_index + 1,
+                watch_dir_path=Path(f"/fixture/{source_scope_id}"),
+                filename=f"{traj_id}.md",
+                scope=session_scope,
+                session_ref=session_ref,
+                session_hash=session_hash,
+                metadata={},
+                atoms=tuple(atoms),
+                usage_events=(),
+                explicit_outcome={},
+            )
+        )
+    return tuple(trajectories), session_assignment, atom_ids
+
+
+def _partition_counts(gold: dict[str, str], predicted: dict[str, str]) -> dict:
+    gold_sizes = Counter(gold.values())
+    predicted_sizes = Counter(predicted.values())
+    contingency = Counter((gold[atom_id], predicted[atom_id]) for atom_id in gold)
+    true_positive_pairs = sum(
+        count * (count - 1) // 2 for count in contingency.values()
+    )
+    gold_pairs = sum(count * (count - 1) // 2 for count in gold_sizes.values())
+    predicted_pairs = sum(
+        count * (count - 1) // 2 for count in predicted_sizes.values()
+    )
+    b3_precision_sum = 0.0
+    b3_recall_sum = 0.0
+    for atom_id, gold_task_id in gold.items():
+        predicted_task_id = predicted[atom_id]
+        overlap = contingency[(gold_task_id, predicted_task_id)]
+        b3_precision_sum += overlap / predicted_sizes[predicted_task_id]
+        b3_recall_sum += overlap / gold_sizes[gold_task_id]
+    return {
+        "atom_count": len(gold),
+        "gold_pairs": gold_pairs,
+        "predicted_pairs": predicted_pairs,
+        "true_positive_pairs": true_positive_pairs,
+        "b3_precision_sum": b3_precision_sum,
+        "b3_recall_sum": b3_recall_sum,
+    }
+
+
+def _ratio(numerator: float, denominator: float, *, empty: float = 1.0) -> float:
+    return round(numerator / denominator, 6) if denominator else empty
+
+
+def _public_partition(counts: dict) -> dict:
+    true_positive = counts["true_positive_pairs"]
+    false_positive = counts["predicted_pairs"] - true_positive
+    false_negative = counts["gold_pairs"] - true_positive
+    precision = _ratio(true_positive, true_positive + false_positive)
+    recall = _ratio(true_positive, true_positive + false_negative)
+    pairwise_f1 = (
+        2 * precision * recall / (precision + recall) if precision + recall else 0.0
+    )
+    b3_precision = _ratio(counts["b3_precision_sum"], counts["atom_count"])
+    b3_recall = _ratio(counts["b3_recall_sum"], counts["atom_count"])
+    b3_f1 = (
+        2 * b3_precision * b3_recall / (b3_precision + b3_recall)
+        if b3_precision + b3_recall
+        else 0.0
+    )
+    return {
+        "pairwise": {
+            "true_positive": true_positive,
+            "false_positive": false_positive,
+            "false_negative": false_negative,
+            "precision": precision,
+            "recall": recall,
+            "f1": round(pairwise_f1, 6),
+        },
+        "b3": {
+            "precision": b3_precision,
+            "recall": b3_recall,
+            "f1": round(b3_f1, 6),
+        },
+    }
+
+
+def _merge_partition_counts(target: dict, source: dict) -> None:
+    for key, value in source.items():
+        target[key] = target.get(key, 0) + value
+
+
+def _proposal_counts(
+    gold: dict[str, str],
+    confirmed: dict[str, str],
+    proposed: list[tuple[str, str]],
+) -> tuple[dict, dict[str, str]]:
+    confirmed_clusters: dict[str, set[str]] = defaultdict(set)
+    for atom_id, task_id in confirmed.items():
+        confirmed_clusters[task_id].add(atom_id)
+    proposals_by_atom: dict[str, list[str]] = defaultdict(list)
+    useful_proposals = []
+    useful_proposers: dict[tuple[str, str], set[str]] = defaultdict(set)
+    for atom_id, candidate_task_id in proposed:
+        proposals_by_atom[atom_id].append(candidate_task_id)
+        candidate_atoms = confirmed_clusters.get(candidate_task_id, set())
+        if (
+            candidate_atoms
+            and atom_id not in candidate_atoms
+            and all(
+                gold[other_atom_id] == gold[atom_id]
+                for other_atom_id in candidate_atoms
+            )
+        ):
+            useful_proposals.append((atom_id, candidate_task_id))
+            useful_proposers[(confirmed[atom_id], candidate_task_id)].add(atom_id)
+    gold_sizes = Counter(gold.values())
+    contingency = Counter((gold[atom_id], confirmed[atom_id]) for atom_id in gold)
+    gold_pair_count = sum(count * (count - 1) // 2 for count in gold_sizes.values())
+    confirmed_gold_pair_count = sum(
+        count * (count - 1) // 2 for count in contingency.values()
+    )
+    false_split_pair_count = gold_pair_count - confirmed_gold_pair_count
+    recoverable_pair_count = 0
+    task_pairs = {
+        tuple(sorted((source_task_id, candidate_task_id)))
+        for source_task_id, candidate_task_id in useful_proposers
+    }
+    for left_task_id, right_task_id in task_pairs:
+        left_proposers = useful_proposers.get((left_task_id, right_task_id), set())
+        right_proposers = useful_proposers.get((right_task_id, left_task_id), set())
+        recoverable_pair_count += (
+            len(left_proposers) * len(confirmed_clusters[right_task_id])
+            + len(right_proposers) * len(confirmed_clusters[left_task_id])
+            - len(left_proposers) * len(right_proposers)
+        )
+
+    parent = {task_id: task_id for task_id in set(confirmed.values())}
+
+    def find(task_id: str) -> str:
+        while parent[task_id] != task_id:
+            parent[task_id] = parent[parent[task_id]]
+            task_id = parent[task_id]
+        return task_id
+
+    def union(left: str, right: str) -> None:
+        left_root = find(left)
+        right_root = find(right)
+        if left_root != right_root:
+            parent[max(left_root, right_root)] = min(left_root, right_root)
+
+    for atom_id, candidate_task_id in set(useful_proposals):
+        union(confirmed[atom_id], candidate_task_id)
+    oracle_review = {atom_id: find(task_id) for atom_id, task_id in confirmed.items()}
+    return (
+        {
+            "proposed": len(proposed),
+            "useful": len(useful_proposals),
+            "false_split_pairs": false_split_pair_count,
+            "recoverable_false_split_pairs": recoverable_pair_count,
+            "atoms_with_proposals": len(proposals_by_atom),
+            "max_proposals_per_atom": max(
+                (len(candidates) for candidates in proposals_by_atom.values()),
+                default=0,
+            ),
+            "atom_count": len(gold),
+        },
+        oracle_review,
+    )
+
+
+def _public_proposals(counts: dict) -> dict:
+    return {
+        "proposed": counts["proposed"],
+        "useful": counts["useful"],
+        "precision": _ratio(counts["useful"], counts["proposed"], empty=1.0),
+        "false_split_pairs": counts["false_split_pairs"],
+        "recoverable_false_split_pairs": counts["recoverable_false_split_pairs"],
+        "recoverable_recall": _ratio(
+            counts["recoverable_false_split_pairs"],
+            counts["false_split_pairs"],
+            empty=1.0,
+        ),
+        "atoms_with_proposals": counts["atoms_with_proposals"],
+        "candidates_per_atom": _ratio(
+            counts["proposed"], counts["atom_count"], empty=0.0
+        ),
+        "max_proposals_per_atom": counts["max_proposals_per_atom"],
+    }
+
+
+def _relation_counts(expected: Counter, predicted: Counter) -> dict:
+    true_positive = sum((expected & predicted).values())
+    predicted_total = sum(predicted.values())
+    expected_total = sum(expected.values())
+    return {
+        "true_positive": true_positive,
+        "false_positive": predicted_total - true_positive,
+        "false_negative": expected_total - true_positive,
+    }
+
+
+def _public_relation(counts: dict) -> dict:
+    true_positive = counts["true_positive"]
+    false_positive = counts["false_positive"]
+    false_negative = counts["false_negative"]
+    precision = _ratio(true_positive, true_positive + false_positive)
+    recall = _ratio(true_positive, true_positive + false_negative)
+    f1 = 2 * precision * recall / (precision + recall) if precision + recall else 0.0
+    return {
+        **counts,
+        "precision": precision,
+        "recall": recall,
+        "f1": round(f1, 6),
+    }
+
+
+def _evaluate_case(
+    case: dict[str, Any],
+    case_index: int,
+    linker: BoundedTaskLinker,
+) -> tuple[dict, dict]:
+    trajectories, session_assignment, atom_ids = _compile_case(case, case_index)
+    generation = linker.build(
+        tenant_id="tenant-linker-replay",
+        task_scope_id=f"task-scope-{case['case_id']}",
+        trajectories=trajectories,
+        source_revision=f"sha256:{_hash(case)}",
+    )
+    gold = {
+        membership["atom_id"]: membership["task_id"]
+        for membership in case["gold_memberships"]
+    }
+    confirmed = {
+        membership.atom_ref.atom_id: membership.task_id
+        for membership in generation.memberships
+        if membership.role == "primary"
+        and membership.decision == "confirmed"
+        and not membership.stale
+    }
+    if set(confirmed) != set(gold):
+        raise RuntimeError(
+            f"{case['case_id']}: production linker omitted confirmed Atom memberships"
+        )
+    proposed = [
+        (membership.atom_ref.atom_id, membership.task_id)
+        for membership in generation.memberships
+        if membership.role == "primary"
+        and membership.decision == "proposed"
+        and not membership.stale
+    ]
+    proposal_counts, oracle_review = _proposal_counts(gold, confirmed, proposed)
+    baselines = {
+        "session_as_task": session_assignment,
+        "atom_as_task": {atom_id: atom_id for atom_id in atom_ids},
+        "task_graph": confirmed,
+        "task_graph_oracle_review": oracle_review,
+    }
+    grouping_counts = {
+        name: _partition_counts(gold, predicted)
+        for name, predicted in baselines.items()
+    }
+    expected_relations = Counter(
+        (relation["relation_type"], relation["decision"])
+        for relation in case["expected_attempt_relations"]
+    )
+    predicted_relations = Counter(
+        (relation.relation_type, relation.decision)
+        for relation in generation.attempt_relations
+    )
+    relation_counts = _relation_counts(expected_relations, predicted_relations)
+    expected_attempt_count = case["expected_attempt_count"]
+    attempt_count = len(generation.attempts)
+    case_report = {
+        "case_id": case["case_id"],
+        "atom_count": len(atom_ids),
+        "gold_task_count": len(set(gold.values())),
+        "predicted_task_count": len(set(confirmed.values())),
+        "grouping": {
+            name: _public_partition(counts) for name, counts in grouping_counts.items()
+        },
+        "proposals": _public_proposals(proposal_counts),
+        "attempts": {
+            "expected": expected_attempt_count,
+            "predicted": attempt_count,
+            "absolute_error": abs(attempt_count - expected_attempt_count),
+        },
+        "attempt_relations": _public_relation(relation_counts),
+        "expected_attempt_relation_types": sorted(
+            f"{relation_type}:{decision}"
+            for relation_type, decision in expected_relations.elements()
+        ),
+        "predicted_attempt_relation_types": sorted(
+            f"{relation_type}:{decision}"
+            for relation_type, decision in predicted_relations.elements()
+        ),
+    }
+    raw_counts = {
+        "grouping": grouping_counts,
+        "proposals": proposal_counts,
+        "relation": relation_counts,
+        "attempt_absolute_error": abs(attempt_count - expected_attempt_count),
+        "attempt_exact": int(attempt_count == expected_attempt_count),
+    }
+    return case_report, raw_counts
+
+
+def evaluate_suite(suite: dict[str, Any]) -> dict[str, Any]:
+    validate_suite(suite)
+    linker = BoundedTaskLinker(**suite["linker_config"])
+    case_results = [
+        _evaluate_case(case, index, linker) for index, case in enumerate(suite["cases"])
+    ]
+    merged_grouping: dict[str, dict] = defaultdict(dict)
+    merged_proposals = {
+        "proposed": 0,
+        "useful": 0,
+        "false_split_pairs": 0,
+        "recoverable_false_split_pairs": 0,
+        "atoms_with_proposals": 0,
+        "max_proposals_per_atom": 0,
+        "atom_count": 0,
+    }
+    merged_relations = {
+        "true_positive": 0,
+        "false_positive": 0,
+        "false_negative": 0,
+    }
+    attempt_absolute_error = 0
+    attempt_exact_cases = 0
+    for _case_report, counts in case_results:
+        for name, grouping_counts in counts["grouping"].items():
+            _merge_partition_counts(merged_grouping[name], grouping_counts)
+        for key, value in counts["proposals"].items():
+            if key == "max_proposals_per_atom":
+                merged_proposals[key] = max(merged_proposals[key], value)
+            else:
+                merged_proposals[key] += value
+        for key, value in counts["relation"].items():
+            merged_relations[key] += value
+        attempt_absolute_error += counts["attempt_absolute_error"]
+        attempt_exact_cases += counts["attempt_exact"]
+    report = {
+        "schema_version": SCHEMA_VERSION,
+        "suite_id": suite["suite_id"],
+        "run_manifest": suite["run_manifest"],
+        "linker": linker.generator_descriptor(),
+        "metrics": {
+            "grouping": {
+                name: _public_partition(counts)
+                for name, counts in sorted(merged_grouping.items())
+            },
+            "proposals": _public_proposals(merged_proposals),
+            "attempts": {
+                "case_count": len(case_results),
+                "exact_cases": attempt_exact_cases,
+                "exact_case_rate": _ratio(
+                    attempt_exact_cases, len(case_results), empty=0.0
+                ),
+                "absolute_error": attempt_absolute_error,
+            },
+            "attempt_relations": _public_relation(merged_relations),
+        },
+        "cases": [case_report for case_report, _counts in case_results],
+    }
+    canonical_report = json.loads(
+        json.dumps(report, ensure_ascii=False, sort_keys=True)
+    )
+    payload = json.dumps(canonical_report, ensure_ascii=False, sort_keys=True).encode(
+        "utf-8"
+    )
+    canonical_report["report_sha256"] = hashlib.sha256(payload).hexdigest()
+    return canonical_report
+
+
+def render_text(report: dict[str, Any]) -> str:
+    grouping = report["metrics"]["grouping"]
+    proposals = report["metrics"]["proposals"]
+    attempts = report["metrics"]["attempts"]
+    relations = report["metrics"]["attempt_relations"]
+    return "\n".join(
+        (
+            f"suite: {report['suite_id']}",
+            f"linker: {report['linker']['version']}",
+            (
+                "session_as_task "
+                f"pairwise_f1={grouping['session_as_task']['pairwise']['f1']:.3f} "
+                f"b3_f1={grouping['session_as_task']['b3']['f1']:.3f}"
+            ),
+            (
+                "atom_as_task "
+                f"pairwise_f1={grouping['atom_as_task']['pairwise']['f1']:.3f} "
+                f"b3_f1={grouping['atom_as_task']['b3']['f1']:.3f}"
+            ),
+            (
+                "task_graph "
+                f"pairwise_f1={grouping['task_graph']['pairwise']['f1']:.3f} "
+                f"b3_f1={grouping['task_graph']['b3']['f1']:.3f}"
+            ),
+            (
+                "oracle_review_upper_bound "
+                f"pairwise_f1={grouping['task_graph_oracle_review']['pairwise']['f1']:.3f} "
+                f"b3_f1={grouping['task_graph_oracle_review']['b3']['f1']:.3f}"
+            ),
+            (
+                f"proposal_precision={proposals['precision']:.3f} "
+                f"recoverable_recall={proposals['recoverable_recall']:.3f} "
+                f"candidates_per_atom={proposals['candidates_per_atom']:.3f}"
+            ),
+            (
+                f"attempt_exact_case_rate={attempts['exact_case_rate']:.3f} "
+                f"attempt_relation_f1={relations['f1']:.3f}"
+            ),
+            f"report_sha256={report['report_sha256']}",
+        )
+    )
+
+
+def _parser() -> argparse.ArgumentParser:
+    parser = argparse.ArgumentParser(
+        description="Evaluate xskill's production Task linker on structural cases."
+    )
+    parser.add_argument("suite", type=Path, help="Path to the linker replay JSON")
+    parser.add_argument("--format", choices=("text", "json"), default="text")
+    return parser
+
+
+def main(argv: list[str] | None = None) -> int:
+    args = _parser().parse_args(argv)
+    report = evaluate_suite(load_suite(args.suite))
+    if args.format == "json":
+        print(json.dumps(report, ensure_ascii=False, indent=2, sort_keys=True))
+    else:
+        print(render_text(report))
+    return 0
+
+
+if __name__ == "__main__":
+    raise SystemExit(main())

--- a/scripts/bench/task_graph_replay/fixtures/linker_structure_v1.json
+++ b/scripts/bench/task_graph_replay/fixtures/linker_structure_v1.json
@@ -81,7 +81,16 @@
       ],
       "expected_attempt_count": 3,
       "expected_attempt_relations": [
-        {"relation_type": "continuation_of", "decision": "proposed"}
+        {
+          "from_evidence": [
+            {"atom_id": "atom-auth-continue", "start": 11, "end": 16}
+          ],
+          "to_evidence": [
+            {"atom_id": "atom-auth-start", "start": 1, "end": 6}
+          ],
+          "relation_type": "continuation_of",
+          "decision": "proposed"
+        }
       ]
     },
     {
@@ -157,7 +166,16 @@
       ],
       "expected_attempt_count": 2,
       "expected_attempt_relations": [
-        {"relation_type": "continuation_of", "decision": "proposed"}
+        {
+          "from_evidence": [
+            {"atom_id": "atom-cache-continue", "start": 1, "end": 6}
+          ],
+          "to_evidence": [
+            {"atom_id": "atom-cache-analysis", "start": 1, "end": 6}
+          ],
+          "relation_type": "continuation_of",
+          "decision": "proposed"
+        }
       ]
     },
     {
@@ -264,7 +282,16 @@
       ],
       "expected_attempt_count": 2,
       "expected_attempt_relations": [
-        {"relation_type": "retry_of", "decision": "confirmed"}
+        {
+          "from_evidence": [
+            {"atom_id": "atom-concurrency-retry", "start": 6, "end": 11}
+          ],
+          "to_evidence": [
+            {"atom_id": "atom-concurrency-failed", "start": 1, "end": 6}
+          ],
+          "relation_type": "retry_of",
+          "decision": "confirmed"
+        }
       ]
     },
     {
@@ -289,7 +316,16 @@
       ],
       "expected_attempt_count": 2,
       "expected_attempt_relations": [
-        {"relation_type": "retry_of", "decision": "confirmed"}
+        {
+          "from_evidence": [
+            {"atom_id": "atom-intra-retry", "start": 7, "end": 12}
+          ],
+          "to_evidence": [
+            {"atom_id": "atom-intra-retry", "start": 1, "end": 7}
+          ],
+          "relation_type": "retry_of",
+          "decision": "confirmed"
+        }
       ]
     },
     {
@@ -314,7 +350,16 @@
       ],
       "expected_attempt_count": 2,
       "expected_attempt_relations": [
-        {"relation_type": "correction_of", "decision": "confirmed"}
+        {
+          "from_evidence": [
+            {"atom_id": "atom-export-correction", "start": 7, "end": 12}
+          ],
+          "to_evidence": [
+            {"atom_id": "atom-export-correction", "start": 1, "end": 7}
+          ],
+          "relation_type": "correction_of",
+          "decision": "confirmed"
+        }
       ]
     },
     {

--- a/scripts/bench/task_graph_replay/fixtures/linker_structure_v1.json
+++ b/scripts/bench/task_graph_replay/fixtures/linker_structure_v1.json
@@ -1,0 +1,375 @@
+{
+  "schema_version": 1,
+  "suite_id": "production-linker-structure-pilot-v1",
+  "run_manifest": {
+    "repository_revision": "b1e08786becab32b2c1289f20e59b42a6c243789",
+    "generated_at": "2026-08-30T00:00:00Z",
+    "fixture_kind": "synthetic-structural-pilot"
+  },
+  "linker_config": {
+    "top_k": 8,
+    "recent_k": 6,
+    "posting_cap": 64
+  },
+  "cases": [
+    {
+      "case_id": "same-session-new-goal",
+      "sessions": [
+        {
+          "source_scope_id": "source-codex",
+          "traj_id": "traj-new-goal",
+          "atoms": [
+            {
+              "atom_id": "atom-migrate",
+              "intent": "迁移 SQLite 表结构",
+              "summary": "迁移字段和历史数据",
+              "raw_segment": "## User\n迁移 SQLite 表结构。\n\n## Assistant\n字段和历史数据已经迁移。\n",
+              "skills": ["sqlite-migration"]
+            },
+            {
+              "atom_id": "atom-validate",
+              "intent": "验证迁移后的约束和索引",
+              "summary": "检查联合主键和索引",
+              "raw_segment": "## User\n验证迁移后的约束和索引。\n\n## Assistant\n联合主键和索引符合预期。\n",
+              "skills": ["sqlite-validation"]
+            }
+          ]
+        }
+      ],
+      "gold_memberships": [
+        {"atom_id": "atom-migrate", "task_id": "task-migrate"},
+        {"atom_id": "atom-validate", "task_id": "task-validate"}
+      ],
+      "expected_attempt_count": 2,
+      "expected_attempt_relations": []
+    },
+    {
+      "case_id": "same-session-a-b-a",
+      "sessions": [
+        {
+          "source_scope_id": "source-codex",
+          "traj_id": "traj-a-b-a",
+          "atoms": [
+            {
+              "atom_id": "atom-auth-start",
+              "intent": "修复登录认证失败",
+              "summary": "定位登录 token 校验错误",
+              "raw_segment": "## User\n修复登录认证失败。\n\n## Assistant\n已定位 token 校验错误。\n",
+              "skills": ["authentication-debugging"]
+            },
+            {
+              "atom_id": "atom-release-notes",
+              "intent": "编写版本发布说明",
+              "summary": "整理本次版本的文档变更",
+              "raw_segment": "## User\n编写版本发布说明。\n\n## Assistant\n已整理文档变更。\n",
+              "skills": ["documentation-maintenance"]
+            },
+            {
+              "atom_id": "atom-auth-continue",
+              "intent": "继续修复登录认证失败",
+              "summary": "修正 token 校验并验证登录测试",
+              "raw_segment": "## User\n继续修复登录认证失败。\n\n## Assistant\n已修正 token 校验并通过测试。\n",
+              "skills": ["authentication-debugging"]
+            }
+          ]
+        }
+      ],
+      "gold_memberships": [
+        {"atom_id": "atom-auth-start", "task_id": "task-auth"},
+        {"atom_id": "atom-release-notes", "task_id": "task-docs"},
+        {"atom_id": "atom-auth-continue", "task_id": "task-auth"}
+      ],
+      "expected_attempt_count": 3,
+      "expected_attempt_relations": [
+        {"relation_type": "continuation_of", "decision": "proposed"}
+      ]
+    },
+    {
+      "case_id": "cross-session-phase-shift",
+      "sessions": [
+        {
+          "source_scope_id": "source-codex",
+          "traj_id": "traj-index-analysis",
+          "atoms": [
+            {
+              "atom_id": "atom-index-analysis",
+              "intent": "优化数据库索引查询性能",
+              "summary": "分析数据库索引查询的慢路径",
+              "raw_segment": "## User\n优化数据库索引查询性能。\n\n## Assistant\n已分析慢查询路径。\n",
+              "skills": ["sqlite-validation"]
+            }
+          ]
+        },
+        {
+          "source_scope_id": "source-openclaw",
+          "traj_id": "traj-index-implementation",
+          "atoms": [
+            {
+              "atom_id": "atom-index-implementation",
+              "intent": "继续优化数据库索引查询性能",
+              "summary": "补充联合索引并复测慢查询",
+              "raw_segment": "## User\n继续优化数据库索引查询性能。\n\n## Assistant\n已补充联合索引并复测。\n",
+              "skills": ["sqlite-validation"]
+            }
+          ]
+        }
+      ],
+      "gold_memberships": [
+        {"atom_id": "atom-index-analysis", "task_id": "task-index"},
+        {"atom_id": "atom-index-implementation", "task_id": "task-index"}
+      ],
+      "expected_attempt_count": 2,
+      "expected_attempt_relations": []
+    },
+    {
+      "case_id": "cross-session-high-overlap",
+      "sessions": [
+        {
+          "source_scope_id": "source-codex",
+          "traj_id": "traj-cache-analysis",
+          "atoms": [
+            {
+              "atom_id": "atom-cache-analysis",
+              "intent": "优化缓存命中率和查询性能",
+              "summary": "分析缓存命中率和查询性能",
+              "raw_segment": "## User\n优化缓存命中率和查询性能。\n\n## Assistant\n已分析缓存命中率和查询性能。\n",
+              "skills": ["cache-analysis"]
+            }
+          ]
+        },
+        {
+          "source_scope_id": "source-codex",
+          "traj_id": "traj-cache-continue",
+          "atoms": [
+            {
+              "atom_id": "atom-cache-continue",
+              "intent": "继续优化缓存命中率和查询性能",
+              "summary": "继续分析缓存命中率和查询性能",
+              "raw_segment": "## User\n继续优化缓存命中率和查询性能。\n\n## Assistant\n已继续分析缓存命中率和查询性能。\n",
+              "skills": ["cache-analysis"]
+            }
+          ]
+        }
+      ],
+      "gold_memberships": [
+        {"atom_id": "atom-cache-analysis", "task_id": "task-cache"},
+        {"atom_id": "atom-cache-continue", "task_id": "task-cache"}
+      ],
+      "expected_attempt_count": 2,
+      "expected_attempt_relations": [
+        {"relation_type": "continuation_of", "decision": "proposed"}
+      ]
+    },
+    {
+      "case_id": "cross-session-implicit-continuation",
+      "sessions": [
+        {
+          "source_scope_id": "source-codex",
+          "traj_id": "traj-api-start",
+          "atoms": [
+            {
+              "atom_id": "atom-api-start",
+              "intent": "拒绝空 API 请求体",
+              "summary": "在写入边界拒绝空请求体",
+              "raw_segment": "## User\n拒绝空 API 请求体。\n\n## Assistant\n已在写入边界增加校验。\n",
+              "skills": ["api-validation"]
+            }
+          ]
+        },
+        {
+          "source_scope_id": "source-codex",
+          "traj_id": "traj-api-tests",
+          "atoms": [
+            {
+              "atom_id": "atom-api-tests",
+              "intent": "为空 API 请求体增加回归测试",
+              "summary": "验证写入边界拒绝空请求体",
+              "raw_segment": "## User\n为空 API 请求体增加回归测试。\n\n## Assistant\n已验证写入边界拒绝空请求体。\n",
+              "skills": ["api-validation", "regression-testing"]
+            }
+          ]
+        }
+      ],
+      "gold_memberships": [
+        {"atom_id": "atom-api-start", "task_id": "task-api-validation"},
+        {"atom_id": "atom-api-tests", "task_id": "task-api-validation"}
+      ],
+      "expected_attempt_count": 2,
+      "expected_attempt_relations": []
+    },
+    {
+      "case_id": "cross-session-similar-negative",
+      "sessions": [
+        {
+          "source_scope_id": "source-codex",
+          "traj_id": "traj-login-timeout",
+          "atoms": [
+            {
+              "atom_id": "atom-login-timeout",
+              "intent": "修复登录请求超时",
+              "summary": "分析登录请求的超时配置",
+              "raw_segment": "## User\n修复登录请求超时。\n\n## Assistant\n已分析登录请求的超时配置。\n",
+              "skills": ["authentication-debugging"]
+            }
+          ]
+        },
+        {
+          "source_scope_id": "source-codex",
+          "traj_id": "traj-payment-timeout",
+          "atoms": [
+            {
+              "atom_id": "atom-payment-timeout",
+              "intent": "继续修复支付请求超时",
+              "summary": "分析支付请求的超时配置",
+              "raw_segment": "## User\n继续修复支付请求超时。\n\n## Assistant\n已分析支付请求的超时配置。\n",
+              "skills": ["payment-debugging"]
+            }
+          ]
+        }
+      ],
+      "gold_memberships": [
+        {"atom_id": "atom-login-timeout", "task_id": "task-login"},
+        {"atom_id": "atom-payment-timeout", "task_id": "task-payment"}
+      ],
+      "expected_attempt_count": 2,
+      "expected_attempt_relations": []
+    },
+    {
+      "case_id": "same-session-explicit-retry",
+      "sessions": [
+        {
+          "source_scope_id": "source-codex",
+          "traj_id": "traj-concurrency-retry",
+          "atoms": [
+            {
+              "atom_id": "atom-concurrency-failed",
+              "intent": "修复并发测试失败",
+              "summary": "首次执行仍然超时",
+              "raw_segment": "## User\n修复并发测试失败。\n\n## Assistant\n首次执行仍然超时。\n",
+              "skills": ["flaky-test-debugging"]
+            },
+            {
+              "atom_id": "atom-concurrency-retry",
+              "intent": "重试修复并发测试失败",
+              "summary": "补充同步后测试通过",
+              "raw_segment": "## User\n重试修复并发测试失败。\n\n## Assistant\n补充同步后测试通过。\n",
+              "skills": ["flaky-test-debugging"]
+            }
+          ]
+        }
+      ],
+      "gold_memberships": [
+        {"atom_id": "atom-concurrency-failed", "task_id": "task-concurrency"},
+        {"atom_id": "atom-concurrency-retry", "task_id": "task-concurrency"}
+      ],
+      "expected_attempt_count": 2,
+      "expected_attempt_relations": [
+        {"relation_type": "retry_of", "decision": "confirmed"}
+      ]
+    },
+    {
+      "case_id": "intra-atom-retry",
+      "sessions": [
+        {
+          "source_scope_id": "source-codex",
+          "traj_id": "traj-intra-retry",
+          "atoms": [
+            {
+              "atom_id": "atom-intra-retry",
+              "intent": "修复登录问题",
+              "summary": "执行并重试登录修复",
+              "raw_segment": "## User\n修复登录问题。\n\n## Assistant\n第一次执行失败。\n\n## User\n重试修复登录问题。\n\n## Assistant\n第二次执行成功。\n",
+              "skills": ["authentication-debugging"]
+            }
+          ]
+        }
+      ],
+      "gold_memberships": [
+        {"atom_id": "atom-intra-retry", "task_id": "task-login"}
+      ],
+      "expected_attempt_count": 2,
+      "expected_attempt_relations": [
+        {"relation_type": "retry_of", "decision": "confirmed"}
+      ]
+    },
+    {
+      "case_id": "intra-atom-correction",
+      "sessions": [
+        {
+          "source_scope_id": "source-codex",
+          "traj_id": "traj-intra-correction",
+          "atoms": [
+            {
+              "atom_id": "atom-export-correction",
+              "intent": "导出汇总结果为 XLSX",
+              "summary": "将 CSV 方案更正为 XLSX",
+              "raw_segment": "## User\n把汇总结果导出为 CSV。\n\n## Assistant\n正在生成 CSV。\n\n## User\n更正一下，不要 CSV，请导出成 XLSX。\n\n## Assistant\n已生成 XLSX 工作簿。\n",
+              "skills": ["spreadsheet-export"]
+            }
+          ]
+        }
+      ],
+      "gold_memberships": [
+        {"atom_id": "atom-export-correction", "task_id": "task-export"}
+      ],
+      "expected_attempt_count": 2,
+      "expected_attempt_relations": [
+        {"relation_type": "correction_of", "decision": "confirmed"}
+      ]
+    },
+    {
+      "case_id": "same-session-similar-new-goals",
+      "sessions": [
+        {
+          "source_scope_id": "source-codex",
+          "traj_id": "traj-docs",
+          "atoms": [
+            {
+              "atom_id": "atom-readme-docs",
+              "intent": "更新 README 安装说明",
+              "summary": "替换 README 的旧安装命令",
+              "raw_segment": "## User\n更新 README 安装说明。\n\n## Assistant\n已替换旧安装命令。\n",
+              "skills": ["documentation-maintenance"]
+            },
+            {
+              "atom_id": "atom-api-docs",
+              "intent": "更新 API 安装说明",
+              "summary": "替换 API 文档的旧安装命令",
+              "raw_segment": "## User\n更新 API 安装说明。\n\n## Assistant\n已替换 API 文档的旧安装命令。\n",
+              "skills": ["documentation-maintenance"]
+            }
+          ]
+        }
+      ],
+      "gold_memberships": [
+        {"atom_id": "atom-readme-docs", "task_id": "task-readme"},
+        {"atom_id": "atom-api-docs", "task_id": "task-api-docs"}
+      ],
+      "expected_attempt_count": 2,
+      "expected_attempt_relations": []
+    },
+    {
+      "case_id": "single-atom-multi-skill",
+      "sessions": [
+        {
+          "source_scope_id": "source-codex",
+          "traj_id": "traj-multi-skill",
+          "atoms": [
+            {
+              "atom_id": "atom-multi-skill",
+              "intent": "拒绝空请求体并增加回归测试",
+              "summary": "增加输入校验和回归覆盖",
+              "raw_segment": "## User\n拒绝空请求体并增加回归测试。\n\n## Assistant\n输入校验和回归测试已经完成。\n",
+              "skills": ["api-validation", "regression-testing"]
+            }
+          ]
+        }
+      ],
+      "gold_memberships": [
+        {"atom_id": "atom-multi-skill", "task_id": "task-multi-skill"}
+      ],
+      "expected_attempt_count": 1,
+      "expected_attempt_relations": []
+    }
+  ]
+}

--- a/scripts/bench/task_graph_replay/fixtures/linker_structure_v1.report.json
+++ b/scripts/bench/task_graph_replay/fixtures/linker_structure_v1.report.json
@@ -16,7 +16,7 @@
         "predicted": 2
       },
       "case_id": "same-session-new-goal",
-      "expected_attempt_relation_types": [],
+      "expected_attempt_relations": [],
       "gold_task_count": 2,
       "grouping": {
         "atom_as_task": {
@@ -80,7 +80,7 @@
           }
         }
       },
-      "predicted_attempt_relation_types": [],
+      "predicted_attempt_relations": [],
       "predicted_task_count": 2,
       "proposals": {
         "atoms_with_proposals": 0,
@@ -110,8 +110,25 @@
         "predicted": 3
       },
       "case_id": "same-session-a-b-a",
-      "expected_attempt_relation_types": [
-        "continuation_of:proposed"
+      "expected_attempt_relations": [
+        {
+          "decision": "proposed",
+          "from_evidence": [
+            {
+              "atom_id": "atom-auth-continue",
+              "end": 16,
+              "start": 11
+            }
+          ],
+          "relation_type": "continuation_of",
+          "to_evidence": [
+            {
+              "atom_id": "atom-auth-start",
+              "end": 6,
+              "start": 1
+            }
+          ]
+        }
       ],
       "gold_task_count": 2,
       "grouping": {
@@ -176,8 +193,25 @@
           }
         }
       },
-      "predicted_attempt_relation_types": [
-        "continuation_of:proposed"
+      "predicted_attempt_relations": [
+        {
+          "decision": "proposed",
+          "from_evidence": [
+            {
+              "atom_id": "atom-auth-continue",
+              "end": 16,
+              "start": 11
+            }
+          ],
+          "relation_type": "continuation_of",
+          "to_evidence": [
+            {
+              "atom_id": "atom-auth-start",
+              "end": 6,
+              "start": 1
+            }
+          ]
+        }
       ],
       "predicted_task_count": 2,
       "proposals": {
@@ -208,7 +242,7 @@
         "predicted": 2
       },
       "case_id": "cross-session-phase-shift",
-      "expected_attempt_relation_types": [],
+      "expected_attempt_relations": [],
       "gold_task_count": 1,
       "grouping": {
         "atom_as_task": {
@@ -272,7 +306,7 @@
           }
         }
       },
-      "predicted_attempt_relation_types": [],
+      "predicted_attempt_relations": [],
       "predicted_task_count": 2,
       "proposals": {
         "atoms_with_proposals": 1,
@@ -302,8 +336,25 @@
         "predicted": 2
       },
       "case_id": "cross-session-high-overlap",
-      "expected_attempt_relation_types": [
-        "continuation_of:proposed"
+      "expected_attempt_relations": [
+        {
+          "decision": "proposed",
+          "from_evidence": [
+            {
+              "atom_id": "atom-cache-continue",
+              "end": 6,
+              "start": 1
+            }
+          ],
+          "relation_type": "continuation_of",
+          "to_evidence": [
+            {
+              "atom_id": "atom-cache-analysis",
+              "end": 6,
+              "start": 1
+            }
+          ]
+        }
       ],
       "gold_task_count": 1,
       "grouping": {
@@ -368,8 +419,25 @@
           }
         }
       },
-      "predicted_attempt_relation_types": [
-        "continuation_of:proposed"
+      "predicted_attempt_relations": [
+        {
+          "decision": "proposed",
+          "from_evidence": [
+            {
+              "atom_id": "atom-cache-continue",
+              "end": 6,
+              "start": 1
+            }
+          ],
+          "relation_type": "continuation_of",
+          "to_evidence": [
+            {
+              "atom_id": "atom-cache-analysis",
+              "end": 6,
+              "start": 1
+            }
+          ]
+        }
       ],
       "predicted_task_count": 1,
       "proposals": {
@@ -400,7 +468,7 @@
         "predicted": 2
       },
       "case_id": "cross-session-implicit-continuation",
-      "expected_attempt_relation_types": [],
+      "expected_attempt_relations": [],
       "gold_task_count": 1,
       "grouping": {
         "atom_as_task": {
@@ -464,7 +532,7 @@
           }
         }
       },
-      "predicted_attempt_relation_types": [],
+      "predicted_attempt_relations": [],
       "predicted_task_count": 2,
       "proposals": {
         "atoms_with_proposals": 1,
@@ -494,7 +562,7 @@
         "predicted": 2
       },
       "case_id": "cross-session-similar-negative",
-      "expected_attempt_relation_types": [],
+      "expected_attempt_relations": [],
       "gold_task_count": 2,
       "grouping": {
         "atom_as_task": {
@@ -558,7 +626,7 @@
           }
         }
       },
-      "predicted_attempt_relation_types": [],
+      "predicted_attempt_relations": [],
       "predicted_task_count": 2,
       "proposals": {
         "atoms_with_proposals": 1,
@@ -588,8 +656,25 @@
         "predicted": 2
       },
       "case_id": "same-session-explicit-retry",
-      "expected_attempt_relation_types": [
-        "retry_of:confirmed"
+      "expected_attempt_relations": [
+        {
+          "decision": "confirmed",
+          "from_evidence": [
+            {
+              "atom_id": "atom-concurrency-retry",
+              "end": 11,
+              "start": 6
+            }
+          ],
+          "relation_type": "retry_of",
+          "to_evidence": [
+            {
+              "atom_id": "atom-concurrency-failed",
+              "end": 6,
+              "start": 1
+            }
+          ]
+        }
       ],
       "gold_task_count": 1,
       "grouping": {
@@ -654,8 +739,25 @@
           }
         }
       },
-      "predicted_attempt_relation_types": [
-        "retry_of:confirmed"
+      "predicted_attempt_relations": [
+        {
+          "decision": "confirmed",
+          "from_evidence": [
+            {
+              "atom_id": "atom-concurrency-retry",
+              "end": 11,
+              "start": 6
+            }
+          ],
+          "relation_type": "retry_of",
+          "to_evidence": [
+            {
+              "atom_id": "atom-concurrency-failed",
+              "end": 6,
+              "start": 1
+            }
+          ]
+        }
       ],
       "predicted_task_count": 1,
       "proposals": {
@@ -686,8 +788,25 @@
         "predicted": 2
       },
       "case_id": "intra-atom-retry",
-      "expected_attempt_relation_types": [
-        "retry_of:confirmed"
+      "expected_attempt_relations": [
+        {
+          "decision": "confirmed",
+          "from_evidence": [
+            {
+              "atom_id": "atom-intra-retry",
+              "end": 12,
+              "start": 7
+            }
+          ],
+          "relation_type": "retry_of",
+          "to_evidence": [
+            {
+              "atom_id": "atom-intra-retry",
+              "end": 7,
+              "start": 1
+            }
+          ]
+        }
       ],
       "gold_task_count": 1,
       "grouping": {
@@ -752,8 +871,25 @@
           }
         }
       },
-      "predicted_attempt_relation_types": [
-        "retry_of:confirmed"
+      "predicted_attempt_relations": [
+        {
+          "decision": "confirmed",
+          "from_evidence": [
+            {
+              "atom_id": "atom-intra-retry",
+              "end": 12,
+              "start": 7
+            }
+          ],
+          "relation_type": "retry_of",
+          "to_evidence": [
+            {
+              "atom_id": "atom-intra-retry",
+              "end": 7,
+              "start": 1
+            }
+          ]
+        }
       ],
       "predicted_task_count": 1,
       "proposals": {
@@ -784,8 +920,25 @@
         "predicted": 2
       },
       "case_id": "intra-atom-correction",
-      "expected_attempt_relation_types": [
-        "correction_of:confirmed"
+      "expected_attempt_relations": [
+        {
+          "decision": "confirmed",
+          "from_evidence": [
+            {
+              "atom_id": "atom-export-correction",
+              "end": 12,
+              "start": 7
+            }
+          ],
+          "relation_type": "correction_of",
+          "to_evidence": [
+            {
+              "atom_id": "atom-export-correction",
+              "end": 7,
+              "start": 1
+            }
+          ]
+        }
       ],
       "gold_task_count": 1,
       "grouping": {
@@ -850,8 +1003,25 @@
           }
         }
       },
-      "predicted_attempt_relation_types": [
-        "correction_of:confirmed"
+      "predicted_attempt_relations": [
+        {
+          "decision": "confirmed",
+          "from_evidence": [
+            {
+              "atom_id": "atom-export-correction",
+              "end": 12,
+              "start": 7
+            }
+          ],
+          "relation_type": "correction_of",
+          "to_evidence": [
+            {
+              "atom_id": "atom-export-correction",
+              "end": 7,
+              "start": 1
+            }
+          ]
+        }
       ],
       "predicted_task_count": 1,
       "proposals": {
@@ -882,7 +1052,7 @@
         "predicted": 2
       },
       "case_id": "same-session-similar-new-goals",
-      "expected_attempt_relation_types": [],
+      "expected_attempt_relations": [],
       "gold_task_count": 2,
       "grouping": {
         "atom_as_task": {
@@ -946,7 +1116,7 @@
           }
         }
       },
-      "predicted_attempt_relation_types": [],
+      "predicted_attempt_relations": [],
       "predicted_task_count": 2,
       "proposals": {
         "atoms_with_proposals": 1,
@@ -976,7 +1146,7 @@
         "predicted": 1
       },
       "case_id": "single-atom-multi-skill",
-      "expected_attempt_relation_types": [],
+      "expected_attempt_relations": [],
       "gold_task_count": 1,
       "grouping": {
         "atom_as_task": {
@@ -1040,7 +1210,7 @@
           }
         }
       },
-      "predicted_attempt_relation_types": [],
+      "predicted_attempt_relations": [],
       "predicted_task_count": 1,
       "proposals": {
         "atoms_with_proposals": 0,
@@ -1151,7 +1321,7 @@
       "useful": 2
     }
   },
-  "report_sha256": "d645d1bfb4d2f2a00cf85e5001609b420d9c630e6d47ed5833f897627daed2e0",
+  "report_sha256": "785d188b22c1614706401b4afe4b57308693275d93d0d514a74ea7117020213e",
   "run_manifest": {
     "fixture_kind": "synthetic-structural-pilot",
     "generated_at": "2026-08-30T00:00:00Z",

--- a/scripts/bench/task_graph_replay/fixtures/linker_structure_v1.report.json
+++ b/scripts/bench/task_graph_replay/fixtures/linker_structure_v1.report.json
@@ -1,0 +1,1162 @@
+{
+  "cases": [
+    {
+      "atom_count": 2,
+      "attempt_relations": {
+        "f1": 1.0,
+        "false_negative": 0,
+        "false_positive": 0,
+        "precision": 1.0,
+        "recall": 1.0,
+        "true_positive": 0
+      },
+      "attempts": {
+        "absolute_error": 0,
+        "expected": 2,
+        "predicted": 2
+      },
+      "case_id": "same-session-new-goal",
+      "expected_attempt_relation_types": [],
+      "gold_task_count": 2,
+      "grouping": {
+        "atom_as_task": {
+          "b3": {
+            "f1": 1.0,
+            "precision": 1.0,
+            "recall": 1.0
+          },
+          "pairwise": {
+            "f1": 1.0,
+            "false_negative": 0,
+            "false_positive": 0,
+            "precision": 1.0,
+            "recall": 1.0,
+            "true_positive": 0
+          }
+        },
+        "session_as_task": {
+          "b3": {
+            "f1": 0.666667,
+            "precision": 0.5,
+            "recall": 1.0
+          },
+          "pairwise": {
+            "f1": 0.0,
+            "false_negative": 0,
+            "false_positive": 1,
+            "precision": 0.0,
+            "recall": 1.0,
+            "true_positive": 0
+          }
+        },
+        "task_graph": {
+          "b3": {
+            "f1": 1.0,
+            "precision": 1.0,
+            "recall": 1.0
+          },
+          "pairwise": {
+            "f1": 1.0,
+            "false_negative": 0,
+            "false_positive": 0,
+            "precision": 1.0,
+            "recall": 1.0,
+            "true_positive": 0
+          }
+        },
+        "task_graph_oracle_review": {
+          "b3": {
+            "f1": 1.0,
+            "precision": 1.0,
+            "recall": 1.0
+          },
+          "pairwise": {
+            "f1": 1.0,
+            "false_negative": 0,
+            "false_positive": 0,
+            "precision": 1.0,
+            "recall": 1.0,
+            "true_positive": 0
+          }
+        }
+      },
+      "predicted_attempt_relation_types": [],
+      "predicted_task_count": 2,
+      "proposals": {
+        "atoms_with_proposals": 0,
+        "candidates_per_atom": 0.0,
+        "false_split_pairs": 0,
+        "max_proposals_per_atom": 0,
+        "precision": 1.0,
+        "proposed": 0,
+        "recoverable_false_split_pairs": 0,
+        "recoverable_recall": 1.0,
+        "useful": 0
+      }
+    },
+    {
+      "atom_count": 3,
+      "attempt_relations": {
+        "f1": 1.0,
+        "false_negative": 0,
+        "false_positive": 0,
+        "precision": 1.0,
+        "recall": 1.0,
+        "true_positive": 1
+      },
+      "attempts": {
+        "absolute_error": 0,
+        "expected": 3,
+        "predicted": 3
+      },
+      "case_id": "same-session-a-b-a",
+      "expected_attempt_relation_types": [
+        "continuation_of:proposed"
+      ],
+      "gold_task_count": 2,
+      "grouping": {
+        "atom_as_task": {
+          "b3": {
+            "f1": 0.8,
+            "precision": 1.0,
+            "recall": 0.666667
+          },
+          "pairwise": {
+            "f1": 0.0,
+            "false_negative": 1,
+            "false_positive": 0,
+            "precision": 1.0,
+            "recall": 0.0,
+            "true_positive": 0
+          }
+        },
+        "session_as_task": {
+          "b3": {
+            "f1": 0.714286,
+            "precision": 0.555556,
+            "recall": 1.0
+          },
+          "pairwise": {
+            "f1": 0.5,
+            "false_negative": 0,
+            "false_positive": 2,
+            "precision": 0.333333,
+            "recall": 1.0,
+            "true_positive": 1
+          }
+        },
+        "task_graph": {
+          "b3": {
+            "f1": 1.0,
+            "precision": 1.0,
+            "recall": 1.0
+          },
+          "pairwise": {
+            "f1": 1.0,
+            "false_negative": 0,
+            "false_positive": 0,
+            "precision": 1.0,
+            "recall": 1.0,
+            "true_positive": 1
+          }
+        },
+        "task_graph_oracle_review": {
+          "b3": {
+            "f1": 1.0,
+            "precision": 1.0,
+            "recall": 1.0
+          },
+          "pairwise": {
+            "f1": 1.0,
+            "false_negative": 0,
+            "false_positive": 0,
+            "precision": 1.0,
+            "recall": 1.0,
+            "true_positive": 1
+          }
+        }
+      },
+      "predicted_attempt_relation_types": [
+        "continuation_of:proposed"
+      ],
+      "predicted_task_count": 2,
+      "proposals": {
+        "atoms_with_proposals": 0,
+        "candidates_per_atom": 0.0,
+        "false_split_pairs": 0,
+        "max_proposals_per_atom": 0,
+        "precision": 1.0,
+        "proposed": 0,
+        "recoverable_false_split_pairs": 0,
+        "recoverable_recall": 1.0,
+        "useful": 0
+      }
+    },
+    {
+      "atom_count": 2,
+      "attempt_relations": {
+        "f1": 1.0,
+        "false_negative": 0,
+        "false_positive": 0,
+        "precision": 1.0,
+        "recall": 1.0,
+        "true_positive": 0
+      },
+      "attempts": {
+        "absolute_error": 0,
+        "expected": 2,
+        "predicted": 2
+      },
+      "case_id": "cross-session-phase-shift",
+      "expected_attempt_relation_types": [],
+      "gold_task_count": 1,
+      "grouping": {
+        "atom_as_task": {
+          "b3": {
+            "f1": 0.666667,
+            "precision": 1.0,
+            "recall": 0.5
+          },
+          "pairwise": {
+            "f1": 0.0,
+            "false_negative": 1,
+            "false_positive": 0,
+            "precision": 1.0,
+            "recall": 0.0,
+            "true_positive": 0
+          }
+        },
+        "session_as_task": {
+          "b3": {
+            "f1": 0.666667,
+            "precision": 1.0,
+            "recall": 0.5
+          },
+          "pairwise": {
+            "f1": 0.0,
+            "false_negative": 1,
+            "false_positive": 0,
+            "precision": 1.0,
+            "recall": 0.0,
+            "true_positive": 0
+          }
+        },
+        "task_graph": {
+          "b3": {
+            "f1": 0.666667,
+            "precision": 1.0,
+            "recall": 0.5
+          },
+          "pairwise": {
+            "f1": 0.0,
+            "false_negative": 1,
+            "false_positive": 0,
+            "precision": 1.0,
+            "recall": 0.0,
+            "true_positive": 0
+          }
+        },
+        "task_graph_oracle_review": {
+          "b3": {
+            "f1": 1.0,
+            "precision": 1.0,
+            "recall": 1.0
+          },
+          "pairwise": {
+            "f1": 1.0,
+            "false_negative": 0,
+            "false_positive": 0,
+            "precision": 1.0,
+            "recall": 1.0,
+            "true_positive": 1
+          }
+        }
+      },
+      "predicted_attempt_relation_types": [],
+      "predicted_task_count": 2,
+      "proposals": {
+        "atoms_with_proposals": 1,
+        "candidates_per_atom": 0.5,
+        "false_split_pairs": 1,
+        "max_proposals_per_atom": 1,
+        "precision": 1.0,
+        "proposed": 1,
+        "recoverable_false_split_pairs": 1,
+        "recoverable_recall": 1.0,
+        "useful": 1
+      }
+    },
+    {
+      "atom_count": 2,
+      "attempt_relations": {
+        "f1": 1.0,
+        "false_negative": 0,
+        "false_positive": 0,
+        "precision": 1.0,
+        "recall": 1.0,
+        "true_positive": 1
+      },
+      "attempts": {
+        "absolute_error": 0,
+        "expected": 2,
+        "predicted": 2
+      },
+      "case_id": "cross-session-high-overlap",
+      "expected_attempt_relation_types": [
+        "continuation_of:proposed"
+      ],
+      "gold_task_count": 1,
+      "grouping": {
+        "atom_as_task": {
+          "b3": {
+            "f1": 0.666667,
+            "precision": 1.0,
+            "recall": 0.5
+          },
+          "pairwise": {
+            "f1": 0.0,
+            "false_negative": 1,
+            "false_positive": 0,
+            "precision": 1.0,
+            "recall": 0.0,
+            "true_positive": 0
+          }
+        },
+        "session_as_task": {
+          "b3": {
+            "f1": 0.666667,
+            "precision": 1.0,
+            "recall": 0.5
+          },
+          "pairwise": {
+            "f1": 0.0,
+            "false_negative": 1,
+            "false_positive": 0,
+            "precision": 1.0,
+            "recall": 0.0,
+            "true_positive": 0
+          }
+        },
+        "task_graph": {
+          "b3": {
+            "f1": 1.0,
+            "precision": 1.0,
+            "recall": 1.0
+          },
+          "pairwise": {
+            "f1": 1.0,
+            "false_negative": 0,
+            "false_positive": 0,
+            "precision": 1.0,
+            "recall": 1.0,
+            "true_positive": 1
+          }
+        },
+        "task_graph_oracle_review": {
+          "b3": {
+            "f1": 1.0,
+            "precision": 1.0,
+            "recall": 1.0
+          },
+          "pairwise": {
+            "f1": 1.0,
+            "false_negative": 0,
+            "false_positive": 0,
+            "precision": 1.0,
+            "recall": 1.0,
+            "true_positive": 1
+          }
+        }
+      },
+      "predicted_attempt_relation_types": [
+        "continuation_of:proposed"
+      ],
+      "predicted_task_count": 1,
+      "proposals": {
+        "atoms_with_proposals": 0,
+        "candidates_per_atom": 0.0,
+        "false_split_pairs": 0,
+        "max_proposals_per_atom": 0,
+        "precision": 1.0,
+        "proposed": 0,
+        "recoverable_false_split_pairs": 0,
+        "recoverable_recall": 1.0,
+        "useful": 0
+      }
+    },
+    {
+      "atom_count": 2,
+      "attempt_relations": {
+        "f1": 1.0,
+        "false_negative": 0,
+        "false_positive": 0,
+        "precision": 1.0,
+        "recall": 1.0,
+        "true_positive": 0
+      },
+      "attempts": {
+        "absolute_error": 0,
+        "expected": 2,
+        "predicted": 2
+      },
+      "case_id": "cross-session-implicit-continuation",
+      "expected_attempt_relation_types": [],
+      "gold_task_count": 1,
+      "grouping": {
+        "atom_as_task": {
+          "b3": {
+            "f1": 0.666667,
+            "precision": 1.0,
+            "recall": 0.5
+          },
+          "pairwise": {
+            "f1": 0.0,
+            "false_negative": 1,
+            "false_positive": 0,
+            "precision": 1.0,
+            "recall": 0.0,
+            "true_positive": 0
+          }
+        },
+        "session_as_task": {
+          "b3": {
+            "f1": 0.666667,
+            "precision": 1.0,
+            "recall": 0.5
+          },
+          "pairwise": {
+            "f1": 0.0,
+            "false_negative": 1,
+            "false_positive": 0,
+            "precision": 1.0,
+            "recall": 0.0,
+            "true_positive": 0
+          }
+        },
+        "task_graph": {
+          "b3": {
+            "f1": 0.666667,
+            "precision": 1.0,
+            "recall": 0.5
+          },
+          "pairwise": {
+            "f1": 0.0,
+            "false_negative": 1,
+            "false_positive": 0,
+            "precision": 1.0,
+            "recall": 0.0,
+            "true_positive": 0
+          }
+        },
+        "task_graph_oracle_review": {
+          "b3": {
+            "f1": 1.0,
+            "precision": 1.0,
+            "recall": 1.0
+          },
+          "pairwise": {
+            "f1": 1.0,
+            "false_negative": 0,
+            "false_positive": 0,
+            "precision": 1.0,
+            "recall": 1.0,
+            "true_positive": 1
+          }
+        }
+      },
+      "predicted_attempt_relation_types": [],
+      "predicted_task_count": 2,
+      "proposals": {
+        "atoms_with_proposals": 1,
+        "candidates_per_atom": 0.5,
+        "false_split_pairs": 1,
+        "max_proposals_per_atom": 1,
+        "precision": 1.0,
+        "proposed": 1,
+        "recoverable_false_split_pairs": 1,
+        "recoverable_recall": 1.0,
+        "useful": 1
+      }
+    },
+    {
+      "atom_count": 2,
+      "attempt_relations": {
+        "f1": 1.0,
+        "false_negative": 0,
+        "false_positive": 0,
+        "precision": 1.0,
+        "recall": 1.0,
+        "true_positive": 0
+      },
+      "attempts": {
+        "absolute_error": 0,
+        "expected": 2,
+        "predicted": 2
+      },
+      "case_id": "cross-session-similar-negative",
+      "expected_attempt_relation_types": [],
+      "gold_task_count": 2,
+      "grouping": {
+        "atom_as_task": {
+          "b3": {
+            "f1": 1.0,
+            "precision": 1.0,
+            "recall": 1.0
+          },
+          "pairwise": {
+            "f1": 1.0,
+            "false_negative": 0,
+            "false_positive": 0,
+            "precision": 1.0,
+            "recall": 1.0,
+            "true_positive": 0
+          }
+        },
+        "session_as_task": {
+          "b3": {
+            "f1": 1.0,
+            "precision": 1.0,
+            "recall": 1.0
+          },
+          "pairwise": {
+            "f1": 1.0,
+            "false_negative": 0,
+            "false_positive": 0,
+            "precision": 1.0,
+            "recall": 1.0,
+            "true_positive": 0
+          }
+        },
+        "task_graph": {
+          "b3": {
+            "f1": 1.0,
+            "precision": 1.0,
+            "recall": 1.0
+          },
+          "pairwise": {
+            "f1": 1.0,
+            "false_negative": 0,
+            "false_positive": 0,
+            "precision": 1.0,
+            "recall": 1.0,
+            "true_positive": 0
+          }
+        },
+        "task_graph_oracle_review": {
+          "b3": {
+            "f1": 1.0,
+            "precision": 1.0,
+            "recall": 1.0
+          },
+          "pairwise": {
+            "f1": 1.0,
+            "false_negative": 0,
+            "false_positive": 0,
+            "precision": 1.0,
+            "recall": 1.0,
+            "true_positive": 0
+          }
+        }
+      },
+      "predicted_attempt_relation_types": [],
+      "predicted_task_count": 2,
+      "proposals": {
+        "atoms_with_proposals": 1,
+        "candidates_per_atom": 0.5,
+        "false_split_pairs": 0,
+        "max_proposals_per_atom": 1,
+        "precision": 0.0,
+        "proposed": 1,
+        "recoverable_false_split_pairs": 0,
+        "recoverable_recall": 1.0,
+        "useful": 0
+      }
+    },
+    {
+      "atom_count": 2,
+      "attempt_relations": {
+        "f1": 1.0,
+        "false_negative": 0,
+        "false_positive": 0,
+        "precision": 1.0,
+        "recall": 1.0,
+        "true_positive": 1
+      },
+      "attempts": {
+        "absolute_error": 0,
+        "expected": 2,
+        "predicted": 2
+      },
+      "case_id": "same-session-explicit-retry",
+      "expected_attempt_relation_types": [
+        "retry_of:confirmed"
+      ],
+      "gold_task_count": 1,
+      "grouping": {
+        "atom_as_task": {
+          "b3": {
+            "f1": 0.666667,
+            "precision": 1.0,
+            "recall": 0.5
+          },
+          "pairwise": {
+            "f1": 0.0,
+            "false_negative": 1,
+            "false_positive": 0,
+            "precision": 1.0,
+            "recall": 0.0,
+            "true_positive": 0
+          }
+        },
+        "session_as_task": {
+          "b3": {
+            "f1": 1.0,
+            "precision": 1.0,
+            "recall": 1.0
+          },
+          "pairwise": {
+            "f1": 1.0,
+            "false_negative": 0,
+            "false_positive": 0,
+            "precision": 1.0,
+            "recall": 1.0,
+            "true_positive": 1
+          }
+        },
+        "task_graph": {
+          "b3": {
+            "f1": 1.0,
+            "precision": 1.0,
+            "recall": 1.0
+          },
+          "pairwise": {
+            "f1": 1.0,
+            "false_negative": 0,
+            "false_positive": 0,
+            "precision": 1.0,
+            "recall": 1.0,
+            "true_positive": 1
+          }
+        },
+        "task_graph_oracle_review": {
+          "b3": {
+            "f1": 1.0,
+            "precision": 1.0,
+            "recall": 1.0
+          },
+          "pairwise": {
+            "f1": 1.0,
+            "false_negative": 0,
+            "false_positive": 0,
+            "precision": 1.0,
+            "recall": 1.0,
+            "true_positive": 1
+          }
+        }
+      },
+      "predicted_attempt_relation_types": [
+        "retry_of:confirmed"
+      ],
+      "predicted_task_count": 1,
+      "proposals": {
+        "atoms_with_proposals": 0,
+        "candidates_per_atom": 0.0,
+        "false_split_pairs": 0,
+        "max_proposals_per_atom": 0,
+        "precision": 1.0,
+        "proposed": 0,
+        "recoverable_false_split_pairs": 0,
+        "recoverable_recall": 1.0,
+        "useful": 0
+      }
+    },
+    {
+      "atom_count": 1,
+      "attempt_relations": {
+        "f1": 1.0,
+        "false_negative": 0,
+        "false_positive": 0,
+        "precision": 1.0,
+        "recall": 1.0,
+        "true_positive": 1
+      },
+      "attempts": {
+        "absolute_error": 0,
+        "expected": 2,
+        "predicted": 2
+      },
+      "case_id": "intra-atom-retry",
+      "expected_attempt_relation_types": [
+        "retry_of:confirmed"
+      ],
+      "gold_task_count": 1,
+      "grouping": {
+        "atom_as_task": {
+          "b3": {
+            "f1": 1.0,
+            "precision": 1.0,
+            "recall": 1.0
+          },
+          "pairwise": {
+            "f1": 1.0,
+            "false_negative": 0,
+            "false_positive": 0,
+            "precision": 1.0,
+            "recall": 1.0,
+            "true_positive": 0
+          }
+        },
+        "session_as_task": {
+          "b3": {
+            "f1": 1.0,
+            "precision": 1.0,
+            "recall": 1.0
+          },
+          "pairwise": {
+            "f1": 1.0,
+            "false_negative": 0,
+            "false_positive": 0,
+            "precision": 1.0,
+            "recall": 1.0,
+            "true_positive": 0
+          }
+        },
+        "task_graph": {
+          "b3": {
+            "f1": 1.0,
+            "precision": 1.0,
+            "recall": 1.0
+          },
+          "pairwise": {
+            "f1": 1.0,
+            "false_negative": 0,
+            "false_positive": 0,
+            "precision": 1.0,
+            "recall": 1.0,
+            "true_positive": 0
+          }
+        },
+        "task_graph_oracle_review": {
+          "b3": {
+            "f1": 1.0,
+            "precision": 1.0,
+            "recall": 1.0
+          },
+          "pairwise": {
+            "f1": 1.0,
+            "false_negative": 0,
+            "false_positive": 0,
+            "precision": 1.0,
+            "recall": 1.0,
+            "true_positive": 0
+          }
+        }
+      },
+      "predicted_attempt_relation_types": [
+        "retry_of:confirmed"
+      ],
+      "predicted_task_count": 1,
+      "proposals": {
+        "atoms_with_proposals": 0,
+        "candidates_per_atom": 0.0,
+        "false_split_pairs": 0,
+        "max_proposals_per_atom": 0,
+        "precision": 1.0,
+        "proposed": 0,
+        "recoverable_false_split_pairs": 0,
+        "recoverable_recall": 1.0,
+        "useful": 0
+      }
+    },
+    {
+      "atom_count": 1,
+      "attempt_relations": {
+        "f1": 1.0,
+        "false_negative": 0,
+        "false_positive": 0,
+        "precision": 1.0,
+        "recall": 1.0,
+        "true_positive": 1
+      },
+      "attempts": {
+        "absolute_error": 0,
+        "expected": 2,
+        "predicted": 2
+      },
+      "case_id": "intra-atom-correction",
+      "expected_attempt_relation_types": [
+        "correction_of:confirmed"
+      ],
+      "gold_task_count": 1,
+      "grouping": {
+        "atom_as_task": {
+          "b3": {
+            "f1": 1.0,
+            "precision": 1.0,
+            "recall": 1.0
+          },
+          "pairwise": {
+            "f1": 1.0,
+            "false_negative": 0,
+            "false_positive": 0,
+            "precision": 1.0,
+            "recall": 1.0,
+            "true_positive": 0
+          }
+        },
+        "session_as_task": {
+          "b3": {
+            "f1": 1.0,
+            "precision": 1.0,
+            "recall": 1.0
+          },
+          "pairwise": {
+            "f1": 1.0,
+            "false_negative": 0,
+            "false_positive": 0,
+            "precision": 1.0,
+            "recall": 1.0,
+            "true_positive": 0
+          }
+        },
+        "task_graph": {
+          "b3": {
+            "f1": 1.0,
+            "precision": 1.0,
+            "recall": 1.0
+          },
+          "pairwise": {
+            "f1": 1.0,
+            "false_negative": 0,
+            "false_positive": 0,
+            "precision": 1.0,
+            "recall": 1.0,
+            "true_positive": 0
+          }
+        },
+        "task_graph_oracle_review": {
+          "b3": {
+            "f1": 1.0,
+            "precision": 1.0,
+            "recall": 1.0
+          },
+          "pairwise": {
+            "f1": 1.0,
+            "false_negative": 0,
+            "false_positive": 0,
+            "precision": 1.0,
+            "recall": 1.0,
+            "true_positive": 0
+          }
+        }
+      },
+      "predicted_attempt_relation_types": [
+        "correction_of:confirmed"
+      ],
+      "predicted_task_count": 1,
+      "proposals": {
+        "atoms_with_proposals": 0,
+        "candidates_per_atom": 0.0,
+        "false_split_pairs": 0,
+        "max_proposals_per_atom": 0,
+        "precision": 1.0,
+        "proposed": 0,
+        "recoverable_false_split_pairs": 0,
+        "recoverable_recall": 1.0,
+        "useful": 0
+      }
+    },
+    {
+      "atom_count": 2,
+      "attempt_relations": {
+        "f1": 1.0,
+        "false_negative": 0,
+        "false_positive": 0,
+        "precision": 1.0,
+        "recall": 1.0,
+        "true_positive": 0
+      },
+      "attempts": {
+        "absolute_error": 0,
+        "expected": 2,
+        "predicted": 2
+      },
+      "case_id": "same-session-similar-new-goals",
+      "expected_attempt_relation_types": [],
+      "gold_task_count": 2,
+      "grouping": {
+        "atom_as_task": {
+          "b3": {
+            "f1": 1.0,
+            "precision": 1.0,
+            "recall": 1.0
+          },
+          "pairwise": {
+            "f1": 1.0,
+            "false_negative": 0,
+            "false_positive": 0,
+            "precision": 1.0,
+            "recall": 1.0,
+            "true_positive": 0
+          }
+        },
+        "session_as_task": {
+          "b3": {
+            "f1": 0.666667,
+            "precision": 0.5,
+            "recall": 1.0
+          },
+          "pairwise": {
+            "f1": 0.0,
+            "false_negative": 0,
+            "false_positive": 1,
+            "precision": 0.0,
+            "recall": 1.0,
+            "true_positive": 0
+          }
+        },
+        "task_graph": {
+          "b3": {
+            "f1": 1.0,
+            "precision": 1.0,
+            "recall": 1.0
+          },
+          "pairwise": {
+            "f1": 1.0,
+            "false_negative": 0,
+            "false_positive": 0,
+            "precision": 1.0,
+            "recall": 1.0,
+            "true_positive": 0
+          }
+        },
+        "task_graph_oracle_review": {
+          "b3": {
+            "f1": 1.0,
+            "precision": 1.0,
+            "recall": 1.0
+          },
+          "pairwise": {
+            "f1": 1.0,
+            "false_negative": 0,
+            "false_positive": 0,
+            "precision": 1.0,
+            "recall": 1.0,
+            "true_positive": 0
+          }
+        }
+      },
+      "predicted_attempt_relation_types": [],
+      "predicted_task_count": 2,
+      "proposals": {
+        "atoms_with_proposals": 1,
+        "candidates_per_atom": 0.5,
+        "false_split_pairs": 0,
+        "max_proposals_per_atom": 1,
+        "precision": 0.0,
+        "proposed": 1,
+        "recoverable_false_split_pairs": 0,
+        "recoverable_recall": 1.0,
+        "useful": 0
+      }
+    },
+    {
+      "atom_count": 1,
+      "attempt_relations": {
+        "f1": 1.0,
+        "false_negative": 0,
+        "false_positive": 0,
+        "precision": 1.0,
+        "recall": 1.0,
+        "true_positive": 0
+      },
+      "attempts": {
+        "absolute_error": 0,
+        "expected": 1,
+        "predicted": 1
+      },
+      "case_id": "single-atom-multi-skill",
+      "expected_attempt_relation_types": [],
+      "gold_task_count": 1,
+      "grouping": {
+        "atom_as_task": {
+          "b3": {
+            "f1": 1.0,
+            "precision": 1.0,
+            "recall": 1.0
+          },
+          "pairwise": {
+            "f1": 1.0,
+            "false_negative": 0,
+            "false_positive": 0,
+            "precision": 1.0,
+            "recall": 1.0,
+            "true_positive": 0
+          }
+        },
+        "session_as_task": {
+          "b3": {
+            "f1": 1.0,
+            "precision": 1.0,
+            "recall": 1.0
+          },
+          "pairwise": {
+            "f1": 1.0,
+            "false_negative": 0,
+            "false_positive": 0,
+            "precision": 1.0,
+            "recall": 1.0,
+            "true_positive": 0
+          }
+        },
+        "task_graph": {
+          "b3": {
+            "f1": 1.0,
+            "precision": 1.0,
+            "recall": 1.0
+          },
+          "pairwise": {
+            "f1": 1.0,
+            "false_negative": 0,
+            "false_positive": 0,
+            "precision": 1.0,
+            "recall": 1.0,
+            "true_positive": 0
+          }
+        },
+        "task_graph_oracle_review": {
+          "b3": {
+            "f1": 1.0,
+            "precision": 1.0,
+            "recall": 1.0
+          },
+          "pairwise": {
+            "f1": 1.0,
+            "false_negative": 0,
+            "false_positive": 0,
+            "precision": 1.0,
+            "recall": 1.0,
+            "true_positive": 0
+          }
+        }
+      },
+      "predicted_attempt_relation_types": [],
+      "predicted_task_count": 1,
+      "proposals": {
+        "atoms_with_proposals": 0,
+        "candidates_per_atom": 0.0,
+        "false_split_pairs": 0,
+        "max_proposals_per_atom": 0,
+        "precision": 1.0,
+        "proposed": 0,
+        "recoverable_false_split_pairs": 0,
+        "recoverable_recall": 1.0,
+        "useful": 0
+      }
+    }
+  ],
+  "linker": {
+    "name": "xskill.task_graph.linker",
+    "posting_cap": 64,
+    "recent_k": 6,
+    "top_k": 8,
+    "version": "bounded-rules-v1"
+  },
+  "metrics": {
+    "attempt_relations": {
+      "f1": 1.0,
+      "false_negative": 0,
+      "false_positive": 0,
+      "precision": 1.0,
+      "recall": 1.0,
+      "true_positive": 5
+    },
+    "attempts": {
+      "absolute_error": 0,
+      "case_count": 11,
+      "exact_case_rate": 1.0,
+      "exact_cases": 11
+    },
+    "grouping": {
+      "atom_as_task": {
+        "b3": {
+          "f1": 0.857143,
+          "precision": 1.0,
+          "recall": 0.75
+        },
+        "pairwise": {
+          "f1": 0.0,
+          "false_negative": 5,
+          "false_positive": 0,
+          "precision": 1.0,
+          "recall": 0.0,
+          "true_positive": 0
+        }
+      },
+      "session_as_task": {
+        "b3": {
+          "f1": 0.841584,
+          "precision": 0.833333,
+          "recall": 0.85
+        },
+        "pairwise": {
+          "f1": 0.363636,
+          "false_negative": 3,
+          "false_positive": 4,
+          "precision": 0.333333,
+          "recall": 0.4,
+          "true_positive": 2
+        }
+      },
+      "task_graph": {
+        "b3": {
+          "f1": 0.947368,
+          "precision": 1.0,
+          "recall": 0.9
+        },
+        "pairwise": {
+          "f1": 0.75,
+          "false_negative": 2,
+          "false_positive": 0,
+          "precision": 1.0,
+          "recall": 0.6,
+          "true_positive": 3
+        }
+      },
+      "task_graph_oracle_review": {
+        "b3": {
+          "f1": 1.0,
+          "precision": 1.0,
+          "recall": 1.0
+        },
+        "pairwise": {
+          "f1": 1.0,
+          "false_negative": 0,
+          "false_positive": 0,
+          "precision": 1.0,
+          "recall": 1.0,
+          "true_positive": 5
+        }
+      }
+    },
+    "proposals": {
+      "atoms_with_proposals": 4,
+      "candidates_per_atom": 0.2,
+      "false_split_pairs": 2,
+      "max_proposals_per_atom": 1,
+      "precision": 0.5,
+      "proposed": 4,
+      "recoverable_false_split_pairs": 2,
+      "recoverable_recall": 1.0,
+      "useful": 2
+    }
+  },
+  "report_sha256": "d645d1bfb4d2f2a00cf85e5001609b420d9c630e6d47ed5833f897627daed2e0",
+  "run_manifest": {
+    "fixture_kind": "synthetic-structural-pilot",
+    "generated_at": "2026-08-30T00:00:00Z",
+    "repository_revision": "b1e08786becab32b2c1289f20e59b42a6c243789"
+  },
+  "schema_version": 1,
+  "suite_id": "production-linker-structure-pilot-v1"
+}

--- a/tests/test_task_graph_replay.py
+++ b/tests/test_task_graph_replay.py
@@ -311,7 +311,7 @@ def test_linker_structure_keeps_a_b_a_and_cross_session_uncertainty_visible():
     a_b_a = cases["same-session-a-b-a"]
     assert a_b_a["predicted_task_count"] == 2
     assert a_b_a["grouping"]["task_graph"]["pairwise"]["f1"] == 1.0
-    assert a_b_a["predicted_attempt_relation_types"] == ["continuation_of:proposed"]
+    assert a_b_a["predicted_attempt_relations"] == a_b_a["expected_attempt_relations"]
 
     phase_shift = cases["cross-session-phase-shift"]
     assert (
@@ -353,6 +353,113 @@ def test_linker_proposal_does_not_treat_a_mixed_target_as_useful():
         "atom-a2": "task-mixed",
         "atom-b": "task-mixed",
     }
+
+
+def test_linker_proposal_does_not_merge_a_mixed_source_cluster():
+    gold = {"atom-a": "gold-a", "atom-b": "gold-b", "atom-c": "gold-a"}
+    confirmed = {
+        "atom-a": "task-mixed",
+        "atom-b": "task-mixed",
+        "atom-c": "task-a",
+    }
+
+    counts, reviewed = evaluate_linker._proposal_counts(
+        gold,
+        confirmed,
+        [("atom-a", "task-a")],
+    )
+
+    assert counts["useful"] == 0
+    assert counts["recoverable_false_split_pairs"] == 0
+    assert reviewed == confirmed
+
+
+def test_linker_proposal_recovery_includes_transitive_fragment_pairs():
+    gold = {atom_id: "gold" for atom_id in ("atom-a", "atom-b", "atom-c", "atom-d")}
+    confirmed = {
+        "atom-a": "task-target",
+        "atom-b": "task-target",
+        "atom-c": "task-c",
+        "atom-d": "task-d",
+    }
+
+    counts, reviewed = evaluate_linker._proposal_counts(
+        gold,
+        confirmed,
+        [("atom-c", "task-target"), ("atom-d", "task-target")],
+    )
+
+    assert counts["false_split_pairs"] == 5
+    assert counts["recoverable_false_split_pairs"] == 5
+    assert len(set(reviewed.values())) == 1
+
+
+def test_linker_proposal_purity_checks_are_linear_in_gold_reads():
+    class CountingGold(dict):
+        reads = 0
+
+        def __getitem__(self, key):
+            type(self).reads += 1
+            return super().__getitem__(key)
+
+    atom_count = 2_000
+    target_count = atom_count // 2
+    gold = CountingGold({f"atom-{index}": "gold" for index in range(atom_count)})
+    confirmed = {
+        **{f"atom-{index}": "task-target" for index in range(target_count)},
+        **{
+            f"atom-{index}": f"task-{index}"
+            for index in range(target_count, atom_count)
+        },
+    }
+    proposed = [
+        (f"atom-{index}", "task-target") for index in range(target_count, atom_count)
+    ]
+
+    evaluate_linker._proposal_counts(gold, confirmed, proposed)
+
+    assert CountingGold.reads <= 4 * atom_count
+
+
+def test_linker_attempt_relation_metric_includes_evidence_endpoints():
+    suite = evaluate_linker.load_suite(LINKER_FIXTURE_PATH)
+    relation = suite["cases"][1]["expected_attempt_relations"][0]
+    relation["from_evidence"], relation["to_evidence"] = (
+        relation["to_evidence"],
+        relation["from_evidence"],
+    )
+
+    case = evaluate_linker.evaluate_suite(suite)["cases"][1]
+
+    assert case["attempt_relations"]["true_positive"] == 0
+    assert case["attempt_relations"]["false_positive"] == 1
+    assert case["attempt_relations"]["false_negative"] == 1
+
+
+def test_linker_structure_fixture_rejects_attempt_evidence_outside_atom():
+    suite = evaluate_linker.load_suite(LINKER_FIXTURE_PATH)
+    relation = suite["cases"][1]["expected_attempt_relations"][0]
+    relation["from_evidence"][0]["start"] = 0
+
+    with pytest.raises(
+        evaluate_linker.LinkerReplayValidationError,
+        match="range must stay within",
+    ):
+        evaluate_linker.validate_suite(suite)
+
+
+def test_linker_structure_fixture_rejects_cross_task_attempt_relation():
+    suite = evaluate_linker.load_suite(LINKER_FIXTURE_PATH)
+    relation = suite["cases"][1]["expected_attempt_relations"][0]
+    relation["from_evidence"] = [
+        {"atom_id": "atom-release-notes", "start": 6, "end": 11}
+    ]
+
+    with pytest.raises(
+        evaluate_linker.LinkerReplayValidationError,
+        match="same gold Task",
+    ):
+        evaluate_linker.validate_suite(suite)
 
 
 def test_linker_structure_fixture_rejects_incomplete_gold():

--- a/tests/test_task_graph_replay.py
+++ b/tests/test_task_graph_replay.py
@@ -8,6 +8,7 @@ from pathlib import Path
 
 import pytest
 
+from scripts.bench.task_graph_replay import evaluate_linker
 from scripts.bench.task_graph_replay.evaluate import (
     ERROR_EXAMPLE_LIMIT,
     TaskReplayValidationError,
@@ -27,6 +28,8 @@ FIXTURE_DIR = (
 )
 BASELINE_PATH = FIXTURE_DIR / "baseline_v1.json"
 REPORT_PATH = FIXTURE_DIR / "baseline_v1.report.json"
+LINKER_FIXTURE_PATH = FIXTURE_DIR / "linker_structure_v1.json"
+LINKER_REPORT_PATH = FIXTURE_DIR / "linker_structure_v1.report.json"
 
 
 pytestmark = pytest.mark.algorithm_replay
@@ -267,3 +270,119 @@ def test_cli_renders_text_and_json(capsys):
     assert json.loads(capsys.readouterr().out) == evaluate_suite(
         load_suite(BASELINE_PATH)
     )
+
+
+def test_linker_structure_report_matches_checked_in_snapshot():
+    report = evaluate_linker.evaluate_suite(
+        evaluate_linker.load_suite(LINKER_FIXTURE_PATH)
+    )
+
+    assert report == json.loads(LINKER_REPORT_PATH.read_text(encoding="utf-8"))
+
+
+def test_production_linker_beats_session_and_atom_grouping_baselines():
+    metrics = evaluate_linker.evaluate_suite(
+        evaluate_linker.load_suite(LINKER_FIXTURE_PATH)
+    )["metrics"]
+    grouping = metrics["grouping"]
+
+    assert grouping["task_graph"]["pairwise"]["precision"] == 1.0
+    assert (
+        grouping["task_graph"]["pairwise"]["f1"]
+        > grouping["session_as_task"]["pairwise"]["f1"]
+    )
+    assert (
+        grouping["task_graph"]["pairwise"]["f1"]
+        > grouping["atom_as_task"]["pairwise"]["f1"]
+    )
+    assert grouping["task_graph_oracle_review"]["pairwise"]["f1"] == 1.0
+    assert metrics["proposals"]["recoverable_recall"] == 1.0
+    assert metrics["proposals"]["max_proposals_per_atom"] <= 8
+    assert metrics["attempts"]["exact_case_rate"] == 1.0
+    assert metrics["attempt_relations"]["f1"] == 1.0
+
+
+def test_linker_structure_keeps_a_b_a_and_cross_session_uncertainty_visible():
+    report = evaluate_linker.evaluate_suite(
+        evaluate_linker.load_suite(LINKER_FIXTURE_PATH)
+    )
+    cases = {case["case_id"]: case for case in report["cases"]}
+
+    a_b_a = cases["same-session-a-b-a"]
+    assert a_b_a["predicted_task_count"] == 2
+    assert a_b_a["grouping"]["task_graph"]["pairwise"]["f1"] == 1.0
+    assert a_b_a["predicted_attempt_relation_types"] == ["continuation_of:proposed"]
+
+    phase_shift = cases["cross-session-phase-shift"]
+    assert (
+        phase_shift["grouping"]["task_graph"]["pairwise"]["recall"] == 1.0
+        or phase_shift["proposals"]["recoverable_recall"] == 1.0
+    )
+    assert phase_shift["grouping"]["task_graph_oracle_review"]["pairwise"]["f1"] == 1.0
+
+    similar_negative = cases["cross-session-similar-negative"]
+    assert similar_negative["grouping"]["task_graph"]["pairwise"]["f1"] == 1.0
+    if similar_negative["proposals"]["proposed"]:
+        assert similar_negative["proposals"]["precision"] == 0.0
+
+
+def test_linker_proposal_pair_recovery_deduplicates_bidirectional_candidates():
+    counts, reviewed = evaluate_linker._proposal_counts(
+        {"atom-a": "gold", "atom-b": "gold"},
+        {"atom-a": "task-a", "atom-b": "task-b"},
+        [("atom-a", "task-b"), ("atom-b", "task-a")],
+    )
+
+    assert counts["false_split_pairs"] == 1
+    assert counts["recoverable_false_split_pairs"] == 1
+    assert counts["useful"] == 2
+    assert len(set(reviewed.values())) == 1
+
+
+def test_linker_proposal_does_not_treat_a_mixed_target_as_useful():
+    counts, reviewed = evaluate_linker._proposal_counts(
+        {"atom-a1": "gold-a", "atom-a2": "gold-a", "atom-b": "gold-b"},
+        {"atom-a1": "task-a", "atom-a2": "task-mixed", "atom-b": "task-mixed"},
+        [("atom-a1", "task-mixed")],
+    )
+
+    assert counts["useful"] == 0
+    assert counts["recoverable_false_split_pairs"] == 0
+    assert reviewed == {
+        "atom-a1": "task-a",
+        "atom-a2": "task-mixed",
+        "atom-b": "task-mixed",
+    }
+
+
+def test_linker_structure_fixture_rejects_incomplete_gold():
+    suite = evaluate_linker.load_suite(LINKER_FIXTURE_PATH)
+    suite["cases"][0]["gold_memberships"].pop()
+
+    with pytest.raises(
+        evaluate_linker.LinkerReplayValidationError,
+        match="every Atom needs one membership",
+    ):
+        evaluate_linker.validate_suite(suite)
+
+
+def test_linker_structure_fixture_rejects_invalid_config():
+    suite = evaluate_linker.load_suite(LINKER_FIXTURE_PATH)
+    suite["linker_config"]["top_k"] = True
+
+    with pytest.raises(
+        evaluate_linker.LinkerReplayValidationError,
+        match="suite.linker_config.top_k: expected int, got bool",
+    ):
+        evaluate_linker.validate_suite(suite)
+
+
+def test_linker_cli_renders_text_and_json(capsys):
+    report = evaluate_linker.evaluate_suite(
+        evaluate_linker.load_suite(LINKER_FIXTURE_PATH)
+    )
+
+    assert evaluate_linker.main([str(LINKER_FIXTURE_PATH)]) == 0
+    assert capsys.readouterr().out == evaluate_linker.render_text(report) + "\n"
+    assert evaluate_linker.main([str(LINKER_FIXTURE_PATH), "--format", "json"]) == 0
+    assert json.loads(capsys.readouterr().out) == report


### PR DESCRIPTION
## Summary

为当前生产 `BoundedTaskLinker` 增加确定性结构回放，并与 Session-as-Task 和 Atom-as-Task 两个朴素基线比较。

回放同时量化自动 Task grouping、proposed membership 的审核价值、oracle review upper bound 和 Attempt 关系，但不修改任何生产行为。

## Changes

- 增加 11 个合成结构 case 和 20 个 gold Atom，覆盖 A→B→A、跨 Session 显式/隐式延续、相似负例、新目标、重试、纠正和多 Skill Atom。
- 直接调用生产 `BoundedTaskLinker`，报告 Session、Atom、Task Graph 与 oracle review upper bound 的 Pairwise 和 B³ 指标。
- 将 proposed membership 只计为纯净 source/target Task fragment 之间的候选，oracle 可恢复 pair 由审核前后分区差值计算，可正确覆盖传递恢复。
- Attempt relation F1 联合比较 from/to evidence 端点、relation type 和 decision，避免方向或连接对象错误仍被计为命中。
- 预计算 cluster purity，并使用 contingency 和 Task-pair 聚合避免全量 Atom pair 物化，proposal 分析保持 O(Atom + proposal)。
- 提交字节稳定的 JSON snapshot，并补充 fixture 端点契约、指标边界、跨 gold Task 关系拒绝和合成 pilot 局限说明。

当前合成 pilot 中，Task Graph Pairwise F1 为 0.750，高于 Session-as-Task 的 0.364 和 Atom-as-Task 的 0，自动确认 precision 为 1.0，4 个 proposed 中有 2 个 useful，这只支持“不应直接降低自动确认阈值”，真实数据仍需分别评估候选过滤、校准与排序，不将当前结果解读为排序已是主要瓶颈。

## Test plan

- [x] `make test` passes（2749 passed, 10 skipped）
- [x] Added/updated unit tests for the change（Task Graph replay/runtime 专项 72 passed）
- [ ] `make e2e` passes (if the change touches ingestion / install / daemon)（不涉及 ingestion、install 或 daemon）
- [x] Manually verified the affected user flow（同一 fixture 连续运行报告 hash 均为 `3d73ac9605facdfd372405cb2e894a606559e04462989bc07da6d7d7f5be4b6e`）

补充检查：Ruff 0.16.5、Python 3.9 `py_compile`、`git diff --check` 和 JSON 校验通过；10 万 Atom / 5 万 proposal 最坏形态 sanity run 约 0.42 秒、峰值约 132 MiB，性能回归门禁使用确定性 gold-read 计数而非墙钟阈值。

## Linked issues

Closes #378

## 给外人看的背景（Task Graph 结构回放是什么）

下面按给第三方看的问题单来写：每个词第一次出现都会说明它是什么。代码位置只是提示，不是必须先读完整个仓库才能看懂。

### 这是什么

XSkill 平时学技能，走的是这条主路：先把一次完整会话收成 Session，再把 Session 切成一段段 Atom，Atom 进入候选，攒够了再写成 Skill。Session 就是一次连续对话。Atom 是里面意图相对单一的一小段。Skill 是后来写给助手用的说明书。

有些用户目标会跨好几个 Session，或者同一件事失败了再试、被人纠正后再做。只看单个 Session 或单个 Atom，会把同一件事拆散。Task Graph 就是架在这条主路上面的一层任务图：它把相关 Atom 收成更大的任务。

Task Graph 里有两个核心对象。Logical Task 是用户想完成的那件逻辑上的事，即使中间换了会话、重试过、被纠正过，仍算同一件。Task Attempt 是这件逻辑事的某一次具体执行，记下用了哪个模型、哪个助手、有没有重试、最后做成没做成。

生产里负责把 Atom 收进 Logical Task 的，是一份确定性规则程序，名字叫 BoundedTaskLinker。确定性的意思是：同样的输入再跑一遍，得到同一份图，不会因为模型采样而变。它不调用大模型。

本 PR 是 Q1 评测链里的结构回放。结构回放的意思是：拿已经标好对错的合成 Atom，原样喂给当前生产这份 linker，看它有没有把该在一起的 Atom 收到同一个 Logical Task 里。问的是「图有没有收对」，不是「收对了之后，用这张图去写技能会不会更好」。后面那问在 #385。

### 评测侧实际在比什么

评测器同时算三种收法，对照同一份人工标好的归属，这份标准答案叫 gold。本套合成有 11 个 case、20 条 gold Atom。

Session 基线（评测里写成 Session-as-Task）：同一条 Session 里的 Atom 一律算同一个任务。一条会话里做了两件不同的事，会被错并；一件事跨了两条会话，会被错拆。

Atom 基线（评测里写成 Atom-as-Task）：每条 Atom 单独算一个任务。它永远不会把两条 Atom 收在一起。只要 gold 里存在「这两条本该是一件事」，这对就会算漏。

Task Graph：直接调用当前生产 BoundedTaskLinker，只拿它自动确认（confirmed）的归属来打分。拿不准时，linker 会另写一条 proposed，留给人审，这条不计入自动确认分数。

主指标是 Pairwise F1。先看任意两条 Atom 算不算一对：gold 把它们放在同一个 Logical Task 里，这一对就是 gold 对；某种收法也把它们放在同一个预测任务里，这一对就是预测对。precision 是「预测成一对的里面，有多少真是一对」。recall 是「gold 里那些该成对的，找回了多少」。F1 是这两个数的调和平均。它只衡量「谁和谁该在一起」，不衡量写成技能之后好不好用。

### 规则怎么认出同一件事

linker 从每条 Atom 的 intent 和 summary 里抽词。intent 是这段 Atom 在说用户要干什么，summary 是这段的摘要。抽出来的词做成集合，再算两边重叠的比例：两边共有的词数，除以两边合在一起去重后的词数。这个比例就是 Jaccard。它不是 TF-IDF，也不会按词的稀有程度加权。

另外再看 intent 里有没有继续、重试、纠正这类标记。有标记、分数够高、而且第一名和第二名分得开，才会自动确认接到已有的 Logical Task 上。否则就新开一个任务，把看起来有点像的候选写成 proposed。

所以它认的是「字面上抽出来的词叠不重叠、有没有继续或重试或纠正的字样」，不是大模型在理解用户目标。

### 合成分数怎么读

当前这份合成 pilot 上，Task Graph 的 Pairwise F1 是 0.750，Session 基线是 0.364，Atom 基线是 0；自动确认的 precision 是 1.0。4 条 proposed 里有 2 条对审核有用。

这些数字只用来锁指标算法、锁风险口径、锁当前 linker 在这 11 个合成 case 上的行为。README 写明：合成不能当真实效果，也不能替代后面 50 到 100 个经人工复核的代表性离线样本。不要把 0.750 读成「已经证明 Task Graph 更好」。真实轨迹上的词更乱、目标更隐，分数会变。

自动确认 precision 1.0 的含义更窄：这次自动钉死的那些对，没有误并。它不表示召回已经够，也不表示该把自动确认门槛再放宽。PR 正文里写过，这只支持「不应直接降低自动确认阈值」，候选过滤、校准和排序还要在真实数据上分别看。

### 合本 PR 之前缺了什么

#346 已经有 Logical Task 和 Task Attempt 的离线回放，但那份 fixture 用的是手工录好的预测，主要锁 schema、指标和正式模型不变量。它回答不了：当前生产这份 BoundedTaskLinker，比起「整段会话算一件事」和「每条 Atom 算一件事」，在先做 A 再做 B 再回到 A、跨 Session 延续、失败重试、用户纠正这些结构上，有没有收得更对。

也量化不了：没自动确认的 proposed 能不能补上漏掉的关联、每条 Atom 要人审多少候选、理想审核能挽回多少收组错误。

### 本 PR 具体改哪

增加一套只调用当前生产 BoundedTaskLinker 的确定性结构回放。不调用大模型、Embedding、外部 Harness、数据库或网络。不改生产 linker 的阈值、候选召回、自动确认或落盘契约。

新增 11 个合成结构 case 和 20 条 gold Atom，覆盖同 Session 新目标、先做 A 再做 B 再回到 A、跨 Session 显式或隐式延续、相似负例、重试、纠正和一条 Atom 对应多个 Skill。

同一组 gold 上同时报告 Session 基线、Atom 基线、Task Graph 自动结果，以及 oracle review upper bound。后者用 gold 信息模拟「人把有用的 proposed 都审对了」之后还能挽回多少，不是自动算法分数，也不能当线上效果宣称。

提交字节稳定的 JSON snapshot。CI 只核这份 snapshot 和契约，不把合成分数当成质量门槛。

### 不要和什么搞混

不要和 #394 搞混。#394 把 Task Graph 的生产开关改成默认开，让实例开始画这层只读图。本 PR 不改那个开关，也不改现网。Agent 接触不到格力内网现网。这张补丁合进 main 之后，现网行为也不会因为多了一套评测脚本而变化。

不要和 #385 搞混。#385 问的是：用 Task Graph 收好的任务去形成 Skill，会不会比只看 Session 或只看 Atom 更有效。那是下游方法效果。本 PR 只问图有没有收对。

不要和 #375 搞混。#375 是 Atom 拆分与路由的真实模型离线回放，测的是「一段对话怎么切成 Atom、Atom 怎么进技能候选」。本 PR 假定 Atom 已经在，只测 linker 怎么把 Atom 收成 Logical Task。Issue #378 也写过：等 #375 的真实模型 Atom 再开始，会把 Atom 生成质量和 Task linking 结构质量混在一起。

### 怎么算这段背景对齐了

能说出 Logical Task 是跨会话的那件用户目标，Task Attempt 是某一次具体执行。能说出 Session 基线是「一条会话一个任务」，Atom 基线是「一条 Atom 一个任务」，Pairwise F1 看的是「哪两条 Atom 该在一起」。能说出 linker 看的是 intent 和 summary 抽词，加上继续、重试、纠正标记，不是大模型理解目标。能说出 0.750 只是合成 pilot，不能当真实效果，更不能说已经证明 Task Graph 更好。能把本 PR 和 #394、#385、#375 分开：这里不改默认开关，不测写成技能好不好用，也不测 Atom 怎么切。
