### PR TITLE
fix(codex): 完整采集 rollout 工具证据并覆盖归档会话

### DIFF
--- a/README.md
+++ b/README.md
@@ -318,7 +318,7 @@ skillhub:
 | Agent | 状态 | 轨迹采集 | 技能安装 |
 | ----- | ---- | -------- | -------- |
 | **Claude Code** | ✅ 已验证 | `~/.claude/projects/` | 软链 → `~/.claude/skills/<name>/` |
-| **Codex CLI** | ✅ 已验证 | `~/.codex/sessions/` | 软链 → `~/.agents/skills/<name>/` |
+| **Codex CLI** | ✅ 已验证 | `~/.codex/sessions/` + `~/.codex/archived_sessions/` | 软链 → `~/.agents/skills/<name>/` |
 | **OpenCode** | ✅ 已验证 | SQLite `~/.local/share/opencode/opencode.db` | 软链 → `~/.agents/skills/<name>/` |
 | **OpenClaw** | 🟡 已实现 | `~/.openclaw/agents/` | 拷贝 → `~/.agents/skills/<name>/` |
 | **Cursor** | 🟡 已实现 | `~/.cursor/projects/*/agent-transcripts/` | 软链 → `~/.cursor/skills/<name>/` |

--- a/docs/ecosystem/codex.md
+++ b/docs/ecosystem/codex.md
@@ -94,7 +94,7 @@ metadata:
 - 默认：`~/.codex/`
 - env 覆盖：`CODEX_HOME`
 
-archived sessions 路径：`{codex_home}/archived_sessions/`（`codex-rs/rollout/src/lib.rs:23`）。xskill 摄取可选 *include* archived（决策上：archived 默认 ignore，避免重复消费陈旧数据，与 OpenCode `time_archived` 处理对齐）。
+archived sessions 路径是 `{codex_home}/archived_sessions/`（`codex-rs/rollout/src/lib.rs:23`），xskill 默认同时摄取活跃与已归档轨迹，同一 session id 只选 mtime 最新的来源。
 
 ### 3.2 JSONL 行结构
 
@@ -176,22 +176,21 @@ src/xskill/adapters.py
 
 ```python
 {
-    "id": "codex_cli",
+    "id": "codex",
     "source_kind": "jsonl",
-    "source_subpath": ".codex/sessions",   # 递归扫 YYYY/MM/DD/rollout-*.jsonl
-    "home_env_override": "CODEX_HOME",     # daemon 启动时优先读 env
+    "source_subpath": ".codex",
     "bridge": "codex_rollout_jsonl",
 }
 ```
 
-`detect_known_ecosystems()` 加 codex 探测；存在 `<home>/.codex/sessions/` 目录或 `$CODEX_HOME/sessions/` 即注册。
+`detect_known_ecosystems()` 在 `<home>/.codex/` 存在时注册 Codex，因此只剩归档轨迹的环境也不会漏掉。
 
 ### 4.4 watcher 配置
 
-- 根：`<codex_home>/sessions/`
-- glob：`*/*/*/rollout-*.jsonl`（深度恒定 3：year/month/day/file）
-- 写入特性是 append-only，与 CC 一致，可直接复用 mtime + offset cursor。
-- **不扫** `archived_sessions/`（默认）。
+- 根：`<codex_home>/`。
+- 活跃 glob：`sessions/*/*/*/rollout-*.jsonl`。
+- 归档 glob：`archived_sessions/rollout-*.jsonl`。
+- 轨迹按 settle 屏障读取稳定快照，大文件通过路径流式 adapter 处理，不会把整份 UTF-8 历史加载到内存。
 
 ### 4.5 不需要做的
 

--- a/src/xskill/ecosystems/_shared.py
+++ b/src/xskill/ecosystems/_shared.py
@@ -86,7 +86,8 @@ class EcosystemSpec:
             和 `detect_known_ecosystems` 上报
         source_kind: 轨迹存储形态。P2 只支持 ``jsonl``；P3 加 ``sqlite``
         sessions_path: ``(home_root) -> Path``，返回该生态的 sessions/projects 根目录
-        sessions_glob: 相对 ``sessions_path`` 的 glob，用于扫所有 session 文件
+        sessions_glob: 相对 ``sessions_path`` 的 glob 或 glob 列表，用于扫所有
+            session 文件
         session_id_from_path: ``(jsonl_path) -> session_id``。CC 用文件名（``stem``），
             codex 用文件名里的 uuid 段
         cwd_from_content: ``(jsonl_content) -> cwd``。CC 扫每条事件找首个 ``cwd``
@@ -98,12 +99,16 @@ class EcosystemSpec:
             ``traj_codex_``）
         skills_install_path: ``(home_root) -> Path``，skill 安装目标根目录
         label: 短标签，给 logger 用
+        is_session_complete_path: 路径流式 adapter 的完成态检查。
+        adapt_path: 可选的路径流式 adapter，用于避免整份大轨迹入内存。
+        prefer_newest_session_source: 同一 session id 存在多个来源时，只处理
+            mtime 最新的文件；用于 Codex 活跃/归档轨迹去重。
     """
 
     name: str
     source_kind: Literal["jsonl"]
     sessions_path: Callable[[Path], Path]
-    sessions_glob: str
+    sessions_glob: str | tuple[str, ...]
     session_id_from_path: Callable[[Path], str]
     cwd_from_content: Callable[[str], str]
     adapter_format: str
@@ -111,12 +116,15 @@ class EcosystemSpec:
     skills_install_path: Callable[[Path], Path]
     label: str
     is_session_complete: Optional[Callable[[str], bool]] = None
+    is_session_complete_path: Optional[Callable[[Path], bool]] = None
     cwd_from_path: Optional[Callable[[Path], str]] = None
+    adapt_path: Optional[Callable[[Path, dict], tuple[str, dict]]] = None
     # 可选：自定义「文件 → 文本」读取。默认 None = ``read_text``。给需要先
     # 解码再解析的生态用（DeepSeek Harness 默认写 zstd 帧序列的
     # ``session.jsonl.zstd``）。返回 None 表示本轮读不了（例如缺解码依赖），
     # ingester 跳过该文件并由 reader 自己负责告警。
     read_content: Optional[Callable[[Path], Optional[str]]] = None
+    prefer_newest_session_source: bool = False
 
 
 @dataclass(frozen=True)
@@ -158,8 +166,8 @@ _KNOWN_ECOSYSTEMS: list[dict] = [
     },
     {
         "id": "codex",
-        # Codex CLI 写 <home>/.codex/sessions/YYYY/MM/DD/rollout-*.jsonl
-        "source_subpath": ".codex/sessions",
+        # Codex CLI 在 <home>/.codex 下保留活跃与已归档 rollout。
+        "source_subpath": ".codex",
         "bridge_subpath": ".xskill/codex_sessions",
         "source_kind": "dir",
     },
@@ -439,9 +447,24 @@ def session_start_time(jsonl_path: Path) -> Optional[float]:
     """
     if not jsonl_path.is_file():
         return None
-    return session_start_time_from_content(
-        jsonl_path.read_text(encoding="utf-8", errors="ignore")
-    )
+    try:
+        with jsonl_path.open("r", encoding="utf-8", errors="ignore") as source:
+            for line in source:
+                line = line.strip()
+                if not line:
+                    continue
+                try:
+                    event = json.loads(line)
+                except json.JSONDecodeError:
+                    continue
+                timestamp = event.get("timestamp")
+                if timestamp:
+                    parsed = _parse_iso_to_epoch(timestamp)
+                    if parsed is not None:
+                        return parsed
+    except OSError:
+        return None
+    return None
 
 
 def session_start_time_from_content(content: str) -> Optional[float]:
@@ -704,6 +727,24 @@ def submit_trajectory(
         traj_id = generate_traj_id(traj_dir)
 
     md_content, json_metadata = adapt_trajectory(content, format, metadata)
+    return _store_adapted_trajectory(
+        md_content,
+        json_metadata,
+        traj_id=traj_id,
+        traj_dir=traj_dir,
+        mask_patterns=mask_patterns,
+    )
+
+
+def _store_adapted_trajectory(
+    md_content: str,
+    json_metadata: dict,
+    *,
+    traj_id: str,
+    traj_dir: Path,
+    mask_patterns: Optional[list[str]] = None,
+) -> dict:
+    """持久化已适配的轨迹；供字符串与路径流式 adapter 共用。"""
 
     # 落盘前清洗：去 ANSI 转义 + 控制字符（终端/tool 原始输出常掺入），
     # 保证 splitlines 行数 == \n 行数（atom offset 与人类行号一致）、不喂垃圾给模型。
@@ -738,6 +779,19 @@ def submit_trajectory(
 # ─────────────────────────────────────────────────────────────────
 # JsonlIngester — spec-driven 扫盘 + 桥接
 # ─────────────────────────────────────────────────────────────────
+
+
+def _glob_session_paths(
+    sessions_root: Path,
+    patterns: str | tuple[str, ...],
+) -> list[Path]:
+    """按一个或多个 glob 扫描 JSONL session，并以路径去重。"""
+    normalized = (patterns,) if isinstance(patterns, str) else patterns
+    return sorted({
+        path
+        for pattern in normalized
+        for path in sessions_root.glob(pattern)
+    })
 
 
 class JsonlIngester:
@@ -969,8 +1023,31 @@ class JsonlIngester:
         source_paths = (
             sorted(candidate_paths)
             if candidate_paths is not None
-            else sorted(sessions_root.glob(self.spec.sessions_glob))
+            else _glob_session_paths(sessions_root, self.spec.sessions_glob)
         )
+        if self.spec.prefer_newest_session_source:
+            newest_source_by_session: dict[
+                str, tuple[tuple[int, int, str], Path]
+            ] = {}
+            for source_path in source_paths:
+                source_session_id = self.spec.session_id_from_path(source_path)
+                try:
+                    source_stat = source_path.stat()
+                except OSError:
+                    continue
+                source_key = (
+                    int(source_stat.st_mtime_ns),
+                    int(source_stat.st_size),
+                    str(source_path),
+                )
+                previous = newest_source_by_session.get(source_session_id)
+                if previous is None or source_key > previous[0]:
+                    newest_source_by_session[source_session_id] = (
+                        source_key, source_path,
+                    )
+            source_paths = sorted(
+                value[1] for value in newest_source_by_session.values()
+            )
         for jsonl_path in source_paths:
             sid = self.spec.session_id_from_path(jsonl_path)
             try:
@@ -998,38 +1075,68 @@ class JsonlIngester:
                         continue
                 rebridged = True  # 源在转换后又增长 → 全量重转换覆盖
 
-            if self.spec.read_content is not None:
-                content = self.spec.read_content(jsonl_path)
-                if content is None:
-                    continue  # reader 已告警（如缺解码依赖），本轮跳过
-            else:
-                content = jsonl_path.read_text(encoding="utf-8", errors="ignore")
-            if not content.strip():
-                continue
-            if (
-                self.spec.is_session_complete is not None
-                and settle <= 0
-                and not self.spec.is_session_complete(content)
-            ):
-                # settle=0 的低延迟模式不能把刚创建、仍在续写的 session
-                # 永久记 seen；有明确完成事件后才桥接并触发 side 轮转。
-                continue
-            session_start_t = session_start_time_from_content(content)
-            if before_bridge is not None:
-                before_bridge(
-                    jsonl_path,
-                    sid,
-                    content,
-                    session_start_t,
-                )
-            traj_id = self._make_traj_id(content, sid, source_path=jsonl_path)
-            result = submit_trajectory(
-                content=content,
-                format=self.spec.adapter_format,
-                metadata={"session_id": sid},
-                traj_id=traj_id,
-                traj_dir=target_traj_dir,
+            use_path_adapter = (
+                self.spec.adapt_path is not None
+                and before_bridge is None
+                and after_bridge is None
             )
+            if use_path_adapter:
+                try:
+                    if jsonl_path.stat().st_size <= 0:
+                        continue
+                except OSError:
+                    continue
+                if (
+                    self.spec.is_session_complete_path is not None
+                    and settle <= 0
+                    and not self.spec.is_session_complete_path(jsonl_path)
+                ):
+                    continue
+                session_start_t = session_start_time(jsonl_path)
+                traj_id = self._make_traj_id("", sid, source_path=jsonl_path)
+                md_content, json_metadata = self.spec.adapt_path(
+                    jsonl_path, {"session_id": sid},
+                )
+                result = _store_adapted_trajectory(
+                    md_content,
+                    json_metadata,
+                    traj_id=traj_id,
+                    traj_dir=target_traj_dir,
+                )
+                content = ""
+            else:
+                if self.spec.read_content is not None:
+                    content = self.spec.read_content(jsonl_path)
+                    if content is None:
+                        continue  # reader 已告警（如缺解码依赖），本轮跳过
+                else:
+                    content = jsonl_path.read_text(encoding="utf-8", errors="ignore")
+                if not content.strip():
+                    continue
+                if (
+                    self.spec.is_session_complete is not None
+                    and settle <= 0
+                    and not self.spec.is_session_complete(content)
+                ):
+                    # settle=0 的低延迟模式不能把刚创建、仍在续写的 session
+                    # 永久记 seen；有明确完成事件后才桥接并触发 side 轮转。
+                    continue
+                session_start_t = session_start_time_from_content(content)
+                if before_bridge is not None:
+                    before_bridge(
+                        jsonl_path,
+                        sid,
+                        content,
+                        session_start_t,
+                    )
+                traj_id = self._make_traj_id(content, sid, source_path=jsonl_path)
+                result = submit_trajectory(
+                    content=content,
+                    format=self.spec.adapter_format,
+                    metadata={"session_id": sid},
+                    traj_id=traj_id,
+                    traj_dir=target_traj_dir,
+                )
             result["session_id"] = sid
             result["source_jsonl"] = str(jsonl_path)
             result["session_start_t"] = session_start_t

--- a/src/xskill/ecosystems/codex.py
+++ b/src/xskill/ecosystems/codex.py
@@ -14,6 +14,7 @@ ecosystems/codex.py -- Codex CLI 生态适配
 
 from __future__ import annotations
 
+import hashlib
 import json
 import logging
 import re
@@ -30,6 +31,8 @@ from xskill.ecosystems._shared import (
 )
 
 logger = logging.getLogger("xskill.ecosystems")
+
+_CODEX_TOOL_INPUT_LIMIT = 2000
 
 
 # ─────────────────────────────────────────────────────────────────
@@ -312,16 +315,37 @@ def _codex_tool_input(payload: dict):
         else payload.get("arguments")
     )
     if isinstance(raw, str) and payload.get("type") == "function_call":
+        if len(raw) > _CODEX_TOOL_INPUT_LIMIT:
+            return _bounded_codex_tool_input(raw)
         try:
             decoded = json.loads(raw)
         except json.JSONDecodeError:
             decoded = raw
         raw = decoded
     if isinstance(raw, str):
-        return raw[:2000]
+        return _bounded_codex_tool_input(raw)
     if isinstance(raw, (dict, list)):
-        return raw
-    return "" if raw is None else str(raw)[:2000]
+        encoded = json.dumps(
+            raw,
+            ensure_ascii=False,
+            separators=(",", ":"),
+            sort_keys=True,
+        )
+        if len(encoded) <= _CODEX_TOOL_INPUT_LIMIT:
+            return raw
+        return _bounded_codex_tool_input(encoded)
+    return "" if raw is None else _bounded_codex_tool_input(str(raw))
+
+
+def _bounded_codex_tool_input(value: str) -> str:
+    if len(value) <= _CODEX_TOOL_INPUT_LIMIT:
+        return value
+    hasher = hashlib.sha256()
+    for offset in range(0, len(value), 4096):
+        hasher.update(value[offset : offset + 4096].encode("utf-8"))
+    digest = hasher.hexdigest()
+    suffix = f"...[truncated original_chars={len(value)} sha256={digest}]"
+    return value[: _CODEX_TOOL_INPUT_LIMIT - len(suffix)] + suffix
 
 
 def _codex_tool_output_text(output) -> str:

--- a/src/xskill/ecosystems/codex.py
+++ b/src/xskill/ecosystems/codex.py
@@ -4,8 +4,8 @@ ecosystems/codex.py -- Codex CLI 生态适配
 
 把蒸馏出的 Skill 装进 Codex 的 user-scope skill 目录
 （``~/.agents/skills/<name>/``——与 OpenCode / OpenClaw 共享），并把 Codex CLI
-原生 rollout JSONL（``~/.codex/sessions/YYYY/MM/DD/rollout-*.jsonl``）桥接回
-xskill 的标准 ``traj_*.md`` 格式。
+原生活跃与已归档 rollout JSONL（``~/.codex/sessions/YYYY/MM/DD/rollout-*.jsonl``
+与 ``~/.codex/archived_sessions/rollout-*.jsonl``）桥接回 xskill 的标准 ``traj_*.md`` 格式。
 
 本模块含 Codex 平台的「读」（``_adapt_codex_rollout_jsonl`` +
 ``ingest_codex_sessions``）与「写」（``install_to_codex`` /
@@ -16,6 +16,7 @@ from __future__ import annotations
 
 import json
 import logging
+import re
 from pathlib import Path
 from typing import Iterable, Optional
 
@@ -48,6 +49,11 @@ def _codex_sessions_path(home: Path) -> Path:
     "Codex CLI > 轨迹采集"段）。
     """
     return home / ".codex" / "sessions"
+
+
+def _codex_rollout_root_path(home: Path) -> Path:
+    """Codex 活跃与已归档 rollout 的共同根目录。"""
+    return home / ".codex"
 
 
 # ─────────────────────────────────────────────────────────────────
@@ -122,22 +128,28 @@ def _read_cwd_from_codex_jsonl(jsonl_content: str) -> str:
     codex schema：首行（且仅首行）是 ``type=session_meta`` 行，``payload.cwd``
     即用户当时的 cwd。与 CC 不同——CC 每条事件都带 ``cwd``。
     """
-    for line in jsonl_content.splitlines():
-        line = line.strip()
-        if not line:
-            continue
-        try:
-            ev = json.loads(line)
-        except json.JSONDecodeError:
-            continue
-        if ev.get("type") == "session_meta":
-            payload = ev.get("payload") or {}
-            cwd = payload.get("cwd")
-            if cwd:
-                return str(cwd)
-        # session_meta 不出现在首条则放弃（codex schema 保证首条就是它）
-        break
+    line_end = jsonl_content.find("\n")
+    line = jsonl_content[:line_end if line_end >= 0 else len(jsonl_content)].strip()
+    if not line:
+        return ""
+    try:
+        ev = json.loads(line)
+    except json.JSONDecodeError:
+        return ""
+    if ev.get("type") == "session_meta":
+        payload = ev.get("payload") or {}
+        cwd = payload.get("cwd")
+        if cwd:
+            return str(cwd)
     return ""
+
+
+def _read_cwd_from_codex_path(path: Path) -> str:
+    try:
+        with path.open("r", encoding="utf-8", errors="ignore") as source:
+            return _read_cwd_from_codex_jsonl(source.readline())
+    except OSError:
+        return ""
 
 
 def _codex_traj_id(jsonl_path: Path, session_id: str) -> str:
@@ -146,8 +158,13 @@ def _codex_traj_id(jsonl_path: Path, session_id: str) -> str:
     与 ``_cc_traj_id`` 同形，前缀换成 ``traj_codex_`` 让 trajectory 元数据能
     一眼区分来源。cwd 从 codex JSONL 首行抽（不是 CC 的 per-event 字段）。
     """
-    content = jsonl_path.read_text(encoding="utf-8", errors="ignore") if jsonl_path.is_file() else ""
-    cwd = _read_cwd_from_codex_jsonl(content)
+    cwd = ""
+    if jsonl_path.is_file():
+        try:
+            with jsonl_path.open("r", encoding="utf-8", errors="ignore") as source:
+                cwd = _read_cwd_from_codex_jsonl(source.readline())
+        except OSError:
+            pass
     project = _sanitize_for_filename(Path(cwd).name if cwd else "", maxlen=32) or "unknown"
     sid_short = _sanitize_for_filename(session_id, maxlen=8) or "nosid"
     return f"traj_codex_{project}_{sid_short}"
@@ -157,17 +174,74 @@ def _codex_traj_id(jsonl_path: Path, session_id: str) -> str:
 # Ecosystem spec
 # ─────────────────────────────────────────────────────────────────
 
+def _codex_session_complete(content: str) -> bool:
+    """Codex 低延迟入库只接受已结束或已中止的 turn。"""
+    line_end = len(content)
+    saw_lifecycle_event = False
+    while line_end > 0:
+        line_start = content.rfind("\n", 0, line_end) + 1
+        line = content[line_start:line_end].strip()
+        line_end = max(0, line_start - 1)
+        if not line:
+            continue
+        try:
+            event = json.loads(line)
+        except json.JSONDecodeError:
+            continue
+        if event.get("type") != "event_msg":
+            continue
+        payload = event.get("payload") or {}
+        subtype = payload.get("type")
+        if subtype in {"task_complete", "turn_aborted"}:
+            return True
+        if subtype == "task_started":
+            saw_lifecycle_event = True
+            return False
+    # 0.147 及更早的 rollout 没有 task lifecycle 事件，保持兼容。
+    return not saw_lifecycle_event
+
+
+def _codex_session_complete_path(path: Path) -> bool:
+    latest_lifecycle = ""
+    try:
+        for _line_number, event in _iter_codex_path_events(path):
+            if event.get("type") != "event_msg":
+                continue
+            payload = event.get("payload") or {}
+            subtype = payload.get("type")
+            if subtype in {"task_started", "task_complete", "turn_aborted"}:
+                latest_lifecycle = str(subtype)
+    except OSError:
+        return False
+    if not latest_lifecycle:
+        return True
+    return latest_lifecycle in {"task_complete", "turn_aborted"}
+
+
+def _adapt_codex_rollout_path(path: Path, metadata: dict) -> tuple[str, dict]:
+    """Adapt a Codex rollout directly from disk with bounded source memory."""
+    return _adapt_codex_events(_iter_codex_path_events(path), metadata)
+
+
 CODEX_SPEC = EcosystemSpec(
     name="codex",
     source_kind="jsonl",
-    sessions_path=_codex_sessions_path,
-    sessions_glob="*/*/*/rollout-*.jsonl",  # YYYY/MM/DD/rollout-<ts>-<uuid>.jsonl
+    sessions_path=_codex_rollout_root_path,
+    sessions_glob=(
+        "sessions/*/*/*/rollout-*.jsonl",
+        "archived_sessions/rollout-*.jsonl",
+    ),
     session_id_from_path=_codex_session_id_from_path,
     cwd_from_content=_read_cwd_from_codex_jsonl,
     adapter_format="codex_rollout_jsonl",
     traj_id_prefix="traj_codex_",
     skills_install_path=_agents_skills_path,
     label="codex",
+    is_session_complete=_codex_session_complete,
+    is_session_complete_path=_codex_session_complete_path,
+    cwd_from_path=_read_cwd_from_codex_path,
+    adapt_path=_adapt_codex_rollout_path,
+    prefer_newest_session_source=True,
 )
 
 
@@ -194,7 +268,125 @@ def _codex_message_text(content) -> str:
     return ""
 
 
-def _adapt_codex_rollout_jsonl(content: str, metadata: dict) -> tuple[str, dict]:
+def _iter_codex_events(content: str):
+    """逐行解析 rollout，避免 ``splitlines()`` 为整个大文件复制字符串。"""
+    line_start = 0
+    line_number = 0
+    content_length = len(content)
+    while line_start < content_length:
+        line_end = content.find("\n", line_start)
+        if line_end < 0:
+            line_end = content_length
+        raw_line = content[line_start:line_end].strip()
+        line_start = line_end + 1
+        line_number += 1
+        if not raw_line:
+            continue
+        try:
+            event = json.loads(raw_line)
+        except json.JSONDecodeError:
+            continue
+        if isinstance(event, dict):
+            yield line_number, event
+
+
+def _iter_codex_path_events(path: Path):
+    """从文件流式解析 rollout，不把整份 UTF-8 历史解码成一个巨大字符串。"""
+    with path.open("rb") as source:
+        for line_number, raw_line in enumerate(source, 1):
+            raw_line = raw_line.strip()
+            if not raw_line:
+                continue
+            try:
+                event = json.loads(raw_line)
+            except (json.JSONDecodeError, UnicodeDecodeError):
+                continue
+            if isinstance(event, dict):
+                yield line_number, event
+
+
+def _codex_tool_input(payload: dict):
+    raw = (
+        payload.get("input")
+        if payload.get("type") == "custom_tool_call"
+        else payload.get("arguments")
+    )
+    if isinstance(raw, str) and payload.get("type") == "function_call":
+        try:
+            decoded = json.loads(raw)
+        except json.JSONDecodeError:
+            decoded = raw
+        raw = decoded
+    if isinstance(raw, str):
+        return raw[:2000]
+    if isinstance(raw, (dict, list)):
+        return raw
+    return "" if raw is None else str(raw)[:2000]
+
+
+def _codex_tool_output_text(output) -> str:
+    """将 Codex 的 string / content-block 工具输出有界转成文本。"""
+    parts: list[str] = []
+    remaining = 2000
+    items = output if isinstance(output, list) else [output]
+    for item in items:
+        if remaining <= 0:
+            break
+        text = ""
+        if isinstance(item, str):
+            text = item
+        elif isinstance(item, dict):
+            block_type = item.get("type")
+            if block_type in {"input_text", "output_text", "text"}:
+                text = str(item.get("text") or "")
+            elif block_type in {"input_image", "output_image", "image"}:
+                text = "[image output]"
+            else:
+                text = json.dumps(item, ensure_ascii=False)
+        elif item is not None:
+            text = str(item)
+        if not text:
+            continue
+        if parts:
+            parts.append("\n")
+            remaining -= 1
+        if remaining <= 0:
+            break
+        piece = text[:remaining]
+        parts.append(piece)
+        remaining -= len(piece)
+    return "".join(parts)
+
+
+_CODEX_EXIT_CODE_RE = re.compile(r'"exit_code"\s*:\s*(-?\d+)')
+_CODEX_IS_ERROR_RE = re.compile(r'"isError"\s*:\s*(true|false)', re.IGNORECASE)
+
+
+def _codex_tool_output_is_error(payload: dict) -> bool:
+    if str(payload.get("status") or "").lower() in {"failed", "error", "cancelled"}:
+        return True
+    output = payload.get("output")
+    items = output if isinstance(output, list) else [output]
+    for item in items:
+        if isinstance(item, dict):
+            text = item.get("text")
+            if item.get("is_error") is True or item.get("isError") is True:
+                return True
+        else:
+            text = item
+        if not isinstance(text, str):
+            continue
+        structured_prefix = text[:4096]
+        is_error = _CODEX_IS_ERROR_RE.search(structured_prefix)
+        if is_error and is_error.group(1).lower() == "true":
+            return True
+        exit_code = _CODEX_EXIT_CODE_RE.search(structured_prefix)
+        if exit_code and int(exit_code.group(1)) != 0:
+            return True
+    return False
+
+
+def _adapt_codex_events(events, metadata: dict) -> tuple[str, dict]:
     """Convert a Codex CLI rollout JSONL (``~/.codex/sessions/YYYY/MM/DD/rollout-*.jsonl``)
     to markdown + metadata.
 
@@ -208,9 +400,9 @@ def _adapt_codex_rollout_jsonl(content: str, metadata: dict) -> tuple[str, dict]
     - ``turn_context`` —— 每 turn 的 cwd / approval / sandbox / model
     - ``compacted`` —— 上下文压缩事件
 
-    P2 阶段我们抽 ``session_meta``（session_id + cwd + originator + cli_version）+
-    ``event_msg::user_message``（user query），其它行**透传到 timeline 但不深度解析**
-    （codex 的 ``response_item`` 内部结构与 CC 不同，等 P4 再深化）。
+    适配器保留用户/助手文本、结构化工具调用与输出、模型及 Token 事件。
+    Codex 新版会把同一条用户或助手消息以两种相邻事件同时记录，这里只去重
+    相邻、文本完全相同且来源不同的一对，不会吞掉用户真实重复输入。
     """
     timeline: list[dict] = []
     session_id = ""
@@ -222,19 +414,34 @@ def _adapt_codex_rollout_jsonl(content: str, metadata: dict) -> tuple[str, dict]
     current_model = ""
     first_user_query = ""
     execution_usage_events: list[dict] = []
+    tool_calls: list[dict] = []
+    tool_names: list[str] = []
+    pending_tool_by_id: dict[str, str] = {}
     previous_cumulative_usage: dict = {}
+    last_message: tuple[int, str, str, str] | None = None
     t = 0
+    step = 0
     response_count = 0
     usage_ordinal = 0
 
-    for raw_line in content.splitlines():
-        raw_line = raw_line.strip()
-        if not raw_line:
-            continue
-        try:
-            event = json.loads(raw_line)
-        except json.JSONDecodeError:
-            continue
+    def append_message(line_number: int, role: str, text: str, origin: str) -> None:
+        nonlocal first_user_query, last_message, t
+        duplicate = (
+            last_message is not None
+            and last_message[0] + 1 == line_number
+            and last_message[1] == role
+            and last_message[2] != origin
+            and last_message[3] == text
+        )
+        last_message = (line_number, role, origin, text)
+        if duplicate:
+            return
+        if role == "user" and not first_user_query:
+            first_user_query = text[:500]
+        timeline.append({"t": t, "role": role, "content": text[:2000]})
+        t += 1
+
+    for line_number, event in events:
 
         ev_type = event.get("type")
         payload = event.get("payload") or {}
@@ -254,13 +461,11 @@ def _adapt_codex_rollout_jsonl(content: str, metadata: dict) -> tuple[str, dict]
             if sub_type == "user_message":
                 msg = str(payload.get("message") or "")
                 if msg:
-                    if not first_user_query:
-                        first_user_query = msg[:500]
-                    timeline.append({
-                        "t": t, "role": "user",
-                        "content": msg[:2000],
-                    })
-                    t += 1
+                    append_message(line_number, "user", msg, "event_msg")
+            elif sub_type == "agent_message":
+                msg = str(payload.get("message") or "")
+                if msg:
+                    append_message(line_number, "assistant", msg, "event_msg")
             elif sub_type == "token_count":
                 info = payload.get("info") or {}
                 usage = info.get("last_token_usage") or {}
@@ -331,28 +536,73 @@ def _adapt_codex_rollout_jsonl(content: str, metadata: dict) -> tuple[str, dict]
 
         if ev_type == "response_item":
             response_count += 1
-            # codex-cli ≥0.148 把用户输入也写成 response_item/message/role=user
-            # （不再有 event_msg::user_message），并把注入上下文混在同一形态里：
+            # codex-cli ≥0.148 把用户输入也写成 response_item/message/role=user，
+            # 并把注入上下文混在同一形态里：
             # role=developer 的 skills 说明、role=user 的 <environment_context>
             # 环境快照——只有不以 "<" 开头的 user 文本才是用户真正说的话。
-            # 助手回复同形态 role=assistant / output_text。旧版（≤0.147）没有这
-            # 类 role=user 的 response_item，走上面的 event_msg 分支，两种格式并存。
-            if payload.get("type") == "message":
+            response_type = payload.get("type")
+            if response_type == "message":
                 role = payload.get("role")
                 text = _codex_message_text(payload.get("content"))
                 if role == "user" and text and not text.lstrip().startswith("<"):
-                    if not first_user_query:
-                        first_user_query = text[:500]
-                    timeline.append({"t": t, "role": "user", "content": text[:2000]})
-                    t += 1
+                    append_message(line_number, "user", text, "response_item")
                     continue
                 if role == "assistant" and text:
-                    timeline.append({"t": t, "role": "assistant", "content": text[:2000]})
-                    t += 1
+                    append_message(line_number, "assistant", text, "response_item")
                     continue
                 if role in ("user", "developer"):
                     continue  # 注入的运行时上下文 / 系统说明，不进 timeline
-            # 其它 response_item（tool call / function output / 未知）：计数 + 透传占位
+            if response_type in {"custom_tool_call", "function_call"}:
+                tool_name = str(payload.get("name") or "unknown")
+                call_id = str(payload.get("call_id") or payload.get("id") or "")
+                tool_input = _codex_tool_input(payload)
+                if tool_name not in tool_names:
+                    tool_names.append(tool_name)
+                if call_id:
+                    pending_tool_by_id[call_id] = tool_name
+                timeline.append({
+                    "t": t,
+                    "role": "tool_call",
+                    "tool": tool_name,
+                    "input": tool_input,
+                })
+                tool_calls.append({
+                    "step": step,
+                    "tool": tool_name,
+                    "input": tool_input,
+                    "output": "",
+                    "output_available": False,
+                    "is_error": False,
+                    "_tc_id": call_id,
+                })
+                step += 1
+                t += 1
+                continue
+            if response_type in {"custom_tool_call_output", "function_call_output"}:
+                call_id = str(payload.get("call_id") or payload.get("id") or "")
+                tool_name = str(
+                    payload.get("name") or pending_tool_by_id.get(call_id) or "unknown"
+                )
+                output_text = _codex_tool_output_text(payload.get("output"))
+                is_error = _codex_tool_output_is_error(payload)
+                timeline.append({
+                    "t": t,
+                    "role": "tool_output",
+                    "tool": tool_name,
+                    "output": output_text,
+                    "is_error": is_error,
+                })
+                for entry in reversed(tool_calls):
+                    if call_id and entry.get("_tc_id") == call_id:
+                        entry["output"] = output_text
+                        entry["output_available"] = True
+                        entry["is_error"] = is_error
+                        break
+                t += 1
+                continue
+            if response_type in {"reasoning", "agent_message"}:
+                continue
+            # 旧版无 tagged payload 的 response_item 保留占位以兼容旧轨迹。
             timeline.append({
                 "t": t, "role": "assistant",
                 "content": f"[codex response_item #{payload.get('index', response_count - 1)}]",
@@ -366,6 +616,9 @@ def _adapt_codex_rollout_jsonl(content: str, metadata: dict) -> tuple[str, dict]
             "kind": ev_type or "unknown",
         })
         t += 1
+
+    for entry in tool_calls:
+        entry.pop("_tc_id", None)
 
     # Build markdown
     lines: list[str] = ["# Codex Rollout Trajectory", ""]
@@ -397,6 +650,25 @@ def _adapt_codex_rollout_jsonl(content: str, metadata: dict) -> tuple[str, dict]
             lines.append("## Assistant")
             lines.append("")
             lines.append(entry["content"])
+            lines.append("")
+        elif role == "tool_call":
+            lines.append(f"## Tool Call: {entry['tool']}")
+            lines.append("```json")
+            tool_input = entry["input"]
+            encoded_input = (
+                tool_input
+                if isinstance(tool_input, str)
+                else json.dumps(tool_input, ensure_ascii=False)
+            )
+            lines.append(encoded_input[:1000])
+            lines.append("```")
+            lines.append("")
+        elif role == "tool_output":
+            err_tag = " (error)" if entry.get("is_error") else ""
+            lines.append(f"## Tool Output: {entry['tool']}{err_tag}")
+            lines.append("```")
+            lines.append(entry["output"])
+            lines.append("```")
             lines.append("")
         elif role == "event":
             lines.append(f"## Event: {entry['kind']}")
@@ -432,12 +704,20 @@ def _adapt_codex_rollout_jsonl(content: str, metadata: dict) -> tuple[str, dict]
             }
         meta["execution_usage_events"] = execution_usage_events
     meta["timeline"] = timeline
+    meta["tool_calls"] = tool_calls
+    meta["tool_names"] = tool_names
+    meta["total_tool_calls"] = len(tool_calls)
     meta["total_turns"] = len(timeline)
     meta["response_items"] = response_count
     if first_user_query:
         meta.setdefault("query", first_user_query)
 
     return md, meta
+
+
+def _adapt_codex_rollout_jsonl(content: str, metadata: dict) -> tuple[str, dict]:
+    """Adapt an in-memory Codex rollout JSONL snapshot."""
+    return _adapt_codex_events(_iter_codex_events(content), metadata)
 
 
 # ─────────────────────────────────────────────────────────────────
@@ -453,8 +733,9 @@ def ingest_codex_sessions(
 ) -> list[dict]:
     """Bridge Codex CLI rollout JSONLs into xskill's trajectory directory.
 
-    Scans ``<home_root>/.codex/sessions/YYYY/MM/DD/rollout-*.jsonl`` and
-    submits any session whose UUID is not in ``seen_sessions`` as a new
+    Scans active ``<home_root>/.codex/sessions/YYYY/MM/DD/rollout-*.jsonl``
+    and flat ``<home_root>/.codex/archived_sessions/rollout-*.jsonl`` files,
+    then submits any session whose UUID is not in ``seen_sessions`` as a new
     trajectory under ``target_traj_dir`` using the ``codex_rollout_jsonl``
     adapter. ``seen_sessions`` is updated in place so repeat calls are
     idempotent. Returns the list of submission results (each augmented with

--- a/src/xskill/ecosystems/local_bootstrap.py
+++ b/src/xskill/ecosystems/local_bootstrap.py
@@ -154,6 +154,8 @@ def _bridge_index_empty(bridge: Path) -> bool:
 
 
 def _jsonl_needs_ingest(eco: str, home_root: Path, bridge: Path) -> bool:
+    from xskill.ecosystems._shared import _glob_session_paths
+
     spec = _jsonl_spec_for(eco)
     if spec is None:
         # OpenCode / ngagent / Trae 不是 JSONL。空库也会被探测到，
@@ -164,7 +166,7 @@ def _jsonl_needs_ingest(eco: str, home_root: Path, bridge: Path) -> bool:
     if not glob or not root.is_dir():
         return False
     source_ids: set[str] = set()
-    for path in root.glob(glob):
+    for path in _glob_session_paths(root, glob):
         sid = spec.session_id_from_path(path)
         if not sid:
             continue

--- a/tests/test_codex_adapter.py
+++ b/tests/test_codex_adapter.py
@@ -25,6 +25,7 @@ from __future__ import annotations
 
 import json
 import logging
+import os
 import sys
 from pathlib import Path
 
@@ -43,9 +44,11 @@ from xskill.ecosystems import (
     _codex_sessions_path,
     _codex_session_id_from_path,
     _read_cwd_from_codex_jsonl,
+    detect_known_ecosystems,
     ingest_codex_sessions,
     install_to_codex,
 )
+from xskill.ecosystems.codex import _codex_session_complete
 from xskill.skill.frontmatter import serialize as fm_serialize
 
 
@@ -261,6 +264,76 @@ class TestIngestCodexSessions:
             "bbbbbbbb-cccc-dddd-eeee-222222222222",
         ]
 
+    def test_ingest_includes_flat_archived_sessions(self, tmp_path, fixture_content):
+        archive = tmp_path / ".codex" / "archived_sessions"
+        archive.mkdir(parents=True)
+        archived_session_id = "cccccccc-dddd-eeee-ffff-333333333333"
+        path = archive / (
+            "rollout-2026-02-20T10-00-00-"
+            f"{archived_session_id}.jsonl"
+        )
+        path.write_text(
+            fixture_content.replace(EXPECTED_SESSION_ID, archived_session_id),
+            encoding="utf-8",
+        )
+
+        results = ingest_codex_sessions(tmp_path / "traj", home_root=tmp_path)
+
+        assert [result["session_id"] for result in results] == [archived_session_id]
+
+    def test_ingest_uses_streaming_path_adapter(self, tmp_path, fixture_content, monkeypatch):
+        source_path = _place_fixture_in_codex_home(tmp_path, fixture_content)
+        original_read_text = Path.read_text
+
+        def guarded_read_text(path, *args, **kwargs):
+            if path == source_path:
+                raise AssertionError("Codex source must not be loaded with Path.read_text")
+            return original_read_text(path, *args, **kwargs)
+
+        monkeypatch.setattr(Path, "read_text", guarded_read_text)
+
+        results = ingest_codex_sessions(tmp_path / "traj", home_root=tmp_path)
+
+        assert len(results) == 1
+
+    def test_streaming_and_in_memory_adapters_are_equivalent(self, tmp_path, fixture_content):
+        source_path = _place_fixture_in_codex_home(tmp_path, fixture_content)
+
+        expected = adapt_trajectory(fixture_content, "codex_rollout_jsonl")
+        actual = CODEX_SPEC.adapt_path(source_path, {})
+
+        assert actual == expected
+
+    def test_archive_only_codex_home_is_detected(self, tmp_path):
+        (tmp_path / ".codex" / "archived_sessions").mkdir(parents=True)
+
+        detected = detect_known_ecosystems(home_root=tmp_path)
+
+        assert {item["ecosystem"] for item in detected} == {"codex"}
+
+    def test_duplicate_session_id_uses_newest_source(self, tmp_path, fixture_content):
+        active_path = _place_fixture_in_codex_home(
+            tmp_path,
+            fixture_content.replace(EXPECTED_USER_MESSAGE, "active newer"),
+        )
+        archive = tmp_path / ".codex" / "archived_sessions"
+        archive.mkdir(parents=True)
+        archived_path = archive / active_path.name
+        archived_path.write_text(
+            fixture_content.replace(EXPECTED_USER_MESSAGE, "archived older"),
+            encoding="utf-8",
+        )
+        os.utime(archived_path, ns=(1_000_000_000, 1_000_000_000))
+        os.utime(active_path, ns=(2_000_000_000, 2_000_000_000))
+
+        results = ingest_codex_sessions(tmp_path / "traj", home_root=tmp_path)
+
+        assert len(results) == 1
+        metadata = json.loads(
+            Path(results[0]["path"]).with_suffix(".json").read_text(encoding="utf-8")
+        )
+        assert metadata["query"] == "active newer"
+
 
 # ──────────────────────────────────────────────────────────────────
 # T3. JsonlIngester spec dispatching
@@ -457,7 +530,11 @@ class TestPathResolversCrossPlatform:
         """
         home = Path("/another/home")
         assert CC_SPEC.sessions_path(home) == home / ".claude" / "projects"
-        assert CODEX_SPEC.sessions_path(home) == home / ".codex" / "sessions"
+        assert CODEX_SPEC.sessions_path(home) == home / ".codex"
+        assert CODEX_SPEC.sessions_glob == (
+            "sessions/*/*/*/rollout-*.jsonl",
+            "archived_sessions/rollout-*.jsonl",
+        )
         assert CC_SPEC.skills_install_path(home) == home / ".claude" / "skills"
         assert CODEX_SPEC.skills_install_path(home) == home / ".agents" / "skills"
 
@@ -489,6 +566,120 @@ class TestCodexHelpers:
             "payload": {"record_type": "response", "index": 0},
         })
         assert _read_cwd_from_codex_jsonl(only_response) == ""
+
+    def test_completion_follows_latest_task_lifecycle_event(self):
+        started = json.dumps({
+            "type": "event_msg",
+            "payload": {"type": "task_started"},
+        })
+        completed = json.dumps({
+            "type": "event_msg",
+            "payload": {"type": "task_complete"},
+        })
+        tool_call = json.dumps({
+            "type": "response_item",
+            "payload": {"type": "custom_tool_call", "name": "exec"},
+        })
+
+        assert _codex_session_complete("\n".join((started, completed))) is True
+        assert _codex_session_complete("\n".join((completed, started, tool_call))) is False
+
+    def test_legacy_rollout_without_lifecycle_is_complete(self, fixture_content):
+        assert _codex_session_complete(fixture_content) is True
+
+
+class TestCodexStructuredEvidence:
+    @staticmethod
+    def _content() -> str:
+        events = [
+            {
+                "type": "session_meta",
+                "payload": {
+                    "id": "sid", "cwd": "/workspace/demo",
+                    "model_provider": "openai",
+                },
+            },
+            {
+                "type": "response_item",
+                "payload": {
+                    "type": "message", "role": "user",
+                    "content": [{"type": "input_text", "text": "fix tests"}],
+                },
+            },
+            {
+                "type": "event_msg",
+                "payload": {"type": "user_message", "message": "fix tests"},
+            },
+            {
+                "type": "event_msg",
+                "payload": {"type": "agent_message", "message": "checking"},
+            },
+            {
+                "type": "response_item",
+                "payload": {
+                    "type": "message", "role": "assistant",
+                    "content": [{"type": "output_text", "text": "checking"}],
+                },
+            },
+            {
+                "type": "response_item",
+                "payload": {
+                    "type": "custom_tool_call", "call_id": "call-1",
+                    "name": "exec", "input": "await tools.exec_command({})",
+                    "status": "completed",
+                },
+            },
+            {
+                "type": "response_item",
+                "payload": {
+                    "type": "custom_tool_call_output", "call_id": "call-1",
+                    "output": [{
+                        "type": "input_text",
+                        "text": '{"exit_code":1,"output":"failed"}',
+                    }],
+                },
+            },
+            {
+                "type": "response_item",
+                "payload": {
+                    "type": "function_call", "call_id": "call-2",
+                    "name": "shell", "arguments": '{"cmd":"true"}',
+                },
+            },
+            {
+                "type": "response_item",
+                "payload": {
+                    "type": "function_call_output", "call_id": "call-2",
+                    "output": '{"exit_code":0,"output":"ok"}',
+                },
+            },
+        ]
+        return "\n".join(json.dumps(event) for event in events)
+
+    def test_adjacent_mirrored_messages_are_deduplicated(self):
+        _md, meta = adapt_trajectory(self._content(), "codex_rollout_jsonl")
+
+        assert [
+            entry["content"] for entry in meta["timeline"]
+            if entry["role"] == "user"
+        ] == ["fix tests"]
+        assert [
+            entry["content"] for entry in meta["timeline"]
+            if entry["role"] == "assistant"
+        ] == ["checking"]
+
+    def test_tool_calls_outputs_and_errors_match_by_call_id(self):
+        md, meta = adapt_trajectory(self._content(), "codex_rollout_jsonl")
+
+        assert meta["tool_names"] == ["exec", "shell"]
+        assert meta["total_tool_calls"] == 2
+        assert meta["tool_calls"][0]["output_available"] is True
+        assert meta["tool_calls"][0]["is_error"] is True
+        assert meta["tool_calls"][1]["input"] == {"cmd": "true"}
+        assert meta["tool_calls"][1]["is_error"] is False
+        assert "## Tool Call: exec" in md
+        assert "## Tool Output: exec (error)" in md
+        assert "## Tool Output: shell\n" in md
 
 
 # ──────────────────────────────────────────────────────────────────

--- a/tests/test_codex_adapter.py
+++ b/tests/test_codex_adapter.py
@@ -681,6 +681,31 @@ class TestCodexStructuredEvidence:
         assert "## Tool Output: exec (error)" in md
         assert "## Tool Output: shell\n" in md
 
+    def test_large_structured_tool_input_is_bounded_with_provenance(self):
+        oversized = {"cmd": "x" * 10_000}
+        event = {
+            "type": "response_item",
+            "payload": {
+                "type": "function_call",
+                "call_id": "call-large",
+                "name": "shell",
+                "arguments": json.dumps(oversized),
+            },
+        }
+
+        md, meta = adapt_trajectory(
+            self._content() + "\n" + json.dumps(event),
+            "codex_rollout_jsonl",
+        )
+
+        tool_input = meta["tool_calls"][-1]["input"]
+        assert isinstance(tool_input, str)
+        assert len(tool_input) == 2000
+        assert "truncated original_chars=" in tool_input
+        assert "sha256=" in tool_input
+        assert "x" * 3000 not in json.dumps(meta)
+        assert len(md) < 10_000
+
 
 # ──────────────────────────────────────────────────────────────────
 # codex-cli ≥0.148 rollout format (user input moved into response_item)


### PR DESCRIPTION
## Summary

修复 Codex rollout 只采集活跃目录、丢失结构化工具证据并在大文件上整份加载内存的问题。

本 PR 将 Codex 的活跃与归档轨迹统一到可流式读取的 spec 契约，同时保持其他生态的默认摄取行为不变。

## Changes

- 同时扫描 `sessions/*/*/*/rollout-*.jsonl` 与 `archived_sessions/rollout-*.jsonl`，只剩归档目录时也能探测 Codex。
- 同一 Codex session id 存在多个来源时只选择 mtime 最新的文件，并把该去重语义限制在 Codex spec 内。
- 为 JSONL ingester 增加可选的路径 adapter 与路径完成态检查，避免通过 `Path.read_text()` 加载完整原始 rollout。
- 解析用户和助手消息、custom/function tool call、对应输出、错误状态、模型与 Token usage，并按 `call_id` 配对调用和结果。
- 仅去除相邻、跨来源且文本完全相同的新版 Codex 镜像消息，保留真实重复输入。
- 根据最新 lifecycle 事件阻止低延迟模式提前固化未完成 turn，并兼容没有 lifecycle 的旧 rollout。
- 更新 Codex 文档与回归测试。

## Performance evidence

在一份约 456 MB 的隐私隔离本地 rollout 上，旧整文件路径的峰值 RSS 约为 4,021,360 KB、耗时约 5.7 秒，新的路径 adapter 峰值 RSS 为 185,372 KB、耗时约 1.73 秒。

同一次新路径回放恢复了 10,554 条工具调用与 154 条错误证据，而旧 adapter 的结构化工具调用数量为 0；该数据用于验证相对变化，不作为跨机器绝对性能承诺。

## Test plan

- [x] 完整 pytest：`2745 passed, 10 skipped`。
- [x] Codex 与 bootstrap 定向回归：`53 passed`。
- [x] Added/updated unit tests for the change。
- [x] `make e2e` passes：2 个 Docker runtime discovery/bridge 场景通过。
- [x] Manually verified the affected user flow：使用隐私隔离的本地 Codex 历史验证活跃/归档发现、流式内存、消息去重、工具证据和完成态。
- [x] ruff 对本 PR 变更文件检查通过。
- [ ] `make lint` 未能完整运行：当前开发环境缺少 semgrep、pylint 与 vulture；全仓 ruff 仍有 29 个既有基线问题，本 PR 变更文件没有新增命中。

## Linked issues

Closes #391

Related to #1

## 给外人看的背景（Codex rollout 是什么）

下面按给第三方看的问题单来写：每个词第一次出现都会说明它是什么。代码位置只是提示，不是必须先读完整个仓库才能看懂。

### 这是什么

XSkill 要学技能，先得把人在编码助手里做过的事收进来。这件事叫采集：把某个编码助手自己记下的会话文件，转成 XSkill 统一的轨迹。轨迹就是一份按时间排好的对话记录，后面会再切成更小的片段去学。

Codex 是 OpenAI 的命令行编码助手，也就是用户在终端里跑的那个 `codex`。它每开一轮会话，都会在本机追加写一份原始日志。这份日志就叫 rollout。不是 XSkill 发明的词，是 Codex 自己的文件名和源码用语。

所以「Codex rollout」就是：Codex 把这一轮会话里发生过的事，一行一行记下来的原始文件。XSkill 不改这份文件，只读它，再转成自己的轨迹。

### 用户侧实际发生了什么

用户在自己电脑上用 Codex 干活。Codex 会在用户主目录下写日志，默认根目录是 `~/.codex/`。

正在进行、还没被归档的会话，落在按日期分的目录里，例如：

```
~/.codex/sessions/2026/08/31/rollout-2026-08-31T15-00-00-<这一轮的编号>.jsonl
```

文件名以 `rollout-` 开头。后面先是开始时间（冒号写成了短横，免得 Windows 文件名不认），再是这一轮会话的编号。后缀 `.jsonl` 的意思是：每一行是一条独立的 JSON，文件只能往后追加，不会把旧行改掉。

会话变旧之后，Codex 可能把它挪到归档目录：

```
~/.codex/archived_sessions/rollout-....jsonl
```

活跃目录和归档目录里，可能同时出现同一轮会话的副本。这时应当只采修改时间最新的那一份，不要同一轮学两遍。

### 文件里一行是什么

每一行通常是三件套：时间、类型、内容。常见类型可以先记住这几个。

第一行一般是会话头（session_meta）：这一轮的编号、当时在哪个工作目录、是 Codex 命令行还是编辑器插件开的、Codex 版本、模型提供方。

然后是用户说了什么、模型回了什么。新一点的 Codex 会把这些也写成响应项（response_item）。

模型中途会调用工具，比如读文件、跑命令。调用和结果各记一行，用同一个 call_id 对上。call_id 就是「这一次工具调用的编号」，有了它才能知道哪条输出属于哪次调用，以及这次是成功还是报错。

另外还有每一轮用的模型、Token 用量、这一轮有没有开始、做完或中途放弃。这些后面判断「这轮能不能当完成样本」时要用。

### XSkill 拿它做什么

采集程序扫到一份 rollout 后，会把它编成一份轨迹，写进 XSkill 的轨迹目录。轨迹编号大致长这样：`traj_codex_<项目名>_<会话编号前几位>`。

后面的拆分、归类、写成技能，吃的都是这份轨迹。尤其是工具有没有调用、有没有报错、这一轮有没有真正做完：这些是后面判断「这段值不值得学」的证据。Skill 装进 Codex 是另一条路，写到 `~/.agents/skills/`，和读 rollout 无关。本 PR 只修读的这一侧。

### 合本 PR 之前缺了什么

只扫 `~/.codex/sessions/`。人把会话归档后，或者机器上只剩归档目录时，这些会话从 XSkill 眼里消失，连「这台机器有没有 Codex」都可能探测不到。

工具调用大多没被拆开，轨迹里只剩一行占位文字，例如 `[codex response_item #3]`。后面只能看见「模型好像做了点事」，看不见调用了什么、返回了什么、是不是失败。

新版 Codex 会把同一句用户话或助手话，用两种来源各记一次。旧逻辑可能把镜像也算进去，轨迹变长，后面的 Token 预算也会被灌胖。这里说的镜像，是相邻、来源不同、正文完全一样的重复记录，不是用户真的连说两遍。

整份文件一次读进内存。一份大约 456 MB 的本地 rollout，旧路径峰值内存大约 4 GB；本 PR 改成按行流式读之后，大约 185 MB，并且能恢复上万条工具调用。这组数字只用来对照同一份文件的前后差别，不是跨机器的承诺。

### 本 PR 具体改哪

活跃目录和归档目录一起扫。只有归档时，也能认出这台机器有 Codex。同一会话编号出现多份时，只留最新那份，而且这个去重只作用于 Codex，不改其他助手的采集。

读文件改为按路径流式读，不再 `Path.read_text()` 整份加载。其他也用 JSONL 的助手，默认采集方式不变。

按 call_id 把工具调用和结果配对，保留用户话、助手话、错误状态、模型和 Token 用量。只丢掉那种相邻且正文完全相同的镜像，用户真实的重复输入还在。

看最新的生命周期事件，决定这一轮能不能标成已经采集完。正在写、还没结束的一轮，低延迟模式下不要提前钉死。没有这些事件的旧 rollout 仍然能读。

### 不要和什么搞混

rollout 不是 XSkill 的轨迹，也不是后来切出来的 Atom。它是 Codex 自己的原始会话账本。XSkill 的轨迹是读完这份账本之后的转写。

它也不是 Skill。Skill 是后来写给助手用的说明书；rollout 是人已经做过的事。

本 PR 不改往 Codex 里装 Skill，不改拆分、归类、编辑这些生产流水线的算法，也不改现网。它只让本机或团队侧采集 Codex 会话时，证据更全、大文件更省内存。

### 怎么算这段背景对齐了

能指出本机哪两类目录里会有 `rollout-*.jsonl`。能说出采集之后，XSkill 要的是对话加工具证据，而不只是「有过一个会话」。能把本 PR 的三件事分开：归档也要扫到、工具调用要对上、大文件不能整份进内存。
