### PR TITLE
test(formation): add paired Task-Grounded method-effect replay

### DIFF
--- a/scripts/bench/README.md
+++ b/scripts/bench/README.md
@@ -16,6 +16,7 @@ scripts/bench/
 ├── baseline_window.md        基线报告(合成/真实两套并排)
 ├── baseline_window.json      基线机器可读结果(run_baseline.py 产出)
 ├── algorithm_replay/         拆分 + 路由的版本化离线质量回放（普通 CI）
+├── formation_effect_replay/  Session、Atom、Task-Grounded 与 Gold Task 的方法效果配对回放
 ├── synthetic/
 │   ├── gen_cases_v2.py       合成集生成器(纯数据,无 LLM/无网络)
 │   ├── ground_truth.json     合成集真值 {case: {scenario,total_lines,boundaries,...}}

--- a/scripts/bench/formation_effect_replay/README.md
+++ b/scripts/bench/formation_effect_replay/README.md
@@ -1,0 +1,85 @@
+# Formation 方法效果配对回放
+
+这套评测器用于回答一个核心问题：在其他实验条件保持不变时，Task-Grounded Formation 是否比 Session 和 Atom 粒度产生更有效的 Skill。
+
+评测器只读取已经录制的不可变结果，不调用推理服务、外部 Harness、工作区命令或 xskill 生产状态，因此普通 CI 可以确定性复算方法效果。
+
+运行合成契约基线：
+
+```bash
+python -m scripts.bench.formation_effect_replay.evaluate scripts/bench/formation_effect_replay/fixtures/baseline_v1.json
+```
+
+使用 `--format json` 可以输出机器可读报告。
+
+测试会将报告与入仓的 `baseline_v1.report.json` 快照比较，因此 schema、指标或通过标准发生变化时会形成显式 diff。
+
+## 方法条件
+
+每个 held-out task 与 seed 必须完整包含以下五个配对条件。
+
+- `no_skill`：不加载 Skill 的执行下限。
+- `session`：以完整 Session 作为 Skill 学习证据。
+- `atom`：以单个 Atom 作为 Skill 学习证据，也是 Q1 的主要生产基线。
+- `task_grounded`：使用 Atom、Logical Task 和 Attempt 形成的 Q1 方法。
+- `gold_task`：使用人工 Task episode 的结构上限，不视为可部署方法。
+
+主对照固定为 `task_grounded - atom`，同时报告相对 Session、No-Skill 和 Gold 上限的差距。
+
+具体运行环境只通过不可逆的 `runtime_config_fingerprint` 固定，不进入方法名称、主对照或通过结论。
+
+## 两种预算模式
+
+`natural_output` 保留每种 Formation 方法自然产生的 Skill 数量与长度，用于测量真实端到端净效果。
+
+`matched_budget` 要求所有非控制方法具有完全相同的序列化 Skill Token 预算，用于排除某种方法只是生成更多内容所带来的优势。
+
+两个模式中同一方法的 `evidence_fingerprint` 必须一致，确保 matched-budget 只改变输出预算而不更换学习证据。
+
+每个方法与预算模式都必须拥有独立的 `skill_library_fingerprint`，防止条件之间复用 Skill library。
+
+## 数据与配对契约
+
+训练集、held-out 集、评分协议、运行环境、Formation 配置、Skill 生成配置、激活配置和 scorer 都由 SHA-256 指纹固定。
+
+训练集与 held-out 集的指纹必须不同，真实 recorder 还应在导出前按 task family、workspace 和来源 Session 检查无交叉泄漏。
+
+同一 `task_fingerprint × seed` 的所有方法必须完整存在，缺少任一条件会直接失败，而不是按可用结果静默计算。
+
+重复 seed 可以共享 `task_fingerprint`，但每个 Task 必须使用完全相同的 seed 集合，置信区间按 Task 聚类 bootstrap，避免不平衡重复和把同一 Task 的运行当成独立样本。
+
+每条 observation 记录 `[0, 1]` 得分、相关 Skill 是否激活、实际激活 Skill、输入输出 Token 和可选错误类型。
+
+`novel`、`known` 和 `negative` 三个 cohort 必须同时存在，并且数据至少覆盖两个 task family。
+
+入仓 fixture 只允许保存合成 ID、指纹和数值结果，不保存真实任务文本、轨迹、工作区路径或用户标识。
+
+## 指标
+
+每个方法报告 mean score、Pass Rate、正例激活 recall、负例 false-trigger rate、novel/known Pass Rate、错误类型、Token 和按 task family 拆分的结果。
+
+每个对照报告逐 case 配对差值、按 Task 聚类的 percentile bootstrap 置信区间、wins/ties/losses 和二元成功的 McNemar exact test。
+
+McNemar 结果按 `task × seed` 配对，仅作为辅助描述，包含重复 seed 时以按 Task 聚类 bootstrap 为主要统计证据。
+
+评测器根据 case 数、bootstrap 次数、预算模式、对照数量和 task family 数估算总工作量，超过固定上限时明确失败，避免扩大样本后出现最坏情况的计算膨胀。
+
+Formation utility density 定义为相对 No-Skill 的 mean-score 增益除以序列化 Skill Token 千数，分子、分母和原始方法结果必须同时保留。
+
+Token 只用于评估方法的 Skill 预算与执行开销，不用于比较运行环境优劣。
+
+## 预注册通过标准
+
+通过标准在录制前写入 `decision_policy`，不能看到结果后再修改阈值。
+
+默认关注以下条件是否同时成立：Q1 相对 Atom 的 Pass Rate 增益达到最小实际收益、置信区间下界超过预注册阈值、false-trigger 不恶化、known task 不回归、至少两个 task family 同方向改善，并且 matched-budget 结果仍为正。
+
+合成 fixture 只验证评测契约和指标方向，不能作为 Q1 已经有效的经验结论。
+
+正式结论需要隐私安全且经过人工复核的 Formation 数据，以及由相同 recorder 和确定性 scorer 生成的 held-out 原生执行结果。
+
+## 与现有评测的关系
+
+raw-only Formation 数据契约负责防止 Gold 信息进入方法输入，Task Graph 结构回放负责验证边界、membership 和 Attempt 关系，本回放只负责验证这些结构差异是否转化为 held-out Skill utility。
+
+库感知 Skill 回放用于进一步解释收益来自 Skill 正文、激活描述还是库内竞争，但不能替代本回放对不同 Formation 方法的主对照。

--- a/scripts/bench/formation_effect_replay/README.md
+++ b/scripts/bench/formation_effect_replay/README.md
@@ -60,7 +60,7 @@ python -m scripts.bench.formation_effect_replay.evaluate scripts/bench/formation
 
 每个对照报告逐 case 配对差值、按 Task 聚类的 percentile bootstrap 置信区间、wins/ties/losses 和二元成功的 McNemar exact test。
 
-McNemar 结果按 `task × seed` 配对，仅作为辅助描述，包含重复 seed 时以按 Task 聚类 bootstrap 为主要统计证据。
+McNemar 先在每个 Task 内汇总 seed：某方法至少一半 seed 通过时将该 Task 记为通过，再在 Task 间计算 exact test，避免把重复 seed 当成独立样本；按 Task 聚类 bootstrap 仍是主要统计证据。
 
 评测器根据 case 数、bootstrap 次数、预算模式、对照数量和 task family 数估算总工作量，超过固定上限时明确失败，避免扩大样本后出现最坏情况的计算膨胀。
 

--- a/scripts/bench/formation_effect_replay/__init__.py
+++ b/scripts/bench/formation_effect_replay/__init__.py
@@ -1,0 +1,1 @@
+"""Offline paired evaluation for Formation methods."""

--- a/scripts/bench/formation_effect_replay/evaluate.py
+++ b/scripts/bench/formation_effect_replay/evaluate.py
@@ -1,0 +1,975 @@
+"""Evaluate Formation methods from immutable paired outcomes.
+
+The evaluator is runtime-agnostic and never invokes a model, harness, workspace,
+or production xskill state.
+"""
+
+from __future__ import annotations
+
+import argparse
+import json
+import math
+import random
+from collections import Counter, defaultdict
+from collections.abc import Sequence
+from pathlib import Path
+from typing import Any, Callable
+
+SCHEMA_VERSION = 1
+METHODS = ("no_skill", "session", "atom", "task_grounded", "gold_task")
+FORMATION_METHODS = METHODS[1:]
+MODE_IDS = ("natural_output", "matched_budget")
+COHORTS = ("novel", "known", "negative")
+RESOURCE_FIELDS = ("input_tokens", "output_tokens")
+FINGERPRINT_PREFIX = "sha256:"
+MAX_BOOTSTRAP_OPERATIONS = 10_000_000
+
+
+class FormationEffectValidationError(ValueError):
+    """Raised when a Formation effect suite violates its data contract."""
+
+
+def _require(mapping: dict[str, Any], key: str, expected: type, context: str) -> Any:
+    if key not in mapping:
+        raise FormationEffectValidationError(
+            f"{context}: missing required field {key!r}"
+        )
+    value = mapping[key]
+    if expected is int and isinstance(value, bool):
+        raise FormationEffectValidationError(f"{context}.{key}: expected int")
+    if not isinstance(value, expected):
+        raise FormationEffectValidationError(
+            f"{context}.{key}: expected {expected.__name__}, "
+            f"got {type(value).__name__}"
+        )
+    return value
+
+
+def _require_keys(
+    mapping: dict[str, Any], expected: set[str], context: str
+) -> None:
+    actual = set(mapping)
+    if actual != expected:
+        missing = sorted(expected - actual)
+        unknown = sorted(actual - expected)
+        raise FormationEffectValidationError(
+            f"{context}: field mismatch; missing={missing}, unknown={unknown}"
+        )
+
+
+def _non_empty_string(mapping: dict[str, Any], key: str, context: str) -> str:
+    value = _require(mapping, key, str, context)
+    if not value:
+        raise FormationEffectValidationError(f"{context}.{key}: must not be empty")
+    return value
+
+
+def _number(
+    mapping: dict[str, Any], key: str, context: str, *, minimum: float = 0.0
+) -> float:
+    if key not in mapping:
+        raise FormationEffectValidationError(
+            f"{context}: missing required field {key!r}"
+        )
+    value = mapping[key]
+    if isinstance(value, bool) or not isinstance(value, (int, float)):
+        raise FormationEffectValidationError(f"{context}.{key}: expected a number")
+    result = float(value)
+    if not math.isfinite(result) or result < minimum:
+        raise FormationEffectValidationError(
+            f"{context}.{key}: expected a finite number >= {minimum:g}"
+        )
+    return result
+
+
+def _fingerprint(value: Any, context: str) -> None:
+    if (
+        not isinstance(value, str)
+        or not value.startswith(FINGERPRINT_PREFIX)
+        or len(value) != len(FINGERPRINT_PREFIX) + 64
+        or any(
+            char not in "0123456789abcdef"
+            for char in value[len(FINGERPRINT_PREFIX) :]
+        )
+    ):
+        raise FormationEffectValidationError(
+            f"{context}: expected sha256:<64 lowercase hex>"
+        )
+
+
+def _validate_observation(
+    value: Any,
+    *,
+    context: str,
+    run_ids: set[str],
+    expects_skill: bool,
+    is_control: bool,
+) -> None:
+    if not isinstance(value, dict):
+        raise FormationEffectValidationError(f"{context}: expected an object")
+    _require_keys(
+        value,
+        {
+            "run_id",
+            "score",
+            "relevant_skill_activated",
+            "activated_skills",
+            "input_tokens",
+            "output_tokens",
+            "error_type",
+        },
+        context,
+    )
+    run_id = _non_empty_string(value, "run_id", context)
+    if run_id in run_ids:
+        raise FormationEffectValidationError(
+            f"{context}.run_id: duplicate {run_id!r}"
+        )
+    run_ids.add(run_id)
+    score = _number(value, "score", context)
+    if score > 1:
+        raise FormationEffectValidationError(
+            f"{context}.score: expected 0 <= score <= 1"
+        )
+    relevant = _require(value, "relevant_skill_activated", bool, context)
+    activated = _require(value, "activated_skills", list, context)
+    if any(not isinstance(item, str) or not item for item in activated):
+        raise FormationEffectValidationError(
+            f"{context}.activated_skills: expected non-empty strings"
+        )
+    if len(activated) != len(set(activated)):
+        raise FormationEffectValidationError(
+            f"{context}.activated_skills: duplicate entries are not allowed"
+        )
+    if relevant and not activated:
+        raise FormationEffectValidationError(
+            f"{context}: relevant_skill_activated requires an activated Skill"
+        )
+    if not expects_skill and relevant:
+        raise FormationEffectValidationError(
+            f"{context}: a negative case cannot activate a relevant Skill"
+        )
+    if is_control and (activated or relevant):
+        raise FormationEffectValidationError(
+            f"{context}: no_skill control cannot activate Skills"
+        )
+    for field in RESOURCE_FIELDS:
+        amount = _require(value, field, int, context)
+        if amount < 0:
+            raise FormationEffectValidationError(
+                f"{context}.{field}: must be >= 0"
+            )
+    error_type = value["error_type"]
+    if error_type is not None and (
+        not isinstance(error_type, str) or not error_type
+    ):
+        raise FormationEffectValidationError(
+            f"{context}.error_type: expected null or a non-empty string"
+        )
+
+
+def validate_suite(suite: Any) -> None:
+    """Validate all pairing, provenance, budget, and outcome invariants."""
+    if not isinstance(suite, dict):
+        raise FormationEffectValidationError("suite: expected an object")
+    _require_keys(
+        suite,
+        {
+            "schema_version",
+            "suite_id",
+            "metric_config",
+            "decision_policy",
+            "run_manifest",
+            "modes",
+            "cases",
+        },
+        "suite",
+    )
+    version = _require(suite, "schema_version", int, "suite")
+    if version != SCHEMA_VERSION:
+        raise FormationEffectValidationError(
+            f"suite.schema_version: supported={SCHEMA_VERSION}, got={version}"
+        )
+    _non_empty_string(suite, "suite_id", "suite")
+
+    metric = _require(suite, "metric_config", dict, "suite")
+    _require_keys(
+        metric,
+        {"pass_threshold", "bootstrap_samples", "bootstrap_seed", "confidence_level"},
+        "suite.metric_config",
+    )
+    pass_threshold = _number(metric, "pass_threshold", "suite.metric_config")
+    if pass_threshold > 1:
+        raise FormationEffectValidationError(
+            "suite.metric_config.pass_threshold must be <= 1"
+        )
+    samples = _require(metric, "bootstrap_samples", int, "suite.metric_config")
+    if not 100 <= samples <= 50_000:
+        raise FormationEffectValidationError(
+            "suite.metric_config.bootstrap_samples must be within [100, 50000]"
+        )
+    seed = _require(metric, "bootstrap_seed", int, "suite.metric_config")
+    if seed < 0:
+        raise FormationEffectValidationError(
+            "suite.metric_config.bootstrap_seed must be >= 0"
+        )
+    confidence = _number(metric, "confidence_level", "suite.metric_config")
+    if not 0 < confidence < 1:
+        raise FormationEffectValidationError(
+            "suite.metric_config.confidence_level must satisfy 0 < value < 1"
+        )
+
+    policy = _require(suite, "decision_policy", dict, "suite")
+    _require_keys(
+        policy,
+        {
+            "primary_mode",
+            "minimum_primary_pass_rate_delta",
+            "minimum_primary_ci_lower",
+            "maximum_false_trigger_rate_delta",
+            "maximum_known_pass_rate_drop",
+            "minimum_improved_task_families",
+            "require_matched_budget_positive",
+        },
+        "suite.decision_policy",
+    )
+    primary_mode = _non_empty_string(policy, "primary_mode", "suite.decision_policy")
+    if primary_mode not in MODE_IDS:
+        raise FormationEffectValidationError(
+            f"suite.decision_policy.primary_mode: expected one of {MODE_IDS}"
+        )
+    for field in (
+        "minimum_primary_pass_rate_delta",
+        "minimum_primary_ci_lower",
+        "maximum_false_trigger_rate_delta",
+        "maximum_known_pass_rate_drop",
+    ):
+        value = policy[field]
+        if isinstance(value, bool) or not isinstance(value, (int, float)):
+            raise FormationEffectValidationError(
+                f"suite.decision_policy.{field}: expected a number"
+            )
+        if not math.isfinite(float(value)) or not -1 <= float(value) <= 1:
+            raise FormationEffectValidationError(
+                f"suite.decision_policy.{field}: expected a finite value within [-1, 1]"
+            )
+    for field in (
+        "minimum_primary_pass_rate_delta",
+        "maximum_known_pass_rate_drop",
+    ):
+        if float(policy[field]) < 0:
+            raise FormationEffectValidationError(
+                f"suite.decision_policy.{field}: expected a value within [0, 1]"
+            )
+    families = _require(
+        policy,
+        "minimum_improved_task_families",
+        int,
+        "suite.decision_policy",
+    )
+    if families < 1:
+        raise FormationEffectValidationError(
+            "suite.decision_policy.minimum_improved_task_families must be >= 1"
+        )
+    _require(
+        policy,
+        "require_matched_budget_positive",
+        bool,
+        "suite.decision_policy",
+    )
+
+    manifest = _require(suite, "run_manifest", dict, "suite")
+    _require_keys(
+        manifest,
+        {
+            "repository_revision",
+            "recorded_at",
+            "training_set_fingerprint",
+            "held_out_task_set_fingerprint",
+            "evaluation_protocol_fingerprint",
+            "runtime_config_fingerprint",
+            "scorer_fingerprint",
+            "formation_config_fingerprint",
+            "skill_generation_config_fingerprint",
+            "activation_config_fingerprint",
+        },
+        "suite.run_manifest",
+    )
+    _non_empty_string(manifest, "repository_revision", "suite.run_manifest")
+    _non_empty_string(manifest, "recorded_at", "suite.run_manifest")
+    for field in set(manifest) - {"repository_revision", "recorded_at"}:
+        _fingerprint(manifest[field], f"suite.run_manifest.{field}")
+    if manifest["training_set_fingerprint"] == manifest["held_out_task_set_fingerprint"]:
+        raise FormationEffectValidationError(
+            "suite.run_manifest: training and held-out fingerprints must differ"
+        )
+
+    modes = _require(suite, "modes", list, "suite")
+    if len(modes) != len(MODE_IDS):
+        raise FormationEffectValidationError(
+            f"suite.modes: expected exactly {list(MODE_IDS)}"
+        )
+    modes_by_id: dict[str, dict[str, Any]] = {}
+    evidence_by_method: dict[str, str] = {}
+    for index, mode in enumerate(modes):
+        context = f"suite.modes[{index}]"
+        if not isinstance(mode, dict):
+            raise FormationEffectValidationError(f"{context}: expected an object")
+        mode_id = _non_empty_string(mode, "mode_id", context)
+        if mode_id in modes_by_id:
+            raise FormationEffectValidationError(f"{context}.mode_id: duplicate")
+        if mode_id == "natural_output":
+            _require_keys(mode, {"mode_id", "budget_policy", "arms"}, context)
+            if mode["budget_policy"] != "natural_output":
+                raise FormationEffectValidationError(
+                    f"{context}.budget_policy: expected 'natural_output'"
+                )
+        elif mode_id == "matched_budget":
+            _require_keys(
+                mode,
+                {"mode_id", "budget_policy", "budget_value", "arms"},
+                context,
+            )
+            if mode["budget_policy"] != "matched_serialized_skill_tokens":
+                raise FormationEffectValidationError(
+                    f"{context}.budget_policy: expected "
+                    "'matched_serialized_skill_tokens'"
+                )
+            budget = _require(mode, "budget_value", int, context)
+            if budget <= 0:
+                raise FormationEffectValidationError(
+                    f"{context}.budget_value: must be > 0"
+                )
+        else:
+            raise FormationEffectValidationError(
+                f"{context}.mode_id: expected one of {MODE_IDS}"
+            )
+        arms = _require(mode, "arms", dict, context)
+        if set(arms) != set(FORMATION_METHODS):
+            raise FormationEffectValidationError(
+                f"{context}.arms: expected exactly {list(FORMATION_METHODS)}"
+            )
+        library_fingerprints: set[str] = set()
+        for method in FORMATION_METHODS:
+            arm_context = f"{context}.arms.{method}"
+            arm = arms[method]
+            if not isinstance(arm, dict):
+                raise FormationEffectValidationError(
+                    f"{arm_context}: expected an object"
+                )
+            _require_keys(
+                arm,
+                {
+                    "evidence_fingerprint",
+                    "skill_library_fingerprint",
+                    "skill_count",
+                    "serialized_skill_tokens",
+                },
+                arm_context,
+            )
+            for field in ("evidence_fingerprint", "skill_library_fingerprint"):
+                _fingerprint(arm[field], f"{arm_context}.{field}")
+            if arm["skill_library_fingerprint"] in library_fingerprints:
+                raise FormationEffectValidationError(
+                    f"{context}.arms: each method requires an independent Skill library"
+                )
+            library_fingerprints.add(arm["skill_library_fingerprint"])
+            skill_count = _require(arm, "skill_count", int, arm_context)
+            skill_tokens = _require(
+                arm, "serialized_skill_tokens", int, arm_context
+            )
+            if skill_count <= 0 or skill_tokens <= 0:
+                raise FormationEffectValidationError(
+                    f"{arm_context}: Skill count and tokens must be > 0"
+                )
+            if mode_id == "matched_budget" and skill_tokens != mode["budget_value"]:
+                raise FormationEffectValidationError(
+                    f"{arm_context}.serialized_skill_tokens: must equal matched budget"
+                )
+            previous = evidence_by_method.setdefault(
+                method, arm["evidence_fingerprint"]
+            )
+            if previous != arm["evidence_fingerprint"]:
+                raise FormationEffectValidationError(
+                    f"{arm_context}.evidence_fingerprint: evidence must remain fixed "
+                    "across budget modes"
+                )
+        modes_by_id[mode_id] = mode
+    if set(modes_by_id) != set(MODE_IDS):
+        raise FormationEffectValidationError(
+            f"suite.modes: expected exactly {list(MODE_IDS)}"
+        )
+
+    cases = _require(suite, "cases", list, "suite")
+    if not cases:
+        raise FormationEffectValidationError("suite.cases must not be empty")
+    case_ids: set[str] = set()
+    run_ids: set[str] = set()
+    pair_keys: set[tuple[str, int]] = set()
+    seeds_by_task: dict[str, set[int]] = defaultdict(set)
+    cohorts: set[str] = set()
+    task_families: set[str] = set()
+    task_metadata: dict[str, tuple[str, str, bool]] = {}
+    for index, case in enumerate(cases):
+        context = f"suite.cases[{index}]"
+        if not isinstance(case, dict):
+            raise FormationEffectValidationError(f"{context}: expected an object")
+        _require_keys(
+            case,
+            {
+                "case_id",
+                "task_fingerprint",
+                "task_family",
+                "seed",
+                "cohort",
+                "expects_skill",
+                "control",
+                "observations",
+            },
+            context,
+        )
+        case_id = _non_empty_string(case, "case_id", context)
+        if case_id in case_ids:
+            raise FormationEffectValidationError(f"{context}.case_id: duplicate")
+        case_ids.add(case_id)
+        _fingerprint(case["task_fingerprint"], f"{context}.task_fingerprint")
+        task_family = _non_empty_string(case, "task_family", context)
+        task_families.add(task_family)
+        seed_value = _require(case, "seed", int, context)
+        if seed_value < 0:
+            raise FormationEffectValidationError(f"{context}.seed: must be >= 0")
+        pair_key = (case["task_fingerprint"], seed_value)
+        if pair_key in pair_keys:
+            raise FormationEffectValidationError(
+                f"{context}: duplicate task_fingerprint × seed pair"
+            )
+        pair_keys.add(pair_key)
+        seeds_by_task[case["task_fingerprint"]].add(seed_value)
+        cohort = _non_empty_string(case, "cohort", context)
+        if cohort not in COHORTS:
+            raise FormationEffectValidationError(
+                f"{context}.cohort: expected one of {COHORTS}"
+            )
+        cohorts.add(cohort)
+        expects_skill = _require(case, "expects_skill", bool, context)
+        if expects_skill != (cohort != "negative"):
+            raise FormationEffectValidationError(
+                f"{context}: expects_skill must be false only for negative cases"
+            )
+        metadata = (task_family, cohort, expects_skill)
+        previous_metadata = task_metadata.setdefault(case["task_fingerprint"], metadata)
+        if previous_metadata != metadata:
+            raise FormationEffectValidationError(
+                f"{context}: repeated task_fingerprint changed task metadata"
+            )
+        _validate_observation(
+            case["control"],
+            context=f"{context}.control",
+            run_ids=run_ids,
+            expects_skill=expects_skill,
+            is_control=True,
+        )
+        observations = _require(case, "observations", dict, context)
+        if set(observations) != set(MODE_IDS):
+            raise FormationEffectValidationError(
+                f"{context}.observations: expected exactly {list(MODE_IDS)}"
+            )
+        for mode_id in MODE_IDS:
+            mode_observations = observations[mode_id]
+            mode_context = f"{context}.observations.{mode_id}"
+            if not isinstance(mode_observations, dict):
+                raise FormationEffectValidationError(
+                    f"{mode_context}: expected an object"
+                )
+            if set(mode_observations) != set(FORMATION_METHODS):
+                raise FormationEffectValidationError(
+                    f"{mode_context}: expected exactly {list(FORMATION_METHODS)}"
+                )
+            for method in FORMATION_METHODS:
+                _validate_observation(
+                    mode_observations[method],
+                    context=f"{mode_context}.{method}",
+                    run_ids=run_ids,
+                    expects_skill=expects_skill,
+                    is_control=False,
+                )
+    if cohorts != set(COHORTS):
+        raise FormationEffectValidationError(
+            f"suite.cases: expected all cohorts {list(COHORTS)}"
+        )
+    if len(task_families) < 2:
+        raise FormationEffectValidationError(
+            "suite.cases: at least two task families are required"
+        )
+    expected_seeds = next(iter(seeds_by_task.values()))
+    if any(seeds != expected_seeds for seeds in seeds_by_task.values()):
+        raise FormationEffectValidationError(
+            "suite.cases: every task_fingerprint must use the same seed set"
+        )
+    if families > len(task_families):
+        raise FormationEffectValidationError(
+            "suite.decision_policy.minimum_improved_task_families exceeds "
+            "available task families"
+        )
+    statistics_per_mode = 12 + len(RESOURCE_FIELDS) + len(task_families)
+    estimated_operations = (
+        len(cases)
+        * samples
+        * len(MODE_IDS)
+        * statistics_per_mode
+    )
+    if estimated_operations > MAX_BOOTSTRAP_OPERATIONS:
+        raise FormationEffectValidationError(
+            "suite: estimated bootstrap work exceeds "
+            f"{MAX_BOOTSTRAP_OPERATIONS:,} paired observations"
+        )
+
+
+def _round(value: float) -> float:
+    return round(float(value), 6)
+
+
+def _mean(values: Sequence[float]) -> float:
+    return sum(values) / len(values) if values else 0.0
+
+
+def _percentile(values: list[float], quantile: float) -> float:
+    ordered = sorted(values)
+    position = (len(ordered) - 1) * quantile
+    lower = math.floor(position)
+    upper = math.ceil(position)
+    if lower == upper:
+        return ordered[lower]
+    fraction = position - lower
+    return ordered[lower] * (1 - fraction) + ordered[upper] * fraction
+
+
+def _observation(case: dict[str, Any], mode_id: str, method: str) -> dict[str, Any]:
+    if method == "no_skill":
+        return case["control"]
+    return case["observations"][mode_id][method]
+
+
+def _paired_stat(
+    cases: list[dict[str, Any]],
+    mode_id: str,
+    treated: str,
+    control: str,
+    metric: Callable[[dict[str, Any]], float],
+    metric_config: dict[str, Any],
+    *,
+    include: Callable[[dict[str, Any]], bool] | None = None,
+    seed_offset: int = 0,
+) -> dict[str, Any]:
+    selected = [case for case in cases if include is None or include(case)]
+    deltas = [
+        metric(_observation(case, mode_id, treated))
+        - metric(_observation(case, mode_id, control))
+        for case in selected
+    ]
+    by_task: dict[str, list[float]] = defaultdict(list)
+    for case, delta in zip(selected, deltas):
+        by_task[case["task_fingerprint"]].append(delta)
+    interval = None
+    if len(by_task) >= 2:
+        rng = random.Random(metric_config["bootstrap_seed"] + seed_offset)
+        task_ids = sorted(by_task)
+        samples: list[float] = []
+        for _ in range(metric_config["bootstrap_samples"]):
+            drawn: list[float] = []
+            for _ in task_ids:
+                drawn.extend(by_task[rng.choice(task_ids)])
+            samples.append(_mean(drawn))
+        alpha = (1 - metric_config["confidence_level"]) / 2
+        interval = [
+            _round(_percentile(samples, alpha)),
+            _round(_percentile(samples, 1 - alpha)),
+        ]
+    return {
+        "n_pairs": len(deltas),
+        "n_tasks": len(by_task),
+        "mean": _round(_mean(deltas)),
+        "confidence_interval": interval,
+        "wins": sum(delta > 0 for delta in deltas),
+        "ties": sum(delta == 0 for delta in deltas),
+        "losses": sum(delta < 0 for delta in deltas),
+    }
+
+
+def _mcnemar(
+    cases: list[dict[str, Any]],
+    mode_id: str,
+    treated: str,
+    control: str,
+    pass_threshold: float,
+) -> dict[str, Any]:
+    treated_only = 0
+    control_only = 0
+    for case in cases:
+        treated_passed = _observation(case, mode_id, treated)["score"] >= pass_threshold
+        control_passed = _observation(case, mode_id, control)["score"] >= pass_threshold
+        treated_only += int(treated_passed and not control_passed)
+        control_only += int(control_passed and not treated_passed)
+    discordant = treated_only + control_only
+    if discordant == 0:
+        p_value = 1.0
+    else:
+        tail = sum(
+            math.comb(discordant, index)
+            for index in range(min(treated_only, control_only) + 1)
+        ) / (2**discordant)
+        p_value = min(1.0, 2 * tail)
+    return {
+        "treated_only_pass": treated_only,
+        "control_only_pass": control_only,
+        "discordant_pairs": discordant,
+        "exact_two_sided_p": _round(p_value),
+    }
+
+
+def _summary(
+    cases: list[dict[str, Any]],
+    mode_id: str,
+    method: str,
+    pass_threshold: float,
+) -> dict[str, Any]:
+    observations = [_observation(case, mode_id, method) for case in cases]
+    positive = [
+        (case, observation)
+        for case, observation in zip(cases, observations)
+        if case["expects_skill"]
+    ]
+    negative = [
+        (case, observation)
+        for case, observation in zip(cases, observations)
+        if not case["expects_skill"]
+    ]
+    errors = Counter(
+        observation["error_type"]
+        for observation in observations
+        if observation["error_type"] is not None
+    )
+    result = {
+        "n": len(cases),
+        "mean_score": _round(_mean([item["score"] for item in observations])),
+        "pass_rate": _round(
+            _mean([float(item["score"] >= pass_threshold) for item in observations])
+        ),
+        "positive_recall": _round(
+            _mean([float(item["relevant_skill_activated"]) for _, item in positive])
+        ),
+        "negative_false_trigger_rate": _round(
+            _mean([float(bool(item["activated_skills"])) for _, item in negative])
+        ),
+        "novel_pass_rate": _round(
+            _mean(
+                [
+                    float(item["score"] >= pass_threshold)
+                    for case, item in zip(cases, observations)
+                    if case["cohort"] == "novel"
+                ]
+            )
+        ),
+        "known_pass_rate": _round(
+            _mean(
+                [
+                    float(item["score"] >= pass_threshold)
+                    for case, item in zip(cases, observations)
+                    if case["cohort"] == "known"
+                ]
+            )
+        ),
+        "errors": dict(sorted(errors.items())),
+        "resources": {
+            field: _round(_mean([float(item[field]) for item in observations]))
+            for field in RESOURCE_FIELDS
+        },
+    }
+    return result
+
+
+def _contrast(
+    cases: list[dict[str, Any]],
+    mode_id: str,
+    treated: str,
+    control: str,
+    metric_config: dict[str, Any],
+    *,
+    detailed: bool,
+) -> dict[str, Any]:
+    pass_threshold = metric_config["pass_threshold"]
+    metrics: dict[
+        str,
+        tuple[
+            Callable[[dict[str, Any]], float],
+            Callable[[dict[str, Any]], bool] | None,
+        ],
+    ] = {
+        "score_delta": (lambda item: item["score"], None),
+        "pass_rate_delta": (
+            lambda item: float(item["score"] >= pass_threshold),
+            None,
+        ),
+    }
+    if detailed:
+        metrics.update(
+            {
+                "positive_recall_delta": (
+                    lambda item: float(item["relevant_skill_activated"]),
+                    lambda case: case["expects_skill"],
+                ),
+                "false_trigger_rate_delta": (
+                    lambda item: float(bool(item["activated_skills"])),
+                    lambda case: not case["expects_skill"],
+                ),
+                "novel_pass_rate_delta": (
+                    lambda item: float(item["score"] >= pass_threshold),
+                    lambda case: case["cohort"] == "novel",
+                ),
+                "known_pass_rate_delta": (
+                    lambda item: float(item["score"] >= pass_threshold),
+                    lambda case: case["cohort"] == "known",
+                ),
+            }
+        )
+    result = {}
+    for offset, (name, (metric, include)) in enumerate(metrics.items()):
+        result[name] = _paired_stat(
+            cases,
+            mode_id,
+            treated,
+            control,
+            metric,
+            metric_config,
+            include=include,
+            seed_offset=offset,
+        )
+    if detailed:
+        result["resource_deltas"] = {
+            field: _paired_stat(
+                cases,
+                mode_id,
+                treated,
+                control,
+                lambda item, resource=field: float(item[resource]),
+                metric_config,
+                seed_offset=100 + offset,
+            )
+            for offset, field in enumerate(RESOURCE_FIELDS)
+        }
+        result["score_delta_by_task_family"] = {
+            family: _paired_stat(
+                cases,
+                mode_id,
+                treated,
+                control,
+                lambda item: item["score"],
+                metric_config,
+                include=lambda case, expected=family: (
+                    case["task_family"] == expected
+                ),
+                seed_offset=200 + index,
+            )
+            for index, family in enumerate(
+                sorted({case["task_family"] for case in cases})
+            )
+        }
+    result["mcnemar_pass"] = _mcnemar(
+        cases, mode_id, treated, control, pass_threshold
+    )
+    return result
+
+
+def _mode_report(
+    suite: dict[str, Any], mode: dict[str, Any]
+) -> dict[str, Any]:
+    mode_id = mode["mode_id"]
+    cases = suite["cases"]
+    metric = suite["metric_config"]
+    summaries = {
+        method: _summary(cases, mode_id, method, metric["pass_threshold"])
+        for method in METHODS
+    }
+    arms = {
+        "no_skill": {
+            "skill_count": 0,
+            "serialized_skill_tokens": 0,
+        },
+        **mode["arms"],
+    }
+    control_score = _mean(
+        [_observation(case, mode_id, "no_skill")["score"] for case in cases]
+    )
+    utility_density = {"no_skill": None}
+    for method in FORMATION_METHODS:
+        method_score = _mean(
+            [_observation(case, mode_id, method)["score"] for case in cases]
+        )
+        delta = method_score - control_score
+        denominator = arms[method]["serialized_skill_tokens"] / 1000
+        utility_density[method] = _round(delta / denominator)
+    contrasts = {
+        "task_grounded_minus_atom": _contrast(
+            cases,
+            mode_id,
+            "task_grounded",
+            "atom",
+            metric,
+            detailed=True,
+        ),
+        "task_grounded_minus_session": _contrast(
+            cases,
+            mode_id,
+            "task_grounded",
+            "session",
+            metric,
+            detailed=False,
+        ),
+        "task_grounded_minus_no_skill": _contrast(
+            cases,
+            mode_id,
+            "task_grounded",
+            "no_skill",
+            metric,
+            detailed=False,
+        ),
+        "gold_task_minus_task_grounded": _contrast(
+            cases,
+            mode_id,
+            "gold_task",
+            "task_grounded",
+            metric,
+            detailed=False,
+        ),
+    }
+    result = {
+        "mode_id": mode_id,
+        "budget_policy": mode["budget_policy"],
+        "artifacts": arms,
+        "methods": summaries,
+        "utility_density_per_1000_skill_tokens": utility_density,
+        "contrasts": contrasts,
+    }
+    if "budget_value" in mode:
+        result["budget_value"] = mode["budget_value"]
+    return result
+
+
+def _decision(
+    suite: dict[str, Any], reports: dict[str, dict[str, Any]]
+) -> dict[str, Any]:
+    policy = suite["decision_policy"]
+    primary = reports[policy["primary_mode"]]["contrasts"][
+        "task_grounded_minus_atom"
+    ]
+    pass_delta = primary["pass_rate_delta"]
+    interval = pass_delta["confidence_interval"]
+    checks = {
+        "minimum_pass_rate_delta": (
+            pass_delta["mean"] >= policy["minimum_primary_pass_rate_delta"]
+        ),
+        "confidence_interval_lower_bound": (
+            interval is not None
+            and interval[0] > policy["minimum_primary_ci_lower"]
+        ),
+        "false_trigger_not_worse": (
+            primary["false_trigger_rate_delta"]["mean"]
+            <= policy["maximum_false_trigger_rate_delta"]
+        ),
+        "known_tasks_not_regressed": (
+            primary["known_pass_rate_delta"]["mean"]
+            >= -policy["maximum_known_pass_rate_drop"]
+        ),
+        "enough_improved_task_families": (
+            sum(
+                effect["mean"] > 0
+                for effect in primary["score_delta_by_task_family"].values()
+            )
+            >= policy["minimum_improved_task_families"]
+        ),
+    }
+    matched_delta = reports["matched_budget"]["contrasts"][
+        "task_grounded_minus_atom"
+    ]["pass_rate_delta"]["mean"]
+    checks["matched_budget_same_direction"] = (
+        not policy["require_matched_budget_positive"] or matched_delta > 0
+    )
+    return {
+        "primary_mode": policy["primary_mode"],
+        "primary_contrast": "task_grounded_minus_atom",
+        "checks": checks,
+        "passed": all(checks.values()),
+    }
+
+
+def evaluate_suite(suite: dict[str, Any]) -> dict[str, Any]:
+    """Return a deterministic report after validating the complete suite."""
+    validate_suite(suite)
+    modes_by_id = {mode["mode_id"]: mode for mode in suite["modes"]}
+    mode_reports = [_mode_report(suite, modes_by_id[mode_id]) for mode_id in MODE_IDS]
+    reports_by_id = {report["mode_id"]: report for report in mode_reports}
+    return {
+        "schema_version": SCHEMA_VERSION,
+        "suite_id": suite["suite_id"],
+        "run_manifest": suite["run_manifest"],
+        "metric_config": suite["metric_config"],
+        "decision_policy": suite["decision_policy"],
+        "n_cases": len(suite["cases"]),
+        "n_tasks": len({case["task_fingerprint"] for case in suite["cases"]}),
+        "modes": mode_reports,
+        "decision": _decision(suite, reports_by_id),
+    }
+
+
+def load_suite(path: Path) -> dict[str, Any]:
+    value = json.loads(path.read_text(encoding="utf-8"))
+    if not isinstance(value, dict):
+        raise FormationEffectValidationError("suite: expected an object")
+    return value
+
+
+def render_text(report: dict[str, Any]) -> str:
+    lines = [
+        f"suite: {report['suite_id']}",
+        f"paired cases: {report['n_cases']} (tasks={report['n_tasks']})",
+    ]
+    for mode in report["modes"]:
+        primary = mode["contrasts"]["task_grounded_minus_atom"]
+        lines.extend(
+            [
+                f"[{mode['mode_id']}]",
+                (
+                    "  task_grounded - atom pass-rate: "
+                    f"{primary['pass_rate_delta']['mean']:+.6f}"
+                ),
+                (
+                    "  task_grounded - atom score: "
+                    f"{primary['score_delta']['mean']:+.6f}"
+                ),
+                (
+                    "  false-trigger delta: "
+                    f"{primary['false_trigger_rate_delta']['mean']:+.6f}"
+                ),
+            ]
+        )
+    lines.append(f"decision: {'PASS' if report['decision']['passed'] else 'FAIL'}")
+    return "\n".join(lines)
+
+
+def main(argv: Sequence[str] | None = None) -> int:
+    parser = argparse.ArgumentParser(
+        description="Evaluate paired Formation-method outcomes without runtime calls."
+    )
+    parser.add_argument("suite", type=Path)
+    parser.add_argument("--format", choices=("text", "json"), default="text")
+    args = parser.parse_args(argv)
+    report = evaluate_suite(load_suite(args.suite))
+    if args.format == "json":
+        print(json.dumps(report, ensure_ascii=False, indent=2, sort_keys=True))
+    else:
+        print(render_text(report))
+    return 0
+
+
+if __name__ == "__main__":
+    raise SystemExit(main())

--- a/scripts/bench/formation_effect_replay/evaluate.py
+++ b/scripts/bench/formation_effect_replay/evaluate.py
@@ -603,11 +603,20 @@ def _mcnemar(
     control: str,
     pass_threshold: float,
 ) -> dict[str, Any]:
+    paired_passes_by_task: dict[str, list[tuple[bool, bool]]] = defaultdict(list)
+    for case in cases:
+        paired_passes_by_task[case["task_fingerprint"]].append(
+            (
+                _observation(case, mode_id, treated)["score"] >= pass_threshold,
+                _observation(case, mode_id, control)["score"] >= pass_threshold,
+            )
+        )
     treated_only = 0
     control_only = 0
-    for case in cases:
-        treated_passed = _observation(case, mode_id, treated)["score"] >= pass_threshold
-        control_passed = _observation(case, mode_id, control)["score"] >= pass_threshold
+    for task_id in sorted(paired_passes_by_task):
+        paired_passes = paired_passes_by_task[task_id]
+        treated_passed = _mean([float(pair[0]) for pair in paired_passes]) >= 0.5
+        control_passed = _mean([float(pair[1]) for pair in paired_passes]) >= 0.5
         treated_only += int(treated_passed and not control_passed)
         control_only += int(control_passed and not treated_passed)
     discordant = treated_only + control_only
@@ -620,9 +629,11 @@ def _mcnemar(
         ) / (2**discordant)
         p_value = min(1.0, 2 * tail)
     return {
+        "n_tasks": len(paired_passes_by_task),
+        "task_pass_rule": "seed_pass_rate>=0.5",
         "treated_only_pass": treated_only,
         "control_only_pass": control_only,
-        "discordant_pairs": discordant,
+        "discordant_tasks": discordant,
         "exact_two_sided_p": _round(p_value),
     }
 

--- a/scripts/bench/formation_effect_replay/fixtures/baseline_v1.json
+++ b/scripts/bench/formation_effect_replay/fixtures/baseline_v1.json
@@ -1,0 +1,746 @@
+{
+  "schema_version": 1,
+  "suite_id": "formation-effect-contract-v1",
+  "metric_config": {
+    "pass_threshold": 1,
+    "bootstrap_samples": 1000,
+    "bootstrap_seed": 42,
+    "confidence_level": 0.95
+  },
+  "decision_policy": {
+    "primary_mode": "natural_output",
+    "minimum_primary_pass_rate_delta": 0.05,
+    "minimum_primary_ci_lower": 0,
+    "maximum_false_trigger_rate_delta": 0,
+    "maximum_known_pass_rate_drop": 0,
+    "minimum_improved_task_families": 2,
+    "require_matched_budget_positive": true
+  },
+  "run_manifest": {
+    "repository_revision": "synthetic-revision",
+    "recorded_at": "2026-08-30T00:00:00Z",
+    "training_set_fingerprint": "sha256:5555555555555555555555555555555555555555555555555555555555555555",
+    "held_out_task_set_fingerprint": "sha256:6666666666666666666666666666666666666666666666666666666666666666",
+    "evaluation_protocol_fingerprint": "sha256:7777777777777777777777777777777777777777777777777777777777777777",
+    "runtime_config_fingerprint": "sha256:8888888888888888888888888888888888888888888888888888888888888888",
+    "scorer_fingerprint": "sha256:9999999999999999999999999999999999999999999999999999999999999999",
+    "formation_config_fingerprint": "sha256:aaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaa",
+    "skill_generation_config_fingerprint": "sha256:bbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbb",
+    "activation_config_fingerprint": "sha256:cccccccccccccccccccccccccccccccccccccccccccccccccccccccccccccccc"
+  },
+  "modes": [
+    {
+      "mode_id": "natural_output",
+      "budget_policy": "natural_output",
+      "arms": {
+        "session": {
+          "evidence_fingerprint": "sha256:1111111111111111111111111111111111111111111111111111111111111111",
+          "skill_library_fingerprint": "sha256:bbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbb",
+          "skill_count": 2,
+          "serialized_skill_tokens": 240
+        },
+        "atom": {
+          "evidence_fingerprint": "sha256:2222222222222222222222222222222222222222222222222222222222222222",
+          "skill_library_fingerprint": "sha256:cccccccccccccccccccccccccccccccccccccccccccccccccccccccccccccccc",
+          "skill_count": 3,
+          "serialized_skill_tokens": 300
+        },
+        "task_grounded": {
+          "evidence_fingerprint": "sha256:3333333333333333333333333333333333333333333333333333333333333333",
+          "skill_library_fingerprint": "sha256:dddddddddddddddddddddddddddddddddddddddddddddddddddddddddddddddd",
+          "skill_count": 2,
+          "serialized_skill_tokens": 180
+        },
+        "gold_task": {
+          "evidence_fingerprint": "sha256:4444444444444444444444444444444444444444444444444444444444444444",
+          "skill_library_fingerprint": "sha256:eeeeeeeeeeeeeeeeeeeeeeeeeeeeeeeeeeeeeeeeeeeeeeeeeeeeeeeeeeeeeeee",
+          "skill_count": 2,
+          "serialized_skill_tokens": 170
+        }
+      }
+    },
+    {
+      "mode_id": "matched_budget",
+      "budget_policy": "matched_serialized_skill_tokens",
+      "budget_value": 200,
+      "arms": {
+        "session": {
+          "evidence_fingerprint": "sha256:1111111111111111111111111111111111111111111111111111111111111111",
+          "skill_library_fingerprint": "sha256:ffffffffffffffffffffffffffffffffffffffffffffffffffffffffffffffff",
+          "skill_count": 2,
+          "serialized_skill_tokens": 200
+        },
+        "atom": {
+          "evidence_fingerprint": "sha256:2222222222222222222222222222222222222222222222222222222222222222",
+          "skill_library_fingerprint": "sha256:0000000000000000000000000000000000000000000000000000000000000000",
+          "skill_count": 2,
+          "serialized_skill_tokens": 200
+        },
+        "task_grounded": {
+          "evidence_fingerprint": "sha256:3333333333333333333333333333333333333333333333333333333333333333",
+          "skill_library_fingerprint": "sha256:1111111111111111111111111111111111111111111111111111111111111111",
+          "skill_count": 2,
+          "serialized_skill_tokens": 200
+        },
+        "gold_task": {
+          "evidence_fingerprint": "sha256:4444444444444444444444444444444444444444444444444444444444444444",
+          "skill_library_fingerprint": "sha256:2222222222222222222222222222222222222222222222222222222222222222",
+          "skill_count": 2,
+          "serialized_skill_tokens": 200
+        }
+      }
+    }
+  ],
+  "cases": [
+    {
+      "case_id": "data-novel",
+      "task_fingerprint": "sha256:5555555555555555555555555555555555555555555555555555555555555555",
+      "task_family": "data",
+      "seed": 1,
+      "cohort": "novel",
+      "expects_skill": true,
+      "control": {
+        "run_id": "data-novel-no-skill",
+        "score": 0,
+        "relevant_skill_activated": false,
+        "activated_skills": [],
+        "input_tokens": 100,
+        "output_tokens": 10,
+        "error_type": "task_failure"
+      },
+      "observations": {
+        "natural_output": {
+          "session": {
+            "run_id": "data-novel-natural_output-session",
+            "score": 0,
+            "relevant_skill_activated": true,
+            "activated_skills": [
+              "session-skill"
+            ],
+            "input_tokens": 130,
+            "output_tokens": 10,
+            "error_type": "task_failure"
+          },
+          "atom": {
+            "run_id": "data-novel-natural_output-atom",
+            "score": 0,
+            "relevant_skill_activated": false,
+            "activated_skills": [
+              "atom-skill"
+            ],
+            "input_tokens": 135,
+            "output_tokens": 10,
+            "error_type": "task_failure"
+          },
+          "task_grounded": {
+            "run_id": "data-novel-natural_output-task_grounded",
+            "score": 1,
+            "relevant_skill_activated": true,
+            "activated_skills": [
+              "task-grounded-skill"
+            ],
+            "input_tokens": 125,
+            "output_tokens": 10,
+            "error_type": null
+          },
+          "gold_task": {
+            "run_id": "data-novel-natural_output-gold_task",
+            "score": 1,
+            "relevant_skill_activated": true,
+            "activated_skills": [
+              "gold-task-skill"
+            ],
+            "input_tokens": 123,
+            "output_tokens": 10,
+            "error_type": null
+          }
+        },
+        "matched_budget": {
+          "session": {
+            "run_id": "data-novel-matched_budget-session",
+            "score": 0,
+            "relevant_skill_activated": true,
+            "activated_skills": [
+              "session-skill"
+            ],
+            "input_tokens": 128,
+            "output_tokens": 10,
+            "error_type": "task_failure"
+          },
+          "atom": {
+            "run_id": "data-novel-matched_budget-atom",
+            "score": 0,
+            "relevant_skill_activated": false,
+            "activated_skills": [
+              "atom-skill"
+            ],
+            "input_tokens": 128,
+            "output_tokens": 10,
+            "error_type": "task_failure"
+          },
+          "task_grounded": {
+            "run_id": "data-novel-matched_budget-task_grounded",
+            "score": 1,
+            "relevant_skill_activated": true,
+            "activated_skills": [
+              "task-grounded-skill"
+            ],
+            "input_tokens": 128,
+            "output_tokens": 10,
+            "error_type": null
+          },
+          "gold_task": {
+            "run_id": "data-novel-matched_budget-gold_task",
+            "score": 1,
+            "relevant_skill_activated": true,
+            "activated_skills": [
+              "gold-task-skill"
+            ],
+            "input_tokens": 128,
+            "output_tokens": 10,
+            "error_type": null
+          }
+        }
+      }
+    },
+    {
+      "case_id": "data-known",
+      "task_fingerprint": "sha256:6666666666666666666666666666666666666666666666666666666666666666",
+      "task_family": "data",
+      "seed": 1,
+      "cohort": "known",
+      "expects_skill": true,
+      "control": {
+        "run_id": "data-known-no-skill",
+        "score": 1,
+        "relevant_skill_activated": false,
+        "activated_skills": [],
+        "input_tokens": 100,
+        "output_tokens": 10,
+        "error_type": null
+      },
+      "observations": {
+        "natural_output": {
+          "session": {
+            "run_id": "data-known-natural_output-session",
+            "score": 1,
+            "relevant_skill_activated": true,
+            "activated_skills": [
+              "session-skill"
+            ],
+            "input_tokens": 130,
+            "output_tokens": 10,
+            "error_type": null
+          },
+          "atom": {
+            "run_id": "data-known-natural_output-atom",
+            "score": 0,
+            "relevant_skill_activated": false,
+            "activated_skills": [
+              "atom-skill"
+            ],
+            "input_tokens": 135,
+            "output_tokens": 10,
+            "error_type": "task_failure"
+          },
+          "task_grounded": {
+            "run_id": "data-known-natural_output-task_grounded",
+            "score": 1,
+            "relevant_skill_activated": true,
+            "activated_skills": [
+              "task-grounded-skill"
+            ],
+            "input_tokens": 125,
+            "output_tokens": 10,
+            "error_type": null
+          },
+          "gold_task": {
+            "run_id": "data-known-natural_output-gold_task",
+            "score": 1,
+            "relevant_skill_activated": true,
+            "activated_skills": [
+              "gold-task-skill"
+            ],
+            "input_tokens": 123,
+            "output_tokens": 10,
+            "error_type": null
+          }
+        },
+        "matched_budget": {
+          "session": {
+            "run_id": "data-known-matched_budget-session",
+            "score": 1,
+            "relevant_skill_activated": true,
+            "activated_skills": [
+              "session-skill"
+            ],
+            "input_tokens": 128,
+            "output_tokens": 10,
+            "error_type": null
+          },
+          "atom": {
+            "run_id": "data-known-matched_budget-atom",
+            "score": 0,
+            "relevant_skill_activated": false,
+            "activated_skills": [
+              "atom-skill"
+            ],
+            "input_tokens": 128,
+            "output_tokens": 10,
+            "error_type": "task_failure"
+          },
+          "task_grounded": {
+            "run_id": "data-known-matched_budget-task_grounded",
+            "score": 1,
+            "relevant_skill_activated": true,
+            "activated_skills": [
+              "task-grounded-skill"
+            ],
+            "input_tokens": 128,
+            "output_tokens": 10,
+            "error_type": null
+          },
+          "gold_task": {
+            "run_id": "data-known-matched_budget-gold_task",
+            "score": 1,
+            "relevant_skill_activated": true,
+            "activated_skills": [
+              "gold-task-skill"
+            ],
+            "input_tokens": 128,
+            "output_tokens": 10,
+            "error_type": null
+          }
+        }
+      }
+    },
+    {
+      "case_id": "data-negative",
+      "task_fingerprint": "sha256:7777777777777777777777777777777777777777777777777777777777777777",
+      "task_family": "data",
+      "seed": 1,
+      "cohort": "negative",
+      "expects_skill": false,
+      "control": {
+        "run_id": "data-negative-no-skill",
+        "score": 1,
+        "relevant_skill_activated": false,
+        "activated_skills": [],
+        "input_tokens": 100,
+        "output_tokens": 10,
+        "error_type": null
+      },
+      "observations": {
+        "natural_output": {
+          "session": {
+            "run_id": "data-negative-natural_output-session",
+            "score": 0,
+            "relevant_skill_activated": false,
+            "activated_skills": [
+              "session-skill"
+            ],
+            "input_tokens": 130,
+            "output_tokens": 10,
+            "error_type": "task_failure"
+          },
+          "atom": {
+            "run_id": "data-negative-natural_output-atom",
+            "score": 0,
+            "relevant_skill_activated": false,
+            "activated_skills": [
+              "atom-skill"
+            ],
+            "input_tokens": 135,
+            "output_tokens": 10,
+            "error_type": "task_failure"
+          },
+          "task_grounded": {
+            "run_id": "data-negative-natural_output-task_grounded",
+            "score": 1,
+            "relevant_skill_activated": false,
+            "activated_skills": [],
+            "input_tokens": 125,
+            "output_tokens": 10,
+            "error_type": null
+          },
+          "gold_task": {
+            "run_id": "data-negative-natural_output-gold_task",
+            "score": 1,
+            "relevant_skill_activated": false,
+            "activated_skills": [],
+            "input_tokens": 123,
+            "output_tokens": 10,
+            "error_type": null
+          }
+        },
+        "matched_budget": {
+          "session": {
+            "run_id": "data-negative-matched_budget-session",
+            "score": 0,
+            "relevant_skill_activated": false,
+            "activated_skills": [
+              "session-skill"
+            ],
+            "input_tokens": 128,
+            "output_tokens": 10,
+            "error_type": "task_failure"
+          },
+          "atom": {
+            "run_id": "data-negative-matched_budget-atom",
+            "score": 0,
+            "relevant_skill_activated": false,
+            "activated_skills": [
+              "atom-skill"
+            ],
+            "input_tokens": 128,
+            "output_tokens": 10,
+            "error_type": "task_failure"
+          },
+          "task_grounded": {
+            "run_id": "data-negative-matched_budget-task_grounded",
+            "score": 1,
+            "relevant_skill_activated": false,
+            "activated_skills": [],
+            "input_tokens": 128,
+            "output_tokens": 10,
+            "error_type": null
+          },
+          "gold_task": {
+            "run_id": "data-negative-matched_budget-gold_task",
+            "score": 1,
+            "relevant_skill_activated": false,
+            "activated_skills": [],
+            "input_tokens": 128,
+            "output_tokens": 10,
+            "error_type": null
+          }
+        }
+      }
+    },
+    {
+      "case_id": "code-novel",
+      "task_fingerprint": "sha256:8888888888888888888888888888888888888888888888888888888888888888",
+      "task_family": "code",
+      "seed": 1,
+      "cohort": "novel",
+      "expects_skill": true,
+      "control": {
+        "run_id": "code-novel-no-skill",
+        "score": 0,
+        "relevant_skill_activated": false,
+        "activated_skills": [],
+        "input_tokens": 100,
+        "output_tokens": 10,
+        "error_type": "task_failure"
+      },
+      "observations": {
+        "natural_output": {
+          "session": {
+            "run_id": "code-novel-natural_output-session",
+            "score": 0,
+            "relevant_skill_activated": true,
+            "activated_skills": [
+              "session-skill"
+            ],
+            "input_tokens": 130,
+            "output_tokens": 10,
+            "error_type": "task_failure"
+          },
+          "atom": {
+            "run_id": "code-novel-natural_output-atom",
+            "score": 0,
+            "relevant_skill_activated": false,
+            "activated_skills": [
+              "atom-skill"
+            ],
+            "input_tokens": 135,
+            "output_tokens": 10,
+            "error_type": "task_failure"
+          },
+          "task_grounded": {
+            "run_id": "code-novel-natural_output-task_grounded",
+            "score": 1,
+            "relevant_skill_activated": true,
+            "activated_skills": [
+              "task-grounded-skill"
+            ],
+            "input_tokens": 125,
+            "output_tokens": 10,
+            "error_type": null
+          },
+          "gold_task": {
+            "run_id": "code-novel-natural_output-gold_task",
+            "score": 1,
+            "relevant_skill_activated": true,
+            "activated_skills": [
+              "gold-task-skill"
+            ],
+            "input_tokens": 123,
+            "output_tokens": 10,
+            "error_type": null
+          }
+        },
+        "matched_budget": {
+          "session": {
+            "run_id": "code-novel-matched_budget-session",
+            "score": 0,
+            "relevant_skill_activated": true,
+            "activated_skills": [
+              "session-skill"
+            ],
+            "input_tokens": 128,
+            "output_tokens": 10,
+            "error_type": "task_failure"
+          },
+          "atom": {
+            "run_id": "code-novel-matched_budget-atom",
+            "score": 0,
+            "relevant_skill_activated": false,
+            "activated_skills": [
+              "atom-skill"
+            ],
+            "input_tokens": 128,
+            "output_tokens": 10,
+            "error_type": "task_failure"
+          },
+          "task_grounded": {
+            "run_id": "code-novel-matched_budget-task_grounded",
+            "score": 1,
+            "relevant_skill_activated": true,
+            "activated_skills": [
+              "task-grounded-skill"
+            ],
+            "input_tokens": 128,
+            "output_tokens": 10,
+            "error_type": null
+          },
+          "gold_task": {
+            "run_id": "code-novel-matched_budget-gold_task",
+            "score": 1,
+            "relevant_skill_activated": true,
+            "activated_skills": [
+              "gold-task-skill"
+            ],
+            "input_tokens": 128,
+            "output_tokens": 10,
+            "error_type": null
+          }
+        }
+      }
+    },
+    {
+      "case_id": "code-known",
+      "task_fingerprint": "sha256:9999999999999999999999999999999999999999999999999999999999999999",
+      "task_family": "code",
+      "seed": 1,
+      "cohort": "known",
+      "expects_skill": true,
+      "control": {
+        "run_id": "code-known-no-skill",
+        "score": 1,
+        "relevant_skill_activated": false,
+        "activated_skills": [],
+        "input_tokens": 100,
+        "output_tokens": 10,
+        "error_type": null
+      },
+      "observations": {
+        "natural_output": {
+          "session": {
+            "run_id": "code-known-natural_output-session",
+            "score": 1,
+            "relevant_skill_activated": true,
+            "activated_skills": [
+              "session-skill"
+            ],
+            "input_tokens": 130,
+            "output_tokens": 10,
+            "error_type": null
+          },
+          "atom": {
+            "run_id": "code-known-natural_output-atom",
+            "score": 1,
+            "relevant_skill_activated": true,
+            "activated_skills": [
+              "atom-skill"
+            ],
+            "input_tokens": 135,
+            "output_tokens": 10,
+            "error_type": null
+          },
+          "task_grounded": {
+            "run_id": "code-known-natural_output-task_grounded",
+            "score": 1,
+            "relevant_skill_activated": true,
+            "activated_skills": [
+              "task-grounded-skill"
+            ],
+            "input_tokens": 125,
+            "output_tokens": 10,
+            "error_type": null
+          },
+          "gold_task": {
+            "run_id": "code-known-natural_output-gold_task",
+            "score": 1,
+            "relevant_skill_activated": true,
+            "activated_skills": [
+              "gold-task-skill"
+            ],
+            "input_tokens": 123,
+            "output_tokens": 10,
+            "error_type": null
+          }
+        },
+        "matched_budget": {
+          "session": {
+            "run_id": "code-known-matched_budget-session",
+            "score": 1,
+            "relevant_skill_activated": true,
+            "activated_skills": [
+              "session-skill"
+            ],
+            "input_tokens": 128,
+            "output_tokens": 10,
+            "error_type": null
+          },
+          "atom": {
+            "run_id": "code-known-matched_budget-atom",
+            "score": 1,
+            "relevant_skill_activated": true,
+            "activated_skills": [
+              "atom-skill"
+            ],
+            "input_tokens": 128,
+            "output_tokens": 10,
+            "error_type": null
+          },
+          "task_grounded": {
+            "run_id": "code-known-matched_budget-task_grounded",
+            "score": 1,
+            "relevant_skill_activated": true,
+            "activated_skills": [
+              "task-grounded-skill"
+            ],
+            "input_tokens": 128,
+            "output_tokens": 10,
+            "error_type": null
+          },
+          "gold_task": {
+            "run_id": "code-known-matched_budget-gold_task",
+            "score": 1,
+            "relevant_skill_activated": true,
+            "activated_skills": [
+              "gold-task-skill"
+            ],
+            "input_tokens": 128,
+            "output_tokens": 10,
+            "error_type": null
+          }
+        }
+      }
+    },
+    {
+      "case_id": "code-negative",
+      "task_fingerprint": "sha256:aaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaa",
+      "task_family": "code",
+      "seed": 1,
+      "cohort": "negative",
+      "expects_skill": false,
+      "control": {
+        "run_id": "code-negative-no-skill",
+        "score": 1,
+        "relevant_skill_activated": false,
+        "activated_skills": [],
+        "input_tokens": 100,
+        "output_tokens": 10,
+        "error_type": null
+      },
+      "observations": {
+        "natural_output": {
+          "session": {
+            "run_id": "code-negative-natural_output-session",
+            "score": 0,
+            "relevant_skill_activated": false,
+            "activated_skills": [
+              "session-skill"
+            ],
+            "input_tokens": 130,
+            "output_tokens": 10,
+            "error_type": "task_failure"
+          },
+          "atom": {
+            "run_id": "code-negative-natural_output-atom",
+            "score": 0,
+            "relevant_skill_activated": false,
+            "activated_skills": [
+              "atom-skill"
+            ],
+            "input_tokens": 135,
+            "output_tokens": 10,
+            "error_type": "task_failure"
+          },
+          "task_grounded": {
+            "run_id": "code-negative-natural_output-task_grounded",
+            "score": 1,
+            "relevant_skill_activated": false,
+            "activated_skills": [],
+            "input_tokens": 125,
+            "output_tokens": 10,
+            "error_type": null
+          },
+          "gold_task": {
+            "run_id": "code-negative-natural_output-gold_task",
+            "score": 1,
+            "relevant_skill_activated": false,
+            "activated_skills": [],
+            "input_tokens": 123,
+            "output_tokens": 10,
+            "error_type": null
+          }
+        },
+        "matched_budget": {
+          "session": {
+            "run_id": "code-negative-matched_budget-session",
+            "score": 0,
+            "relevant_skill_activated": false,
+            "activated_skills": [
+              "session-skill"
+            ],
+            "input_tokens": 128,
+            "output_tokens": 10,
+            "error_type": "task_failure"
+          },
+          "atom": {
+            "run_id": "code-negative-matched_budget-atom",
+            "score": 0,
+            "relevant_skill_activated": false,
+            "activated_skills": [
+              "atom-skill"
+            ],
+            "input_tokens": 128,
+            "output_tokens": 10,
+            "error_type": "task_failure"
+          },
+          "task_grounded": {
+            "run_id": "code-negative-matched_budget-task_grounded",
+            "score": 1,
+            "relevant_skill_activated": false,
+            "activated_skills": [],
+            "input_tokens": 128,
+            "output_tokens": 10,
+            "error_type": null
+          },
+          "gold_task": {
+            "run_id": "code-negative-matched_budget-gold_task",
+            "score": 1,
+            "relevant_skill_activated": false,
+            "activated_skills": [],
+            "input_tokens": 128,
+            "output_tokens": 10,
+            "error_type": null
+          }
+        }
+      }
+    }
+  ]
+}

--- a/scripts/bench/formation_effect_replay/fixtures/baseline_v1.report.json
+++ b/scripts/bench/formation_effect_replay/fixtures/baseline_v1.report.json
@@ -1,0 +1,747 @@
+{
+  "decision": {
+    "checks": {
+      "confidence_interval_lower_bound": true,
+      "enough_improved_task_families": true,
+      "false_trigger_not_worse": true,
+      "known_tasks_not_regressed": true,
+      "matched_budget_same_direction": true,
+      "minimum_pass_rate_delta": true
+    },
+    "passed": true,
+    "primary_contrast": "task_grounded_minus_atom",
+    "primary_mode": "natural_output"
+  },
+  "decision_policy": {
+    "maximum_false_trigger_rate_delta": 0,
+    "maximum_known_pass_rate_drop": 0,
+    "minimum_improved_task_families": 2,
+    "minimum_primary_ci_lower": 0,
+    "minimum_primary_pass_rate_delta": 0.05,
+    "primary_mode": "natural_output",
+    "require_matched_budget_positive": true
+  },
+  "metric_config": {
+    "bootstrap_samples": 1000,
+    "bootstrap_seed": 42,
+    "confidence_level": 0.95,
+    "pass_threshold": 1
+  },
+  "modes": [
+    {
+      "artifacts": {
+        "atom": {
+          "evidence_fingerprint": "sha256:2222222222222222222222222222222222222222222222222222222222222222",
+          "serialized_skill_tokens": 300,
+          "skill_count": 3,
+          "skill_library_fingerprint": "sha256:cccccccccccccccccccccccccccccccccccccccccccccccccccccccccccccccc"
+        },
+        "gold_task": {
+          "evidence_fingerprint": "sha256:4444444444444444444444444444444444444444444444444444444444444444",
+          "serialized_skill_tokens": 170,
+          "skill_count": 2,
+          "skill_library_fingerprint": "sha256:eeeeeeeeeeeeeeeeeeeeeeeeeeeeeeeeeeeeeeeeeeeeeeeeeeeeeeeeeeeeeeee"
+        },
+        "no_skill": {
+          "serialized_skill_tokens": 0,
+          "skill_count": 0
+        },
+        "session": {
+          "evidence_fingerprint": "sha256:1111111111111111111111111111111111111111111111111111111111111111",
+          "serialized_skill_tokens": 240,
+          "skill_count": 2,
+          "skill_library_fingerprint": "sha256:bbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbb"
+        },
+        "task_grounded": {
+          "evidence_fingerprint": "sha256:3333333333333333333333333333333333333333333333333333333333333333",
+          "serialized_skill_tokens": 180,
+          "skill_count": 2,
+          "skill_library_fingerprint": "sha256:dddddddddddddddddddddddddddddddddddddddddddddddddddddddddddddddd"
+        }
+      },
+      "budget_policy": "natural_output",
+      "contrasts": {
+        "gold_task_minus_task_grounded": {
+          "mcnemar_pass": {
+            "control_only_pass": 0,
+            "discordant_pairs": 0,
+            "exact_two_sided_p": 1.0,
+            "treated_only_pass": 0
+          },
+          "pass_rate_delta": {
+            "confidence_interval": [
+              0.0,
+              0.0
+            ],
+            "losses": 0,
+            "mean": 0.0,
+            "n_pairs": 6,
+            "n_tasks": 6,
+            "ties": 6,
+            "wins": 0
+          },
+          "score_delta": {
+            "confidence_interval": [
+              0.0,
+              0.0
+            ],
+            "losses": 0,
+            "mean": 0.0,
+            "n_pairs": 6,
+            "n_tasks": 6,
+            "ties": 6,
+            "wins": 0
+          }
+        },
+        "task_grounded_minus_atom": {
+          "false_trigger_rate_delta": {
+            "confidence_interval": [
+              -1.0,
+              -1.0
+            ],
+            "losses": 2,
+            "mean": -1.0,
+            "n_pairs": 2,
+            "n_tasks": 2,
+            "ties": 0,
+            "wins": 0
+          },
+          "known_pass_rate_delta": {
+            "confidence_interval": [
+              0.0,
+              1.0
+            ],
+            "losses": 0,
+            "mean": 0.5,
+            "n_pairs": 2,
+            "n_tasks": 2,
+            "ties": 1,
+            "wins": 1
+          },
+          "mcnemar_pass": {
+            "control_only_pass": 0,
+            "discordant_pairs": 5,
+            "exact_two_sided_p": 0.0625,
+            "treated_only_pass": 5
+          },
+          "novel_pass_rate_delta": {
+            "confidence_interval": [
+              1.0,
+              1.0
+            ],
+            "losses": 0,
+            "mean": 1.0,
+            "n_pairs": 2,
+            "n_tasks": 2,
+            "ties": 0,
+            "wins": 2
+          },
+          "pass_rate_delta": {
+            "confidence_interval": [
+              0.5,
+              1.0
+            ],
+            "losses": 0,
+            "mean": 0.833333,
+            "n_pairs": 6,
+            "n_tasks": 6,
+            "ties": 1,
+            "wins": 5
+          },
+          "positive_recall_delta": {
+            "confidence_interval": [
+              0.25,
+              1.0
+            ],
+            "losses": 0,
+            "mean": 0.75,
+            "n_pairs": 4,
+            "n_tasks": 4,
+            "ties": 1,
+            "wins": 3
+          },
+          "resource_deltas": {
+            "input_tokens": {
+              "confidence_interval": [
+                -10.0,
+                -10.0
+              ],
+              "losses": 6,
+              "mean": -10.0,
+              "n_pairs": 6,
+              "n_tasks": 6,
+              "ties": 0,
+              "wins": 0
+            },
+            "output_tokens": {
+              "confidence_interval": [
+                0.0,
+                0.0
+              ],
+              "losses": 0,
+              "mean": 0.0,
+              "n_pairs": 6,
+              "n_tasks": 6,
+              "ties": 6,
+              "wins": 0
+            }
+          },
+          "score_delta": {
+            "confidence_interval": [
+              0.5,
+              1.0
+            ],
+            "losses": 0,
+            "mean": 0.833333,
+            "n_pairs": 6,
+            "n_tasks": 6,
+            "ties": 1,
+            "wins": 5
+          },
+          "score_delta_by_task_family": {
+            "code": {
+              "confidence_interval": [
+                0.0,
+                1.0
+              ],
+              "losses": 0,
+              "mean": 0.666667,
+              "n_pairs": 3,
+              "n_tasks": 3,
+              "ties": 1,
+              "wins": 2
+            },
+            "data": {
+              "confidence_interval": [
+                1.0,
+                1.0
+              ],
+              "losses": 0,
+              "mean": 1.0,
+              "n_pairs": 3,
+              "n_tasks": 3,
+              "ties": 0,
+              "wins": 3
+            }
+          }
+        },
+        "task_grounded_minus_no_skill": {
+          "mcnemar_pass": {
+            "control_only_pass": 0,
+            "discordant_pairs": 2,
+            "exact_two_sided_p": 0.5,
+            "treated_only_pass": 2
+          },
+          "pass_rate_delta": {
+            "confidence_interval": [
+              0.0,
+              0.666667
+            ],
+            "losses": 0,
+            "mean": 0.333333,
+            "n_pairs": 6,
+            "n_tasks": 6,
+            "ties": 4,
+            "wins": 2
+          },
+          "score_delta": {
+            "confidence_interval": [
+              0.0,
+              0.666667
+            ],
+            "losses": 0,
+            "mean": 0.333333,
+            "n_pairs": 6,
+            "n_tasks": 6,
+            "ties": 4,
+            "wins": 2
+          }
+        },
+        "task_grounded_minus_session": {
+          "mcnemar_pass": {
+            "control_only_pass": 0,
+            "discordant_pairs": 4,
+            "exact_two_sided_p": 0.125,
+            "treated_only_pass": 4
+          },
+          "pass_rate_delta": {
+            "confidence_interval": [
+              0.333333,
+              1.0
+            ],
+            "losses": 0,
+            "mean": 0.666667,
+            "n_pairs": 6,
+            "n_tasks": 6,
+            "ties": 2,
+            "wins": 4
+          },
+          "score_delta": {
+            "confidence_interval": [
+              0.333333,
+              1.0
+            ],
+            "losses": 0,
+            "mean": 0.666667,
+            "n_pairs": 6,
+            "n_tasks": 6,
+            "ties": 2,
+            "wins": 4
+          }
+        }
+      },
+      "methods": {
+        "atom": {
+          "errors": {
+            "task_failure": 5
+          },
+          "known_pass_rate": 0.5,
+          "mean_score": 0.166667,
+          "n": 6,
+          "negative_false_trigger_rate": 1.0,
+          "novel_pass_rate": 0.0,
+          "pass_rate": 0.166667,
+          "positive_recall": 0.25,
+          "resources": {
+            "input_tokens": 135.0,
+            "output_tokens": 10.0
+          }
+        },
+        "gold_task": {
+          "errors": {},
+          "known_pass_rate": 1.0,
+          "mean_score": 1.0,
+          "n": 6,
+          "negative_false_trigger_rate": 0.0,
+          "novel_pass_rate": 1.0,
+          "pass_rate": 1.0,
+          "positive_recall": 1.0,
+          "resources": {
+            "input_tokens": 123.0,
+            "output_tokens": 10.0
+          }
+        },
+        "no_skill": {
+          "errors": {
+            "task_failure": 2
+          },
+          "known_pass_rate": 1.0,
+          "mean_score": 0.666667,
+          "n": 6,
+          "negative_false_trigger_rate": 0.0,
+          "novel_pass_rate": 0.0,
+          "pass_rate": 0.666667,
+          "positive_recall": 0.0,
+          "resources": {
+            "input_tokens": 100.0,
+            "output_tokens": 10.0
+          }
+        },
+        "session": {
+          "errors": {
+            "task_failure": 4
+          },
+          "known_pass_rate": 1.0,
+          "mean_score": 0.333333,
+          "n": 6,
+          "negative_false_trigger_rate": 1.0,
+          "novel_pass_rate": 0.0,
+          "pass_rate": 0.333333,
+          "positive_recall": 1.0,
+          "resources": {
+            "input_tokens": 130.0,
+            "output_tokens": 10.0
+          }
+        },
+        "task_grounded": {
+          "errors": {},
+          "known_pass_rate": 1.0,
+          "mean_score": 1.0,
+          "n": 6,
+          "negative_false_trigger_rate": 0.0,
+          "novel_pass_rate": 1.0,
+          "pass_rate": 1.0,
+          "positive_recall": 1.0,
+          "resources": {
+            "input_tokens": 125.0,
+            "output_tokens": 10.0
+          }
+        }
+      },
+      "mode_id": "natural_output",
+      "utility_density_per_1000_skill_tokens": {
+        "atom": -1.666667,
+        "gold_task": 1.960784,
+        "no_skill": null,
+        "session": -1.388889,
+        "task_grounded": 1.851852
+      }
+    },
+    {
+      "artifacts": {
+        "atom": {
+          "evidence_fingerprint": "sha256:2222222222222222222222222222222222222222222222222222222222222222",
+          "serialized_skill_tokens": 200,
+          "skill_count": 2,
+          "skill_library_fingerprint": "sha256:0000000000000000000000000000000000000000000000000000000000000000"
+        },
+        "gold_task": {
+          "evidence_fingerprint": "sha256:4444444444444444444444444444444444444444444444444444444444444444",
+          "serialized_skill_tokens": 200,
+          "skill_count": 2,
+          "skill_library_fingerprint": "sha256:2222222222222222222222222222222222222222222222222222222222222222"
+        },
+        "no_skill": {
+          "serialized_skill_tokens": 0,
+          "skill_count": 0
+        },
+        "session": {
+          "evidence_fingerprint": "sha256:1111111111111111111111111111111111111111111111111111111111111111",
+          "serialized_skill_tokens": 200,
+          "skill_count": 2,
+          "skill_library_fingerprint": "sha256:ffffffffffffffffffffffffffffffffffffffffffffffffffffffffffffffff"
+        },
+        "task_grounded": {
+          "evidence_fingerprint": "sha256:3333333333333333333333333333333333333333333333333333333333333333",
+          "serialized_skill_tokens": 200,
+          "skill_count": 2,
+          "skill_library_fingerprint": "sha256:1111111111111111111111111111111111111111111111111111111111111111"
+        }
+      },
+      "budget_policy": "matched_serialized_skill_tokens",
+      "budget_value": 200,
+      "contrasts": {
+        "gold_task_minus_task_grounded": {
+          "mcnemar_pass": {
+            "control_only_pass": 0,
+            "discordant_pairs": 0,
+            "exact_two_sided_p": 1.0,
+            "treated_only_pass": 0
+          },
+          "pass_rate_delta": {
+            "confidence_interval": [
+              0.0,
+              0.0
+            ],
+            "losses": 0,
+            "mean": 0.0,
+            "n_pairs": 6,
+            "n_tasks": 6,
+            "ties": 6,
+            "wins": 0
+          },
+          "score_delta": {
+            "confidence_interval": [
+              0.0,
+              0.0
+            ],
+            "losses": 0,
+            "mean": 0.0,
+            "n_pairs": 6,
+            "n_tasks": 6,
+            "ties": 6,
+            "wins": 0
+          }
+        },
+        "task_grounded_minus_atom": {
+          "false_trigger_rate_delta": {
+            "confidence_interval": [
+              -1.0,
+              -1.0
+            ],
+            "losses": 2,
+            "mean": -1.0,
+            "n_pairs": 2,
+            "n_tasks": 2,
+            "ties": 0,
+            "wins": 0
+          },
+          "known_pass_rate_delta": {
+            "confidence_interval": [
+              0.0,
+              1.0
+            ],
+            "losses": 0,
+            "mean": 0.5,
+            "n_pairs": 2,
+            "n_tasks": 2,
+            "ties": 1,
+            "wins": 1
+          },
+          "mcnemar_pass": {
+            "control_only_pass": 0,
+            "discordant_pairs": 5,
+            "exact_two_sided_p": 0.0625,
+            "treated_only_pass": 5
+          },
+          "novel_pass_rate_delta": {
+            "confidence_interval": [
+              1.0,
+              1.0
+            ],
+            "losses": 0,
+            "mean": 1.0,
+            "n_pairs": 2,
+            "n_tasks": 2,
+            "ties": 0,
+            "wins": 2
+          },
+          "pass_rate_delta": {
+            "confidence_interval": [
+              0.5,
+              1.0
+            ],
+            "losses": 0,
+            "mean": 0.833333,
+            "n_pairs": 6,
+            "n_tasks": 6,
+            "ties": 1,
+            "wins": 5
+          },
+          "positive_recall_delta": {
+            "confidence_interval": [
+              0.25,
+              1.0
+            ],
+            "losses": 0,
+            "mean": 0.75,
+            "n_pairs": 4,
+            "n_tasks": 4,
+            "ties": 1,
+            "wins": 3
+          },
+          "resource_deltas": {
+            "input_tokens": {
+              "confidence_interval": [
+                0.0,
+                0.0
+              ],
+              "losses": 0,
+              "mean": 0.0,
+              "n_pairs": 6,
+              "n_tasks": 6,
+              "ties": 6,
+              "wins": 0
+            },
+            "output_tokens": {
+              "confidence_interval": [
+                0.0,
+                0.0
+              ],
+              "losses": 0,
+              "mean": 0.0,
+              "n_pairs": 6,
+              "n_tasks": 6,
+              "ties": 6,
+              "wins": 0
+            }
+          },
+          "score_delta": {
+            "confidence_interval": [
+              0.5,
+              1.0
+            ],
+            "losses": 0,
+            "mean": 0.833333,
+            "n_pairs": 6,
+            "n_tasks": 6,
+            "ties": 1,
+            "wins": 5
+          },
+          "score_delta_by_task_family": {
+            "code": {
+              "confidence_interval": [
+                0.0,
+                1.0
+              ],
+              "losses": 0,
+              "mean": 0.666667,
+              "n_pairs": 3,
+              "n_tasks": 3,
+              "ties": 1,
+              "wins": 2
+            },
+            "data": {
+              "confidence_interval": [
+                1.0,
+                1.0
+              ],
+              "losses": 0,
+              "mean": 1.0,
+              "n_pairs": 3,
+              "n_tasks": 3,
+              "ties": 0,
+              "wins": 3
+            }
+          }
+        },
+        "task_grounded_minus_no_skill": {
+          "mcnemar_pass": {
+            "control_only_pass": 0,
+            "discordant_pairs": 2,
+            "exact_two_sided_p": 0.5,
+            "treated_only_pass": 2
+          },
+          "pass_rate_delta": {
+            "confidence_interval": [
+              0.0,
+              0.666667
+            ],
+            "losses": 0,
+            "mean": 0.333333,
+            "n_pairs": 6,
+            "n_tasks": 6,
+            "ties": 4,
+            "wins": 2
+          },
+          "score_delta": {
+            "confidence_interval": [
+              0.0,
+              0.666667
+            ],
+            "losses": 0,
+            "mean": 0.333333,
+            "n_pairs": 6,
+            "n_tasks": 6,
+            "ties": 4,
+            "wins": 2
+          }
+        },
+        "task_grounded_minus_session": {
+          "mcnemar_pass": {
+            "control_only_pass": 0,
+            "discordant_pairs": 4,
+            "exact_two_sided_p": 0.125,
+            "treated_only_pass": 4
+          },
+          "pass_rate_delta": {
+            "confidence_interval": [
+              0.333333,
+              1.0
+            ],
+            "losses": 0,
+            "mean": 0.666667,
+            "n_pairs": 6,
+            "n_tasks": 6,
+            "ties": 2,
+            "wins": 4
+          },
+          "score_delta": {
+            "confidence_interval": [
+              0.333333,
+              1.0
+            ],
+            "losses": 0,
+            "mean": 0.666667,
+            "n_pairs": 6,
+            "n_tasks": 6,
+            "ties": 2,
+            "wins": 4
+          }
+        }
+      },
+      "methods": {
+        "atom": {
+          "errors": {
+            "task_failure": 5
+          },
+          "known_pass_rate": 0.5,
+          "mean_score": 0.166667,
+          "n": 6,
+          "negative_false_trigger_rate": 1.0,
+          "novel_pass_rate": 0.0,
+          "pass_rate": 0.166667,
+          "positive_recall": 0.25,
+          "resources": {
+            "input_tokens": 128.0,
+            "output_tokens": 10.0
+          }
+        },
+        "gold_task": {
+          "errors": {},
+          "known_pass_rate": 1.0,
+          "mean_score": 1.0,
+          "n": 6,
+          "negative_false_trigger_rate": 0.0,
+          "novel_pass_rate": 1.0,
+          "pass_rate": 1.0,
+          "positive_recall": 1.0,
+          "resources": {
+            "input_tokens": 128.0,
+            "output_tokens": 10.0
+          }
+        },
+        "no_skill": {
+          "errors": {
+            "task_failure": 2
+          },
+          "known_pass_rate": 1.0,
+          "mean_score": 0.666667,
+          "n": 6,
+          "negative_false_trigger_rate": 0.0,
+          "novel_pass_rate": 0.0,
+          "pass_rate": 0.666667,
+          "positive_recall": 0.0,
+          "resources": {
+            "input_tokens": 100.0,
+            "output_tokens": 10.0
+          }
+        },
+        "session": {
+          "errors": {
+            "task_failure": 4
+          },
+          "known_pass_rate": 1.0,
+          "mean_score": 0.333333,
+          "n": 6,
+          "negative_false_trigger_rate": 1.0,
+          "novel_pass_rate": 0.0,
+          "pass_rate": 0.333333,
+          "positive_recall": 1.0,
+          "resources": {
+            "input_tokens": 128.0,
+            "output_tokens": 10.0
+          }
+        },
+        "task_grounded": {
+          "errors": {},
+          "known_pass_rate": 1.0,
+          "mean_score": 1.0,
+          "n": 6,
+          "negative_false_trigger_rate": 0.0,
+          "novel_pass_rate": 1.0,
+          "pass_rate": 1.0,
+          "positive_recall": 1.0,
+          "resources": {
+            "input_tokens": 128.0,
+            "output_tokens": 10.0
+          }
+        }
+      },
+      "mode_id": "matched_budget",
+      "utility_density_per_1000_skill_tokens": {
+        "atom": -2.5,
+        "gold_task": 1.666667,
+        "no_skill": null,
+        "session": -1.666667,
+        "task_grounded": 1.666667
+      }
+    }
+  ],
+  "n_cases": 6,
+  "n_tasks": 6,
+  "run_manifest": {
+    "activation_config_fingerprint": "sha256:cccccccccccccccccccccccccccccccccccccccccccccccccccccccccccccccc",
+    "evaluation_protocol_fingerprint": "sha256:7777777777777777777777777777777777777777777777777777777777777777",
+    "formation_config_fingerprint": "sha256:aaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaa",
+    "held_out_task_set_fingerprint": "sha256:6666666666666666666666666666666666666666666666666666666666666666",
+    "recorded_at": "2026-08-30T00:00:00Z",
+    "repository_revision": "synthetic-revision",
+    "runtime_config_fingerprint": "sha256:8888888888888888888888888888888888888888888888888888888888888888",
+    "scorer_fingerprint": "sha256:9999999999999999999999999999999999999999999999999999999999999999",
+    "skill_generation_config_fingerprint": "sha256:bbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbb",
+    "training_set_fingerprint": "sha256:5555555555555555555555555555555555555555555555555555555555555555"
+  },
+  "schema_version": 1,
+  "suite_id": "formation-effect-contract-v1"
+}

--- a/scripts/bench/formation_effect_replay/fixtures/baseline_v1.report.json
+++ b/scripts/bench/formation_effect_replay/fixtures/baseline_v1.report.json
@@ -64,8 +64,10 @@
         "gold_task_minus_task_grounded": {
           "mcnemar_pass": {
             "control_only_pass": 0,
-            "discordant_pairs": 0,
+            "discordant_tasks": 0,
             "exact_two_sided_p": 1.0,
+            "n_tasks": 6,
+            "task_pass_rule": "seed_pass_rate>=0.5",
             "treated_only_pass": 0
           },
           "pass_rate_delta": {
@@ -120,8 +122,10 @@
           },
           "mcnemar_pass": {
             "control_only_pass": 0,
-            "discordant_pairs": 5,
+            "discordant_tasks": 5,
             "exact_two_sided_p": 0.0625,
+            "n_tasks": 6,
+            "task_pass_rule": "seed_pass_rate>=0.5",
             "treated_only_pass": 5
           },
           "novel_pass_rate_delta": {
@@ -228,8 +232,10 @@
         "task_grounded_minus_no_skill": {
           "mcnemar_pass": {
             "control_only_pass": 0,
-            "discordant_pairs": 2,
+            "discordant_tasks": 2,
             "exact_two_sided_p": 0.5,
+            "n_tasks": 6,
+            "task_pass_rule": "seed_pass_rate>=0.5",
             "treated_only_pass": 2
           },
           "pass_rate_delta": {
@@ -260,8 +266,10 @@
         "task_grounded_minus_session": {
           "mcnemar_pass": {
             "control_only_pass": 0,
-            "discordant_pairs": 4,
+            "discordant_tasks": 4,
             "exact_two_sided_p": 0.125,
+            "n_tasks": 6,
+            "task_pass_rule": "seed_pass_rate>=0.5",
             "treated_only_pass": 4
           },
           "pass_rate_delta": {
@@ -414,8 +422,10 @@
         "gold_task_minus_task_grounded": {
           "mcnemar_pass": {
             "control_only_pass": 0,
-            "discordant_pairs": 0,
+            "discordant_tasks": 0,
             "exact_two_sided_p": 1.0,
+            "n_tasks": 6,
+            "task_pass_rule": "seed_pass_rate>=0.5",
             "treated_only_pass": 0
           },
           "pass_rate_delta": {
@@ -470,8 +480,10 @@
           },
           "mcnemar_pass": {
             "control_only_pass": 0,
-            "discordant_pairs": 5,
+            "discordant_tasks": 5,
             "exact_two_sided_p": 0.0625,
+            "n_tasks": 6,
+            "task_pass_rule": "seed_pass_rate>=0.5",
             "treated_only_pass": 5
           },
           "novel_pass_rate_delta": {
@@ -578,8 +590,10 @@
         "task_grounded_minus_no_skill": {
           "mcnemar_pass": {
             "control_only_pass": 0,
-            "discordant_pairs": 2,
+            "discordant_tasks": 2,
             "exact_two_sided_p": 0.5,
+            "n_tasks": 6,
+            "task_pass_rule": "seed_pass_rate>=0.5",
             "treated_only_pass": 2
           },
           "pass_rate_delta": {
@@ -610,8 +624,10 @@
         "task_grounded_minus_session": {
           "mcnemar_pass": {
             "control_only_pass": 0,
-            "discordant_pairs": 4,
+            "discordant_tasks": 4,
             "exact_two_sided_p": 0.125,
+            "n_tasks": 6,
+            "task_pass_rule": "seed_pass_rate>=0.5",
             "treated_only_pass": 4
           },
           "pass_rate_delta": {

--- a/tests/test_formation_effect_replay.py
+++ b/tests/test_formation_effect_replay.py
@@ -1,0 +1,233 @@
+"""Contracts for the deterministic Formation-method effect replay."""
+
+from __future__ import annotations
+
+import json
+from copy import deepcopy
+from pathlib import Path
+
+import pytest
+
+from scripts.bench.formation_effect_replay.evaluate import (
+    FormationEffectValidationError,
+    evaluate_suite,
+    load_suite,
+    main,
+    render_text,
+    validate_suite,
+)
+
+FIXTURE_DIR = (
+    Path(__file__).parent.parent
+    / "scripts"
+    / "bench"
+    / "formation_effect_replay"
+    / "fixtures"
+)
+BASELINE_PATH = FIXTURE_DIR / "baseline_v1.json"
+REPORT_PATH = FIXTURE_DIR / "baseline_v1.report.json"
+
+pytestmark = pytest.mark.algorithm_replay
+
+
+def _mode(report: dict, mode_id: str) -> dict:
+    return next(mode for mode in report["modes"] if mode["mode_id"] == mode_id)
+
+
+def _suffix_run_ids(case: dict, suffix: str) -> None:
+    case["control"]["run_id"] += suffix
+    for observations in case["observations"].values():
+        for observation in observations.values():
+            observation["run_id"] += suffix
+
+
+def test_baseline_report_matches_checked_in_snapshot():
+    report = evaluate_suite(load_suite(BASELINE_PATH))
+
+    assert report == json.loads(REPORT_PATH.read_text(encoding="utf-8"))
+
+
+def test_primary_contrast_measures_method_effect_and_quality_guards():
+    report = evaluate_suite(load_suite(BASELINE_PATH))
+    primary = _mode(report, "natural_output")["contrasts"][
+        "task_grounded_minus_atom"
+    ]
+
+    assert primary["pass_rate_delta"]["mean"] == 0.833333
+    assert primary["pass_rate_delta"]["confidence_interval"] == [0.5, 1.0]
+    assert primary["false_trigger_rate_delta"]["mean"] == -1.0
+    assert primary["known_pass_rate_delta"]["mean"] == 0.5
+    assert primary["mcnemar_pass"] == {
+        "treated_only_pass": 5,
+        "control_only_pass": 0,
+        "discordant_pairs": 5,
+        "exact_two_sided_p": 0.0625,
+    }
+    assert report["decision"]["passed"] is True
+
+
+def test_report_retains_floor_ceiling_and_utility_density():
+    mode = _mode(evaluate_suite(load_suite(BASELINE_PATH)), "natural_output")
+
+    assert mode["methods"]["no_skill"]["pass_rate"] == 0.666667
+    assert mode["methods"]["gold_task"]["pass_rate"] == 1.0
+    assert mode["utility_density_per_1000_skill_tokens"]["atom"] < 0
+    assert mode["utility_density_per_1000_skill_tokens"]["task_grounded"] > 0
+    gold_gap = mode["contrasts"]["gold_task_minus_task_grounded"]
+    assert gold_gap["pass_rate_delta"]["mean"] == 0.0
+
+
+def test_provenance_is_runtime_agnostic_and_method_names_are_fixed():
+    report = evaluate_suite(load_suite(BASELINE_PATH))
+
+    assert set(report["run_manifest"]) == {
+        "repository_revision",
+        "recorded_at",
+        "training_set_fingerprint",
+        "held_out_task_set_fingerprint",
+        "evaluation_protocol_fingerprint",
+        "runtime_config_fingerprint",
+        "scorer_fingerprint",
+        "formation_config_fingerprint",
+        "skill_generation_config_fingerprint",
+        "activation_config_fingerprint",
+    }
+    assert set(_mode(report, "natural_output")["methods"]) == {
+        "no_skill",
+        "session",
+        "atom",
+        "task_grounded",
+        "gold_task",
+    }
+
+
+def test_matched_budget_requires_equal_serialized_skill_tokens():
+    suite = load_suite(BASELINE_PATH)
+    suite["modes"][1]["arms"]["atom"]["serialized_skill_tokens"] -= 1
+
+    with pytest.raises(FormationEffectValidationError, match="matched budget"):
+        validate_suite(suite)
+
+
+def test_budget_modes_must_reuse_the_same_method_evidence():
+    suite = load_suite(BASELINE_PATH)
+    suite["modes"][1]["arms"]["atom"]["evidence_fingerprint"] = (
+        "sha256:" + "b" * 64
+    )
+
+    with pytest.raises(FormationEffectValidationError, match="evidence must remain fixed"):
+        validate_suite(suite)
+
+
+def test_each_case_requires_every_method_in_every_mode():
+    suite = load_suite(BASELINE_PATH)
+    del suite["cases"][0]["observations"]["natural_output"]["atom"]
+
+    with pytest.raises(FormationEffectValidationError, match="expected exactly"):
+        validate_suite(suite)
+
+
+def test_control_cannot_activate_a_skill():
+    suite = load_suite(BASELINE_PATH)
+    suite["cases"][0]["control"]["activated_skills"] = ["unexpected-skill"]
+
+    with pytest.raises(FormationEffectValidationError, match="control cannot activate"):
+        validate_suite(suite)
+
+
+def test_negative_case_cannot_claim_relevant_activation():
+    suite = load_suite(BASELINE_PATH)
+    observation = suite["cases"][2]["observations"]["natural_output"]["atom"]
+    observation["relevant_skill_activated"] = True
+
+    with pytest.raises(FormationEffectValidationError, match="negative case"):
+        validate_suite(suite)
+
+
+def test_training_and_held_out_fingerprints_must_differ():
+    suite = load_suite(BASELINE_PATH)
+    suite["run_manifest"]["held_out_task_set_fingerprint"] = suite[
+        "run_manifest"
+    ]["training_set_fingerprint"]
+
+    with pytest.raises(FormationEffectValidationError, match="must differ"):
+        validate_suite(suite)
+
+
+def test_duplicate_run_id_fails_loudly():
+    suite = load_suite(BASELINE_PATH)
+    duplicate = suite["cases"][0]["control"]["run_id"]
+    suite["cases"][1]["control"]["run_id"] = duplicate
+
+    with pytest.raises(FormationEffectValidationError, match="duplicate"):
+        validate_suite(suite)
+
+
+def test_repeated_seeds_are_clustered_by_task():
+    suite = load_suite(BASELINE_PATH)
+    for original in list(suite["cases"]):
+        repeated = deepcopy(original)
+        repeated["case_id"] += "-seed-2"
+        repeated["seed"] = 2
+        _suffix_run_ids(repeated, "-seed-2")
+        suite["cases"].append(repeated)
+
+    report = evaluate_suite(suite)
+    effect = _mode(report, "natural_output")["contrasts"][
+        "task_grounded_minus_atom"
+    ]["pass_rate_delta"]
+
+    assert effect["n_pairs"] == 12
+    assert effect["n_tasks"] == 6
+
+
+def test_unbalanced_seed_sets_fail_loudly():
+    suite = load_suite(BASELINE_PATH)
+    repeated = deepcopy(suite["cases"][0])
+    repeated["case_id"] = "data-novel-seed-2"
+    repeated["seed"] = 2
+    _suffix_run_ids(repeated, "-seed-2")
+    suite["cases"].append(repeated)
+
+    with pytest.raises(FormationEffectValidationError, match="same seed set"):
+        validate_suite(suite)
+
+
+def test_bootstrap_work_is_bounded_by_total_statistics():
+    suite = load_suite(BASELINE_PATH)
+    suite["metric_config"]["bootstrap_samples"] = 50_000
+    for original in list(suite["cases"]):
+        repeated = deepcopy(original)
+        repeated["case_id"] += "-seed-2"
+        repeated["seed"] = 2
+        _suffix_run_ids(repeated, "-seed-2")
+        suite["cases"].append(repeated)
+
+    with pytest.raises(FormationEffectValidationError, match="bootstrap work"):
+        validate_suite(suite)
+
+
+@pytest.mark.parametrize("score", [True, -0.1, 1.1, "1"])
+def test_invalid_scores_fail_loudly(score):
+    suite = load_suite(BASELINE_PATH)
+    suite["cases"][0]["control"]["score"] = score
+
+    with pytest.raises(FormationEffectValidationError, match="score"):
+        validate_suite(suite)
+
+
+def test_unknown_observation_field_fails_loudly():
+    suite = load_suite(BASELINE_PATH)
+    suite["cases"][0]["control"]["undocumented"] = True
+
+    with pytest.raises(FormationEffectValidationError, match="field mismatch"):
+        validate_suite(suite)
+
+
+def test_cli_renders_text_and_json(capsys):
+    report = evaluate_suite(load_suite(BASELINE_PATH))
+
+    assert main([str(BASELINE_PATH)]) == 0
+    assert capsys.readouterr().out == render_text(report) + "\n"
+    assert main([str(BASELINE_PATH), "--format", "json"]) == 0
+    assert json.loads(capsys.readouterr().out) == report

--- a/tests/test_formation_effect_replay.py
+++ b/tests/test_formation_effect_replay.py
@@ -58,9 +58,11 @@ def test_primary_contrast_measures_method_effect_and_quality_guards():
     assert primary["false_trigger_rate_delta"]["mean"] == -1.0
     assert primary["known_pass_rate_delta"]["mean"] == 0.5
     assert primary["mcnemar_pass"] == {
+        "n_tasks": 6,
+        "task_pass_rule": "seed_pass_rate>=0.5",
         "treated_only_pass": 5,
         "control_only_pass": 0,
-        "discordant_pairs": 5,
+        "discordant_tasks": 5,
         "exact_two_sided_p": 0.0625,
     }
     assert report["decision"]["passed"] is True
@@ -165,6 +167,7 @@ def test_duplicate_run_id_fails_loudly():
 
 def test_repeated_seeds_are_clustered_by_task():
     suite = load_suite(BASELINE_PATH)
+    baseline = evaluate_suite(deepcopy(suite))
     for original in list(suite["cases"]):
         repeated = deepcopy(original)
         repeated["case_id"] += "-seed-2"
@@ -179,6 +182,14 @@ def test_repeated_seeds_are_clustered_by_task():
 
     assert effect["n_pairs"] == 12
     assert effect["n_tasks"] == 6
+    repeated_mcnemar = _mode(report, "natural_output")["contrasts"][
+        "task_grounded_minus_atom"
+    ]["mcnemar_pass"]
+    baseline_mcnemar = _mode(baseline, "natural_output")["contrasts"][
+        "task_grounded_minus_atom"
+    ]["mcnemar_pass"]
+    assert repeated_mcnemar == baseline_mcnemar
+    assert repeated_mcnemar["n_tasks"] == 6
 
 
 def test_unbalanced_seed_sets_fail_loudly():


### PR DESCRIPTION
## Summary

增加运行环境无关的 Formation 方法效果配对回放，用相同 held-out task 和 seed 比较 No-Skill、Session、Atom、Task-Grounded 与 Gold Task 条件。

本 PR 只验证不同 Formation 证据是否转化为下游 Skill utility，不调用外部运行时，也不修改生产 Formation、Skill 生成、激活或晋升行为。

## Changes

- 增加严格的版本化 schema，冻结训练集、held-out 集、评分协议、运行环境、Formation、Skill 生成、激活和 scorer 指纹。
- 将 `task_grounded - atom` 固定为主对照，并保留 No-Skill 下限、Session 基线和 Gold Task 上限。
- 同时评估 natural-output 与 matched-budget，后者强制所有非控制方法具有相同序列化 Skill Token 预算。
- 要求完整的 `task × seed × mode × method` 配对、相同 seed 集、独立 Skill library 和跨预算模式不变的 evidence。
- 报告 score、Pass Rate、novel/known、激活 recall、false-trigger、错误类型、Token 和每千 Skill Token 的 utility。
- 增加逐 Task 配对效应、McNemar exact test、按 Task 聚类 bootstrap 置信区间、跨 task family 结果和预注册 go/no-go 检查。
- 对 bootstrap 总工作量设置确定性上限，并增加隐私安全的合成 fixture、稳定报告快照、README 和 20 个契约测试。

合成 fixture 中的 PASS 只验证指标和通过规则的方向，不作为 Task-Grounded Formation 已经取得真实经验收益的结论。

## Test plan

- [x] `make test` passes（2755 passed, 10 skipped）
- [x] Added/updated unit tests for the change（20 passed；与现有 benchmark replay 联合检查 82 passed）
- [ ] `make e2e` passes (if the change touches ingestion / install / daemon)（不涉及 ingestion、install 或 daemon）
- [x] Manually verified the affected user flow

手动连续生成两次 JSON 报告并与入仓快照比较，三者 SHA-256 均为 `e93575b9458f35ad0baf46cfb7a96e309a2acf6937a20df6ae7647e50e5352f4`。

200 个配对 case、1,000 次 bootstrap 的本机离线复算约为 0.526 秒，性能门禁本身使用确定性的总工作量上限而不是墙钟阈值。

Ruff 0.16.5 默认检查及项目指定规则检查通过。

## Linked issues

Closes #383

Refs #327

## 给外人看的背景（Task-Grounded 方法效果评测是什么）

下面按给第三方看的问题单来写：每个词第一次出现都会说明它是什么。代码位置只是提示，不是必须先读完整个仓库才能看懂。

### 这是什么

XSkill 平时学技能，走的是这条主路：先把一次完整会话收成 Session，再把 Session 切成一段段 Atom，Atom 进入候选，攒够了再写成 Skill。Session 就是一次连续对话。Atom 是里面意图相对单一的一小段。Skill 是后来写给助手用的说明书。

有些用户目标会跨好几个 Session。只看整段 Session 或单个 Atom 去写 Skill，可能把同一件事拆散，或把无关的话写进去。Task Graph 是架在主路上面的一层任务图：它把相关 Atom 收成更大的任务。图里的 Logical Task 是用户想完成的那件逻辑上的事。Task Attempt 是这件逻辑事的某一次具体执行。

Formation 是「用哪一类证据去形成 Skill」的那条被评测算法。Task-Grounded Formation 就是：不只看单个 Atom，而是把 Atom、Logical Task 和 Attempt 一起当作学习证据，再写出 Skill。

Q1 问的就是这件事有没有用：在其他条件保持不变时，这样形成的 Skill，会不会比只看整段 Session、或只看单个 Atom 形成的 Skill，在没见过的任务上更好用。本 PR 是 Q1 本题。前面的 #375、#377、#379 是底座：先能录拆分和路由、先把原文和标准答案拆开、先证明图有没有收对。本题才拿已经录好的下游分数，比较几种形成方法。

### 五组对照是什么

同一条 held-out 任务、同一个 seed，必须五种方法都有结果。held-out 是训练时没见过、专门留着测的任务。seed 是同一条任务重复跑时用的随机种子。五种都齐了，才能一对一对减，这叫配对。缺一种就整套失败，不会拿剩下的悄悄算完。

五组是：

1. no_skill：不加载任何 Skill，只看助手自己做。这是下限，用来判断装了技能之后到底有没有比裸跑强。
2. session：用整段 Session 当学习证据去形成 Skill。
3. atom：用单个 Atom 当学习证据去形成 Skill。这是更接近生产的主基线。Q1 不拿「比不装技能强」当主结论，因为单 Atom 已经能写出技能。
4. task_grounded：用 Atom、Logical Task 和 Attempt 一起当学习证据。这是 Q1 要验的方法。
5. gold_task：用人工标好的任务当学习证据。这是结构上限，用来看「如果任务边界完全正确，还能好多少」。它不是能上线的方法。

主对照固定为 task_grounded 减 atom。同时也会看相对 session、相对 no_skill，以及离 gold_task 还差多远。具体跑在哪套运行环境，只记一串不可改的指纹，不写进方法名，也不写进通过结论。

### 两种预算是什么

Skill 写多了、写长了，助手看见的说明就更多，分数也可能跟着涨。这不一定是形成方法更好，可能只是字数更多。所以同一套配对要算两遍。

natural_output：每种方法按自己平时会写出多少条、多长的 Skill 来评。看的是端到端净效果。

matched_budget：除了 no_skill，其余方法强制用完全相同的序列化 Skill Token 预算。Token 是把 Skill 正文算成用量的单位。这一遍用来排除「只是生成了更多内容」。

两遍里，同一种方法用的学习证据指纹必须一样，只改输出预算，不换学的材料。每种方法、每种预算还要有自己独立的 Skill 库指纹，不能几组共用一份库。

### 三类测试任务是什么

测试任务分成三类，评测里叫 cohort。三类必须同时在，而且至少覆盖两个 task family。task family 是任务所属的大类，避免只在一个类型上好看。入仓的合成包里用 data 和 code 两个名字占位，不是现网任务分类。

novel：训练时没见过的新任务。期望相关技能能帮上忙。

known：已经见过、技能本来就该会的任务。用来看新方法有没有把旧任务做坏。

negative：不该触发相关技能的任务。用来看会不会乱激活。乱激活在报告里叫 false-trigger。

### 输入是什么，输出是什么

输入不是现场再开一个 agent 去跑任务。输入是已经录好、不能改的配对观测：每一格都是「这条任务、这个 seed、这种预算、这种方法」上，当时记下的分数、有没有激活相关技能、实际激活了哪些技能、输入输出 Token、以及可选的错误类型。分数在 0 到 1 之间。评测器只读这份 JSON，不调用推理服务、外部 Harness、工作区命令，也不碰生产 xskill 状态。Harness 是任务真正执行时外面那层外壳。

输出是一份报告。每种方法给出平均分、Pass Rate（分数达到门槛的比例）、novel 和 known 上的通过率、该激活时有没有激活、不该激活时有没有误触发、Token，以及按 task family 拆开的结果。主对照给出逐条配对差值、按任务聚类的置信区间，以及预注册的通过或不通过。预注册的意思是：门槛在看结果之前就写进 decision_policy，不能看完数再改标准。

入仓的 `baseline_v1.json` 是合成 fixture。fixture 就是这份写好的固定输入包。里面只有合成编号、指纹和数值，没有真实任务正文、轨迹、工作区路径或用户标识。合成包上的 PASS，只表示指标和通过规则的方向算对了，不能当成 Task-Grounded Formation 已经在真实经验上赢了 atom。正式结论还要另备隐私安全、经过人工复核的 Formation 数据，以及同一套录制器和打分器产出的 held-out 原生结果。

### 评测侧实际发生了什么

维护者把录好的 suite 交给：

```
python -m scripts.bench.formation_effect_replay.evaluate scripts/bench/formation_effect_replay/fixtures/baseline_v1.json
```

普通 CI 只做这件事。CI 是每次提交后自动跑的那组检查。它不调外部运行时，也不改生产 Formation、Skill 生成、激活或晋升。用户电脑上不会因为合入这张补丁就多一次模型调用。现网是格力内网那套正在给人用的服务。Agent 接触不到现网，合进仓库也不等于现网已经换成这种形成方法。

### 合本 PR 之前缺了什么

#375 能把真实模型的拆分和路由录下来，CI 只回放，不再调模型。#377 把 Formation 能看见的原文和打分用的标准答案拆开，避免算法偷看标注。#379 能问 Task Graph 有没有把该在一起的 Atom 收到同一个 Logical Task 里。

这些仍回答不了 Q1 本题：结构更准，会不会变成 held-out 任务上 Skill 更好用。如果只报结构指标，证明不了下游成功率。如果只比一次完整运行，又会把 Skill 条数、Skill 长度、激活误差、运行配置和随机波动，都算进形成方法的效果。

### 本 PR 具体改哪

新增 `scripts/bench/formation_effect_replay/`：版本化 schema、校验器、指标、合成 fixture、稳定报告快照、README 和契约测试。

每个 task 与 seed 必须五种方法、两种预算都齐。每个任务用同一组 seed。主对照锁成 task_grounded 减 atom。两种预算都算。通过标准写在录制前的 decision_policy 里。重采样算置信区间时，总工作量有确定性上限，避免样本变大之后计算膨胀。

不修改生产 Formation、Skill 生成、激活或晋升。不调用外部运行时。

### 不要和什么搞混

不要和 #375 搞混。#375 回答拆分和路由录下来之后能不能复算。本 PR 假定下游观测已经在，只比较形成方法。

不要和 #377 搞混。#377 回答形成技能时能不能看见标准答案。本 PR 不生产那种隔离契约，它消费已经配对好的观测分数。

不要和 #379 搞混。#379 问图有没有收对。本 PR 问：用收好的任务去形成 Skill，会不会比只看 Session 或只看 Atom 更有效。

不要和 #394 搞混。#394 把生产里 Task Graph 的开关改成默认开。本 PR 不改那个开关，也不改现网。

不要把合成 baseline 上的数字读成方法已经赢了。那份 fixture 是为了让评测器把配对、两种预算、三类任务和通过规则都走通。PASS 只证明计算器会算，不证明 Task-Grounded Formation 已经取得真实经验收益。

### 怎么算这段背景对齐了

能说出这是 Q1 本题，#375、#377、#379 是底座。能说出五组对照：不加载技能、按 Session 学、按 Atom 学、按任务图学、按人工任务学，主对照是按任务图的那组减去按 Atom 的那组。能说出两种预算：一种保留各方法自己写出的长度，一种把 Token 预算对齐。能说出三类测试任务：没见过的、已经会的、不该触发的。能说出输入是已经录好的配对观测分数，不是现场再跑 agent。能说出合成 fixture 的 PASS 不能当成方法已经赢。
