### PR TITLE
feat(officeqa): SkillOpt 划分名单与多模型评测约定（接 #262 / #309）

### DIFF
--- a/benchmarks/officeqa/README.md
+++ b/benchmarks/officeqa/README.md
@@ -10,6 +10,17 @@ xskill README 中的 60.47% 是历史下游子集结果。仓库没有保留该�
 
 Microsoft SkillOpt 另行发布了基于 OfficeQA Full 的 ID-only manifest，train/val/test 为 50/24/172。它的三部分并集恰好覆盖 246 个唯一 UID（113 easy、133 hard），但这是 SkillOpt 的下游划分，不是 OfficeQA 官方 split。本目录的 `officeqa_full.json` 仅借它公开的 UID 和 difficulty 构造无 split 的 Full 清单，不把 SkillOpt 的 train/val/test 语义带入官方口径。
 
+若论文或实验要和 SkillOpt 用同一套划分比分，请用 [`manifests/officeqa_skillopt_id_split.json`](manifests/officeqa_skillopt_id_split.json)。里面写清 train / val / test 各自有哪些 UID。正式主对比建议都在 test（172 题）上评；训练时 val 是否并进 train，属于算法用法差异，写进训练说明即可，不要换测试题单。
+
+模型不限于某一个（例如不只有 DeepSeek V4 Flash）。每换一个做题模型，就开一次独立 run，在 `run_config.json` 的 `model` 字段写明；同一划分、同一文档、同一 `reward.py` 下可以横向比较多个模型。不要把多个模型的逐题结果写进同一个 `results.jsonl`。
+
+公平对比的做题环境：xskill 与 SkillOpt 在训练做题和正式测评时，都应使用同一套 Claude Code 原生 Skills（不要训练用 `openai_chat` 做题、测评却换 Claude Code）。SkillOpt 的 `openai_chat` 若保留，只用于改技能文案，不用于答题。详见 [`what-these-files-are.md`](what-these-files-are.md)。
+
+SkillOpt 训练里「做题」（target）和「改技能文案」（optimizer）可以分开：做题应与评测一样走 Claude Code 原生 Skills；改文案仍可用 `openai_chat`，只改技能正文。最终成绩在同一做题环境、同一 test 上比冻结技能，这样对最终分数是公平的。`optimizer` 留在 Chat 是方法选择，必须在 `train_provenance.json` 写明。
+
+各文件白话说明见 [`what-these-files-are.md`](what-these-files-are.md)（文首有「每跑一趟要记下哪些信息」清单）。字段约定见 `schemas/`，填法示例见 `examples/`。若用 LiteLLM 记 token / 费用，见 `scripts/bench/officeqa/litellm_usage.py`。
+
+
 ## 固定版本
 
 | 工件 | 固定值 | 核验说明 |

--- a/benchmarks/officeqa/artifacts/.gitignore
+++ b/benchmarks/officeqa/artifacts/.gitignore
@@ -1,0 +1,4 @@
+# Real experiment outputs stay outside git.
+*
+!.gitignore
+!README.md

--- a/benchmarks/officeqa/artifacts/README.md
+++ b/benchmarks/officeqa/artifacts/README.md
@@ -1,0 +1,15 @@
+# 实验产出放哪里
+
+真实跑分不要默认提交进 Git。可以放在本目录，或放在 `~/.cache/xskill/officeqa/runs/<run_id>/`。
+
+每次实验通常会有（一次实验 = 一个算法设定 + 一个做题模型）：
+
+- `run_config.json`（或 runner 写的 `run.json`）：这一次怎么跑（含 `model`）
+- 若是训练：`train_provenance.json`
+- 冻结技能：`skill/` 及其 SHA-256
+- `results.jsonl`：逐题结果
+- `summary.json`：汇总数字
+
+要测多个模型：每个模型单独一个目录或 `run_id`，不要混在同一份 `results.jsonl` 里。
+
+每趟具体要统计哪些字段，见上级目录 `what-these-files-are.md` 文首清单。

--- a/benchmarks/officeqa/examples/result_record.example.json
+++ b/benchmarks/officeqa/examples/result_record.example.json
@@ -1,0 +1,22 @@
+{
+  "schema_version": 1,
+  "run_id": "demo-eval-20260831",
+  "uid": "UID0002",
+  "status": "pass",
+  "difficulty": "easy",
+  "is_correct": true,
+  "pred_answer": "(示例占位；真实预测不要提交进 Git)",
+  "latency_ms": 12345,
+  "usage": {
+    "source": "litellm",
+    "input_tokens": 1000,
+    "output_tokens": 200,
+    "cache_read_tokens": 100,
+    "total_tokens": 1200,
+    "cost_usd": 0.0012,
+    "request_ids": ["chatcmpl-demo-1"]
+  },
+  "skill_sha256": "replace-with-frozen-skill-sha256",
+  "scorer_commit": "7b9a3c154ef9fb40215bb67934afc43e6799de16",
+  "attempts": 1
+}

--- a/benchmarks/officeqa/examples/run_config.example.json
+++ b/benchmarks/officeqa/examples/run_config.example.json
@@ -1,0 +1,43 @@
+{
+  "schema_version": 1,
+  "run_id": "demo-eval-20260831",
+  "phase": "eval",
+  "algo": "xskill",
+  "split_manifest": "benchmarks/officeqa/manifests/officeqa_skillopt_id_split.json",
+  "split_manifest_sha256": "replace-after-generating-real-run",
+  "split_name": "test",
+  "full_manifest": "benchmarks/officeqa/manifests/officeqa_full.json",
+  "full_manifest_sha256": "replace-after-generating-real-run",
+  "docs_tree_sha256": "851bfc5dbf2fc42abb1cc5aa4a4b5de872cf1f3b473d8cf6dd8f7c637d0c7d24",
+  "model": "deepseek-v4-flash",
+  "api_base_kind": "litellm_proxy",
+  "endpoint_label": "local-litellm",
+  "harness": {
+    "id": "claude_code_native_skills",
+    "tools": ["Read", "Write", "Edit", "Bash", "Skill"],
+    "notes": "示例只用 deepseek-v4-flash。换模型时新建 run_id，改 model 字段，不要和别的模型共用一份 results.jsonl。现成的 scripts/bench/officeqa/run.py 是另一套 OpenAI 兼容工具环境；实际用哪套就把 harness.id 写成哪套。"
+  },
+  "scorer": {
+    "commit": "7b9a3c154ef9fb40215bb67934afc43e6799de16",
+    "sha256": "0d91698c87df6d889339aac36f63ae0966607f169890b0bf8b472b26bfe8138f",
+    "tolerance": 0.0,
+    "path": "scripts/bench/officeqa/vendor/reward.py"
+  },
+  "code": {
+    "xskill_commit": "replace-with-real-commit"
+  },
+  "skill_sha256": "replace-with-frozen-skill-sha256",
+  "workers": 4,
+  "timeout_s": 600,
+  "max_tool_turns": 24,
+  "retry": {
+    "request_retries": 3,
+    "case_retries": 1
+  },
+  "seed": 0,
+  "failure_policy": "timeout 在结果里单独标成 timeout（方便区分原因），计分时与 fail 一样算未通过；和榜单一致。准确率 = pass 数 / 全部应考题数（含 timeout）",
+  "usage": {
+    "provider": "litellm",
+    "metadata_keys": ["run_id", "uid", "phase", "algo"]
+  }
+}

--- a/benchmarks/officeqa/examples/summary.example.json
+++ b/benchmarks/officeqa/examples/summary.example.json
@@ -1,0 +1,36 @@
+{
+  "schema_version": 1,
+  "run_id": "demo-eval-20260831",
+  "model": "deepseek-v4-flash",
+  "n_total": 172,
+  "n_pass": 120,
+  "accuracy": 0.6977,
+  "by_difficulty": {
+    "easy": { "n_total": 79, "n_pass": 64, "accuracy": 0.8101 },
+    "hard": { "n_total": 93, "n_pass": 56, "accuracy": 0.6022 }
+  },
+  "status_counts": {
+    "pass": 120,
+    "fail": 40,
+    "invalid": 2,
+    "timeout": 6,
+    "infra_error": 0,
+    "skipped": 4
+  },
+  "usage_totals": {
+    "input_tokens": 1000000,
+    "output_tokens": 200000,
+    "cost_usd": 12.34,
+    "usage_missing_n": 4
+  },
+  "refs": {
+    "run_config_sha256": "replace",
+    "results_sha256": "replace",
+    "skill_sha256": "replace",
+    "split_manifest_sha256": "replace",
+    "full_manifest_sha256": "replace"
+  },
+  "started_at": "2026-08-31T00:00:00+00:00",
+  "finished_at": "2026-08-31T06:00:00+00:00",
+  "resumed": false
+}

--- a/benchmarks/officeqa/examples/train_provenance.example.json
+++ b/benchmarks/officeqa/examples/train_provenance.example.json
@@ -1,0 +1,20 @@
+{
+  "schema_version": 1,
+  "run_id": "demo-train-20260831",
+  "algo": "xskill",
+  "split_manifest": "benchmarks/officeqa/manifests/officeqa_skillopt_id_split.json",
+  "split_manifest_sha256": "replace-after-generating-real-run",
+  "train_uids_sha256": "replace-with-sha-of-actual-train-uid-list",
+  "merge_val_into_train": true,
+  "selection_split": null,
+  "hyperparameters": {
+    "note": "按具体算法填写；这里只是占位"
+  },
+  "optimizer_backend": "openai_chat",
+  "target_harness": "claude_code_native_skills",
+  "code": {
+    "xskill_commit": "replace-with-real-commit"
+  },
+  "skill_sha256": "replace-with-frozen-skill-sha256",
+  "notes": "train_uids_sha256：对本趟实际训练用的 UID 名单（排好序后）算的校验和，用来核对训了哪几道题；不是 SkillOpt 划分文件自带的哈希。若 merge_val_into_train=true，名单应是 train+val 合并后的题号。示例：xskill 常把 val 并进 train，最终分数另用冻结技能在 test 上评。SkillOpt：optimizer_backend=openai_chat 表示只改技能正文；target_harness=claude_code_native_skills 表示训练做题与评测同一环境。"
+}

--- a/benchmarks/officeqa/manifests/officeqa_skillopt_id_split.json
+++ b/benchmarks/officeqa/manifests/officeqa_skillopt_id_split.json
@@ -1,0 +1,1018 @@
+{
+  "schema_version": 1,
+  "benchmark": "officeqa_skillopt_id_split",
+  "description": "按 SkillOpt 公开的题号划分：训练约 50 题、验证约 24 题、测试 172 题。父集是 OfficeQA Full 的 246 题。这里只存题号和难度，不存题目和答案。",
+  "parent_benchmark": "officeqa_full",
+  "parent_manifest": "benchmarks/officeqa/manifests/officeqa_full.json",
+  "source": {
+    "repository": "microsoft/SkillOpt",
+    "repository_url": "https://github.com/microsoft/SkillOpt",
+    "commit": "da06b157cb9878e378663ee1ecf429c83fe1a8f9",
+    "path": "data/officeqa_id_split",
+    "source_file_sha256": {
+      "split_manifest.json": "8f76983eadeb6670df2fc88f568fa86c6318d4e8f02912bf05c5c69955a867e7",
+      "train/items.json": "1bb3a9ca003f6ba7aff34cf2d1fe23d9af12ff647060ac8b7d4c22dcb9e84b56",
+      "val/items.json": "1d7fc4443718a8fc565faf4450d31109880dbf8103759a306289f5ba9407f11b",
+      "test/items.json": "563c30589e897f08161df4d2778578e14a8a2887391813e8d45c3d39eafd900d"
+    },
+    "note": "划分来自 SkillOpt 仓库的公开 id split，不是 OfficeQA 上游自己划的 train/val/test。每题 easy/hard 来自同目录的 officeqa_full.json。"
+  },
+  "counts": {
+    "train": 50,
+    "val": 24,
+    "test": 172
+  },
+  "splits": {
+    "train": [
+      {
+        "uid": "UID0002",
+        "difficulty": "easy"
+      },
+      {
+        "uid": "UID0007",
+        "difficulty": "hard"
+      },
+      {
+        "uid": "UID0014",
+        "difficulty": "easy"
+      },
+      {
+        "uid": "UID0017",
+        "difficulty": "hard"
+      },
+      {
+        "uid": "UID0018",
+        "difficulty": "hard"
+      },
+      {
+        "uid": "UID0019",
+        "difficulty": "hard"
+      },
+      {
+        "uid": "UID0026",
+        "difficulty": "easy"
+      },
+      {
+        "uid": "UID0028",
+        "difficulty": "hard"
+      },
+      {
+        "uid": "UID0030",
+        "difficulty": "hard"
+      },
+      {
+        "uid": "UID0031",
+        "difficulty": "hard"
+      },
+      {
+        "uid": "UID0033",
+        "difficulty": "easy"
+      },
+      {
+        "uid": "UID0034",
+        "difficulty": "easy"
+      },
+      {
+        "uid": "UID0044",
+        "difficulty": "hard"
+      },
+      {
+        "uid": "UID0046",
+        "difficulty": "easy"
+      },
+      {
+        "uid": "UID0049",
+        "difficulty": "hard"
+      },
+      {
+        "uid": "UID0056",
+        "difficulty": "hard"
+      },
+      {
+        "uid": "UID0063",
+        "difficulty": "easy"
+      },
+      {
+        "uid": "UID0065",
+        "difficulty": "hard"
+      },
+      {
+        "uid": "UID0073",
+        "difficulty": "hard"
+      },
+      {
+        "uid": "UID0079",
+        "difficulty": "easy"
+      },
+      {
+        "uid": "UID0083",
+        "difficulty": "hard"
+      },
+      {
+        "uid": "UID0085",
+        "difficulty": "hard"
+      },
+      {
+        "uid": "UID0087",
+        "difficulty": "easy"
+      },
+      {
+        "uid": "UID0092",
+        "difficulty": "easy"
+      },
+      {
+        "uid": "UID0098",
+        "difficulty": "easy"
+      },
+      {
+        "uid": "UID0101",
+        "difficulty": "hard"
+      },
+      {
+        "uid": "UID0110",
+        "difficulty": "hard"
+      },
+      {
+        "uid": "UID0115",
+        "difficulty": "easy"
+      },
+      {
+        "uid": "UID0122",
+        "difficulty": "hard"
+      },
+      {
+        "uid": "UID0123",
+        "difficulty": "hard"
+      },
+      {
+        "uid": "UID0133",
+        "difficulty": "hard"
+      },
+      {
+        "uid": "UID0141",
+        "difficulty": "easy"
+      },
+      {
+        "uid": "UID0144",
+        "difficulty": "easy"
+      },
+      {
+        "uid": "UID0145",
+        "difficulty": "easy"
+      },
+      {
+        "uid": "UID0150",
+        "difficulty": "hard"
+      },
+      {
+        "uid": "UID0151",
+        "difficulty": "easy"
+      },
+      {
+        "uid": "UID0162",
+        "difficulty": "easy"
+      },
+      {
+        "uid": "UID0163",
+        "difficulty": "easy"
+      },
+      {
+        "uid": "UID0165",
+        "difficulty": "hard"
+      },
+      {
+        "uid": "UID0166",
+        "difficulty": "easy"
+      },
+      {
+        "uid": "UID0169",
+        "difficulty": "hard"
+      },
+      {
+        "uid": "UID0189",
+        "difficulty": "easy"
+      },
+      {
+        "uid": "UID0195",
+        "difficulty": "hard"
+      },
+      {
+        "uid": "UID0202",
+        "difficulty": "easy"
+      },
+      {
+        "uid": "UID0212",
+        "difficulty": "hard"
+      },
+      {
+        "uid": "UID0222",
+        "difficulty": "hard"
+      },
+      {
+        "uid": "UID0228",
+        "difficulty": "hard"
+      },
+      {
+        "uid": "UID0229",
+        "difficulty": "easy"
+      },
+      {
+        "uid": "UID0238",
+        "difficulty": "hard"
+      },
+      {
+        "uid": "UID0241",
+        "difficulty": "easy"
+      }
+    ],
+    "val": [
+      {
+        "uid": "UID0001",
+        "difficulty": "hard"
+      },
+      {
+        "uid": "UID0027",
+        "difficulty": "hard"
+      },
+      {
+        "uid": "UID0039",
+        "difficulty": "hard"
+      },
+      {
+        "uid": "UID0041",
+        "difficulty": "easy"
+      },
+      {
+        "uid": "UID0052",
+        "difficulty": "easy"
+      },
+      {
+        "uid": "UID0070",
+        "difficulty": "easy"
+      },
+      {
+        "uid": "UID0072",
+        "difficulty": "easy"
+      },
+      {
+        "uid": "UID0086",
+        "difficulty": "hard"
+      },
+      {
+        "uid": "UID0091",
+        "difficulty": "easy"
+      },
+      {
+        "uid": "UID0109",
+        "difficulty": "hard"
+      },
+      {
+        "uid": "UID0142",
+        "difficulty": "easy"
+      },
+      {
+        "uid": "UID0154",
+        "difficulty": "hard"
+      },
+      {
+        "uid": "UID0159",
+        "difficulty": "easy"
+      },
+      {
+        "uid": "UID0161",
+        "difficulty": "hard"
+      },
+      {
+        "uid": "UID0170",
+        "difficulty": "hard"
+      },
+      {
+        "uid": "UID0190",
+        "difficulty": "hard"
+      },
+      {
+        "uid": "UID0213",
+        "difficulty": "hard"
+      },
+      {
+        "uid": "UID0217",
+        "difficulty": "easy"
+      },
+      {
+        "uid": "UID0220",
+        "difficulty": "hard"
+      },
+      {
+        "uid": "UID0233",
+        "difficulty": "hard"
+      },
+      {
+        "uid": "UID0234",
+        "difficulty": "easy"
+      },
+      {
+        "uid": "UID0235",
+        "difficulty": "easy"
+      },
+      {
+        "uid": "UID0239",
+        "difficulty": "easy"
+      },
+      {
+        "uid": "UID0240",
+        "difficulty": "hard"
+      }
+    ],
+    "test": [
+      {
+        "uid": "UID0003",
+        "difficulty": "hard"
+      },
+      {
+        "uid": "UID0004",
+        "difficulty": "hard"
+      },
+      {
+        "uid": "UID0005",
+        "difficulty": "hard"
+      },
+      {
+        "uid": "UID0006",
+        "difficulty": "easy"
+      },
+      {
+        "uid": "UID0008",
+        "difficulty": "easy"
+      },
+      {
+        "uid": "UID0009",
+        "difficulty": "hard"
+      },
+      {
+        "uid": "UID0010",
+        "difficulty": "hard"
+      },
+      {
+        "uid": "UID0011",
+        "difficulty": "easy"
+      },
+      {
+        "uid": "UID0012",
+        "difficulty": "hard"
+      },
+      {
+        "uid": "UID0013",
+        "difficulty": "hard"
+      },
+      {
+        "uid": "UID0015",
+        "difficulty": "hard"
+      },
+      {
+        "uid": "UID0016",
+        "difficulty": "easy"
+      },
+      {
+        "uid": "UID0020",
+        "difficulty": "easy"
+      },
+      {
+        "uid": "UID0021",
+        "difficulty": "easy"
+      },
+      {
+        "uid": "UID0022",
+        "difficulty": "hard"
+      },
+      {
+        "uid": "UID0023",
+        "difficulty": "easy"
+      },
+      {
+        "uid": "UID0024",
+        "difficulty": "easy"
+      },
+      {
+        "uid": "UID0025",
+        "difficulty": "hard"
+      },
+      {
+        "uid": "UID0029",
+        "difficulty": "hard"
+      },
+      {
+        "uid": "UID0032",
+        "difficulty": "hard"
+      },
+      {
+        "uid": "UID0035",
+        "difficulty": "hard"
+      },
+      {
+        "uid": "UID0036",
+        "difficulty": "hard"
+      },
+      {
+        "uid": "UID0037",
+        "difficulty": "hard"
+      },
+      {
+        "uid": "UID0038",
+        "difficulty": "easy"
+      },
+      {
+        "uid": "UID0040",
+        "difficulty": "easy"
+      },
+      {
+        "uid": "UID0042",
+        "difficulty": "hard"
+      },
+      {
+        "uid": "UID0043",
+        "difficulty": "easy"
+      },
+      {
+        "uid": "UID0045",
+        "difficulty": "easy"
+      },
+      {
+        "uid": "UID0047",
+        "difficulty": "easy"
+      },
+      {
+        "uid": "UID0048",
+        "difficulty": "easy"
+      },
+      {
+        "uid": "UID0050",
+        "difficulty": "hard"
+      },
+      {
+        "uid": "UID0051",
+        "difficulty": "easy"
+      },
+      {
+        "uid": "UID0053",
+        "difficulty": "hard"
+      },
+      {
+        "uid": "UID0054",
+        "difficulty": "easy"
+      },
+      {
+        "uid": "UID0055",
+        "difficulty": "hard"
+      },
+      {
+        "uid": "UID0057",
+        "difficulty": "hard"
+      },
+      {
+        "uid": "UID0058",
+        "difficulty": "hard"
+      },
+      {
+        "uid": "UID0059",
+        "difficulty": "hard"
+      },
+      {
+        "uid": "UID0060",
+        "difficulty": "easy"
+      },
+      {
+        "uid": "UID0061",
+        "difficulty": "easy"
+      },
+      {
+        "uid": "UID0062",
+        "difficulty": "hard"
+      },
+      {
+        "uid": "UID0064",
+        "difficulty": "easy"
+      },
+      {
+        "uid": "UID0066",
+        "difficulty": "easy"
+      },
+      {
+        "uid": "UID0067",
+        "difficulty": "easy"
+      },
+      {
+        "uid": "UID0068",
+        "difficulty": "hard"
+      },
+      {
+        "uid": "UID0069",
+        "difficulty": "hard"
+      },
+      {
+        "uid": "UID0071",
+        "difficulty": "hard"
+      },
+      {
+        "uid": "UID0074",
+        "difficulty": "easy"
+      },
+      {
+        "uid": "UID0075",
+        "difficulty": "easy"
+      },
+      {
+        "uid": "UID0076",
+        "difficulty": "easy"
+      },
+      {
+        "uid": "UID0077",
+        "difficulty": "hard"
+      },
+      {
+        "uid": "UID0078",
+        "difficulty": "easy"
+      },
+      {
+        "uid": "UID0080",
+        "difficulty": "easy"
+      },
+      {
+        "uid": "UID0081",
+        "difficulty": "easy"
+      },
+      {
+        "uid": "UID0082",
+        "difficulty": "easy"
+      },
+      {
+        "uid": "UID0084",
+        "difficulty": "hard"
+      },
+      {
+        "uid": "UID0088",
+        "difficulty": "easy"
+      },
+      {
+        "uid": "UID0089",
+        "difficulty": "easy"
+      },
+      {
+        "uid": "UID0090",
+        "difficulty": "easy"
+      },
+      {
+        "uid": "UID0093",
+        "difficulty": "hard"
+      },
+      {
+        "uid": "UID0094",
+        "difficulty": "hard"
+      },
+      {
+        "uid": "UID0095",
+        "difficulty": "easy"
+      },
+      {
+        "uid": "UID0096",
+        "difficulty": "hard"
+      },
+      {
+        "uid": "UID0097",
+        "difficulty": "hard"
+      },
+      {
+        "uid": "UID0099",
+        "difficulty": "easy"
+      },
+      {
+        "uid": "UID0100",
+        "difficulty": "hard"
+      },
+      {
+        "uid": "UID0102",
+        "difficulty": "hard"
+      },
+      {
+        "uid": "UID0103",
+        "difficulty": "hard"
+      },
+      {
+        "uid": "UID0104",
+        "difficulty": "easy"
+      },
+      {
+        "uid": "UID0105",
+        "difficulty": "easy"
+      },
+      {
+        "uid": "UID0106",
+        "difficulty": "easy"
+      },
+      {
+        "uid": "UID0107",
+        "difficulty": "easy"
+      },
+      {
+        "uid": "UID0108",
+        "difficulty": "hard"
+      },
+      {
+        "uid": "UID0111",
+        "difficulty": "hard"
+      },
+      {
+        "uid": "UID0112",
+        "difficulty": "hard"
+      },
+      {
+        "uid": "UID0113",
+        "difficulty": "hard"
+      },
+      {
+        "uid": "UID0114",
+        "difficulty": "hard"
+      },
+      {
+        "uid": "UID0116",
+        "difficulty": "easy"
+      },
+      {
+        "uid": "UID0117",
+        "difficulty": "hard"
+      },
+      {
+        "uid": "UID0118",
+        "difficulty": "hard"
+      },
+      {
+        "uid": "UID0119",
+        "difficulty": "easy"
+      },
+      {
+        "uid": "UID0120",
+        "difficulty": "hard"
+      },
+      {
+        "uid": "UID0121",
+        "difficulty": "hard"
+      },
+      {
+        "uid": "UID0124",
+        "difficulty": "hard"
+      },
+      {
+        "uid": "UID0125",
+        "difficulty": "easy"
+      },
+      {
+        "uid": "UID0126",
+        "difficulty": "easy"
+      },
+      {
+        "uid": "UID0127",
+        "difficulty": "easy"
+      },
+      {
+        "uid": "UID0128",
+        "difficulty": "easy"
+      },
+      {
+        "uid": "UID0129",
+        "difficulty": "easy"
+      },
+      {
+        "uid": "UID0130",
+        "difficulty": "hard"
+      },
+      {
+        "uid": "UID0131",
+        "difficulty": "easy"
+      },
+      {
+        "uid": "UID0132",
+        "difficulty": "easy"
+      },
+      {
+        "uid": "UID0134",
+        "difficulty": "hard"
+      },
+      {
+        "uid": "UID0135",
+        "difficulty": "hard"
+      },
+      {
+        "uid": "UID0136",
+        "difficulty": "hard"
+      },
+      {
+        "uid": "UID0137",
+        "difficulty": "easy"
+      },
+      {
+        "uid": "UID0138",
+        "difficulty": "easy"
+      },
+      {
+        "uid": "UID0139",
+        "difficulty": "easy"
+      },
+      {
+        "uid": "UID0140",
+        "difficulty": "hard"
+      },
+      {
+        "uid": "UID0143",
+        "difficulty": "easy"
+      },
+      {
+        "uid": "UID0146",
+        "difficulty": "easy"
+      },
+      {
+        "uid": "UID0147",
+        "difficulty": "hard"
+      },
+      {
+        "uid": "UID0148",
+        "difficulty": "hard"
+      },
+      {
+        "uid": "UID0149",
+        "difficulty": "hard"
+      },
+      {
+        "uid": "UID0152",
+        "difficulty": "easy"
+      },
+      {
+        "uid": "UID0153",
+        "difficulty": "easy"
+      },
+      {
+        "uid": "UID0155",
+        "difficulty": "hard"
+      },
+      {
+        "uid": "UID0156",
+        "difficulty": "easy"
+      },
+      {
+        "uid": "UID0157",
+        "difficulty": "easy"
+      },
+      {
+        "uid": "UID0158",
+        "difficulty": "easy"
+      },
+      {
+        "uid": "UID0160",
+        "difficulty": "easy"
+      },
+      {
+        "uid": "UID0164",
+        "difficulty": "easy"
+      },
+      {
+        "uid": "UID0167",
+        "difficulty": "easy"
+      },
+      {
+        "uid": "UID0168",
+        "difficulty": "hard"
+      },
+      {
+        "uid": "UID0171",
+        "difficulty": "easy"
+      },
+      {
+        "uid": "UID0172",
+        "difficulty": "hard"
+      },
+      {
+        "uid": "UID0173",
+        "difficulty": "hard"
+      },
+      {
+        "uid": "UID0174",
+        "difficulty": "hard"
+      },
+      {
+        "uid": "UID0175",
+        "difficulty": "hard"
+      },
+      {
+        "uid": "UID0176",
+        "difficulty": "easy"
+      },
+      {
+        "uid": "UID0177",
+        "difficulty": "hard"
+      },
+      {
+        "uid": "UID0178",
+        "difficulty": "easy"
+      },
+      {
+        "uid": "UID0179",
+        "difficulty": "hard"
+      },
+      {
+        "uid": "UID0180",
+        "difficulty": "hard"
+      },
+      {
+        "uid": "UID0181",
+        "difficulty": "easy"
+      },
+      {
+        "uid": "UID0182",
+        "difficulty": "hard"
+      },
+      {
+        "uid": "UID0183",
+        "difficulty": "hard"
+      },
+      {
+        "uid": "UID0184",
+        "difficulty": "hard"
+      },
+      {
+        "uid": "UID0185",
+        "difficulty": "easy"
+      },
+      {
+        "uid": "UID0186",
+        "difficulty": "easy"
+      },
+      {
+        "uid": "UID0187",
+        "difficulty": "hard"
+      },
+      {
+        "uid": "UID0188",
+        "difficulty": "hard"
+      },
+      {
+        "uid": "UID0191",
+        "difficulty": "easy"
+      },
+      {
+        "uid": "UID0192",
+        "difficulty": "easy"
+      },
+      {
+        "uid": "UID0193",
+        "difficulty": "hard"
+      },
+      {
+        "uid": "UID0194",
+        "difficulty": "hard"
+      },
+      {
+        "uid": "UID0196",
+        "difficulty": "hard"
+      },
+      {
+        "uid": "UID0197",
+        "difficulty": "easy"
+      },
+      {
+        "uid": "UID0198",
+        "difficulty": "easy"
+      },
+      {
+        "uid": "UID0199",
+        "difficulty": "easy"
+      },
+      {
+        "uid": "UID0200",
+        "difficulty": "easy"
+      },
+      {
+        "uid": "UID0201",
+        "difficulty": "hard"
+      },
+      {
+        "uid": "UID0203",
+        "difficulty": "hard"
+      },
+      {
+        "uid": "UID0204",
+        "difficulty": "hard"
+      },
+      {
+        "uid": "UID0205",
+        "difficulty": "hard"
+      },
+      {
+        "uid": "UID0206",
+        "difficulty": "easy"
+      },
+      {
+        "uid": "UID0207",
+        "difficulty": "hard"
+      },
+      {
+        "uid": "UID0208",
+        "difficulty": "easy"
+      },
+      {
+        "uid": "UID0209",
+        "difficulty": "easy"
+      },
+      {
+        "uid": "UID0210",
+        "difficulty": "easy"
+      },
+      {
+        "uid": "UID0211",
+        "difficulty": "hard"
+      },
+      {
+        "uid": "UID0214",
+        "difficulty": "hard"
+      },
+      {
+        "uid": "UID0215",
+        "difficulty": "hard"
+      },
+      {
+        "uid": "UID0216",
+        "difficulty": "hard"
+      },
+      {
+        "uid": "UID0218",
+        "difficulty": "hard"
+      },
+      {
+        "uid": "UID0219",
+        "difficulty": "hard"
+      },
+      {
+        "uid": "UID0221",
+        "difficulty": "hard"
+      },
+      {
+        "uid": "UID0223",
+        "difficulty": "hard"
+      },
+      {
+        "uid": "UID0224",
+        "difficulty": "hard"
+      },
+      {
+        "uid": "UID0225",
+        "difficulty": "hard"
+      },
+      {
+        "uid": "UID0226",
+        "difficulty": "hard"
+      },
+      {
+        "uid": "UID0227",
+        "difficulty": "hard"
+      },
+      {
+        "uid": "UID0230",
+        "difficulty": "hard"
+      },
+      {
+        "uid": "UID0231",
+        "difficulty": "easy"
+      },
+      {
+        "uid": "UID0232",
+        "difficulty": "easy"
+      },
+      {
+        "uid": "UID0236",
+        "difficulty": "easy"
+      },
+      {
+        "uid": "UID0237",
+        "difficulty": "hard"
+      },
+      {
+        "uid": "UID0242",
+        "difficulty": "easy"
+      },
+      {
+        "uid": "UID0243",
+        "difficulty": "hard"
+      },
+      {
+        "uid": "UID0244",
+        "difficulty": "hard"
+      },
+      {
+        "uid": "UID0245",
+        "difficulty": "hard"
+      },
+      {
+        "uid": "UID0246",
+        "difficulty": "hard"
+      }
+    ]
+  },
+  "splits_sha256": "0b971653970a7a81efefec1fe85fc00fdc4ac5b37af72acedafc06e6693458d2"
+}

--- a/benchmarks/officeqa/schemas/result_record.schema.json
+++ b/benchmarks/officeqa/schemas/result_record.schema.json
@@ -1,0 +1,53 @@
+{
+  "$schema": "https://json-schema.org/draft/2020-12/schema",
+  "$id": "https://github.com/SkillNerds/xskill/benchmarks/officeqa/schemas/result_record.schema.json",
+  "title": "OfficeQA 单题结果",
+  "description": "results.jsonl 里的一行，表示一题的最终结果。不要把受控题目原文提交进 Git。",
+  "type": "object",
+  "required": ["schema_version", "run_id", "uid", "status"],
+  "properties": {
+    "schema_version": { "type": "integer", "const": 1 },
+    "run_id": { "type": "string" },
+    "uid": { "type": "string", "description": "题号，例如 UID0002" },
+    "status": {
+      "type": "string",
+      "enum": ["pass", "fail", "invalid", "timeout", "infra_error", "skipped"],
+      "description": "pass=答对；fail=答错；timeout=超时（计分时与 fail 一样算未通过）；invalid=输出无法判分（计分也算未通过）；infra_error=基础设施错误；skipped=跳过。status 区分原因；准确率只有 pass 算对"
+    },
+    "difficulty": { "type": "string", "enum": ["easy", "hard"] },
+    "is_correct": {
+      "type": ["boolean", "null"],
+      "description": "是否答对；不可判分时可为 null"
+    },
+    "pred_answer": {
+      "type": ["string", "null"],
+      "description": "模型预测答案；对外分享前按数据许可决定是否删除"
+    },
+    "latency_ms": { "type": ["number", "null"], "description": "耗时（毫秒）" },
+    "usage": {
+      "type": "object",
+      "description": "本题的 token 与费用",
+      "properties": {
+        "source": {
+          "type": "string",
+          "enum": ["litellm", "runner_reported", "missing"],
+          "description": "litellm=从 LiteLLM 补；runner_reported=runner 自己记；missing=没有采到"
+        },
+        "input_tokens": { "type": ["integer", "null"] },
+        "output_tokens": { "type": ["integer", "null"] },
+        "cache_read_tokens": { "type": ["integer", "null"] },
+        "total_tokens": { "type": ["integer", "null"] },
+        "cost_usd": { "type": ["number", "null"] },
+        "request_ids": {
+          "type": "array",
+          "items": { "type": "string" },
+          "description": "相关请求 id，便于去 LiteLLM 对账"
+        }
+      }
+    },
+    "skill_sha256": { "type": "string" },
+    "scorer_commit": { "type": "string" },
+    "attempts": { "type": "integer", "description": "本题尝试次数" }
+  },
+  "additionalProperties": true
+}

--- a/benchmarks/officeqa/schemas/run_config.schema.json
+++ b/benchmarks/officeqa/schemas/run_config.schema.json
@@ -1,0 +1,141 @@
+{
+  "$schema": "https://json-schema.org/draft/2020-12/schema",
+  "$id": "https://github.com/SkillNerds/xskill/benchmarks/officeqa/schemas/run_config.schema.json",
+  "title": "OfficeQA 单次运行配置",
+  "description": "记录这一次怎么跑：题单、模型、超时、技能版本、代码版本等。不要把 API key 写进来。",
+  "type": "object",
+  "required": [
+    "schema_version",
+    "run_id",
+    "phase",
+    "algo",
+    "split_manifest",
+    "split_name",
+    "full_manifest",
+    "model",
+    "harness",
+    "scorer"
+  ],
+  "properties": {
+    "schema_version": { "type": "integer", "const": 1 },
+    "run_id": { "type": "string", "minLength": 1 },
+    "phase": {
+      "type": "string",
+      "enum": ["train", "eval"],
+      "description": "train=训练；eval=评测"
+    },
+    "algo": { "type": "string", "description": "算法名，例如 xskill 或 skillopt" },
+    "split_manifest": {
+      "type": "string",
+      "description": "划分文件路径，例如 manifests/officeqa_skillopt_id_split.json"
+    },
+    "split_manifest_sha256": {
+      "type": "string",
+      "description": "上述划分文件的 SHA-256，跑完后填真实值"
+    },
+    "split_name": {
+      "type": "string",
+      "enum": ["train", "val", "test", "full"],
+      "description": "这次实际跑哪一段；主对比用 test"
+    },
+    "full_manifest": {
+      "type": "string",
+      "description": "Full 246 题名单路径"
+    },
+    "full_manifest_sha256": { "type": "string" },
+    "docs_tree_sha256": {
+      "type": "string",
+      "description": "本地语料树的 SHA-256，应与 Full manifest 里写死的一致"
+    },
+    "model": {
+      "type": "string",
+      "description": "本 run 的做题模型名。一次 run 只写一个模型；要测多个模型就开多次 run"
+    },
+    "api_base_kind": {
+      "type": "string",
+      "description": "请求怎么走，例如 litellm_proxy 或 openai_compatible；不要写带密钥的完整 URL"
+    },
+    "endpoint_label": {
+      "type": "string",
+      "description": "给人看的 endpoint 昵称，例如 local-litellm"
+    },
+    "harness": {
+      "type": "object",
+      "description": "做题环境：用哪套 agent / 工具",
+      "required": ["id"],
+      "properties": {
+        "id": {
+          "type": "string",
+          "description": "例如 claude_code_native_skills"
+        },
+        "tools": {
+          "type": "array",
+          "items": { "type": "string" },
+          "description": "允许的工具名列表"
+        },
+        "notes": { "type": "string" }
+      }
+    },
+    "scorer": {
+      "type": "object",
+      "description": "判分用的官方 reward.py 版本",
+      "required": ["commit", "sha256", "tolerance"],
+      "properties": {
+        "commit": { "type": "string" },
+        "sha256": { "type": "string" },
+        "tolerance": { "type": "number" },
+        "path": { "type": "string" }
+      }
+    },
+    "code": {
+      "type": "object",
+      "description": "本次用到的代码版本",
+      "properties": {
+        "xskill_commit": { "type": "string" },
+        "skillopt_commit": { "type": "string" },
+        "image_digest": { "type": "string" }
+      }
+    },
+    "skill_sha256": {
+      "type": "string",
+      "description": "本次评测所用冻结技能的 SHA-256"
+    },
+    "workers": { "type": "integer", "minimum": 1, "description": "并行工人数" },
+    "timeout_s": { "type": "number", "description": "单题超时（秒）" },
+    "max_tool_turns": { "type": "integer", "description": "单题最多工具轮数" },
+    "retry": {
+      "type": "object",
+      "properties": {
+        "request_retries": {
+          "type": "integer",
+          "description": "单次请求失败后的重试次数"
+        },
+        "case_retries": {
+          "type": "integer",
+          "description": "整题失败后的外层重试次数"
+        }
+      }
+    },
+    "seed": { "type": "integer" },
+    "failure_policy": {
+      "type": "string",
+      "description": "失败怎么计分。约定：timeout 可单独标记原因，但计分时与 fail 一样算未通过（与榜单一致）；准确率分母含 timeout"
+    },
+    "usage": {
+      "type": "object",
+      "description": "token / 费用从哪来",
+      "properties": {
+        "provider": {
+          "type": "string",
+          "enum": ["litellm", "runner_reported", "none"]
+        },
+        "metadata_keys": {
+          "type": "array",
+          "items": { "type": "string" },
+          "description": "打到 LiteLLM 请求上的标记，例如 run_id、uid"
+        }
+      }
+    }
+  },
+  "additionalProperties": true
+}

--- a/benchmarks/officeqa/schemas/summary.schema.json
+++ b/benchmarks/officeqa/schemas/summary.schema.json
@@ -1,0 +1,65 @@
+{
+  "$schema": "https://json-schema.org/draft/2020-12/schema",
+  "$id": "https://github.com/SkillNerds/xskill/benchmarks/officeqa/schemas/summary.schema.json",
+  "title": "OfficeQA 汇总",
+  "description": "从 results.jsonl 汇总出的数字。论文主表应引用本文件（并保留其 SHA-256）。",
+  "type": "object",
+  "required": [
+    "schema_version",
+    "run_id",
+    "n_total",
+    "n_pass",
+    "accuracy",
+    "status_counts"
+  ],
+  "properties": {
+    "schema_version": { "type": "integer", "const": 1 },
+    "run_id": { "type": "string" },
+    "model": {
+      "type": "string",
+      "description": "本 run 的做题模型，与 run_config.model 一致；多模型对比时靠这个字段区分"
+    },
+    "n_total": { "type": "integer", "description": "题数" },
+    "n_pass": { "type": "integer", "description": "答对题数" },
+    "accuracy": { "type": "number", "description": "准确率，n_pass / n_total" },
+    "by_difficulty": {
+      "type": "object",
+      "description": "按 easy / hard 拆开的统计"
+    },
+    "status_counts": {
+      "type": "object",
+      "description": "pass / fail / timeout 等各有多少"
+    },
+    "usage_totals": {
+      "type": "object",
+      "description": "全 run 的 token 与费用合计",
+      "properties": {
+        "input_tokens": { "type": ["integer", "null"] },
+        "output_tokens": { "type": ["integer", "null"] },
+        "cost_usd": { "type": ["number", "null"] },
+        "usage_missing_n": {
+          "type": "integer",
+          "description": "有多少题没有采到用量"
+        }
+      }
+    },
+    "refs": {
+      "type": "object",
+      "description": "汇总时用到的配置、结果、技能、名单的 SHA-256",
+      "properties": {
+        "run_config_sha256": { "type": "string" },
+        "results_sha256": { "type": "string" },
+        "skill_sha256": { "type": "string" },
+        "split_manifest_sha256": { "type": "string" },
+        "full_manifest_sha256": { "type": "string" }
+      }
+    },
+    "started_at": { "type": "string" },
+    "finished_at": { "type": "string" },
+    "resumed": {
+      "type": "boolean",
+      "description": "是否从中断处续跑过"
+    }
+  },
+  "additionalProperties": true
+}

--- a/benchmarks/officeqa/schemas/train_provenance.schema.json
+++ b/benchmarks/officeqa/schemas/train_provenance.schema.json
@@ -1,0 +1,59 @@
+{
+  "$schema": "https://json-schema.org/draft/2020-12/schema",
+  "$id": "https://github.com/SkillNerds/xskill/benchmarks/officeqa/schemas/train_provenance.schema.json",
+  "title": "OfficeQA 训练来源说明",
+  "description": "这个技能是怎么训出来的。论文主表分数应另用冻结技能做评测，不要用训练中的中间分。",
+  "type": "object",
+  "required": [
+    "schema_version",
+    "run_id",
+    "algo",
+    "split_manifest",
+    "merge_val_into_train",
+    "skill_sha256"
+  ],
+  "properties": {
+    "schema_version": { "type": "integer", "const": 1 },
+    "run_id": { "type": "string" },
+    "algo": { "type": "string", "description": "例如 xskill 或 skillopt" },
+    "split_manifest": { "type": "string" },
+    "split_manifest_sha256": { "type": "string" },
+    "train_uids_sha256": {
+      "type": "string",
+      "description": "对本趟实际用于训练的题号（UID）名单计算的 SHA-256。先把 UID 按固定顺序排好再哈希。用来证明训了哪几道题；与仓库里的 SkillOpt 标准 train 划分不是同一个概念（例如 val 并进 train 后，这里对应合并后的那一子集）"
+    },
+    "merge_val_into_train": {
+      "type": "boolean",
+      "description": "是否把 val 并进 train。xskill 常见为 true；SkillOpt 常见为 false（val 用于 gate）"
+    },
+    "selection_split": {
+      "type": ["string", "null"],
+      "description": "若用某一段数据做 gate / 选技能，填 val；否则填 null"
+    },
+    "hyperparameters": {
+      "type": "object",
+      "description": "训练超参，按算法自己填"
+    },
+    "optimizer_backend": {
+      "type": "string",
+      "description": "改技能文案用的后端，例如 openai_chat。不去做题。"
+    },
+    "target_harness": {
+      "type": "string",
+      "description": "训练时真正做题的环境，例如 claude_code_native_skills；应与正式评测一致。"
+    },
+    "code": {
+      "type": "object",
+      "properties": {
+        "xskill_commit": { "type": "string" },
+        "skillopt_commit": { "type": "string" }
+      }
+    },
+    "skill_sha256": {
+      "type": "string",
+      "description": "训练结束冻结技能的 SHA-256"
+    },
+    "notes": { "type": "string" }
+  },
+  "additionalProperties": true
+}

--- a/benchmarks/officeqa/what-these-files-are.md
+++ b/benchmarks/officeqa/what-these-files-are.md
@@ -1,0 +1,135 @@
+# 这些文件是干什么的
+
+用直白话说明：本目录里每个文件管什么。写 PR、写论文、交接实验时按这个理解即可。读者如果已经熟悉 xskill / SkillOpt / Claude Code，下面会保留这些专有名词，但尽量少绕弯。
+
+## 每跑一趟要记下哪些信息
+
+「一趟」= 一个算法设定 + 一个做题模型 + 一次评测（或一次训练）。换模型、换算法、换技能，都算新的一趟。下面这些尽量在当趟收齐；写进对应文件，不要只留在聊天记录里。
+
+开跑前先写清楚（进 `run_config.json`）
+
+- 跑的是哪一段题：一般正式比分用 test（172）；并写明用的是哪份划分文件  
+- 做题模型叫什么（一趟只写一个模型）  
+- 做题环境：例如 Claude Code 原生 Skills，用了哪些工具  
+- 技能是哪一份（技能内容的 SHA-256）；评测必须是冻结后的技能  
+- 代码版本：xskill / SkillOpt 的 commit，或镜像 digest  
+- 文档语料是否对得上（语料树 SHA-256）  
+- 评分代码是哪一版（`reward.py` 的 commit 与 SHA-256）、容差是多少  
+- 超时、并行数、最大工具轮数、重试次数、随机种子  
+- 请求是否走 LiteLLM（方便事后对 token / 费用）
+
+若这一趟包含训练，再多记（进 `train_provenance.json`）
+
+- 实际用了哪些训练题。可以在说明里附上 UID 列表；更常见的是只存「训练 UID 列表的 SHA-256」（字段名 `train_uids_sha256`）：把本趟真正拿去训练的题号排好（例如按字母序），做成一段固定文本或 JSON，再算 SHA-256。它用来证明「训的时候到底用了哪几道题」，又不必把长名单到处复制。注意：这和仓库里的 SkillOpt 划分文件不是一回事——划分文件是标准的 train/val/test；这个校验和是「你这一趟实际训练子集」（例如把 val 并进 train 之后那 74 题）  
+- val 有没有并进 train  
+- 若有 gate / 选技能，用的是哪一段数据  
+- 关键超参（轮数、batch 等，按算法填）  
+- SkillOpt 还要分开写：`optimizer_backend`（改文案，常为 openai_chat）和 `target_harness`（做题环境，应与评测一致）  
+- 训练结束交出的冻结技能 SHA-256  
+
+跑的过程中逐题记（进 `results.jsonl`，一行一题）
+
+- 题号 UID  
+- 最终状态：pass / fail / timeout / invalid / infra_error / skipped（timeout 计分算未通过，与榜单一致）  
+- 是否答对  
+- 预测答案（对外分享前按许可决定是否删除）  
+- 耗时  
+- 尝试了几次  
+- token：输入、输出、缓存（若有）  
+- 费用（美元；没有就标明未采集，不要瞎填）  
+- 相关 request_id（方便去 LiteLLM 对账）
+
+跑完后汇总（进 `summary.json`）
+
+- 总题数、答对题数、准确率  
+- 按 easy / hard 拆开的准确率  
+- 各类状态各有多少（含 timeout 多少）  
+- 全趟合计 token、合计费用；有多少题没采到用量  
+- 做题模型名（与 `run_config.model` 一致）  
+- 指向本趟用过的配置、结果文件、技能、划分名单的 SHA-256  
+- 开始时间、结束时间；是否中断后续跑过  
+
+不必进 Git、但本机建议留着的
+
+- 冻结技能目录本身  
+- 若 runner 写了 `attempts.jsonl`，留着查重试  
+- LiteLLM 拉下来的原始 spend 片段（可选）  
+
+一趟最少要能回答别人这三个问题：考的是哪套题、哪个模型、哪份技能？每题对错和超时各多少？一共花了多少 token / 钱？答不上来，这趟结果就很难写进论文或复现。
+
+## 仓库里长期保存的（不含题目和答案）
+
+`manifests/officeqa_full.json`  
+OfficeQA Full 的 246 道题各是哪个 UID，简单还是困难（easy / hard）。同时写明：数据从哪份 Hugging Face revision 来、CSV 的 SHA-256、语料树的 SHA-256、官方 `reward.py` 是哪一版。这里不存题目正文和答案，也不分 train / val / test。
+
+`manifests/officeqa_skillopt_id_split.json`  
+按 SkillOpt 公开的划分：哪些 UID 进 train（约 50）、val（约 24）、test（172）。父集仍是上面的 246 题。要和 SkillOpt 用同一套划分做对比，就用这份名单。同样不存题目和答案。
+
+`README.md`  
+操作说明：怎么申请数据、怎么核对校验和、怎么用评分代码、怎么跑评测、哪些内容不能提交到 Git。
+
+`schemas/`  
+约定实验产出的 JSON 里应有哪些字段。这不是某一次的真实跑分。
+
+`examples/`  
+按上面约定填好的示例（假数据），方便对照着写自己的文件。
+
+`what-these-files-are.md`  
+就是本说明。
+
+## 每次实验在仓库外生成的（默认不进 Git）
+
+常见目录：`~/.cache/xskill/officeqa/runs/<run_id>/`，或你自己指定的输出目录。
+
+`run.json` / `run_config.json`  
+记录「这一次怎么跑」：用哪份划分、跑 train 还是 test、**哪个模型**、超时、并发、技能包 SHA-256、代码 commit、做题环境（harness）等。开跑前或开跑时写好。
+
+一次评测只对应一个模型。要看多个模型在同一项目（同一划分、同一文档、同一评分、同一技能或同一套对比协议）上的效果，就开多次 run：每个模型一份 `run_id` / `run_config.json` / `results.jsonl` / `summary.json`，不要把多个模型的结果混进同一个 `results.jsonl`。汇总表可以事后把多份 `summary.json` 拼在一起比。
+
+`train_provenance.json`（训练才有）  
+记录「这个技能是怎么训出来的」：实际用了哪些训练题、val 有没有并进 train、关键超参、最后交出的技能 SHA-256。其中 `train_uids_sha256` 就是对本趟实际训练题号名单算的校验和（见上文「每跑一趟」里的说明），用来核对有没有多吃题或少用题。论文主表的分数不要用训练过程中的中间分，应另用冻结技能做评测。
+
+`skill/` 和技能的 SHA-256 文件  
+训练结束后冻结、拿去正式评测的那份技能。评测必须用这一份。
+
+`results.jsonl`  
+逐题结果：对错、失败类型（如 timeout）、耗时、token、费用等。一行一题。中断后可以续跑；已有最终结果的题可以跳过。token / 费用也可以事后用 LiteLLM 的 spend 日志补上。
+
+关于 timeout：结果里可以单独写成 `timeout`，方便和「答错了」区分原因；计分时与 fail 一样算未通过，和榜单网站一致。准确率 = 答对题数 / 全部应考题数（timeout 进分母，不进分子）。不要把 timeout 当成既不算对也不算错的「第三种成绩」。
+
+`attempts.jsonl`（若 runner 会写）  
+同一题多次尝试的明细，用来查重试；最终是否算对，仍以 `results.jsonl` 为准。
+
+`summary.json`  
+把 `results.jsonl` 汇总成总准确率、按 easy/hard、按失败类型、总费用等，并写明汇总依据了哪份配置、哪份结果文件。论文表格应指向这个文件。
+
+## LiteLLM 做什么、不做什么
+
+若请求走 LiteLLM 代理，可以用它的 spend 日志统计每题的 token 和费用。它不负责出题，也不负责判分。跑完后按 `run_id`、`uid` 等 metadata 填回 `results.jsonl`，再汇总到 `summary.json`。没有 LiteLLM 时，费用可以留空，但要标明未采集，不要写成精确账单。
+
+## 和 SkillOpt / xskill 对比时怎么用
+
+正式比分：两边都用 `officeqa_skillopt_id_split.json` 里的 test（172 题），同一套文档语料，同一版 `reward.py`。
+
+做题环境也要同一套：训练时真正答题（SkillOpt 的 target / xskill 的 rollout）和正式测评，都走 Claude Code 原生 Skills（技能装进 skills 目录，用 Skill 工具调用）。不要一边用 `openai_chat` 工具循环做题、一边用 Claude Code 考试。这样 xskill 和 SkillOpt 比的是算法和技能怎么演化，不是比两套不同的做题外壳。SkillOpt 里若还有 `openai_chat`，只用于改技能文案（optimizer），不用于做题。
+
+模型可以换：DeepSeek V4 Flash 以及其他要报的模型，各自单独跑一轮并写进各自的 `run_config.json`（字段 `model`）。对比时同一张表里应标明模型；换模型等于换一轮实验。  
+训练阶段可以不同：例如 xskill 把 val 并进 train；SkillOpt 用 val 做 gate。这些差异写在 `train_provenance.json` 和论文方法里，不要因此换成另一套测试题或另一套做题环境。
+
+## SkillOpt 里：改技能（optimizer）和做题（target）不是一回事
+
+SkillOpt 训练里有两个角色：
+
+target（做题）：用当前技能去读文档、答题。要和 xskill 公平对比时，target 应与正式评测一样，走 Claude Code 的原生 Skills（技能装到 skills 目录，通过 Skill 工具调用）。不要再用 `openai_chat` 那条 Chat + 工具循环去做题。
+
+optimizer（改技能）：根据做题对错，修改技能正文（SKILL.md 里的说明文字）。它不去做 OfficeQA 题。这一步仍可用 `openai_chat`（普通 Chat Completions）。
+
+这样比最终分数算不算公平：算公平——只要正式评测时，两边都在同一 Claude Code 原生 Skills 环境、同一 test、同一文档和评分下，考的是冻结后的技能。此时若还有 `openai_chat`，只用于 SkillOpt 改技能文案，不用于考试。  
+训练过程中每一次调用是否完全相同：不需要相同；论文比的是两套方法。还要写明：SkillOpt 的 optimizer 通常只改文本，默认演化不出带 `scripts/`、`references/` 的技能包，这是方法差异，不是评测作弊。建议写明：同一张对比表里，xskill 与 SkillOpt 使用同一做题模型；若还要报其它模型，每个模型各跑一轮。若 SkillOpt 的 optimizer（改文案）也用同一模型的 Chat 接口，一并写上。
+
+请在 `train_provenance.json` 里分别填写：
+
+- `optimizer_backend`：例如 `openai_chat`（改文案）
+- `target_harness`：例如 `claude_code_native_skills`（做题，应与评测一致）
+
+避免以后被人理解成「训练做题仍是 openai_chat」。

--- a/scripts/bench/officeqa/contracts.py
+++ b/scripts/bench/officeqa/contracts.py
@@ -1,0 +1,62 @@
+"""SkillOpt 划分名单，以及读写这些约定文件的小工具。"""
+
+from __future__ import annotations
+
+import hashlib
+import json
+from pathlib import Path
+from typing import Any
+
+REPOSITORY_ROOT = Path(__file__).resolve().parents[3]
+SPLIT_MANIFEST = (
+    REPOSITORY_ROOT
+    / "benchmarks"
+    / "officeqa"
+    / "manifests"
+    / "officeqa_skillopt_id_split.json"
+)
+FULL_MANIFEST = (
+    REPOSITORY_ROOT / "benchmarks" / "officeqa" / "manifests" / "officeqa_full.json"
+)
+
+
+def sha256_text(text: str) -> str:
+    return hashlib.sha256(text.encode("utf-8")).hexdigest()
+
+
+def sha256_json(value: Any) -> str:
+    """对 JSON 对象做稳定序列化后再算 SHA-256（末尾带换行）。"""
+    payload = json.dumps(value, ensure_ascii=False, separators=(",", ":"), sort_keys=True)
+    return sha256_text(payload + "\n")
+
+
+def load_json(path: Path | str) -> dict[str, Any]:
+    return json.loads(Path(path).read_text(encoding="utf-8"))
+
+
+def load_skillopt_split(
+    path: Path | str | None = None,
+) -> dict[str, Any]:
+    """读取 SkillOpt 的 train/val/test 划分名单。"""
+    return load_json(path or SPLIT_MANIFEST)
+
+
+def uids_for_split(
+    split_name: str,
+    *,
+    manifest: dict[str, Any] | None = None,
+) -> list[str]:
+    """返回某一段（train/val/test）或 full（三段并集）的 UID 列表。"""
+    data = manifest or load_skillopt_split()
+    if split_name == "full":
+        items = []
+        for name in ("train", "val", "test"):
+            items.extend(data["splits"][name])
+    else:
+        items = data["splits"][split_name]
+    return [str(item["uid"]) for item in items]
+
+
+def required_keys_present(obj: dict[str, Any], required: list[str]) -> list[str]:
+    """返回缺失的必填字段名；都在则返回空列表。"""
+    return [key for key in required if key not in obj]

--- a/scripts/bench/officeqa/litellm_usage.py
+++ b/scripts/bench/officeqa/litellm_usage.py
@@ -1,0 +1,146 @@
+"""从 LiteLLM 代理的 spend 日志里补 token / 费用。
+
+不做判分。只根据请求里带的 metadata（如 run_id、uid）把用量填回结果。
+"""
+
+from __future__ import annotations
+
+import json
+from typing import Any
+from urllib.error import HTTPError, URLError
+from urllib.parse import urlencode
+from urllib.request import Request, urlopen
+
+
+def aggregate_spend_logs_by_uid(
+    logs: list[dict[str, Any]],
+    *,
+    run_id: str | None = None,
+) -> dict[str, dict[str, Any]]:
+    """按 metadata.uid 汇总 LiteLLM spend 日志。
+
+    每条日志常见字段（不同版本名字可能略有差别，这里多认几种）：
+    - metadata.run_id / metadata.uid（或 spend_logs_metadata）
+    - prompt_tokens / completion_tokens / total_tokens
+    - spend（美元）
+    - request_id
+    """
+    by_uid: dict[str, dict[str, Any]] = {}
+    for row in logs:
+        meta = _metadata(row)
+        if run_id is not None and str(meta.get("run_id") or "") != run_id:
+            continue
+        uid = str(meta.get("uid") or "").strip()
+        if not uid:
+            continue
+        bucket = by_uid.setdefault(
+            uid,
+            {
+                "source": "litellm",
+                "input_tokens": 0,
+                "output_tokens": 0,
+                "cache_read_tokens": 0,
+                "total_tokens": 0,
+                "cost_usd": 0.0,
+                "request_ids": [],
+            },
+        )
+        prompt = int(row.get("prompt_tokens") or row.get("input_tokens") or 0)
+        completion = int(row.get("completion_tokens") or row.get("output_tokens") or 0)
+        cache_read = int(row.get("cache_read_input_tokens") or row.get("cache_read_tokens") or 0)
+        total = int(row.get("total_tokens") or (prompt + completion))
+        spend = float(row.get("spend") or row.get("cost") or 0.0)
+        bucket["input_tokens"] += prompt
+        bucket["output_tokens"] += completion
+        bucket["cache_read_tokens"] += cache_read
+        bucket["total_tokens"] += total
+        bucket["cost_usd"] = float(bucket["cost_usd"]) + spend
+        req_id = row.get("request_id") or row.get("id")
+        if req_id:
+            bucket["request_ids"].append(str(req_id))
+    return by_uid
+
+
+def merge_usage_into_results(
+    results: list[dict[str, Any]],
+    usage_by_uid: dict[str, dict[str, Any]],
+) -> list[dict[str, Any]]:
+    """把按 uid 汇总好的用量写回结果列表（浅拷贝每一行）。"""
+    out: list[dict[str, Any]] = []
+    for row in results:
+        item = dict(row)
+        uid = str(item.get("uid") or "")
+        usage = usage_by_uid.get(uid)
+        if usage is None:
+            current = dict(item.get("usage") or {})
+            current.setdefault("source", "missing")
+            item["usage"] = current
+        else:
+            item["usage"] = dict(usage)
+        out.append(item)
+    return out
+
+
+def fetch_spend_logs(
+    *,
+    base_url: str,
+    api_key: str,
+    start_date: str,
+    end_date: str,
+    timeout_s: float = 60.0,
+) -> list[dict[str, Any]]:
+    """向 LiteLLM 代理请求 /spend/logs?summarize=false。
+
+    api_key 从环境变量传入，不要写进仓库。
+    """
+    query = urlencode(
+        {
+            "start_date": start_date,
+            "end_date": end_date,
+            "summarize": "false",
+        }
+    )
+    url = base_url.rstrip("/") + "/spend/logs?" + query
+    req = Request(url, headers={"Authorization": f"Bearer {api_key}"})
+    try:
+        with urlopen(req, timeout=timeout_s) as resp:
+            payload = json.loads(resp.read().decode("utf-8"))
+    except (HTTPError, URLError, TimeoutError, json.JSONDecodeError) as exc:
+        raise RuntimeError(f"LiteLLM spend log fetch failed: {exc}") from exc
+    if isinstance(payload, list):
+        return payload
+    if isinstance(payload, dict):
+        for key in ("data", "logs", "results"):
+            value = payload.get(key)
+            if isinstance(value, list):
+                return value
+    raise RuntimeError("LiteLLM spend log response was not a list of rows")
+
+
+def _metadata(row: dict[str, Any]) -> dict[str, Any]:
+    meta = row.get("metadata")
+    if not isinstance(meta, dict):
+        meta = {}
+    nested = meta.get("spend_logs_metadata")
+    if isinstance(nested, dict):
+        merged = dict(nested)
+        merged.update({k: v for k, v in meta.items() if k != "spend_logs_metadata"})
+        return merged
+    return meta
+
+
+def load_jsonl(path: str) -> list[dict[str, Any]]:
+    rows: list[dict[str, Any]] = []
+    with open(path, encoding="utf-8") as handle:
+        for line in handle:
+            line = line.strip()
+            if not line:
+                continue
+            rows.append(json.loads(line))
+    return rows
+
+
+def write_jsonl(path: str, rows: list[dict[str, Any]]) -> None:
+    with open(path, "w", encoding="utf-8") as handle:
+        for row in rows:
+            handle.write(json.dumps(row, ensure_ascii=False) + "\n")

--- a/tests/test_officeqa_contracts.py
+++ b/tests/test_officeqa_contracts.py
@@ -1,0 +1,135 @@
+"""SkillOpt 划分与实验约定文件的测试。"""
+
+from __future__ import annotations
+
+import json
+from pathlib import Path
+
+from scripts.bench.officeqa.contracts import (
+    FULL_MANIFEST,
+    SPLIT_MANIFEST,
+    load_json,
+    required_keys_present,
+    sha256_json,
+    uids_for_split,
+)
+from scripts.bench.officeqa.litellm_usage import (
+    aggregate_spend_logs_by_uid,
+    merge_usage_into_results,
+)
+
+ROOT = Path(__file__).resolve().parents[1]
+EXAMPLES = ROOT / "benchmarks" / "officeqa" / "examples"
+
+
+def test_skillopt_split_counts_and_union_match_full():
+    split = load_json(SPLIT_MANIFEST)
+    full = load_json(FULL_MANIFEST)
+
+    assert split["counts"] == {"train": 50, "val": 24, "test": 172}
+    assert len(split["splits"]["train"]) == 50
+    assert len(split["splits"]["val"]) == 24
+    assert len(split["splits"]["test"]) == 172
+
+    split_uids = set(uids_for_split("full", manifest=split))
+    full_uids = {sample["uid"] for sample in full["samples"]}
+    assert split_uids == full_uids
+    assert len(split_uids) == 246
+
+    difficulty = {sample["uid"]: sample["difficulty"] for sample in full["samples"]}
+    for part in ("train", "val", "test"):
+        for item in split["splits"][part]:
+            assert set(item) == {"uid", "difficulty"}
+            assert item["difficulty"] == difficulty[item["uid"]]
+
+    assert sha256_json(split["splits"]) == split["splits_sha256"]
+
+
+def test_example_contracts_have_required_fields():
+    run_config = load_json(EXAMPLES / "run_config.example.json")
+    train = load_json(EXAMPLES / "train_provenance.example.json")
+    result = load_json(EXAMPLES / "result_record.example.json")
+    summary = load_json(EXAMPLES / "summary.example.json")
+
+    assert not required_keys_present(
+        run_config,
+        [
+            "schema_version",
+            "run_id",
+            "phase",
+            "algo",
+            "split_manifest",
+            "split_name",
+            "full_manifest",
+            "model",
+            "harness",
+            "scorer",
+        ],
+    )
+    assert not required_keys_present(
+        train,
+        [
+            "schema_version",
+            "run_id",
+            "algo",
+            "split_manifest",
+            "merge_val_into_train",
+            "skill_sha256",
+        ],
+    )
+    assert not required_keys_present(
+        result,
+        ["schema_version", "run_id", "uid", "status"],
+    )
+    assert not required_keys_present(
+        summary,
+        [
+            "schema_version",
+            "run_id",
+            "n_total",
+            "n_pass",
+            "accuracy",
+            "status_counts",
+        ],
+    )
+    assert run_config["split_name"] == "test"
+    assert train["merge_val_into_train"] is True
+
+
+def test_litellm_usage_aggregate_and_merge():
+    logs = [
+        {
+            "request_id": "r1",
+            "prompt_tokens": 10,
+            "completion_tokens": 5,
+            "total_tokens": 15,
+            "spend": 0.01,
+            "metadata": {"run_id": "demo", "uid": "UID0002"},
+        },
+        {
+            "request_id": "r2",
+            "prompt_tokens": 3,
+            "completion_tokens": 2,
+            "total_tokens": 5,
+            "spend": 0.002,
+            "metadata": {"run_id": "demo", "uid": "UID0002"},
+        },
+        {
+            "request_id": "other",
+            "prompt_tokens": 9,
+            "completion_tokens": 1,
+            "total_tokens": 10,
+            "spend": 0.1,
+            "metadata": {"run_id": "other-run", "uid": "UID0002"},
+        },
+    ]
+    by_uid = aggregate_spend_logs_by_uid(logs, run_id="demo")
+    assert by_uid["UID0002"]["input_tokens"] == 13
+    assert by_uid["UID0002"]["output_tokens"] == 7
+    assert abs(by_uid["UID0002"]["cost_usd"] - 0.012) < 1e-9
+    assert by_uid["UID0002"]["request_ids"] == ["r1", "r2"]
+
+    results = [{"uid": "UID0002", "status": "pass", "usage": {"source": "missing"}}]
+    merged = merge_usage_into_results(results, by_uid)
+    assert merged[0]["usage"]["source"] == "litellm"
+    assert merged[0]["usage"]["total_tokens"] == 20


### PR DESCRIPTION
## Summary

在 OfficeQA Full 来源与 246 题名单（#309 / 现有 runner 底座）之上，补上：
- 与 SkillOpt 对齐的 train/val/test 划分名单（50/24/172）
- 每跑一趟要记下哪些信息（白话清单）
- run_config / 训练说明 / 逐题结果 / 汇总的字段约定与示例
- 可选：用 LiteLLM 补 token 与费用

本 PR 不跑付费全量，不改训练主逻辑，不提交题目、答案、真实轨迹。

## 训练和测评用的做题环境

对比 xskill 和 SkillOpt 时，正式测评应在同一套 Claude Code 原生 Skills（native_cc）下进行：技能装进 skills 目录，通过 Skill 工具调用；同一 SkillOpt test（172）、同一文档、同一 reward.py、同一做题模型。最终都用冻结技能再测，不用训练中间分。

SkillOpt 里若仍出现 openai_chat：通常只用于改技能文案（optimizer），不是用来做 OfficeQA 题。真正做题的 target 与测评是否同一套壳，必须在 train_provenance / run_config 里写清楚。

## 做题环境怎么选（和 SkillOpt 论文对齐、也说明我们为什么常 openai_chat 训 + native_cc 测）

SkillOpt 论文怎么用 Agent Harness：
主表是「两端同一套」。direct chat / Codex / Claude Code 三种 harness 各自一格：训练时 target 做题就用该 harness，测评也用该 harness，不是只在测评时才挂上 agent harness。
论文另外做了跨 harness 迁移：在一套环境里把技能训好，不再继续训，换到另一套环境（例如 Claude Code）直接测。公开介绍里举过例子：在 Codex 里训好的表格技能丢进 Claude Code，可以略好于「训练和测评都在 Claude Code 里做」。说明「更强的考试壳」不一定适合从头训到底。

我们当前常见做法：训练做题用 openai_chat，正式测评用 Claude Code 原生 Skills（native_cc）。
这不是偷换外壳糊弄对比，而是有意的设定：测评对齐产品侧 / xskill 的 Claude Code 原生 Skills；训练若也上很强的 CC harness，selection 容易顶得太高、失败信号变少，门禁难通过，技能正文反而不容易继续变好（训练溢出 / 进化顶死）。所以「openai_chat 训 + native_cc 测」往往比「两端都上 CC」更稳，分数也不一定更差；这和 SkillOpt 跨 harness 迁移的观察同向。

若要做严格的「同壳公平消融」：再单开一趟「训练 target 也走 native_cc + 测评也 native_cc」，和「openai_chat 训 + native_cc 测」对照，写进表里，不要混称同一种设定。
和 xskill 比最终分时：仍应在同一 native_cc、同一 test、同一模型下考冻结技能；表上注明 SkillOpt 训练做题用的是 openai_chat 还是 native_cc。

## 每跑一趟需要记录哪些信息

「一趟」= 一个算法设定 + 一个做题模型 + 一次评测（或一次训练）。换模型、换算法、换技能都算新的一趟。

开跑前（run_config.json）
- 跑哪一段题（正式比分一般用 test 172）和哪份划分文件
- 做题模型（一趟一个）
- 做题环境（写明 Claude Code 原生 Skills 或实际用的 harness）和工具列表
- 冻结技能 SHA-256；代码 commit / 镜像 digest
- 语料树 SHA-256；reward.py 的 commit / SHA-256；容差
- 超时、并行、工具轮数、重试、种子；是否走 LiteLLM

若含训练（train_provenance.json）
- 实际训练题范围；或「训练 UID 列表的 SHA-256」：对本趟实际训练题号名单（排好序）算的校验和，用来核对训了哪几道题（例如 val 并进 train 后是合并后的那一子集；不是划分文件自带的哈希）
- val 是否并进 train；gate 用哪一段；关键超参
- SkillOpt：optimizer_backend（改文案，常为 openai_chat）与 target_harness（做题环境，须与当趟设定一致并写明）
- 冻结技能 SHA-256

逐题（results.jsonl）
- UID、状态、是否答对、预测（按许可处理）、耗时、尝试次数、token、费用、request_id
- timeout 单独标记原因，计分与 fail 一样算未通过（与榜单一致）

跑完（summary.json）
- 准确率、按 easy/hard、各类状态数量、合计 token/费用、模型名、相关文件 SHA-256、时间与是否续跑

最少能回答：哪套题、哪个模型、哪份技能、训练/测评各自用的做题环境？对错和超时？花了多少 token/钱？

仓库内同款说明：benchmarks/officeqa/what-these-files-are.md

## 这些文件是干什么的（本 PR 新增 / 改动）

用直白话说明每个文件管什么、里面有什么。不含题目和答案。

说明类
- benchmarks/officeqa/what-these-files-are.md
  总说明书：每跑一趟要记什么、每个产物文件干什么、timeout 怎么计分、多模型怎么跑、SkillOpt 的 optimizer 和 target 有何不同。
- benchmarks/officeqa/README.md
  操作说明（在原有下载数据、评分、runner 说明上）：怎么用 SkillOpt 划分、多模型、公平对比时注意什么；并链到上面这份总说明。
- benchmarks/officeqa/artifacts/README.md
  真实跑分建议放哪；默认不进 Git；提醒每趟记账看总说明。
- benchmarks/officeqa/artifacts/.gitignore
  避免把真实 results / summary 误提交进仓库。

名单类（写死题号，方便复现对比）
- benchmarks/officeqa/manifests/officeqa_skillopt_id_split.json（本 PR 新增）
  按 SkillOpt 公开划分：哪些 UID 进 train（约 50）、val（约 24）、test（172）。父集是 Full 246。只含题号和 easy/hard，不含题目正文和答案。要和 SkillOpt 同一套划分比分，就用这份。
- （底座已有，本 PR 不改）manifests/officeqa_full.json
  Full 246 题 UID + 数据 revision、语料 SHA、reward.py 版本等。

字段约定与示例（告诉以后每次实验 JSON 长什么样）
- benchmarks/officeqa/schemas/run_config.schema.json
  「这一趟怎么跑」必须有哪些字段：划分、模型、做题环境、技能 SHA、超时并发等。
- benchmarks/officeqa/schemas/train_provenance.schema.json
  「这个技能怎么训出来的」：是否 merge val、optimizer_backend、target_harness、train_uids_sha256（对本趟实际训练题号名单算的校验和）等。
- benchmarks/officeqa/schemas/result_record.schema.json
  results.jsonl 里一行一题：状态、对错、token、费用等。
- benchmarks/officeqa/schemas/summary.schema.json
  跑完汇总：准确率、按难度、状态计数、总费用、相关文件 SHA 等。
- benchmarks/officeqa/examples/*.example.json
  按上面约定填好的假例子（含 run_config / train_provenance / result / summary），对照着写即可；不是真实跑分。

小工具与测试
- scripts/bench/officeqa/contracts.py
  读取 SkillOpt 划分、取出某段 UID 列表等小工具。
- scripts/bench/officeqa/litellm_usage.py
  可选：从 LiteLLM spend 日志按 uid 汇总 token / 费用，填回结果；不做判分。
- tests/test_officeqa_contracts.py
  检查划分并集是否等于 246、示例必填字段是否齐全、LiteLLM 汇总逻辑（假数据，不联网）。

底座已有、本 PR 不重复造（审 PR 时知道边界即可）
- scripts/bench/officeqa/run.py、evaluate.py、vendor/reward.py
  可续跑评测与官方评分副本，仍用现有实现。

每次实验在仓库外生成、默认不进本 PR 的产物（约定长这样，方便对照）
- run_config.json：这一趟怎么跑（含 model、harness）
- train_provenance.json：技能怎么训出来的（仅训练）
- skill/ + SHA：冻结后拿去考试的技能
- results.jsonl：逐题结果
- summary.json：汇总数字，论文主表应指向它

## 非目标

- 不提交真实付费跑分与 gated 数据
- 不在本 PR 内完成 SkillOpt 训练改 native_cc 的工程改造（口径与消融写法先定清；实现另开）
- 不把 LiteLLM 绑进 xskill 核心限流

## Test plan

- [x] python3.11 -m pytest tests/test_officeqa_contracts.py tests/test_officeqa_manifest.py -q
- [ ] 对照「做题环境」与「每趟记账」两段，确认 examples 字段对得上
- [ ] 确认 skillopt id-split 与 SkillOpt 钉死 commit 的 items SHA 一致

## Linked issues

Progresses #262
Builds on #309 / officeqa-full-runner 底座

Made with [Cursor](https://cursor.com)