### PR TITLE
test(algorithms): add library-aware Skill body × activation description replay

### DIFF
--- a/scripts/bench/README.md
+++ b/scripts/bench/README.md
@@ -16,6 +16,7 @@ scripts/bench/
 ├── baseline_window.md        基线报告(合成/真实两套并排)
 ├── baseline_window.json      基线机器可读结果(run_baseline.py 产出)
 ├── algorithm_replay/         拆分 + 路由的版本化离线质量回放（普通 CI）
+├── skill_library_replay/     Skill 正文 × 激活描述 × 库规模的配对 2×2 回放
 ├── synthetic/
 │   ├── gen_cases_v2.py       合成集生成器(纯数据,无 LLM/无网络)
 │   ├── ground_truth.json     合成集真值 {case: {scenario,total_lines,boundaries,...}}

--- a/scripts/bench/skill_library_replay/README.md
+++ b/scripts/bench/skill_library_replay/README.md
@@ -73,7 +73,7 @@ python -m scripts.bench.skill_library_replay.evaluate scripts/bench/skill_librar
 
 单样本子集的 `confidence_interval` 为 `null`，避免把没有统计信息的点估计伪装成零宽区间。
 
-评测器限制 `cases × bootstrap_samples` 不超过 5,000,000，且预先索引每个 case 的 library level，因此除 bootstrap 外的聚合复杂度为 `O(cases × library_levels)`。
+评测器按 `cases × bootstrap_samples × 实际统计量数量` 限制总 bootstrap 工作量不超过 5,000,000，统计量数量随 library ladder 级数增长；评测器同时预先索引每个 case 的 library level，因此除 bootstrap 外的聚合复杂度为 `O(cases × library_levels)`。
 
 ## 因果边界
 

--- a/scripts/bench/skill_library_replay/README.md
+++ b/scripts/bench/skill_library_replay/README.md
@@ -1,0 +1,94 @@
+# Skill 库感知 2×2 离线回放
+
+这套评测器接收目标 Harness 预先录制的不可变运行结果，并在普通 CI 中离线计算 Skill 正文、激活描述和库内竞争的配对效应。
+
+评测器不会调用 LLM、Embedding、coding-agent CLI 或 xskill 生产状态，因此入仓 fixture 的测试结果是确定的。
+
+运行合成契约基线：
+
+```bash
+python -m scripts.bench.skill_library_replay.evaluate scripts/bench/skill_library_replay/fixtures/baseline_v1.json
+```
+
+使用 `--format json` 可以输出机器可读报告。
+
+测试会将报告与入仓的 `baseline_v1.report.json` 快照比较，因此 schema 或指标口径变化会成为可 review 的显式 diff。
+
+## 为什么需要 2×2
+
+只比较 main 与 staging 会把正文变化和 description 变化绑成一个整体，无法判断收益来自执行知识还是激活边界。
+
+每个 `task_fingerprint × seed × distractor_count` 必须完整录制以下四个库内部署单元：
+
+- `old_body__old_description`
+- `old_body__new_description`
+- `new_body__old_description`
+- `new_body__new_description`
+
+报告以 `old_body__old_description` 为部署基线，分别计算两个正文效应、两个 description 效应、整体部署效应和二阶交互项。
+
+同一 case 还必须录制 `old_body` 与 `new_body` 的隔离强制激活结果，从而把正文自身收益与自然激活后的库内收益分开。
+
+## Fixture 契约
+
+`schema_version` 当前只支持 `1`，未知版本会直接失败。
+
+`run_manifest` 固定仓库 revision、模型、Harness、生成参数、任务集、评测协议以及 old/new body 和 description 的 SHA-256 指纹。
+
+`library_ladder` 必须从零干扰项开始，并声明逐级增长的语义相似干扰 Skill，后一级必须保留前一级的名称和顺序，避免把工具顺序变化混进库规模效应。
+
+每一级的 `distractor_catalog_fingerprint` 固定该级干扰 Skill 的名称、顺序、正文和 description，目标 Skill 的四个版本则由 `run_manifest` 单独固定。
+
+`cases` 至少包含一条应触发目标 Skill 的正例和一条不应触发的负例。
+
+每个 case 用 `task_fingerprint` 和 `seed` 固定配对单位，并且必须覆盖完整的 library ladder 和四个部署单元。
+
+每条 observation 记录唯一 `run_id`、`score`、目标 Skill 是否激活、按调用顺序排列的 `activated_skills`、Token、费用、延迟和可选错误类型。
+
+隔离运行只能强制激活目标 Skill，部署运行只能激活目标 Skill 与该级 library ladder 中列出的干扰 Skill。
+
+`score` 支持 `[0, 1]` 连续值，因此既可以承载 pass/fail，也可以承载 OfficeQA 等 benchmark 的部分得分。
+
+`catalog_tokens` 表示运行时可见的 Skill 激活目录开销，`loaded_skill_tokens` 表示实际加载的 Skill 正文开销，二者不要混为输入总 Token。
+
+## 指标定义
+
+隔离正文效应 `Δ_iso` 是每个配对 case 的 `isolated(new_body) - isolated(old_body)` 的均值，并额外按正例与负例分别报告，避免正文收益与非适用任务上的副作用相互抵消。
+
+整体库内部署效应 `Δ_lib` 是 `new_body__new_description - old_body__old_description` 的配对均值。
+
+干扰量 `I = Δ_iso - Δ_lib`，正值表示正文在隔离环境中的收益有一部分在库内竞争中丢失，负值表示新的激活边界让部署收益超过正文自身收益。
+
+正文效应和 description 效应分别在对方的 old/new 水平计算，避免只报告一个依赖选定基线的主效应。
+
+交互项计算为 `new/new - new/old - old/new + old/old`，用于发现“正文和 description 单独无效但联合有效”等非加性行为。
+
+激活指标同时报告总体激活率变化、正例 recall 变化、负例 false-positive-rate 变化以及每个 cell 的实际 Skill 激活计数，因此正负变化或不同 Skill 的挤占不会被总体触发率掩盖。
+
+每个 cell 还按 `error_type` 聚合失败原因，便于区分未触发、错误 Skill 激活、任务执行错误和基础设施失败。
+
+资源指标报告激活 Skill 数、catalog Token、已加载正文 Token、输入输出 Token、费用和延迟的 `new/new - old/old` 配对变化。
+
+所有至少包含两个配对样本的效应使用固定随机种子的配对 percentile bootstrap 置信区间，并同时报告 wins、ties 和 losses。
+
+单样本子集的 `confidence_interval` 为 `null`，避免把没有统计信息的点估计伪装成零宽区间。
+
+评测器限制 `cases × bootstrap_samples` 不超过 5,000,000，且预先索引每个 case 的 library level，因此除 bootstrap 外的聚合复杂度为 `O(cases × library_levels)`。
+
+## 因果边界
+
+这个评测器保证数据完整性、配对口径和指标计算，但不能证明上游录制过程真的执行了声明的 Harness、Skill 版本或随机种子。
+
+真实实验必须由目标原生运行时生成每条 observation，并在运行前固定任务、seed、模型、采样参数、Skill 顺序和评分器。
+
+Agno trigger probe 的结果可以用于预筛选，但不能冒充 Claude Code、Codex 或 DeepSeek Harness 的原生库内反事实结果。
+
+当前 PR 只建立评测和数据契约，不修改 description optimizer、canary 晋升规则或生产流量路由。
+
+在代表性真实录制结果经过维护者 review 前，不应把任何效应阈值设为阻塞晋升条件。
+
+## 隐私约束
+
+入仓 fixture 只使用合成 ID、指纹和数值结果，不保存真实任务文本、模型输出、轨迹原文、workspace 路径或用户标识。
+
+真实任务内容和原生 Harness 轨迹应保留在受控实验环境，公共回放只导出通过隐私检查的聚合字段。

--- a/scripts/bench/skill_library_replay/__init__.py
+++ b/scripts/bench/skill_library_replay/__init__.py
@@ -1,0 +1,1 @@
+"""Deterministic replay metrics for library-aware Skill evaluation."""

--- a/scripts/bench/skill_library_replay/evaluate.py
+++ b/scripts/bench/skill_library_replay/evaluate.py
@@ -33,11 +33,24 @@ RESOURCE_FIELDS = (
     "cost_usd",
     "latency_ms",
 )
+MAX_BOOTSTRAP_OPERATIONS = 5_000_000
+ISOLATED_BOOTSTRAP_STATISTICS = 3
+BOOTSTRAP_STATISTICS_PER_LIBRARY_LEVEL = 10 + len(RESOURCE_FIELDS)
 _SHA256_RE = "sha256:"
 
 
 class LibraryReplayValidationError(ValueError):
     """Raised when a library-aware replay violates its data contract."""
+
+
+def _estimated_bootstrap_operations(
+    *, case_count: int, library_levels: int, bootstrap_samples: int
+) -> int:
+    statistics = (
+        ISOLATED_BOOTSTRAP_STATISTICS
+        + library_levels * BOOTSTRAP_STATISTICS_PER_LIBRARY_LEVEL
+    )
+    return case_count * bootstrap_samples * statistics
 
 
 def _require(mapping: dict[str, Any], key: str, expected: type, context: str) -> Any:
@@ -360,9 +373,15 @@ def validate_suite(suite: Any) -> None:
         raise LibraryReplayValidationError(
             "suite.cases must include both positive and negative activation cases"
         )
-    if len(cases) * bootstrap_samples > 5_000_000:
+    estimated_operations = _estimated_bootstrap_operations(
+        case_count=len(cases),
+        library_levels=len(ladder),
+        bootstrap_samples=bootstrap_samples,
+    )
+    if estimated_operations > MAX_BOOTSTRAP_OPERATIONS:
         raise LibraryReplayValidationError(
-            "suite: cases * bootstrap_samples exceeds the 5000000 work bound"
+            "suite: estimated bootstrap work exceeds "
+            f"the {MAX_BOOTSTRAP_OPERATIONS} operation bound"
         )
 
 

--- a/scripts/bench/skill_library_replay/evaluate.py
+++ b/scripts/bench/skill_library_replay/evaluate.py
@@ -1,0 +1,774 @@
+"""Evaluate matched Skill body/description experiments without model calls.
+
+The evaluator consumes recorded native-runtime outcomes.
+It never invokes a model, harness, workspace command, or production xskill state.
+"""
+
+from __future__ import annotations
+
+import argparse
+import hashlib
+import json
+import math
+import random
+from collections import Counter
+from collections.abc import Iterable
+from pathlib import Path
+from typing import Any
+
+SCHEMA_VERSION = 1
+BODY_VERSIONS = ("old_body", "new_body")
+CELL_KEYS = (
+    "old_body__old_description",
+    "old_body__new_description",
+    "new_body__old_description",
+    "new_body__new_description",
+)
+RESOURCE_FIELDS = (
+    "activated_skill_count",
+    "catalog_tokens",
+    "loaded_skill_tokens",
+    "input_tokens",
+    "output_tokens",
+    "cost_usd",
+    "latency_ms",
+)
+_SHA256_RE = "sha256:"
+
+
+class LibraryReplayValidationError(ValueError):
+    """Raised when a library-aware replay violates its data contract."""
+
+
+def _require(mapping: dict[str, Any], key: str, expected: type, context: str) -> Any:
+    if key not in mapping:
+        raise LibraryReplayValidationError(f"{context}: missing required field {key!r}")
+    value = mapping[key]
+    if expected is int and isinstance(value, bool):
+        raise LibraryReplayValidationError(f"{context}.{key}: expected int, got bool")
+    if not isinstance(value, expected):
+        raise LibraryReplayValidationError(
+            f"{context}.{key}: expected {expected.__name__}, got {type(value).__name__}"
+        )
+    return value
+
+
+def _require_non_empty_string(mapping: dict[str, Any], key: str, context: str) -> str:
+    value = _require(mapping, key, str, context)
+    if not value:
+        raise LibraryReplayValidationError(f"{context}.{key}: must not be empty")
+    return value
+
+
+def _require_number(
+    mapping: dict[str, Any], key: str, context: str, *, minimum: float = 0.0
+) -> float:
+    if key not in mapping:
+        raise LibraryReplayValidationError(f"{context}: missing required field {key!r}")
+    value = mapping[key]
+    if isinstance(value, bool) or not isinstance(value, (int, float)):
+        raise LibraryReplayValidationError(f"{context}.{key}: expected a number")
+    number = float(value)
+    if not math.isfinite(number) or number < minimum:
+        raise LibraryReplayValidationError(
+            f"{context}.{key}: expected a finite number >= {minimum:g}"
+        )
+    return number
+
+
+def _validate_fingerprint(value: Any, context: str) -> None:
+    if (
+        not isinstance(value, str)
+        or not value.startswith(_SHA256_RE)
+        or len(value) != len(_SHA256_RE) + 64
+        or any(char not in "0123456789abcdef" for char in value[len(_SHA256_RE) :])
+    ):
+        raise LibraryReplayValidationError(
+            f"{context}: expected sha256:<64 lowercase hex>"
+        )
+
+
+def _validate_observation(
+    observation: Any,
+    *,
+    context: str,
+    target_skill: str,
+    run_ids: set[str],
+    isolated: bool,
+    allowed_skills: set[str],
+) -> None:
+    if not isinstance(observation, dict):
+        raise LibraryReplayValidationError(f"{context}: expected an object")
+    run_id = _require_non_empty_string(observation, "run_id", context)
+    if run_id in run_ids:
+        raise LibraryReplayValidationError(f"{context}.run_id: duplicate {run_id!r}")
+    run_ids.add(run_id)
+    score = _require_number(observation, "score", context)
+    if score > 1:
+        raise LibraryReplayValidationError(f"{context}.score: expected 0 <= score <= 1")
+    target_activated = _require(observation, "target_activated", bool, context)
+    activated_skills = _require(observation, "activated_skills", list, context)
+    if any(not isinstance(skill, str) or not skill for skill in activated_skills):
+        raise LibraryReplayValidationError(
+            f"{context}.activated_skills: expected non-empty strings"
+        )
+    if len(activated_skills) != len(set(activated_skills)):
+        raise LibraryReplayValidationError(
+            f"{context}.activated_skills: duplicate skill names are not allowed"
+        )
+    unknown_skills = set(activated_skills) - allowed_skills
+    if unknown_skills:
+        raise LibraryReplayValidationError(
+            f"{context}.activated_skills: unknown skills {sorted(unknown_skills)}"
+        )
+    if target_activated != (target_skill in activated_skills):
+        raise LibraryReplayValidationError(
+            f"{context}: target_activated disagrees with activated_skills"
+        )
+    if isolated and activated_skills != [target_skill]:
+        raise LibraryReplayValidationError(
+            f"{context}.activated_skills: isolated runs must force only target_skill"
+        )
+    for key in (
+        "catalog_tokens",
+        "loaded_skill_tokens",
+        "input_tokens",
+        "output_tokens",
+    ):
+        value = _require(observation, key, int, context)
+        if value < 0:
+            raise LibraryReplayValidationError(f"{context}.{key}: must be >= 0")
+    _require_number(observation, "cost_usd", context)
+    _require_number(observation, "latency_ms", context)
+    error_type = observation.get("error_type")
+    if error_type is not None and (not isinstance(error_type, str) or not error_type):
+        raise LibraryReplayValidationError(
+            f"{context}.error_type: expected null or a non-empty string"
+        )
+
+
+def validate_suite(suite: Any) -> None:
+    """Validate the complete matched-replay contract before computing metrics."""
+    if not isinstance(suite, dict):
+        raise LibraryReplayValidationError("suite: expected an object")
+    version = _require(suite, "schema_version", int, "suite")
+    if version != SCHEMA_VERSION:
+        raise LibraryReplayValidationError(
+            f"suite.schema_version: supported={SCHEMA_VERSION}, got={version}"
+        )
+    _require_non_empty_string(suite, "suite_id", "suite")
+    target_skill = _require_non_empty_string(suite, "target_skill", "suite")
+
+    metric_config = _require(suite, "metric_config", dict, "suite")
+    bootstrap_samples = _require(
+        metric_config, "bootstrap_samples", int, "suite.metric_config"
+    )
+    if not 100 <= bootstrap_samples <= 50_000:
+        raise LibraryReplayValidationError(
+            "suite.metric_config.bootstrap_samples must be within [100, 50000]"
+        )
+    bootstrap_seed = _require(
+        metric_config, "bootstrap_seed", int, "suite.metric_config"
+    )
+    if bootstrap_seed < 0:
+        raise LibraryReplayValidationError(
+            "suite.metric_config.bootstrap_seed must be >= 0"
+        )
+    confidence_level = _require_number(
+        metric_config, "confidence_level", "suite.metric_config"
+    )
+    if not 0 < confidence_level < 1:
+        raise LibraryReplayValidationError(
+            "suite.metric_config.confidence_level must satisfy 0 < value < 1"
+        )
+
+    manifest = _require(suite, "run_manifest", dict, "suite")
+    for key in (
+        "repository_revision",
+        "model",
+        "harness",
+        "generated_at",
+    ):
+        _require_non_empty_string(manifest, key, "suite.run_manifest")
+    for key in (
+        "task_set_fingerprint",
+        "evaluation_protocol_fingerprint",
+        "old_body_fingerprint",
+        "new_body_fingerprint",
+        "old_description_fingerprint",
+        "new_description_fingerprint",
+    ):
+        _validate_fingerprint(manifest.get(key), f"suite.run_manifest.{key}")
+    if manifest["old_body_fingerprint"] == manifest["new_body_fingerprint"]:
+        raise LibraryReplayValidationError(
+            "suite.run_manifest: old and new body fingerprints must differ"
+        )
+    if (
+        manifest["old_description_fingerprint"]
+        == manifest["new_description_fingerprint"]
+    ):
+        raise LibraryReplayValidationError(
+            "suite.run_manifest: old and new description fingerprints must differ"
+        )
+    generation_config = _require(
+        manifest, "generation_config", dict, "suite.run_manifest"
+    )
+    _require_number(generation_config, "temperature", "generation_config")
+    top_p = _require_number(generation_config, "top_p", "generation_config")
+    if not 0 < top_p <= 1:
+        raise LibraryReplayValidationError(
+            "generation_config.top_p must satisfy 0 < value <= 1"
+        )
+    max_output_tokens = _require(
+        generation_config, "max_output_tokens", int, "generation_config"
+    )
+    if max_output_tokens <= 0:
+        raise LibraryReplayValidationError(
+            "generation_config.max_output_tokens must be > 0"
+        )
+
+    ladder = _require(suite, "library_ladder", list, "suite")
+    if not ladder:
+        raise LibraryReplayValidationError("suite.library_ladder must not be empty")
+    distractor_counts: list[int] = []
+    previous_skills: list[str] = []
+    for index, level in enumerate(ladder):
+        context = f"suite.library_ladder[{index}]"
+        if not isinstance(level, dict):
+            raise LibraryReplayValidationError(f"{context}: expected an object")
+        count = _require(level, "distractor_count", int, context)
+        if count < 0:
+            raise LibraryReplayValidationError(
+                f"{context}.distractor_count: must be >= 0"
+            )
+        skills = _require(level, "distractor_skills", list, context)
+        _validate_fingerprint(
+            level.get("distractor_catalog_fingerprint"),
+            f"{context}.distractor_catalog_fingerprint",
+        )
+        if len(skills) != count:
+            raise LibraryReplayValidationError(
+                f"{context}.distractor_skills: expected exactly {count} entries"
+            )
+        if any(not isinstance(skill, str) or not skill for skill in skills):
+            raise LibraryReplayValidationError(
+                f"{context}.distractor_skills: expected non-empty strings"
+            )
+        skill_set = set(skills)
+        if len(skill_set) != len(skills) or target_skill in skill_set:
+            raise LibraryReplayValidationError(
+                f"{context}.distractor_skills: duplicates and target_skill are forbidden"
+            )
+        if skills[: len(previous_skills)] != previous_skills:
+            raise LibraryReplayValidationError(
+                f"{context}.distractor_skills: library growth must retain prior order"
+            )
+        previous_skills = skills
+        distractor_counts.append(count)
+    if any(
+        left >= right for left, right in zip(distractor_counts, distractor_counts[1:])
+    ):
+        raise LibraryReplayValidationError(
+            "suite.library_ladder.distractor_count values must be strictly increasing"
+        )
+    if distractor_counts[0] != 0:
+        raise LibraryReplayValidationError(
+            "suite.library_ladder must start with distractor_count=0"
+        )
+
+    cases = _require(suite, "cases", list, "suite")
+    if not cases:
+        raise LibraryReplayValidationError("suite.cases must not be empty")
+    case_ids: set[str] = set()
+    task_seed_pairs: set[tuple[str, int]] = set()
+    run_ids: set[str] = set()
+    activation_labels: set[bool] = set()
+    for case_index, case in enumerate(cases):
+        context = f"suite.cases[{case_index}]"
+        if not isinstance(case, dict):
+            raise LibraryReplayValidationError(f"{context}: expected an object")
+        case_id = _require_non_empty_string(case, "case_id", context)
+        if case_id in case_ids:
+            raise LibraryReplayValidationError(
+                f"{context}.case_id: duplicate {case_id!r}"
+            )
+        case_ids.add(case_id)
+        task_fingerprint = case.get("task_fingerprint")
+        _validate_fingerprint(task_fingerprint, f"{context}.task_fingerprint")
+        seed = _require(case, "seed", int, context)
+        if seed < 0:
+            raise LibraryReplayValidationError(f"{context}.seed: must be >= 0")
+        pair = (task_fingerprint, seed)
+        if pair in task_seed_pairs:
+            raise LibraryReplayValidationError(
+                f"{context}: duplicate task_fingerprint and seed pair"
+            )
+        task_seed_pairs.add(pair)
+        should_activate = _require(case, "should_activate", bool, context)
+        activation_labels.add(should_activate)
+
+        isolated_runs = _require(case, "isolated", dict, context)
+        if set(isolated_runs) != set(BODY_VERSIONS):
+            raise LibraryReplayValidationError(
+                f"{context}.isolated: expected exactly {list(BODY_VERSIONS)}"
+            )
+        for body in BODY_VERSIONS:
+            _validate_observation(
+                isolated_runs[body],
+                context=f"{context}.isolated.{body}",
+                target_skill=target_skill,
+                run_ids=run_ids,
+                isolated=True,
+                allowed_skills={target_skill},
+            )
+
+        libraries = _require(case, "libraries", list, context)
+        if len(libraries) != len(distractor_counts):
+            raise LibraryReplayValidationError(
+                f"{context}.libraries: expected {len(distractor_counts)} levels"
+            )
+        observed_counts: list[int] = []
+        for level_index, level in enumerate(libraries):
+            level_context = f"{context}.libraries[{level_index}]"
+            if not isinstance(level, dict):
+                raise LibraryReplayValidationError(
+                    f"{level_context}: expected an object"
+                )
+            observed_counts.append(
+                _require(level, "distractor_count", int, level_context)
+            )
+            deployed = _require(level, "deployed", dict, level_context)
+            if set(deployed) != set(CELL_KEYS):
+                raise LibraryReplayValidationError(
+                    f"{level_context}.deployed: expected exactly {list(CELL_KEYS)}"
+                )
+            for cell in CELL_KEYS:
+                _validate_observation(
+                    deployed[cell],
+                    context=f"{level_context}.deployed.{cell}",
+                    target_skill=target_skill,
+                    run_ids=run_ids,
+                    isolated=False,
+                    allowed_skills={target_skill}
+                    | set(ladder[level_index]["distractor_skills"]),
+                )
+        if observed_counts != distractor_counts:
+            raise LibraryReplayValidationError(
+                f"{context}.libraries: expected distractor counts {distractor_counts}"
+            )
+    if activation_labels != {False, True}:
+        raise LibraryReplayValidationError(
+            "suite.cases must include both positive and negative activation cases"
+        )
+    if len(cases) * bootstrap_samples > 5_000_000:
+        raise LibraryReplayValidationError(
+            "suite: cases * bootstrap_samples exceeds the 5000000 work bound"
+        )
+
+
+def load_suite(path: Path | str) -> dict[str, Any]:
+    """Load and validate a recorded replay suite."""
+    suite_path = Path(path)
+    try:
+        suite = json.loads(suite_path.read_text(encoding="utf-8"))
+    except json.JSONDecodeError as error:
+        raise LibraryReplayValidationError(
+            f"invalid JSON in {suite_path}: {error}"
+        ) from error
+    validate_suite(suite)
+    return suite
+
+
+def _round(value: float) -> float:
+    return round(float(value), 6)
+
+
+def _mean(values: Iterable[float]) -> float:
+    materialized = list(values)
+    return sum(materialized) / len(materialized)
+
+
+def _percentile(sorted_values: list[float], quantile: float) -> float:
+    if len(sorted_values) == 1:
+        return sorted_values[0]
+    position = (len(sorted_values) - 1) * quantile
+    lower = math.floor(position)
+    upper = math.ceil(position)
+    if lower == upper:
+        return sorted_values[lower]
+    weight = position - lower
+    return sorted_values[lower] * (1 - weight) + sorted_values[upper] * weight
+
+
+def _stable_seed(base_seed: int, label: str) -> int:
+    digest = hashlib.sha256(label.encode("utf-8")).digest()
+    return base_seed ^ int.from_bytes(digest[:8], "big")
+
+
+def _paired_effect(
+    deltas: list[float], metric_config: dict[str, Any], label: str
+) -> dict[str, Any]:
+    point = _mean(deltas)
+    confidence_interval: list[float] | None
+    if len(deltas) == 1:
+        confidence_interval = None
+    else:
+        rng = random.Random(_stable_seed(metric_config["bootstrap_seed"], label))
+        sample_count = metric_config["bootstrap_samples"]
+        size = len(deltas)
+        bootstrap_means = [
+            sum(deltas[rng.randrange(size)] for _ in range(size)) / size
+            for _ in range(sample_count)
+        ]
+        bootstrap_means.sort()
+        alpha = (1 - metric_config["confidence_level"]) / 2
+        low = _percentile(bootstrap_means, alpha)
+        high = _percentile(bootstrap_means, 1 - alpha)
+        confidence_interval = [_round(low), _round(high)]
+    return {
+        "n": len(deltas),
+        "mean": _round(point),
+        "confidence_interval": confidence_interval,
+        "wins": sum(delta > 0 for delta in deltas),
+        "ties": sum(delta == 0 for delta in deltas),
+        "losses": sum(delta < 0 for delta in deltas),
+    }
+
+
+def _observation_value(observation: dict[str, Any], field: str) -> float:
+    if field == "activated_skill_count":
+        return float(len(observation["activated_skills"]))
+    return float(observation[field])
+
+
+def _observation_summary(rows: list[tuple[dict[str, Any], bool]]) -> dict[str, Any]:
+    positives = [observation for observation, label in rows if label]
+    negatives = [observation for observation, label in rows if not label]
+    observations = [observation for observation, _ in rows]
+    activated_skill_counts = Counter(
+        skill
+        for observation in observations
+        for skill in observation["activated_skills"]
+    )
+    error_types = Counter(
+        observation["error_type"]
+        for observation in observations
+        if observation.get("error_type") is not None
+    )
+    return {
+        "score_mean": _round(_mean(row["score"] for row in observations)),
+        "target_activation_rate": _round(
+            _mean(float(row["target_activated"]) for row in observations)
+        ),
+        "positive_recall": _round(
+            _mean(float(row["target_activated"]) for row in positives)
+        ),
+        "negative_false_positive_rate": _round(
+            _mean(float(row["target_activated"]) for row in negatives)
+        ),
+        "activated_skill_counts": dict(sorted(activated_skill_counts.items())),
+        "error_types": dict(sorted(error_types.items())),
+        **{
+            f"{field}_mean": _round(
+                _mean(_observation_value(row, field) for row in observations)
+            )
+            for field in RESOURCE_FIELDS
+        },
+    }
+
+
+def _isolated_summary(observations: list[dict[str, Any]]) -> dict[str, Any]:
+    return {
+        "score_mean": _round(_mean(row["score"] for row in observations)),
+        **{
+            f"{field}_mean": _round(
+                _mean(_observation_value(row, field) for row in observations)
+            )
+            for field in RESOURCE_FIELDS
+        },
+    }
+
+
+def _effect(
+    cases: list[dict[str, Any]],
+    metric_config: dict[str, Any],
+    label: str,
+    left,
+    right,
+) -> dict[str, Any]:
+    return _paired_effect(
+        [float(left(case)) - float(right(case)) for case in cases],
+        metric_config,
+        label,
+    )
+
+
+def evaluate_suite(suite: dict[str, Any]) -> dict[str, Any]:
+    """Compute paired isolated, factorial, activation, and resource effects."""
+    validate_suite(suite)
+    cases = suite["cases"]
+    metric_config = suite["metric_config"]
+    isolated_rows = {
+        body: [case["isolated"][body] for case in cases] for body in BODY_VERSIONS
+    }
+    isolated_effect = _effect(
+        cases,
+        metric_config,
+        "isolated_body_effect",
+        lambda case: case["isolated"]["new_body"]["score"],
+        lambda case: case["isolated"]["old_body"]["score"],
+    )
+    isolated_positive_cases = [case for case in cases if case["should_activate"]]
+    isolated_negative_cases = [case for case in cases if not case["should_activate"]]
+    isolated_positive_effect = _effect(
+        isolated_positive_cases,
+        metric_config,
+        "isolated_positive_body_effect",
+        lambda case: case["isolated"]["new_body"]["score"],
+        lambda case: case["isolated"]["old_body"]["score"],
+    )
+    isolated_negative_effect = _effect(
+        isolated_negative_cases,
+        metric_config,
+        "isolated_negative_body_effect",
+        lambda case: case["isolated"]["new_body"]["score"],
+        lambda case: case["isolated"]["old_body"]["score"],
+    )
+    levels_by_case = {
+        case["case_id"]: {
+            level["distractor_count"]: level for level in case["libraries"]
+        }
+        for case in cases
+    }
+
+    library_curve: list[dict[str, Any]] = []
+    for ladder_level in suite["library_ladder"]:
+        distractor_count = ladder_level["distractor_count"]
+
+        def deployed(
+            item: dict[str, Any], cell: str, count: int = distractor_count
+        ) -> dict[str, Any]:
+            level = levels_by_case[item["case_id"]][count]
+            return level["deployed"][cell]
+
+        cell_rows = {
+            cell: [(deployed(case, cell), case["should_activate"]) for case in cases]
+            for cell in CELL_KEYS
+        }
+        old_old = "old_body__old_description"
+        old_new = "old_body__new_description"
+        new_old = "new_body__old_description"
+        new_new = "new_body__new_description"
+
+        def score(cell: str):
+            return lambda item, key=cell: deployed(item, key)["score"]
+
+        factorial_effects = {
+            "body_at_old_description": _effect(
+                cases,
+                metric_config,
+                f"{distractor_count}:body_at_old_description",
+                score(new_old),
+                score(old_old),
+            ),
+            "body_at_new_description": _effect(
+                cases,
+                metric_config,
+                f"{distractor_count}:body_at_new_description",
+                score(new_new),
+                score(old_new),
+            ),
+            "description_at_old_body": _effect(
+                cases,
+                metric_config,
+                f"{distractor_count}:description_at_old_body",
+                score(old_new),
+                score(old_old),
+            ),
+            "description_at_new_body": _effect(
+                cases,
+                metric_config,
+                f"{distractor_count}:description_at_new_body",
+                score(new_new),
+                score(new_old),
+            ),
+            "joint_deployed_effect": _effect(
+                cases,
+                metric_config,
+                f"{distractor_count}:joint_deployed_effect",
+                score(new_new),
+                score(old_old),
+            ),
+        }
+        interaction_deltas = [
+            deployed(case, new_new)["score"]
+            - deployed(case, new_old)["score"]
+            - deployed(case, old_new)["score"]
+            + deployed(case, old_old)["score"]
+            for case in cases
+        ]
+        factorial_effects["interaction"] = _paired_effect(
+            interaction_deltas,
+            metric_config,
+            f"{distractor_count}:interaction",
+        )
+        interference_deltas = [
+            case["isolated"]["new_body"]["score"]
+            - case["isolated"]["old_body"]["score"]
+            - deployed(case, new_new)["score"]
+            + deployed(case, old_old)["score"]
+            for case in cases
+        ]
+        activation_cases = {
+            "all": cases,
+            "positive": [case for case in cases if case["should_activate"]],
+            "negative": [case for case in cases if not case["should_activate"]],
+        }
+        activation_effects = {
+            "target_activation_delta": _effect(
+                activation_cases["all"],
+                metric_config,
+                f"{distractor_count}:target_activation_delta",
+                lambda item, key=new_new: deployed(item, key)["target_activated"],
+                lambda item, key=old_old: deployed(item, key)["target_activated"],
+            ),
+            "positive_recall_delta": _effect(
+                activation_cases["positive"],
+                metric_config,
+                f"{distractor_count}:positive_recall_delta",
+                lambda item, key=new_new: deployed(item, key)["target_activated"],
+                lambda item, key=old_old: deployed(item, key)["target_activated"],
+            ),
+            "negative_false_positive_rate_delta": _effect(
+                activation_cases["negative"],
+                metric_config,
+                f"{distractor_count}:negative_false_positive_rate_delta",
+                lambda item, key=new_new: deployed(item, key)["target_activated"],
+                lambda item, key=old_old: deployed(item, key)["target_activated"],
+            ),
+        }
+        resource_effects = {
+            field: _effect(
+                cases,
+                metric_config,
+                f"{distractor_count}:{field}",
+                lambda item, key=field, cell=new_new: _observation_value(
+                    deployed(item, cell), key
+                ),
+                lambda item, key=field, cell=old_old: _observation_value(
+                    deployed(item, cell), key
+                ),
+            )
+            for field in RESOURCE_FIELDS
+        }
+        library_curve.append(
+            {
+                "distractor_count": distractor_count,
+                "distractor_catalog_fingerprint": ladder_level[
+                    "distractor_catalog_fingerprint"
+                ],
+                "distractor_skills": ladder_level["distractor_skills"],
+                "cells": {
+                    cell: _observation_summary(cell_rows[cell]) for cell in CELL_KEYS
+                },
+                "factorial_effects": factorial_effects,
+                "interference": _paired_effect(
+                    interference_deltas,
+                    metric_config,
+                    f"{distractor_count}:interference",
+                ),
+                "activation_effects": activation_effects,
+                "resource_effects": resource_effects,
+            }
+        )
+
+    return {
+        "schema_version": SCHEMA_VERSION,
+        "suite_id": suite["suite_id"],
+        "target_skill": suite["target_skill"],
+        "run_manifest": suite["run_manifest"],
+        "cases": len(cases),
+        "positive_cases": sum(case["should_activate"] for case in cases),
+        "negative_cases": sum(not case["should_activate"] for case in cases),
+        "isolated": {
+            "old_body": _isolated_summary(isolated_rows["old_body"]),
+            "new_body": _isolated_summary(isolated_rows["new_body"]),
+            "body_effect": isolated_effect,
+            "positive_body_effect": isolated_positive_effect,
+            "negative_body_effect": isolated_negative_effect,
+        },
+        "library_curve": library_curve,
+    }
+
+
+def render_text(report: dict[str, Any]) -> str:
+    """Render a compact human-readable summary."""
+    isolated = report["isolated"]["body_effect"]
+    lines = [
+        f"suite: {report['suite_id']}",
+        f"target_skill: {report['target_skill']}",
+        (
+            f"cases: {report['cases']} "
+            f"(positive={report['positive_cases']}, negative={report['negative_cases']})"
+        ),
+        (
+            "isolated_body_effect: "
+            f"{isolated['mean']} CI={isolated['confidence_interval']} n={isolated['n']}"
+        ),
+    ]
+    for level in report["library_curve"]:
+        joint = level["factorial_effects"]["joint_deployed_effect"]
+        interaction = level["factorial_effects"]["interaction"]
+        interference = level["interference"]
+        activation = level["activation_effects"]
+        resources = level["resource_effects"]
+        lines.extend(
+            [
+                f"library[distractors={level['distractor_count']}]:",
+                (
+                    "  joint_deployed_effect: "
+                    f"{joint['mean']} CI={joint['confidence_interval']}"
+                ),
+                (
+                    "  factorial_interaction: "
+                    f"{interaction['mean']} CI={interaction['confidence_interval']}"
+                ),
+                (
+                    "  interference: "
+                    f"{interference['mean']} CI={interference['confidence_interval']}"
+                ),
+                (
+                    "  activation_delta: "
+                    f"all={activation['target_activation_delta']['mean']} "
+                    f"positive={activation['positive_recall_delta']['mean']} "
+                    "negative_fpr="
+                    f"{activation['negative_false_positive_rate_delta']['mean']}"
+                ),
+                (
+                    "  resource_delta: "
+                    f"catalog_tokens={resources['catalog_tokens']['mean']} "
+                    f"loaded_skill_tokens={resources['loaded_skill_tokens']['mean']} "
+                    f"cost_usd={resources['cost_usd']['mean']}"
+                ),
+            ]
+        )
+    return "\n".join(lines)
+
+
+def main(argv: list[str] | None = None) -> int:
+    parser = argparse.ArgumentParser(
+        description="Evaluate a recorded library-aware Skill 2x2 replay."
+    )
+    parser.add_argument("suite", type=Path)
+    parser.add_argument("--format", choices=("text", "json"), default="text")
+    args = parser.parse_args(argv)
+    report = evaluate_suite(load_suite(args.suite))
+    if args.format == "json":
+        print(json.dumps(report, ensure_ascii=False, indent=2, sort_keys=True))
+    else:
+        print(render_text(report))
+    return 0
+
+
+if __name__ == "__main__":
+    raise SystemExit(main())

--- a/scripts/bench/skill_library_replay/fixtures/baseline_v1.json
+++ b/scripts/bench/skill_library_replay/fixtures/baseline_v1.json
@@ -1,0 +1,344 @@
+{
+  "schema_version": 1,
+  "suite_id": "synthetic-library-aware-v1",
+  "target_skill": "spreadsheet-formula-repair",
+  "metric_config": {
+    "bootstrap_samples": 1000,
+    "bootstrap_seed": 42,
+    "confidence_level": 0.95
+  },
+  "run_manifest": {
+    "repository_revision": "synthetic-recorded-fixture",
+    "model": "recorded-fixture",
+    "harness": "recorded-fixture",
+    "generated_at": "2026-08-30T00:00:00Z",
+    "task_set_fingerprint": "sha256:aaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaa",
+    "evaluation_protocol_fingerprint": "sha256:bbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbb",
+    "old_body_fingerprint": "sha256:cccccccccccccccccccccccccccccccccccccccccccccccccccccccccccccccc",
+    "new_body_fingerprint": "sha256:dddddddddddddddddddddddddddddddddddddddddddddddddddddddddddddddd",
+    "old_description_fingerprint": "sha256:eeeeeeeeeeeeeeeeeeeeeeeeeeeeeeeeeeeeeeeeeeeeeeeeeeeeeeeeeeeeeeee",
+    "new_description_fingerprint": "sha256:ffffffffffffffffffffffffffffffffffffffffffffffffffffffffffffffff",
+    "generation_config": {
+      "temperature": 0.0,
+      "top_p": 1.0,
+      "max_output_tokens": 4096
+    }
+  },
+  "library_ladder": [
+    {
+      "distractor_count": 0,
+      "distractor_catalog_fingerprint": "sha256:0000000000000000000000000000000000000000000000000000000000000000",
+      "distractor_skills": []
+    },
+    {
+      "distractor_count": 2,
+      "distractor_catalog_fingerprint": "sha256:9999999999999999999999999999999999999999999999999999999999999999",
+      "distractor_skills": [
+        "spreadsheet-formatting",
+        "spreadsheet-charting"
+      ]
+    }
+  ],
+  "cases": [
+    {
+      "case_id": "positive-formula-repair",
+      "task_fingerprint": "sha256:1111111111111111111111111111111111111111111111111111111111111111",
+      "seed": 7,
+      "should_activate": true,
+      "isolated": {
+        "old_body": {
+          "run_id": "positive-isolated-old-body",
+          "score": 0.0,
+          "target_activated": true,
+          "activated_skills": ["spreadsheet-formula-repair"],
+          "catalog_tokens": 0,
+          "loaded_skill_tokens": 80,
+          "input_tokens": 980,
+          "output_tokens": 120,
+          "cost_usd": 0.002,
+          "latency_ms": 1000,
+          "error_type": "incorrect_result"
+        },
+        "new_body": {
+          "run_id": "positive-isolated-new-body",
+          "score": 1.0,
+          "target_activated": true,
+          "activated_skills": ["spreadsheet-formula-repair"],
+          "catalog_tokens": 0,
+          "loaded_skill_tokens": 100,
+          "input_tokens": 1000,
+          "output_tokens": 100,
+          "cost_usd": 0.002,
+          "latency_ms": 900,
+          "error_type": null
+        }
+      },
+      "libraries": [
+        {
+          "distractor_count": 0,
+          "deployed": {
+            "old_body__old_description": {
+              "run_id": "positive-d0-old-old",
+              "score": 0.0,
+              "target_activated": false,
+              "activated_skills": [],
+              "catalog_tokens": 20,
+              "loaded_skill_tokens": 0,
+              "input_tokens": 900,
+              "output_tokens": 120,
+              "cost_usd": 0.002,
+              "latency_ms": 1000,
+              "error_type": "missed_activation"
+            },
+            "old_body__new_description": {
+              "run_id": "positive-d0-old-new",
+              "score": 0.0,
+              "target_activated": true,
+              "activated_skills": ["spreadsheet-formula-repair"],
+              "catalog_tokens": 24,
+              "loaded_skill_tokens": 80,
+              "input_tokens": 984,
+              "output_tokens": 120,
+              "cost_usd": 0.0021,
+              "latency_ms": 1020,
+              "error_type": "incorrect_result"
+            },
+            "new_body__old_description": {
+              "run_id": "positive-d0-new-old",
+              "score": 0.0,
+              "target_activated": false,
+              "activated_skills": [],
+              "catalog_tokens": 20,
+              "loaded_skill_tokens": 0,
+              "input_tokens": 900,
+              "output_tokens": 120,
+              "cost_usd": 0.002,
+              "latency_ms": 1000,
+              "error_type": "missed_activation"
+            },
+            "new_body__new_description": {
+              "run_id": "positive-d0-new-new",
+              "score": 1.0,
+              "target_activated": true,
+              "activated_skills": ["spreadsheet-formula-repair"],
+              "catalog_tokens": 24,
+              "loaded_skill_tokens": 100,
+              "input_tokens": 1004,
+              "output_tokens": 100,
+              "cost_usd": 0.002,
+              "latency_ms": 900,
+              "error_type": null
+            }
+          }
+        },
+        {
+          "distractor_count": 2,
+          "deployed": {
+            "old_body__old_description": {
+              "run_id": "positive-d2-old-old",
+              "score": 0.0,
+              "target_activated": false,
+              "activated_skills": ["spreadsheet-formatting"],
+              "catalog_tokens": 60,
+              "loaded_skill_tokens": 70,
+              "input_tokens": 1010,
+              "output_tokens": 120,
+              "cost_usd": 0.0022,
+              "latency_ms": 1080,
+              "error_type": "wrong_skill_activation"
+            },
+            "old_body__new_description": {
+              "run_id": "positive-d2-old-new",
+              "score": 0.0,
+              "target_activated": true,
+              "activated_skills": ["spreadsheet-formula-repair"],
+              "catalog_tokens": 64,
+              "loaded_skill_tokens": 80,
+              "input_tokens": 1024,
+              "output_tokens": 120,
+              "cost_usd": 0.0022,
+              "latency_ms": 1050,
+              "error_type": "incorrect_result"
+            },
+            "new_body__old_description": {
+              "run_id": "positive-d2-new-old",
+              "score": 0.0,
+              "target_activated": false,
+              "activated_skills": ["spreadsheet-formatting"],
+              "catalog_tokens": 60,
+              "loaded_skill_tokens": 70,
+              "input_tokens": 1010,
+              "output_tokens": 120,
+              "cost_usd": 0.0022,
+              "latency_ms": 1080,
+              "error_type": "wrong_skill_activation"
+            },
+            "new_body__new_description": {
+              "run_id": "positive-d2-new-new",
+              "score": 1.0,
+              "target_activated": true,
+              "activated_skills": ["spreadsheet-formula-repair"],
+              "catalog_tokens": 64,
+              "loaded_skill_tokens": 100,
+              "input_tokens": 1044,
+              "output_tokens": 100,
+              "cost_usd": 0.0021,
+              "latency_ms": 920,
+              "error_type": null
+            }
+          }
+        }
+      ]
+    },
+    {
+      "case_id": "negative-formatting-request",
+      "task_fingerprint": "sha256:2222222222222222222222222222222222222222222222222222222222222222",
+      "seed": 7,
+      "should_activate": false,
+      "isolated": {
+        "old_body": {
+          "run_id": "negative-isolated-old-body",
+          "score": 0.5,
+          "target_activated": true,
+          "activated_skills": ["spreadsheet-formula-repair"],
+          "catalog_tokens": 0,
+          "loaded_skill_tokens": 80,
+          "input_tokens": 980,
+          "output_tokens": 120,
+          "cost_usd": 0.002,
+          "latency_ms": 1000,
+          "error_type": "partial_result"
+        },
+        "new_body": {
+          "run_id": "negative-isolated-new-body",
+          "score": 0.5,
+          "target_activated": true,
+          "activated_skills": ["spreadsheet-formula-repair"],
+          "catalog_tokens": 0,
+          "loaded_skill_tokens": 100,
+          "input_tokens": 1000,
+          "output_tokens": 120,
+          "cost_usd": 0.0021,
+          "latency_ms": 1020,
+          "error_type": "partial_result"
+        }
+      },
+      "libraries": [
+        {
+          "distractor_count": 0,
+          "deployed": {
+            "old_body__old_description": {
+              "run_id": "negative-d0-old-old",
+              "score": 0.0,
+              "target_activated": true,
+              "activated_skills": ["spreadsheet-formula-repair"],
+              "catalog_tokens": 20,
+              "loaded_skill_tokens": 80,
+              "input_tokens": 980,
+              "output_tokens": 120,
+              "cost_usd": 0.0021,
+              "latency_ms": 1050,
+              "error_type": "harmful_activation"
+            },
+            "old_body__new_description": {
+              "run_id": "negative-d0-old-new",
+              "score": 1.0,
+              "target_activated": false,
+              "activated_skills": [],
+              "catalog_tokens": 24,
+              "loaded_skill_tokens": 0,
+              "input_tokens": 904,
+              "output_tokens": 100,
+              "cost_usd": 0.0018,
+              "latency_ms": 850,
+              "error_type": null
+            },
+            "new_body__old_description": {
+              "run_id": "negative-d0-new-old",
+              "score": 0.0,
+              "target_activated": true,
+              "activated_skills": ["spreadsheet-formula-repair"],
+              "catalog_tokens": 20,
+              "loaded_skill_tokens": 100,
+              "input_tokens": 1000,
+              "output_tokens": 120,
+              "cost_usd": 0.0022,
+              "latency_ms": 1080,
+              "error_type": "harmful_activation"
+            },
+            "new_body__new_description": {
+              "run_id": "negative-d0-new-new",
+              "score": 1.0,
+              "target_activated": false,
+              "activated_skills": [],
+              "catalog_tokens": 24,
+              "loaded_skill_tokens": 0,
+              "input_tokens": 904,
+              "output_tokens": 100,
+              "cost_usd": 0.0018,
+              "latency_ms": 850,
+              "error_type": null
+            }
+          }
+        },
+        {
+          "distractor_count": 2,
+          "deployed": {
+            "old_body__old_description": {
+              "run_id": "negative-d2-old-old",
+              "score": 0.0,
+              "target_activated": true,
+              "activated_skills": ["spreadsheet-formula-repair"],
+              "catalog_tokens": 60,
+              "loaded_skill_tokens": 80,
+              "input_tokens": 1020,
+              "output_tokens": 120,
+              "cost_usd": 0.0022,
+              "latency_ms": 1080,
+              "error_type": "harmful_activation"
+            },
+            "old_body__new_description": {
+              "run_id": "negative-d2-old-new",
+              "score": 1.0,
+              "target_activated": false,
+              "activated_skills": ["spreadsheet-formatting"],
+              "catalog_tokens": 64,
+              "loaded_skill_tokens": 70,
+              "input_tokens": 1034,
+              "output_tokens": 100,
+              "cost_usd": 0.002,
+              "latency_ms": 900,
+              "error_type": null
+            },
+            "new_body__old_description": {
+              "run_id": "negative-d2-new-old",
+              "score": 0.0,
+              "target_activated": true,
+              "activated_skills": ["spreadsheet-formula-repair"],
+              "catalog_tokens": 60,
+              "loaded_skill_tokens": 100,
+              "input_tokens": 1040,
+              "output_tokens": 120,
+              "cost_usd": 0.0023,
+              "latency_ms": 1100,
+              "error_type": "harmful_activation"
+            },
+            "new_body__new_description": {
+              "run_id": "negative-d2-new-new",
+              "score": 1.0,
+              "target_activated": false,
+              "activated_skills": ["spreadsheet-formatting"],
+              "catalog_tokens": 64,
+              "loaded_skill_tokens": 70,
+              "input_tokens": 1034,
+              "output_tokens": 100,
+              "cost_usd": 0.002,
+              "latency_ms": 900,
+              "error_type": null
+            }
+          }
+        }
+      ]
+    }
+  ]
+}

--- a/scripts/bench/skill_library_replay/fixtures/baseline_v1.report.json
+++ b/scripts/bench/skill_library_replay/fixtures/baseline_v1.report.json
@@ -1,0 +1,623 @@
+{
+  "cases": 2,
+  "isolated": {
+    "body_effect": {
+      "confidence_interval": [
+        0.0,
+        1.0
+      ],
+      "losses": 0,
+      "mean": 0.5,
+      "n": 2,
+      "ties": 1,
+      "wins": 1
+    },
+    "negative_body_effect": {
+      "confidence_interval": null,
+      "losses": 0,
+      "mean": 0.0,
+      "n": 1,
+      "ties": 1,
+      "wins": 0
+    },
+    "new_body": {
+      "activated_skill_count_mean": 1.0,
+      "catalog_tokens_mean": 0.0,
+      "cost_usd_mean": 0.00205,
+      "input_tokens_mean": 1000.0,
+      "latency_ms_mean": 960.0,
+      "loaded_skill_tokens_mean": 100.0,
+      "output_tokens_mean": 110.0,
+      "score_mean": 0.75
+    },
+    "old_body": {
+      "activated_skill_count_mean": 1.0,
+      "catalog_tokens_mean": 0.0,
+      "cost_usd_mean": 0.002,
+      "input_tokens_mean": 980.0,
+      "latency_ms_mean": 1000.0,
+      "loaded_skill_tokens_mean": 80.0,
+      "output_tokens_mean": 120.0,
+      "score_mean": 0.25
+    },
+    "positive_body_effect": {
+      "confidence_interval": null,
+      "losses": 0,
+      "mean": 1.0,
+      "n": 1,
+      "ties": 0,
+      "wins": 1
+    }
+  },
+  "library_curve": [
+    {
+      "activation_effects": {
+        "negative_false_positive_rate_delta": {
+          "confidence_interval": null,
+          "losses": 1,
+          "mean": -1.0,
+          "n": 1,
+          "ties": 0,
+          "wins": 0
+        },
+        "positive_recall_delta": {
+          "confidence_interval": null,
+          "losses": 0,
+          "mean": 1.0,
+          "n": 1,
+          "ties": 0,
+          "wins": 1
+        },
+        "target_activation_delta": {
+          "confidence_interval": [
+            -1.0,
+            1.0
+          ],
+          "losses": 1,
+          "mean": 0.0,
+          "n": 2,
+          "ties": 0,
+          "wins": 1
+        }
+      },
+      "cells": {
+        "new_body__new_description": {
+          "activated_skill_count_mean": 0.5,
+          "activated_skill_counts": {
+            "spreadsheet-formula-repair": 1
+          },
+          "catalog_tokens_mean": 24.0,
+          "cost_usd_mean": 0.0019,
+          "error_types": {},
+          "input_tokens_mean": 954.0,
+          "latency_ms_mean": 875.0,
+          "loaded_skill_tokens_mean": 50.0,
+          "negative_false_positive_rate": 0.0,
+          "output_tokens_mean": 100.0,
+          "positive_recall": 1.0,
+          "score_mean": 1.0,
+          "target_activation_rate": 0.5
+        },
+        "new_body__old_description": {
+          "activated_skill_count_mean": 0.5,
+          "activated_skill_counts": {
+            "spreadsheet-formula-repair": 1
+          },
+          "catalog_tokens_mean": 20.0,
+          "cost_usd_mean": 0.0021,
+          "error_types": {
+            "harmful_activation": 1,
+            "missed_activation": 1
+          },
+          "input_tokens_mean": 950.0,
+          "latency_ms_mean": 1040.0,
+          "loaded_skill_tokens_mean": 50.0,
+          "negative_false_positive_rate": 1.0,
+          "output_tokens_mean": 120.0,
+          "positive_recall": 0.0,
+          "score_mean": 0.0,
+          "target_activation_rate": 0.5
+        },
+        "old_body__new_description": {
+          "activated_skill_count_mean": 0.5,
+          "activated_skill_counts": {
+            "spreadsheet-formula-repair": 1
+          },
+          "catalog_tokens_mean": 24.0,
+          "cost_usd_mean": 0.00195,
+          "error_types": {
+            "incorrect_result": 1
+          },
+          "input_tokens_mean": 944.0,
+          "latency_ms_mean": 935.0,
+          "loaded_skill_tokens_mean": 40.0,
+          "negative_false_positive_rate": 0.0,
+          "output_tokens_mean": 110.0,
+          "positive_recall": 1.0,
+          "score_mean": 0.5,
+          "target_activation_rate": 0.5
+        },
+        "old_body__old_description": {
+          "activated_skill_count_mean": 0.5,
+          "activated_skill_counts": {
+            "spreadsheet-formula-repair": 1
+          },
+          "catalog_tokens_mean": 20.0,
+          "cost_usd_mean": 0.00205,
+          "error_types": {
+            "harmful_activation": 1,
+            "missed_activation": 1
+          },
+          "input_tokens_mean": 940.0,
+          "latency_ms_mean": 1025.0,
+          "loaded_skill_tokens_mean": 40.0,
+          "negative_false_positive_rate": 1.0,
+          "output_tokens_mean": 120.0,
+          "positive_recall": 0.0,
+          "score_mean": 0.0,
+          "target_activation_rate": 0.5
+        }
+      },
+      "distractor_catalog_fingerprint": "sha256:0000000000000000000000000000000000000000000000000000000000000000",
+      "distractor_count": 0,
+      "distractor_skills": [],
+      "factorial_effects": {
+        "body_at_new_description": {
+          "confidence_interval": [
+            0.0,
+            1.0
+          ],
+          "losses": 0,
+          "mean": 0.5,
+          "n": 2,
+          "ties": 1,
+          "wins": 1
+        },
+        "body_at_old_description": {
+          "confidence_interval": [
+            0.0,
+            0.0
+          ],
+          "losses": 0,
+          "mean": 0.0,
+          "n": 2,
+          "ties": 2,
+          "wins": 0
+        },
+        "description_at_new_body": {
+          "confidence_interval": [
+            1.0,
+            1.0
+          ],
+          "losses": 0,
+          "mean": 1.0,
+          "n": 2,
+          "ties": 0,
+          "wins": 2
+        },
+        "description_at_old_body": {
+          "confidence_interval": [
+            0.0,
+            1.0
+          ],
+          "losses": 0,
+          "mean": 0.5,
+          "n": 2,
+          "ties": 1,
+          "wins": 1
+        },
+        "interaction": {
+          "confidence_interval": [
+            0.0,
+            1.0
+          ],
+          "losses": 0,
+          "mean": 0.5,
+          "n": 2,
+          "ties": 1,
+          "wins": 1
+        },
+        "joint_deployed_effect": {
+          "confidence_interval": [
+            1.0,
+            1.0
+          ],
+          "losses": 0,
+          "mean": 1.0,
+          "n": 2,
+          "ties": 0,
+          "wins": 2
+        }
+      },
+      "interference": {
+        "confidence_interval": [
+          -1.0,
+          0.0
+        ],
+        "losses": 1,
+        "mean": -0.5,
+        "n": 2,
+        "ties": 1,
+        "wins": 0
+      },
+      "resource_effects": {
+        "activated_skill_count": {
+          "confidence_interval": [
+            -1.0,
+            1.0
+          ],
+          "losses": 1,
+          "mean": 0.0,
+          "n": 2,
+          "ties": 0,
+          "wins": 1
+        },
+        "catalog_tokens": {
+          "confidence_interval": [
+            4.0,
+            4.0
+          ],
+          "losses": 0,
+          "mean": 4.0,
+          "n": 2,
+          "ties": 0,
+          "wins": 2
+        },
+        "cost_usd": {
+          "confidence_interval": [
+            -0.0003,
+            0.0
+          ],
+          "losses": 1,
+          "mean": -0.00015,
+          "n": 2,
+          "ties": 1,
+          "wins": 0
+        },
+        "input_tokens": {
+          "confidence_interval": [
+            -76.0,
+            104.0
+          ],
+          "losses": 1,
+          "mean": 14.0,
+          "n": 2,
+          "ties": 0,
+          "wins": 1
+        },
+        "latency_ms": {
+          "confidence_interval": [
+            -200.0,
+            -100.0
+          ],
+          "losses": 2,
+          "mean": -150.0,
+          "n": 2,
+          "ties": 0,
+          "wins": 0
+        },
+        "loaded_skill_tokens": {
+          "confidence_interval": [
+            -80.0,
+            100.0
+          ],
+          "losses": 1,
+          "mean": 10.0,
+          "n": 2,
+          "ties": 0,
+          "wins": 1
+        },
+        "output_tokens": {
+          "confidence_interval": [
+            -20.0,
+            -20.0
+          ],
+          "losses": 2,
+          "mean": -20.0,
+          "n": 2,
+          "ties": 0,
+          "wins": 0
+        }
+      }
+    },
+    {
+      "activation_effects": {
+        "negative_false_positive_rate_delta": {
+          "confidence_interval": null,
+          "losses": 1,
+          "mean": -1.0,
+          "n": 1,
+          "ties": 0,
+          "wins": 0
+        },
+        "positive_recall_delta": {
+          "confidence_interval": null,
+          "losses": 0,
+          "mean": 1.0,
+          "n": 1,
+          "ties": 0,
+          "wins": 1
+        },
+        "target_activation_delta": {
+          "confidence_interval": [
+            -1.0,
+            1.0
+          ],
+          "losses": 1,
+          "mean": 0.0,
+          "n": 2,
+          "ties": 0,
+          "wins": 1
+        }
+      },
+      "cells": {
+        "new_body__new_description": {
+          "activated_skill_count_mean": 1.0,
+          "activated_skill_counts": {
+            "spreadsheet-formatting": 1,
+            "spreadsheet-formula-repair": 1
+          },
+          "catalog_tokens_mean": 64.0,
+          "cost_usd_mean": 0.00205,
+          "error_types": {},
+          "input_tokens_mean": 1039.0,
+          "latency_ms_mean": 910.0,
+          "loaded_skill_tokens_mean": 85.0,
+          "negative_false_positive_rate": 0.0,
+          "output_tokens_mean": 100.0,
+          "positive_recall": 1.0,
+          "score_mean": 1.0,
+          "target_activation_rate": 0.5
+        },
+        "new_body__old_description": {
+          "activated_skill_count_mean": 1.0,
+          "activated_skill_counts": {
+            "spreadsheet-formatting": 1,
+            "spreadsheet-formula-repair": 1
+          },
+          "catalog_tokens_mean": 60.0,
+          "cost_usd_mean": 0.00225,
+          "error_types": {
+            "harmful_activation": 1,
+            "wrong_skill_activation": 1
+          },
+          "input_tokens_mean": 1025.0,
+          "latency_ms_mean": 1090.0,
+          "loaded_skill_tokens_mean": 85.0,
+          "negative_false_positive_rate": 1.0,
+          "output_tokens_mean": 120.0,
+          "positive_recall": 0.0,
+          "score_mean": 0.0,
+          "target_activation_rate": 0.5
+        },
+        "old_body__new_description": {
+          "activated_skill_count_mean": 1.0,
+          "activated_skill_counts": {
+            "spreadsheet-formatting": 1,
+            "spreadsheet-formula-repair": 1
+          },
+          "catalog_tokens_mean": 64.0,
+          "cost_usd_mean": 0.0021,
+          "error_types": {
+            "incorrect_result": 1
+          },
+          "input_tokens_mean": 1029.0,
+          "latency_ms_mean": 975.0,
+          "loaded_skill_tokens_mean": 75.0,
+          "negative_false_positive_rate": 0.0,
+          "output_tokens_mean": 110.0,
+          "positive_recall": 1.0,
+          "score_mean": 0.5,
+          "target_activation_rate": 0.5
+        },
+        "old_body__old_description": {
+          "activated_skill_count_mean": 1.0,
+          "activated_skill_counts": {
+            "spreadsheet-formatting": 1,
+            "spreadsheet-formula-repair": 1
+          },
+          "catalog_tokens_mean": 60.0,
+          "cost_usd_mean": 0.0022,
+          "error_types": {
+            "harmful_activation": 1,
+            "wrong_skill_activation": 1
+          },
+          "input_tokens_mean": 1015.0,
+          "latency_ms_mean": 1080.0,
+          "loaded_skill_tokens_mean": 75.0,
+          "negative_false_positive_rate": 1.0,
+          "output_tokens_mean": 120.0,
+          "positive_recall": 0.0,
+          "score_mean": 0.0,
+          "target_activation_rate": 0.5
+        }
+      },
+      "distractor_catalog_fingerprint": "sha256:9999999999999999999999999999999999999999999999999999999999999999",
+      "distractor_count": 2,
+      "distractor_skills": [
+        "spreadsheet-formatting",
+        "spreadsheet-charting"
+      ],
+      "factorial_effects": {
+        "body_at_new_description": {
+          "confidence_interval": [
+            0.0,
+            1.0
+          ],
+          "losses": 0,
+          "mean": 0.5,
+          "n": 2,
+          "ties": 1,
+          "wins": 1
+        },
+        "body_at_old_description": {
+          "confidence_interval": [
+            0.0,
+            0.0
+          ],
+          "losses": 0,
+          "mean": 0.0,
+          "n": 2,
+          "ties": 2,
+          "wins": 0
+        },
+        "description_at_new_body": {
+          "confidence_interval": [
+            1.0,
+            1.0
+          ],
+          "losses": 0,
+          "mean": 1.0,
+          "n": 2,
+          "ties": 0,
+          "wins": 2
+        },
+        "description_at_old_body": {
+          "confidence_interval": [
+            0.0,
+            1.0
+          ],
+          "losses": 0,
+          "mean": 0.5,
+          "n": 2,
+          "ties": 1,
+          "wins": 1
+        },
+        "interaction": {
+          "confidence_interval": [
+            0.0,
+            1.0
+          ],
+          "losses": 0,
+          "mean": 0.5,
+          "n": 2,
+          "ties": 1,
+          "wins": 1
+        },
+        "joint_deployed_effect": {
+          "confidence_interval": [
+            1.0,
+            1.0
+          ],
+          "losses": 0,
+          "mean": 1.0,
+          "n": 2,
+          "ties": 0,
+          "wins": 2
+        }
+      },
+      "interference": {
+        "confidence_interval": [
+          -1.0,
+          0.0
+        ],
+        "losses": 1,
+        "mean": -0.5,
+        "n": 2,
+        "ties": 1,
+        "wins": 0
+      },
+      "resource_effects": {
+        "activated_skill_count": {
+          "confidence_interval": [
+            0.0,
+            0.0
+          ],
+          "losses": 0,
+          "mean": 0.0,
+          "n": 2,
+          "ties": 2,
+          "wins": 0
+        },
+        "catalog_tokens": {
+          "confidence_interval": [
+            4.0,
+            4.0
+          ],
+          "losses": 0,
+          "mean": 4.0,
+          "n": 2,
+          "ties": 0,
+          "wins": 2
+        },
+        "cost_usd": {
+          "confidence_interval": [
+            -0.0002,
+            -0.0001
+          ],
+          "losses": 2,
+          "mean": -0.00015,
+          "n": 2,
+          "ties": 0,
+          "wins": 0
+        },
+        "input_tokens": {
+          "confidence_interval": [
+            14.0,
+            34.0
+          ],
+          "losses": 0,
+          "mean": 24.0,
+          "n": 2,
+          "ties": 0,
+          "wins": 2
+        },
+        "latency_ms": {
+          "confidence_interval": [
+            -180.0,
+            -160.0
+          ],
+          "losses": 2,
+          "mean": -170.0,
+          "n": 2,
+          "ties": 0,
+          "wins": 0
+        },
+        "loaded_skill_tokens": {
+          "confidence_interval": [
+            -10.0,
+            30.0
+          ],
+          "losses": 1,
+          "mean": 10.0,
+          "n": 2,
+          "ties": 0,
+          "wins": 1
+        },
+        "output_tokens": {
+          "confidence_interval": [
+            -20.0,
+            -20.0
+          ],
+          "losses": 2,
+          "mean": -20.0,
+          "n": 2,
+          "ties": 0,
+          "wins": 0
+        }
+      }
+    }
+  ],
+  "negative_cases": 1,
+  "positive_cases": 1,
+  "run_manifest": {
+    "evaluation_protocol_fingerprint": "sha256:bbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbb",
+    "generated_at": "2026-08-30T00:00:00Z",
+    "generation_config": {
+      "max_output_tokens": 4096,
+      "temperature": 0.0,
+      "top_p": 1.0
+    },
+    "harness": "recorded-fixture",
+    "model": "recorded-fixture",
+    "new_body_fingerprint": "sha256:dddddddddddddddddddddddddddddddddddddddddddddddddddddddddddddddd",
+    "new_description_fingerprint": "sha256:ffffffffffffffffffffffffffffffffffffffffffffffffffffffffffffffff",
+    "old_body_fingerprint": "sha256:cccccccccccccccccccccccccccccccccccccccccccccccccccccccccccccccc",
+    "old_description_fingerprint": "sha256:eeeeeeeeeeeeeeeeeeeeeeeeeeeeeeeeeeeeeeeeeeeeeeeeeeeeeeeeeeeeeeee",
+    "repository_revision": "synthetic-recorded-fixture",
+    "task_set_fingerprint": "sha256:aaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaa"
+  },
+  "schema_version": 1,
+  "suite_id": "synthetic-library-aware-v1",
+  "target_skill": "spreadsheet-formula-repair"
+}

--- a/tests/test_skill_library_replay.py
+++ b/tests/test_skill_library_replay.py
@@ -202,6 +202,23 @@ def test_suite_requires_positive_and_negative_activation_cases():
         validate_suite(suite)
 
 
+def test_bootstrap_bound_counts_every_reported_statistic():
+    suite = load_suite(BASELINE_PATH)
+    suite["metric_config"]["bootstrap_samples"] = 50_000
+    repeated = deepcopy(suite["cases"][0])
+    repeated["case_id"] += "-repeated"
+    repeated["task_fingerprint"] = "sha256:" + "f" * 64
+    for observation in repeated["isolated"].values():
+        observation["run_id"] += "-repeated"
+    for level in repeated["libraries"]:
+        for observation in level["deployed"].values():
+            observation["run_id"] += "-repeated"
+    suite["cases"].append(repeated)
+
+    with pytest.raises(LibraryReplayValidationError, match="bootstrap work"):
+        validate_suite(suite)
+
+
 def test_cli_renders_text_and_json(capsys):
     report = evaluate_suite(load_suite(BASELINE_PATH))
 

--- a/tests/test_skill_library_replay.py
+++ b/tests/test_skill_library_replay.py
@@ -1,0 +1,211 @@
+"""Contracts for the deterministic library-aware Skill replay evaluator."""
+
+from __future__ import annotations
+
+import json
+from copy import deepcopy
+from pathlib import Path
+
+import pytest
+
+from scripts.bench.skill_library_replay.evaluate import (
+    LibraryReplayValidationError,
+    evaluate_suite,
+    load_suite,
+    main,
+    render_text,
+    validate_suite,
+)
+
+FIXTURE_DIR = (
+    Path(__file__).parent.parent
+    / "scripts"
+    / "bench"
+    / "skill_library_replay"
+    / "fixtures"
+)
+BASELINE_PATH = FIXTURE_DIR / "baseline_v1.json"
+REPORT_PATH = FIXTURE_DIR / "baseline_v1.report.json"
+
+pytestmark = pytest.mark.algorithm_replay
+
+
+def test_baseline_report_matches_checked_in_snapshot():
+    report = evaluate_suite(load_suite(BASELINE_PATH))
+
+    assert report == json.loads(REPORT_PATH.read_text(encoding="utf-8"))
+
+
+def test_factorial_replay_separates_body_description_and_joint_effects():
+    report = evaluate_suite(load_suite(BASELINE_PATH))
+    effects = report["library_curve"][0]["factorial_effects"]
+
+    assert report["isolated"]["body_effect"]["mean"] == 0.5
+    assert report["isolated"]["positive_body_effect"]["mean"] == 1.0
+    assert report["isolated"]["negative_body_effect"]["mean"] == 0.0
+    assert effects["body_at_old_description"]["mean"] == 0.0
+    assert effects["description_at_old_body"]["mean"] == 0.5
+    assert effects["joint_deployed_effect"]["mean"] == 1.0
+    assert effects["interaction"]["mean"] == 0.5
+    assert report["library_curve"][0]["interference"]["mean"] == -0.5
+
+
+def test_activation_metrics_do_not_hide_positive_and_negative_cancellation():
+    activation = report_level(0)["activation_effects"]
+
+    assert activation["target_activation_delta"]["mean"] == 0.0
+    assert activation["positive_recall_delta"]["mean"] == 1.0
+    assert activation["negative_false_positive_rate_delta"]["mean"] == -1.0
+
+
+def test_library_curve_retains_resource_and_distractor_context():
+    level = report_level(2)
+
+    assert level["distractor_skills"] == [
+        "spreadsheet-formatting",
+        "spreadsheet-charting",
+    ]
+    assert level["resource_effects"]["catalog_tokens"]["mean"] == 4.0
+    assert level["resource_effects"]["cost_usd"]["mean"] == -0.00015
+    old_cell = level["cells"]["old_body__old_description"]
+    assert old_cell["activated_skill_counts"] == {
+        "spreadsheet-formula-repair": 1,
+        "spreadsheet-formatting": 1,
+    }
+    assert old_cell["error_types"] == {
+        "harmful_activation": 1,
+        "wrong_skill_activation": 1,
+    }
+
+
+def report_level(distractor_count: int) -> dict:
+    report = evaluate_suite(load_suite(BASELINE_PATH))
+    return next(
+        level
+        for level in report["library_curve"]
+        if level["distractor_count"] == distractor_count
+    )
+
+
+def test_missing_factorial_cell_fails_loudly():
+    suite = load_suite(BASELINE_PATH)
+    del suite["cases"][0]["libraries"][0]["deployed"]["new_body__new_description"]
+
+    with pytest.raises(LibraryReplayValidationError, match="expected exactly"):
+        validate_suite(suite)
+
+
+def test_each_case_must_cover_the_same_library_ladder():
+    suite = load_suite(BASELINE_PATH)
+    suite["cases"][0]["libraries"][1]["distractor_count"] = 1
+
+    with pytest.raises(
+        LibraryReplayValidationError, match="expected distractor counts"
+    ):
+        validate_suite(suite)
+
+
+def test_library_ladder_must_include_zero_distractor_control():
+    suite = load_suite(BASELINE_PATH)
+    suite["library_ladder"] = suite["library_ladder"][1:]
+    for case in suite["cases"]:
+        case["libraries"] = case["libraries"][1:]
+
+    with pytest.raises(LibraryReplayValidationError, match="must start"):
+        validate_suite(suite)
+
+
+def test_library_growth_must_preserve_distractor_order():
+    suite = load_suite(BASELINE_PATH)
+    suite["library_ladder"].insert(
+        1,
+        {
+            "distractor_count": 1,
+            "distractor_catalog_fingerprint": (
+                "sha256:8888888888888888888888888888888888888888888888888888888888888888"
+            ),
+            "distractor_skills": ["spreadsheet-charting"],
+        },
+    )
+    for case in suite["cases"]:
+        copied = deepcopy(case["libraries"][1])
+        copied["distractor_count"] = 1
+        case["libraries"].insert(1, copied)
+
+    with pytest.raises(LibraryReplayValidationError, match="retain prior order"):
+        validate_suite(suite)
+
+
+def test_target_activation_flag_must_match_recorded_skill_sequence():
+    suite = load_suite(BASELINE_PATH)
+    observation = suite["cases"][0]["libraries"][0]["deployed"][
+        "new_body__new_description"
+    ]
+    observation["target_activated"] = False
+
+    with pytest.raises(LibraryReplayValidationError, match="disagrees"):
+        validate_suite(suite)
+
+
+def test_deployed_activation_cannot_reference_skill_outside_catalog():
+    suite = load_suite(BASELINE_PATH)
+    observation = suite["cases"][0]["libraries"][1]["deployed"][
+        "old_body__old_description"
+    ]
+    observation["activated_skills"] = ["unlisted-skill"]
+
+    with pytest.raises(LibraryReplayValidationError, match="unknown skills"):
+        validate_suite(suite)
+
+
+def test_isolated_run_must_force_only_the_target_skill():
+    suite = load_suite(BASELINE_PATH)
+    suite["cases"][0]["isolated"]["old_body"]["activated_skills"] = []
+    suite["cases"][0]["isolated"]["old_body"]["target_activated"] = False
+
+    with pytest.raises(LibraryReplayValidationError, match="force only target_skill"):
+        validate_suite(suite)
+
+
+def test_duplicate_run_id_fails_loudly():
+    suite = load_suite(BASELINE_PATH)
+    duplicate = suite["cases"][0]["isolated"]["old_body"]["run_id"]
+    suite["cases"][0]["isolated"]["new_body"]["run_id"] = duplicate
+
+    with pytest.raises(LibraryReplayValidationError, match="duplicate"):
+        validate_suite(suite)
+
+
+def test_old_and_new_artifact_fingerprints_must_differ():
+    suite = load_suite(BASELINE_PATH)
+    manifest = suite["run_manifest"]
+    manifest["new_description_fingerprint"] = manifest["old_description_fingerprint"]
+
+    with pytest.raises(LibraryReplayValidationError, match="must differ"):
+        validate_suite(suite)
+
+
+@pytest.mark.parametrize("score", [True, -0.1, 1.1, "1.0"])
+def test_invalid_outcome_score_fails_loudly(score):
+    suite = load_suite(BASELINE_PATH)
+    suite["cases"][0]["isolated"]["old_body"]["score"] = score
+
+    with pytest.raises(LibraryReplayValidationError, match="score"):
+        validate_suite(suite)
+
+
+def test_suite_requires_positive_and_negative_activation_cases():
+    suite = load_suite(BASELINE_PATH)
+    suite["cases"] = [suite["cases"][0]]
+
+    with pytest.raises(LibraryReplayValidationError, match="positive and negative"):
+        validate_suite(suite)
+
+
+def test_cli_renders_text_and_json(capsys):
+    report = evaluate_suite(load_suite(BASELINE_PATH))
+
+    assert main([str(BASELINE_PATH)]) == 0
+    assert capsys.readouterr().out == render_text(report) + "\n"
+    assert main([str(BASELINE_PATH), "--format", "json"]) == 0
+    assert json.loads(capsys.readouterr().out) == report


### PR DESCRIPTION
## Summary

增加库感知的 Skill 2×2 离线回放，用相同 task、seed 和竞争库分别评估 old/new body 与 old/new description。

本 PR 只处理已录制结果的验证和统计，不调用模型或外部 Harness，也不修改生产路由、description optimizer 或 canary 晋升规则。

## Changes

- 增加版本化 replay schema，固定任务、评测协议、正文、description、模型、Harness、采样参数和干扰 Skill 目录。
- 要求每个配对 case 完整提供四个部署单元及 old/new body 的隔离强制激活结果，缺少任一单元时直接失败。
- 报告隔离正文效应、正文与 description 的 simple effects、整体部署效应、二阶交互和干扰量，并使用固定种子的配对 bootstrap 置信区间。
- 分开统计正例 recall 与负例 false-positive-rate，同时保留逐 Skill 激活次数和错误类型，避免总体触发率掩盖 Skill 挤占。
- 记录激活 Skill 数、catalog Token、已加载正文 Token、输入输出 Token、费用和延迟变化。
- 增加隐私安全的合成 fixture、可审查报告快照、19 个契约测试和运行说明。
- 预先索引每个 case 的 library level，并限制 bootstrap 工作量，253 个 case、4 档库规模、每个效应 1,000 次 bootstrap 的本机测量约为 1.49 秒。

## Test plan

- [ ] `make test` passes
- [x] Added/updated unit tests for the change
- [ ] `make e2e` passes (if the change touches ingestion / install / daemon)
- [x] Manually verified the affected user flow

本机没有裸 `python3.11` 命令，因此未勾选字面命令 `make test`，使用同一 Makefile 目标 `make test PY=<existing-venv>/bin/python` 在 Python 3.14.6 上得到 `2754 passed, 10 skipped`。

聚焦回放测试 `python -m pytest tests/test_skill_library_replay.py tests/test_algorithm_replay.py tests/test_task_graph_replay.py -q` 得到 `67 passed`。

Ruff 0.16.5、`git diff --check`、JSON 快照和提交签名检查通过。

手动运行 text 与 JSON 两种报告输出，并用 253 个 case、4 档库规模和 1,000 次 bootstrap 做了性能测量。

E2E 不适用，因为本 PR 不修改 ingestion、install、daemon 或任何生产流水线。

## Linked issues

Closes #380

Refs #48


## 给外人看的背景（技能正文乘激活描述的 2×2 回放是什么）

下面按给第三方看的问题单来写：每个词第一次出现都会说明它是什么。代码位置只是提示，不是必须先读完整个仓库才能看懂。

### 这是什么

XSkill 平时学技能，走的是这条主路：把会话收成轨迹，切成 Atom，再写成 Skill。Skill 是后来写给助手用的说明书。一份 Skill 通常有两块会被助手看见。

技能正文是说明书里真正教助手怎么做事的那一段知识：步骤、规则、脚本、注意点。英文源码里叫 Skill body。激活描述是说明书外沿那一小段话，用来告诉助手这次任务该不该把这份 Skill 唤醒。英文源码里叫 activation description。唤醒就是激活：这次要不要把这份说明书装进来用。

用户机器上往往不止一份 Skill。这些 Skill 会一起出现在技能库里。竞争库就是这种有多份语义相近 Skill 的库：它们会抢着被激活。更泛的 Skill 可能把更贴题的 Skill 挤掉。挤占就是该醒的没醒，不该醒的却醒了。Issue #48 写过这种缺口：总体触发次数看起来不低，但看不出库里谁挤了谁。

本 PR 是 Q2 评测的第一张。Q2 问的是：在有竞争者的技能库里，一次 Skill 更新看起来变好了，到底是正文知识变好了，还是激活描述把技能唤醒了，还是库里互相挤占把收益吃掉了。

做法是 2×2 回放。2×2 的意思是：正文有旧稿和新稿，激活描述也有旧稿和新稿，交叉成四个部署单元。回放的意思是：不在 CI 里再跑模型，只读已经录好的任务结果，按固定口径算出诊断指标。CI 是持续集成，也就是每次提交后自动跑的那组检查。

这是诊断，不是放行。诊断只回答这四个部署单元各自发生了什么。放行是后面 #388 才做的事：预先写死门槛，再给出 admit、reject 或 inconclusive。本 PR 不改生产发布。

### 评测侧实际发生了什么

用户日常用助手时，生产里的 description optimizer 和 Canary 仍按原样跑。description optimizer 是现在用来改激活描述的那套优化，它会用 Agno trigger probe 看候选描述在相似 Skill 里好不好被选中。Canary 是灰度对比：比较主干 main 和灰度 staging 整包版本的 `ux_score`。`ux_score` 是现有技能好不好的分数。本 PR 不改这两套，也不改生产路由。用户电脑上不会因为合入这张补丁就多一次模型调用。

现网是格力内网那套正在给人用的服务。Agent 接触不到现网。合进仓库不等于现网已经换成这份评测，而且这张补丁本来就不改生产流水线。

评测侧才用到本 PR。维护者如果要采一份真实结果，必须先在目标原生运行时上，用同一条任务、同一个随机种子、同一级竞争库，把四个部署单元和隔离强制激活都跑完，再把分数、激活名单、Token、费用、延迟和错误类型记下来。原生运行时在源码里叫 Harness，也就是这次任务跑在哪套外壳上，例如 Claude Code、Codex 或 DeepSeek。普通 CI 不调模型、不调 Embedding、不调编码助手命令行，也不碰 xskill 生产状态。它只读入仓的 JSON，复算报告。

入仓的是一份合成 fixture。fixture 就是评测里写好的固定输入输出包。这一份叫 `synthetic-library-aware-v1`，目标 Skill 名叫 `spreadsheet-formula-repair`，只有一条正例和一条负例，竞争库从零个干扰项加到两个。合成的意思是：编号、指纹和数字结果是编出来锁约定的，没有真实任务文本、轨迹原文、工作区路径或用户标识。它只能证明评测器会算，不能用来宣称正文或激活描述已经更好。

本机另外用 253 个 case、4 档库规模、每个效应 1,000 次 bootstrap 测过耗时，大约 1.49 秒。bootstrap 是把已有配对结果再抽样，估计均值会落在哪一段。那是工作量测量，不是入仓 fixture 的大小，也不是现网效果。

### 四个部署单元和隔离强制激活是什么

每个配对单位是：同一条任务指纹、同一个种子、同一级干扰 Skill 数量。四个部署单元是：

- 旧正文配旧激活描述（`old_body__old_description`），当作部署基线
- 旧正文配新激活描述（`old_body__new_description`）
- 新正文配旧激活描述（`new_body__old_description`）
- 新正文配新激活描述（`new_body__new_description`）

缺任一单元，评测器直接失败。这样才分得开：正文知识变了，分数会不会变；只改激活描述，技能会不会被唤醒；两样一起改，是不是还有单独改看不出来的交互。

同一条任务还必须录隔离强制激活。隔离强制激活的意思是：库里只留目标 Skill，并且强制把它唤醒，不再让描述去竞争谁该醒。旧正文和新正文各录一次。这样得到的是「正文自己会不会把事情做对」，没有库里互相挤占。

竞争库按固定梯子往上加语义相近的干扰 Skill。干扰 Skill 就是会跟目标抢激活的其他 Skill。梯子必须从零个干扰项开始，后一级必须保留前一级的名字和顺序，避免把工具顺序变化混进库规模效应。

报告会算几组诊断数。隔离正文效应是隔离环境下新正文减旧正文，并且正例、负例分开报，避免适用任务上的收益和不适用任务上的副作用互相抵消。整体库内部署效应是新正文配新描述，减去旧正文配旧描述。正文效应在旧描述和新描述上各算一次，描述效应在旧正文和新正文上各算一次，避免只报一个依赖选定基线的数。交互项是「新正文新描述」减去「新正文旧描述」再减去「旧正文新描述」再加上「旧正文旧描述」，用来发现单独改正文或单独改描述都没用、两样一起改才有用这种情况。干扰量是隔离正文效应减去整体库内部署效应：正值表示正文在隔离里赚到的，有一部分在库里丢了；负值表示新的激活边界让部署收益超过正文自身。

正例 recall 是该醒的有没有醒。负例误触发率是不该醒的却醒了。这两种要分开报，还要留下每个 Skill 被激活的次数和错误类型，避免总体触发率把挤占盖住。错误类型用来区分没唤醒、唤醒了错误 Skill、任务执行错了，以及基础设施失败。

资源侧还记激活了几份 Skill、目录 Token、已经加载的正文 Token、输入输出 Token、费用和延迟。Token 是模型计费用的文本用量单位。目录 Token 是激活目录本身的开销，已经加载的正文 Token 是真正读进上下文的说明书开销，不要和输入总 Token 糊在一起。有至少两个配对样本时，用固定种子的配对 bootstrap 给出置信区间。单样本子集的区间记成空，避免把没有统计信息的点估计伪装成宽度为零的区间。

### 合本 PR 之前缺了什么

只比较主干和灰度，看到的是整包版本的 `ux_score`，正文变化和激活描述变化绑在一起。Agno trigger probe 可以低成本筛掉明显过宽的描述，但不能代替目标 Harness 上的任务分数，也不能做库内对照：同一条任务、同一个种子，只换正文或只换描述。

因此一次灰度分数变了，仍然不知道是正文知识、激活边界，还是库内竞争造成的。#380 要的就是：先把这张 2×2 回放和指标口径建起来，生产发布先不动。后续再由独立 PR 接入原生 Harness 录制，并用真实数据校准准入门槛。那是 #388 的事，必须等本 PR 先合。

### 本 PR 具体改哪

新增 `scripts/bench/skill_library_replay/`。评测器读已录制结果，校验 schema、四个部署单元、隔离运行、竞争库梯子和指纹，再算出上面那些诊断指标。schema 就是这份 JSON 必须长什么样的约定。当前只认版本 1。普通 CI 不调用模型或外部 Harness。

入仓合成 fixture 和报告快照。快照的意思是：同样的输入再跑一遍，报告必须对得上已经提交的那份。约定或指标口径一变，会变成可以审查的 diff。

19 个契约测试锁住：缺单元就失败、隔离运行只能强制目标 Skill、正负例都要有、资源字段和激活名单要对上。生产 description optimizer、Canary 晋升规则和生产路由都不动。

#388 会在这张回放上加预注册准入策略。那张必须等本 PR 先合；合完应只留准入增量。

### 不要和什么搞混

不要把它和 Q1 的 #385 搞混。#385 问的是：用 Task Graph 去形成 Skill，会不会比只看 Session 或只看 Atom 更有效。那是技能怎么形成的。本 PR 假定目标 Skill 的旧稿和新稿已经在了，问的是这份更新在竞争库里，正文和激活描述各自起了什么作用。

不要把它和 Q3 的 #389 搞混。#389 问的是：同一个已经过准入的更新，在不同场景、模型、Runtime 组合里会不会正负反向，按人群发布会不会比全局一刀切更少误伤。本 PR 不按人群拆发布策略。

不要把它和 #388 搞混。#388 才是 Q2 的准入：先把门槛写死，再给出 admit、reject 或 inconclusive。本 PR 只出诊断指标，不给出放行结论，也不改生产 Canary。

也不要把入仓合成 fixture 的分数当成正文已经更好，或新描述已经更能唤醒技能。那两组数字是为了让评测器有东西可算。真实实验必须由目标原生运行时按声明的任务、种子、模型和 Skill 版本录出来。在代表性真实录制经过 review 之前，也不该把任何效应阈值写成阻塞晋升的条件。

也不要把它理解成合进去就会改现网技能。Agent 接触不到格力内网现网。这张补丁只增加离线评测器，不改生产路由，也不改 Canary。

### 怎么算这段背景对齐了

能说出技能正文是说明书里的做事知识，激活描述是唤醒这份 Skill 的那段话，竞争库是有多份相近 Skill 会互相挤占的库。能说出 2×2 是旧正文、新正文分别配上旧描述、新描述，隔离强制激活是不让描述和邻居来抢、只看正文自己会不会把事情做对。能说出这是 Q2 的诊断回放，不是放行，不是 Q1 的形成方法评测，也不是 Q3 的按人群发布评测。能说出 #388 必须后合。能说出合进仓库不改现网，也不改生产 Canary。
