### PR TITLE
feat(tasks): 默认开启 Task Graph 并保留显式回退

### DIFF
--- a/docs/task-graph-runtime.md
+++ b/docs/task-graph-runtime.md
@@ -2,7 +2,7 @@
 
 ## 状态
 
-本实现把 #326 定义的 Logical Task 与 Task Attempt 模型落成可运行代码，但在 #326 与 #325 评审完成前通过 `task_graph.enabled: false` 默认关闭。
+本实现把 Logical Task 与 Task Attempt 模型落成为默认开启的独立读模型分支，可通过 `task_graph.enabled: false` 显式暂停投影。
 
 关闭时，现有 `Session → Atom → candidate → Skill` 生产路径、Atom 多 Skill 语义、`ux_score` 和 `weightscore` 均保持不变。
 
@@ -117,7 +117,7 @@ Task 与 Attempt relation 在写入 override log 前完成唯一 parent、同 Ta
 
 ## 启用与回退
 
-完成 #326 模型评审和 #325 离线回放门禁后，可在配置中设置 `task_graph.enabled: true`。
+Task Graph 默认开启，首次启动会在后台分批回填；资源受限或排查期可显式设置 `task_graph.enabled: false`。
 
 首次启用会把已有 `split_done`、`indexed` 和 `done` 轨迹加入持久回填队列，并按 `max_scopes_per_run` 分批处理。
 

--- a/src/xskill/config.py
+++ b/src/xskill/config.py
@@ -228,7 +228,7 @@ watcher:
 # ===== Logical Task Graph =====
 # Deterministic semantic branch above Session/Atom; it never changes Atom→Skill routing, and uncertain links remain proposed without consuming LLM tokens.
 task_graph:
-  enabled: false                 # enable after ADR/replay-baseline review
+  enabled: true                  # default-on; set false to pause projection while retaining dirty fences
   top_k: 8                      # hard bound on classified candidates per Atom
   recent_k: 6                   # same-Session recent Task candidates
   posting_cap: 64               # bounded inverted-index posting list
@@ -377,7 +377,7 @@ def normalize_runtime_config(config_data: dict) -> dict:
     if not isinstance(task_graph, dict):
         raise ValueError("task_graph 必须是 mapping")
     task_graph = dict(task_graph)
-    enabled = task_graph.get("enabled", False)
+    enabled = task_graph.get("enabled", True)
     if not isinstance(enabled, bool):
         raise ValueError("task_graph.enabled 必须是布尔")
     task_graph["enabled"] = enabled

--- a/src/xskill/tasks/projection.py
+++ b/src/xskill/tasks/projection.py
@@ -9,6 +9,8 @@ from xskill.pipeline.registry import pooled_connection
 from xskill.tasks.evidence import ExecutionUsageEvent, ScopedTrajectoryEvidence
 from xskill.tasks.models import TaskGraphGeneration
 
+DEFAULT_BACKFILL_BATCH_SIZE = 512
+
 
 def _json(value) -> str:
     return json.dumps(
@@ -73,35 +75,54 @@ def mark_task_graph_dirty(
         connection.commit()
 
 
-def enqueue_untracked_sources(*, db_path: Path | None = None) -> int:
-    """Backfill the durable queue for existing Atom sources after upgrade."""
+def enqueue_untracked_sources(
+    *,
+    batch_size: int = DEFAULT_BACKFILL_BATCH_SIZE,
+    db_path: Path | None = None,
+) -> int:
+    """Backfill existing Atom sources in bounded, independently committed batches."""
+    if (
+        isinstance(batch_size, bool)
+        or not isinstance(batch_size, int)
+        or batch_size <= 0
+    ):
+        raise ValueError("batch_size must be a positive integer")
     with pooled_connection(db_path) as connection:
-        rows = connection.execute(
-            "SELECT t.watch_dir_id,t.filename,w.source_scope_id"
-            " FROM trajectories t JOIN watch_dirs w ON w.id=t.watch_dir_id"
-            " WHERE t.status IN ('split_done','indexed','done')"
-            " OR COALESCE(t.tasks_extracted,0)>0"
-        ).fetchall()
-        tracked = {
-            (row["source_scope_id"], row["traj_id"])
-            for row in connection.execute(
-                "SELECT source_scope_id,traj_id FROM task_graph_source_state"
-            ).fetchall()
-        }
         queued = 0
-        for row in rows:
-            traj_id = row["filename"].removesuffix(".md")
-            if (row["source_scope_id"], traj_id) in tracked:
-                continue
-            cursor = connection.execute(
+        last_trajectory_id = 0
+        while True:
+            rows = connection.execute(
+                "SELECT t.id,t.watch_dir_id,t.filename,w.source_scope_id"
+                " FROM trajectories t JOIN watch_dirs w ON w.id=t.watch_dir_id"
+                " LEFT JOIN task_graph_source_state s"
+                " ON s.source_scope_id=w.source_scope_id"
+                " AND s.traj_id=CASE WHEN substr(t.filename,-3)='.md'"
+                " THEN substr(t.filename,1,length(t.filename)-3) ELSE t.filename END"
+                " LEFT JOIN task_graph_dirty_sources d"
+                " ON d.watch_dir_id=t.watch_dir_id AND d.filename=t.filename"
+                " WHERE t.id>?"
+                " AND (t.status IN ('split_done','indexed','done')"
+                " OR COALESCE(t.tasks_extracted,0)>0)"
+                " AND s.source_scope_id IS NULL AND d.watch_dir_id IS NULL"
+                " ORDER BY t.id LIMIT ?",
+                (last_trajectory_id, batch_size),
+            ).fetchall()
+            if not rows:
+                break
+            last_trajectory_id = int(rows[-1]["id"])
+            changes_before = connection.total_changes
+            connection.executemany(
                 "INSERT INTO task_graph_dirty_sources("
                 "watch_dir_id,filename,source_scope_id,deleted,generation,reason,marked_at)"
                 " VALUES(?,?,?,0,1,'initial_backfill',datetime('now'))"
                 " ON CONFLICT(watch_dir_id,filename) DO NOTHING",
-                (row["watch_dir_id"], row["filename"], row["source_scope_id"]),
+                [
+                    (row["watch_dir_id"], row["filename"], row["source_scope_id"])
+                    for row in rows
+                ],
             )
-            queued += max(0, cursor.rowcount)
-        connection.commit()
+            queued += connection.total_changes - changes_before
+            connection.commit()
         return queued
 
 

--- a/src/xskill/tasks/service.py
+++ b/src/xskill/tasks/service.py
@@ -116,7 +116,7 @@ class TaskGraphService:
         task_config = self.config.get("task_graph") or {}
         if not isinstance(task_config, dict):
             raise ValueError("task_graph config must be a mapping")
-        enabled = task_config.get("enabled", False)
+        enabled = task_config.get("enabled", True)
         if not isinstance(enabled, bool):
             raise ValueError("task_graph.enabled must be a boolean")
         self.enabled = enabled

--- a/tests/test_agent_worker_runtime.py
+++ b/tests/test_agent_worker_runtime.py
@@ -128,7 +128,6 @@ def test_seats_are_fixed_completion_clears_only_own_index():
             gate.set()
         pool.shutdown(wait=True)
 
-
 def test_new_task_takes_lowest_free_seat_and_task_factory_overrides():
     """新任务补最低空席；task_factory 在工作线程起跑时求值并覆盖静态 task。"""
     pool = BoundedExecutor("edit", 2)
@@ -405,6 +404,7 @@ def test_missing_new_sections_use_release_defaults():
     assert effective["embedding"]["rate_limit"] == {"max_inflight": 4}
     assert effective["agent_worker"]["pools"]["cluster"]["batch_size"] == 8
     assert effective["agent_worker"]["pools"]["edit"]["batch_size"] == 5
+    assert effective["task_graph"]["enabled"] is True
 
 
 def test_edit_batch_size_must_be_a_positive_integer():
@@ -806,4 +806,3 @@ def test_set_workers_shrink_keeps_inflight_then_trims():
         for gate in gates:
             gate.set()
         pool.shutdown(wait=True)
-

--- a/tests/test_config_autoinit.py
+++ b/tests/test_config_autoinit.py
@@ -53,7 +53,7 @@ def test_template_is_valid_yaml_with_required_sections():
     # llm / embedding 带 api_key 占位符（用户要填）
     assert parsed["llm"]["api_key"] == "PUT_YOUR_LLM_API_KEY_HERE"
     assert parsed["embedding"]["api_key"] == "PUT_YOUR_EMBEDDING_API_KEY_HERE"
-    assert parsed["task_graph"]["enabled"] is False
+    assert parsed["task_graph"]["enabled"] is True
 
 
 def test_template_top_level_keys_are_exactly_live_set():

--- a/tests/test_task_graph_runtime.py
+++ b/tests/test_task_graph_runtime.py
@@ -130,6 +130,22 @@ def test_reading_missing_tenant_identity_has_no_filesystem_side_effect(tmp_path)
     assert not (tmp_path / "task_graph").exists()
 
 
+def test_task_graph_is_enabled_by_default_and_explicit_false_still_wins(tmp_path):
+    default_service = TaskGraphService(
+        state_root=tmp_path,
+        db_path=tmp_path / "registry.db",
+        config={},
+    )
+    disabled_service = TaskGraphService(
+        state_root=tmp_path,
+        db_path=tmp_path / "registry.db",
+        config={"task_graph": {"enabled": False}},
+    )
+
+    assert default_service.enabled is True
+    assert disabled_service.enabled is False
+
+
 def test_runtime_projects_task_attempt_evidence_and_conserved_usage(tmp_path):
     db_path = tmp_path / "registry.db"
     source = _add_source(

--- a/tests/test_task_graph_runtime.py
+++ b/tests/test_task_graph_runtime.py
@@ -3,6 +3,7 @@ from __future__ import annotations
 import json
 import os
 import sqlite3
+from contextlib import contextmanager
 from pathlib import Path
 
 import pytest
@@ -25,6 +26,7 @@ from xskill.pipeline.registry import (
 )
 from xskill.tasks.models import stable_ref_key
 from xskill.tasks.projection import (
+    enqueue_untracked_sources,
     get_logical_task,
     list_dirty_task_scopes,
     list_dirty_sources,
@@ -144,6 +146,91 @@ def test_task_graph_is_enabled_by_default_and_explicit_false_still_wins(tmp_path
 
     assert default_service.enabled is True
     assert disabled_service.enabled is False
+
+
+def test_initial_backfill_enqueues_in_committed_bounded_batches(
+    tmp_path, monkeypatch,
+):
+    db_path = tmp_path / "registry.db"
+    for index in range(5):
+        _add_source(
+            tmp_path,
+            db_path,
+            source_name=f"backfill-{index}",
+            atoms=[{"intent": f"回填任务 {index}", "summary": "加入持久队列"}],
+        )
+    connection = get_connection(db_path)
+    connection.execute("DELETE FROM task_graph_dirty_sources")
+    connection.commit()
+
+    class CountingConnection:
+        def __init__(self, wrapped):
+            self.wrapped = wrapped
+            self.commits = 0
+
+        def __getattr__(self, name):
+            return getattr(self.wrapped, name)
+
+        def commit(self):
+            self.commits += 1
+            self.wrapped.commit()
+
+    counted = CountingConnection(connection)
+
+    @contextmanager
+    def counted_pool(_db_path):
+        yield counted
+
+    monkeypatch.setattr(
+        "xskill.tasks.projection.pooled_connection",
+        counted_pool,
+    )
+
+    assert enqueue_untracked_sources(batch_size=2, db_path=db_path) == 5
+    assert counted.commits == 3
+    assert enqueue_untracked_sources(batch_size=2, db_path=db_path) == 0
+    assert counted.commits == 3
+    assert connection.execute(
+        "SELECT COUNT(*) FROM task_graph_dirty_sources",
+    ).fetchone()[0] == 5
+    tracked = connection.execute(
+        "SELECT t.watch_dir_id,t.filename,w.source_scope_id"
+        " FROM trajectories t JOIN watch_dirs w ON w.id=t.watch_dir_id"
+        " ORDER BY t.id LIMIT 1",
+    ).fetchone()
+    connection.execute(
+        "DELETE FROM task_graph_dirty_sources WHERE watch_dir_id=? AND filename=?",
+        (tracked["watch_dir_id"], tracked["filename"]),
+    )
+    connection.execute(
+        "INSERT INTO task_graph_source_state("
+        "tenant_id,task_scope_id,source_scope_id,watch_dir_id,traj_id,"
+        "source_revision,generation_id) VALUES(?,?,?,?,?,?,?)",
+        (
+            "ten_test",
+            "tsc_test",
+            tracked["source_scope_id"],
+            tracked["watch_dir_id"],
+            tracked["filename"].removesuffix(".md"),
+            "rev_test",
+            "gen_test",
+        ),
+    )
+    connection.commit()
+    assert enqueue_untracked_sources(batch_size=2, db_path=db_path) == 0
+    assert connection.execute(
+        "SELECT COUNT(*) FROM task_graph_dirty_sources",
+    ).fetchone()[0] == 4
+    connection.close()
+
+
+@pytest.mark.parametrize("batch_size", [True, 0, -1, 1.5])
+def test_initial_backfill_rejects_invalid_batch_size(tmp_path, batch_size):
+    with pytest.raises(ValueError, match="batch_size"):
+        enqueue_untracked_sources(
+            batch_size=batch_size,
+            db_path=tmp_path / "registry.db",
+        )
 
 
 def test_runtime_projects_task_attempt_evidence_and_conserved_usage(tmp_path):


### PR DESCRIPTION
## Summary

在 #326 运行时和 #325 离线回放基线已经落地后，将 Task Graph 对新配置与缺省配置设为默认开启。

显式 `task_graph.enabled: false` 仍然优先，因此管理员可以安全暂停投影，不影响现有 Session、Atom 或 Skill 主路径数据。

## Changes

- 将生成配置模板中的 `task_graph.enabled` 改为 `true`。
- 将缺失字段时的配置归一化与 `TaskGraphService` 默认值统一改为 `true`。
- 保留显式 `false` 的 opt-out 行为。
- 更新运行时文档，说明默认后台分批回填和回退方式。
- 增加缺省开启、显式关闭与配置模板回归测试。

## Safety boundary

Task Graph 仍是确定性、有界的独立读模型分支，不调用 LLM，也不改变 `Session → Atom → candidate → Skill`、Atom 多 Skill 语义、`ux_score` 或 `weightscore`。

首次启动继续受 `max_scopes_per_run` 限制分批回填，旧配置中已经明确写入 `enabled: false` 的实例不会在升级时被强制开启。

## Test plan

- [x] 完整 pytest：`2745 passed, 10 skipped`。
- [x] 配置、worker 与 Task Graph 定向回归：`77 passed`。
- [x] Added/updated unit tests for the change。
- [x] `make e2e` passes：2 个 Docker runtime discovery/bridge 场景通过。
- [x] Manually verified the affected user flow：隐私隔离历史两轮回放无失败 scope，primary membership 与 evidence 全覆盖，无变化重放 generation id 稳定，Token ledger 与 allocation 总量守恒。
- [x] ruff 对本 PR 变更文件检查通过。
- [ ] `make lint` 未能完整运行：当前开发环境缺少 semgrep、pylint 与 vulture；全仓 ruff 仍有 29 个既有基线问题，本 PR 变更文件没有新增命中。

## Linked issues

Closes #392

Related to #325

Follow-up to #326

## 给外人看的背景（Task Graph 默认开启是什么）

下面按给第三方看的问题单来写：每个词第一次出现都会说明它是什么。代码位置只是提示，不是必须先读完整个仓库才能看懂。

### 这是什么

XSkill 平时学技能，走的是这条主路：先把一次完整会话收成 Session，再把 Session 切成一段段 Atom，Atom 进入候选，攒够了再写成 Skill。Session 就是一次连续对话。Atom 是里面意图相对单一的一小段。Skill 是后来写给助手用的说明书。

有些用户目标会跨好几个 Session，或者同一件事失败了再试、被人纠正后再做。只看单个 Session 或单个 Atom，会把同一件事拆散。Task Graph 就是架在这条主路上面的一层任务图：它把相关 Atom 收成更大的任务，方便后面按「这件事」而不是「这一小段」去观察和评测。

Task Graph 里有两个核心对象。Logical Task 是用户想完成的那件逻辑上的事，即使中间换了会话、重试过、被纠正过，仍算同一件。Task Attempt 是这件逻辑事的某一次具体执行，记下用了哪个模型、哪个助手、有没有重试、最后做成没做成。

所以本 PR 不是新发明 Task Graph，而是把已经落地的这层图，从「默认关着，要人自己打开」改成「新装和没写这个开关的实例默认开」。

### 用户侧实际会发生什么

新生成的配置模板里，`task_graph.enabled` 变成 true。配置文件里根本没写这个字段时，运行时也按开启处理。

第一次启动后，后台会把已经拆完、建过索引的旧轨迹推进回填队列。回填就是：历史轨迹不是一次全算完，而是分批投影成 Logical Task 和 Task Attempt。默认每批 512 条，避免旧账太多时一次打满内存。主路上的拆分、归类、写 Skill 不会因此停下来等这层图。

管理员如果资源紧，或者要排查故障，可以在配置里显式写下：

```
task_graph:
  enabled: false
```

这句话优先。旧配置里已经写明 false 的实例，升级时不会被强行打开。关掉只是暂停投影，已有的 Session、Atom、Skill，以及已经算出的 Task Graph 文件都不会被删掉。

### 它算不算进主路

不算。Task Graph 是独立的只读分支。只读的意思是：它读 Atom 已经有的事实，不改 Atom 本身，也不改某个 Atom 该进哪个 Skill。

它不调用大模型。关联规则是确定性的，候选数量、词项数量、回填批量都有上限。确定性的意思是：同样的输入再跑一遍，得到同一份图，不会因为模型采样而变。

它也不改 `ux_score` 和 `weightscore`。这两个是现有技能好不好、权重大不大的分数。默认打开 Task Graph，不会让现有技能突然变得更该推荐或更不该推荐。

### 合本 PR 之前是什么状态

运行时（#326）和离线回放基线（#325）已经落地，但配置模板、缺省归一化和运行时服务仍把开关默认写成 false。新装或没写这个字段的实例不会生成这层读模型，已经实现的 Logical Task、Task Attempt、关系和用量归属，进不了日常观测。

继续长期默认关，后台确实更省事，但这层能力会一直停在「要人自己发现并手工打开」的实验状态。本 PR 认为现在可以默认开，因为模型、脏队列、崩溃恢复和固定回放基线都已经有了。

### 本 PR 具体改哪

配置模板里的默认值改为 true。

配置里缺这个字段时，归一化结果和 `TaskGraphService` 的运行时默认值也改为 true。`TaskGraphService` 就是负责后台投影这层图的服务。

显式 false 仍然关闭。文档改成说明「默认开、后台分批回填、可以显式关」。测试锁住这三件事：缺省是开、写出 false 是关、模板默认是开。回填从一次扫完全表，改成按批提交，每批独立落盘。

### 不要和什么搞混

不要把它和 #393 搞混。#393 修的是 Codex 原始会话文件怎么采集进来。本 PR 不碰 Codex rollout，也不依赖那张补丁。建议审阅顺序上放在 #393 后面，只是因为先把采集证据收全，再开这层图更顺，不是代码必须先合那张。

不要把它和后面的 Q1 评测搞混。Q1 问的是：用 Task Graph 去形成 Skill，会不会比只看 Session 或只看 Atom 更有效。本 PR 只是让生产实例默认开始画这层图，并不在这里证明「画了图之后技能就更好」。

也不要把它理解成「打开就会改现网技能」。Agent 接触不到格力内网现网。这张补丁改的是软件默认开关，合进 main 之后，要等现网侧自己升级才会生效。

### 怎么算这段背景对齐了

能说出 Task Graph 是主路上面的一层只读任务图，不是新的写 Skill 流水线。能说出 Logical Task 是跨会话的那件用户目标，Task Attempt 是某一次具体执行。能说出本 PR 只改默认开还是关：新装和没写字段的会开，已经写明 false 的继续关。能说出关掉不会删已有 Session、Atom 或 Skill。
