### PR TITLE
test(canary): add cohort-scoped publication replay

### DIFF
--- a/scripts/bench/cohort_canary_replay/README.md
+++ b/scripts/bench/cohort_canary_replay/README.md
@@ -28,6 +28,8 @@ python -m scripts.bench.cohort_canary_replay.evaluate scripts/bench/cohort_canar
 
 每个 Task 先平均自己的多个 seed，再对 Task 做 paired clustered bootstrap，避免把重复 seed 当成独立样本。
 
+全局效应先按 Task 对齐各 cohort 的 delta 并应用流量权重，再联合重采样同一批 Task，避免独立重采样各 cohort 后破坏配对关系。
+
 同一个 update 的 cohort 区间使用 Bonferroni family-wise 修正，只有修正区间完全高于正 practical margin 时才是 `supported_positive`，完全低于负 margin 时才是 `supported_negative`，其余情况均为 `unresolved`。
 
 只有一个 update 同时具有至少一个可靠正 cohort 和一个可靠负 cohort 时才记录 supported sign reversal，点估计方向不同不足以成立。

--- a/scripts/bench/cohort_canary_replay/README.md
+++ b/scripts/bench/cohort_canary_replay/README.md
@@ -1,0 +1,43 @@
+# Cohort-scoped publication 离线回放
+
+这套评测器用于回答 Q3 的第一个可检验问题：同一个已经通过固定库准入的 Skill 更新，在预声明的模型、任务场景和原生 Runtime cohort 中是否出现可靠的正负反向效果，以及 cohort-scoped publication 是否比一个全局发布决定更安全。
+
+评测器只读取不可变的 old/new 配对结果，不调用 LLM、Harness、Git、网络或 xskill 生产 Canary，因此普通 CI 可以确定性复算统计结果和版本选择。
+
+运行合成契约基线：
+
+```bash
+python -m scripts.bench.cohort_canary_replay.evaluate scripts/bench/cohort_canary_replay/fixtures/baseline_v1.json
+```
+
+使用 `--format json` 可以输出机器可读报告。
+
+## 数据契约
+
+每个 cohort 由 `scenario × model × runtime` 三元组唯一标识，并具有预声明且总和为一的流量权重。
+
+每个 candidate update 固定 old/new Skill 指纹和激活控制方式，并在每个 cohort 中分别记录预注册的 `decision` 与 `evaluation` Task 集及其 old/new 配对 outcome。
+
+`decision` 集只用于决定各 cohort 是否选择新版本，`evaluation` 集只用于在选择冻结后计算 policy gain、harmful promotion 和 oracle gap，从而避免使用同一批 outcome 既选版本又证明收益。
+
+一个 outcome 记录 `[0, 1]` score、是否通过、费用、延迟和可选错误类型，fixture 不保存任务文本、模型输出、轨迹原文、workspace 路径或用户标识。
+
+同一 update、cohort 与数据角色内的每个 Task 必须使用相同 seed 集，所有 cohort 必须共享同一 Task×seed 矩阵，`decision` 与 `evaluation` Task 集必须互斥且都至少包含两个 Task，违反这些条件或出现重复 run id、重复 role/Task/seed、非有限数值和未知字段都会明确失败。
+
+## 统计与判定
+
+每个 Task 先平均自己的多个 seed，再对 Task 做 paired clustered bootstrap，避免把重复 seed 当成独立样本。
+
+同一个 update 的 cohort 区间使用 Bonferroni family-wise 修正，只有修正区间完全高于正 practical margin 时才是 `supported_positive`，完全低于负 margin 时才是 `supported_negative`，其余情况均为 `unresolved`。
+
+只有一个 update 同时具有至少一个可靠正 cohort 和一个可靠负 cohort 时才记录 supported sign reversal，点估计方向不同不足以成立。
+
+全局策略根据 `decision` 集的流量加权 old/new 效果只选择一个版本，scoped 策略仅在 `decision` 集具有可靠正证据的 cohort 发布新版本，并在负向或未决 cohort 保留旧版本。
+
+报告同时保留两个数据角色上的 score 与 Pass Rate 配对效果、全局与 scoped 选择，以及仅由 held-out `evaluation` 集计算的加权 policy gain、观测到的有害晋升、并存版本数、oracle value 和评测成本。
+
+## 结论边界
+
+入仓的合成 fixture 只验证 schema、Task-clustered 统计、反向效果判定和 global/scoped 策略比较能够工作，不能证明真实流量中已经存在反向效果或 scoped publication 已经提高收益。
+
+当前 PR 不修改生产 `canary.py`、main/staging Git 分支、安装同步、Dashboard 或真实流量路由，后续必须先使用原生 Runtime 保存的真实配对矩阵验证 Q3 假设，再考虑实现 cohort version map。

--- a/scripts/bench/cohort_canary_replay/__init__.py
+++ b/scripts/bench/cohort_canary_replay/__init__.py
@@ -1,0 +1,1 @@
+"""Deterministic replay for cohort-scoped Skill publication decisions."""

--- a/scripts/bench/cohort_canary_replay/evaluate.py
+++ b/scripts/bench/cohort_canary_replay/evaluate.py
@@ -1,0 +1,1070 @@
+"""Evaluate immutable old/new Skill outcomes across deployment cohorts.
+
+The evaluator is deliberately offline: it validates a recorded matrix, computes
+Task-clustered paired effects, and compares global with cohort-scoped publication
+without reading production Canary state or invoking a model, Harness, Git, or the
+network.
+"""
+
+from __future__ import annotations
+
+import argparse
+import hashlib
+import json
+import math
+import random
+import re
+from collections import Counter
+from pathlib import Path
+from typing import Any, Callable
+
+SCHEMA_VERSION = 1
+_FINGERPRINT_RE = re.compile(r"sha256:[0-9a-f]{64}\Z")
+_ACTIVATION_CONTROLS = {"forced", "matched"}
+_DECISION_METRICS = {"score", "pass_rate"}
+_OBSERVATION_ROLES = {"decision", "evaluation"}
+_FAMILYWISE_METHOD = "bonferroni"
+_MAX_WORK_UNITS = 5_000_000
+
+
+class CohortReplayValidationError(ValueError):
+    """Raised when an immutable replay suite violates its data contract."""
+
+
+def _require(mapping: dict[str, Any], key: str, expected: type, context: str) -> Any:
+    if key not in mapping:
+        raise CohortReplayValidationError(
+            f"{context}: missing required field {key!r}"
+        )
+    value = mapping[key]
+    if expected is int and isinstance(value, bool):
+        raise CohortReplayValidationError(f"{context}.{key}: expected int")
+    if not isinstance(value, expected):
+        raise CohortReplayValidationError(
+            f"{context}.{key}: expected {expected.__name__}"
+        )
+    return value
+
+
+def _require_string(mapping: dict[str, Any], key: str, context: str) -> str:
+    value = _require(mapping, key, str, context)
+    if not value.strip():
+        raise CohortReplayValidationError(
+            f"{context}.{key}: expected a non-empty string"
+        )
+    return value
+
+
+def _require_number(
+    mapping: dict[str, Any],
+    key: str,
+    context: str,
+    *,
+    minimum: float | None = None,
+    maximum: float | None = None,
+) -> float:
+    if key not in mapping:
+        raise CohortReplayValidationError(
+            f"{context}: missing required field {key!r}"
+        )
+    value = mapping[key]
+    if isinstance(value, bool) or not isinstance(value, (int, float)):
+        raise CohortReplayValidationError(f"{context}.{key}: expected a number")
+    number = float(value)
+    if not math.isfinite(number):
+        raise CohortReplayValidationError(
+            f"{context}.{key}: expected a finite number"
+        )
+    if minimum is not None and number < minimum:
+        raise CohortReplayValidationError(
+            f"{context}.{key}: expected a number >= {minimum:g}"
+        )
+    if maximum is not None and number > maximum:
+        raise CohortReplayValidationError(
+            f"{context}.{key}: expected a number <= {maximum:g}"
+        )
+    return number
+
+
+def _require_exact_keys(
+    mapping: dict[str, Any], expected: set[str], context: str
+) -> None:
+    if set(mapping) == expected:
+        return
+    missing = sorted(expected - set(mapping))
+    unknown = sorted(set(mapping) - expected)
+    raise CohortReplayValidationError(
+        f"{context}: keys do not match schema; missing={missing}, unknown={unknown}"
+    )
+
+
+def _validate_fingerprint(value: Any, context: str) -> None:
+    if not isinstance(value, str) or _FINGERPRINT_RE.fullmatch(value) is None:
+        raise CohortReplayValidationError(
+            f"{context}: expected sha256 followed by 64 lowercase hex characters"
+        )
+
+
+def _validate_outcome(
+    outcome: Any,
+    *,
+    context: str,
+    run_ids: set[str],
+) -> None:
+    if not isinstance(outcome, dict):
+        raise CohortReplayValidationError(f"{context}: expected an object")
+    _require_exact_keys(
+        outcome,
+        {"run_id", "score", "passed", "cost_usd", "latency_ms", "error_type"},
+        context,
+    )
+    run_id = _require_string(outcome, "run_id", context)
+    if run_id in run_ids:
+        raise CohortReplayValidationError(f"{context}.run_id: duplicate {run_id!r}")
+    run_ids.add(run_id)
+    _require_number(outcome, "score", context, minimum=0.0, maximum=1.0)
+    _require(outcome, "passed", bool, context)
+    _require_number(outcome, "cost_usd", context, minimum=0.0)
+    _require_number(outcome, "latency_ms", context, minimum=0.0)
+    error_type = outcome["error_type"]
+    if error_type is not None and (
+        not isinstance(error_type, str) or not error_type.strip()
+    ):
+        raise CohortReplayValidationError(
+            f"{context}.error_type: expected null or a non-empty string"
+        )
+
+
+def validate_suite(suite: Any) -> None:
+    """Validate one cohort replay suite without changing it."""
+    if not isinstance(suite, dict):
+        raise CohortReplayValidationError("suite: expected an object")
+    _require_exact_keys(
+        suite,
+        {
+            "schema_version",
+            "suite_id",
+            "metric_config",
+            "run_manifest",
+            "cohorts",
+            "updates",
+        },
+        "suite",
+    )
+    version = _require(suite, "schema_version", int, "suite")
+    if version != SCHEMA_VERSION:
+        raise CohortReplayValidationError(
+            f"suite.schema_version: supported={SCHEMA_VERSION}, got={version}"
+        )
+    _require_string(suite, "suite_id", "suite")
+
+    metric = _require(suite, "metric_config", dict, "suite")
+    _require_exact_keys(
+        metric,
+        {
+            "bootstrap_samples",
+            "bootstrap_seed",
+            "confidence_level",
+            "familywise_method",
+            "practical_margin",
+            "decision_metric",
+            "non_evaluable_error_types",
+        },
+        "suite.metric_config",
+    )
+    bootstrap_samples = _require(
+        metric, "bootstrap_samples", int, "suite.metric_config"
+    )
+    if bootstrap_samples < 100:
+        raise CohortReplayValidationError(
+            "suite.metric_config.bootstrap_samples: must be >= 100"
+        )
+    _require(metric, "bootstrap_seed", int, "suite.metric_config")
+    confidence = _require_number(
+        metric,
+        "confidence_level",
+        "suite.metric_config",
+        minimum=0.5,
+        maximum=0.999,
+    )
+    if confidence <= 0.5:
+        raise CohortReplayValidationError(
+            "suite.metric_config.confidence_level: must be > 0.5"
+        )
+    familywise_method = _require_string(
+        metric, "familywise_method", "suite.metric_config"
+    )
+    if familywise_method != _FAMILYWISE_METHOD:
+        raise CohortReplayValidationError(
+            "suite.metric_config.familywise_method: only 'bonferroni' is supported"
+        )
+    margin = _require_number(
+        metric,
+        "practical_margin",
+        "suite.metric_config",
+        minimum=0.0,
+        maximum=1.0,
+    )
+    if margin <= 0:
+        raise CohortReplayValidationError(
+            "suite.metric_config.practical_margin: must be > 0"
+        )
+    decision_metric = _require_string(
+        metric, "decision_metric", "suite.metric_config"
+    )
+    if decision_metric not in _DECISION_METRICS:
+        raise CohortReplayValidationError(
+            "suite.metric_config.decision_metric: expected 'score' or 'pass_rate'"
+        )
+    error_types = _require(
+        metric, "non_evaluable_error_types", list, "suite.metric_config"
+    )
+    if (
+        not error_types
+        or any(not isinstance(item, str) or not item.strip() for item in error_types)
+        or len(error_types) != len(set(error_types))
+    ):
+        raise CohortReplayValidationError(
+            "suite.metric_config.non_evaluable_error_types: "
+            "expected unique non-empty strings"
+        )
+
+    manifest = _require(suite, "run_manifest", dict, "suite")
+    _require_exact_keys(
+        manifest,
+        {
+            "repository_revision",
+            "generated_at",
+            "candidate_stream_fingerprint",
+            "task_set_fingerprint",
+            "evaluation_protocol_fingerprint",
+            "cohort_definition_fingerprint",
+        },
+        "suite.run_manifest",
+    )
+    _require_string(manifest, "repository_revision", "suite.run_manifest")
+    _require_string(manifest, "generated_at", "suite.run_manifest")
+    for key in (
+        "candidate_stream_fingerprint",
+        "task_set_fingerprint",
+        "evaluation_protocol_fingerprint",
+        "cohort_definition_fingerprint",
+    ):
+        _validate_fingerprint(manifest[key], f"suite.run_manifest.{key}")
+
+    cohorts = _require(suite, "cohorts", list, "suite")
+    if len(cohorts) < 2:
+        raise CohortReplayValidationError("suite.cohorts: expected at least two cohorts")
+    cohort_ids: set[str] = set()
+    cohort_tuples: set[tuple[str, str, str]] = set()
+    weight_total = 0.0
+    for index, cohort in enumerate(cohorts):
+        context = f"suite.cohorts[{index}]"
+        if not isinstance(cohort, dict):
+            raise CohortReplayValidationError(f"{context}: expected an object")
+        _require_exact_keys(
+            cohort,
+            {"cohort_id", "scenario", "model", "runtime", "traffic_weight"},
+            context,
+        )
+        cohort_id = _require_string(cohort, "cohort_id", context)
+        if cohort_id in cohort_ids:
+            raise CohortReplayValidationError(
+                f"{context}.cohort_id: duplicate {cohort_id!r}"
+            )
+        cohort_ids.add(cohort_id)
+        identity = tuple(
+            _require_string(cohort, key, context)
+            for key in ("scenario", "model", "runtime")
+        )
+        if identity in cohort_tuples:
+            raise CohortReplayValidationError(
+                f"{context}: duplicate scenario/model/runtime identity {identity!r}"
+            )
+        cohort_tuples.add(identity)
+        weight_total += _require_number(
+            cohort, "traffic_weight", context, minimum=0.0, maximum=1.0
+        )
+        if cohort["traffic_weight"] <= 0:
+            raise CohortReplayValidationError(
+                f"{context}.traffic_weight: must be greater than zero"
+            )
+    if not math.isclose(weight_total, 1.0, rel_tol=0.0, abs_tol=1e-9):
+        raise CohortReplayValidationError(
+            f"suite.cohorts: traffic weights must sum to 1, got {weight_total}"
+        )
+
+    updates = _require(suite, "updates", list, "suite")
+    if not updates:
+        raise CohortReplayValidationError("suite.updates: must not be empty")
+    update_ids: set[str] = set()
+    epochs: list[int] = []
+    run_ids: set[str] = set()
+    total_pairs = 0
+    for update_index, update in enumerate(updates):
+        context = f"suite.updates[{update_index}]"
+        if not isinstance(update, dict):
+            raise CohortReplayValidationError(f"{context}: expected an object")
+        _require_exact_keys(
+            update,
+            {
+                "update_id",
+                "epoch",
+                "old_skill_fingerprint",
+                "new_skill_fingerprint",
+                "activation_control",
+                "observations",
+            },
+            context,
+        )
+        update_id = _require_string(update, "update_id", context)
+        if update_id in update_ids:
+            raise CohortReplayValidationError(
+                f"{context}.update_id: duplicate {update_id!r}"
+            )
+        update_ids.add(update_id)
+        epoch = _require(update, "epoch", int, context)
+        if epoch < 0:
+            raise CohortReplayValidationError(f"{context}.epoch: must be >= 0")
+        epochs.append(epoch)
+        for key in ("old_skill_fingerprint", "new_skill_fingerprint"):
+            _validate_fingerprint(update[key], f"{context}.{key}")
+        if update["old_skill_fingerprint"] == update["new_skill_fingerprint"]:
+            raise CohortReplayValidationError(
+                f"{context}: old and new Skill fingerprints must differ"
+            )
+        activation_control = _require_string(update, "activation_control", context)
+        if activation_control not in _ACTIVATION_CONTROLS:
+            raise CohortReplayValidationError(
+                f"{context}.activation_control: expected one of "
+                f"{sorted(_ACTIVATION_CONTROLS)}"
+            )
+        observations = _require(update, "observations", list, context)
+        if not observations:
+            raise CohortReplayValidationError(
+                f"{context}.observations: must not be empty"
+            )
+        total_pairs += len(observations)
+        case_ids: set[str] = set()
+        pairs_by_cohort: dict[str, set[tuple[str, str, int]]] = {
+            cohort_id: set() for cohort_id in cohort_ids
+        }
+        seeds_by_cohort_task: dict[str, dict[str, set[int]]] = {
+            cohort_id: {} for cohort_id in cohort_ids
+        }
+        for obs_index, observation in enumerate(observations):
+            obs_context = f"{context}.observations[{obs_index}]"
+            if not isinstance(observation, dict):
+                raise CohortReplayValidationError(
+                    f"{obs_context}: expected an object"
+                )
+            _require_exact_keys(
+                observation,
+                {
+                    "case_id",
+                    "task_fingerprint",
+                    "seed",
+                    "cohort_id",
+                    "role",
+                    "old",
+                    "new",
+                },
+                obs_context,
+            )
+            case_id = _require_string(observation, "case_id", obs_context)
+            if case_id in case_ids:
+                raise CohortReplayValidationError(
+                    f"{obs_context}.case_id: duplicate {case_id!r} within update"
+                )
+            case_ids.add(case_id)
+            task_fingerprint = observation["task_fingerprint"]
+            _validate_fingerprint(
+                task_fingerprint, f"{obs_context}.task_fingerprint"
+            )
+            seed = _require(observation, "seed", int, obs_context)
+            cohort_id = _require_string(observation, "cohort_id", obs_context)
+            if cohort_id not in cohort_ids:
+                raise CohortReplayValidationError(
+                    f"{obs_context}.cohort_id: undeclared cohort {cohort_id!r}"
+                )
+            role = _require_string(observation, "role", obs_context)
+            if role not in _OBSERVATION_ROLES:
+                raise CohortReplayValidationError(
+                    f"{obs_context}.role: expected one of "
+                    f"{sorted(_OBSERVATION_ROLES)}"
+                )
+            role_pair = (role, task_fingerprint, seed)
+            if role_pair in pairs_by_cohort[cohort_id]:
+                raise CohortReplayValidationError(
+                    f"{obs_context}: duplicate role/task_fingerprint/seed in cohort"
+                )
+            pairs_by_cohort[cohort_id].add(role_pair)
+            seeds_by_cohort_task[cohort_id].setdefault(
+                f"{role}:{task_fingerprint}", set()
+            ).add(seed)
+            _validate_outcome(
+                observation["old"], context=f"{obs_context}.old", run_ids=run_ids
+            )
+            _validate_outcome(
+                observation["new"], context=f"{obs_context}.new", run_ids=run_ids
+            )
+        for cohort_id in sorted(cohort_ids):
+            task_seeds = seeds_by_cohort_task[cohort_id]
+            for role in sorted(_OBSERVATION_ROLES):
+                role_tasks = {
+                    key: seeds
+                    for key, seeds in task_seeds.items()
+                    if key.startswith(f"{role}:")
+                }
+                if len(role_tasks) < 2:
+                    raise CohortReplayValidationError(
+                        f"{context}: cohort {cohort_id!r} role {role!r} "
+                        "requires at least two Tasks"
+                    )
+                expected_seeds = next(iter(role_tasks.values()))
+                if any(seeds != expected_seeds for seeds in role_tasks.values()):
+                    raise CohortReplayValidationError(
+                        f"{context}: every Task in cohort {cohort_id!r} role "
+                        f"{role!r} must use the same seed set"
+                    )
+            decision_tasks = {
+                key.removeprefix("decision:")
+                for key in task_seeds
+                if key.startswith("decision:")
+            }
+            evaluation_tasks = {
+                key.removeprefix("evaluation:")
+                for key in task_seeds
+                if key.startswith("evaluation:")
+            }
+            if decision_tasks & evaluation_tasks:
+                raise CohortReplayValidationError(
+                    f"{context}: cohort {cohort_id!r} decision and evaluation "
+                    "Task sets must be disjoint"
+                )
+        for role in sorted(_OBSERVATION_ROLES):
+            matrices = {
+                cohort_id: {
+                    (task_fingerprint, seed)
+                    for item_role, task_fingerprint, seed in pairs_by_cohort[
+                        cohort_id
+                    ]
+                    if item_role == role
+                }
+                for cohort_id in cohort_ids
+            }
+            expected_matrix = matrices[next(iter(sorted(cohort_ids)))]
+            if any(matrix != expected_matrix for matrix in matrices.values()):
+                raise CohortReplayValidationError(
+                    f"{context}: role {role!r} must use the same Task/seed "
+                    "matrix in every cohort"
+                )
+    if epochs != sorted(epochs) or len(epochs) != len(set(epochs)):
+        raise CohortReplayValidationError(
+            "suite.updates: epochs must be unique and strictly increasing"
+        )
+    if total_pairs * bootstrap_samples * (len(cohorts) + 2) > _MAX_WORK_UNITS:
+        raise CohortReplayValidationError(
+            "suite: replay work exceeds the deterministic 5000000-unit bound"
+        )
+
+
+def load_suite(path: Path | str) -> dict[str, Any]:
+    """Load and validate one JSON replay suite."""
+    suite_path = Path(path)
+    try:
+        suite = json.loads(suite_path.read_text(encoding="utf-8"))
+    except json.JSONDecodeError as error:
+        raise CohortReplayValidationError(
+            f"invalid JSON in {suite_path}: {error}"
+        ) from error
+    validate_suite(suite)
+    return suite
+
+
+def _round(value: float) -> float:
+    return round(float(value), 6)
+
+
+def _mean(values: list[float]) -> float:
+    return sum(values) / len(values) if values else 0.0
+
+
+def _stable_seed(base_seed: int, label: str) -> int:
+    digest = hashlib.sha256(label.encode("utf-8")).digest()
+    return base_seed ^ int.from_bytes(digest[:8], "big")
+
+
+def _percentile(sorted_values: list[float], quantile: float) -> float:
+    if not sorted_values:
+        return 0.0
+    position = quantile * (len(sorted_values) - 1)
+    lower = math.floor(position)
+    upper = math.ceil(position)
+    if lower == upper:
+        return sorted_values[lower]
+    fraction = position - lower
+    return sorted_values[lower] * (1 - fraction) + sorted_values[upper] * fraction
+
+
+def _task_deltas(
+    observations: list[dict[str, Any]],
+    value: Callable[[dict[str, Any]], float],
+) -> list[float]:
+    by_task: dict[str, list[float]] = {}
+    for observation in observations:
+        delta = value(observation["new"]) - value(observation["old"])
+        by_task.setdefault(observation["task_fingerprint"], []).append(delta)
+    return [_mean(by_task[key]) for key in sorted(by_task)]
+
+
+def _effect_from_task_deltas(
+    task_deltas: list[float],
+    *,
+    pair_count: int,
+    metric_config: dict[str, Any],
+    label: str,
+    family_size: int,
+) -> dict[str, Any]:
+    point = _mean(task_deltas)
+    interval: list[float] | None
+    if len(task_deltas) < 2:
+        interval = None
+    else:
+        alpha = 1.0 - metric_config["confidence_level"]
+        adjusted_alpha = alpha / max(1, family_size)
+        rng = random.Random(_stable_seed(metric_config["bootstrap_seed"], label))
+        size = len(task_deltas)
+        means = [
+            _mean([task_deltas[rng.randrange(size)] for _ in range(size)])
+            for _ in range(metric_config["bootstrap_samples"])
+        ]
+        means.sort()
+        interval = [
+            _round(_percentile(means, adjusted_alpha / 2)),
+            _round(_percentile(means, 1 - adjusted_alpha / 2)),
+        ]
+    return {
+        "n": pair_count,
+        "tasks": len(task_deltas),
+        "mean": _round(point),
+        "confidence_interval": interval,
+        "wins": sum(delta > 0 for delta in task_deltas),
+        "ties": sum(delta == 0 for delta in task_deltas),
+        "losses": sum(delta < 0 for delta in task_deltas),
+    }
+
+
+def _effect(
+    observations: list[dict[str, Any]],
+    *,
+    value: Callable[[dict[str, Any]], float],
+    metric_config: dict[str, Any],
+    label: str,
+    family_size: int,
+) -> tuple[dict[str, Any], list[float]]:
+    deltas = _task_deltas(observations, value)
+    return (
+        _effect_from_task_deltas(
+            deltas,
+            pair_count=len(observations),
+            metric_config=metric_config,
+            label=label,
+            family_size=family_size,
+        ),
+        deltas,
+    )
+
+
+def _global_effect(
+    task_deltas_by_cohort: dict[str, list[float]],
+    weights: dict[str, float],
+    *,
+    pair_count: int,
+    metric_config: dict[str, Any],
+    label: str,
+    family_size: int,
+) -> dict[str, Any]:
+    point = sum(
+        weights[cohort_id] * _mean(task_deltas)
+        for cohort_id, task_deltas in task_deltas_by_cohort.items()
+    )
+    rng = random.Random(_stable_seed(metric_config["bootstrap_seed"], label))
+    means: list[float] = []
+    for _ in range(metric_config["bootstrap_samples"]):
+        aggregate = 0.0
+        for cohort_id, task_deltas in sorted(task_deltas_by_cohort.items()):
+            size = len(task_deltas)
+            sample_mean = _mean(
+                [task_deltas[rng.randrange(size)] for _ in range(size)]
+            )
+            aggregate += weights[cohort_id] * sample_mean
+        means.append(aggregate)
+    means.sort()
+    alpha = (1.0 - metric_config["confidence_level"]) / max(1, family_size)
+    interval = [
+        _round(_percentile(means, alpha / 2)),
+        _round(_percentile(means, 1 - alpha / 2)),
+    ]
+    return {
+        "n": pair_count,
+        "tasks": sum(len(values) for values in task_deltas_by_cohort.values()),
+        "mean": _round(point),
+        "confidence_interval": interval,
+    }
+
+
+def _evidence_status(
+    effect: dict[str, Any],
+    *,
+    margin: float,
+    has_non_evaluable_error: bool,
+) -> str:
+    if has_non_evaluable_error or effect["confidence_interval"] is None:
+        return "unresolved"
+    lower, upper = effect["confidence_interval"]
+    if lower > margin:
+        return "supported_positive"
+    if upper < -margin:
+        return "supported_negative"
+    return "unresolved"
+
+
+def _error_counts(
+    observations: list[dict[str, Any]], non_evaluable_types: set[str]
+) -> Counter[str]:
+    return Counter(
+        outcome["error_type"]
+        for observation in observations
+        for outcome in (observation["old"], observation["new"])
+        if outcome["error_type"] in non_evaluable_types
+    )
+
+
+def evaluate_suite(suite: dict[str, Any]) -> dict[str, Any]:
+    """Return a deterministic cohort and publication-policy report."""
+    validate_suite(suite)
+    metric = suite["metric_config"]
+    cohorts = {cohort["cohort_id"]: cohort for cohort in suite["cohorts"]}
+    cohort_ids = sorted(cohorts)
+    weights = {
+        cohort_id: float(cohorts[cohort_id]["traffic_weight"])
+        for cohort_id in cohort_ids
+    }
+    decision_metric = metric["decision_metric"]
+    decision_value = (
+        (lambda outcome: float(outcome["score"]))
+        if decision_metric == "score"
+        else (lambda outcome: 1.0 if outcome["passed"] else 0.0)
+    )
+    score_value = lambda outcome: float(outcome["score"])
+    pass_value = lambda outcome: 1.0 if outcome["passed"] else 0.0
+    non_evaluable_types = set(metric["non_evaluable_error_types"])
+    update_reports: list[dict[str, Any]] = []
+
+    family_size = len(cohort_ids) * len(suite["updates"])
+    for update in suite["updates"]:
+        by_cohort_role = {
+            (cohort_id, role): [
+                observation
+                for observation in update["observations"]
+                if observation["cohort_id"] == cohort_id
+                and observation["role"] == role
+            ]
+            for cohort_id in cohort_ids
+            for role in sorted(_OBSERVATION_ROLES)
+        }
+        decision_task_deltas_by_cohort: dict[str, list[float]] = {}
+        evaluation_task_deltas_by_cohort: dict[str, list[float]] = {}
+        cohort_reports: list[dict[str, Any]] = []
+        for cohort_id in cohort_ids:
+            decision_observations = by_cohort_role[(cohort_id, "decision")]
+            evaluation_observations = by_cohort_role[(cohort_id, "evaluation")]
+            decision_effect, decision_task_deltas = _effect(
+                decision_observations,
+                value=decision_value,
+                metric_config=metric,
+                label=(
+                    f"{update['update_id']}:{cohort_id}:decision:{decision_metric}"
+                ),
+                family_size=family_size,
+            )
+            decision_task_deltas_by_cohort[cohort_id] = decision_task_deltas
+            decision_score_effect, _ = _effect(
+                decision_observations,
+                value=score_value,
+                metric_config=metric,
+                label=f"{update['update_id']}:{cohort_id}:decision:score",
+                family_size=family_size,
+            )
+            decision_pass_effect, _ = _effect(
+                decision_observations,
+                value=pass_value,
+                metric_config=metric,
+                label=f"{update['update_id']}:{cohort_id}:decision:pass_rate",
+                family_size=family_size,
+            )
+            evaluation_effect, evaluation_task_deltas = _effect(
+                evaluation_observations,
+                value=decision_value,
+                metric_config=metric,
+                label=(
+                    f"{update['update_id']}:{cohort_id}:evaluation:{decision_metric}"
+                ),
+                family_size=family_size,
+            )
+            evaluation_task_deltas_by_cohort[cohort_id] = evaluation_task_deltas
+            evaluation_score_effect, _ = _effect(
+                evaluation_observations,
+                value=score_value,
+                metric_config=metric,
+                label=f"{update['update_id']}:{cohort_id}:evaluation:score",
+                family_size=family_size,
+            )
+            evaluation_pass_effect, _ = _effect(
+                evaluation_observations,
+                value=pass_value,
+                metric_config=metric,
+                label=f"{update['update_id']}:{cohort_id}:evaluation:pass_rate",
+                family_size=family_size,
+            )
+
+            decision_errors = _error_counts(
+                decision_observations, non_evaluable_types
+            )
+            evaluation_errors = _error_counts(
+                evaluation_observations, non_evaluable_types
+            )
+            decision_status = _evidence_status(
+                decision_effect,
+                margin=metric["practical_margin"],
+                has_non_evaluable_error=bool(decision_errors),
+            )
+            evaluation_status = _evidence_status(
+                evaluation_effect,
+                margin=metric["practical_margin"],
+                has_non_evaluable_error=bool(evaluation_errors),
+            )
+            cohort_reports.append(
+                {
+                    "cohort_id": cohort_id,
+                    "scenario": cohorts[cohort_id]["scenario"],
+                    "model": cohorts[cohort_id]["model"],
+                    "runtime": cohorts[cohort_id]["runtime"],
+                    "traffic_weight": _round(weights[cohort_id]),
+                    "decision_metric": decision_metric,
+                    "decision_effect": decision_effect,
+                    "decision_score_effect": decision_score_effect,
+                    "decision_pass_rate_effect": decision_pass_effect,
+                    "decision_evidence_status": decision_status,
+                    "decision_non_evaluable_errors": dict(
+                        sorted(decision_errors.items())
+                    ),
+                    "evaluation_effect": evaluation_effect,
+                    "evaluation_score_effect": evaluation_score_effect,
+                    "evaluation_pass_rate_effect": evaluation_pass_effect,
+                    "evaluation_evidence_status": evaluation_status,
+                    "evaluation_non_evaluable_errors": dict(
+                        sorted(evaluation_errors.items())
+                    ),
+                }
+            )
+
+        positive = [
+            report["cohort_id"]
+            for report in cohort_reports
+            if report["decision_evidence_status"] == "supported_positive"
+        ]
+        negative = [
+            report["cohort_id"]
+            for report in cohort_reports
+            if report["decision_evidence_status"] == "supported_negative"
+        ]
+        unresolved = [
+            report["cohort_id"]
+            for report in cohort_reports
+            if report["decision_evidence_status"] == "unresolved"
+        ]
+        supported_sign_reversal = bool(positive and negative)
+        global_decision_effect = _global_effect(
+            decision_task_deltas_by_cohort,
+            weights,
+            pair_count=sum(
+                len(by_cohort_role[(cohort_id, "decision")])
+                for cohort_id in cohort_ids
+            ),
+            metric_config=metric,
+            label=f"{update['update_id']}:global:decision:{decision_metric}",
+            family_size=len(suite["updates"]),
+        )
+        global_evaluation_effect = _global_effect(
+            evaluation_task_deltas_by_cohort,
+            weights,
+            pair_count=sum(
+                len(by_cohort_role[(cohort_id, "evaluation")])
+                for cohort_id in cohort_ids
+            ),
+            metric_config=metric,
+            label=f"{update['update_id']}:global:evaluation:{decision_metric}",
+            family_size=len(suite["updates"]),
+        )
+        global_status = _evidence_status(
+            global_decision_effect,
+            margin=metric["practical_margin"],
+            has_non_evaluable_error=any(
+                report["decision_non_evaluable_errors"] for report in cohort_reports
+            ),
+        )
+        global_selection = (
+            "new" if global_status == "supported_positive" else "old"
+        )
+        scoped_selection = {
+            report["cohort_id"]: (
+                "new"
+                if report["decision_evidence_status"] == "supported_positive"
+                else "old"
+            )
+            for report in cohort_reports
+        }
+        evaluation_point_effects = {
+            report["cohort_id"]: float(report["evaluation_effect"]["mean"])
+            for report in cohort_reports
+        }
+        global_evaluation_point = sum(
+            weights[cohort_id] * evaluation_point_effects[cohort_id]
+            for cohort_id in cohort_ids
+        )
+        global_policy_gain = (
+            global_evaluation_point if global_selection == "new" else 0.0
+        )
+        scoped_policy_gain = sum(
+            weights[cohort_id] * evaluation_point_effects[cohort_id]
+            for cohort_id in cohort_ids
+            if scoped_selection[cohort_id] == "new"
+        )
+        evaluation_statuses = {
+            report["cohort_id"]: report["evaluation_evidence_status"]
+            for report in cohort_reports
+        }
+        global_harmful = [
+            cohort_id
+            for cohort_id in cohort_ids
+            if global_selection == "new"
+            and evaluation_statuses[cohort_id] == "supported_negative"
+        ]
+        scoped_harmful = [
+            cohort_id
+            for cohort_id in cohort_ids
+            if scoped_selection[cohort_id] == "new"
+            and evaluation_statuses[cohort_id] == "supported_negative"
+        ]
+        oracle_global = max(0.0, global_evaluation_point)
+        oracle_scoped = sum(
+            weights[cohort_id] * max(0.0, evaluation_point_effects[cohort_id])
+            for cohort_id in cohort_ids
+        )
+        total_calls = 2 * len(update["observations"])
+        total_cost = sum(
+            float(outcome["cost_usd"])
+            for observation in update["observations"]
+            for outcome in (observation["old"], observation["new"])
+        )
+        total_latency = sum(
+            float(outcome["latency_ms"])
+            for observation in update["observations"]
+            for outcome in (observation["old"], observation["new"])
+        )
+        update_reports.append(
+            {
+                "update_id": update["update_id"],
+                "epoch": update["epoch"],
+                "activation_control": update["activation_control"],
+                "cohorts": cohort_reports,
+                "supported_positive_cohorts": positive,
+                "supported_negative_cohorts": negative,
+                "unresolved_cohorts": unresolved,
+                "supported_sign_reversal": supported_sign_reversal,
+                "global": {
+                    "decision_effect": global_decision_effect,
+                    "decision_evidence_status": global_status,
+                    "evaluation_effect": global_evaluation_effect,
+                    "selection": global_selection,
+                    "policy_gain": _round(global_policy_gain),
+                    "harmful_promoted_cohorts": global_harmful,
+                    "harmful_traffic_weight": _round(
+                        sum(weights[item] for item in global_harmful)
+                    ),
+                    "retained_version_count": 1,
+                    "oracle_value": _round(oracle_global),
+                },
+                "scoped": {
+                    "selection_by_cohort": scoped_selection,
+                    "policy_gain": _round(scoped_policy_gain),
+                    "harmful_promoted_cohorts": scoped_harmful,
+                    "harmful_traffic_weight": _round(
+                        sum(weights[item] for item in scoped_harmful)
+                    ),
+                    "unresolved_cohort_rate": _round(
+                        len(unresolved) / len(cohort_ids)
+                    ),
+                    "unresolved_traffic_weight": _round(
+                        sum(weights[item] for item in unresolved)
+                    ),
+                    "retained_version_count": len(set(scoped_selection.values())),
+                    "oracle_value": _round(oracle_scoped),
+                    "oracle_value_gap_over_global": _round(
+                        oracle_scoped - oracle_global
+                    ),
+                },
+                "evaluation_resources": {
+                    "calls": total_calls,
+                    "cost_usd": _round(total_cost),
+                    "latency_ms_sum": _round(total_latency),
+                },
+            }
+        )
+
+    update_count = len(update_reports)
+    cohort_decisions = update_count * len(cohort_ids)
+    return {
+        "schema_version": SCHEMA_VERSION,
+        "suite_id": suite["suite_id"],
+        "method": {
+            "cohort_key": "scenario×model×runtime",
+            "decision_metric": decision_metric,
+            "confidence_level": metric["confidence_level"],
+            "familywise_method": metric["familywise_method"],
+            "practical_margin": metric["practical_margin"],
+        },
+        "updates": update_reports,
+        "aggregate": {
+            "updates": update_count,
+            "cohorts": len(cohort_ids),
+            "supported_sign_reversals": sum(
+                report["supported_sign_reversal"] for report in update_reports
+            ),
+            "supported_sign_reversal_rate": _round(
+                sum(report["supported_sign_reversal"] for report in update_reports)
+                / update_count
+            ),
+            "global_mean_policy_gain": _round(
+                _mean([report["global"]["policy_gain"] for report in update_reports])
+            ),
+            "scoped_mean_policy_gain": _round(
+                _mean([report["scoped"]["policy_gain"] for report in update_reports])
+            ),
+            "global_harmful_promotions": sum(
+                len(report["global"]["harmful_promoted_cohorts"])
+                for report in update_reports
+            ),
+            "scoped_harmful_promotions": sum(
+                len(report["scoped"]["harmful_promoted_cohorts"])
+                for report in update_reports
+            ),
+            "global_harmful_promotion_rate": _round(
+                sum(
+                    len(report["global"]["harmful_promoted_cohorts"])
+                    for report in update_reports
+                )
+                / cohort_decisions
+            ),
+            "scoped_harmful_promotion_rate": _round(
+                sum(
+                    len(report["scoped"]["harmful_promoted_cohorts"])
+                    for report in update_reports
+                )
+                / cohort_decisions
+            ),
+            "global_mean_harmful_traffic_weight": _round(
+                _mean(
+                    [
+                        report["global"]["harmful_traffic_weight"]
+                        for report in update_reports
+                    ]
+                )
+            ),
+            "scoped_mean_harmful_traffic_weight": _round(
+                _mean(
+                    [
+                        report["scoped"]["harmful_traffic_weight"]
+                        for report in update_reports
+                    ]
+                )
+            ),
+            "scoped_mean_retained_versions": _round(
+                _mean(
+                    [
+                        report["scoped"]["retained_version_count"]
+                        for report in update_reports
+                    ]
+                )
+            ),
+            "evaluation_calls": sum(
+                report["evaluation_resources"]["calls"]
+                for report in update_reports
+            ),
+            "evaluation_cost_usd": _round(
+                sum(
+                    report["evaluation_resources"]["cost_usd"]
+                    for report in update_reports
+                )
+            ),
+            "evaluation_latency_ms_sum": _round(
+                sum(
+                    report["evaluation_resources"]["latency_ms_sum"]
+                    for report in update_reports
+                )
+            ),
+        },
+    }
+
+
+def render_text(report: dict[str, Any]) -> str:
+    """Render a concise reviewer-facing report."""
+    aggregate = report["aggregate"]
+    lines = [
+        f"suite_id: {report['suite_id']}",
+        f"updates: {aggregate['updates']}",
+        f"cohorts: {aggregate['cohorts']}",
+        (
+            "supported_sign_reversals: "
+            f"{aggregate['supported_sign_reversals']} "
+            f"rate={aggregate['supported_sign_reversal_rate']}"
+        ),
+        (
+            "mean_policy_gain: "
+            f"global={aggregate['global_mean_policy_gain']} "
+            f"scoped={aggregate['scoped_mean_policy_gain']}"
+        ),
+        (
+            "harmful_promotions: "
+            f"global={aggregate['global_harmful_promotions']} "
+            f"scoped={aggregate['scoped_harmful_promotions']}"
+        ),
+    ]
+    for update in report["updates"]:
+        lines.append(
+            f"{update['update_id']}: reversal={str(update['supported_sign_reversal']).lower()} "
+            f"global={update['global']['selection']} "
+            f"scoped={json.dumps(update['scoped']['selection_by_cohort'], sort_keys=True)}"
+        )
+    return "\n".join(lines)
+
+
+def main(argv: list[str] | None = None) -> int:
+    parser = argparse.ArgumentParser(
+        description="Evaluate a recorded cohort-scoped publication replay."
+    )
+    parser.add_argument("suite", type=Path)
+    parser.add_argument("--format", choices=("text", "json"), default="text")
+    args = parser.parse_args(argv)
+    report = evaluate_suite(load_suite(args.suite))
+    if args.format == "json":
+        print(json.dumps(report, ensure_ascii=False, indent=2, sort_keys=True))
+    else:
+        print(render_text(report))
+    return 0
+
+
+if __name__ == "__main__":  # pragma: no cover
+    raise SystemExit(main())

--- a/scripts/bench/cohort_canary_replay/evaluate.py
+++ b/scripts/bench/cohort_canary_replay/evaluate.py
@@ -514,33 +514,34 @@ def _percentile(sorted_values: list[float], quantile: float) -> float:
 def _task_deltas(
     observations: list[dict[str, Any]],
     value: Callable[[dict[str, Any]], float],
-) -> list[float]:
+) -> dict[str, float]:
     by_task: dict[str, list[float]] = {}
     for observation in observations:
         delta = value(observation["new"]) - value(observation["old"])
         by_task.setdefault(observation["task_fingerprint"], []).append(delta)
-    return [_mean(by_task[key]) for key in sorted(by_task)]
+    return {key: _mean(by_task[key]) for key in sorted(by_task)}
 
 
 def _effect_from_task_deltas(
-    task_deltas: list[float],
+    task_deltas: dict[str, float],
     *,
     pair_count: int,
     metric_config: dict[str, Any],
     label: str,
     family_size: int,
 ) -> dict[str, Any]:
-    point = _mean(task_deltas)
+    deltas = list(task_deltas.values())
+    point = _mean(deltas)
     interval: list[float] | None
-    if len(task_deltas) < 2:
+    if len(deltas) < 2:
         interval = None
     else:
         alpha = 1.0 - metric_config["confidence_level"]
         adjusted_alpha = alpha / max(1, family_size)
         rng = random.Random(_stable_seed(metric_config["bootstrap_seed"], label))
-        size = len(task_deltas)
+        size = len(deltas)
         means = [
-            _mean([task_deltas[rng.randrange(size)] for _ in range(size)])
+            _mean([deltas[rng.randrange(size)] for _ in range(size)])
             for _ in range(metric_config["bootstrap_samples"])
         ]
         means.sort()
@@ -550,12 +551,12 @@ def _effect_from_task_deltas(
         ]
     return {
         "n": pair_count,
-        "tasks": len(task_deltas),
+        "tasks": len(deltas),
         "mean": _round(point),
         "confidence_interval": interval,
-        "wins": sum(delta > 0 for delta in task_deltas),
-        "ties": sum(delta == 0 for delta in task_deltas),
-        "losses": sum(delta < 0 for delta in task_deltas),
+        "wins": sum(delta > 0 for delta in deltas),
+        "ties": sum(delta == 0 for delta in deltas),
+        "losses": sum(delta < 0 for delta in deltas),
     }
 
 
@@ -566,7 +567,7 @@ def _effect(
     metric_config: dict[str, Any],
     label: str,
     family_size: int,
-) -> tuple[dict[str, Any], list[float]]:
+) -> tuple[dict[str, Any], dict[str, float]]:
     deltas = _task_deltas(observations, value)
     return (
         _effect_from_task_deltas(
@@ -581,7 +582,7 @@ def _effect(
 
 
 def _global_effect(
-    task_deltas_by_cohort: dict[str, list[float]],
+    task_deltas_by_cohort: dict[str, dict[str, float]],
     weights: dict[str, float],
     *,
     pair_count: int,
@@ -589,21 +590,28 @@ def _global_effect(
     label: str,
     family_size: int,
 ) -> dict[str, Any]:
-    point = sum(
-        weights[cohort_id] * _mean(task_deltas)
-        for cohort_id, task_deltas in task_deltas_by_cohort.items()
-    )
+    task_sets = {frozenset(deltas) for deltas in task_deltas_by_cohort.values()}
+    if len(task_sets) != 1:
+        raise CohortReplayValidationError(
+            "global effect requires the same Task set in every cohort"
+        )
+    task_ids = sorted(next(iter(task_sets)))
+    weighted_task_deltas = [
+        sum(
+            weights[cohort_id] * task_deltas_by_cohort[cohort_id][task_id]
+            for cohort_id in sorted(task_deltas_by_cohort)
+        )
+        for task_id in task_ids
+    ]
+    point = _mean(weighted_task_deltas)
     rng = random.Random(_stable_seed(metric_config["bootstrap_seed"], label))
-    means: list[float] = []
-    for _ in range(metric_config["bootstrap_samples"]):
-        aggregate = 0.0
-        for cohort_id, task_deltas in sorted(task_deltas_by_cohort.items()):
-            size = len(task_deltas)
-            sample_mean = _mean(
-                [task_deltas[rng.randrange(size)] for _ in range(size)]
-            )
-            aggregate += weights[cohort_id] * sample_mean
-        means.append(aggregate)
+    size = len(weighted_task_deltas)
+    means = [
+        _mean(
+            [weighted_task_deltas[rng.randrange(size)] for _ in range(size)]
+        )
+        for _ in range(metric_config["bootstrap_samples"])
+    ]
     means.sort()
     alpha = (1.0 - metric_config["confidence_level"]) / max(1, family_size)
     interval = [
@@ -612,7 +620,7 @@ def _global_effect(
     ]
     return {
         "n": pair_count,
-        "tasks": sum(len(values) for values in task_deltas_by_cohort.values()),
+        "tasks": len(task_ids),
         "mean": _round(point),
         "confidence_interval": interval,
     }
@@ -673,8 +681,8 @@ def evaluate_suite(suite: dict[str, Any]) -> dict[str, Any]:
             for cohort_id in cohort_ids
             for role in sorted(_OBSERVATION_ROLES)
         }
-        decision_task_deltas_by_cohort: dict[str, list[float]] = {}
-        evaluation_task_deltas_by_cohort: dict[str, list[float]] = {}
+        decision_task_deltas_by_cohort: dict[str, dict[str, float]] = {}
+        evaluation_task_deltas_by_cohort: dict[str, dict[str, float]] = {}
         cohort_reports: list[dict[str, Any]] = []
         for cohort_id in cohort_ids:
             decision_observations = by_cohort_role[(cohort_id, "decision")]

--- a/scripts/bench/cohort_canary_replay/evaluate.py
+++ b/scripts/bench/cohort_canary_replay/evaluate.py
@@ -179,7 +179,11 @@ def validate_suite(suite: Any) -> None:
         raise CohortReplayValidationError(
             "suite.metric_config.bootstrap_samples: must be >= 100"
         )
-    _require(metric, "bootstrap_seed", int, "suite.metric_config")
+    bootstrap_seed = _require(metric, "bootstrap_seed", int, "suite.metric_config")
+    if bootstrap_seed < 0:
+        raise CohortReplayValidationError(
+            "suite.metric_config.bootstrap_seed: must be >= 0"
+        )
     confidence = _require_number(
         metric,
         "confidence_level",
@@ -652,11 +656,6 @@ def evaluate_suite(suite: dict[str, Any]) -> dict[str, Any]:
         for cohort_id in cohort_ids
     }
     decision_metric = metric["decision_metric"]
-    decision_value = (
-        (lambda outcome: float(outcome["score"]))
-        if decision_metric == "score"
-        else (lambda outcome: 1.0 if outcome["passed"] else 0.0)
-    )
     score_value = lambda outcome: float(outcome["score"])
     pass_value = lambda outcome: 1.0 if outcome["passed"] else 0.0
     non_evaluable_types = set(metric["non_evaluable_error_types"])
@@ -680,54 +679,46 @@ def evaluate_suite(suite: dict[str, Any]) -> dict[str, Any]:
         for cohort_id in cohort_ids:
             decision_observations = by_cohort_role[(cohort_id, "decision")]
             evaluation_observations = by_cohort_role[(cohort_id, "evaluation")]
-            decision_effect, decision_task_deltas = _effect(
-                decision_observations,
-                value=decision_value,
-                metric_config=metric,
-                label=(
-                    f"{update['update_id']}:{cohort_id}:decision:{decision_metric}"
-                ),
-                family_size=family_size,
-            )
-            decision_task_deltas_by_cohort[cohort_id] = decision_task_deltas
-            decision_score_effect, _ = _effect(
+            decision_score_effect, decision_score_deltas = _effect(
                 decision_observations,
                 value=score_value,
                 metric_config=metric,
                 label=f"{update['update_id']}:{cohort_id}:decision:score",
                 family_size=family_size,
             )
-            decision_pass_effect, _ = _effect(
+            decision_pass_effect, decision_pass_deltas = _effect(
                 decision_observations,
                 value=pass_value,
                 metric_config=metric,
                 label=f"{update['update_id']}:{cohort_id}:decision:pass_rate",
                 family_size=family_size,
             )
-            evaluation_effect, evaluation_task_deltas = _effect(
-                evaluation_observations,
-                value=decision_value,
-                metric_config=metric,
-                label=(
-                    f"{update['update_id']}:{cohort_id}:evaluation:{decision_metric}"
-                ),
-                family_size=family_size,
-            )
-            evaluation_task_deltas_by_cohort[cohort_id] = evaluation_task_deltas
-            evaluation_score_effect, _ = _effect(
+            evaluation_score_effect, evaluation_score_deltas = _effect(
                 evaluation_observations,
                 value=score_value,
                 metric_config=metric,
                 label=f"{update['update_id']}:{cohort_id}:evaluation:score",
                 family_size=family_size,
             )
-            evaluation_pass_effect, _ = _effect(
+            evaluation_pass_effect, evaluation_pass_deltas = _effect(
                 evaluation_observations,
                 value=pass_value,
                 metric_config=metric,
                 label=f"{update['update_id']}:{cohort_id}:evaluation:pass_rate",
                 family_size=family_size,
             )
+            if decision_metric == "score":
+                decision_effect = decision_score_effect
+                decision_task_deltas = decision_score_deltas
+                evaluation_effect = evaluation_score_effect
+                evaluation_task_deltas = evaluation_score_deltas
+            else:
+                decision_effect = decision_pass_effect
+                decision_task_deltas = decision_pass_deltas
+                evaluation_effect = evaluation_pass_effect
+                evaluation_task_deltas = evaluation_pass_deltas
+            decision_task_deltas_by_cohort[cohort_id] = decision_task_deltas
+            evaluation_task_deltas_by_cohort[cohort_id] = evaluation_task_deltas
 
             decision_errors = _error_counts(
                 decision_observations, non_evaluable_types
@@ -878,6 +869,8 @@ def evaluate_suite(suite: dict[str, Any]) -> dict[str, Any]:
             {
                 "update_id": update["update_id"],
                 "epoch": update["epoch"],
+                "old_skill_fingerprint": update["old_skill_fingerprint"],
+                "new_skill_fingerprint": update["new_skill_fingerprint"],
                 "activation_control": update["activation_control"],
                 "cohorts": cohort_reports,
                 "supported_positive_cohorts": positive,
@@ -929,12 +922,19 @@ def evaluate_suite(suite: dict[str, Any]) -> dict[str, Any]:
     return {
         "schema_version": SCHEMA_VERSION,
         "suite_id": suite["suite_id"],
+        "run_manifest": suite["run_manifest"],
         "method": {
             "cohort_key": "scenario×model×runtime",
             "decision_metric": decision_metric,
+            "selection_role": "decision",
+            "held_out_evaluation_role": "evaluation",
+            "bootstrap_samples": metric["bootstrap_samples"],
+            "bootstrap_seed": metric["bootstrap_seed"],
             "confidence_level": metric["confidence_level"],
             "familywise_method": metric["familywise_method"],
             "practical_margin": metric["practical_margin"],
+            "cohort_family_size": family_size,
+            "global_family_size": len(suite["updates"]),
         },
         "updates": update_reports,
         "aggregate": {

--- a/scripts/bench/cohort_canary_replay/fixtures/baseline_v1.json
+++ b/scripts/bench/cohort_canary_replay/fixtures/baseline_v1.json
@@ -1,0 +1,427 @@
+{
+  "schema_version": 1,
+  "suite_id": "synthetic-cohort-canary-v1",
+  "metric_config": {
+    "bootstrap_samples": 1000,
+    "bootstrap_seed": 42,
+    "confidence_level": 0.95,
+    "familywise_method": "bonferroni",
+    "practical_margin": 0.05,
+    "decision_metric": "score",
+    "non_evaluable_error_types": [
+      "infrastructure_failure"
+    ]
+  },
+  "run_manifest": {
+    "repository_revision": "synthetic-recorded-fixture",
+    "generated_at": "2026-08-30T00:00:00Z",
+    "candidate_stream_fingerprint": "sha256:aaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaa",
+    "task_set_fingerprint": "sha256:bbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbb",
+    "evaluation_protocol_fingerprint": "sha256:cccccccccccccccccccccccccccccccccccccccccccccccccccccccccccccccc",
+    "cohort_definition_fingerprint": "sha256:dddddddddddddddddddddddddddddddddddddddddddddddddddddddddddddddd"
+  },
+  "cohorts": [
+    {
+      "cohort_id": "cohort-a",
+      "scenario": "scenario-a",
+      "model": "model-a",
+      "runtime": "runtime-a",
+      "traffic_weight": 0.75
+    },
+    {
+      "cohort_id": "cohort-b",
+      "scenario": "scenario-b",
+      "model": "model-b",
+      "runtime": "runtime-b",
+      "traffic_weight": 0.25
+    }
+  ],
+  "updates": [
+    {
+      "update_id": "update-1",
+      "epoch": 1,
+      "old_skill_fingerprint": "sha256:cccccccccccccccccccccccccccccccccccccccccccccccccccccccccccccccc",
+      "new_skill_fingerprint": "sha256:dddddddddddddddddddddddddddddddddddddddddddddddddddddddddddddddd",
+      "activation_control": "matched",
+      "observations": [
+        {
+          "case_id": "u1-a-task-1-seed-7",
+          "task_fingerprint": "sha256:1111111111111111111111111111111111111111111111111111111111111111",
+          "seed": 7,
+          "cohort_id": "cohort-a",
+          "old": {
+            "run_id": "u1-a-t1-old",
+            "score": 0.4,
+            "passed": false,
+            "cost_usd": 0.001,
+            "latency_ms": 100,
+            "error_type": null
+          },
+          "new": {
+            "run_id": "u1-a-t1-new",
+            "score": 0.6,
+            "passed": true,
+            "cost_usd": 0.001,
+            "latency_ms": 100,
+            "error_type": null
+          },
+          "role": "decision"
+        },
+        {
+          "case_id": "u1-a-task-2-seed-7",
+          "task_fingerprint": "sha256:2222222222222222222222222222222222222222222222222222222222222222",
+          "seed": 7,
+          "cohort_id": "cohort-a",
+          "old": {
+            "run_id": "u1-a-t2-old",
+            "score": 0.5,
+            "passed": false,
+            "cost_usd": 0.001,
+            "latency_ms": 100,
+            "error_type": null
+          },
+          "new": {
+            "run_id": "u1-a-t2-new",
+            "score": 0.7,
+            "passed": true,
+            "cost_usd": 0.001,
+            "latency_ms": 100,
+            "error_type": null
+          },
+          "role": "decision"
+        },
+        {
+          "case_id": "u1-b-task-1-seed-7",
+          "task_fingerprint": "sha256:1111111111111111111111111111111111111111111111111111111111111111",
+          "seed": 7,
+          "cohort_id": "cohort-b",
+          "old": {
+            "run_id": "u1-b-t1-old",
+            "score": 0.7,
+            "passed": true,
+            "cost_usd": 0.001,
+            "latency_ms": 100,
+            "error_type": null
+          },
+          "new": {
+            "run_id": "u1-b-t1-new",
+            "score": 0.5,
+            "passed": false,
+            "cost_usd": 0.001,
+            "latency_ms": 100,
+            "error_type": null
+          },
+          "role": "decision"
+        },
+        {
+          "case_id": "u1-b-task-2-seed-7",
+          "task_fingerprint": "sha256:2222222222222222222222222222222222222222222222222222222222222222",
+          "seed": 7,
+          "cohort_id": "cohort-b",
+          "old": {
+            "run_id": "u1-b-t2-old",
+            "score": 0.8,
+            "passed": true,
+            "cost_usd": 0.001,
+            "latency_ms": 100,
+            "error_type": null
+          },
+          "new": {
+            "run_id": "u1-b-t2-new",
+            "score": 0.6,
+            "passed": false,
+            "cost_usd": 0.001,
+            "latency_ms": 100,
+            "error_type": null
+          },
+          "role": "decision"
+        },
+        {
+          "case_id": "u1-a-task-1-seed-7-eval",
+          "task_fingerprint": "sha256:5555555555555555555555555555555555555555555555555555555555555555",
+          "seed": 7,
+          "cohort_id": "cohort-a",
+          "old": {
+            "run_id": "u1-a-t1-old-eval",
+            "score": 0.4,
+            "passed": false,
+            "cost_usd": 0.001,
+            "latency_ms": 100,
+            "error_type": null
+          },
+          "new": {
+            "run_id": "u1-a-t1-new-eval",
+            "score": 0.6,
+            "passed": true,
+            "cost_usd": 0.001,
+            "latency_ms": 100,
+            "error_type": null
+          },
+          "role": "evaluation"
+        },
+        {
+          "case_id": "u1-a-task-2-seed-7-eval",
+          "task_fingerprint": "sha256:6666666666666666666666666666666666666666666666666666666666666666",
+          "seed": 7,
+          "cohort_id": "cohort-a",
+          "old": {
+            "run_id": "u1-a-t2-old-eval",
+            "score": 0.5,
+            "passed": false,
+            "cost_usd": 0.001,
+            "latency_ms": 100,
+            "error_type": null
+          },
+          "new": {
+            "run_id": "u1-a-t2-new-eval",
+            "score": 0.7,
+            "passed": true,
+            "cost_usd": 0.001,
+            "latency_ms": 100,
+            "error_type": null
+          },
+          "role": "evaluation"
+        },
+        {
+          "case_id": "u1-b-task-1-seed-7-eval",
+          "task_fingerprint": "sha256:5555555555555555555555555555555555555555555555555555555555555555",
+          "seed": 7,
+          "cohort_id": "cohort-b",
+          "old": {
+            "run_id": "u1-b-t1-old-eval",
+            "score": 0.7,
+            "passed": true,
+            "cost_usd": 0.001,
+            "latency_ms": 100,
+            "error_type": null
+          },
+          "new": {
+            "run_id": "u1-b-t1-new-eval",
+            "score": 0.5,
+            "passed": false,
+            "cost_usd": 0.001,
+            "latency_ms": 100,
+            "error_type": null
+          },
+          "role": "evaluation"
+        },
+        {
+          "case_id": "u1-b-task-2-seed-7-eval",
+          "task_fingerprint": "sha256:6666666666666666666666666666666666666666666666666666666666666666",
+          "seed": 7,
+          "cohort_id": "cohort-b",
+          "old": {
+            "run_id": "u1-b-t2-old-eval",
+            "score": 0.8,
+            "passed": true,
+            "cost_usd": 0.001,
+            "latency_ms": 100,
+            "error_type": null
+          },
+          "new": {
+            "run_id": "u1-b-t2-new-eval",
+            "score": 0.6,
+            "passed": false,
+            "cost_usd": 0.001,
+            "latency_ms": 100,
+            "error_type": null
+          },
+          "role": "evaluation"
+        }
+      ]
+    },
+    {
+      "update_id": "update-2",
+      "epoch": 2,
+      "old_skill_fingerprint": "sha256:dddddddddddddddddddddddddddddddddddddddddddddddddddddddddddddddd",
+      "new_skill_fingerprint": "sha256:eeeeeeeeeeeeeeeeeeeeeeeeeeeeeeeeeeeeeeeeeeeeeeeeeeeeeeeeeeeeeeee",
+      "activation_control": "forced",
+      "observations": [
+        {
+          "case_id": "u2-a-task-1-seed-7",
+          "task_fingerprint": "sha256:1111111111111111111111111111111111111111111111111111111111111111",
+          "seed": 7,
+          "cohort_id": "cohort-a",
+          "old": {
+            "run_id": "u2-a-t1-old",
+            "score": 0.6,
+            "passed": true,
+            "cost_usd": 0.001,
+            "latency_ms": 100,
+            "error_type": null
+          },
+          "new": {
+            "run_id": "u2-a-t1-new",
+            "score": 0.7,
+            "passed": true,
+            "cost_usd": 0.001,
+            "latency_ms": 100,
+            "error_type": null
+          },
+          "role": "decision"
+        },
+        {
+          "case_id": "u2-a-task-2-seed-7",
+          "task_fingerprint": "sha256:2222222222222222222222222222222222222222222222222222222222222222",
+          "seed": 7,
+          "cohort_id": "cohort-a",
+          "old": {
+            "run_id": "u2-a-t2-old",
+            "score": 0.7,
+            "passed": true,
+            "cost_usd": 0.001,
+            "latency_ms": 100,
+            "error_type": null
+          },
+          "new": {
+            "run_id": "u2-a-t2-new",
+            "score": 0.8,
+            "passed": true,
+            "cost_usd": 0.001,
+            "latency_ms": 100,
+            "error_type": null
+          },
+          "role": "decision"
+        },
+        {
+          "case_id": "u2-b-task-1-seed-7",
+          "task_fingerprint": "sha256:1111111111111111111111111111111111111111111111111111111111111111",
+          "seed": 7,
+          "cohort_id": "cohort-b",
+          "old": {
+            "run_id": "u2-b-t1-old",
+            "score": 0.5,
+            "passed": false,
+            "cost_usd": 0.001,
+            "latency_ms": 100,
+            "error_type": null
+          },
+          "new": {
+            "run_id": "u2-b-t1-new",
+            "score": 0.6,
+            "passed": true,
+            "cost_usd": 0.001,
+            "latency_ms": 100,
+            "error_type": null
+          },
+          "role": "decision"
+        },
+        {
+          "case_id": "u2-b-task-2-seed-7",
+          "task_fingerprint": "sha256:2222222222222222222222222222222222222222222222222222222222222222",
+          "seed": 7,
+          "cohort_id": "cohort-b",
+          "old": {
+            "run_id": "u2-b-t2-old",
+            "score": 0.6,
+            "passed": false,
+            "cost_usd": 0.001,
+            "latency_ms": 100,
+            "error_type": null
+          },
+          "new": {
+            "run_id": "u2-b-t2-new",
+            "score": 0.7,
+            "passed": true,
+            "cost_usd": 0.001,
+            "latency_ms": 100,
+            "error_type": null
+          },
+          "role": "decision"
+        },
+        {
+          "case_id": "u2-a-task-1-seed-7-eval",
+          "task_fingerprint": "sha256:5555555555555555555555555555555555555555555555555555555555555555",
+          "seed": 7,
+          "cohort_id": "cohort-a",
+          "old": {
+            "run_id": "u2-a-t1-old-eval",
+            "score": 0.6,
+            "passed": true,
+            "cost_usd": 0.001,
+            "latency_ms": 100,
+            "error_type": null
+          },
+          "new": {
+            "run_id": "u2-a-t1-new-eval",
+            "score": 0.7,
+            "passed": true,
+            "cost_usd": 0.001,
+            "latency_ms": 100,
+            "error_type": null
+          },
+          "role": "evaluation"
+        },
+        {
+          "case_id": "u2-a-task-2-seed-7-eval",
+          "task_fingerprint": "sha256:6666666666666666666666666666666666666666666666666666666666666666",
+          "seed": 7,
+          "cohort_id": "cohort-a",
+          "old": {
+            "run_id": "u2-a-t2-old-eval",
+            "score": 0.7,
+            "passed": true,
+            "cost_usd": 0.001,
+            "latency_ms": 100,
+            "error_type": null
+          },
+          "new": {
+            "run_id": "u2-a-t2-new-eval",
+            "score": 0.8,
+            "passed": true,
+            "cost_usd": 0.001,
+            "latency_ms": 100,
+            "error_type": null
+          },
+          "role": "evaluation"
+        },
+        {
+          "case_id": "u2-b-task-1-seed-7-eval",
+          "task_fingerprint": "sha256:5555555555555555555555555555555555555555555555555555555555555555",
+          "seed": 7,
+          "cohort_id": "cohort-b",
+          "old": {
+            "run_id": "u2-b-t1-old-eval",
+            "score": 0.5,
+            "passed": false,
+            "cost_usd": 0.001,
+            "latency_ms": 100,
+            "error_type": null
+          },
+          "new": {
+            "run_id": "u2-b-t1-new-eval",
+            "score": 0.6,
+            "passed": true,
+            "cost_usd": 0.001,
+            "latency_ms": 100,
+            "error_type": null
+          },
+          "role": "evaluation"
+        },
+        {
+          "case_id": "u2-b-task-2-seed-7-eval",
+          "task_fingerprint": "sha256:6666666666666666666666666666666666666666666666666666666666666666",
+          "seed": 7,
+          "cohort_id": "cohort-b",
+          "old": {
+            "run_id": "u2-b-t2-old-eval",
+            "score": 0.6,
+            "passed": false,
+            "cost_usd": 0.001,
+            "latency_ms": 100,
+            "error_type": null
+          },
+          "new": {
+            "run_id": "u2-b-t2-new-eval",
+            "score": 0.7,
+            "passed": true,
+            "cost_usd": 0.001,
+            "latency_ms": 100,
+            "error_type": null
+          },
+          "role": "evaluation"
+        }
+      ]
+    }
+  ]
+}

--- a/scripts/bench/cohort_canary_replay/fixtures/baseline_v1.report.json
+++ b/scripts/bench/cohort_canary_replay/fixtures/baseline_v1.report.json
@@ -18,11 +18,25 @@
     "updates": 2
   },
   "method": {
+    "bootstrap_samples": 1000,
+    "bootstrap_seed": 42,
+    "cohort_family_size": 4,
     "cohort_key": "scenario×model×runtime",
     "confidence_level": 0.95,
     "decision_metric": "score",
     "familywise_method": "bonferroni",
-    "practical_margin": 0.05
+    "global_family_size": 2,
+    "held_out_evaluation_role": "evaluation",
+    "practical_margin": 0.05,
+    "selection_role": "decision"
+  },
+  "run_manifest": {
+    "candidate_stream_fingerprint": "sha256:aaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaa",
+    "cohort_definition_fingerprint": "sha256:dddddddddddddddddddddddddddddddddddddddddddddddddddddddddddddddd",
+    "evaluation_protocol_fingerprint": "sha256:cccccccccccccccccccccccccccccccccccccccccccccccccccccccccccccccc",
+    "generated_at": "2026-08-30T00:00:00Z",
+    "repository_revision": "synthetic-recorded-fixture",
+    "task_set_fingerprint": "sha256:bbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbb"
   },
   "schema_version": 1,
   "suite_id": "synthetic-cohort-canary-v1",
@@ -234,6 +248,8 @@
         "retained_version_count": 1,
         "selection": "new"
       },
+      "new_skill_fingerprint": "sha256:dddddddddddddddddddddddddddddddddddddddddddddddddddddddddddddddd",
+      "old_skill_fingerprint": "sha256:cccccccccccccccccccccccccccccccccccccccccccccccccccccccccccccccc",
       "scoped": {
         "harmful_promoted_cohorts": [],
         "harmful_traffic_weight": 0.0,
@@ -463,6 +479,8 @@
         "retained_version_count": 1,
         "selection": "new"
       },
+      "new_skill_fingerprint": "sha256:eeeeeeeeeeeeeeeeeeeeeeeeeeeeeeeeeeeeeeeeeeeeeeeeeeeeeeeeeeeeeeee",
+      "old_skill_fingerprint": "sha256:dddddddddddddddddddddddddddddddddddddddddddddddddddddddddddddddd",
       "scoped": {
         "harmful_promoted_cohorts": [],
         "harmful_traffic_weight": 0.0,

--- a/scripts/bench/cohort_canary_replay/fixtures/baseline_v1.report.json
+++ b/scripts/bench/cohort_canary_replay/fixtures/baseline_v1.report.json
@@ -227,7 +227,7 @@
           ],
           "mean": 0.1,
           "n": 4,
-          "tasks": 4
+          "tasks": 2
         },
         "decision_evidence_status": "supported_positive",
         "evaluation_effect": {
@@ -237,7 +237,7 @@
           ],
           "mean": 0.1,
           "n": 4,
-          "tasks": 4
+          "tasks": 2
         },
         "harmful_promoted_cohorts": [
           "cohort-b"
@@ -460,7 +460,7 @@
           ],
           "mean": 0.1,
           "n": 4,
-          "tasks": 4
+          "tasks": 2
         },
         "decision_evidence_status": "supported_positive",
         "evaluation_effect": {
@@ -470,7 +470,7 @@
           ],
           "mean": 0.1,
           "n": 4,
-          "tasks": 4
+          "tasks": 2
         },
         "harmful_promoted_cohorts": [],
         "harmful_traffic_weight": 0.0,

--- a/scripts/bench/cohort_canary_replay/fixtures/baseline_v1.report.json
+++ b/scripts/bench/cohort_canary_replay/fixtures/baseline_v1.report.json
@@ -1,0 +1,490 @@
+{
+  "aggregate": {
+    "cohorts": 2,
+    "evaluation_calls": 32,
+    "evaluation_cost_usd": 0.032,
+    "evaluation_latency_ms_sum": 3200.0,
+    "global_harmful_promotion_rate": 0.25,
+    "global_harmful_promotions": 1,
+    "global_mean_harmful_traffic_weight": 0.125,
+    "global_mean_policy_gain": 0.1,
+    "scoped_harmful_promotion_rate": 0.0,
+    "scoped_harmful_promotions": 0,
+    "scoped_mean_harmful_traffic_weight": 0.0,
+    "scoped_mean_policy_gain": 0.125,
+    "scoped_mean_retained_versions": 1.5,
+    "supported_sign_reversal_rate": 0.5,
+    "supported_sign_reversals": 1,
+    "updates": 2
+  },
+  "method": {
+    "cohort_key": "scenario×model×runtime",
+    "confidence_level": 0.95,
+    "decision_metric": "score",
+    "familywise_method": "bonferroni",
+    "practical_margin": 0.05
+  },
+  "schema_version": 1,
+  "suite_id": "synthetic-cohort-canary-v1",
+  "updates": [
+    {
+      "activation_control": "matched",
+      "cohorts": [
+        {
+          "cohort_id": "cohort-a",
+          "decision_effect": {
+            "confidence_interval": [
+              0.2,
+              0.2
+            ],
+            "losses": 0,
+            "mean": 0.2,
+            "n": 2,
+            "tasks": 2,
+            "ties": 0,
+            "wins": 2
+          },
+          "decision_evidence_status": "supported_positive",
+          "decision_metric": "score",
+          "decision_non_evaluable_errors": {},
+          "decision_pass_rate_effect": {
+            "confidence_interval": [
+              1.0,
+              1.0
+            ],
+            "losses": 0,
+            "mean": 1.0,
+            "n": 2,
+            "tasks": 2,
+            "ties": 0,
+            "wins": 2
+          },
+          "decision_score_effect": {
+            "confidence_interval": [
+              0.2,
+              0.2
+            ],
+            "losses": 0,
+            "mean": 0.2,
+            "n": 2,
+            "tasks": 2,
+            "ties": 0,
+            "wins": 2
+          },
+          "evaluation_effect": {
+            "confidence_interval": [
+              0.2,
+              0.2
+            ],
+            "losses": 0,
+            "mean": 0.2,
+            "n": 2,
+            "tasks": 2,
+            "ties": 0,
+            "wins": 2
+          },
+          "evaluation_evidence_status": "supported_positive",
+          "evaluation_non_evaluable_errors": {},
+          "evaluation_pass_rate_effect": {
+            "confidence_interval": [
+              1.0,
+              1.0
+            ],
+            "losses": 0,
+            "mean": 1.0,
+            "n": 2,
+            "tasks": 2,
+            "ties": 0,
+            "wins": 2
+          },
+          "evaluation_score_effect": {
+            "confidence_interval": [
+              0.2,
+              0.2
+            ],
+            "losses": 0,
+            "mean": 0.2,
+            "n": 2,
+            "tasks": 2,
+            "ties": 0,
+            "wins": 2
+          },
+          "model": "model-a",
+          "runtime": "runtime-a",
+          "scenario": "scenario-a",
+          "traffic_weight": 0.75
+        },
+        {
+          "cohort_id": "cohort-b",
+          "decision_effect": {
+            "confidence_interval": [
+              -0.2,
+              -0.2
+            ],
+            "losses": 2,
+            "mean": -0.2,
+            "n": 2,
+            "tasks": 2,
+            "ties": 0,
+            "wins": 0
+          },
+          "decision_evidence_status": "supported_negative",
+          "decision_metric": "score",
+          "decision_non_evaluable_errors": {},
+          "decision_pass_rate_effect": {
+            "confidence_interval": [
+              -1.0,
+              -1.0
+            ],
+            "losses": 2,
+            "mean": -1.0,
+            "n": 2,
+            "tasks": 2,
+            "ties": 0,
+            "wins": 0
+          },
+          "decision_score_effect": {
+            "confidence_interval": [
+              -0.2,
+              -0.2
+            ],
+            "losses": 2,
+            "mean": -0.2,
+            "n": 2,
+            "tasks": 2,
+            "ties": 0,
+            "wins": 0
+          },
+          "evaluation_effect": {
+            "confidence_interval": [
+              -0.2,
+              -0.2
+            ],
+            "losses": 2,
+            "mean": -0.2,
+            "n": 2,
+            "tasks": 2,
+            "ties": 0,
+            "wins": 0
+          },
+          "evaluation_evidence_status": "supported_negative",
+          "evaluation_non_evaluable_errors": {},
+          "evaluation_pass_rate_effect": {
+            "confidence_interval": [
+              -1.0,
+              -1.0
+            ],
+            "losses": 2,
+            "mean": -1.0,
+            "n": 2,
+            "tasks": 2,
+            "ties": 0,
+            "wins": 0
+          },
+          "evaluation_score_effect": {
+            "confidence_interval": [
+              -0.2,
+              -0.2
+            ],
+            "losses": 2,
+            "mean": -0.2,
+            "n": 2,
+            "tasks": 2,
+            "ties": 0,
+            "wins": 0
+          },
+          "model": "model-b",
+          "runtime": "runtime-b",
+          "scenario": "scenario-b",
+          "traffic_weight": 0.25
+        }
+      ],
+      "epoch": 1,
+      "evaluation_resources": {
+        "calls": 16,
+        "cost_usd": 0.016,
+        "latency_ms_sum": 1600.0
+      },
+      "global": {
+        "decision_effect": {
+          "confidence_interval": [
+            0.1,
+            0.1
+          ],
+          "mean": 0.1,
+          "n": 4,
+          "tasks": 4
+        },
+        "decision_evidence_status": "supported_positive",
+        "evaluation_effect": {
+          "confidence_interval": [
+            0.1,
+            0.1
+          ],
+          "mean": 0.1,
+          "n": 4,
+          "tasks": 4
+        },
+        "harmful_promoted_cohorts": [
+          "cohort-b"
+        ],
+        "harmful_traffic_weight": 0.25,
+        "oracle_value": 0.1,
+        "policy_gain": 0.1,
+        "retained_version_count": 1,
+        "selection": "new"
+      },
+      "scoped": {
+        "harmful_promoted_cohorts": [],
+        "harmful_traffic_weight": 0.0,
+        "oracle_value": 0.15,
+        "oracle_value_gap_over_global": 0.05,
+        "policy_gain": 0.15,
+        "retained_version_count": 2,
+        "selection_by_cohort": {
+          "cohort-a": "new",
+          "cohort-b": "old"
+        },
+        "unresolved_cohort_rate": 0.0,
+        "unresolved_traffic_weight": 0.0
+      },
+      "supported_negative_cohorts": [
+        "cohort-b"
+      ],
+      "supported_positive_cohorts": [
+        "cohort-a"
+      ],
+      "supported_sign_reversal": true,
+      "unresolved_cohorts": [],
+      "update_id": "update-1"
+    },
+    {
+      "activation_control": "forced",
+      "cohorts": [
+        {
+          "cohort_id": "cohort-a",
+          "decision_effect": {
+            "confidence_interval": [
+              0.1,
+              0.1
+            ],
+            "losses": 0,
+            "mean": 0.1,
+            "n": 2,
+            "tasks": 2,
+            "ties": 0,
+            "wins": 2
+          },
+          "decision_evidence_status": "supported_positive",
+          "decision_metric": "score",
+          "decision_non_evaluable_errors": {},
+          "decision_pass_rate_effect": {
+            "confidence_interval": [
+              0.0,
+              0.0
+            ],
+            "losses": 0,
+            "mean": 0.0,
+            "n": 2,
+            "tasks": 2,
+            "ties": 2,
+            "wins": 0
+          },
+          "decision_score_effect": {
+            "confidence_interval": [
+              0.1,
+              0.1
+            ],
+            "losses": 0,
+            "mean": 0.1,
+            "n": 2,
+            "tasks": 2,
+            "ties": 0,
+            "wins": 2
+          },
+          "evaluation_effect": {
+            "confidence_interval": [
+              0.1,
+              0.1
+            ],
+            "losses": 0,
+            "mean": 0.1,
+            "n": 2,
+            "tasks": 2,
+            "ties": 0,
+            "wins": 2
+          },
+          "evaluation_evidence_status": "supported_positive",
+          "evaluation_non_evaluable_errors": {},
+          "evaluation_pass_rate_effect": {
+            "confidence_interval": [
+              0.0,
+              0.0
+            ],
+            "losses": 0,
+            "mean": 0.0,
+            "n": 2,
+            "tasks": 2,
+            "ties": 2,
+            "wins": 0
+          },
+          "evaluation_score_effect": {
+            "confidence_interval": [
+              0.1,
+              0.1
+            ],
+            "losses": 0,
+            "mean": 0.1,
+            "n": 2,
+            "tasks": 2,
+            "ties": 0,
+            "wins": 2
+          },
+          "model": "model-a",
+          "runtime": "runtime-a",
+          "scenario": "scenario-a",
+          "traffic_weight": 0.75
+        },
+        {
+          "cohort_id": "cohort-b",
+          "decision_effect": {
+            "confidence_interval": [
+              0.1,
+              0.1
+            ],
+            "losses": 0,
+            "mean": 0.1,
+            "n": 2,
+            "tasks": 2,
+            "ties": 0,
+            "wins": 2
+          },
+          "decision_evidence_status": "supported_positive",
+          "decision_metric": "score",
+          "decision_non_evaluable_errors": {},
+          "decision_pass_rate_effect": {
+            "confidence_interval": [
+              1.0,
+              1.0
+            ],
+            "losses": 0,
+            "mean": 1.0,
+            "n": 2,
+            "tasks": 2,
+            "ties": 0,
+            "wins": 2
+          },
+          "decision_score_effect": {
+            "confidence_interval": [
+              0.1,
+              0.1
+            ],
+            "losses": 0,
+            "mean": 0.1,
+            "n": 2,
+            "tasks": 2,
+            "ties": 0,
+            "wins": 2
+          },
+          "evaluation_effect": {
+            "confidence_interval": [
+              0.1,
+              0.1
+            ],
+            "losses": 0,
+            "mean": 0.1,
+            "n": 2,
+            "tasks": 2,
+            "ties": 0,
+            "wins": 2
+          },
+          "evaluation_evidence_status": "supported_positive",
+          "evaluation_non_evaluable_errors": {},
+          "evaluation_pass_rate_effect": {
+            "confidence_interval": [
+              1.0,
+              1.0
+            ],
+            "losses": 0,
+            "mean": 1.0,
+            "n": 2,
+            "tasks": 2,
+            "ties": 0,
+            "wins": 2
+          },
+          "evaluation_score_effect": {
+            "confidence_interval": [
+              0.1,
+              0.1
+            ],
+            "losses": 0,
+            "mean": 0.1,
+            "n": 2,
+            "tasks": 2,
+            "ties": 0,
+            "wins": 2
+          },
+          "model": "model-b",
+          "runtime": "runtime-b",
+          "scenario": "scenario-b",
+          "traffic_weight": 0.25
+        }
+      ],
+      "epoch": 2,
+      "evaluation_resources": {
+        "calls": 16,
+        "cost_usd": 0.016,
+        "latency_ms_sum": 1600.0
+      },
+      "global": {
+        "decision_effect": {
+          "confidence_interval": [
+            0.1,
+            0.1
+          ],
+          "mean": 0.1,
+          "n": 4,
+          "tasks": 4
+        },
+        "decision_evidence_status": "supported_positive",
+        "evaluation_effect": {
+          "confidence_interval": [
+            0.1,
+            0.1
+          ],
+          "mean": 0.1,
+          "n": 4,
+          "tasks": 4
+        },
+        "harmful_promoted_cohorts": [],
+        "harmful_traffic_weight": 0.0,
+        "oracle_value": 0.1,
+        "policy_gain": 0.1,
+        "retained_version_count": 1,
+        "selection": "new"
+      },
+      "scoped": {
+        "harmful_promoted_cohorts": [],
+        "harmful_traffic_weight": 0.0,
+        "oracle_value": 0.1,
+        "oracle_value_gap_over_global": 0.0,
+        "policy_gain": 0.1,
+        "retained_version_count": 1,
+        "selection_by_cohort": {
+          "cohort-a": "new",
+          "cohort-b": "new"
+        },
+        "unresolved_cohort_rate": 0.0,
+        "unresolved_traffic_weight": 0.0
+      },
+      "supported_negative_cohorts": [],
+      "supported_positive_cohorts": [
+        "cohort-a",
+        "cohort-b"
+      ],
+      "supported_sign_reversal": false,
+      "unresolved_cohorts": [],
+      "update_id": "update-2"
+    }
+  ]
+}

--- a/tests/test_cohort_canary_replay.py
+++ b/tests/test_cohort_canary_replay.py
@@ -188,6 +188,33 @@ def test_repeated_seeds_are_clustered_by_task_not_counted_as_new_tasks():
     assert effect["wins"] == 2
 
 
+def test_global_bootstrap_preserves_cross_cohort_task_pairing():
+    suite = _suite()
+    for cohort in suite["cohorts"]:
+        cohort["traffic_weight"] = 0.5
+    update = suite["updates"][0]
+    decision_tasks = sorted(
+        {
+            observation["task_fingerprint"]
+            for observation in update["observations"]
+            if observation["role"] == "decision"
+        }
+    )
+    for observation in update["observations"]:
+        if observation["role"] != "decision":
+            continue
+        observation["old"]["score"] = 0.5
+        task_sign = 1 if observation["task_fingerprint"] == decision_tasks[0] else -1
+        cohort_sign = 1 if observation["cohort_id"] == "cohort-a" else -1
+        observation["new"]["score"] = 0.5 + 0.2 * task_sign * cohort_sign
+
+    effect = evaluate_suite(suite)["updates"][0]["global"]["decision_effect"]
+
+    assert effect["mean"] == 0.0
+    assert effect["confidence_interval"] == [0.0, 0.0]
+    assert effect["tasks"] == 2
+
+
 def test_opposite_point_estimates_without_corrected_intervals_do_not_reverse():
     suite = _suite()
     observations = [

--- a/tests/test_cohort_canary_replay.py
+++ b/tests/test_cohort_canary_replay.py
@@ -63,6 +63,22 @@ def test_baseline_detects_supported_reversal_and_avoids_scoped_harm():
     assert first["scoped"]["oracle_value_gap_over_global"] == 0.05
 
 
+def test_report_preserves_protocol_and_candidate_bindings():
+    suite = load_suite(BASELINE_PATH)
+    report = evaluate_suite(suite)
+    first = report["updates"][0]
+
+    assert report["run_manifest"] == suite["run_manifest"]
+    assert first["old_skill_fingerprint"] == suite["updates"][0][
+        "old_skill_fingerprint"
+    ]
+    assert first["new_skill_fingerprint"] == suite["updates"][0][
+        "new_skill_fingerprint"
+    ]
+    assert report["method"]["selection_role"] == "decision"
+    assert report["method"]["held_out_evaluation_role"] == "evaluation"
+
+
 def test_aggregate_keeps_policy_gain_harm_and_resource_cost_separate():
     aggregate = evaluate_suite(load_suite(BASELINE_PATH))["aggregate"]
 

--- a/tests/test_cohort_canary_replay.py
+++ b/tests/test_cohort_canary_replay.py
@@ -1,0 +1,289 @@
+"""Deterministic contract tests for cohort-scoped publication replay."""
+
+from __future__ import annotations
+
+import json
+from copy import deepcopy
+from pathlib import Path
+
+import pytest
+
+from scripts.bench.cohort_canary_replay.evaluate import (
+    CohortReplayValidationError,
+    evaluate_suite,
+    load_suite,
+    main,
+    render_text,
+    validate_suite,
+)
+
+FIXTURE_DIR = (
+    Path(__file__).resolve().parents[1]
+    / "scripts"
+    / "bench"
+    / "cohort_canary_replay"
+    / "fixtures"
+)
+BASELINE_PATH = FIXTURE_DIR / "baseline_v1.json"
+REPORT_PATH = FIXTURE_DIR / "baseline_v1.report.json"
+
+pytestmark = pytest.mark.algorithm_replay
+
+
+def _suite() -> dict:
+    return json.loads(BASELINE_PATH.read_text(encoding="utf-8"))
+
+
+def _rewrite_run_ids(observation: dict, suffix: str) -> None:
+    observation["case_id"] = f"{observation['case_id']}-{suffix}"
+    for side in ("old", "new"):
+        observation[side]["run_id"] = f"{observation[side]['run_id']}-{suffix}"
+
+
+def test_baseline_report_matches_checked_in_snapshot():
+    report = evaluate_suite(load_suite(BASELINE_PATH))
+
+    assert report == json.loads(REPORT_PATH.read_text(encoding="utf-8"))
+
+
+def test_baseline_detects_supported_reversal_and_avoids_scoped_harm():
+    report = evaluate_suite(load_suite(BASELINE_PATH))
+    first = report["updates"][0]
+
+    assert first["supported_sign_reversal"] is True
+    assert first["supported_positive_cohorts"] == ["cohort-a"]
+    assert first["supported_negative_cohorts"] == ["cohort-b"]
+    assert first["global"]["selection"] == "new"
+    assert first["global"]["harmful_promoted_cohorts"] == ["cohort-b"]
+    assert first["scoped"]["selection_by_cohort"] == {
+        "cohort-a": "new",
+        "cohort-b": "old",
+    }
+    assert first["scoped"]["harmful_promoted_cohorts"] == []
+    assert first["scoped"]["oracle_value_gap_over_global"] == 0.05
+
+
+def test_aggregate_keeps_policy_gain_harm_and_resource_cost_separate():
+    aggregate = evaluate_suite(load_suite(BASELINE_PATH))["aggregate"]
+
+    assert aggregate["supported_sign_reversal_rate"] == 0.5
+    assert aggregate["global_mean_policy_gain"] == 0.1
+    assert aggregate["scoped_mean_policy_gain"] == 0.125
+    assert aggregate["global_harmful_promotion_rate"] == 0.25
+    assert aggregate["scoped_harmful_promotion_rate"] == 0.0
+    assert aggregate["scoped_mean_retained_versions"] == 1.5
+    assert aggregate["evaluation_calls"] == 32
+    assert aggregate["evaluation_cost_usd"] == 0.032
+
+
+def test_cohort_identity_requires_scenario_model_and_runtime_uniqueness():
+    suite = _suite()
+    suite["cohorts"][1].update(
+        {
+            "scenario": suite["cohorts"][0]["scenario"],
+            "model": suite["cohorts"][0]["model"],
+            "runtime": suite["cohorts"][0]["runtime"],
+        }
+    )
+
+    with pytest.raises(CohortReplayValidationError, match="duplicate scenario"):
+        validate_suite(suite)
+
+
+def test_traffic_weights_must_be_positive_and_sum_to_one():
+    suite = _suite()
+    suite["cohorts"][0]["traffic_weight"] = 0.8
+
+    with pytest.raises(CohortReplayValidationError, match="sum to 1"):
+        validate_suite(suite)
+
+    suite = _suite()
+    suite["cohorts"][1]["traffic_weight"] = 0.0
+    suite["cohorts"][0]["traffic_weight"] = 1.0
+
+    with pytest.raises(CohortReplayValidationError, match="greater than zero"):
+        validate_suite(suite)
+
+
+def test_every_update_must_cover_every_declared_cohort():
+    suite = _suite()
+    suite["updates"][0]["observations"] = [
+        observation
+        for observation in suite["updates"][0]["observations"]
+        if observation["cohort_id"] != "cohort-b"
+    ]
+
+    with pytest.raises(CohortReplayValidationError, match="requires at least two Tasks"):
+        validate_suite(suite)
+
+
+def test_each_task_in_a_cohort_must_use_the_same_seed_set():
+    suite = _suite()
+    copied = deepcopy(suite["updates"][0]["observations"][0])
+    copied["seed"] = 8
+    _rewrite_run_ids(copied, "seed-8")
+    suite["updates"][0]["observations"].append(copied)
+
+    with pytest.raises(CohortReplayValidationError, match="same seed set"):
+        validate_suite(suite)
+
+
+def test_cohorts_share_a_matrix_and_decision_tasks_cannot_leak():
+    suite = _suite()
+    suite["updates"][0]["observations"][2]["task_fingerprint"] = (
+        "sha256:" + "9" * 64
+    )
+
+    with pytest.raises(CohortReplayValidationError, match="same Task/seed matrix"):
+        validate_suite(suite)
+
+    suite = _suite()
+    decision_task = next(
+        observation["task_fingerprint"]
+        for observation in suite["updates"][0]["observations"]
+        if observation["role"] == "decision"
+    )
+    next(
+        observation
+        for observation in suite["updates"][0]["observations"]
+        if observation["role"] == "evaluation"
+    )["task_fingerprint"] = decision_task
+
+    with pytest.raises(CohortReplayValidationError, match="must be disjoint"):
+        validate_suite(suite)
+
+
+def test_repeated_seeds_are_clustered_by_task_not_counted_as_new_tasks():
+    suite = _suite()
+    update = suite["updates"][0]
+    for observation in list(update["observations"]):
+        if observation["role"] != "decision":
+            continue
+        copied = deepcopy(observation)
+        copied["seed"] = 8
+        _rewrite_run_ids(copied, "seed-8")
+        update["observations"].append(copied)
+
+    report = evaluate_suite(suite)
+    effect = report["updates"][0]["cohorts"][0]["decision_effect"]
+
+    assert effect["n"] == 4
+    assert effect["tasks"] == 2
+    assert effect["wins"] == 2
+
+
+def test_opposite_point_estimates_without_corrected_intervals_do_not_reverse():
+    suite = _suite()
+    observations = [
+        observation
+        for observation in suite["updates"][0]["observations"]
+        if observation["cohort_id"] == "cohort-a"
+    ]
+    observations[0]["new"]["score"] = observations[0]["old"]["score"] + 0.2
+    observations[1]["new"]["score"] = observations[1]["old"]["score"] - 0.01
+
+    first = evaluate_suite(suite)["updates"][0]
+
+    assert first["cohorts"][0]["decision_effect"]["mean"] > 0
+    assert first["cohorts"][0]["decision_evidence_status"] == "unresolved"
+    assert first["supported_sign_reversal"] is False
+
+
+def test_non_evaluable_error_keeps_the_cohort_unresolved():
+    suite = _suite()
+    suite["updates"][0]["observations"][0]["new"][
+        "error_type"
+    ] = "infrastructure_failure"
+
+    first = evaluate_suite(suite)["updates"][0]
+
+    assert first["cohorts"][0]["decision_evidence_status"] == "unresolved"
+    assert first["cohorts"][0]["decision_non_evaluable_errors"] == {
+        "infrastructure_failure": 1
+    }
+    assert first["global"]["decision_evidence_status"] == "unresolved"
+
+
+def test_held_out_evaluation_cannot_change_the_frozen_selection():
+    suite = _suite()
+    baseline = evaluate_suite(suite)["updates"][0]
+    for observation in suite["updates"][0]["observations"]:
+        if observation["role"] != "evaluation":
+            continue
+        observation["new"]["score"] = max(
+            0.0, observation["old"]["score"] - 0.3
+        )
+
+    changed = evaluate_suite(suite)["updates"][0]
+
+    assert changed["global"]["selection"] == baseline["global"]["selection"]
+    assert (
+        changed["scoped"]["selection_by_cohort"]
+        == baseline["scoped"]["selection_by_cohort"]
+    )
+    assert changed["global"]["policy_gain"] < baseline["global"]["policy_gain"]
+    assert changed["scoped"]["policy_gain"] < baseline["scoped"]["policy_gain"]
+
+
+def test_outcomes_require_complete_old_new_pairs_and_unique_runs():
+    suite = _suite()
+    del suite["updates"][0]["observations"][0]["new"]
+
+    with pytest.raises(CohortReplayValidationError, match="missing=.*new"):
+        validate_suite(suite)
+
+    suite = _suite()
+    first = suite["updates"][0]["observations"][0]
+    second = suite["updates"][0]["observations"][1]
+    second["old"]["run_id"] = first["old"]["run_id"]
+
+    with pytest.raises(CohortReplayValidationError, match="duplicate"):
+        validate_suite(suite)
+
+
+def test_update_stream_requires_distinct_versions_and_increasing_epochs():
+    suite = _suite()
+    suite["updates"][0]["new_skill_fingerprint"] = suite["updates"][0][
+        "old_skill_fingerprint"
+    ]
+
+    with pytest.raises(CohortReplayValidationError, match="must differ"):
+        validate_suite(suite)
+
+    suite = _suite()
+    suite["updates"][1]["epoch"] = 1
+
+    with pytest.raises(CohortReplayValidationError, match="strictly increasing"):
+        validate_suite(suite)
+
+
+def test_unknown_fields_and_non_finite_scores_fail_closed():
+    suite = _suite()
+    suite["updates"][0]["observations"][0]["gold_label"] = "leak"
+
+    with pytest.raises(CohortReplayValidationError, match="unknown=.*gold_label"):
+        validate_suite(suite)
+
+    suite = _suite()
+    suite["updates"][0]["observations"][0]["new"]["score"] = float("nan")
+
+    with pytest.raises(CohortReplayValidationError, match="finite"):
+        validate_suite(suite)
+
+
+def test_replay_work_has_a_deterministic_upper_bound():
+    suite = _suite()
+    suite["metric_config"]["bootstrap_samples"] = 1_000_000
+
+    with pytest.raises(CohortReplayValidationError, match="work exceeds"):
+        validate_suite(suite)
+
+
+def test_cli_renders_text_and_json(capsys):
+    report = evaluate_suite(load_suite(BASELINE_PATH))
+
+    assert main([str(BASELINE_PATH)]) == 0
+    assert capsys.readouterr().out == render_text(report) + "\n"
+
+    assert main([str(BASELINE_PATH), "--format", "json"]) == 0
+    assert json.loads(capsys.readouterr().out) == report


### PR DESCRIPTION
## Summary

增加一个完全离线、可复算的 cohort-scoped publication 配对回放基线，用于检验同一 Skill 更新是否在不同 `scenario × model × runtime` cohort 中出现可靠的反向效果。

本 PR 只建立 Q3 的数据、统计和 shadow decision 契约，不修改生产 Canary、Git 分支、安装同步或真实流量路由。

## Changes

- 增加严格的不可变 old/new 结果 schema，并固定 candidate stream、任务集、评测协议和 cohort 定义指纹。
- 要求所有 cohort 共享同一 Task×seed 矩阵，并将预注册 `decision` Task 与 held-out `evaluation` Task 完全隔离。
- 先在 Task 内聚合 seed，再使用 Task-clustered bootstrap、Bonferroni family-wise 修正和 practical margin 输出正向、负向或未决证据。
- 使用 decision 集冻结 global 与 scoped 版本选择，只使用 held-out evaluation 集计算 policy gain、harmful promotion 和 oracle gap。
- 报告反向效果、未决 cohort、流量加权收益、并存版本数和评测资源，并设置确定性工作量上限。
- 增加合成 fixture、报告快照、CLI 输出及 18 条数据泄漏、统计和失败关闭测试。

## Test plan

- [x] `make test` passes（通过项目虚拟环境覆盖本机缺失的 `python3.11`：2753 passed, 10 skipped）
- [x] Added/updated unit tests for the change（17 passed）
- [ ] `make e2e` passes (if the change touches ingestion / install / daemon)
- [x] Manually verified the affected user flow（运行 text 与 JSON replay CLI）

## Linked issues

Closes #387

## 给外人看的背景（按人群看 Canary 与发布策略是什么）

下面按给第三方看的问题单来写：每个词第一次出现都会说明它是什么。代码位置只是提示，不是必须先读完整个仓库才能看懂。

### 这是什么

XSkill 给已经在用的技能做更新时，不会立刻让所有人换新版。现有做法是开一条灰度：主干（main）上是旧版，灰度分支（staging）上是新版，系统用 Canary 对比两边好不好。Canary 就是这次灰度对比：看新版和旧版谁更好，最后给出一个全局结论，要么晋升（promoted，全员改用新版），要么拒绝（rejected，丢掉新版，只留旧版）。

这个全局结论有一个盲区。同一份技能更新，即使已经过了库内准入，换一组任务场景、换一个模型、换一种 Runtime，好处和坏处也可能反过来。Runtime 就是技能实际跑在哪个编码助手环境里。任务场景就是这组任务在测哪一类工作。模型就是当时在用的大模型。库内准入是更前面的 Q2：在固定的竞争库里，看正文和激活描述怎么搭配，以及这个更新够不够格当作候选。过了那道门，才进入这里问该怎么发布。

cohort 就是预先声明好的一组流量：同一任务场景、同一模型、同一 Runtime。代码里用这三个维度的组合来标识一个 cohort，每个 cohort 还有事先写好的流量权重，所有权重加起来等于 1。这里说的「按人群看」，指的就是按这样的组合看，不是按工号或部门切人。

Q3 问两件事。第一件：同一个已经通过 Q2 准入的更新，在不同 cohort 里会不会同时出现可靠的正向和可靠的负向，也就是正负反向。第二件：如果按 cohort 分别决定发新版还是留旧版，会不会比一个全局的晋升或拒绝更少误伤。

本 PR 不回答「真实流量里已经出现了反向」。它只先把离线回放的数据格式、统计方法和 shadow 决策契约立住。shadow 的意思是：评测器会按规则选出该发哪个版本，并算出收益和有害晋升，但这些选择只写在报告里。它不改生产 Canary，不改 Git 分支，不改安装同步，也不改真实流量该走哪条路。

### 用户侧实际会发生什么

合上这张补丁之后，日常用技能的人不会感到任何变化。没有新的发布开关，没有按 cohort 装不同版本，客户端也不会因此改走哪条灰度。

开发或评测的人可以在本机跑一套离线脚本，读一份已经录好的旧版与新版配对结果。脚本不调用大模型，不跑外部评测架子，不碰 Git，不访问网络，也不读生产 Canary 的当前状态。同样的输入再跑一遍，数字应当一样。

入仓的第一份数据是合成样例，只用来验证格式、统计方向、反向判定和两种发布策略的比较能跑通。它不能证明真实流量里已经有反向，也不能证明按 cohort 发布已经提高了收益。后面要先用原生 Runtime 存下来的真实配对矩阵验证 Q3 的假设，才谈得上实现按 cohort 选版本。

### 两套任务为什么要拆开

每条候选更新都会带两套预先登记、互不重叠的任务。

decision 集只负责选版本。评测器看这套任务上，每个 cohort 以及全局，新版相对旧版是可靠更好、可靠更差，还是还说不准。选完就冻结，后面不许再改。

evaluation 集是事先留出来的另一套任务。版本选定之后，只用这套任务算三件事：按流量加权，这次选择相对「全部留旧版」多出来的分数；有害晋升；以及和「如果事后全知能怎么发」之间的差距。

两套任务必须互斥。不能用同一批结果既决定发不发，又证明发了对。所有 cohort 还必须共用同一张任务和随机种子矩阵，这样差别来自场景、模型和 Runtime，而不是各 cohort 测了不同的题。

### 怎么判定正向、负向和反向

每个任务先把自己的多个随机种子平均掉，再按任务做配对比较。这样不会把同一个任务的重复种子当成独立样本。

一个 cohort 只有在修正后的区间完全高出预先声明的实际差额时，才算可靠正向；完全低于负的实际差额时，才算可靠负向；其余都是未决。点估计看起来一正一负，不算反向。只有同一个更新里，至少有一个 cohort 可靠为正，同时另一个 cohort 可靠为负，才记一次得到支持的正负反向。

未决不能当成零效果，也不能当成「可以放心发新版」。按 cohort 发布时，负向和未决的 cohort 都留旧版，只有 decision 集上可靠为正的 cohort 才选新版。全局策略更硬：整份流量加权之后，只有全局也可靠为正才全员选新版，否则全员留旧版。

### 有害晋升是什么

有害晋升说的是：策略已经决定给某个 cohort 发新版，但 evaluation 集上这个 cohort 有可靠的负向证据。也就是发上去会伤到这一组。

全局只留一个版本，所以一旦全局选了新版，那些在 evaluation 集上可靠变差的 cohort 都会被算进有害晋升。按 cohort 发布可以在负向或未决的组里继续留旧版。报告会同时给出两种策略伤到了哪些 cohort、对应的流量权重，以及并存了几个版本。

这些数字只出现在回放报告里，不是线上已经按组发了不同版本。

### 不要和什么搞混

不要和 Q1 搞混。Q1 问的是：用任务图去形成技能，会不会比只看一整次会话或只看一小段 Atom 更有效。那是「技能怎么写出来」。本 PR 不形成技能，也不比较形成方法。

不要和 Q2 搞混。Q2 是库内的 2×2：同一套竞争库里，技能正文和激活描述各有旧新，组成四个格子，看收益来自改正文、改描述，还是两者一起变；另外再问这个更新能不能作为候选进库。Q3 的前提是这个更新已经过了 Q2 那道门。本 PR 问的是进库之后，换一组场景、模型和 Runtime，该不该还按一个全局结论发布。

也不要把它理解成生产 Canary 已经按 cohort 分流。今天的生产 Canary 即使按模型分过桶加权，最后仍然折成一个全局的晋升或拒绝，主干和灰度也仍然只留一个线上版本。本 PR 不改生产 Canary，不改主干和灰度分支，不改安装同步，不改看板，也不改真实流量路由。

Agent 接触不到格力内网现网。这张补丁只是仓库里的离线评测脚本和合成数据。合进 main 也不会让现网 Canary 开始按组发布。

### 怎么算这段背景对齐了

能说出 cohort 是任务场景、模型和 Runtime 的预声明组合，不是按工号切人。能说出 shadow 决策只写报告、不改生产发布。能把 decision 集和 evaluation 集分开：前者选版本，后者在选定之后算收益和有害晋升，两套任务不能重叠。能说出有害晋升是「已经决定发新版，但留出的任务上这一组可靠变差」。能把 Q3 和 Q1 形成技能、Q2 库内 2×2 准入分开。
