### PR TITLE
fix(bench): isolate Formation scenario aggregates

### DIFF
--- a/scripts/bench/evaluate.py
+++ b/scripts/bench/evaluate.py
@@ -177,12 +177,12 @@ def aggregate(preds: dict, ground: dict, tol: int = 0) -> dict:
 
     ground[case_id] 需含 boundaries / scenario / total_lines。
     """
-    by_scen: dict[str, dict] = {}
-    tot = {"tp": 0, "fp": 0, "fn": 0, "exact": 0, "eof": 0, "err": 0, "n": 0,
-           "pk_sum": 0.0, "wd_sum": 0.0}
-
     def blank() -> dict:
-        return dict(tot)
+        return {"tp": 0, "fp": 0, "fn": 0, "exact": 0, "eof": 0,
+                "err": 0, "n": 0, "pk_sum": 0.0, "wd_sum": 0.0}
+
+    by_scen: dict[str, dict] = {}
+    tot = blank()
 
     for case_id, gt in ground.items():
         pr = preds.get(case_id, {})

--- a/tests/test_bench_evaluate.py
+++ b/tests/test_bench_evaluate.py
@@ -117,3 +117,35 @@ def test_aggregate_emits_segmentation_metrics():
     o = out["overall"]
     assert o["f1"] == 1.0 and o["pk"] == 0.0 and o["window_diff"] == 0.0
     assert o["eof_coverage"] == 1.0
+
+
+def test_aggregate_scenarios_do_not_inherit_previous_totals():
+    ground = {
+        "a": {"boundaries": [10], "scenario": "FIRST", "total_lines": 20},
+        "b": {"boundaries": [8], "scenario": "SECOND", "total_lines": 20},
+    }
+    preds = {
+        "a": {"boundaries": [10], "covered_eof": True, "error": None},
+        "b": {"boundaries": [], "covered_eof": False, "error": "failed"},
+    }
+
+    scenarios = ev.aggregate(preds, ground, tol=0)["by_scenario"]
+
+    assert scenarios["FIRST"] == {
+        "n": 1,
+        "precision": 1.0,
+        "recall": 1.0,
+        "f1": 1.0,
+        "exact_match": 1.0,
+        "eof_coverage": 1.0,
+        "pk": 0.0,
+        "window_diff": 0.0,
+        "errors": 0,
+        "tp": 1,
+        "fp": 0,
+        "fn": 0,
+    }
+    assert scenarios["SECOND"]["n"] == 1
+    assert scenarios["SECOND"]["tp"] == 0
+    assert scenarios["SECOND"]["fn"] == 1
+    assert scenarios["SECOND"]["errors"] == 1


### PR DESCRIPTION
## Summary

修正 Formation benchmark 分场景计数器继承 overall 累计值的问题，使每个场景从独立的全零状态开始聚合。

本 PR 只修复离线评测结果，不修改 Atom、Task 或生产流水线行为。

## Changes

- 使用同一个全零计数器工厂分别初始化 overall 与每个 scenario。
- 增加两个场景顺序执行的回归测试，确认第二个场景不会继承第一个场景的 case、边界和错误计数。

## Test plan

- [x] `make test` passes（2736 passed, 10 skipped）
- [x] Added/updated unit tests for the change（15 passed）
- [ ] `make e2e` passes (if the change touches ingestion / install / daemon)（不涉及 ingestion、install 或 daemon）
- [x] Manually verified the affected user flow

Ruff 0.16.5 默认检查及项目指定规则检查通过。

## Linked issues

Closes #382
