### PR TITLE
test(interaction): add pre-registered library admission policy

### DIFF
--- a/scripts/bench/README.md
+++ b/scripts/bench/README.md
@@ -16,6 +16,7 @@ scripts/bench/
 ├── baseline_window.md        基线报告(合成/真实两套并排)
 ├── baseline_window.json      基线机器可读结果(run_baseline.py 产出)
 ├── algorithm_replay/         拆分 + 路由的版本化离线质量回放（普通 CI）
+├── skill_library_replay/     Skill 正文 × 激活描述 × 库规模的配对 2×2 回放
 ├── synthetic/
 │   ├── gen_cases_v2.py       合成集生成器(纯数据,无 LLM/无网络)
 │   ├── ground_truth.json     合成集真值 {case: {scenario,total_lines,boundaries,...}}

--- a/scripts/bench/skill_library_replay/README.md
+++ b/scripts/bench/skill_library_replay/README.md
@@ -12,6 +12,12 @@ python -m scripts.bench.skill_library_replay.evaluate scripts/bench/skill_librar
 
 使用 `--format json` 可以输出机器可读报告。
 
+使用独立的预注册策略可以生成不修改生产状态的准入建议：
+
+```bash
+python -m scripts.bench.skill_library_replay.evaluate scripts/bench/skill_library_replay/fixtures/baseline_v1.json --policy scripts/bench/skill_library_replay/fixtures/admission_policy_v1.json
+```
+
 测试会将报告与入仓的 `baseline_v1.report.json` 快照比较，因此 schema 或指标口径变化会成为可 review 的显式 diff。
 
 ## 为什么需要 2×2
@@ -43,6 +49,8 @@ python -m scripts.bench.skill_library_replay.evaluate scripts/bench/skill_librar
 
 每个 case 用 `task_fingerprint` 和 `seed` 固定配对单位，并且必须覆盖完整的 library ladder 和四个部署单元。
 
+同一 Task 的 `should_activate` 必须跨 seed 保持一致，所有 Task 必须使用相同 seed 集，避免某个 Task 因重复运行更多次而获得更大权重。
+
 每条 observation 记录唯一 `run_id`、`score`、目标 Skill 是否激活、按调用顺序排列的 `activated_skills`、Token、费用、延迟和可选错误类型。
 
 隔离运行只能强制激活目标 Skill，部署运行只能激活目标 Skill 与该级 library ladder 中列出的干扰 Skill。
@@ -69,11 +77,25 @@ python -m scripts.bench.skill_library_replay.evaluate scripts/bench/skill_librar
 
 资源指标报告激活 Skill 数、catalog Token、已加载正文 Token、输入输出 Token、费用和延迟的 `new/new - old/old` 配对变化。
 
-所有至少包含两个配对样本的效应使用固定随机种子的配对 percentile bootstrap 置信区间，并同时报告 wins、ties 和 losses。
+所有至少包含两个 Task 的效应先在每个 Task 内平均 seed，再使用固定随机种子的 Task-clustered percentile bootstrap 置信区间，并按 Task 报告 wins、ties 和 losses。
 
-单样本子集的 `confidence_interval` 为 `null`，避免把没有统计信息的点估计伪装成零宽区间。
+只包含一个 Task 的子集将 `confidence_interval` 设为 `null`，避免把多个 seed 或没有跨 Task 信息的点估计伪装成有效区间。
 
 评测器限制 `cases × bootstrap_samples` 不超过 5,000,000，且预先索引每个 case 的 library level，因此除 bootstrap 外的聚合复杂度为 `O(cases × library_levels)`。
+
+## 预注册准入策略
+
+准入策略使用独立 JSON 文件并绑定 suite、目标 Skill、任务集、评分协议、old/new 正文与描述指纹、主 library level 和该级目录指纹，策略的 `registered_at` 必须早于录制结果的 `generated_at`。
+
+策略在运行前固定一个 candidate cell，不能在同一 held-out 结果上从三个候选 cell 中挑最高分再把该分数当成无偏效果；如果诊断显示另一个 cell 更好，应把它作为新候选并使用新的确认集重新评估。
+
+当前策略同时约束最小 Task 数、主 score 增益的置信区间下界、候选正例 recall 的相对下降、负例 false-positive-rate 的相对上升、loaded Skill Token、费用、延迟和不可评测错误。
+
+绝对激活安全门按 Task 计算保守事件：正例 Task 的全部 seed 都触发才算成功，负例 Task 的任一 seed 误触发就算失败，并使用 Wilson 区间避免全成功或全失败的小样本产生退化置信区间。
+
+样本不足、子集置信区间不可计算或出现预声明的基础设施错误时结果为 `inconclusive`，证据完整但任一效果或伤害门禁失败时为 `reject`，全部门禁通过时才为 `admit`。
+
+策略文件中的时间和指纹只能让修改形成显式 diff，正式预注册仍需要在录制结果产生前单独提交或归档策略文件。
 
 ## 因果边界
 
@@ -86,6 +108,8 @@ Agno trigger probe 的结果可以用于预筛选，但不能冒充 Claude Code�
 当前 PR 只建立评测和数据契约，不修改 description optimizer、canary 晋升规则或生产流量路由。
 
 在代表性真实录制结果经过维护者 review 前，不应把任何效应阈值设为阻塞晋升条件。
+
+本后续策略输出也只用于 shadow decision，不能直接替代生产 Canary 或 Q3 的 cohort-scoped 发布决策。
 
 ## 隐私约束
 

--- a/scripts/bench/skill_library_replay/README.md
+++ b/scripts/bench/skill_library_replay/README.md
@@ -81,7 +81,7 @@ python -m scripts.bench.skill_library_replay.evaluate scripts/bench/skill_librar
 
 只包含一个 Task 的子集将 `confidence_interval` 设为 `null`，避免把多个 seed 或没有跨 Task 信息的点估计伪装成有效区间。
 
-评测器限制 `cases × bootstrap_samples` 不超过 5,000,000，且预先索引每个 case 的 library level，因此除 bootstrap 外的聚合复杂度为 `O(cases × library_levels)`。
+评测器按 `cases × bootstrap_samples × 实际统计量数量` 限制总 bootstrap 工作量不超过 5,000,000，统计量数量随 library ladder 级数增长；使用准入策略时还会计入准入效果和资源门禁。评测器同时预先索引每个 case 的 library level，因此除 bootstrap 外的聚合复杂度为 `O(cases × library_levels)`。
 
 ## 预注册准入策略
 

--- a/scripts/bench/skill_library_replay/README.md
+++ b/scripts/bench/skill_library_replay/README.md
@@ -1,0 +1,94 @@
+# Skill 库感知 2×2 离线回放
+
+这套评测器接收目标 Harness 预先录制的不可变运行结果，并在普通 CI 中离线计算 Skill 正文、激活描述和库内竞争的配对效应。
+
+评测器不会调用 LLM、Embedding、coding-agent CLI 或 xskill 生产状态，因此入仓 fixture 的测试结果是确定的。
+
+运行合成契约基线：
+
+```bash
+python -m scripts.bench.skill_library_replay.evaluate scripts/bench/skill_library_replay/fixtures/baseline_v1.json
+```
+
+使用 `--format json` 可以输出机器可读报告。
+
+测试会将报告与入仓的 `baseline_v1.report.json` 快照比较，因此 schema 或指标口径变化会成为可 review 的显式 diff。
+
+## 为什么需要 2×2
+
+只比较 main 与 staging 会把正文变化和 description 变化绑成一个整体，无法判断收益来自执行知识还是激活边界。
+
+每个 `task_fingerprint × seed × distractor_count` 必须完整录制以下四个库内部署单元：
+
+- `old_body__old_description`
+- `old_body__new_description`
+- `new_body__old_description`
+- `new_body__new_description`
+
+报告以 `old_body__old_description` 为部署基线，分别计算两个正文效应、两个 description 效应、整体部署效应和二阶交互项。
+
+同一 case 还必须录制 `old_body` 与 `new_body` 的隔离强制激活结果，从而把正文自身收益与自然激活后的库内收益分开。
+
+## Fixture 契约
+
+`schema_version` 当前只支持 `1`，未知版本会直接失败。
+
+`run_manifest` 固定仓库 revision、模型、Harness、生成参数、任务集、评测协议以及 old/new body 和 description 的 SHA-256 指纹。
+
+`library_ladder` 必须从零干扰项开始，并声明逐级增长的语义相似干扰 Skill，后一级必须保留前一级的名称和顺序，避免把工具顺序变化混进库规模效应。
+
+每一级的 `distractor_catalog_fingerprint` 固定该级干扰 Skill 的名称、顺序、正文和 description，目标 Skill 的四个版本则由 `run_manifest` 单独固定。
+
+`cases` 至少包含一条应触发目标 Skill 的正例和一条不应触发的负例。
+
+每个 case 用 `task_fingerprint` 和 `seed` 固定配对单位，并且必须覆盖完整的 library ladder 和四个部署单元。
+
+每条 observation 记录唯一 `run_id`、`score`、目标 Skill 是否激活、按调用顺序排列的 `activated_skills`、Token、费用、延迟和可选错误类型。
+
+隔离运行只能强制激活目标 Skill，部署运行只能激活目标 Skill 与该级 library ladder 中列出的干扰 Skill。
+
+`score` 支持 `[0, 1]` 连续值，因此既可以承载 pass/fail，也可以承载 OfficeQA 等 benchmark 的部分得分。
+
+`catalog_tokens` 表示运行时可见的 Skill 激活目录开销，`loaded_skill_tokens` 表示实际加载的 Skill 正文开销，二者不要混为输入总 Token。
+
+## 指标定义
+
+隔离正文效应 `Δ_iso` 是每个配对 case 的 `isolated(new_body) - isolated(old_body)` 的均值，并额外按正例与负例分别报告，避免正文收益与非适用任务上的副作用相互抵消。
+
+整体库内部署效应 `Δ_lib` 是 `new_body__new_description - old_body__old_description` 的配对均值。
+
+干扰量 `I = Δ_iso - Δ_lib`，正值表示正文在隔离环境中的收益有一部分在库内竞争中丢失，负值表示新的激活边界让部署收益超过正文自身收益。
+
+正文效应和 description 效应分别在对方的 old/new 水平计算，避免只报告一个依赖选定基线的主效应。
+
+交互项计算为 `new/new - new/old - old/new + old/old`，用于发现“正文和 description 单独无效但联合有效”等非加性行为。
+
+激活指标同时报告总体激活率变化、正例 recall 变化、负例 false-positive-rate 变化以及每个 cell 的实际 Skill 激活计数，因此正负变化或不同 Skill 的挤占不会被总体触发率掩盖。
+
+每个 cell 还按 `error_type` 聚合失败原因，便于区分未触发、错误 Skill 激活、任务执行错误和基础设施失败。
+
+资源指标报告激活 Skill 数、catalog Token、已加载正文 Token、输入输出 Token、费用和延迟的 `new/new - old/old` 配对变化。
+
+所有至少包含两个配对样本的效应使用固定随机种子的配对 percentile bootstrap 置信区间，并同时报告 wins、ties 和 losses。
+
+单样本子集的 `confidence_interval` 为 `null`，避免把没有统计信息的点估计伪装成零宽区间。
+
+评测器限制 `cases × bootstrap_samples` 不超过 5,000,000，且预先索引每个 case 的 library level，因此除 bootstrap 外的聚合复杂度为 `O(cases × library_levels)`。
+
+## 因果边界
+
+这个评测器保证数据完整性、配对口径和指标计算，但不能证明上游录制过程真的执行了声明的 Harness、Skill 版本或随机种子。
+
+真实实验必须由目标原生运行时生成每条 observation，并在运行前固定任务、seed、模型、采样参数、Skill 顺序和评分器。
+
+Agno trigger probe 的结果可以用于预筛选，但不能冒充 Claude Code、Codex 或 DeepSeek Harness 的原生库内反事实结果。
+
+当前 PR 只建立评测和数据契约，不修改 description optimizer、canary 晋升规则或生产流量路由。
+
+在代表性真实录制结果经过维护者 review 前，不应把任何效应阈值设为阻塞晋升条件。
+
+## 隐私约束
+
+入仓 fixture 只使用合成 ID、指纹和数值结果，不保存真实任务文本、模型输出、轨迹原文、workspace 路径或用户标识。
+
+真实任务内容和原生 Harness 轨迹应保留在受控实验环境，公共回放只导出通过隐私检查的聚合字段。

--- a/scripts/bench/skill_library_replay/__init__.py
+++ b/scripts/bench/skill_library_replay/__init__.py
@@ -1,0 +1,1 @@
+"""Deterministic replay metrics for library-aware Skill evaluation."""

--- a/scripts/bench/skill_library_replay/evaluate.py
+++ b/scripts/bench/skill_library_replay/evaluate.py
@@ -13,10 +13,13 @@ import math
 import random
 from collections import Counter
 from collections.abc import Iterable
+from datetime import datetime
 from pathlib import Path
+from statistics import NormalDist
 from typing import Any
 
 SCHEMA_VERSION = 1
+ADMISSION_POLICY_SCHEMA_VERSION = 1
 BODY_VERSIONS = ("old_body", "new_body")
 CELL_KEYS = (
     "old_body__old_description",
@@ -34,6 +37,8 @@ RESOURCE_FIELDS = (
     "latency_ms",
 )
 _SHA256_RE = "sha256:"
+_BASELINE_CELL = "old_body__old_description"
+_CANDIDATE_CELLS = tuple(cell for cell in CELL_KEYS if cell != _BASELINE_CELL)
 
 
 class LibraryReplayValidationError(ValueError):
@@ -86,6 +91,24 @@ def _validate_fingerprint(value: Any, context: str) -> None:
         raise LibraryReplayValidationError(
             f"{context}: expected sha256:<64 lowercase hex>"
         )
+
+
+def _parse_aware_datetime(value: Any, context: str) -> datetime:
+    if not isinstance(value, str) or not value:
+        raise LibraryReplayValidationError(
+            f"{context}: expected a non-empty ISO-8601 timestamp"
+        )
+    try:
+        parsed = datetime.fromisoformat(value.replace("Z", "+00:00"))
+    except ValueError as error:
+        raise LibraryReplayValidationError(
+            f"{context}: expected an ISO-8601 timestamp"
+        ) from error
+    if parsed.tzinfo is None or parsed.utcoffset() is None:
+        raise LibraryReplayValidationError(
+            f"{context}: timestamp must include a UTC offset"
+        )
+    return parsed
 
 
 def _validate_observation(
@@ -281,6 +304,8 @@ def validate_suite(suite: Any) -> None:
         raise LibraryReplayValidationError("suite.cases must not be empty")
     case_ids: set[str] = set()
     task_seed_pairs: set[tuple[str, int]] = set()
+    task_seeds: dict[str, set[int]] = {}
+    task_activation_labels: dict[str, bool] = {}
     run_ids: set[str] = set()
     activation_labels: set[bool] = set()
     for case_index, case in enumerate(cases):
@@ -306,6 +331,14 @@ def validate_suite(suite: Any) -> None:
         task_seed_pairs.add(pair)
         should_activate = _require(case, "should_activate", bool, context)
         activation_labels.add(should_activate)
+        task_seeds.setdefault(task_fingerprint, set()).add(seed)
+        previous_label = task_activation_labels.setdefault(
+            task_fingerprint, should_activate
+        )
+        if previous_label != should_activate:
+            raise LibraryReplayValidationError(
+                f"{context}.should_activate: must be stable across seeds for one task"
+            )
 
         isolated_runs = _require(case, "isolated", dict, context)
         if set(isolated_runs) != set(BODY_VERSIONS):
@@ -360,6 +393,11 @@ def validate_suite(suite: Any) -> None:
         raise LibraryReplayValidationError(
             "suite.cases must include both positive and negative activation cases"
         )
+    expected_seed_set = next(iter(task_seeds.values()))
+    if any(seeds != expected_seed_set for seeds in task_seeds.values()):
+        raise LibraryReplayValidationError(
+            "suite.cases: every task_fingerprint must use the same seed set"
+        )
     if len(cases) * bootstrap_samples > 5_000_000:
         raise LibraryReplayValidationError(
             "suite: cases * bootstrap_samples exceeds the 5000000 work bound"
@@ -377,6 +415,163 @@ def load_suite(path: Path | str) -> dict[str, Any]:
         ) from error
     validate_suite(suite)
     return suite
+
+
+def validate_admission_policy(policy: Any, suite: dict[str, Any]) -> None:
+    """Validate a pre-registered admission policy against one replay suite."""
+    validate_suite(suite)
+    if not isinstance(policy, dict):
+        raise LibraryReplayValidationError("policy: expected an object")
+    expected_keys = {
+        "schema_version",
+        "policy_id",
+        "suite_id",
+        "target_skill",
+        "registered_at",
+        "task_set_fingerprint",
+        "evaluation_protocol_fingerprint",
+        "old_body_fingerprint",
+        "new_body_fingerprint",
+        "old_description_fingerprint",
+        "new_description_fingerprint",
+        "primary_distractor_count",
+        "primary_distractor_catalog_fingerprint",
+        "candidate_cell",
+        "minimum_paired_tasks",
+        "minimum_positive_tasks",
+        "minimum_negative_tasks",
+        "minimum_score_gain",
+        "minimum_candidate_positive_task_activation_rate",
+        "maximum_positive_recall_drop",
+        "maximum_candidate_negative_task_activation_rate",
+        "maximum_negative_false_positive_rate_increase",
+        "resource_increase_limits",
+        "non_evaluable_error_types",
+    }
+    if set(policy) != expected_keys:
+        missing = sorted(expected_keys - set(policy))
+        unknown = sorted(set(policy) - expected_keys)
+        raise LibraryReplayValidationError(
+            f"policy: keys do not match schema; missing={missing}, unknown={unknown}"
+        )
+    version = _require(policy, "schema_version", int, "policy")
+    if version != ADMISSION_POLICY_SCHEMA_VERSION:
+        raise LibraryReplayValidationError(
+            "policy.schema_version: "
+            f"supported={ADMISSION_POLICY_SCHEMA_VERSION}, got={version}"
+        )
+    _require_non_empty_string(policy, "policy_id", "policy")
+    for key in ("suite_id", "target_skill"):
+        value = _require_non_empty_string(policy, key, "policy")
+        if value != suite[key]:
+            raise LibraryReplayValidationError(
+                f"policy.{key}: does not match suite.{key}"
+            )
+    manifest = suite["run_manifest"]
+    for key in (
+        "task_set_fingerprint",
+        "evaluation_protocol_fingerprint",
+        "old_body_fingerprint",
+        "new_body_fingerprint",
+        "old_description_fingerprint",
+        "new_description_fingerprint",
+    ):
+        value = policy.get(key)
+        _validate_fingerprint(value, f"policy.{key}")
+        if value != manifest[key]:
+            raise LibraryReplayValidationError(
+                f"policy.{key}: does not match suite.run_manifest.{key}"
+            )
+    registered_at = _parse_aware_datetime(
+        policy.get("registered_at"), "policy.registered_at"
+    )
+    generated_at = _parse_aware_datetime(
+        manifest["generated_at"], "suite.run_manifest.generated_at"
+    )
+    if registered_at >= generated_at:
+        raise LibraryReplayValidationError(
+            "policy.registered_at: must be earlier than suite.run_manifest.generated_at"
+        )
+
+    primary_count = _require(policy, "primary_distractor_count", int, "policy")
+    primary_level = next(
+        (
+            level
+            for level in suite["library_ladder"]
+            if level["distractor_count"] == primary_count
+        ),
+        None,
+    )
+    if primary_level is None:
+        raise LibraryReplayValidationError(
+            "policy.primary_distractor_count: not present in suite.library_ladder"
+        )
+    catalog_fingerprint = policy.get("primary_distractor_catalog_fingerprint")
+    _validate_fingerprint(
+        catalog_fingerprint, "policy.primary_distractor_catalog_fingerprint"
+    )
+    if catalog_fingerprint != primary_level["distractor_catalog_fingerprint"]:
+        raise LibraryReplayValidationError(
+            "policy.primary_distractor_catalog_fingerprint: "
+            "does not match the selected library level"
+        )
+
+    candidate_cell = _require_non_empty_string(policy, "candidate_cell", "policy")
+    if candidate_cell not in _CANDIDATE_CELLS:
+        raise LibraryReplayValidationError(
+            f"policy.candidate_cell: expected one of {list(_CANDIDATE_CELLS)}"
+        )
+    for key in (
+        "minimum_paired_tasks",
+        "minimum_positive_tasks",
+        "minimum_negative_tasks",
+    ):
+        value = _require(policy, key, int, "policy")
+        if value < 2:
+            raise LibraryReplayValidationError(f"policy.{key}: must be >= 2")
+    for key in (
+        "minimum_score_gain",
+        "minimum_candidate_positive_task_activation_rate",
+        "maximum_positive_recall_drop",
+        "maximum_candidate_negative_task_activation_rate",
+        "maximum_negative_false_positive_rate_increase",
+    ):
+        value = _require_number(policy, key, "policy")
+        if value > 1:
+            raise LibraryReplayValidationError(f"policy.{key}: must be within [0, 1]")
+
+    resource_limits = _require(policy, "resource_increase_limits", dict, "policy")
+    required_resource_limits = {"loaded_skill_tokens", "cost_usd", "latency_ms"}
+    if set(resource_limits) != required_resource_limits:
+        raise LibraryReplayValidationError(
+            "policy.resource_increase_limits: expected exactly "
+            f"{sorted(required_resource_limits)}"
+        )
+    for field in sorted(required_resource_limits):
+        _require_number(resource_limits, field, "policy.resource_increase_limits")
+
+    error_types = _require(policy, "non_evaluable_error_types", list, "policy")
+    if (
+        not error_types
+        or any(not isinstance(value, str) or not value for value in error_types)
+        or len(error_types) != len(set(error_types))
+    ):
+        raise LibraryReplayValidationError(
+            "policy.non_evaluable_error_types: expected unique non-empty strings"
+        )
+
+
+def load_admission_policy(path: Path | str, suite: dict[str, Any]) -> dict[str, Any]:
+    """Load and validate a pre-registered admission policy."""
+    policy_path = Path(path)
+    try:
+        policy = json.loads(policy_path.read_text(encoding="utf-8"))
+    except json.JSONDecodeError as error:
+        raise LibraryReplayValidationError(
+            f"invalid JSON in {policy_path}: {error}"
+        ) from error
+    validate_admission_policy(policy, suite)
+    return policy
 
 
 def _round(value: float) -> float:
@@ -406,18 +601,30 @@ def _stable_seed(base_seed: int, label: str) -> int:
 
 
 def _paired_effect(
-    deltas: list[float], metric_config: dict[str, Any], label: str
+    deltas: list[float],
+    metric_config: dict[str, Any],
+    label: str,
+    *,
+    task_fingerprints: list[str],
 ) -> dict[str, Any]:
-    point = _mean(deltas)
+    if len(task_fingerprints) != len(deltas):
+        raise ValueError("task_fingerprints and deltas must have the same length")
+    by_task: dict[str, list[float]] = {}
+    for task_fingerprint, delta in zip(task_fingerprints, deltas):
+        by_task.setdefault(task_fingerprint, []).append(delta)
+    task_deltas = [
+        _mean(by_task[task_fingerprint]) for task_fingerprint in sorted(by_task)
+    ]
+    point = _mean(task_deltas)
     confidence_interval: list[float] | None
-    if len(deltas) == 1:
+    if len(task_deltas) == 1:
         confidence_interval = None
     else:
         rng = random.Random(_stable_seed(metric_config["bootstrap_seed"], label))
         sample_count = metric_config["bootstrap_samples"]
-        size = len(deltas)
+        size = len(task_deltas)
         bootstrap_means = [
-            sum(deltas[rng.randrange(size)] for _ in range(size)) / size
+            sum(task_deltas[rng.randrange(size)] for _ in range(size)) / size
             for _ in range(sample_count)
         ]
         bootstrap_means.sort()
@@ -427,11 +634,52 @@ def _paired_effect(
         confidence_interval = [_round(low), _round(high)]
     return {
         "n": len(deltas),
+        "tasks": len(task_deltas),
         "mean": _round(point),
         "confidence_interval": confidence_interval,
-        "wins": sum(delta > 0 for delta in deltas),
-        "ties": sum(delta == 0 for delta in deltas),
-        "losses": sum(delta < 0 for delta in deltas),
+        "wins": sum(delta > 0 for delta in task_deltas),
+        "ties": sum(delta == 0 for delta in task_deltas),
+        "losses": sum(delta < 0 for delta in task_deltas),
+    }
+
+
+def _task_binary_rate(
+    cases: list[dict[str, Any]],
+    metric_config: dict[str, Any],
+    value,
+    *,
+    require_all_seeds: bool,
+) -> dict[str, Any]:
+    """Estimate a conservative Task-level binary rate with a Wilson interval."""
+    by_task: dict[str, list[bool]] = {}
+    for case in cases:
+        by_task.setdefault(case["task_fingerprint"], []).append(bool(value(case)))
+    task_outcomes = [
+        all(by_task[task]) if require_all_seeds else any(by_task[task])
+        for task in sorted(by_task)
+    ]
+    task_count = len(task_outcomes)
+    rate = _mean(float(outcome) for outcome in task_outcomes)
+    confidence_level = metric_config["confidence_level"]
+    z_score = NormalDist().inv_cdf(0.5 + confidence_level / 2)
+    z_squared = z_score * z_score
+    denominator = 1 + z_squared / task_count
+    center = (rate + z_squared / (2 * task_count)) / denominator
+    margin = (
+        z_score
+        * math.sqrt(
+            rate * (1 - rate) / task_count + z_squared / (4 * task_count * task_count)
+        )
+        / denominator
+    )
+    successes = sum(task_outcomes)
+    return {
+        "n": len(cases),
+        "tasks": task_count,
+        "mean": _round(rate),
+        "confidence_interval": [_round(center - margin), _round(center + margin)],
+        "successes": successes,
+        "failures": task_count - successes,
     }
 
 
@@ -500,6 +748,7 @@ def _effect(
         [float(left(case)) - float(right(case)) for case in cases],
         metric_config,
         label,
+        task_fingerprints=[case["task_fingerprint"] for case in cases],
     )
 
 
@@ -611,6 +860,7 @@ def evaluate_suite(suite: dict[str, Any]) -> dict[str, Any]:
             interaction_deltas,
             metric_config,
             f"{distractor_count}:interaction",
+            task_fingerprints=[case["task_fingerprint"] for case in cases],
         )
         interference_deltas = [
             case["isolated"]["new_body"]["score"]
@@ -676,6 +926,7 @@ def evaluate_suite(suite: dict[str, Any]) -> dict[str, Any]:
                     interference_deltas,
                     metric_config,
                     f"{distractor_count}:interference",
+                    task_fingerprints=[case["task_fingerprint"] for case in cases],
                 ),
                 "activation_effects": activation_effects,
                 "resource_effects": resource_effects,
@@ -701,6 +952,228 @@ def evaluate_suite(suite: dict[str, Any]) -> dict[str, Any]:
     }
 
 
+def evaluate_admission(suite: dict[str, Any], policy: dict[str, Any]) -> dict[str, Any]:
+    """Apply a pre-registered, fixed-cohort admission policy to one candidate."""
+    validate_admission_policy(policy, suite)
+    cases = suite["cases"]
+    metric_config = suite["metric_config"]
+    primary_count = policy["primary_distractor_count"]
+    candidate_cell = policy["candidate_cell"]
+
+    levels_by_case = {
+        case["case_id"]: {
+            level["distractor_count"]: level for level in case["libraries"]
+        }
+        for case in cases
+    }
+
+    def deployed(item: dict[str, Any], cell: str) -> dict[str, Any]:
+        return levels_by_case[item["case_id"]][primary_count]["deployed"][cell]
+
+    score_effect = _effect(
+        cases,
+        metric_config,
+        f"admission:{policy['policy_id']}:score",
+        lambda case: deployed(case, candidate_cell)["score"],
+        lambda case: deployed(case, _BASELINE_CELL)["score"],
+    )
+    positive_cases = [case for case in cases if case["should_activate"]]
+    negative_cases = [case for case in cases if not case["should_activate"]]
+    positive_recall_effect = _effect(
+        positive_cases,
+        metric_config,
+        f"admission:{policy['policy_id']}:positive_recall",
+        lambda case: deployed(case, candidate_cell)["target_activated"],
+        lambda case: deployed(case, _BASELINE_CELL)["target_activated"],
+    )
+    negative_fpr_effect = _effect(
+        negative_cases,
+        metric_config,
+        f"admission:{policy['policy_id']}:negative_fpr",
+        lambda case: deployed(case, candidate_cell)["target_activated"],
+        lambda case: deployed(case, _BASELINE_CELL)["target_activated"],
+    )
+    candidate_positive_task_activation_rate = _task_binary_rate(
+        positive_cases,
+        metric_config,
+        lambda case: deployed(case, candidate_cell)["target_activated"],
+        require_all_seeds=True,
+    )
+    candidate_negative_task_activation_rate = _task_binary_rate(
+        negative_cases,
+        metric_config,
+        lambda case: deployed(case, candidate_cell)["target_activated"],
+        require_all_seeds=False,
+    )
+    resource_effects = {
+        field: _effect(
+            cases,
+            metric_config,
+            f"admission:{policy['policy_id']}:{field}",
+            lambda case, key=field: _observation_value(
+                deployed(case, candidate_cell), key
+            ),
+            lambda case, key=field: _observation_value(
+                deployed(case, _BASELINE_CELL), key
+            ),
+        )
+        for field in policy["resource_increase_limits"]
+    }
+
+    gates: list[dict[str, Any]] = []
+
+    def add_minimum_count_gate(name: str, observed: int, threshold: int) -> None:
+        gates.append(
+            {
+                "name": name,
+                "status": "pass" if observed >= threshold else "inconclusive",
+                "observed": observed,
+                "comparison": ">=",
+                "threshold": threshold,
+            }
+        )
+
+    add_minimum_count_gate(
+        "minimum_paired_tasks",
+        len({case["task_fingerprint"] for case in cases}),
+        policy["minimum_paired_tasks"],
+    )
+    add_minimum_count_gate(
+        "minimum_positive_tasks",
+        len({case["task_fingerprint"] for case in positive_cases}),
+        policy["minimum_positive_tasks"],
+    )
+    add_minimum_count_gate(
+        "minimum_negative_tasks",
+        len({case["task_fingerprint"] for case in negative_cases}),
+        policy["minimum_negative_tasks"],
+    )
+
+    non_evaluable = set(policy["non_evaluable_error_types"])
+    error_counts = Counter(
+        observation["error_type"]
+        for case in cases
+        for observation in (
+            deployed(case, _BASELINE_CELL),
+            deployed(case, candidate_cell),
+        )
+        if observation.get("error_type") in non_evaluable
+    )
+    gates.append(
+        {
+            "name": "non_evaluable_errors",
+            "status": "pass" if not error_counts else "inconclusive",
+            "observed": dict(sorted(error_counts.items())),
+            "comparison": "==",
+            "threshold": {},
+        }
+    )
+
+    def add_lower_bound_gate(
+        name: str, effect: dict[str, Any], threshold: float
+    ) -> None:
+        interval = effect["confidence_interval"]
+        if interval is None:
+            status = "inconclusive"
+            observed = None
+        else:
+            observed = interval[0]
+            status = "pass" if observed >= threshold else "fail"
+        gates.append(
+            {
+                "name": name,
+                "status": status,
+                "observed": observed,
+                "comparison": ">=",
+                "threshold": _round(threshold),
+            }
+        )
+
+    def add_upper_bound_gate(
+        name: str, effect: dict[str, Any], threshold: float
+    ) -> None:
+        interval = effect["confidence_interval"]
+        if interval is None:
+            status = "inconclusive"
+            observed = None
+        else:
+            observed = interval[1]
+            status = "pass" if observed <= threshold else "fail"
+        gates.append(
+            {
+                "name": name,
+                "status": status,
+                "observed": observed,
+                "comparison": "<=",
+                "threshold": _round(threshold),
+            }
+        )
+
+    add_lower_bound_gate(
+        "minimum_score_gain",
+        score_effect,
+        policy["minimum_score_gain"],
+    )
+    add_lower_bound_gate(
+        "maximum_positive_recall_drop",
+        positive_recall_effect,
+        -policy["maximum_positive_recall_drop"],
+    )
+    add_lower_bound_gate(
+        "minimum_candidate_positive_task_activation_rate",
+        candidate_positive_task_activation_rate,
+        policy["minimum_candidate_positive_task_activation_rate"],
+    )
+    add_upper_bound_gate(
+        "maximum_negative_false_positive_rate_increase",
+        negative_fpr_effect,
+        policy["maximum_negative_false_positive_rate_increase"],
+    )
+    add_upper_bound_gate(
+        "maximum_candidate_negative_task_activation_rate",
+        candidate_negative_task_activation_rate,
+        policy["maximum_candidate_negative_task_activation_rate"],
+    )
+    for field, limit in sorted(policy["resource_increase_limits"].items()):
+        add_upper_bound_gate(
+            f"maximum_{field}_increase",
+            resource_effects[field],
+            limit,
+        )
+
+    statuses = {gate["status"] for gate in gates}
+    if "inconclusive" in statuses:
+        status = "inconclusive"
+    elif "fail" in statuses:
+        status = "reject"
+    else:
+        status = "admit"
+    return {
+        "schema_version": ADMISSION_POLICY_SCHEMA_VERSION,
+        "policy_id": policy["policy_id"],
+        "suite_id": suite["suite_id"],
+        "target_skill": suite["target_skill"],
+        "candidate_cell": candidate_cell,
+        "baseline_cell": _BASELINE_CELL,
+        "primary_distractor_count": primary_count,
+        "status": status,
+        "reasons": [gate["name"] for gate in gates if gate["status"] != "pass"],
+        "gates": gates,
+        "effects": {
+            "score": score_effect,
+            "positive_recall": positive_recall_effect,
+            "negative_false_positive_rate": negative_fpr_effect,
+            "candidate_positive_task_activation_rate": (
+                candidate_positive_task_activation_rate
+            ),
+            "candidate_negative_task_activation_rate": (
+                candidate_negative_task_activation_rate
+            ),
+            "resources": resource_effects,
+        },
+    }
+
+
 def render_text(report: dict[str, Any]) -> str:
     """Render a compact human-readable summary."""
     isolated = report["isolated"]["body_effect"]
@@ -713,7 +1186,8 @@ def render_text(report: dict[str, Any]) -> str:
         ),
         (
             "isolated_body_effect: "
-            f"{isolated['mean']} CI={isolated['confidence_interval']} n={isolated['n']}"
+            f"{isolated['mean']} CI={isolated['confidence_interval']} "
+            f"n={isolated['n']} tasks={isolated['tasks']}"
         ),
     ]
     for level in report["library_curve"]:
@@ -752,6 +1226,17 @@ def render_text(report: dict[str, Any]) -> str:
                 ),
             ]
         )
+    admission = report.get("admission")
+    if admission is not None:
+        lines.extend(
+            [
+                "admission:",
+                f"  policy_id: {admission['policy_id']}",
+                f"  candidate_cell: {admission['candidate_cell']}",
+                f"  status: {admission['status']}",
+                f"  reasons: {','.join(admission['reasons']) or 'none'}",
+            ]
+        )
     return "\n".join(lines)
 
 
@@ -760,9 +1245,18 @@ def main(argv: list[str] | None = None) -> int:
         description="Evaluate a recorded library-aware Skill 2x2 replay."
     )
     parser.add_argument("suite", type=Path)
+    parser.add_argument(
+        "--policy",
+        type=Path,
+        help="pre-registered admission policy to evaluate with the suite",
+    )
     parser.add_argument("--format", choices=("text", "json"), default="text")
     args = parser.parse_args(argv)
-    report = evaluate_suite(load_suite(args.suite))
+    suite = load_suite(args.suite)
+    report = evaluate_suite(suite)
+    if args.policy is not None:
+        policy = load_admission_policy(args.policy, suite)
+        report["admission"] = evaluate_admission(suite, policy)
     if args.format == "json":
         print(json.dumps(report, ensure_ascii=False, indent=2, sort_keys=True))
     else:

--- a/scripts/bench/skill_library_replay/evaluate.py
+++ b/scripts/bench/skill_library_replay/evaluate.py
@@ -1,0 +1,774 @@
+"""Evaluate matched Skill body/description experiments without model calls.
+
+The evaluator consumes recorded native-runtime outcomes.
+It never invokes a model, harness, workspace command, or production xskill state.
+"""
+
+from __future__ import annotations
+
+import argparse
+import hashlib
+import json
+import math
+import random
+from collections import Counter
+from collections.abc import Iterable
+from pathlib import Path
+from typing import Any
+
+SCHEMA_VERSION = 1
+BODY_VERSIONS = ("old_body", "new_body")
+CELL_KEYS = (
+    "old_body__old_description",
+    "old_body__new_description",
+    "new_body__old_description",
+    "new_body__new_description",
+)
+RESOURCE_FIELDS = (
+    "activated_skill_count",
+    "catalog_tokens",
+    "loaded_skill_tokens",
+    "input_tokens",
+    "output_tokens",
+    "cost_usd",
+    "latency_ms",
+)
+_SHA256_RE = "sha256:"
+
+
+class LibraryReplayValidationError(ValueError):
+    """Raised when a library-aware replay violates its data contract."""
+
+
+def _require(mapping: dict[str, Any], key: str, expected: type, context: str) -> Any:
+    if key not in mapping:
+        raise LibraryReplayValidationError(f"{context}: missing required field {key!r}")
+    value = mapping[key]
+    if expected is int and isinstance(value, bool):
+        raise LibraryReplayValidationError(f"{context}.{key}: expected int, got bool")
+    if not isinstance(value, expected):
+        raise LibraryReplayValidationError(
+            f"{context}.{key}: expected {expected.__name__}, got {type(value).__name__}"
+        )
+    return value
+
+
+def _require_non_empty_string(mapping: dict[str, Any], key: str, context: str) -> str:
+    value = _require(mapping, key, str, context)
+    if not value:
+        raise LibraryReplayValidationError(f"{context}.{key}: must not be empty")
+    return value
+
+
+def _require_number(
+    mapping: dict[str, Any], key: str, context: str, *, minimum: float = 0.0
+) -> float:
+    if key not in mapping:
+        raise LibraryReplayValidationError(f"{context}: missing required field {key!r}")
+    value = mapping[key]
+    if isinstance(value, bool) or not isinstance(value, (int, float)):
+        raise LibraryReplayValidationError(f"{context}.{key}: expected a number")
+    number = float(value)
+    if not math.isfinite(number) or number < minimum:
+        raise LibraryReplayValidationError(
+            f"{context}.{key}: expected a finite number >= {minimum:g}"
+        )
+    return number
+
+
+def _validate_fingerprint(value: Any, context: str) -> None:
+    if (
+        not isinstance(value, str)
+        or not value.startswith(_SHA256_RE)
+        or len(value) != len(_SHA256_RE) + 64
+        or any(char not in "0123456789abcdef" for char in value[len(_SHA256_RE) :])
+    ):
+        raise LibraryReplayValidationError(
+            f"{context}: expected sha256:<64 lowercase hex>"
+        )
+
+
+def _validate_observation(
+    observation: Any,
+    *,
+    context: str,
+    target_skill: str,
+    run_ids: set[str],
+    isolated: bool,
+    allowed_skills: set[str],
+) -> None:
+    if not isinstance(observation, dict):
+        raise LibraryReplayValidationError(f"{context}: expected an object")
+    run_id = _require_non_empty_string(observation, "run_id", context)
+    if run_id in run_ids:
+        raise LibraryReplayValidationError(f"{context}.run_id: duplicate {run_id!r}")
+    run_ids.add(run_id)
+    score = _require_number(observation, "score", context)
+    if score > 1:
+        raise LibraryReplayValidationError(f"{context}.score: expected 0 <= score <= 1")
+    target_activated = _require(observation, "target_activated", bool, context)
+    activated_skills = _require(observation, "activated_skills", list, context)
+    if any(not isinstance(skill, str) or not skill for skill in activated_skills):
+        raise LibraryReplayValidationError(
+            f"{context}.activated_skills: expected non-empty strings"
+        )
+    if len(activated_skills) != len(set(activated_skills)):
+        raise LibraryReplayValidationError(
+            f"{context}.activated_skills: duplicate skill names are not allowed"
+        )
+    unknown_skills = set(activated_skills) - allowed_skills
+    if unknown_skills:
+        raise LibraryReplayValidationError(
+            f"{context}.activated_skills: unknown skills {sorted(unknown_skills)}"
+        )
+    if target_activated != (target_skill in activated_skills):
+        raise LibraryReplayValidationError(
+            f"{context}: target_activated disagrees with activated_skills"
+        )
+    if isolated and activated_skills != [target_skill]:
+        raise LibraryReplayValidationError(
+            f"{context}.activated_skills: isolated runs must force only target_skill"
+        )
+    for key in (
+        "catalog_tokens",
+        "loaded_skill_tokens",
+        "input_tokens",
+        "output_tokens",
+    ):
+        value = _require(observation, key, int, context)
+        if value < 0:
+            raise LibraryReplayValidationError(f"{context}.{key}: must be >= 0")
+    _require_number(observation, "cost_usd", context)
+    _require_number(observation, "latency_ms", context)
+    error_type = observation.get("error_type")
+    if error_type is not None and (not isinstance(error_type, str) or not error_type):
+        raise LibraryReplayValidationError(
+            f"{context}.error_type: expected null or a non-empty string"
+        )
+
+
+def validate_suite(suite: Any) -> None:
+    """Validate the complete matched-replay contract before computing metrics."""
+    if not isinstance(suite, dict):
+        raise LibraryReplayValidationError("suite: expected an object")
+    version = _require(suite, "schema_version", int, "suite")
+    if version != SCHEMA_VERSION:
+        raise LibraryReplayValidationError(
+            f"suite.schema_version: supported={SCHEMA_VERSION}, got={version}"
+        )
+    _require_non_empty_string(suite, "suite_id", "suite")
+    target_skill = _require_non_empty_string(suite, "target_skill", "suite")
+
+    metric_config = _require(suite, "metric_config", dict, "suite")
+    bootstrap_samples = _require(
+        metric_config, "bootstrap_samples", int, "suite.metric_config"
+    )
+    if not 100 <= bootstrap_samples <= 50_000:
+        raise LibraryReplayValidationError(
+            "suite.metric_config.bootstrap_samples must be within [100, 50000]"
+        )
+    bootstrap_seed = _require(
+        metric_config, "bootstrap_seed", int, "suite.metric_config"
+    )
+    if bootstrap_seed < 0:
+        raise LibraryReplayValidationError(
+            "suite.metric_config.bootstrap_seed must be >= 0"
+        )
+    confidence_level = _require_number(
+        metric_config, "confidence_level", "suite.metric_config"
+    )
+    if not 0 < confidence_level < 1:
+        raise LibraryReplayValidationError(
+            "suite.metric_config.confidence_level must satisfy 0 < value < 1"
+        )
+
+    manifest = _require(suite, "run_manifest", dict, "suite")
+    for key in (
+        "repository_revision",
+        "model",
+        "harness",
+        "generated_at",
+    ):
+        _require_non_empty_string(manifest, key, "suite.run_manifest")
+    for key in (
+        "task_set_fingerprint",
+        "evaluation_protocol_fingerprint",
+        "old_body_fingerprint",
+        "new_body_fingerprint",
+        "old_description_fingerprint",
+        "new_description_fingerprint",
+    ):
+        _validate_fingerprint(manifest.get(key), f"suite.run_manifest.{key}")
+    if manifest["old_body_fingerprint"] == manifest["new_body_fingerprint"]:
+        raise LibraryReplayValidationError(
+            "suite.run_manifest: old and new body fingerprints must differ"
+        )
+    if (
+        manifest["old_description_fingerprint"]
+        == manifest["new_description_fingerprint"]
+    ):
+        raise LibraryReplayValidationError(
+            "suite.run_manifest: old and new description fingerprints must differ"
+        )
+    generation_config = _require(
+        manifest, "generation_config", dict, "suite.run_manifest"
+    )
+    _require_number(generation_config, "temperature", "generation_config")
+    top_p = _require_number(generation_config, "top_p", "generation_config")
+    if not 0 < top_p <= 1:
+        raise LibraryReplayValidationError(
+            "generation_config.top_p must satisfy 0 < value <= 1"
+        )
+    max_output_tokens = _require(
+        generation_config, "max_output_tokens", int, "generation_config"
+    )
+    if max_output_tokens <= 0:
+        raise LibraryReplayValidationError(
+            "generation_config.max_output_tokens must be > 0"
+        )
+
+    ladder = _require(suite, "library_ladder", list, "suite")
+    if not ladder:
+        raise LibraryReplayValidationError("suite.library_ladder must not be empty")
+    distractor_counts: list[int] = []
+    previous_skills: list[str] = []
+    for index, level in enumerate(ladder):
+        context = f"suite.library_ladder[{index}]"
+        if not isinstance(level, dict):
+            raise LibraryReplayValidationError(f"{context}: expected an object")
+        count = _require(level, "distractor_count", int, context)
+        if count < 0:
+            raise LibraryReplayValidationError(
+                f"{context}.distractor_count: must be >= 0"
+            )
+        skills = _require(level, "distractor_skills", list, context)
+        _validate_fingerprint(
+            level.get("distractor_catalog_fingerprint"),
+            f"{context}.distractor_catalog_fingerprint",
+        )
+        if len(skills) != count:
+            raise LibraryReplayValidationError(
+                f"{context}.distractor_skills: expected exactly {count} entries"
+            )
+        if any(not isinstance(skill, str) or not skill for skill in skills):
+            raise LibraryReplayValidationError(
+                f"{context}.distractor_skills: expected non-empty strings"
+            )
+        skill_set = set(skills)
+        if len(skill_set) != len(skills) or target_skill in skill_set:
+            raise LibraryReplayValidationError(
+                f"{context}.distractor_skills: duplicates and target_skill are forbidden"
+            )
+        if skills[: len(previous_skills)] != previous_skills:
+            raise LibraryReplayValidationError(
+                f"{context}.distractor_skills: library growth must retain prior order"
+            )
+        previous_skills = skills
+        distractor_counts.append(count)
+    if any(
+        left >= right for left, right in zip(distractor_counts, distractor_counts[1:])
+    ):
+        raise LibraryReplayValidationError(
+            "suite.library_ladder.distractor_count values must be strictly increasing"
+        )
+    if distractor_counts[0] != 0:
+        raise LibraryReplayValidationError(
+            "suite.library_ladder must start with distractor_count=0"
+        )
+
+    cases = _require(suite, "cases", list, "suite")
+    if not cases:
+        raise LibraryReplayValidationError("suite.cases must not be empty")
+    case_ids: set[str] = set()
+    task_seed_pairs: set[tuple[str, int]] = set()
+    run_ids: set[str] = set()
+    activation_labels: set[bool] = set()
+    for case_index, case in enumerate(cases):
+        context = f"suite.cases[{case_index}]"
+        if not isinstance(case, dict):
+            raise LibraryReplayValidationError(f"{context}: expected an object")
+        case_id = _require_non_empty_string(case, "case_id", context)
+        if case_id in case_ids:
+            raise LibraryReplayValidationError(
+                f"{context}.case_id: duplicate {case_id!r}"
+            )
+        case_ids.add(case_id)
+        task_fingerprint = case.get("task_fingerprint")
+        _validate_fingerprint(task_fingerprint, f"{context}.task_fingerprint")
+        seed = _require(case, "seed", int, context)
+        if seed < 0:
+            raise LibraryReplayValidationError(f"{context}.seed: must be >= 0")
+        pair = (task_fingerprint, seed)
+        if pair in task_seed_pairs:
+            raise LibraryReplayValidationError(
+                f"{context}: duplicate task_fingerprint and seed pair"
+            )
+        task_seed_pairs.add(pair)
+        should_activate = _require(case, "should_activate", bool, context)
+        activation_labels.add(should_activate)
+
+        isolated_runs = _require(case, "isolated", dict, context)
+        if set(isolated_runs) != set(BODY_VERSIONS):
+            raise LibraryReplayValidationError(
+                f"{context}.isolated: expected exactly {list(BODY_VERSIONS)}"
+            )
+        for body in BODY_VERSIONS:
+            _validate_observation(
+                isolated_runs[body],
+                context=f"{context}.isolated.{body}",
+                target_skill=target_skill,
+                run_ids=run_ids,
+                isolated=True,
+                allowed_skills={target_skill},
+            )
+
+        libraries = _require(case, "libraries", list, context)
+        if len(libraries) != len(distractor_counts):
+            raise LibraryReplayValidationError(
+                f"{context}.libraries: expected {len(distractor_counts)} levels"
+            )
+        observed_counts: list[int] = []
+        for level_index, level in enumerate(libraries):
+            level_context = f"{context}.libraries[{level_index}]"
+            if not isinstance(level, dict):
+                raise LibraryReplayValidationError(
+                    f"{level_context}: expected an object"
+                )
+            observed_counts.append(
+                _require(level, "distractor_count", int, level_context)
+            )
+            deployed = _require(level, "deployed", dict, level_context)
+            if set(deployed) != set(CELL_KEYS):
+                raise LibraryReplayValidationError(
+                    f"{level_context}.deployed: expected exactly {list(CELL_KEYS)}"
+                )
+            for cell in CELL_KEYS:
+                _validate_observation(
+                    deployed[cell],
+                    context=f"{level_context}.deployed.{cell}",
+                    target_skill=target_skill,
+                    run_ids=run_ids,
+                    isolated=False,
+                    allowed_skills={target_skill}
+                    | set(ladder[level_index]["distractor_skills"]),
+                )
+        if observed_counts != distractor_counts:
+            raise LibraryReplayValidationError(
+                f"{context}.libraries: expected distractor counts {distractor_counts}"
+            )
+    if activation_labels != {False, True}:
+        raise LibraryReplayValidationError(
+            "suite.cases must include both positive and negative activation cases"
+        )
+    if len(cases) * bootstrap_samples > 5_000_000:
+        raise LibraryReplayValidationError(
+            "suite: cases * bootstrap_samples exceeds the 5000000 work bound"
+        )
+
+
+def load_suite(path: Path | str) -> dict[str, Any]:
+    """Load and validate a recorded replay suite."""
+    suite_path = Path(path)
+    try:
+        suite = json.loads(suite_path.read_text(encoding="utf-8"))
+    except json.JSONDecodeError as error:
+        raise LibraryReplayValidationError(
+            f"invalid JSON in {suite_path}: {error}"
+        ) from error
+    validate_suite(suite)
+    return suite
+
+
+def _round(value: float) -> float:
+    return round(float(value), 6)
+
+
+def _mean(values: Iterable[float]) -> float:
+    materialized = list(values)
+    return sum(materialized) / len(materialized)
+
+
+def _percentile(sorted_values: list[float], quantile: float) -> float:
+    if len(sorted_values) == 1:
+        return sorted_values[0]
+    position = (len(sorted_values) - 1) * quantile
+    lower = math.floor(position)
+    upper = math.ceil(position)
+    if lower == upper:
+        return sorted_values[lower]
+    weight = position - lower
+    return sorted_values[lower] * (1 - weight) + sorted_values[upper] * weight
+
+
+def _stable_seed(base_seed: int, label: str) -> int:
+    digest = hashlib.sha256(label.encode("utf-8")).digest()
+    return base_seed ^ int.from_bytes(digest[:8], "big")
+
+
+def _paired_effect(
+    deltas: list[float], metric_config: dict[str, Any], label: str
+) -> dict[str, Any]:
+    point = _mean(deltas)
+    confidence_interval: list[float] | None
+    if len(deltas) == 1:
+        confidence_interval = None
+    else:
+        rng = random.Random(_stable_seed(metric_config["bootstrap_seed"], label))
+        sample_count = metric_config["bootstrap_samples"]
+        size = len(deltas)
+        bootstrap_means = [
+            sum(deltas[rng.randrange(size)] for _ in range(size)) / size
+            for _ in range(sample_count)
+        ]
+        bootstrap_means.sort()
+        alpha = (1 - metric_config["confidence_level"]) / 2
+        low = _percentile(bootstrap_means, alpha)
+        high = _percentile(bootstrap_means, 1 - alpha)
+        confidence_interval = [_round(low), _round(high)]
+    return {
+        "n": len(deltas),
+        "mean": _round(point),
+        "confidence_interval": confidence_interval,
+        "wins": sum(delta > 0 for delta in deltas),
+        "ties": sum(delta == 0 for delta in deltas),
+        "losses": sum(delta < 0 for delta in deltas),
+    }
+
+
+def _observation_value(observation: dict[str, Any], field: str) -> float:
+    if field == "activated_skill_count":
+        return float(len(observation["activated_skills"]))
+    return float(observation[field])
+
+
+def _observation_summary(rows: list[tuple[dict[str, Any], bool]]) -> dict[str, Any]:
+    positives = [observation for observation, label in rows if label]
+    negatives = [observation for observation, label in rows if not label]
+    observations = [observation for observation, _ in rows]
+    activated_skill_counts = Counter(
+        skill
+        for observation in observations
+        for skill in observation["activated_skills"]
+    )
+    error_types = Counter(
+        observation["error_type"]
+        for observation in observations
+        if observation.get("error_type") is not None
+    )
+    return {
+        "score_mean": _round(_mean(row["score"] for row in observations)),
+        "target_activation_rate": _round(
+            _mean(float(row["target_activated"]) for row in observations)
+        ),
+        "positive_recall": _round(
+            _mean(float(row["target_activated"]) for row in positives)
+        ),
+        "negative_false_positive_rate": _round(
+            _mean(float(row["target_activated"]) for row in negatives)
+        ),
+        "activated_skill_counts": dict(sorted(activated_skill_counts.items())),
+        "error_types": dict(sorted(error_types.items())),
+        **{
+            f"{field}_mean": _round(
+                _mean(_observation_value(row, field) for row in observations)
+            )
+            for field in RESOURCE_FIELDS
+        },
+    }
+
+
+def _isolated_summary(observations: list[dict[str, Any]]) -> dict[str, Any]:
+    return {
+        "score_mean": _round(_mean(row["score"] for row in observations)),
+        **{
+            f"{field}_mean": _round(
+                _mean(_observation_value(row, field) for row in observations)
+            )
+            for field in RESOURCE_FIELDS
+        },
+    }
+
+
+def _effect(
+    cases: list[dict[str, Any]],
+    metric_config: dict[str, Any],
+    label: str,
+    left,
+    right,
+) -> dict[str, Any]:
+    return _paired_effect(
+        [float(left(case)) - float(right(case)) for case in cases],
+        metric_config,
+        label,
+    )
+
+
+def evaluate_suite(suite: dict[str, Any]) -> dict[str, Any]:
+    """Compute paired isolated, factorial, activation, and resource effects."""
+    validate_suite(suite)
+    cases = suite["cases"]
+    metric_config = suite["metric_config"]
+    isolated_rows = {
+        body: [case["isolated"][body] for case in cases] for body in BODY_VERSIONS
+    }
+    isolated_effect = _effect(
+        cases,
+        metric_config,
+        "isolated_body_effect",
+        lambda case: case["isolated"]["new_body"]["score"],
+        lambda case: case["isolated"]["old_body"]["score"],
+    )
+    isolated_positive_cases = [case for case in cases if case["should_activate"]]
+    isolated_negative_cases = [case for case in cases if not case["should_activate"]]
+    isolated_positive_effect = _effect(
+        isolated_positive_cases,
+        metric_config,
+        "isolated_positive_body_effect",
+        lambda case: case["isolated"]["new_body"]["score"],
+        lambda case: case["isolated"]["old_body"]["score"],
+    )
+    isolated_negative_effect = _effect(
+        isolated_negative_cases,
+        metric_config,
+        "isolated_negative_body_effect",
+        lambda case: case["isolated"]["new_body"]["score"],
+        lambda case: case["isolated"]["old_body"]["score"],
+    )
+    levels_by_case = {
+        case["case_id"]: {
+            level["distractor_count"]: level for level in case["libraries"]
+        }
+        for case in cases
+    }
+
+    library_curve: list[dict[str, Any]] = []
+    for ladder_level in suite["library_ladder"]:
+        distractor_count = ladder_level["distractor_count"]
+
+        def deployed(
+            item: dict[str, Any], cell: str, count: int = distractor_count
+        ) -> dict[str, Any]:
+            level = levels_by_case[item["case_id"]][count]
+            return level["deployed"][cell]
+
+        cell_rows = {
+            cell: [(deployed(case, cell), case["should_activate"]) for case in cases]
+            for cell in CELL_KEYS
+        }
+        old_old = "old_body__old_description"
+        old_new = "old_body__new_description"
+        new_old = "new_body__old_description"
+        new_new = "new_body__new_description"
+
+        def score(cell: str):
+            return lambda item, key=cell: deployed(item, key)["score"]
+
+        factorial_effects = {
+            "body_at_old_description": _effect(
+                cases,
+                metric_config,
+                f"{distractor_count}:body_at_old_description",
+                score(new_old),
+                score(old_old),
+            ),
+            "body_at_new_description": _effect(
+                cases,
+                metric_config,
+                f"{distractor_count}:body_at_new_description",
+                score(new_new),
+                score(old_new),
+            ),
+            "description_at_old_body": _effect(
+                cases,
+                metric_config,
+                f"{distractor_count}:description_at_old_body",
+                score(old_new),
+                score(old_old),
+            ),
+            "description_at_new_body": _effect(
+                cases,
+                metric_config,
+                f"{distractor_count}:description_at_new_body",
+                score(new_new),
+                score(new_old),
+            ),
+            "joint_deployed_effect": _effect(
+                cases,
+                metric_config,
+                f"{distractor_count}:joint_deployed_effect",
+                score(new_new),
+                score(old_old),
+            ),
+        }
+        interaction_deltas = [
+            deployed(case, new_new)["score"]
+            - deployed(case, new_old)["score"]
+            - deployed(case, old_new)["score"]
+            + deployed(case, old_old)["score"]
+            for case in cases
+        ]
+        factorial_effects["interaction"] = _paired_effect(
+            interaction_deltas,
+            metric_config,
+            f"{distractor_count}:interaction",
+        )
+        interference_deltas = [
+            case["isolated"]["new_body"]["score"]
+            - case["isolated"]["old_body"]["score"]
+            - deployed(case, new_new)["score"]
+            + deployed(case, old_old)["score"]
+            for case in cases
+        ]
+        activation_cases = {
+            "all": cases,
+            "positive": [case for case in cases if case["should_activate"]],
+            "negative": [case for case in cases if not case["should_activate"]],
+        }
+        activation_effects = {
+            "target_activation_delta": _effect(
+                activation_cases["all"],
+                metric_config,
+                f"{distractor_count}:target_activation_delta",
+                lambda item, key=new_new: deployed(item, key)["target_activated"],
+                lambda item, key=old_old: deployed(item, key)["target_activated"],
+            ),
+            "positive_recall_delta": _effect(
+                activation_cases["positive"],
+                metric_config,
+                f"{distractor_count}:positive_recall_delta",
+                lambda item, key=new_new: deployed(item, key)["target_activated"],
+                lambda item, key=old_old: deployed(item, key)["target_activated"],
+            ),
+            "negative_false_positive_rate_delta": _effect(
+                activation_cases["negative"],
+                metric_config,
+                f"{distractor_count}:negative_false_positive_rate_delta",
+                lambda item, key=new_new: deployed(item, key)["target_activated"],
+                lambda item, key=old_old: deployed(item, key)["target_activated"],
+            ),
+        }
+        resource_effects = {
+            field: _effect(
+                cases,
+                metric_config,
+                f"{distractor_count}:{field}",
+                lambda item, key=field, cell=new_new: _observation_value(
+                    deployed(item, cell), key
+                ),
+                lambda item, key=field, cell=old_old: _observation_value(
+                    deployed(item, cell), key
+                ),
+            )
+            for field in RESOURCE_FIELDS
+        }
+        library_curve.append(
+            {
+                "distractor_count": distractor_count,
+                "distractor_catalog_fingerprint": ladder_level[
+                    "distractor_catalog_fingerprint"
+                ],
+                "distractor_skills": ladder_level["distractor_skills"],
+                "cells": {
+                    cell: _observation_summary(cell_rows[cell]) for cell in CELL_KEYS
+                },
+                "factorial_effects": factorial_effects,
+                "interference": _paired_effect(
+                    interference_deltas,
+                    metric_config,
+                    f"{distractor_count}:interference",
+                ),
+                "activation_effects": activation_effects,
+                "resource_effects": resource_effects,
+            }
+        )
+
+    return {
+        "schema_version": SCHEMA_VERSION,
+        "suite_id": suite["suite_id"],
+        "target_skill": suite["target_skill"],
+        "run_manifest": suite["run_manifest"],
+        "cases": len(cases),
+        "positive_cases": sum(case["should_activate"] for case in cases),
+        "negative_cases": sum(not case["should_activate"] for case in cases),
+        "isolated": {
+            "old_body": _isolated_summary(isolated_rows["old_body"]),
+            "new_body": _isolated_summary(isolated_rows["new_body"]),
+            "body_effect": isolated_effect,
+            "positive_body_effect": isolated_positive_effect,
+            "negative_body_effect": isolated_negative_effect,
+        },
+        "library_curve": library_curve,
+    }
+
+
+def render_text(report: dict[str, Any]) -> str:
+    """Render a compact human-readable summary."""
+    isolated = report["isolated"]["body_effect"]
+    lines = [
+        f"suite: {report['suite_id']}",
+        f"target_skill: {report['target_skill']}",
+        (
+            f"cases: {report['cases']} "
+            f"(positive={report['positive_cases']}, negative={report['negative_cases']})"
+        ),
+        (
+            "isolated_body_effect: "
+            f"{isolated['mean']} CI={isolated['confidence_interval']} n={isolated['n']}"
+        ),
+    ]
+    for level in report["library_curve"]:
+        joint = level["factorial_effects"]["joint_deployed_effect"]
+        interaction = level["factorial_effects"]["interaction"]
+        interference = level["interference"]
+        activation = level["activation_effects"]
+        resources = level["resource_effects"]
+        lines.extend(
+            [
+                f"library[distractors={level['distractor_count']}]:",
+                (
+                    "  joint_deployed_effect: "
+                    f"{joint['mean']} CI={joint['confidence_interval']}"
+                ),
+                (
+                    "  factorial_interaction: "
+                    f"{interaction['mean']} CI={interaction['confidence_interval']}"
+                ),
+                (
+                    "  interference: "
+                    f"{interference['mean']} CI={interference['confidence_interval']}"
+                ),
+                (
+                    "  activation_delta: "
+                    f"all={activation['target_activation_delta']['mean']} "
+                    f"positive={activation['positive_recall_delta']['mean']} "
+                    "negative_fpr="
+                    f"{activation['negative_false_positive_rate_delta']['mean']}"
+                ),
+                (
+                    "  resource_delta: "
+                    f"catalog_tokens={resources['catalog_tokens']['mean']} "
+                    f"loaded_skill_tokens={resources['loaded_skill_tokens']['mean']} "
+                    f"cost_usd={resources['cost_usd']['mean']}"
+                ),
+            ]
+        )
+    return "\n".join(lines)
+
+
+def main(argv: list[str] | None = None) -> int:
+    parser = argparse.ArgumentParser(
+        description="Evaluate a recorded library-aware Skill 2x2 replay."
+    )
+    parser.add_argument("suite", type=Path)
+    parser.add_argument("--format", choices=("text", "json"), default="text")
+    args = parser.parse_args(argv)
+    report = evaluate_suite(load_suite(args.suite))
+    if args.format == "json":
+        print(json.dumps(report, ensure_ascii=False, indent=2, sort_keys=True))
+    else:
+        print(render_text(report))
+    return 0
+
+
+if __name__ == "__main__":
+    raise SystemExit(main())

--- a/scripts/bench/skill_library_replay/evaluate.py
+++ b/scripts/bench/skill_library_replay/evaluate.py
@@ -36,6 +36,10 @@ RESOURCE_FIELDS = (
     "cost_usd",
     "latency_ms",
 )
+MAX_BOOTSTRAP_OPERATIONS = 5_000_000
+ISOLATED_BOOTSTRAP_STATISTICS = 3
+BOOTSTRAP_STATISTICS_PER_LIBRARY_LEVEL = 10 + len(RESOURCE_FIELDS)
+ADMISSION_BASE_BOOTSTRAP_STATISTICS = 3
 _SHA256_RE = "sha256:"
 _BASELINE_CELL = "old_body__old_description"
 _CANDIDATE_CELLS = tuple(cell for cell in CELL_KEYS if cell != _BASELINE_CELL)
@@ -43,6 +47,37 @@ _CANDIDATE_CELLS = tuple(cell for cell in CELL_KEYS if cell != _BASELINE_CELL)
 
 class LibraryReplayValidationError(ValueError):
     """Raised when a library-aware replay violates its data contract."""
+
+
+def _estimated_bootstrap_operations(
+    *,
+    case_count: int,
+    library_levels: int,
+    bootstrap_samples: int,
+    additional_statistics: int = 0,
+) -> int:
+    statistics = (
+        ISOLATED_BOOTSTRAP_STATISTICS
+        + library_levels * BOOTSTRAP_STATISTICS_PER_LIBRARY_LEVEL
+        + additional_statistics
+    )
+    return case_count * bootstrap_samples * statistics
+
+
+def _validate_bootstrap_work(
+    suite: dict[str, Any], *, additional_statistics: int = 0
+) -> None:
+    estimated_operations = _estimated_bootstrap_operations(
+        case_count=len(suite["cases"]),
+        library_levels=len(suite["library_ladder"]),
+        bootstrap_samples=suite["metric_config"]["bootstrap_samples"],
+        additional_statistics=additional_statistics,
+    )
+    if estimated_operations > MAX_BOOTSTRAP_OPERATIONS:
+        raise LibraryReplayValidationError(
+            "suite: estimated bootstrap work exceeds "
+            f"the {MAX_BOOTSTRAP_OPERATIONS} operation bound"
+        )
 
 
 def _require(mapping: dict[str, Any], key: str, expected: type, context: str) -> Any:
@@ -398,10 +433,7 @@ def validate_suite(suite: Any) -> None:
         raise LibraryReplayValidationError(
             "suite.cases: every task_fingerprint must use the same seed set"
         )
-    if len(cases) * bootstrap_samples > 5_000_000:
-        raise LibraryReplayValidationError(
-            "suite: cases * bootstrap_samples exceeds the 5000000 work bound"
-        )
+    _validate_bootstrap_work(suite)
 
 
 def load_suite(path: Path | str) -> dict[str, Any]:
@@ -559,6 +591,12 @@ def validate_admission_policy(policy: Any, suite: dict[str, Any]) -> None:
         raise LibraryReplayValidationError(
             "policy.non_evaluable_error_types: expected unique non-empty strings"
         )
+    _validate_bootstrap_work(
+        suite,
+        additional_statistics=(
+            ADMISSION_BASE_BOOTSTRAP_STATISTICS + len(resource_limits)
+        ),
+    )
 
 
 def load_admission_policy(path: Path | str, suite: dict[str, Any]) -> dict[str, Any]:

--- a/scripts/bench/skill_library_replay/fixtures/admission_policy_v1.json
+++ b/scripts/bench/skill_library_replay/fixtures/admission_policy_v1.json
@@ -1,0 +1,32 @@
+{
+  "schema_version": 1,
+  "policy_id": "synthetic-library-admission-policy-v1",
+  "suite_id": "synthetic-library-aware-v1",
+  "target_skill": "spreadsheet-formula-repair",
+  "registered_at": "2026-08-29T00:00:00Z",
+  "task_set_fingerprint": "sha256:aaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaa",
+  "evaluation_protocol_fingerprint": "sha256:bbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbb",
+  "old_body_fingerprint": "sha256:cccccccccccccccccccccccccccccccccccccccccccccccccccccccccccccccc",
+  "new_body_fingerprint": "sha256:dddddddddddddddddddddddddddddddddddddddddddddddddddddddddddddddd",
+  "old_description_fingerprint": "sha256:eeeeeeeeeeeeeeeeeeeeeeeeeeeeeeeeeeeeeeeeeeeeeeeeeeeeeeeeeeeeeeee",
+  "new_description_fingerprint": "sha256:ffffffffffffffffffffffffffffffffffffffffffffffffffffffffffffffff",
+  "primary_distractor_count": 2,
+  "primary_distractor_catalog_fingerprint": "sha256:9999999999999999999999999999999999999999999999999999999999999999",
+  "candidate_cell": "new_body__new_description",
+  "minimum_paired_tasks": 50,
+  "minimum_positive_tasks": 25,
+  "minimum_negative_tasks": 25,
+  "minimum_score_gain": 0.05,
+  "minimum_candidate_positive_task_activation_rate": 0.85,
+  "maximum_positive_recall_drop": 0.0,
+  "maximum_candidate_negative_task_activation_rate": 0.15,
+  "maximum_negative_false_positive_rate_increase": 0.05,
+  "resource_increase_limits": {
+    "loaded_skill_tokens": 64,
+    "cost_usd": 0.001,
+    "latency_ms": 1000
+  },
+  "non_evaluable_error_types": [
+    "infrastructure_failure"
+  ]
+}

--- a/scripts/bench/skill_library_replay/fixtures/baseline_v1.json
+++ b/scripts/bench/skill_library_replay/fixtures/baseline_v1.json
@@ -1,0 +1,344 @@
+{
+  "schema_version": 1,
+  "suite_id": "synthetic-library-aware-v1",
+  "target_skill": "spreadsheet-formula-repair",
+  "metric_config": {
+    "bootstrap_samples": 1000,
+    "bootstrap_seed": 42,
+    "confidence_level": 0.95
+  },
+  "run_manifest": {
+    "repository_revision": "synthetic-recorded-fixture",
+    "model": "recorded-fixture",
+    "harness": "recorded-fixture",
+    "generated_at": "2026-08-30T00:00:00Z",
+    "task_set_fingerprint": "sha256:aaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaa",
+    "evaluation_protocol_fingerprint": "sha256:bbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbb",
+    "old_body_fingerprint": "sha256:cccccccccccccccccccccccccccccccccccccccccccccccccccccccccccccccc",
+    "new_body_fingerprint": "sha256:dddddddddddddddddddddddddddddddddddddddddddddddddddddddddddddddd",
+    "old_description_fingerprint": "sha256:eeeeeeeeeeeeeeeeeeeeeeeeeeeeeeeeeeeeeeeeeeeeeeeeeeeeeeeeeeeeeeee",
+    "new_description_fingerprint": "sha256:ffffffffffffffffffffffffffffffffffffffffffffffffffffffffffffffff",
+    "generation_config": {
+      "temperature": 0.0,
+      "top_p": 1.0,
+      "max_output_tokens": 4096
+    }
+  },
+  "library_ladder": [
+    {
+      "distractor_count": 0,
+      "distractor_catalog_fingerprint": "sha256:0000000000000000000000000000000000000000000000000000000000000000",
+      "distractor_skills": []
+    },
+    {
+      "distractor_count": 2,
+      "distractor_catalog_fingerprint": "sha256:9999999999999999999999999999999999999999999999999999999999999999",
+      "distractor_skills": [
+        "spreadsheet-formatting",
+        "spreadsheet-charting"
+      ]
+    }
+  ],
+  "cases": [
+    {
+      "case_id": "positive-formula-repair",
+      "task_fingerprint": "sha256:1111111111111111111111111111111111111111111111111111111111111111",
+      "seed": 7,
+      "should_activate": true,
+      "isolated": {
+        "old_body": {
+          "run_id": "positive-isolated-old-body",
+          "score": 0.0,
+          "target_activated": true,
+          "activated_skills": ["spreadsheet-formula-repair"],
+          "catalog_tokens": 0,
+          "loaded_skill_tokens": 80,
+          "input_tokens": 980,
+          "output_tokens": 120,
+          "cost_usd": 0.002,
+          "latency_ms": 1000,
+          "error_type": "incorrect_result"
+        },
+        "new_body": {
+          "run_id": "positive-isolated-new-body",
+          "score": 1.0,
+          "target_activated": true,
+          "activated_skills": ["spreadsheet-formula-repair"],
+          "catalog_tokens": 0,
+          "loaded_skill_tokens": 100,
+          "input_tokens": 1000,
+          "output_tokens": 100,
+          "cost_usd": 0.002,
+          "latency_ms": 900,
+          "error_type": null
+        }
+      },
+      "libraries": [
+        {
+          "distractor_count": 0,
+          "deployed": {
+            "old_body__old_description": {
+              "run_id": "positive-d0-old-old",
+              "score": 0.0,
+              "target_activated": false,
+              "activated_skills": [],
+              "catalog_tokens": 20,
+              "loaded_skill_tokens": 0,
+              "input_tokens": 900,
+              "output_tokens": 120,
+              "cost_usd": 0.002,
+              "latency_ms": 1000,
+              "error_type": "missed_activation"
+            },
+            "old_body__new_description": {
+              "run_id": "positive-d0-old-new",
+              "score": 0.0,
+              "target_activated": true,
+              "activated_skills": ["spreadsheet-formula-repair"],
+              "catalog_tokens": 24,
+              "loaded_skill_tokens": 80,
+              "input_tokens": 984,
+              "output_tokens": 120,
+              "cost_usd": 0.0021,
+              "latency_ms": 1020,
+              "error_type": "incorrect_result"
+            },
+            "new_body__old_description": {
+              "run_id": "positive-d0-new-old",
+              "score": 0.0,
+              "target_activated": false,
+              "activated_skills": [],
+              "catalog_tokens": 20,
+              "loaded_skill_tokens": 0,
+              "input_tokens": 900,
+              "output_tokens": 120,
+              "cost_usd": 0.002,
+              "latency_ms": 1000,
+              "error_type": "missed_activation"
+            },
+            "new_body__new_description": {
+              "run_id": "positive-d0-new-new",
+              "score": 1.0,
+              "target_activated": true,
+              "activated_skills": ["spreadsheet-formula-repair"],
+              "catalog_tokens": 24,
+              "loaded_skill_tokens": 100,
+              "input_tokens": 1004,
+              "output_tokens": 100,
+              "cost_usd": 0.002,
+              "latency_ms": 900,
+              "error_type": null
+            }
+          }
+        },
+        {
+          "distractor_count": 2,
+          "deployed": {
+            "old_body__old_description": {
+              "run_id": "positive-d2-old-old",
+              "score": 0.0,
+              "target_activated": false,
+              "activated_skills": ["spreadsheet-formatting"],
+              "catalog_tokens": 60,
+              "loaded_skill_tokens": 70,
+              "input_tokens": 1010,
+              "output_tokens": 120,
+              "cost_usd": 0.0022,
+              "latency_ms": 1080,
+              "error_type": "wrong_skill_activation"
+            },
+            "old_body__new_description": {
+              "run_id": "positive-d2-old-new",
+              "score": 0.0,
+              "target_activated": true,
+              "activated_skills": ["spreadsheet-formula-repair"],
+              "catalog_tokens": 64,
+              "loaded_skill_tokens": 80,
+              "input_tokens": 1024,
+              "output_tokens": 120,
+              "cost_usd": 0.0022,
+              "latency_ms": 1050,
+              "error_type": "incorrect_result"
+            },
+            "new_body__old_description": {
+              "run_id": "positive-d2-new-old",
+              "score": 0.0,
+              "target_activated": false,
+              "activated_skills": ["spreadsheet-formatting"],
+              "catalog_tokens": 60,
+              "loaded_skill_tokens": 70,
+              "input_tokens": 1010,
+              "output_tokens": 120,
+              "cost_usd": 0.0022,
+              "latency_ms": 1080,
+              "error_type": "wrong_skill_activation"
+            },
+            "new_body__new_description": {
+              "run_id": "positive-d2-new-new",
+              "score": 1.0,
+              "target_activated": true,
+              "activated_skills": ["spreadsheet-formula-repair"],
+              "catalog_tokens": 64,
+              "loaded_skill_tokens": 100,
+              "input_tokens": 1044,
+              "output_tokens": 100,
+              "cost_usd": 0.0021,
+              "latency_ms": 920,
+              "error_type": null
+            }
+          }
+        }
+      ]
+    },
+    {
+      "case_id": "negative-formatting-request",
+      "task_fingerprint": "sha256:2222222222222222222222222222222222222222222222222222222222222222",
+      "seed": 7,
+      "should_activate": false,
+      "isolated": {
+        "old_body": {
+          "run_id": "negative-isolated-old-body",
+          "score": 0.5,
+          "target_activated": true,
+          "activated_skills": ["spreadsheet-formula-repair"],
+          "catalog_tokens": 0,
+          "loaded_skill_tokens": 80,
+          "input_tokens": 980,
+          "output_tokens": 120,
+          "cost_usd": 0.002,
+          "latency_ms": 1000,
+          "error_type": "partial_result"
+        },
+        "new_body": {
+          "run_id": "negative-isolated-new-body",
+          "score": 0.5,
+          "target_activated": true,
+          "activated_skills": ["spreadsheet-formula-repair"],
+          "catalog_tokens": 0,
+          "loaded_skill_tokens": 100,
+          "input_tokens": 1000,
+          "output_tokens": 120,
+          "cost_usd": 0.0021,
+          "latency_ms": 1020,
+          "error_type": "partial_result"
+        }
+      },
+      "libraries": [
+        {
+          "distractor_count": 0,
+          "deployed": {
+            "old_body__old_description": {
+              "run_id": "negative-d0-old-old",
+              "score": 0.0,
+              "target_activated": true,
+              "activated_skills": ["spreadsheet-formula-repair"],
+              "catalog_tokens": 20,
+              "loaded_skill_tokens": 80,
+              "input_tokens": 980,
+              "output_tokens": 120,
+              "cost_usd": 0.0021,
+              "latency_ms": 1050,
+              "error_type": "harmful_activation"
+            },
+            "old_body__new_description": {
+              "run_id": "negative-d0-old-new",
+              "score": 1.0,
+              "target_activated": false,
+              "activated_skills": [],
+              "catalog_tokens": 24,
+              "loaded_skill_tokens": 0,
+              "input_tokens": 904,
+              "output_tokens": 100,
+              "cost_usd": 0.0018,
+              "latency_ms": 850,
+              "error_type": null
+            },
+            "new_body__old_description": {
+              "run_id": "negative-d0-new-old",
+              "score": 0.0,
+              "target_activated": true,
+              "activated_skills": ["spreadsheet-formula-repair"],
+              "catalog_tokens": 20,
+              "loaded_skill_tokens": 100,
+              "input_tokens": 1000,
+              "output_tokens": 120,
+              "cost_usd": 0.0022,
+              "latency_ms": 1080,
+              "error_type": "harmful_activation"
+            },
+            "new_body__new_description": {
+              "run_id": "negative-d0-new-new",
+              "score": 1.0,
+              "target_activated": false,
+              "activated_skills": [],
+              "catalog_tokens": 24,
+              "loaded_skill_tokens": 0,
+              "input_tokens": 904,
+              "output_tokens": 100,
+              "cost_usd": 0.0018,
+              "latency_ms": 850,
+              "error_type": null
+            }
+          }
+        },
+        {
+          "distractor_count": 2,
+          "deployed": {
+            "old_body__old_description": {
+              "run_id": "negative-d2-old-old",
+              "score": 0.0,
+              "target_activated": true,
+              "activated_skills": ["spreadsheet-formula-repair"],
+              "catalog_tokens": 60,
+              "loaded_skill_tokens": 80,
+              "input_tokens": 1020,
+              "output_tokens": 120,
+              "cost_usd": 0.0022,
+              "latency_ms": 1080,
+              "error_type": "harmful_activation"
+            },
+            "old_body__new_description": {
+              "run_id": "negative-d2-old-new",
+              "score": 1.0,
+              "target_activated": false,
+              "activated_skills": ["spreadsheet-formatting"],
+              "catalog_tokens": 64,
+              "loaded_skill_tokens": 70,
+              "input_tokens": 1034,
+              "output_tokens": 100,
+              "cost_usd": 0.002,
+              "latency_ms": 900,
+              "error_type": null
+            },
+            "new_body__old_description": {
+              "run_id": "negative-d2-new-old",
+              "score": 0.0,
+              "target_activated": true,
+              "activated_skills": ["spreadsheet-formula-repair"],
+              "catalog_tokens": 60,
+              "loaded_skill_tokens": 100,
+              "input_tokens": 1040,
+              "output_tokens": 120,
+              "cost_usd": 0.0023,
+              "latency_ms": 1100,
+              "error_type": "harmful_activation"
+            },
+            "new_body__new_description": {
+              "run_id": "negative-d2-new-new",
+              "score": 1.0,
+              "target_activated": false,
+              "activated_skills": ["spreadsheet-formatting"],
+              "catalog_tokens": 64,
+              "loaded_skill_tokens": 70,
+              "input_tokens": 1034,
+              "output_tokens": 100,
+              "cost_usd": 0.002,
+              "latency_ms": 900,
+              "error_type": null
+            }
+          }
+        }
+      ]
+    }
+  ]
+}

--- a/scripts/bench/skill_library_replay/fixtures/baseline_v1.report.json
+++ b/scripts/bench/skill_library_replay/fixtures/baseline_v1.report.json
@@ -9,6 +9,7 @@
       "losses": 0,
       "mean": 0.5,
       "n": 2,
+      "tasks": 2,
       "ties": 1,
       "wins": 1
     },
@@ -17,6 +18,7 @@
       "losses": 0,
       "mean": 0.0,
       "n": 1,
+      "tasks": 1,
       "ties": 1,
       "wins": 0
     },
@@ -45,6 +47,7 @@
       "losses": 0,
       "mean": 1.0,
       "n": 1,
+      "tasks": 1,
       "ties": 0,
       "wins": 1
     }
@@ -57,6 +60,7 @@
           "losses": 1,
           "mean": -1.0,
           "n": 1,
+          "tasks": 1,
           "ties": 0,
           "wins": 0
         },
@@ -65,6 +69,7 @@
           "losses": 0,
           "mean": 1.0,
           "n": 1,
+          "tasks": 1,
           "ties": 0,
           "wins": 1
         },
@@ -76,6 +81,7 @@
           "losses": 1,
           "mean": 0.0,
           "n": 2,
+          "tasks": 2,
           "ties": 0,
           "wins": 1
         }
@@ -170,6 +176,7 @@
           "losses": 0,
           "mean": 0.5,
           "n": 2,
+          "tasks": 2,
           "ties": 1,
           "wins": 1
         },
@@ -181,6 +188,7 @@
           "losses": 0,
           "mean": 0.0,
           "n": 2,
+          "tasks": 2,
           "ties": 2,
           "wins": 0
         },
@@ -192,6 +200,7 @@
           "losses": 0,
           "mean": 1.0,
           "n": 2,
+          "tasks": 2,
           "ties": 0,
           "wins": 2
         },
@@ -203,6 +212,7 @@
           "losses": 0,
           "mean": 0.5,
           "n": 2,
+          "tasks": 2,
           "ties": 1,
           "wins": 1
         },
@@ -214,6 +224,7 @@
           "losses": 0,
           "mean": 0.5,
           "n": 2,
+          "tasks": 2,
           "ties": 1,
           "wins": 1
         },
@@ -225,6 +236,7 @@
           "losses": 0,
           "mean": 1.0,
           "n": 2,
+          "tasks": 2,
           "ties": 0,
           "wins": 2
         }
@@ -237,6 +249,7 @@
         "losses": 1,
         "mean": -0.5,
         "n": 2,
+        "tasks": 2,
         "ties": 1,
         "wins": 0
       },
@@ -249,6 +262,7 @@
           "losses": 1,
           "mean": 0.0,
           "n": 2,
+          "tasks": 2,
           "ties": 0,
           "wins": 1
         },
@@ -260,6 +274,7 @@
           "losses": 0,
           "mean": 4.0,
           "n": 2,
+          "tasks": 2,
           "ties": 0,
           "wins": 2
         },
@@ -271,6 +286,7 @@
           "losses": 1,
           "mean": -0.00015,
           "n": 2,
+          "tasks": 2,
           "ties": 1,
           "wins": 0
         },
@@ -282,6 +298,7 @@
           "losses": 1,
           "mean": 14.0,
           "n": 2,
+          "tasks": 2,
           "ties": 0,
           "wins": 1
         },
@@ -293,6 +310,7 @@
           "losses": 2,
           "mean": -150.0,
           "n": 2,
+          "tasks": 2,
           "ties": 0,
           "wins": 0
         },
@@ -304,6 +322,7 @@
           "losses": 1,
           "mean": 10.0,
           "n": 2,
+          "tasks": 2,
           "ties": 0,
           "wins": 1
         },
@@ -315,6 +334,7 @@
           "losses": 2,
           "mean": -20.0,
           "n": 2,
+          "tasks": 2,
           "ties": 0,
           "wins": 0
         }
@@ -327,6 +347,7 @@
           "losses": 1,
           "mean": -1.0,
           "n": 1,
+          "tasks": 1,
           "ties": 0,
           "wins": 0
         },
@@ -335,6 +356,7 @@
           "losses": 0,
           "mean": 1.0,
           "n": 1,
+          "tasks": 1,
           "ties": 0,
           "wins": 1
         },
@@ -346,6 +368,7 @@
           "losses": 1,
           "mean": 0.0,
           "n": 2,
+          "tasks": 2,
           "ties": 0,
           "wins": 1
         }
@@ -447,6 +470,7 @@
           "losses": 0,
           "mean": 0.5,
           "n": 2,
+          "tasks": 2,
           "ties": 1,
           "wins": 1
         },
@@ -458,6 +482,7 @@
           "losses": 0,
           "mean": 0.0,
           "n": 2,
+          "tasks": 2,
           "ties": 2,
           "wins": 0
         },
@@ -469,6 +494,7 @@
           "losses": 0,
           "mean": 1.0,
           "n": 2,
+          "tasks": 2,
           "ties": 0,
           "wins": 2
         },
@@ -480,6 +506,7 @@
           "losses": 0,
           "mean": 0.5,
           "n": 2,
+          "tasks": 2,
           "ties": 1,
           "wins": 1
         },
@@ -491,6 +518,7 @@
           "losses": 0,
           "mean": 0.5,
           "n": 2,
+          "tasks": 2,
           "ties": 1,
           "wins": 1
         },
@@ -502,6 +530,7 @@
           "losses": 0,
           "mean": 1.0,
           "n": 2,
+          "tasks": 2,
           "ties": 0,
           "wins": 2
         }
@@ -514,6 +543,7 @@
         "losses": 1,
         "mean": -0.5,
         "n": 2,
+        "tasks": 2,
         "ties": 1,
         "wins": 0
       },
@@ -526,6 +556,7 @@
           "losses": 0,
           "mean": 0.0,
           "n": 2,
+          "tasks": 2,
           "ties": 2,
           "wins": 0
         },
@@ -537,6 +568,7 @@
           "losses": 0,
           "mean": 4.0,
           "n": 2,
+          "tasks": 2,
           "ties": 0,
           "wins": 2
         },
@@ -548,6 +580,7 @@
           "losses": 2,
           "mean": -0.00015,
           "n": 2,
+          "tasks": 2,
           "ties": 0,
           "wins": 0
         },
@@ -559,6 +592,7 @@
           "losses": 0,
           "mean": 24.0,
           "n": 2,
+          "tasks": 2,
           "ties": 0,
           "wins": 2
         },
@@ -570,6 +604,7 @@
           "losses": 2,
           "mean": -170.0,
           "n": 2,
+          "tasks": 2,
           "ties": 0,
           "wins": 0
         },
@@ -581,6 +616,7 @@
           "losses": 1,
           "mean": 10.0,
           "n": 2,
+          "tasks": 2,
           "ties": 0,
           "wins": 1
         },
@@ -592,6 +628,7 @@
           "losses": 2,
           "mean": -20.0,
           "n": 2,
+          "tasks": 2,
           "ties": 0,
           "wins": 0
         }

--- a/scripts/bench/skill_library_replay/fixtures/baseline_v1.report.json
+++ b/scripts/bench/skill_library_replay/fixtures/baseline_v1.report.json
@@ -1,0 +1,623 @@
+{
+  "cases": 2,
+  "isolated": {
+    "body_effect": {
+      "confidence_interval": [
+        0.0,
+        1.0
+      ],
+      "losses": 0,
+      "mean": 0.5,
+      "n": 2,
+      "ties": 1,
+      "wins": 1
+    },
+    "negative_body_effect": {
+      "confidence_interval": null,
+      "losses": 0,
+      "mean": 0.0,
+      "n": 1,
+      "ties": 1,
+      "wins": 0
+    },
+    "new_body": {
+      "activated_skill_count_mean": 1.0,
+      "catalog_tokens_mean": 0.0,
+      "cost_usd_mean": 0.00205,
+      "input_tokens_mean": 1000.0,
+      "latency_ms_mean": 960.0,
+      "loaded_skill_tokens_mean": 100.0,
+      "output_tokens_mean": 110.0,
+      "score_mean": 0.75
+    },
+    "old_body": {
+      "activated_skill_count_mean": 1.0,
+      "catalog_tokens_mean": 0.0,
+      "cost_usd_mean": 0.002,
+      "input_tokens_mean": 980.0,
+      "latency_ms_mean": 1000.0,
+      "loaded_skill_tokens_mean": 80.0,
+      "output_tokens_mean": 120.0,
+      "score_mean": 0.25
+    },
+    "positive_body_effect": {
+      "confidence_interval": null,
+      "losses": 0,
+      "mean": 1.0,
+      "n": 1,
+      "ties": 0,
+      "wins": 1
+    }
+  },
+  "library_curve": [
+    {
+      "activation_effects": {
+        "negative_false_positive_rate_delta": {
+          "confidence_interval": null,
+          "losses": 1,
+          "mean": -1.0,
+          "n": 1,
+          "ties": 0,
+          "wins": 0
+        },
+        "positive_recall_delta": {
+          "confidence_interval": null,
+          "losses": 0,
+          "mean": 1.0,
+          "n": 1,
+          "ties": 0,
+          "wins": 1
+        },
+        "target_activation_delta": {
+          "confidence_interval": [
+            -1.0,
+            1.0
+          ],
+          "losses": 1,
+          "mean": 0.0,
+          "n": 2,
+          "ties": 0,
+          "wins": 1
+        }
+      },
+      "cells": {
+        "new_body__new_description": {
+          "activated_skill_count_mean": 0.5,
+          "activated_skill_counts": {
+            "spreadsheet-formula-repair": 1
+          },
+          "catalog_tokens_mean": 24.0,
+          "cost_usd_mean": 0.0019,
+          "error_types": {},
+          "input_tokens_mean": 954.0,
+          "latency_ms_mean": 875.0,
+          "loaded_skill_tokens_mean": 50.0,
+          "negative_false_positive_rate": 0.0,
+          "output_tokens_mean": 100.0,
+          "positive_recall": 1.0,
+          "score_mean": 1.0,
+          "target_activation_rate": 0.5
+        },
+        "new_body__old_description": {
+          "activated_skill_count_mean": 0.5,
+          "activated_skill_counts": {
+            "spreadsheet-formula-repair": 1
+          },
+          "catalog_tokens_mean": 20.0,
+          "cost_usd_mean": 0.0021,
+          "error_types": {
+            "harmful_activation": 1,
+            "missed_activation": 1
+          },
+          "input_tokens_mean": 950.0,
+          "latency_ms_mean": 1040.0,
+          "loaded_skill_tokens_mean": 50.0,
+          "negative_false_positive_rate": 1.0,
+          "output_tokens_mean": 120.0,
+          "positive_recall": 0.0,
+          "score_mean": 0.0,
+          "target_activation_rate": 0.5
+        },
+        "old_body__new_description": {
+          "activated_skill_count_mean": 0.5,
+          "activated_skill_counts": {
+            "spreadsheet-formula-repair": 1
+          },
+          "catalog_tokens_mean": 24.0,
+          "cost_usd_mean": 0.00195,
+          "error_types": {
+            "incorrect_result": 1
+          },
+          "input_tokens_mean": 944.0,
+          "latency_ms_mean": 935.0,
+          "loaded_skill_tokens_mean": 40.0,
+          "negative_false_positive_rate": 0.0,
+          "output_tokens_mean": 110.0,
+          "positive_recall": 1.0,
+          "score_mean": 0.5,
+          "target_activation_rate": 0.5
+        },
+        "old_body__old_description": {
+          "activated_skill_count_mean": 0.5,
+          "activated_skill_counts": {
+            "spreadsheet-formula-repair": 1
+          },
+          "catalog_tokens_mean": 20.0,
+          "cost_usd_mean": 0.00205,
+          "error_types": {
+            "harmful_activation": 1,
+            "missed_activation": 1
+          },
+          "input_tokens_mean": 940.0,
+          "latency_ms_mean": 1025.0,
+          "loaded_skill_tokens_mean": 40.0,
+          "negative_false_positive_rate": 1.0,
+          "output_tokens_mean": 120.0,
+          "positive_recall": 0.0,
+          "score_mean": 0.0,
+          "target_activation_rate": 0.5
+        }
+      },
+      "distractor_catalog_fingerprint": "sha256:0000000000000000000000000000000000000000000000000000000000000000",
+      "distractor_count": 0,
+      "distractor_skills": [],
+      "factorial_effects": {
+        "body_at_new_description": {
+          "confidence_interval": [
+            0.0,
+            1.0
+          ],
+          "losses": 0,
+          "mean": 0.5,
+          "n": 2,
+          "ties": 1,
+          "wins": 1
+        },
+        "body_at_old_description": {
+          "confidence_interval": [
+            0.0,
+            0.0
+          ],
+          "losses": 0,
+          "mean": 0.0,
+          "n": 2,
+          "ties": 2,
+          "wins": 0
+        },
+        "description_at_new_body": {
+          "confidence_interval": [
+            1.0,
+            1.0
+          ],
+          "losses": 0,
+          "mean": 1.0,
+          "n": 2,
+          "ties": 0,
+          "wins": 2
+        },
+        "description_at_old_body": {
+          "confidence_interval": [
+            0.0,
+            1.0
+          ],
+          "losses": 0,
+          "mean": 0.5,
+          "n": 2,
+          "ties": 1,
+          "wins": 1
+        },
+        "interaction": {
+          "confidence_interval": [
+            0.0,
+            1.0
+          ],
+          "losses": 0,
+          "mean": 0.5,
+          "n": 2,
+          "ties": 1,
+          "wins": 1
+        },
+        "joint_deployed_effect": {
+          "confidence_interval": [
+            1.0,
+            1.0
+          ],
+          "losses": 0,
+          "mean": 1.0,
+          "n": 2,
+          "ties": 0,
+          "wins": 2
+        }
+      },
+      "interference": {
+        "confidence_interval": [
+          -1.0,
+          0.0
+        ],
+        "losses": 1,
+        "mean": -0.5,
+        "n": 2,
+        "ties": 1,
+        "wins": 0
+      },
+      "resource_effects": {
+        "activated_skill_count": {
+          "confidence_interval": [
+            -1.0,
+            1.0
+          ],
+          "losses": 1,
+          "mean": 0.0,
+          "n": 2,
+          "ties": 0,
+          "wins": 1
+        },
+        "catalog_tokens": {
+          "confidence_interval": [
+            4.0,
+            4.0
+          ],
+          "losses": 0,
+          "mean": 4.0,
+          "n": 2,
+          "ties": 0,
+          "wins": 2
+        },
+        "cost_usd": {
+          "confidence_interval": [
+            -0.0003,
+            0.0
+          ],
+          "losses": 1,
+          "mean": -0.00015,
+          "n": 2,
+          "ties": 1,
+          "wins": 0
+        },
+        "input_tokens": {
+          "confidence_interval": [
+            -76.0,
+            104.0
+          ],
+          "losses": 1,
+          "mean": 14.0,
+          "n": 2,
+          "ties": 0,
+          "wins": 1
+        },
+        "latency_ms": {
+          "confidence_interval": [
+            -200.0,
+            -100.0
+          ],
+          "losses": 2,
+          "mean": -150.0,
+          "n": 2,
+          "ties": 0,
+          "wins": 0
+        },
+        "loaded_skill_tokens": {
+          "confidence_interval": [
+            -80.0,
+            100.0
+          ],
+          "losses": 1,
+          "mean": 10.0,
+          "n": 2,
+          "ties": 0,
+          "wins": 1
+        },
+        "output_tokens": {
+          "confidence_interval": [
+            -20.0,
+            -20.0
+          ],
+          "losses": 2,
+          "mean": -20.0,
+          "n": 2,
+          "ties": 0,
+          "wins": 0
+        }
+      }
+    },
+    {
+      "activation_effects": {
+        "negative_false_positive_rate_delta": {
+          "confidence_interval": null,
+          "losses": 1,
+          "mean": -1.0,
+          "n": 1,
+          "ties": 0,
+          "wins": 0
+        },
+        "positive_recall_delta": {
+          "confidence_interval": null,
+          "losses": 0,
+          "mean": 1.0,
+          "n": 1,
+          "ties": 0,
+          "wins": 1
+        },
+        "target_activation_delta": {
+          "confidence_interval": [
+            -1.0,
+            1.0
+          ],
+          "losses": 1,
+          "mean": 0.0,
+          "n": 2,
+          "ties": 0,
+          "wins": 1
+        }
+      },
+      "cells": {
+        "new_body__new_description": {
+          "activated_skill_count_mean": 1.0,
+          "activated_skill_counts": {
+            "spreadsheet-formatting": 1,
+            "spreadsheet-formula-repair": 1
+          },
+          "catalog_tokens_mean": 64.0,
+          "cost_usd_mean": 0.00205,
+          "error_types": {},
+          "input_tokens_mean": 1039.0,
+          "latency_ms_mean": 910.0,
+          "loaded_skill_tokens_mean": 85.0,
+          "negative_false_positive_rate": 0.0,
+          "output_tokens_mean": 100.0,
+          "positive_recall": 1.0,
+          "score_mean": 1.0,
+          "target_activation_rate": 0.5
+        },
+        "new_body__old_description": {
+          "activated_skill_count_mean": 1.0,
+          "activated_skill_counts": {
+            "spreadsheet-formatting": 1,
+            "spreadsheet-formula-repair": 1
+          },
+          "catalog_tokens_mean": 60.0,
+          "cost_usd_mean": 0.00225,
+          "error_types": {
+            "harmful_activation": 1,
+            "wrong_skill_activation": 1
+          },
+          "input_tokens_mean": 1025.0,
+          "latency_ms_mean": 1090.0,
+          "loaded_skill_tokens_mean": 85.0,
+          "negative_false_positive_rate": 1.0,
+          "output_tokens_mean": 120.0,
+          "positive_recall": 0.0,
+          "score_mean": 0.0,
+          "target_activation_rate": 0.5
+        },
+        "old_body__new_description": {
+          "activated_skill_count_mean": 1.0,
+          "activated_skill_counts": {
+            "spreadsheet-formatting": 1,
+            "spreadsheet-formula-repair": 1
+          },
+          "catalog_tokens_mean": 64.0,
+          "cost_usd_mean": 0.0021,
+          "error_types": {
+            "incorrect_result": 1
+          },
+          "input_tokens_mean": 1029.0,
+          "latency_ms_mean": 975.0,
+          "loaded_skill_tokens_mean": 75.0,
+          "negative_false_positive_rate": 0.0,
+          "output_tokens_mean": 110.0,
+          "positive_recall": 1.0,
+          "score_mean": 0.5,
+          "target_activation_rate": 0.5
+        },
+        "old_body__old_description": {
+          "activated_skill_count_mean": 1.0,
+          "activated_skill_counts": {
+            "spreadsheet-formatting": 1,
+            "spreadsheet-formula-repair": 1
+          },
+          "catalog_tokens_mean": 60.0,
+          "cost_usd_mean": 0.0022,
+          "error_types": {
+            "harmful_activation": 1,
+            "wrong_skill_activation": 1
+          },
+          "input_tokens_mean": 1015.0,
+          "latency_ms_mean": 1080.0,
+          "loaded_skill_tokens_mean": 75.0,
+          "negative_false_positive_rate": 1.0,
+          "output_tokens_mean": 120.0,
+          "positive_recall": 0.0,
+          "score_mean": 0.0,
+          "target_activation_rate": 0.5
+        }
+      },
+      "distractor_catalog_fingerprint": "sha256:9999999999999999999999999999999999999999999999999999999999999999",
+      "distractor_count": 2,
+      "distractor_skills": [
+        "spreadsheet-formatting",
+        "spreadsheet-charting"
+      ],
+      "factorial_effects": {
+        "body_at_new_description": {
+          "confidence_interval": [
+            0.0,
+            1.0
+          ],
+          "losses": 0,
+          "mean": 0.5,
+          "n": 2,
+          "ties": 1,
+          "wins": 1
+        },
+        "body_at_old_description": {
+          "confidence_interval": [
+            0.0,
+            0.0
+          ],
+          "losses": 0,
+          "mean": 0.0,
+          "n": 2,
+          "ties": 2,
+          "wins": 0
+        },
+        "description_at_new_body": {
+          "confidence_interval": [
+            1.0,
+            1.0
+          ],
+          "losses": 0,
+          "mean": 1.0,
+          "n": 2,
+          "ties": 0,
+          "wins": 2
+        },
+        "description_at_old_body": {
+          "confidence_interval": [
+            0.0,
+            1.0
+          ],
+          "losses": 0,
+          "mean": 0.5,
+          "n": 2,
+          "ties": 1,
+          "wins": 1
+        },
+        "interaction": {
+          "confidence_interval": [
+            0.0,
+            1.0
+          ],
+          "losses": 0,
+          "mean": 0.5,
+          "n": 2,
+          "ties": 1,
+          "wins": 1
+        },
+        "joint_deployed_effect": {
+          "confidence_interval": [
+            1.0,
+            1.0
+          ],
+          "losses": 0,
+          "mean": 1.0,
+          "n": 2,
+          "ties": 0,
+          "wins": 2
+        }
+      },
+      "interference": {
+        "confidence_interval": [
+          -1.0,
+          0.0
+        ],
+        "losses": 1,
+        "mean": -0.5,
+        "n": 2,
+        "ties": 1,
+        "wins": 0
+      },
+      "resource_effects": {
+        "activated_skill_count": {
+          "confidence_interval": [
+            0.0,
+            0.0
+          ],
+          "losses": 0,
+          "mean": 0.0,
+          "n": 2,
+          "ties": 2,
+          "wins": 0
+        },
+        "catalog_tokens": {
+          "confidence_interval": [
+            4.0,
+            4.0
+          ],
+          "losses": 0,
+          "mean": 4.0,
+          "n": 2,
+          "ties": 0,
+          "wins": 2
+        },
+        "cost_usd": {
+          "confidence_interval": [
+            -0.0002,
+            -0.0001
+          ],
+          "losses": 2,
+          "mean": -0.00015,
+          "n": 2,
+          "ties": 0,
+          "wins": 0
+        },
+        "input_tokens": {
+          "confidence_interval": [
+            14.0,
+            34.0
+          ],
+          "losses": 0,
+          "mean": 24.0,
+          "n": 2,
+          "ties": 0,
+          "wins": 2
+        },
+        "latency_ms": {
+          "confidence_interval": [
+            -180.0,
+            -160.0
+          ],
+          "losses": 2,
+          "mean": -170.0,
+          "n": 2,
+          "ties": 0,
+          "wins": 0
+        },
+        "loaded_skill_tokens": {
+          "confidence_interval": [
+            -10.0,
+            30.0
+          ],
+          "losses": 1,
+          "mean": 10.0,
+          "n": 2,
+          "ties": 0,
+          "wins": 1
+        },
+        "output_tokens": {
+          "confidence_interval": [
+            -20.0,
+            -20.0
+          ],
+          "losses": 2,
+          "mean": -20.0,
+          "n": 2,
+          "ties": 0,
+          "wins": 0
+        }
+      }
+    }
+  ],
+  "negative_cases": 1,
+  "positive_cases": 1,
+  "run_manifest": {
+    "evaluation_protocol_fingerprint": "sha256:bbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbb",
+    "generated_at": "2026-08-30T00:00:00Z",
+    "generation_config": {
+      "max_output_tokens": 4096,
+      "temperature": 0.0,
+      "top_p": 1.0
+    },
+    "harness": "recorded-fixture",
+    "model": "recorded-fixture",
+    "new_body_fingerprint": "sha256:dddddddddddddddddddddddddddddddddddddddddddddddddddddddddddddddd",
+    "new_description_fingerprint": "sha256:ffffffffffffffffffffffffffffffffffffffffffffffffffffffffffffffff",
+    "old_body_fingerprint": "sha256:cccccccccccccccccccccccccccccccccccccccccccccccccccccccccccccccc",
+    "old_description_fingerprint": "sha256:eeeeeeeeeeeeeeeeeeeeeeeeeeeeeeeeeeeeeeeeeeeeeeeeeeeeeeeeeeeeeeee",
+    "repository_revision": "synthetic-recorded-fixture",
+    "task_set_fingerprint": "sha256:aaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaa"
+  },
+  "schema_version": 1,
+  "suite_id": "synthetic-library-aware-v1",
+  "target_skill": "spreadsheet-formula-repair"
+}

--- a/tests/test_skill_library_replay.py
+++ b/tests/test_skill_library_replay.py
@@ -293,6 +293,38 @@ def test_policy_rejects_negative_gain_and_resource_limits():
         validate_admission_policy(policy, suite)
 
 
+def test_bootstrap_bound_counts_every_reported_statistic():
+    suite = load_suite(BASELINE_PATH)
+    suite["metric_config"]["bootstrap_samples"] = 50_000
+    suite["cases"].append(
+        _copy_case(
+            suite["cases"][0],
+            suffix="work-bound",
+            task_fingerprint="sha256:" + "f" * 64,
+        )
+    )
+
+    with pytest.raises(LibraryReplayValidationError, match="bootstrap work"):
+        validate_suite(suite)
+
+
+def test_admission_work_is_included_in_bootstrap_bound():
+    suite = load_suite(BASELINE_PATH)
+    suite["metric_config"]["bootstrap_samples"] = 43_000
+    suite["cases"].append(
+        _copy_case(
+            suite["cases"][0],
+            suffix="admission-work-bound",
+            task_fingerprint="sha256:" + "f" * 64,
+        )
+    )
+    policy = json.loads(POLICY_PATH.read_text(encoding="utf-8"))
+
+    validate_suite(suite)
+    with pytest.raises(LibraryReplayValidationError, match="bootstrap work"):
+        validate_admission_policy(policy, suite)
+
+
 def test_admission_rejects_bad_absolute_activation_even_without_regression():
     suite, policy = _expanded_policy_suite()
     for case in suite["cases"]:

--- a/tests/test_skill_library_replay.py
+++ b/tests/test_skill_library_replay.py
@@ -10,10 +10,13 @@ import pytest
 
 from scripts.bench.skill_library_replay.evaluate import (
     LibraryReplayValidationError,
+    evaluate_admission,
     evaluate_suite,
+    load_admission_policy,
     load_suite,
     main,
     render_text,
+    validate_admission_policy,
     validate_suite,
 )
 
@@ -26,8 +29,59 @@ FIXTURE_DIR = (
 )
 BASELINE_PATH = FIXTURE_DIR / "baseline_v1.json"
 REPORT_PATH = FIXTURE_DIR / "baseline_v1.report.json"
+POLICY_PATH = FIXTURE_DIR / "admission_policy_v1.json"
 
 pytestmark = pytest.mark.algorithm_replay
+
+
+def _copy_case(
+    case: dict,
+    *,
+    suffix: str,
+    task_fingerprint: str | None = None,
+    seed: int | None = None,
+) -> dict:
+    copied = deepcopy(case)
+    copied["case_id"] = f"{case['case_id']}-{suffix}"
+    if task_fingerprint is not None:
+        copied["task_fingerprint"] = task_fingerprint
+    if seed is not None:
+        copied["seed"] = seed
+
+    def rewrite_run_ids(value):
+        if isinstance(value, dict):
+            if "run_id" in value:
+                value["run_id"] = f"{value['run_id']}-{suffix}"
+            for nested in value.values():
+                rewrite_run_ids(nested)
+        elif isinstance(value, list):
+            for nested in value:
+                rewrite_run_ids(nested)
+
+    rewrite_run_ids(copied)
+    return copied
+
+
+def _expanded_policy_suite() -> tuple[dict, dict]:
+    suite = load_suite(BASELINE_PATH)
+    originals = list(suite["cases"])
+    for index in range(1, 25):
+        suite["cases"].append(
+            _copy_case(
+                originals[0],
+                suffix=f"positive-copy-{index}",
+                task_fingerprint=f"sha256:{index + 2:064x}",
+            )
+        )
+        suite["cases"].append(
+            _copy_case(
+                originals[1],
+                suffix=f"negative-copy-{index}",
+                task_fingerprint=f"sha256:{index + 26:064x}",
+            )
+        )
+    policy = load_admission_policy(POLICY_PATH, suite)
+    return suite, policy
 
 
 def test_baseline_report_matches_checked_in_snapshot():
@@ -76,6 +130,207 @@ def test_library_curve_retains_resource_and_distractor_context():
         "harmful_activation": 1,
         "wrong_skill_activation": 1,
     }
+
+
+def test_effect_confidence_intervals_cluster_repeated_seeds_by_task():
+    suite = load_suite(BASELINE_PATH)
+    originals = list(suite["cases"])
+    suite["cases"].extend(
+        _copy_case(case, suffix="seed-8", seed=8) for case in originals
+    )
+
+    effect = evaluate_suite(suite)["library_curve"][0]["factorial_effects"][
+        "joint_deployed_effect"
+    ]
+
+    assert effect["n"] == 4
+    assert effect["tasks"] == 2
+    assert effect["wins"] == 2
+
+
+def test_every_task_must_use_the_same_seed_set():
+    suite = load_suite(BASELINE_PATH)
+    suite["cases"].append(_copy_case(suite["cases"][0], suffix="seed-8", seed=8))
+
+    with pytest.raises(LibraryReplayValidationError, match="same seed set"):
+        validate_suite(suite)
+
+
+def test_activation_label_must_be_stable_across_task_seeds():
+    suite = load_suite(BASELINE_PATH)
+    copied = _copy_case(suite["cases"][0], suffix="seed-8", seed=8)
+    copied["should_activate"] = False
+    suite["cases"].append(copied)
+
+    with pytest.raises(LibraryReplayValidationError, match="stable across seeds"):
+        validate_suite(suite)
+
+
+def test_small_synthetic_fixture_is_inconclusive_under_registered_policy():
+    suite = load_suite(BASELINE_PATH)
+    policy = load_admission_policy(POLICY_PATH, suite)
+
+    admission = evaluate_admission(suite, policy)
+
+    assert admission["status"] == "inconclusive"
+    assert admission["reasons"][:3] == [
+        "minimum_paired_tasks",
+        "minimum_positive_tasks",
+        "minimum_negative_tasks",
+    ]
+
+
+def test_admission_requires_all_pre_registered_effect_and_harm_gates():
+    suite, policy = _expanded_policy_suite()
+
+    admission = evaluate_admission(suite, policy)
+
+    assert admission["status"] == "admit"
+    assert admission["reasons"] == []
+    assert all(gate["status"] == "pass" for gate in admission["gates"])
+    assert (
+        admission["effects"]["candidate_positive_task_activation_rate"][
+            "confidence_interval"
+        ][0]
+        < 1
+    )
+    assert (
+        admission["effects"]["candidate_negative_task_activation_rate"][
+            "confidence_interval"
+        ][1]
+        > 0
+    )
+
+
+def test_admission_rejects_complete_evidence_below_minimum_gain():
+    suite, policy = _expanded_policy_suite()
+    for case in suite["cases"]:
+        level = next(
+            level
+            for level in case["libraries"]
+            if level["distractor_count"] == policy["primary_distractor_count"]
+        )
+        cells = level["deployed"]
+        cells[policy["candidate_cell"]]["score"] = cells["old_body__old_description"][
+            "score"
+        ]
+
+    admission = evaluate_admission(suite, policy)
+
+    assert admission["status"] == "reject"
+    assert "minimum_score_gain" in admission["reasons"]
+
+
+def test_non_evaluable_errors_make_admission_inconclusive():
+    suite, policy = _expanded_policy_suite()
+    suite["cases"][0]["libraries"][1]["deployed"][policy["candidate_cell"]][
+        "error_type"
+    ] = "infrastructure_failure"
+
+    admission = evaluate_admission(suite, policy)
+
+    assert admission["status"] == "inconclusive"
+    assert "non_evaluable_errors" in admission["reasons"]
+
+
+def test_policy_must_be_registered_before_recorded_results():
+    suite = load_suite(BASELINE_PATH)
+    policy = json.loads(POLICY_PATH.read_text(encoding="utf-8"))
+    policy["registered_at"] = suite["run_manifest"]["generated_at"]
+
+    with pytest.raises(LibraryReplayValidationError, match="earlier"):
+        validate_admission_policy(policy, suite)
+
+
+def test_policy_must_bind_the_selected_library_snapshot():
+    suite = load_suite(BASELINE_PATH)
+    policy = json.loads(POLICY_PATH.read_text(encoding="utf-8"))
+    policy["primary_distractor_catalog_fingerprint"] = "sha256:" + "8" * 64
+
+    with pytest.raises(LibraryReplayValidationError, match="selected library level"):
+        validate_admission_policy(policy, suite)
+
+
+def test_policy_must_bind_the_candidate_skill_versions():
+    suite = load_suite(BASELINE_PATH)
+    policy = json.loads(POLICY_PATH.read_text(encoding="utf-8"))
+    policy["new_body_fingerprint"] = "sha256:" + "8" * 64
+
+    with pytest.raises(LibraryReplayValidationError, match="new_body_fingerprint"):
+        validate_admission_policy(policy, suite)
+
+
+def test_policy_cannot_use_the_deployed_baseline_as_candidate():
+    suite = load_suite(BASELINE_PATH)
+    policy = json.loads(POLICY_PATH.read_text(encoding="utf-8"))
+    policy["candidate_cell"] = "old_body__old_description"
+
+    with pytest.raises(LibraryReplayValidationError, match="candidate_cell"):
+        validate_admission_policy(policy, suite)
+
+
+def test_policy_rejects_vacuous_score_and_activation_thresholds():
+    suite = load_suite(BASELINE_PATH)
+    policy = json.loads(POLICY_PATH.read_text(encoding="utf-8"))
+    policy["maximum_negative_false_positive_rate_increase"] = 1.1
+
+    with pytest.raises(LibraryReplayValidationError, match=r"within \[0, 1\]"):
+        validate_admission_policy(policy, suite)
+
+
+def test_policy_rejects_negative_gain_and_resource_limits():
+    suite = load_suite(BASELINE_PATH)
+    policy = json.loads(POLICY_PATH.read_text(encoding="utf-8"))
+    policy["minimum_score_gain"] = -0.1
+
+    with pytest.raises(LibraryReplayValidationError, match="finite number >= 0"):
+        validate_admission_policy(policy, suite)
+
+    policy = json.loads(POLICY_PATH.read_text(encoding="utf-8"))
+    policy["resource_increase_limits"]["cost_usd"] = -0.1
+
+    with pytest.raises(LibraryReplayValidationError, match="finite number >= 0"):
+        validate_admission_policy(policy, suite)
+
+
+def test_admission_rejects_bad_absolute_activation_even_without_regression():
+    suite, policy = _expanded_policy_suite()
+    for case in suite["cases"]:
+        level = next(
+            level
+            for level in case["libraries"]
+            if level["distractor_count"] == policy["primary_distractor_count"]
+        )
+        for cell in ("old_body__old_description", policy["candidate_cell"]):
+            level["deployed"][cell]["target_activated"] = False
+            level["deployed"][cell]["activated_skills"] = []
+
+    admission = evaluate_admission(suite, policy)
+
+    assert admission["status"] == "reject"
+    assert "minimum_candidate_positive_task_activation_rate" in admission["reasons"]
+    assert "maximum_positive_recall_drop" not in admission["reasons"]
+
+
+def test_admission_rejects_absolute_false_activations_without_regression():
+    suite, policy = _expanded_policy_suite()
+    for case in suite["cases"]:
+        if case["should_activate"]:
+            continue
+        level = next(
+            level
+            for level in case["libraries"]
+            if level["distractor_count"] == policy["primary_distractor_count"]
+        )
+        for cell in ("old_body__old_description", policy["candidate_cell"]):
+            level["deployed"][cell]["target_activated"] = True
+            level["deployed"][cell]["activated_skills"] = [suite["target_skill"]]
+
+    admission = evaluate_admission(suite, policy)
+
+    assert admission["status"] == "reject"
+    assert "maximum_candidate_negative_task_activation_rate" in admission["reasons"]
+    assert "maximum_negative_false_positive_rate_increase" not in admission["reasons"]
 
 
 def report_level(distractor_count: int) -> dict:
@@ -209,3 +464,24 @@ def test_cli_renders_text_and_json(capsys):
     assert capsys.readouterr().out == render_text(report) + "\n"
     assert main([str(BASELINE_PATH), "--format", "json"]) == 0
     assert json.loads(capsys.readouterr().out) == report
+
+    assert main([str(BASELINE_PATH), "--policy", str(POLICY_PATH)]) == 0
+    policy_text = capsys.readouterr().out
+    assert "status: inconclusive" in policy_text
+
+    assert (
+        main(
+            [
+                str(BASELINE_PATH),
+                "--policy",
+                str(POLICY_PATH),
+                "--format",
+                "json",
+            ]
+        )
+        == 0
+    )
+    policy_report = json.loads(capsys.readouterr().out)
+    assert policy_report["admission"]["policy_id"] == (
+        "synthetic-library-admission-policy-v1"
+    )

--- a/tests/test_skill_library_replay.py
+++ b/tests/test_skill_library_replay.py
@@ -1,0 +1,211 @@
+"""Contracts for the deterministic library-aware Skill replay evaluator."""
+
+from __future__ import annotations
+
+import json
+from copy import deepcopy
+from pathlib import Path
+
+import pytest
+
+from scripts.bench.skill_library_replay.evaluate import (
+    LibraryReplayValidationError,
+    evaluate_suite,
+    load_suite,
+    main,
+    render_text,
+    validate_suite,
+)
+
+FIXTURE_DIR = (
+    Path(__file__).parent.parent
+    / "scripts"
+    / "bench"
+    / "skill_library_replay"
+    / "fixtures"
+)
+BASELINE_PATH = FIXTURE_DIR / "baseline_v1.json"
+REPORT_PATH = FIXTURE_DIR / "baseline_v1.report.json"
+
+pytestmark = pytest.mark.algorithm_replay
+
+
+def test_baseline_report_matches_checked_in_snapshot():
+    report = evaluate_suite(load_suite(BASELINE_PATH))
+
+    assert report == json.loads(REPORT_PATH.read_text(encoding="utf-8"))
+
+
+def test_factorial_replay_separates_body_description_and_joint_effects():
+    report = evaluate_suite(load_suite(BASELINE_PATH))
+    effects = report["library_curve"][0]["factorial_effects"]
+
+    assert report["isolated"]["body_effect"]["mean"] == 0.5
+    assert report["isolated"]["positive_body_effect"]["mean"] == 1.0
+    assert report["isolated"]["negative_body_effect"]["mean"] == 0.0
+    assert effects["body_at_old_description"]["mean"] == 0.0
+    assert effects["description_at_old_body"]["mean"] == 0.5
+    assert effects["joint_deployed_effect"]["mean"] == 1.0
+    assert effects["interaction"]["mean"] == 0.5
+    assert report["library_curve"][0]["interference"]["mean"] == -0.5
+
+
+def test_activation_metrics_do_not_hide_positive_and_negative_cancellation():
+    activation = report_level(0)["activation_effects"]
+
+    assert activation["target_activation_delta"]["mean"] == 0.0
+    assert activation["positive_recall_delta"]["mean"] == 1.0
+    assert activation["negative_false_positive_rate_delta"]["mean"] == -1.0
+
+
+def test_library_curve_retains_resource_and_distractor_context():
+    level = report_level(2)
+
+    assert level["distractor_skills"] == [
+        "spreadsheet-formatting",
+        "spreadsheet-charting",
+    ]
+    assert level["resource_effects"]["catalog_tokens"]["mean"] == 4.0
+    assert level["resource_effects"]["cost_usd"]["mean"] == -0.00015
+    old_cell = level["cells"]["old_body__old_description"]
+    assert old_cell["activated_skill_counts"] == {
+        "spreadsheet-formula-repair": 1,
+        "spreadsheet-formatting": 1,
+    }
+    assert old_cell["error_types"] == {
+        "harmful_activation": 1,
+        "wrong_skill_activation": 1,
+    }
+
+
+def report_level(distractor_count: int) -> dict:
+    report = evaluate_suite(load_suite(BASELINE_PATH))
+    return next(
+        level
+        for level in report["library_curve"]
+        if level["distractor_count"] == distractor_count
+    )
+
+
+def test_missing_factorial_cell_fails_loudly():
+    suite = load_suite(BASELINE_PATH)
+    del suite["cases"][0]["libraries"][0]["deployed"]["new_body__new_description"]
+
+    with pytest.raises(LibraryReplayValidationError, match="expected exactly"):
+        validate_suite(suite)
+
+
+def test_each_case_must_cover_the_same_library_ladder():
+    suite = load_suite(BASELINE_PATH)
+    suite["cases"][0]["libraries"][1]["distractor_count"] = 1
+
+    with pytest.raises(
+        LibraryReplayValidationError, match="expected distractor counts"
+    ):
+        validate_suite(suite)
+
+
+def test_library_ladder_must_include_zero_distractor_control():
+    suite = load_suite(BASELINE_PATH)
+    suite["library_ladder"] = suite["library_ladder"][1:]
+    for case in suite["cases"]:
+        case["libraries"] = case["libraries"][1:]
+
+    with pytest.raises(LibraryReplayValidationError, match="must start"):
+        validate_suite(suite)
+
+
+def test_library_growth_must_preserve_distractor_order():
+    suite = load_suite(BASELINE_PATH)
+    suite["library_ladder"].insert(
+        1,
+        {
+            "distractor_count": 1,
+            "distractor_catalog_fingerprint": (
+                "sha256:8888888888888888888888888888888888888888888888888888888888888888"
+            ),
+            "distractor_skills": ["spreadsheet-charting"],
+        },
+    )
+    for case in suite["cases"]:
+        copied = deepcopy(case["libraries"][1])
+        copied["distractor_count"] = 1
+        case["libraries"].insert(1, copied)
+
+    with pytest.raises(LibraryReplayValidationError, match="retain prior order"):
+        validate_suite(suite)
+
+
+def test_target_activation_flag_must_match_recorded_skill_sequence():
+    suite = load_suite(BASELINE_PATH)
+    observation = suite["cases"][0]["libraries"][0]["deployed"][
+        "new_body__new_description"
+    ]
+    observation["target_activated"] = False
+
+    with pytest.raises(LibraryReplayValidationError, match="disagrees"):
+        validate_suite(suite)
+
+
+def test_deployed_activation_cannot_reference_skill_outside_catalog():
+    suite = load_suite(BASELINE_PATH)
+    observation = suite["cases"][0]["libraries"][1]["deployed"][
+        "old_body__old_description"
+    ]
+    observation["activated_skills"] = ["unlisted-skill"]
+
+    with pytest.raises(LibraryReplayValidationError, match="unknown skills"):
+        validate_suite(suite)
+
+
+def test_isolated_run_must_force_only_the_target_skill():
+    suite = load_suite(BASELINE_PATH)
+    suite["cases"][0]["isolated"]["old_body"]["activated_skills"] = []
+    suite["cases"][0]["isolated"]["old_body"]["target_activated"] = False
+
+    with pytest.raises(LibraryReplayValidationError, match="force only target_skill"):
+        validate_suite(suite)
+
+
+def test_duplicate_run_id_fails_loudly():
+    suite = load_suite(BASELINE_PATH)
+    duplicate = suite["cases"][0]["isolated"]["old_body"]["run_id"]
+    suite["cases"][0]["isolated"]["new_body"]["run_id"] = duplicate
+
+    with pytest.raises(LibraryReplayValidationError, match="duplicate"):
+        validate_suite(suite)
+
+
+def test_old_and_new_artifact_fingerprints_must_differ():
+    suite = load_suite(BASELINE_PATH)
+    manifest = suite["run_manifest"]
+    manifest["new_description_fingerprint"] = manifest["old_description_fingerprint"]
+
+    with pytest.raises(LibraryReplayValidationError, match="must differ"):
+        validate_suite(suite)
+
+
+@pytest.mark.parametrize("score", [True, -0.1, 1.1, "1.0"])
+def test_invalid_outcome_score_fails_loudly(score):
+    suite = load_suite(BASELINE_PATH)
+    suite["cases"][0]["isolated"]["old_body"]["score"] = score
+
+    with pytest.raises(LibraryReplayValidationError, match="score"):
+        validate_suite(suite)
+
+
+def test_suite_requires_positive_and_negative_activation_cases():
+    suite = load_suite(BASELINE_PATH)
+    suite["cases"] = [suite["cases"][0]]
+
+    with pytest.raises(LibraryReplayValidationError, match="positive and negative"):
+        validate_suite(suite)
+
+
+def test_cli_renders_text_and_json(capsys):
+    report = evaluate_suite(load_suite(BASELINE_PATH))
+
+    assert main([str(BASELINE_PATH)]) == 0
+    assert capsys.readouterr().out == render_text(report) + "\n"
+    assert main([str(BASELINE_PATH), "--format", "json"]) == 0
+    assert json.loads(capsys.readouterr().out) == report


### PR DESCRIPTION
## Summary

在 #381 的库感知 2×2 回放基础上增加预注册、固定候选的 shadow admission policy，避免查看 held-out 结果后再选择候选或调整阈值。

本 PR 只输出 `admit`、`reject` 或 `inconclusive` 建议，不修改生产 Canary 或发布行为。

依赖并应在 #381 合并后再合并，届时本 PR 会只保留准入策略增量。

## Changes

- 增加严格的策略 JSON 契约，并绑定 suite、任务集、评测协议、候选版本和竞争库指纹。
- 将重复 seed 先聚合到 Task，再按 Task 做 clustered bootstrap，并验证统一 seed 集和稳定激活标签。
- 增加 score、正例 recall、负例误触发率、loaded Skill Token、费用、延迟和不可评测错误门禁。
- 同时检查激活质量的绝对水平与相对变化，避免一个原本已很差但没有继续退化的候选通过。
- 增加确定性 fixture、报告快照、CLI 输出和失败关闭测试。

## Test plan

- [x] `make test` passes（通过项目虚拟环境覆盖本机缺失的 `python3.11`：2769 passed, 10 skipped）
- [x] Added/updated unit tests for the change（34 passed）
- [ ] `make e2e` passes (if the change touches ingestion / install / daemon)
- [x] Manually verified the affected user flow（使用 fixture 与预注册策略运行 replay CLI）

## Linked issues

Closes #386

Depends on #381

## 给外人看的背景（库准入策略评测是什么）

下面按给第三方看的问题单来写：每个词第一次出现都会说明它是什么。代码位置只是提示，不是必须先读完整个仓库才能看懂。

### 这是什么

XSkill 会改已经在用的技能。一次改动里，常常同时动两块。一块是正文：`SKILL.md` 里教助手怎么做的那份说明书。一块是激活描述：什么时候该把这份说明书拿出来用。技能也不是单独待着的。运行时旁边还有别的技能在抢注意力，这些旁边的技能组成竞争库。

#381 已经能把这三件事拆开看。同一批任务、同一组随机种子、同一份竞争库，分别回放旧正文和新正文、旧描述和新描述，一共四个组合。这叫库感知 2×2 回放。它只出诊断数字：正文自己有没有变好、描述有没有帮上忙、库里会不会互相挤占。它不回答「这个候选该不该进入下一步」。

本 PR 是 Q2 准入。它在 #381 的回放上面加一层事先写好的规则，叫预注册准入策略。预注册的意思是：在打开评测结果之前，先把要比的是哪一格、门槛是多少、跟哪一套任务和协议绑定，写进一份独立的策略文件并钉死。评测器再拿这份文件去对照已经录好的结果，只给出三种建议。admit 表示证据完整且门禁全过，建议收下这个候选。reject 表示证据完整但有门禁没过，建议不要收下。inconclusive 表示样本不够、区间算不出来，或出现事先声明过的基础设施错误，这时不能假装已经否决。

这层建议是 shadow 的。shadow 的意思是：只出建议，不改生产 Canary，不改发布，也不改现网流量。Canary 是现有的灰度对比晋升路径：主干上是旧版，灰度分支上是新版，对比后再决定升不升。本 PR 不接入那条路径。

### 为什么要先固定门槛再看结果

评测用的那批结果叫 held-out：事先留出来，评测时才打开。如果先看这批结果，再从四个组合里挑分数最高的那一格，或者看完数字再把门槛往对自己有利的方向挪，这个数字就不能当成「事先说好的规则下，这个候选好不好」。issue #386 把这种做法叫选择偏差。

所以规则必须先固定，再看结果。策略文件里的候选单元、最小任务数、分数增益、正例该触发的比例、负例不该误触发的比例、已加载技能 Token、费用、延迟、哪些错误算不可评测，都要在录制结果产生之前写好。策略上的注册时间必须早于这批结果的生成时间。指纹对不上、时间反了、多了未知字段，评测器直接失败，不给一个看起来像结论的数字。

四个组合里，旧正文配旧描述是对照基线，不能当成候选。剩下三格里，策略只能事先指定一格。如果诊断发现另一格其实更好，不能在同一批 held-out 上改选。应把它当作新候选，换一批还没看过的确认集再评一次。

### 评测侧实际在看什么

没有用户界面变化。这是给审阅者和实验的人用的离线命令。人不调用大模型，也不碰生产状态。先有一份已经录好的回放套件，再挂上一份预注册策略。输出里能看到候选是哪一格、每一条门禁的观测值、阈值、过没过，以及最后是 admit、reject 还是 inconclusive。

门禁同时看绝对水平和相对变化。相对变化是：和旧正文配旧描述相比，分数有没有升够、正例召回有没有掉、负例误触发有没有升、Token、费用、延迟有没有涨过上限。绝对水平是：这个候选自己，正例任务够不够经常触发、负例任务会不会误触发。一个本来就很差、只是没有更差的候选，相对变化可能看起来还行，但过不了绝对门槛。

同一任务如果录了多个随机种子，先收到这个任务里再平均，再按任务做聚类抽样。不能把多个种子当成彼此独立的任务，否则样本多的任务会占更大权重，区间也会偏窄。每个任务必须用同一组种子，激活标签跨种子不能变。

样本不足、子集区间算不出、出现预声明的基础设施错误时，结论是 inconclusive，不能装成 reject。证据齐且门禁全过，才是 admit。证据齐但有门禁失败，才是 reject。入仓的是合成 fixture，用来锁契约和决策方向，不是真实任务文本，也不能冒充原生 Harness 已经跑过。

### 必须先等 #381

没有 #381，本 PR 没有可对照的回放套件。#381 负责把 2×2 诊断回放送进来：固定任务、协议、正文、描述、模型和竞争库，算出隔离正文效应、库内部署效应、交互项、激活质量和资源变化。本 PR 不重做那一层，只在那一层上面钉候选、钉门槛、给出三种结论。

两边现在改了大量同一文件，因为这张 PR 是从带 #381 的分支开出来的。必须等 #381 先合进主干。合完之后，这张 PR 应只留下准入增量：策略文件、评测器上的策略校验和三态结论、对应测试和说明。不要把 2×2 诊断本身再审一遍。

### 本 PR 具体改哪

增加一份严格的策略 JSON。绑定套件、目标技能、任务集、评分协议、旧新正文、旧新描述、主竞争库层级和目录指纹。运行前固定一个候选单元。

重复种子先聚合到任务，再按任务做 clustered bootstrap，并检查统一种子集和稳定激活标签。

增加分数、正例召回、负例误触发率、已加载技能 Token、费用、延迟和不可评测错误这些门禁。同时检查激活质量的绝对水平与相对变化。

增加确定性 fixture、报告快照、命令行输出和失败关闭测试。合成数据只证明评测器能按事先写好的规则给出建议。

### 不要和什么搞混

不要和 #381 搞混。#381 是 2×2 诊断回放，回答「正文和描述各自贡献了什么」。本 PR 是准入政策，回答「事先钉死的那一个候选，在事先钉死的门槛下，建议收下、建议拒绝，还是证据不够下不了结论」。两件事叠在同一套回放文件上，但不是同一问。

不要和生产 Canary 搞混。Canary 是线上灰度对比后决定升不升主干。本 PR 的结论只是 shadow 建议，不改 Canary，不改描述优化器，不改发布，也不改现网。Agent 接触不到格力内网现网。这张补丁只进评测脚本和测试。

不要和后面的 Q3 搞混。Q3 问的是：同一个已经过了这道准入的更新，换一组任务场景、换一个模型、换一种运行环境，会不会好处和坏处反过来，以及按组发布会不会比全局晋升或拒绝更少误伤。本 PR 不替代那一步。

### 怎么算这段背景对齐了

能说出必须先有 #381 的 2×2 回放，本 PR 才有东西可准入。能说出预注册是先写门槛和候选，再打开 held-out，不能看完再改阈值。能说出三种结论分别是收下、拒绝、证据不够。能说出 shadow 只出建议，不改生产 Canary 和现网。能说出 #381 合完后这张 PR 应只留准入增量。
