### PR TITLE
feat(eval): 技能精度实验设置规范与 OfficeQA 数据划分（接 #262）

### DIFF
--- a/benchmarks/officeqa/README.md
+++ b/benchmarks/officeqa/README.md
@@ -10,6 +10,17 @@ xskill README 中的 60.47% 是历史下游子集结果。仓库没有保留该�
 
 Microsoft SkillOpt 另行发布了基于 OfficeQA Full 的 ID-only manifest，train/val/test 为 50/24/172。它的三部分并集恰好覆盖 246 个唯一 UID（113 easy、133 hard），但这是 SkillOpt 的下游划分，不是 OfficeQA 官方 split。本目录的 `officeqa_full.json` 仅借它公开的 UID 和 difficulty 构造无 split 的 Full 清单，不把 SkillOpt 的 train/val/test 语义带入官方口径。
 
+若论文或实验要和 SkillOpt 用同一套划分比分，请用 [`manifests/officeqa_skillopt_id_split.json`](manifests/officeqa_skillopt_id_split.json)。里面写清 train / val / test 各自有哪些 UID。正式主对比建议都在 test（172 题）上评；训练时 val 是否并进 train，属于算法用法差异，写进训练说明即可，不要换测试题单。
+
+模型不限于某一个（例如不只有 DeepSeek V4 Flash）。每换一个做题模型，就开一次独立 run，在 `run_config.json` 的 `model` 字段写明；同一划分、同一文档、同一 `reward.py` 下可以横向比较多个模型。不要把多个模型的逐题结果写进同一个 `results.jsonl`。
+
+公平对比的做题环境：xskill 与 SkillOpt 在训练做题和正式测评时，都应使用同一套 Claude Code 原生 Skills（不要训练用 `openai_chat` 做题、测评却换 Claude Code）。SkillOpt 的 `openai_chat` 若保留，只用于改技能文案，不用于答题。详见 [`what-these-files-are.md`](what-these-files-are.md)。
+
+SkillOpt 训练里「做题」（target）和「改技能文案」（optimizer）可以分开：做题应与评测一样走 Claude Code 原生 Skills；改文案仍可用 `openai_chat`，只改技能正文。最终成绩在同一做题环境、同一 test 上比冻结技能，这样对最终分数是公平的。`optimizer` 留在 Chat 是方法选择，必须在 `train_provenance.json` 写明。
+
+各文件白话说明见 [`what-these-files-are.md`](what-these-files-are.md)（文首有「每跑一趟要记下哪些信息」清单）。字段约定见 `schemas/`，填法示例见 `examples/`。若用 LiteLLM 记 token / 费用，见 `scripts/bench/officeqa/litellm_usage.py`。
+
+
 ## 固定版本
 
 | 工件 | 固定值 | 核验说明 |

--- a/benchmarks/officeqa/README.md
+++ b/benchmarks/officeqa/README.md
@@ -8,17 +8,17 @@ Databricks 当前把 OfficeQA 定义为三个基准：OfficeQA Pro 有 133 道 h
 
 xskill README 中的 60.47% 是历史下游子集结果。仓库没有保留该次运行的 UID、抽样代码、配置或原始输出，无法证明它等于任何上游 split，也不能从分数反推出样本。因此本次先纠正“官方 1/4”的表述并保留历史数值，不为缺失产物补造 manifest。
 
-Microsoft SkillOpt 另行发布了基于 OfficeQA Full 的 ID-only manifest，train/val/test 为 50/24/172。它的三部分并集恰好覆盖 246 个唯一 UID（113 easy、133 hard），但这是 SkillOpt 的下游划分，不是 OfficeQA 官方 split。本目录的 `officeqa_full.json` 仅借它公开的 UID 和 difficulty 构造无 split 的 Full 清单，不把 SkillOpt 的 train/val/test 语义带入官方口径。
+Microsoft SkillOpt 另行发布了基于 OfficeQA Full 的题号划分名单，训练集、验证集与测试集（train、val、test）分别为 50、24 和 172 题。三部分并集覆盖 246 个唯一 UID（113 道 easy、133 道 hard），这是 SkillOpt 的下游划分，并非 OfficeQA 官方数据集定义的 split。本目录的 `officeqa_full.json` 仅参考其公开的 UID 和难度构建无划分的 Full 清单，不将 SkillOpt 的划分语义混入官方基准口径。
 
-若论文或实验要和 SkillOpt 用同一套划分比分，请用 [`manifests/officeqa_skillopt_id_split.json`](manifests/officeqa_skillopt_id_split.json)。里面写清 train / val / test 各自有哪些 UID。正式主对比建议都在 test（172 题）上评；训练时 val 是否并进 train，属于算法用法差异，写进训练说明即可，不要换测试题单。
+如果论文或实验需要与 SkillOpt 使用相同的数据划分进行对比，请使用 [`manifests/officeqa_skillopt_id_split.json`](manifests/officeqa_skillopt_id_split.json)。其中明确记录了 train、val、test 各自包含的 UID。正式主对比建议均在测试集（test，172 题）上评测；训练时是否将验证集合并入训练集属于算法策略差异，记录在训练说明中即可，无需更换测试集题单。
 
-模型不限于某一个（例如不只有 DeepSeek V4 Flash）。每换一个做题模型，就开一次独立 run，在 `run_config.json` 的 `model` 字段写明；同一划分、同一文档、同一 `reward.py` 下可以横向比较多个模型。不要把多个模型的逐题结果写进同一个 `results.jsonl`。
+评测模型不限于某一款（例如不仅限于 DeepSeek V4 Flash）。每更换一个做题模型，均需开启独立的一轮运行，并在 `run_config.json` 的 `model` 字段中注明；在相同划分、相同语料和相同 `reward.py` 下可以横向对比多个模型。请勿将不同模型的逐题结果混入同一个 `results.jsonl`。
 
-公平对比的做题环境：xskill 与 SkillOpt 在训练做题和正式测评时，都应使用同一套 Claude Code 原生 Skills（不要训练用 `openai_chat` 做题、测评却换 Claude Code）。SkillOpt 的 `openai_chat` 若保留，只用于改技能文案，不用于答题。详见 [`what-these-files-are.md`](what-these-files-are.md)。
+关于公平对比的做题环境：xskill 与 SkillOpt 在训练答题与正式评测时，均应使用相同的 Claude Code 原生技能环境（避免训练时使用 Chat 接口答题、评测时却切换为 Claude Code）。SkillOpt 中的 Chat 接口如果保留，仅用于改写技能文案，不用于答题，详见 [`what-these-files-are.md`](what-these-files-are.md)。
 
-SkillOpt 训练里「做题」（target）和「改技能文案」（optimizer）可以分开：做题应与评测一样走 Claude Code 原生 Skills；改文案仍可用 `openai_chat`，只改技能正文。最终成绩在同一做题环境、同一 test 上比冻结技能，这样对最终分数是公平的。`optimizer` 留在 Chat 是方法选择，必须在 `train_provenance.json` 写明。
+SkillOpt 训练中的「做题」（target）与「改写技能」（optimizer）可以明确分工：做题环节与评测一致，使用 Claude Code 原生技能；改写文案可继续使用标准 Chat 接口修改技能正文。最终评测在相同做题环境与相同测试集上测试冻结技能，对最终分数是公平的。optimizer 选择 Chat 接口属于方法设定，需在 `train_provenance.json` 中写明。
 
-各文件白话说明见 [`what-these-files-are.md`](what-these-files-are.md)（文首有「每跑一趟要记下哪些信息」清单）。字段约定见 `schemas/`，填法示例见 `examples/`。若用 LiteLLM 记 token / 费用，见 `scripts/bench/officeqa/litellm_usage.py`。
+各文件的详细说明见 [`what-these-files-are.md`](what-these-files-are.md)（文首附有实验记录清单）。字段规范见 `schemas/` 目录，示例见 `examples/` 目录。若需要使用 LiteLLM 记录 token 和费用，可参考 `scripts/bench/officeqa/litellm_usage.py`。
 
 
 ## 固定版本

--- a/benchmarks/officeqa/artifacts/.gitignore
+++ b/benchmarks/officeqa/artifacts/.gitignore
@@ -1,0 +1,4 @@
+# Real experiment outputs stay outside git.
+*
+!.gitignore
+!README.md

--- a/benchmarks/officeqa/artifacts/README.md
+++ b/benchmarks/officeqa/artifacts/README.md
@@ -1,0 +1,15 @@
+# 实验产出放哪里
+
+真实跑分不要默认提交进 Git。可以放在本目录，或放在 `~/.cache/xskill/officeqa/runs/<run_id>/`。
+
+每次实验通常会有（一次实验 = 一个算法设定 + 一个做题模型）：
+
+- `run_config.json`（或 runner 写的 `run.json`）：这一次怎么跑（含 `model`）
+- 若是训练：`train_provenance.json`
+- 冻结技能：`skill/` 及其 SHA-256
+- `results.jsonl`：逐题结果
+- `summary.json`：汇总数字
+
+要测多个模型：每个模型单独一个目录或 `run_id`，不要混在同一份 `results.jsonl` 里。
+
+每趟具体要统计哪些字段，见上级目录 `what-these-files-are.md` 文首清单。

--- a/benchmarks/officeqa/artifacts/README.md
+++ b/benchmarks/officeqa/artifacts/README.md
@@ -1,15 +1,15 @@
-# 实验产出放哪里
+# 实验产出存放说明
 
-真实跑分不要默认提交进 Git。可以放在本目录，或放在 `~/.cache/xskill/officeqa/runs/<run_id>/`。
+真实的实验跑分数据请勿直接提交到 Git 仓库中。建议存放在本目录，或保存在本地缓存路径 `~/.cache/xskill/officeqa/runs/<run_id>/` 下。
 
-每次实验通常会有（一次实验 = 一个算法设定 + 一个做题模型）：
+每次实验通常包含以下文件（一次实验对应一个算法设定与一个做题模型）：
 
-- `run_config.json`（或 runner 写的 `run.json`）：这一次怎么跑（含 `model`）
-- 若是训练：`train_provenance.json`
-- 冻结技能：`skill/` 及其 SHA-256
-- `results.jsonl`：逐题结果
-- `summary.json`：汇总数字
+- `run_config.json`（或评测程序输出的 `run.json`）：记录本次实验的具体配置（包含 `model`）
+- `train_provenance.json`（若包含训练流程）：记录训练来源与数据设定
+- `skill/` 目录及其 SHA-256 哈希值：训练完成后固定并用于评测的技能包
+- `results.jsonl`：逐题评测明细
+- `summary.json`：汇总统计指标
 
-要测多个模型：每个模型单独一个目录或 `run_id`，不要混在同一份 `results.jsonl` 里。
+如果需要测试多个模型，请为每个模型建立独立的目录或配置独立的 `run_id`，不要将不同模型的结果混在同一个 `results.jsonl` 中。
 
-每趟具体要统计哪些字段，见上级目录 `what-these-files-are.md` 文首清单。
+每次实验具体需要记录的字段清单，请参考上级目录中的 `what-these-files-are.md`。

--- a/benchmarks/officeqa/examples/result_record.example.json
+++ b/benchmarks/officeqa/examples/result_record.example.json
@@ -1,0 +1,22 @@
+{
+  "schema_version": 1,
+  "run_id": "demo-eval-20260831",
+  "uid": "UID0002",
+  "status": "pass",
+  "difficulty": "easy",
+  "is_correct": true,
+  "pred_answer": "(示例占位；真实预测不要提交进 Git)",
+  "latency_ms": 12345,
+  "usage": {
+    "source": "litellm",
+    "input_tokens": 1000,
+    "output_tokens": 200,
+    "cache_read_tokens": 100,
+    "total_tokens": 1200,
+    "cost_usd": 0.0012,
+    "request_ids": ["chatcmpl-demo-1"]
+  },
+  "skill_sha256": "replace-with-frozen-skill-sha256",
+  "scorer_commit": "7b9a3c154ef9fb40215bb67934afc43e6799de16",
+  "attempts": 1
+}

--- a/benchmarks/officeqa/examples/run_config.example.json
+++ b/benchmarks/officeqa/examples/run_config.example.json
@@ -1,0 +1,43 @@
+{
+  "schema_version": 1,
+  "run_id": "demo-eval-20260831",
+  "phase": "eval",
+  "algo": "xskill",
+  "split_manifest": "benchmarks/officeqa/manifests/officeqa_skillopt_id_split.json",
+  "split_manifest_sha256": "replace-after-generating-real-run",
+  "split_name": "test",
+  "full_manifest": "benchmarks/officeqa/manifests/officeqa_full.json",
+  "full_manifest_sha256": "replace-after-generating-real-run",
+  "docs_tree_sha256": "851bfc5dbf2fc42abb1cc5aa4a4b5de872cf1f3b473d8cf6dd8f7c637d0c7d24",
+  "model": "deepseek-v4-flash",
+  "api_base_kind": "litellm_proxy",
+  "endpoint_label": "local-litellm",
+  "harness": {
+    "id": "claude_code_native_skills",
+    "tools": ["Read", "Write", "Edit", "Bash", "Skill"],
+    "notes": "示例只用 deepseek-v4-flash。换模型时新建 run_id，改 model 字段，不要和别的模型共用一份 results.jsonl。现成的 scripts/bench/officeqa/run.py 是另一套 OpenAI 兼容工具环境；实际用哪套就把 harness.id 写成哪套。"
+  },
+  "scorer": {
+    "commit": "7b9a3c154ef9fb40215bb67934afc43e6799de16",
+    "sha256": "0d91698c87df6d889339aac36f63ae0966607f169890b0bf8b472b26bfe8138f",
+    "tolerance": 0.0,
+    "path": "scripts/bench/officeqa/vendor/reward.py"
+  },
+  "code": {
+    "xskill_commit": "replace-with-real-commit"
+  },
+  "skill_sha256": "replace-with-frozen-skill-sha256",
+  "workers": 4,
+  "timeout_s": 600,
+  "max_tool_turns": 24,
+  "retry": {
+    "request_retries": 3,
+    "case_retries": 1
+  },
+  "seed": 0,
+  "failure_policy": "timeout 在结果里单独标成 timeout（方便区分原因），计分时与 fail 一样算未通过；和榜单一致。准确率 = pass 数 / 全部应考题数（含 timeout）",
+  "usage": {
+    "provider": "litellm",
+    "metadata_keys": ["run_id", "uid", "phase", "algo"]
+  }
+}

--- a/benchmarks/officeqa/examples/run_config.example.json
+++ b/benchmarks/officeqa/examples/run_config.example.json
@@ -15,7 +15,7 @@
   "harness": {
     "id": "claude_code_native_skills",
     "tools": ["Read", "Write", "Edit", "Bash", "Skill"],
-    "notes": "示例只用 deepseek-v4-flash。换模型时新建 run_id，改 model 字段，不要和别的模型共用一份 results.jsonl。现成的 scripts/bench/officeqa/run.py 是另一套 OpenAI 兼容工具环境；实际用哪套就把 harness.id 写成哪套。"
+    "notes": "示例模型为 deepseek-v4-flash。测试不同模型时需新建 run_id 并修改 model 字段，不要与其它模型共用一份 results.jsonl。scripts/bench/officeqa/run.py 是另一套 OpenAI 兼容工具环境，实际使用哪套环境请在 harness.id 中如实记录。"
   },
   "scorer": {
     "commit": "7b9a3c154ef9fb40215bb67934afc43e6799de16",
@@ -35,7 +35,7 @@
     "case_retries": 1
   },
   "seed": 0,
-  "failure_policy": "timeout 在结果里单独标成 timeout（方便区分原因），计分时与 fail 一样算未通过；和榜单一致。准确率 = pass 数 / 全部应考题数（含 timeout）",
+  "failure_policy": "timeout 状态单独记录便于排查原因，在计算准确率时与 fail 同样计为未通过（准确率 = pass 数量 / 总题数，分母包含 timeout）",
   "usage": {
     "provider": "litellm",
     "metadata_keys": ["run_id", "uid", "phase", "algo"]

--- a/benchmarks/officeqa/examples/summary.example.json
+++ b/benchmarks/officeqa/examples/summary.example.json
@@ -1,0 +1,36 @@
+{
+  "schema_version": 1,
+  "run_id": "demo-eval-20260831",
+  "model": "deepseek-v4-flash",
+  "n_total": 172,
+  "n_pass": 120,
+  "accuracy": 0.6977,
+  "by_difficulty": {
+    "easy": { "n_total": 79, "n_pass": 64, "accuracy": 0.8101 },
+    "hard": { "n_total": 93, "n_pass": 56, "accuracy": 0.6022 }
+  },
+  "status_counts": {
+    "pass": 120,
+    "fail": 40,
+    "invalid": 2,
+    "timeout": 6,
+    "infra_error": 0,
+    "skipped": 4
+  },
+  "usage_totals": {
+    "input_tokens": 1000000,
+    "output_tokens": 200000,
+    "cost_usd": 12.34,
+    "usage_missing_n": 4
+  },
+  "refs": {
+    "run_config_sha256": "replace",
+    "results_sha256": "replace",
+    "skill_sha256": "replace",
+    "split_manifest_sha256": "replace",
+    "full_manifest_sha256": "replace"
+  },
+  "started_at": "2026-08-31T00:00:00+00:00",
+  "finished_at": "2026-08-31T06:00:00+00:00",
+  "resumed": false
+}

--- a/benchmarks/officeqa/examples/train_provenance.example.json
+++ b/benchmarks/officeqa/examples/train_provenance.example.json
@@ -1,0 +1,20 @@
+{
+  "schema_version": 1,
+  "run_id": "demo-train-20260831",
+  "algo": "xskill",
+  "split_manifest": "benchmarks/officeqa/manifests/officeqa_skillopt_id_split.json",
+  "split_manifest_sha256": "replace-after-generating-real-run",
+  "train_uids_sha256": "replace-with-sha-of-actual-train-uid-list",
+  "merge_val_into_train": true,
+  "selection_split": null,
+  "hyperparameters": {
+    "note": "按具体算法填写；这里只是占位"
+  },
+  "optimizer_backend": "openai_chat",
+  "target_harness": "claude_code_native_skills",
+  "code": {
+    "xskill_commit": "replace-with-real-commit"
+  },
+  "skill_sha256": "replace-with-frozen-skill-sha256",
+  "notes": "train_uids_sha256：对本趟实际训练用的 UID 名单（排好序后）算的校验和，用来核对训了哪几道题；不是 SkillOpt 划分文件自带的哈希。若 merge_val_into_train=true，名单应是 train+val 合并后的题号。示例：xskill 常把 val 并进 train，最终分数另用冻结技能在 test 上评。SkillOpt：optimizer_backend=openai_chat 表示只改技能正文；target_harness=claude_code_native_skills 表示训练做题与评测同一环境。"
+}

--- a/benchmarks/officeqa/examples/train_provenance.example.json
+++ b/benchmarks/officeqa/examples/train_provenance.example.json
@@ -8,7 +8,7 @@
   "merge_val_into_train": true,
   "selection_split": null,
   "hyperparameters": {
-    "note": "按具体算法填写；这里只是占位"
+    "note": "按具体算法填写；此处仅为占位"
   },
   "optimizer_backend": "openai_chat",
   "target_harness": "claude_code_native_skills",
@@ -16,5 +16,5 @@
     "xskill_commit": "replace-with-real-commit"
   },
   "skill_sha256": "replace-with-frozen-skill-sha256",
-  "notes": "train_uids_sha256：对本趟实际训练用的 UID 名单（排好序后）算的校验和，用来核对训了哪几道题；不是 SkillOpt 划分文件自带的哈希。若 merge_val_into_train=true，名单应是 train+val 合并后的题号。示例：xskill 常把 val 并进 train，最终分数另用冻结技能在 test 上评。SkillOpt：optimizer_backend=openai_chat 表示只改技能正文；target_harness=claude_code_native_skills 表示训练做题与评测同一环境。"
+  "notes": "train_uids_sha256 记录本趟实际参与训练的 UID 名单（排序后）的哈希值，用于确认训练使用的确切题目范围。如果 merge_val_into_train 为 true，该哈希对应 train 与 val 合并后的题目列表。例如：xskill 常将验证集合并入训练集，最终成绩使用冻结技能在测试集（test）上另行评测；SkillOpt 的 optimizer_backend=openai_chat 表示仅用于修改技能说明文本，target_harness=claude_code_native_skills 表示训练做题与评测在相同环境中运行。"
 }

--- a/benchmarks/officeqa/manifests/officeqa_skillopt_id_split.json
+++ b/benchmarks/officeqa/manifests/officeqa_skillopt_id_split.json
@@ -1,0 +1,1018 @@
+{
+  "schema_version": 1,
+  "benchmark": "officeqa_skillopt_id_split",
+  "description": "按 SkillOpt 公开的题号划分：训练约 50 题、验证约 24 题、测试 172 题。父集是 OfficeQA Full 的 246 题。这里只存题号和难度，不存题目和答案。",
+  "parent_benchmark": "officeqa_full",
+  "parent_manifest": "benchmarks/officeqa/manifests/officeqa_full.json",
+  "source": {
+    "repository": "microsoft/SkillOpt",
+    "repository_url": "https://github.com/microsoft/SkillOpt",
+    "commit": "da06b157cb9878e378663ee1ecf429c83fe1a8f9",
+    "path": "data/officeqa_id_split",
+    "source_file_sha256": {
+      "split_manifest.json": "8f76983eadeb6670df2fc88f568fa86c6318d4e8f02912bf05c5c69955a867e7",
+      "train/items.json": "1bb3a9ca003f6ba7aff34cf2d1fe23d9af12ff647060ac8b7d4c22dcb9e84b56",
+      "val/items.json": "1d7fc4443718a8fc565faf4450d31109880dbf8103759a306289f5ba9407f11b",
+      "test/items.json": "563c30589e897f08161df4d2778578e14a8a2887391813e8d45c3d39eafd900d"
+    },
+    "note": "划分来自 SkillOpt 仓库的公开 id split，不是 OfficeQA 上游自己划的 train/val/test。每题 easy/hard 来自同目录的 officeqa_full.json。"
+  },
+  "counts": {
+    "train": 50,
+    "val": 24,
+    "test": 172
+  },
+  "splits": {
+    "train": [
+      {
+        "uid": "UID0002",
+        "difficulty": "easy"
+      },
+      {
+        "uid": "UID0007",
+        "difficulty": "hard"
+      },
+      {
+        "uid": "UID0014",
+        "difficulty": "easy"
+      },
+      {
+        "uid": "UID0017",
+        "difficulty": "hard"
+      },
+      {
+        "uid": "UID0018",
+        "difficulty": "hard"
+      },
+      {
+        "uid": "UID0019",
+        "difficulty": "hard"
+      },
+      {
+        "uid": "UID0026",
+        "difficulty": "easy"
+      },
+      {
+        "uid": "UID0028",
+        "difficulty": "hard"
+      },
+      {
+        "uid": "UID0030",
+        "difficulty": "hard"
+      },
+      {
+        "uid": "UID0031",
+        "difficulty": "hard"
+      },
+      {
+        "uid": "UID0033",
+        "difficulty": "easy"
+      },
+      {
+        "uid": "UID0034",
+        "difficulty": "easy"
+      },
+      {
+        "uid": "UID0044",
+        "difficulty": "hard"
+      },
+      {
+        "uid": "UID0046",
+        "difficulty": "easy"
+      },
+      {
+        "uid": "UID0049",
+        "difficulty": "hard"
+      },
+      {
+        "uid": "UID0056",
+        "difficulty": "hard"
+      },
+      {
+        "uid": "UID0063",
+        "difficulty": "easy"
+      },
+      {
+        "uid": "UID0065",
+        "difficulty": "hard"
+      },
+      {
+        "uid": "UID0073",
+        "difficulty": "hard"
+      },
+      {
+        "uid": "UID0079",
+        "difficulty": "easy"
+      },
+      {
+        "uid": "UID0083",
+        "difficulty": "hard"
+      },
+      {
+        "uid": "UID0085",
+        "difficulty": "hard"
+      },
+      {
+        "uid": "UID0087",
+        "difficulty": "easy"
+      },
+      {
+        "uid": "UID0092",
+        "difficulty": "easy"
+      },
+      {
+        "uid": "UID0098",
+        "difficulty": "easy"
+      },
+      {
+        "uid": "UID0101",
+        "difficulty": "hard"
+      },
+      {
+        "uid": "UID0110",
+        "difficulty": "hard"
+      },
+      {
+        "uid": "UID0115",
+        "difficulty": "easy"
+      },
+      {
+        "uid": "UID0122",
+        "difficulty": "hard"
+      },
+      {
+        "uid": "UID0123",
+        "difficulty": "hard"
+      },
+      {
+        "uid": "UID0133",
+        "difficulty": "hard"
+      },
+      {
+        "uid": "UID0141",
+        "difficulty": "easy"
+      },
+      {
+        "uid": "UID0144",
+        "difficulty": "easy"
+      },
+      {
+        "uid": "UID0145",
+        "difficulty": "easy"
+      },
+      {
+        "uid": "UID0150",
+        "difficulty": "hard"
+      },
+      {
+        "uid": "UID0151",
+        "difficulty": "easy"
+      },
+      {
+        "uid": "UID0162",
+        "difficulty": "easy"
+      },
+      {
+        "uid": "UID0163",
+        "difficulty": "easy"
+      },
+      {
+        "uid": "UID0165",
+        "difficulty": "hard"
+      },
+      {
+        "uid": "UID0166",
+        "difficulty": "easy"
+      },
+      {
+        "uid": "UID0169",
+        "difficulty": "hard"
+      },
+      {
+        "uid": "UID0189",
+        "difficulty": "easy"
+      },
+      {
+        "uid": "UID0195",
+        "difficulty": "hard"
+      },
+      {
+        "uid": "UID0202",
+        "difficulty": "easy"
+      },
+      {
+        "uid": "UID0212",
+        "difficulty": "hard"
+      },
+      {
+        "uid": "UID0222",
+        "difficulty": "hard"
+      },
+      {
+        "uid": "UID0228",
+        "difficulty": "hard"
+      },
+      {
+        "uid": "UID0229",
+        "difficulty": "easy"
+      },
+      {
+        "uid": "UID0238",
+        "difficulty": "hard"
+      },
+      {
+        "uid": "UID0241",
+        "difficulty": "easy"
+      }
+    ],
+    "val": [
+      {
+        "uid": "UID0001",
+        "difficulty": "hard"
+      },
+      {
+        "uid": "UID0027",
+        "difficulty": "hard"
+      },
+      {
+        "uid": "UID0039",
+        "difficulty": "hard"
+      },
+      {
+        "uid": "UID0041",
+        "difficulty": "easy"
+      },
+      {
+        "uid": "UID0052",
+        "difficulty": "easy"
+      },
+      {
+        "uid": "UID0070",
+        "difficulty": "easy"
+      },
+      {
+        "uid": "UID0072",
+        "difficulty": "easy"
+      },
+      {
+        "uid": "UID0086",
+        "difficulty": "hard"
+      },
+      {
+        "uid": "UID0091",
+        "difficulty": "easy"
+      },
+      {
+        "uid": "UID0109",
+        "difficulty": "hard"
+      },
+      {
+        "uid": "UID0142",
+        "difficulty": "easy"
+      },
+      {
+        "uid": "UID0154",
+        "difficulty": "hard"
+      },
+      {
+        "uid": "UID0159",
+        "difficulty": "easy"
+      },
+      {
+        "uid": "UID0161",
+        "difficulty": "hard"
+      },
+      {
+        "uid": "UID0170",
+        "difficulty": "hard"
+      },
+      {
+        "uid": "UID0190",
+        "difficulty": "hard"
+      },
+      {
+        "uid": "UID0213",
+        "difficulty": "hard"
+      },
+      {
+        "uid": "UID0217",
+        "difficulty": "easy"
+      },
+      {
+        "uid": "UID0220",
+        "difficulty": "hard"
+      },
+      {
+        "uid": "UID0233",
+        "difficulty": "hard"
+      },
+      {
+        "uid": "UID0234",
+        "difficulty": "easy"
+      },
+      {
+        "uid": "UID0235",
+        "difficulty": "easy"
+      },
+      {
+        "uid": "UID0239",
+        "difficulty": "easy"
+      },
+      {
+        "uid": "UID0240",
+        "difficulty": "hard"
+      }
+    ],
+    "test": [
+      {
+        "uid": "UID0003",
+        "difficulty": "hard"
+      },
+      {
+        "uid": "UID0004",
+        "difficulty": "hard"
+      },
+      {
+        "uid": "UID0005",
+        "difficulty": "hard"
+      },
+      {
+        "uid": "UID0006",
+        "difficulty": "easy"
+      },
+      {
+        "uid": "UID0008",
+        "difficulty": "easy"
+      },
+      {
+        "uid": "UID0009",
+        "difficulty": "hard"
+      },
+      {
+        "uid": "UID0010",
+        "difficulty": "hard"
+      },
+      {
+        "uid": "UID0011",
+        "difficulty": "easy"
+      },
+      {
+        "uid": "UID0012",
+        "difficulty": "hard"
+      },
+      {
+        "uid": "UID0013",
+        "difficulty": "hard"
+      },
+      {
+        "uid": "UID0015",
+        "difficulty": "hard"
+      },
+      {
+        "uid": "UID0016",
+        "difficulty": "easy"
+      },
+      {
+        "uid": "UID0020",
+        "difficulty": "easy"
+      },
+      {
+        "uid": "UID0021",
+        "difficulty": "easy"
+      },
+      {
+        "uid": "UID0022",
+        "difficulty": "hard"
+      },
+      {
+        "uid": "UID0023",
+        "difficulty": "easy"
+      },
+      {
+        "uid": "UID0024",
+        "difficulty": "easy"
+      },
+      {
+        "uid": "UID0025",
+        "difficulty": "hard"
+      },
+      {
+        "uid": "UID0029",
+        "difficulty": "hard"
+      },
+      {
+        "uid": "UID0032",
+        "difficulty": "hard"
+      },
+      {
+        "uid": "UID0035",
+        "difficulty": "hard"
+      },
+      {
+        "uid": "UID0036",
+        "difficulty": "hard"
+      },
+      {
+        "uid": "UID0037",
+        "difficulty": "hard"
+      },
+      {
+        "uid": "UID0038",
+        "difficulty": "easy"
+      },
+      {
+        "uid": "UID0040",
+        "difficulty": "easy"
+      },
+      {
+        "uid": "UID0042",
+        "difficulty": "hard"
+      },
+      {
+        "uid": "UID0043",
+        "difficulty": "easy"
+      },
+      {
+        "uid": "UID0045",
+        "difficulty": "easy"
+      },
+      {
+        "uid": "UID0047",
+        "difficulty": "easy"
+      },
+      {
+        "uid": "UID0048",
+        "difficulty": "easy"
+      },
+      {
+        "uid": "UID0050",
+        "difficulty": "hard"
+      },
+      {
+        "uid": "UID0051",
+        "difficulty": "easy"
+      },
+      {
+        "uid": "UID0053",
+        "difficulty": "hard"
+      },
+      {
+        "uid": "UID0054",
+        "difficulty": "easy"
+      },
+      {
+        "uid": "UID0055",
+        "difficulty": "hard"
+      },
+      {
+        "uid": "UID0057",
+        "difficulty": "hard"
+      },
+      {
+        "uid": "UID0058",
+        "difficulty": "hard"
+      },
+      {
+        "uid": "UID0059",
+        "difficulty": "hard"
+      },
+      {
+        "uid": "UID0060",
+        "difficulty": "easy"
+      },
+      {
+        "uid": "UID0061",
+        "difficulty": "easy"
+      },
+      {
+        "uid": "UID0062",
+        "difficulty": "hard"
+      },
+      {
+        "uid": "UID0064",
+        "difficulty": "easy"
+      },
+      {
+        "uid": "UID0066",
+        "difficulty": "easy"
+      },
+      {
+        "uid": "UID0067",
+        "difficulty": "easy"
+      },
+      {
+        "uid": "UID0068",
+        "difficulty": "hard"
+      },
+      {
+        "uid": "UID0069",
+        "difficulty": "hard"
+      },
+      {
+        "uid": "UID0071",
+        "difficulty": "hard"
+      },
+      {
+        "uid": "UID0074",
+        "difficulty": "easy"
+      },
+      {
+        "uid": "UID0075",
+        "difficulty": "easy"
+      },
+      {
+        "uid": "UID0076",
+        "difficulty": "easy"
+      },
+      {
+        "uid": "UID0077",
+        "difficulty": "hard"
+      },
+      {
+        "uid": "UID0078",
+        "difficulty": "easy"
+      },
+      {
+        "uid": "UID0080",
+        "difficulty": "easy"
+      },
+      {
+        "uid": "UID0081",
+        "difficulty": "easy"
+      },
+      {
+        "uid": "UID0082",
+        "difficulty": "easy"
+      },
+      {
+        "uid": "UID0084",
+        "difficulty": "hard"
+      },
+      {
+        "uid": "UID0088",
+        "difficulty": "easy"
+      },
+      {
+        "uid": "UID0089",
+        "difficulty": "easy"
+      },
+      {
+        "uid": "UID0090",
+        "difficulty": "easy"
+      },
+      {
+        "uid": "UID0093",
+        "difficulty": "hard"
+      },
+      {
+        "uid": "UID0094",
+        "difficulty": "hard"
+      },
+      {
+        "uid": "UID0095",
+        "difficulty": "easy"
+      },
+      {
+        "uid": "UID0096",
+        "difficulty": "hard"
+      },
+      {
+        "uid": "UID0097",
+        "difficulty": "hard"
+      },
+      {
+        "uid": "UID0099",
+        "difficulty": "easy"
+      },
+      {
+        "uid": "UID0100",
+        "difficulty": "hard"
+      },
+      {
+        "uid": "UID0102",
+        "difficulty": "hard"
+      },
+      {
+        "uid": "UID0103",
+        "difficulty": "hard"
+      },
+      {
+        "uid": "UID0104",
+        "difficulty": "easy"
+      },
+      {
+        "uid": "UID0105",
+        "difficulty": "easy"
+      },
+      {
+        "uid": "UID0106",
+        "difficulty": "easy"
+      },
+      {
+        "uid": "UID0107",
+        "difficulty": "easy"
+      },
+      {
+        "uid": "UID0108",
+        "difficulty": "hard"
+      },
+      {
+        "uid": "UID0111",
+        "difficulty": "hard"
+      },
+      {
+        "uid": "UID0112",
+        "difficulty": "hard"
+      },
+      {
+        "uid": "UID0113",
+        "difficulty": "hard"
+      },
+      {
+        "uid": "UID0114",
+        "difficulty": "hard"
+      },
+      {
+        "uid": "UID0116",
+        "difficulty": "easy"
+      },
+      {
+        "uid": "UID0117",
+        "difficulty": "hard"
+      },
+      {
+        "uid": "UID0118",
+        "difficulty": "hard"
+      },
+      {
+        "uid": "UID0119",
+        "difficulty": "easy"
+      },
+      {
+        "uid": "UID0120",
+        "difficulty": "hard"
+      },
+      {
+        "uid": "UID0121",
+        "difficulty": "hard"
+      },
+      {
+        "uid": "UID0124",
+        "difficulty": "hard"
+      },
+      {
+        "uid": "UID0125",
+        "difficulty": "easy"
+      },
+      {
+        "uid": "UID0126",
+        "difficulty": "easy"
+      },
+      {
+        "uid": "UID0127",
+        "difficulty": "easy"
+      },
+      {
+        "uid": "UID0128",
+        "difficulty": "easy"
+      },
+      {
+        "uid": "UID0129",
+        "difficulty": "easy"
+      },
+      {
+        "uid": "UID0130",
+        "difficulty": "hard"
+      },
+      {
+        "uid": "UID0131",
+        "difficulty": "easy"
+      },
+      {
+        "uid": "UID0132",
+        "difficulty": "easy"
+      },
+      {
+        "uid": "UID0134",
+        "difficulty": "hard"
+      },
+      {
+        "uid": "UID0135",
+        "difficulty": "hard"
+      },
+      {
+        "uid": "UID0136",
+        "difficulty": "hard"
+      },
+      {
+        "uid": "UID0137",
+        "difficulty": "easy"
+      },
+      {
+        "uid": "UID0138",
+        "difficulty": "easy"
+      },
+      {
+        "uid": "UID0139",
+        "difficulty": "easy"
+      },
+      {
+        "uid": "UID0140",
+        "difficulty": "hard"
+      },
+      {
+        "uid": "UID0143",
+        "difficulty": "easy"
+      },
+      {
+        "uid": "UID0146",
+        "difficulty": "easy"
+      },
+      {
+        "uid": "UID0147",
+        "difficulty": "hard"
+      },
+      {
+        "uid": "UID0148",
+        "difficulty": "hard"
+      },
+      {
+        "uid": "UID0149",
+        "difficulty": "hard"
+      },
+      {
+        "uid": "UID0152",
+        "difficulty": "easy"
+      },
+      {
+        "uid": "UID0153",
+        "difficulty": "easy"
+      },
+      {
+        "uid": "UID0155",
+        "difficulty": "hard"
+      },
+      {
+        "uid": "UID0156",
+        "difficulty": "easy"
+      },
+      {
+        "uid": "UID0157",
+        "difficulty": "easy"
+      },
+      {
+        "uid": "UID0158",
+        "difficulty": "easy"
+      },
+      {
+        "uid": "UID0160",
+        "difficulty": "easy"
+      },
+      {
+        "uid": "UID0164",
+        "difficulty": "easy"
+      },
+      {
+        "uid": "UID0167",
+        "difficulty": "easy"
+      },
+      {
+        "uid": "UID0168",
+        "difficulty": "hard"
+      },
+      {
+        "uid": "UID0171",
+        "difficulty": "easy"
+      },
+      {
+        "uid": "UID0172",
+        "difficulty": "hard"
+      },
+      {
+        "uid": "UID0173",
+        "difficulty": "hard"
+      },
+      {
+        "uid": "UID0174",
+        "difficulty": "hard"
+      },
+      {
+        "uid": "UID0175",
+        "difficulty": "hard"
+      },
+      {
+        "uid": "UID0176",
+        "difficulty": "easy"
+      },
+      {
+        "uid": "UID0177",
+        "difficulty": "hard"
+      },
+      {
+        "uid": "UID0178",
+        "difficulty": "easy"
+      },
+      {
+        "uid": "UID0179",
+        "difficulty": "hard"
+      },
+      {
+        "uid": "UID0180",
+        "difficulty": "hard"
+      },
+      {
+        "uid": "UID0181",
+        "difficulty": "easy"
+      },
+      {
+        "uid": "UID0182",
+        "difficulty": "hard"
+      },
+      {
+        "uid": "UID0183",
+        "difficulty": "hard"
+      },
+      {
+        "uid": "UID0184",
+        "difficulty": "hard"
+      },
+      {
+        "uid": "UID0185",
+        "difficulty": "easy"
+      },
+      {
+        "uid": "UID0186",
+        "difficulty": "easy"
+      },
+      {
+        "uid": "UID0187",
+        "difficulty": "hard"
+      },
+      {
+        "uid": "UID0188",
+        "difficulty": "hard"
+      },
+      {
+        "uid": "UID0191",
+        "difficulty": "easy"
+      },
+      {
+        "uid": "UID0192",
+        "difficulty": "easy"
+      },
+      {
+        "uid": "UID0193",
+        "difficulty": "hard"
+      },
+      {
+        "uid": "UID0194",
+        "difficulty": "hard"
+      },
+      {
+        "uid": "UID0196",
+        "difficulty": "hard"
+      },
+      {
+        "uid": "UID0197",
+        "difficulty": "easy"
+      },
+      {
+        "uid": "UID0198",
+        "difficulty": "easy"
+      },
+      {
+        "uid": "UID0199",
+        "difficulty": "easy"
+      },
+      {
+        "uid": "UID0200",
+        "difficulty": "easy"
+      },
+      {
+        "uid": "UID0201",
+        "difficulty": "hard"
+      },
+      {
+        "uid": "UID0203",
+        "difficulty": "hard"
+      },
+      {
+        "uid": "UID0204",
+        "difficulty": "hard"
+      },
+      {
+        "uid": "UID0205",
+        "difficulty": "hard"
+      },
+      {
+        "uid": "UID0206",
+        "difficulty": "easy"
+      },
+      {
+        "uid": "UID0207",
+        "difficulty": "hard"
+      },
+      {
+        "uid": "UID0208",
+        "difficulty": "easy"
+      },
+      {
+        "uid": "UID0209",
+        "difficulty": "easy"
+      },
+      {
+        "uid": "UID0210",
+        "difficulty": "easy"
+      },
+      {
+        "uid": "UID0211",
+        "difficulty": "hard"
+      },
+      {
+        "uid": "UID0214",
+        "difficulty": "hard"
+      },
+      {
+        "uid": "UID0215",
+        "difficulty": "hard"
+      },
+      {
+        "uid": "UID0216",
+        "difficulty": "hard"
+      },
+      {
+        "uid": "UID0218",
+        "difficulty": "hard"
+      },
+      {
+        "uid": "UID0219",
+        "difficulty": "hard"
+      },
+      {
+        "uid": "UID0221",
+        "difficulty": "hard"
+      },
+      {
+        "uid": "UID0223",
+        "difficulty": "hard"
+      },
+      {
+        "uid": "UID0224",
+        "difficulty": "hard"
+      },
+      {
+        "uid": "UID0225",
+        "difficulty": "hard"
+      },
+      {
+        "uid": "UID0226",
+        "difficulty": "hard"
+      },
+      {
+        "uid": "UID0227",
+        "difficulty": "hard"
+      },
+      {
+        "uid": "UID0230",
+        "difficulty": "hard"
+      },
+      {
+        "uid": "UID0231",
+        "difficulty": "easy"
+      },
+      {
+        "uid": "UID0232",
+        "difficulty": "easy"
+      },
+      {
+        "uid": "UID0236",
+        "difficulty": "easy"
+      },
+      {
+        "uid": "UID0237",
+        "difficulty": "hard"
+      },
+      {
+        "uid": "UID0242",
+        "difficulty": "easy"
+      },
+      {
+        "uid": "UID0243",
+        "difficulty": "hard"
+      },
+      {
+        "uid": "UID0244",
+        "difficulty": "hard"
+      },
+      {
+        "uid": "UID0245",
+        "difficulty": "hard"
+      },
+      {
+        "uid": "UID0246",
+        "difficulty": "hard"
+      }
+    ]
+  },
+  "splits_sha256": "0b971653970a7a81efefec1fe85fc00fdc4ac5b37af72acedafc06e6693458d2"
+}

--- a/benchmarks/officeqa/schemas/result_record.schema.json
+++ b/benchmarks/officeqa/schemas/result_record.schema.json
@@ -1,0 +1,53 @@
+{
+  "$schema": "https://json-schema.org/draft/2020-12/schema",
+  "$id": "https://github.com/SkillNerds/xskill/benchmarks/officeqa/schemas/result_record.schema.json",
+  "title": "OfficeQA 单题结果",
+  "description": "results.jsonl 里的一行，表示一题的最终结果。不要把受控题目原文提交进 Git。",
+  "type": "object",
+  "required": ["schema_version", "run_id", "uid", "status"],
+  "properties": {
+    "schema_version": { "type": "integer", "const": 1 },
+    "run_id": { "type": "string" },
+    "uid": { "type": "string", "description": "题号，例如 UID0002" },
+    "status": {
+      "type": "string",
+      "enum": ["pass", "fail", "invalid", "timeout", "infra_error", "skipped"],
+      "description": "pass=答对；fail=答错；timeout=超时（计分时与 fail 一样算未通过）；invalid=输出无法判分（计分也算未通过）；infra_error=基础设施错误；skipped=跳过。status 区分原因；准确率只有 pass 算对"
+    },
+    "difficulty": { "type": "string", "enum": ["easy", "hard"] },
+    "is_correct": {
+      "type": ["boolean", "null"],
+      "description": "是否答对；不可判分时可为 null"
+    },
+    "pred_answer": {
+      "type": ["string", "null"],
+      "description": "模型预测答案；对外分享前按数据许可决定是否删除"
+    },
+    "latency_ms": { "type": ["number", "null"], "description": "耗时（毫秒）" },
+    "usage": {
+      "type": "object",
+      "description": "本题的 token 与费用",
+      "properties": {
+        "source": {
+          "type": "string",
+          "enum": ["litellm", "runner_reported", "missing"],
+          "description": "litellm=从 LiteLLM 补；runner_reported=runner 自己记；missing=没有采到"
+        },
+        "input_tokens": { "type": ["integer", "null"] },
+        "output_tokens": { "type": ["integer", "null"] },
+        "cache_read_tokens": { "type": ["integer", "null"] },
+        "total_tokens": { "type": ["integer", "null"] },
+        "cost_usd": { "type": ["number", "null"] },
+        "request_ids": {
+          "type": "array",
+          "items": { "type": "string" },
+          "description": "相关请求 id，便于去 LiteLLM 对账"
+        }
+      }
+    },
+    "skill_sha256": { "type": "string" },
+    "scorer_commit": { "type": "string" },
+    "attempts": { "type": "integer", "description": "本题尝试次数" }
+  },
+  "additionalProperties": true
+}

--- a/benchmarks/officeqa/schemas/result_record.schema.json
+++ b/benchmarks/officeqa/schemas/result_record.schema.json
@@ -1,8 +1,8 @@
 {
   "$schema": "https://json-schema.org/draft/2020-12/schema",
   "$id": "https://github.com/SkillNerds/xskill/benchmarks/officeqa/schemas/result_record.schema.json",
-  "title": "OfficeQA 单题结果",
-  "description": "results.jsonl 里的一行，表示一题的最终结果。不要把受控题目原文提交进 Git。",
+  "title": "OfficeQA 单题评测结果",
+  "description": "results.jsonl 中记录的单题结果明细。请勿将受保护的题目正文或私有数据提交至 Git 仓库。",
   "type": "object",
   "required": ["schema_version", "run_id", "uid", "status"],
   "properties": {
@@ -12,26 +12,26 @@
     "status": {
       "type": "string",
       "enum": ["pass", "fail", "invalid", "timeout", "infra_error", "skipped"],
-      "description": "pass=答对；fail=答错；timeout=超时（计分时与 fail 一样算未通过）；invalid=输出无法判分（计分也算未通过）；infra_error=基础设施错误；skipped=跳过。status 区分原因；准确率只有 pass 算对"
+      "description": "pass 表示答对；fail 表示答错；timeout 表示超时；invalid 表示输出无法解析；infra_error 表示基础设施异常；skipped 表示跳过。计算准确率时只有 pass 计为正确，其他均计为未通过。"
     },
     "difficulty": { "type": "string", "enum": ["easy", "hard"] },
     "is_correct": {
       "type": ["boolean", "null"],
-      "description": "是否答对；不可判分时可为 null"
+      "description": "是否判定为正确；无法判分时可为 null"
     },
     "pred_answer": {
       "type": ["string", "null"],
-      "description": "模型预测答案；对外分享前按数据许可决定是否删除"
+      "description": "模型输出的预测答案；对外分享前根据数据许可决定是否脱敏"
     },
-    "latency_ms": { "type": ["number", "null"], "description": "耗时（毫秒）" },
+    "latency_ms": { "type": ["number", "null"], "description": "单题耗时（毫秒）" },
     "usage": {
       "type": "object",
-      "description": "本题的 token 与费用",
+      "description": "单题的 token 消耗与费用统计",
       "properties": {
         "source": {
           "type": "string",
           "enum": ["litellm", "runner_reported", "missing"],
-          "description": "litellm=从 LiteLLM 补；runner_reported=runner 自己记；missing=没有采到"
+          "description": "litellm 表示从 LiteLLM 日志补充；runner_reported 表示评测程序自行记录；missing 表示未采集到"
         },
         "input_tokens": { "type": ["integer", "null"] },
         "output_tokens": { "type": ["integer", "null"] },
@@ -41,13 +41,13 @@
         "request_ids": {
           "type": "array",
           "items": { "type": "string" },
-          "description": "相关请求 id，便于去 LiteLLM 对账"
+          "description": "关联的请求 ID 列表，便于在网关中对账"
         }
       }
     },
     "skill_sha256": { "type": "string" },
     "scorer_commit": { "type": "string" },
-    "attempts": { "type": "integer", "description": "本题尝试次数" }
+    "attempts": { "type": "integer", "description": "本题的尝试次数" }
   },
   "additionalProperties": true
 }

--- a/benchmarks/officeqa/schemas/run_config.schema.json
+++ b/benchmarks/officeqa/schemas/run_config.schema.json
@@ -1,0 +1,141 @@
+{
+  "$schema": "https://json-schema.org/draft/2020-12/schema",
+  "$id": "https://github.com/SkillNerds/xskill/benchmarks/officeqa/schemas/run_config.schema.json",
+  "title": "OfficeQA 单次运行配置",
+  "description": "记录这一次怎么跑：题单、模型、超时、技能版本、代码版本等。不要把 API key 写进来。",
+  "type": "object",
+  "required": [
+    "schema_version",
+    "run_id",
+    "phase",
+    "algo",
+    "split_manifest",
+    "split_name",
+    "full_manifest",
+    "model",
+    "harness",
+    "scorer"
+  ],
+  "properties": {
+    "schema_version": { "type": "integer", "const": 1 },
+    "run_id": { "type": "string", "minLength": 1 },
+    "phase": {
+      "type": "string",
+      "enum": ["train", "eval"],
+      "description": "train=训练；eval=评测"
+    },
+    "algo": { "type": "string", "description": "算法名，例如 xskill 或 skillopt" },
+    "split_manifest": {
+      "type": "string",
+      "description": "划分文件路径，例如 manifests/officeqa_skillopt_id_split.json"
+    },
+    "split_manifest_sha256": {
+      "type": "string",
+      "description": "上述划分文件的 SHA-256，跑完后填真实值"
+    },
+    "split_name": {
+      "type": "string",
+      "enum": ["train", "val", "test", "full"],
+      "description": "这次实际跑哪一段；主对比用 test"
+    },
+    "full_manifest": {
+      "type": "string",
+      "description": "Full 246 题名单路径"
+    },
+    "full_manifest_sha256": { "type": "string" },
+    "docs_tree_sha256": {
+      "type": "string",
+      "description": "本地语料树的 SHA-256，应与 Full manifest 里写死的一致"
+    },
+    "model": {
+      "type": "string",
+      "description": "本 run 的做题模型名。一次 run 只写一个模型；要测多个模型就开多次 run"
+    },
+    "api_base_kind": {
+      "type": "string",
+      "description": "请求怎么走，例如 litellm_proxy 或 openai_compatible；不要写带密钥的完整 URL"
+    },
+    "endpoint_label": {
+      "type": "string",
+      "description": "给人看的 endpoint 昵称，例如 local-litellm"
+    },
+    "harness": {
+      "type": "object",
+      "description": "做题环境：用哪套 agent / 工具",
+      "required": ["id"],
+      "properties": {
+        "id": {
+          "type": "string",
+          "description": "例如 claude_code_native_skills"
+        },
+        "tools": {
+          "type": "array",
+          "items": { "type": "string" },
+          "description": "允许的工具名列表"
+        },
+        "notes": { "type": "string" }
+      }
+    },
+    "scorer": {
+      "type": "object",
+      "description": "判分用的官方 reward.py 版本",
+      "required": ["commit", "sha256", "tolerance"],
+      "properties": {
+        "commit": { "type": "string" },
+        "sha256": { "type": "string" },
+        "tolerance": { "type": "number" },
+        "path": { "type": "string" }
+      }
+    },
+    "code": {
+      "type": "object",
+      "description": "本次用到的代码版本",
+      "properties": {
+        "xskill_commit": { "type": "string" },
+        "skillopt_commit": { "type": "string" },
+        "image_digest": { "type": "string" }
+      }
+    },
+    "skill_sha256": {
+      "type": "string",
+      "description": "本次评测所用冻结技能的 SHA-256"
+    },
+    "workers": { "type": "integer", "minimum": 1, "description": "并行工人数" },
+    "timeout_s": { "type": "number", "description": "单题超时（秒）" },
+    "max_tool_turns": { "type": "integer", "description": "单题最多工具轮数" },
+    "retry": {
+      "type": "object",
+      "properties": {
+        "request_retries": {
+          "type": "integer",
+          "description": "单次请求失败后的重试次数"
+        },
+        "case_retries": {
+          "type": "integer",
+          "description": "整题失败后的外层重试次数"
+        }
+      }
+    },
+    "seed": { "type": "integer" },
+    "failure_policy": {
+      "type": "string",
+      "description": "失败怎么计分。约定：timeout 可单独标记原因，但计分时与 fail 一样算未通过（与榜单一致）；准确率分母含 timeout"
+    },
+    "usage": {
+      "type": "object",
+      "description": "token / 费用从哪来",
+      "properties": {
+        "provider": {
+          "type": "string",
+          "enum": ["litellm", "runner_reported", "none"]
+        },
+        "metadata_keys": {
+          "type": "array",
+          "items": { "type": "string" },
+          "description": "打到 LiteLLM 请求上的标记，例如 run_id、uid"
+        }
+      }
+    }
+  },
+  "additionalProperties": true
+}

--- a/benchmarks/officeqa/schemas/run_config.schema.json
+++ b/benchmarks/officeqa/schemas/run_config.schema.json
@@ -1,8 +1,8 @@
 {
   "$schema": "https://json-schema.org/draft/2020-12/schema",
   "$id": "https://github.com/SkillNerds/xskill/benchmarks/officeqa/schemas/run_config.schema.json",
-  "title": "OfficeQA 单次运行配置",
-  "description": "记录这一次怎么跑：题单、模型、超时、技能版本、代码版本等。不要把 API key 写进来。",
+  "title": "OfficeQA 实验运行配置",
+  "description": "记录本次实验的具体配置：数据划分、做题模型、超时时间、技能版本与代码版本等。请勿将 API Key 写入此文件。",
   "type": "object",
   "required": [
     "schema_version",
@@ -22,46 +22,46 @@
     "phase": {
       "type": "string",
       "enum": ["train", "eval"],
-      "description": "train=训练；eval=评测"
+      "description": "train 表示训练；eval 表示评测"
     },
-    "algo": { "type": "string", "description": "算法名，例如 xskill 或 skillopt" },
+    "algo": { "type": "string", "description": "算法名称，例如 xskill 或 skillopt" },
     "split_manifest": {
       "type": "string",
-      "description": "划分文件路径，例如 manifests/officeqa_skillopt_id_split.json"
+      "description": "划分文件相对路径，例如 manifests/officeqa_skillopt_id_split.json"
     },
     "split_manifest_sha256": {
       "type": "string",
-      "description": "上述划分文件的 SHA-256，跑完后填真实值"
+      "description": "上述划分文件的 SHA-256 哈希值，实验完成后填入真实值"
     },
     "split_name": {
       "type": "string",
       "enum": ["train", "val", "test", "full"],
-      "description": "这次实际跑哪一段；主对比用 test"
+      "description": "本次实际评测的子集；主对比建议使用 test"
     },
     "full_manifest": {
       "type": "string",
-      "description": "Full 246 题名单路径"
+      "description": "Full 246 题总名单文件路径"
     },
     "full_manifest_sha256": { "type": "string" },
     "docs_tree_sha256": {
       "type": "string",
-      "description": "本地语料树的 SHA-256，应与 Full manifest 里写死的一致"
+      "description": "本地语料树的 SHA-256 哈希值，应与 Full manifest 中的哈希一致"
     },
     "model": {
       "type": "string",
-      "description": "本 run 的做题模型名。一次 run 只写一个模型；要测多个模型就开多次 run"
+      "description": "本次实验使用的做题模型名称。一次实验只记录一个模型；测试多模型时分别开启独立实验"
     },
     "api_base_kind": {
       "type": "string",
-      "description": "请求怎么走，例如 litellm_proxy 或 openai_compatible；不要写带密钥的完整 URL"
+      "description": "API 调用方式，例如 litellm_proxy 或 openai_compatible；请勿包含带密钥的完整 URL"
     },
     "endpoint_label": {
       "type": "string",
-      "description": "给人看的 endpoint 昵称，例如 local-litellm"
+      "description": "端点标识或别名，例如 local-litellm"
     },
     "harness": {
       "type": "object",
-      "description": "做题环境：用哪套 agent / 工具",
+      "description": "做题环境配置，记录使用的 Agent 框架与工具列表",
       "required": ["id"],
       "properties": {
         "id": {
@@ -71,14 +71,14 @@
         "tools": {
           "type": "array",
           "items": { "type": "string" },
-          "description": "允许的工具名列表"
+          "description": "允许使用的工具列表"
         },
         "notes": { "type": "string" }
       }
     },
     "scorer": {
       "type": "object",
-      "description": "判分用的官方 reward.py 版本",
+      "description": "判分所用的官方 reward.py 版本与参数",
       "required": ["commit", "sha256", "tolerance"],
       "properties": {
         "commit": { "type": "string" },
@@ -89,7 +89,7 @@
     },
     "code": {
       "type": "object",
-      "description": "本次用到的代码版本",
+      "description": "本次实验所用的代码版本信息",
       "properties": {
         "xskill_commit": { "type": "string" },
         "skillopt_commit": { "type": "string" },
@@ -98,32 +98,32 @@
     },
     "skill_sha256": {
       "type": "string",
-      "description": "本次评测所用冻结技能的 SHA-256"
+      "description": "本次评测所使用的冻结技能文件的 SHA-256 哈希值"
     },
-    "workers": { "type": "integer", "minimum": 1, "description": "并行工人数" },
-    "timeout_s": { "type": "number", "description": "单题超时（秒）" },
-    "max_tool_turns": { "type": "integer", "description": "单题最多工具轮数" },
+    "workers": { "type": "integer", "minimum": 1, "description": "并发运行的工作进程数" },
+    "timeout_s": { "type": "number", "description": "单道题目的超时时间（秒）" },
+    "max_tool_turns": { "type": "integer", "description": "单道题目允许的最大工具调用轮数" },
     "retry": {
       "type": "object",
       "properties": {
         "request_retries": {
           "type": "integer",
-          "description": "单次请求失败后的重试次数"
+          "description": "单次 API 请求失败后的重试次数"
         },
         "case_retries": {
           "type": "integer",
-          "description": "整题失败后的外层重试次数"
+          "description": "整道题目执行失败后的重试次数"
         }
       }
     },
     "seed": { "type": "integer" },
     "failure_policy": {
       "type": "string",
-      "description": "失败怎么计分。约定：timeout 可单独标记原因，但计分时与 fail 一样算未通过（与榜单一致）；准确率分母含 timeout"
+      "description": "失败与超时计分规则。约定：timeout 记录为超时状态，在计算准确率时与 fail 同样计为未通过（准确率 = pass 数量 / 总题数，分母包含 timeout）"
     },
     "usage": {
       "type": "object",
-      "description": "token / 费用从哪来",
+      "description": "token 与费用统计来源",
       "properties": {
         "provider": {
           "type": "string",
@@ -132,7 +132,7 @@
         "metadata_keys": {
           "type": "array",
           "items": { "type": "string" },
-          "description": "打到 LiteLLM 请求上的标记，例如 run_id、uid"
+          "description": "附加在 API 请求上的追踪标签，例如 run_id、uid"
         }
       }
     }

--- a/benchmarks/officeqa/schemas/summary.schema.json
+++ b/benchmarks/officeqa/schemas/summary.schema.json
@@ -1,0 +1,65 @@
+{
+  "$schema": "https://json-schema.org/draft/2020-12/schema",
+  "$id": "https://github.com/SkillNerds/xskill/benchmarks/officeqa/schemas/summary.schema.json",
+  "title": "OfficeQA 汇总",
+  "description": "从 results.jsonl 汇总出的数字。论文主表应引用本文件（并保留其 SHA-256）。",
+  "type": "object",
+  "required": [
+    "schema_version",
+    "run_id",
+    "n_total",
+    "n_pass",
+    "accuracy",
+    "status_counts"
+  ],
+  "properties": {
+    "schema_version": { "type": "integer", "const": 1 },
+    "run_id": { "type": "string" },
+    "model": {
+      "type": "string",
+      "description": "本 run 的做题模型，与 run_config.model 一致；多模型对比时靠这个字段区分"
+    },
+    "n_total": { "type": "integer", "description": "题数" },
+    "n_pass": { "type": "integer", "description": "答对题数" },
+    "accuracy": { "type": "number", "description": "准确率，n_pass / n_total" },
+    "by_difficulty": {
+      "type": "object",
+      "description": "按 easy / hard 拆开的统计"
+    },
+    "status_counts": {
+      "type": "object",
+      "description": "pass / fail / timeout 等各有多少"
+    },
+    "usage_totals": {
+      "type": "object",
+      "description": "全 run 的 token 与费用合计",
+      "properties": {
+        "input_tokens": { "type": ["integer", "null"] },
+        "output_tokens": { "type": ["integer", "null"] },
+        "cost_usd": { "type": ["number", "null"] },
+        "usage_missing_n": {
+          "type": "integer",
+          "description": "有多少题没有采到用量"
+        }
+      }
+    },
+    "refs": {
+      "type": "object",
+      "description": "汇总时用到的配置、结果、技能、名单的 SHA-256",
+      "properties": {
+        "run_config_sha256": { "type": "string" },
+        "results_sha256": { "type": "string" },
+        "skill_sha256": { "type": "string" },
+        "split_manifest_sha256": { "type": "string" },
+        "full_manifest_sha256": { "type": "string" }
+      }
+    },
+    "started_at": { "type": "string" },
+    "finished_at": { "type": "string" },
+    "resumed": {
+      "type": "boolean",
+      "description": "是否从中断处续跑过"
+    }
+  },
+  "additionalProperties": true
+}

--- a/benchmarks/officeqa/schemas/summary.schema.json
+++ b/benchmarks/officeqa/schemas/summary.schema.json
@@ -1,8 +1,8 @@
 {
   "$schema": "https://json-schema.org/draft/2020-12/schema",
   "$id": "https://github.com/SkillNerds/xskill/benchmarks/officeqa/schemas/summary.schema.json",
-  "title": "OfficeQA 汇总",
-  "description": "从 results.jsonl 汇总出的数字。论文主表应引用本文件（并保留其 SHA-256）。",
+  "title": "OfficeQA 评测汇总",
+  "description": "从 results.jsonl 汇总得出的统计指标。论文表格应引用此文件及对应的 SHA-256 哈希值。",
   "type": "object",
   "required": [
     "schema_version",
@@ -17,35 +17,35 @@
     "run_id": { "type": "string" },
     "model": {
       "type": "string",
-      "description": "本 run 的做题模型，与 run_config.model 一致；多模型对比时靠这个字段区分"
+      "description": "本次实验的做题模型名称，与 run_config.model 保持一致；多模型对比时据此区分"
     },
-    "n_total": { "type": "integer", "description": "题数" },
-    "n_pass": { "type": "integer", "description": "答对题数" },
-    "accuracy": { "type": "number", "description": "准确率，n_pass / n_total" },
+    "n_total": { "type": "integer", "description": "评测总题数" },
+    "n_pass": { "type": "integer", "description": "通过（答对）的题数" },
+    "accuracy": { "type": "number", "description": "整体准确率（n_pass / n_total）" },
     "by_difficulty": {
       "type": "object",
-      "description": "按 easy / hard 拆开的统计"
+      "description": "按难度（easy 和 hard）分别统计的题数与准确率"
     },
     "status_counts": {
       "type": "object",
-      "description": "pass / fail / timeout 等各有多少"
+      "description": "各类状态（pass、fail、timeout 等）的题目数量统计"
     },
     "usage_totals": {
       "type": "object",
-      "description": "全 run 的 token 与费用合计",
+      "description": "全量评测消耗的 token 与费用汇总",
       "properties": {
         "input_tokens": { "type": ["integer", "null"] },
         "output_tokens": { "type": ["integer", "null"] },
         "cost_usd": { "type": ["number", "null"] },
         "usage_missing_n": {
           "type": "integer",
-          "description": "有多少题没有采到用量"
+          "description": "未采集到用量信息的题目数量"
         }
       }
     },
     "refs": {
       "type": "object",
-      "description": "汇总时用到的配置、结果、技能、名单的 SHA-256",
+      "description": "生成汇总时关联的配置文件、逐题结果、技能文件及划分名单的 SHA-256 哈希值",
       "properties": {
         "run_config_sha256": { "type": "string" },
         "results_sha256": { "type": "string" },
@@ -58,7 +58,7 @@
     "finished_at": { "type": "string" },
     "resumed": {
       "type": "boolean",
-      "description": "是否从中断处续跑过"
+      "description": "本次实验是否从中断处恢复续跑"
     }
   },
   "additionalProperties": true

--- a/benchmarks/officeqa/schemas/train_provenance.schema.json
+++ b/benchmarks/officeqa/schemas/train_provenance.schema.json
@@ -1,0 +1,59 @@
+{
+  "$schema": "https://json-schema.org/draft/2020-12/schema",
+  "$id": "https://github.com/SkillNerds/xskill/benchmarks/officeqa/schemas/train_provenance.schema.json",
+  "title": "OfficeQA 训练来源说明",
+  "description": "这个技能是怎么训出来的。论文主表分数应另用冻结技能做评测，不要用训练中的中间分。",
+  "type": "object",
+  "required": [
+    "schema_version",
+    "run_id",
+    "algo",
+    "split_manifest",
+    "merge_val_into_train",
+    "skill_sha256"
+  ],
+  "properties": {
+    "schema_version": { "type": "integer", "const": 1 },
+    "run_id": { "type": "string" },
+    "algo": { "type": "string", "description": "例如 xskill 或 skillopt" },
+    "split_manifest": { "type": "string" },
+    "split_manifest_sha256": { "type": "string" },
+    "train_uids_sha256": {
+      "type": "string",
+      "description": "对本趟实际用于训练的题号（UID）名单计算的 SHA-256。先把 UID 按固定顺序排好再哈希。用来证明训了哪几道题；与仓库里的 SkillOpt 标准 train 划分不是同一个概念（例如 val 并进 train 后，这里对应合并后的那一子集）"
+    },
+    "merge_val_into_train": {
+      "type": "boolean",
+      "description": "是否把 val 并进 train。xskill 常见为 true；SkillOpt 常见为 false（val 用于 gate）"
+    },
+    "selection_split": {
+      "type": ["string", "null"],
+      "description": "若用某一段数据做 gate / 选技能，填 val；否则填 null"
+    },
+    "hyperparameters": {
+      "type": "object",
+      "description": "训练超参，按算法自己填"
+    },
+    "optimizer_backend": {
+      "type": "string",
+      "description": "改技能文案用的后端，例如 openai_chat。不去做题。"
+    },
+    "target_harness": {
+      "type": "string",
+      "description": "训练时真正做题的环境，例如 claude_code_native_skills；应与正式评测一致。"
+    },
+    "code": {
+      "type": "object",
+      "properties": {
+        "xskill_commit": { "type": "string" },
+        "skillopt_commit": { "type": "string" }
+      }
+    },
+    "skill_sha256": {
+      "type": "string",
+      "description": "训练结束冻结技能的 SHA-256"
+    },
+    "notes": { "type": "string" }
+  },
+  "additionalProperties": true
+}

--- a/benchmarks/officeqa/schemas/train_provenance.schema.json
+++ b/benchmarks/officeqa/schemas/train_provenance.schema.json
@@ -2,7 +2,7 @@
   "$schema": "https://json-schema.org/draft/2020-12/schema",
   "$id": "https://github.com/SkillNerds/xskill/benchmarks/officeqa/schemas/train_provenance.schema.json",
   "title": "OfficeQA 训练来源说明",
-  "description": "这个技能是怎么训出来的。论文主表分数应另用冻结技能做评测，不要用训练中的中间分。",
+  "description": "记录技能的训练来源与过程配置。论文中的最终成绩应使用训练完成后的冻结技能另行评测，不建议直接使用训练过程中的中间成绩。",
   "type": "object",
   "required": [
     "schema_version",
@@ -20,27 +20,27 @@
     "split_manifest_sha256": { "type": "string" },
     "train_uids_sha256": {
       "type": "string",
-      "description": "对本趟实际用于训练的题号（UID）名单计算的 SHA-256。先把 UID 按固定顺序排好再哈希。用来证明训了哪几道题；与仓库里的 SkillOpt 标准 train 划分不是同一个概念（例如 val 并进 train 后，这里对应合并后的那一子集）"
+      "description": "对本趟实际用于训练的题号（UID）名单计算的 SHA-256 哈希值。计算方式为将参与训练的 UID 按固定顺序排好后取哈希，用于核验训练使用的确切题目范围。注意：若将验证集合并入训练集，此处应为合并后子集的哈希值。"
     },
     "merge_val_into_train": {
       "type": "boolean",
-      "description": "是否把 val 并进 train。xskill 常见为 true；SkillOpt 常见为 false（val 用于 gate）"
+      "description": "是否将验证集（val）合并入训练集（train）。xskill 常见设定为 true；SkillOpt 常见设定为 false（保留 val 用于门禁筛选）"
     },
     "selection_split": {
       "type": ["string", "null"],
-      "description": "若用某一段数据做 gate / 选技能，填 val；否则填 null"
+      "description": "若使用某部分数据作为门禁或筛选技能，填写 val；否则填写 null"
     },
     "hyperparameters": {
       "type": "object",
-      "description": "训练超参，按算法自己填"
+      "description": "训练超参数，按具体算法记录"
     },
     "optimizer_backend": {
       "type": "string",
-      "description": "改技能文案用的后端，例如 openai_chat。不去做题。"
+      "description": "改写技能说明所用的后端，例如 openai_chat。该模块仅修改技能文本，不直接参与答题。"
     },
     "target_harness": {
       "type": "string",
-      "description": "训练时真正做题的环境，例如 claude_code_native_skills；应与正式评测一致。"
+      "description": "训练时模型做题所用的环境，例如 claude_code_native_skills，应与正式评测环境保持一致。"
     },
     "code": {
       "type": "object",
@@ -51,7 +51,7 @@
     },
     "skill_sha256": {
       "type": "string",
-      "description": "训练结束冻结技能的 SHA-256"
+      "description": "训练完成后交付并冻结的技能文件 SHA-256 哈希值"
     },
     "notes": { "type": "string" }
   },

--- a/benchmarks/officeqa/what-these-files-are.md
+++ b/benchmarks/officeqa/what-these-files-are.md
@@ -1,0 +1,135 @@
+# 这些文件是干什么的
+
+用直白话说明：本目录里每个文件管什么。写 PR、写论文、交接实验时按这个理解即可。读者如果已经熟悉 xskill / SkillOpt / Claude Code，下面会保留这些专有名词，但尽量少绕弯。
+
+## 每跑一趟要记下哪些信息
+
+「一趟」= 一个算法设定 + 一个做题模型 + 一次评测（或一次训练）。换模型、换算法、换技能，都算新的一趟。下面这些尽量在当趟收齐；写进对应文件，不要只留在聊天记录里。
+
+开跑前先写清楚（进 `run_config.json`）
+
+- 跑的是哪一段题：一般正式比分用 test（172）；并写明用的是哪份划分文件  
+- 做题模型叫什么（一趟只写一个模型）  
+- 做题环境：例如 Claude Code 原生 Skills，用了哪些工具  
+- 技能是哪一份（技能内容的 SHA-256）；评测必须是冻结后的技能  
+- 代码版本：xskill / SkillOpt 的 commit，或镜像 digest  
+- 文档语料是否对得上（语料树 SHA-256）  
+- 评分代码是哪一版（`reward.py` 的 commit 与 SHA-256）、容差是多少  
+- 超时、并行数、最大工具轮数、重试次数、随机种子  
+- 请求是否走 LiteLLM（方便事后对 token / 费用）
+
+若这一趟包含训练，再多记（进 `train_provenance.json`）
+
+- 实际用了哪些训练题。可以在说明里附上 UID 列表；更常见的是只存「训练 UID 列表的 SHA-256」（字段名 `train_uids_sha256`）：把本趟真正拿去训练的题号排好（例如按字母序），做成一段固定文本或 JSON，再算 SHA-256。它用来证明「训的时候到底用了哪几道题」，又不必把长名单到处复制。注意：这和仓库里的 SkillOpt 划分文件不是一回事——划分文件是标准的 train/val/test；这个校验和是「你这一趟实际训练子集」（例如把 val 并进 train 之后那 74 题）  
+- val 有没有并进 train  
+- 若有 gate / 选技能，用的是哪一段数据  
+- 关键超参（轮数、batch 等，按算法填）  
+- SkillOpt 还要分开写：`optimizer_backend`（改文案，常为 openai_chat）和 `target_harness`（做题环境，应与评测一致）  
+- 训练结束交出的冻结技能 SHA-256  
+
+跑的过程中逐题记（进 `results.jsonl`，一行一题）
+
+- 题号 UID  
+- 最终状态：pass / fail / timeout / invalid / infra_error / skipped（timeout 计分算未通过，与榜单一致）  
+- 是否答对  
+- 预测答案（对外分享前按许可决定是否删除）  
+- 耗时  
+- 尝试了几次  
+- token：输入、输出、缓存（若有）  
+- 费用（美元；没有就标明未采集，不要瞎填）  
+- 相关 request_id（方便去 LiteLLM 对账）
+
+跑完后汇总（进 `summary.json`）
+
+- 总题数、答对题数、准确率  
+- 按 easy / hard 拆开的准确率  
+- 各类状态各有多少（含 timeout 多少）  
+- 全趟合计 token、合计费用；有多少题没采到用量  
+- 做题模型名（与 `run_config.model` 一致）  
+- 指向本趟用过的配置、结果文件、技能、划分名单的 SHA-256  
+- 开始时间、结束时间；是否中断后续跑过  
+
+不必进 Git、但本机建议留着的
+
+- 冻结技能目录本身  
+- 若 runner 写了 `attempts.jsonl`，留着查重试  
+- LiteLLM 拉下来的原始 spend 片段（可选）  
+
+一趟最少要能回答别人这三个问题：考的是哪套题、哪个模型、哪份技能？每题对错和超时各多少？一共花了多少 token / 钱？答不上来，这趟结果就很难写进论文或复现。
+
+## 仓库里长期保存的（不含题目和答案）
+
+`manifests/officeqa_full.json`  
+OfficeQA Full 的 246 道题各是哪个 UID，简单还是困难（easy / hard）。同时写明：数据从哪份 Hugging Face revision 来、CSV 的 SHA-256、语料树的 SHA-256、官方 `reward.py` 是哪一版。这里不存题目正文和答案，也不分 train / val / test。
+
+`manifests/officeqa_skillopt_id_split.json`  
+按 SkillOpt 公开的划分：哪些 UID 进 train（约 50）、val（约 24）、test（172）。父集仍是上面的 246 题。要和 SkillOpt 用同一套划分做对比，就用这份名单。同样不存题目和答案。
+
+`README.md`  
+操作说明：怎么申请数据、怎么核对校验和、怎么用评分代码、怎么跑评测、哪些内容不能提交到 Git。
+
+`schemas/`  
+约定实验产出的 JSON 里应有哪些字段。这不是某一次的真实跑分。
+
+`examples/`  
+按上面约定填好的示例（假数据），方便对照着写自己的文件。
+
+`what-these-files-are.md`  
+就是本说明。
+
+## 每次实验在仓库外生成的（默认不进 Git）
+
+常见目录：`~/.cache/xskill/officeqa/runs/<run_id>/`，或你自己指定的输出目录。
+
+`run.json` / `run_config.json`  
+记录「这一次怎么跑」：用哪份划分、跑 train 还是 test、**哪个模型**、超时、并发、技能包 SHA-256、代码 commit、做题环境（harness）等。开跑前或开跑时写好。
+
+一次评测只对应一个模型。要看多个模型在同一项目（同一划分、同一文档、同一评分、同一技能或同一套对比协议）上的效果，就开多次 run：每个模型一份 `run_id` / `run_config.json` / `results.jsonl` / `summary.json`，不要把多个模型的结果混进同一个 `results.jsonl`。汇总表可以事后把多份 `summary.json` 拼在一起比。
+
+`train_provenance.json`（训练才有）  
+记录「这个技能是怎么训出来的」：实际用了哪些训练题、val 有没有并进 train、关键超参、最后交出的技能 SHA-256。其中 `train_uids_sha256` 就是对本趟实际训练题号名单算的校验和（见上文「每跑一趟」里的说明），用来核对有没有多吃题或少用题。论文主表的分数不要用训练过程中的中间分，应另用冻结技能做评测。
+
+`skill/` 和技能的 SHA-256 文件  
+训练结束后冻结、拿去正式评测的那份技能。评测必须用这一份。
+
+`results.jsonl`  
+逐题结果：对错、失败类型（如 timeout）、耗时、token、费用等。一行一题。中断后可以续跑；已有最终结果的题可以跳过。token / 费用也可以事后用 LiteLLM 的 spend 日志补上。
+
+关于 timeout：结果里可以单独写成 `timeout`，方便和「答错了」区分原因；计分时与 fail 一样算未通过，和榜单网站一致。准确率 = 答对题数 / 全部应考题数（timeout 进分母，不进分子）。不要把 timeout 当成既不算对也不算错的「第三种成绩」。
+
+`attempts.jsonl`（若 runner 会写）  
+同一题多次尝试的明细，用来查重试；最终是否算对，仍以 `results.jsonl` 为准。
+
+`summary.json`  
+把 `results.jsonl` 汇总成总准确率、按 easy/hard、按失败类型、总费用等，并写明汇总依据了哪份配置、哪份结果文件。论文表格应指向这个文件。
+
+## LiteLLM 做什么、不做什么
+
+若请求走 LiteLLM 代理，可以用它的 spend 日志统计每题的 token 和费用。它不负责出题，也不负责判分。跑完后按 `run_id`、`uid` 等 metadata 填回 `results.jsonl`，再汇总到 `summary.json`。没有 LiteLLM 时，费用可以留空，但要标明未采集，不要写成精确账单。
+
+## 和 SkillOpt / xskill 对比时怎么用
+
+正式比分：两边都用 `officeqa_skillopt_id_split.json` 里的 test（172 题），同一套文档语料，同一版 `reward.py`。
+
+做题环境也要同一套：训练时真正答题（SkillOpt 的 target / xskill 的 rollout）和正式测评，都走 Claude Code 原生 Skills（技能装进 skills 目录，用 Skill 工具调用）。不要一边用 `openai_chat` 工具循环做题、一边用 Claude Code 考试。这样 xskill 和 SkillOpt 比的是算法和技能怎么演化，不是比两套不同的做题外壳。SkillOpt 里若还有 `openai_chat`，只用于改技能文案（optimizer），不用于做题。
+
+模型可以换：DeepSeek V4 Flash 以及其他要报的模型，各自单独跑一轮并写进各自的 `run_config.json`（字段 `model`）。对比时同一张表里应标明模型；换模型等于换一轮实验。  
+训练阶段可以不同：例如 xskill 把 val 并进 train；SkillOpt 用 val 做 gate。这些差异写在 `train_provenance.json` 和论文方法里，不要因此换成另一套测试题或另一套做题环境。
+
+## SkillOpt 里：改技能（optimizer）和做题（target）不是一回事
+
+SkillOpt 训练里有两个角色：
+
+target（做题）：用当前技能去读文档、答题。要和 xskill 公平对比时，target 应与正式评测一样，走 Claude Code 的原生 Skills（技能装到 skills 目录，通过 Skill 工具调用）。不要再用 `openai_chat` 那条 Chat + 工具循环去做题。
+
+optimizer（改技能）：根据做题对错，修改技能正文（SKILL.md 里的说明文字）。它不去做 OfficeQA 题。这一步仍可用 `openai_chat`（普通 Chat Completions）。
+
+这样比最终分数算不算公平：算公平——只要正式评测时，两边都在同一 Claude Code 原生 Skills 环境、同一 test、同一文档和评分下，考的是冻结后的技能。此时若还有 `openai_chat`，只用于 SkillOpt 改技能文案，不用于考试。  
+训练过程中每一次调用是否完全相同：不需要相同；论文比的是两套方法。还要写明：SkillOpt 的 optimizer 通常只改文本，默认演化不出带 `scripts/`、`references/` 的技能包，这是方法差异，不是评测作弊。建议写明：同一张对比表里，xskill 与 SkillOpt 使用同一做题模型；若还要报其它模型，每个模型各跑一轮。若 SkillOpt 的 optimizer（改文案）也用同一模型的 Chat 接口，一并写上。
+
+请在 `train_provenance.json` 里分别填写：
+
+- `optimizer_backend`：例如 `openai_chat`（改文案）
+- `target_harness`：例如 `claude_code_native_skills`（做题，应与评测一致）
+
+避免以后被人理解成「训练做题仍是 openai_chat」。

--- a/benchmarks/officeqa/what-these-files-are.md
+++ b/benchmarks/officeqa/what-these-files-are.md
@@ -1,135 +1,127 @@
-# 这些文件是干什么的
+# 实验文件与规范说明
 
-用直白话说明：本目录里每个文件管什么。写 PR、写论文、交接实验时按这个理解即可。读者如果已经熟悉 xskill / SkillOpt / Claude Code，下面会保留这些专有名词，但尽量少绕弯。
+用直白通俗的语言说明：本目录中每个文件负责记录什么。在编写实验记录、论文说明或交接实验时参考本说明即可。文中的专有名词（如 xskill、SkillOpt、Claude Code）保留原有称呼，其他表述尽量直接、易懂。
 
-## 每跑一趟要记下哪些信息
+## 每次实验需要记录哪些信息
 
-「一趟」= 一个算法设定 + 一个做题模型 + 一次评测（或一次训练）。换模型、换算法、换技能，都算新的一趟。下面这些尽量在当趟收齐；写进对应文件，不要只留在聊天记录里。
+「一次实验」对应一个算法设定、一个做题模型以及一次评测（或一次训练）。更换模型、修改算法或更新技能，均视作新的一轮实验。请在实验过程中记录以下信息，并保存在对应的 JSON 文件中，避免仅留存在对话记录中。
 
-开跑前先写清楚（进 `run_config.json`）
+### 1. 运行前记录（写入 `run_config.json`）
 
-- 跑的是哪一段题：一般正式比分用 test（172）；并写明用的是哪份划分文件  
-- 做题模型叫什么（一趟只写一个模型）  
-- 做题环境：例如 Claude Code 原生 Skills，用了哪些工具  
-- 技能是哪一份（技能内容的 SHA-256）；评测必须是冻结后的技能  
-- 代码版本：xskill / SkillOpt 的 commit，或镜像 digest  
-- 文档语料是否对得上（语料树 SHA-256）  
-- 评分代码是哪一版（`reward.py` 的 commit 与 SHA-256）、容差是多少  
-- 超时、并行数、最大工具轮数、重试次数、随机种子  
-- 请求是否走 LiteLLM（方便事后对 token / 费用）
+- 评测范围：正式对比一般使用测试集（test，172 题），并写明使用的是哪份划分文件
+- 做题模型名称：一轮实验只记录一个模型，多模型测试需分别开跑
+- 做题环境：例如 Claude Code 原生技能环境，并记录允许使用的工具列表
+- 技能版本：冻结技能文件的 SHA-256 哈希值；评测必须使用训练完成后的固定版本
+- 代码版本：xskill 或 SkillOpt 的 commit，或者镜像版本（image digest）
+- 文档语料：语料树的 SHA-256 哈希值，用于确认数据文件一致
+- 评分代码：官方 `reward.py` 的 commit 与 SHA-256 哈希值，以及数值容差
+- 运行参数：超时时间、并发数、最大工具轮数、重试次数与随机种子
+- 用量采集方式：是否经过 LiteLLM 代理，以便后续统计 token 和费用
 
-若这一趟包含训练，再多记（进 `train_provenance.json`）
+### 2. 训练过程记录（若包含训练，写入 `train_provenance.json`）
 
-- 实际用了哪些训练题。可以在说明里附上 UID 列表；更常见的是只存「训练 UID 列表的 SHA-256」（字段名 `train_uids_sha256`）：把本趟真正拿去训练的题号排好（例如按字母序），做成一段固定文本或 JSON，再算 SHA-256。它用来证明「训的时候到底用了哪几道题」，又不必把长名单到处复制。注意：这和仓库里的 SkillOpt 划分文件不是一回事——划分文件是标准的 train/val/test；这个校验和是「你这一趟实际训练子集」（例如把 val 并进 train 之后那 74 题）  
-- val 有没有并进 train  
-- 若有 gate / 选技能，用的是哪一段数据  
-- 关键超参（轮数、batch 等，按算法填）  
-- SkillOpt 还要分开写：`optimizer_backend`（改文案，常为 openai_chat）和 `target_harness`（做题环境，应与评测一致）  
-- 训练结束交出的冻结技能 SHA-256  
+- 实际训练题范围：记录「训练 UID 列表的 SHA-256」（字段名 `train_uids_sha256`）。将本趟实际参与训练的题号排好序（如按字母序），转为文本后计算 SHA-256。该校验和用于证明训练究竟使用了哪几道题目，避免复制冗长的题号列表。注意：这和仓库里的标准划分文件不同，此校验和代表本趟实验实际训练的题目子集（例如验证集合并入训练集后的 74 题）
+- 验证集使用方式：验证集（val）是否合并进了训练集（train）
+- 门禁与筛选机制：是否有选拔或门禁环节，具体使用了哪一段数据
+- 关键超参：轮数、批大小等，按实际算法填写
+- 模块分工：改写技能说明所用的后端（`optimizer_backend`，通常为标准 Chat 接口）与训练答题所用的环境（`target_harness`，应与评测环境一致）
+- 训练完成后交付并冻结的技能 SHA-256 哈希值
 
-跑的过程中逐题记（进 `results.jsonl`，一行一题）
+### 3. 运行中逐题记录（写入 `results.jsonl`，每题一行）
 
-- 题号 UID  
-- 最终状态：pass / fail / timeout / invalid / infra_error / skipped（timeout 计分算未通过，与榜单一致）  
-- 是否答对  
-- 预测答案（对外分享前按许可决定是否删除）  
-- 耗时  
-- 尝试了几次  
-- token：输入、输出、缓存（若有）  
-- 费用（美元；没有就标明未采集，不要瞎填）  
-- 相关 request_id（方便去 LiteLLM 对账）
+- 题号 UID
+- 最终状态：pass、fail、timeout、invalid、infra_error 或 skipped（timeout 计分算未通过，与榜单规则一致）
+- 是否答对（is_correct）
+- 预测答案（对外分享前根据数据许可决定是否脱敏或删除）
+- 耗时（毫秒）
+- 尝试次数
+- token 统计：输入、输出、缓存读取（若有）
+- 估算费用（美元；若未采集需明确标明，不随意填写）
+- 相关 request_id（便于在代理网关中核对日志）
 
-跑完后汇总（进 `summary.json`）
+### 4. 运行后汇总统计（写入 `summary.json`）
 
-- 总题数、答对题数、准确率  
-- 按 easy / hard 拆开的准确率  
-- 各类状态各有多少（含 timeout 多少）  
-- 全趟合计 token、合计费用；有多少题没采到用量  
-- 做题模型名（与 `run_config.model` 一致）  
-- 指向本趟用过的配置、结果文件、技能、划分名单的 SHA-256  
-- 开始时间、结束时间；是否中断后续跑过  
+- 总题数、答对题数与整体准确率
+- 按简单题（easy）和困难题（hard）分别统计的准确率
+- 各类状态的数量统计（包含 timeout 数量）
+- 全趟合计 token 与合计费用；标明未采集到用量的题目数量
+- 做题模型名称（需与 `run_config.model` 保持一致）
+- 本趟实验关联的配置、逐题结果、技能文件与划分名单的 SHA-256 哈希值
+- 开始时间、结束时间，以及是否从中断处恢复续跑过
 
-不必进 Git、但本机建议留着的
+### 建议在本地保留的文件（不提交至 Git）
 
-- 冻结技能目录本身  
-- 若 runner 写了 `attempts.jsonl`，留着查重试  
-- LiteLLM 拉下来的原始 spend 片段（可选）  
+- 冻结技能目录本身
+- runner 输出的 `attempts.jsonl`（用于排查重试详情）
+- LiteLLM 导出的原始费用日志片段（可选）
 
-一趟最少要能回答别人这三个问题：考的是哪套题、哪个模型、哪份技能？每题对错和超时各多少？一共花了多少 token / 钱？答不上来，这趟结果就很难写进论文或复现。
+一轮实验最少要能清楚回答三个问题：评测的是哪套题目、哪个模型、哪份技能？每题的对错与超时各是多少？一共消耗了多少 token 和费用？如果这些信息不完整，实验结果就难以在论文中说明或供他人复现。
 
-## 仓库里长期保存的（不含题目和答案）
+## 仓库中长期保存的文件（不包含受控题目与答案）
 
 `manifests/officeqa_full.json`  
-OfficeQA Full 的 246 道题各是哪个 UID，简单还是困难（easy / hard）。同时写明：数据从哪份 Hugging Face revision 来、CSV 的 SHA-256、语料树的 SHA-256、官方 `reward.py` 是哪一版。这里不存题目正文和答案，也不分 train / val / test。
+OfficeQA Full 的 246 道题目 UID 列表与难度标记（easy 或 hard）。同时记录数据来源的 Hugging Face revision、CSV 文件哈希、语料树哈希以及官方 `reward.py` 的版本。此处不包含题目正文与答案，也不包含数据集划分。
 
 `manifests/officeqa_skillopt_id_split.json`  
-按 SkillOpt 公开的划分：哪些 UID 进 train（约 50）、val（约 24）、test（172）。父集仍是上面的 246 题。要和 SkillOpt 用同一套划分做对比，就用这份名单。同样不存题目和答案。
+按照 SkillOpt 公开的划分整理的题号列表：训练集约 50 题、验证集约 24 题、测试集 172 题，总和对应上述 246 题。如果需要与 SkillOpt 在相同划分下对比，使用此名单。同样不包含题目正文与答案。
 
 `README.md`  
-操作说明：怎么申请数据、怎么核对校验和、怎么用评分代码、怎么跑评测、哪些内容不能提交到 Git。
+操作说明：包含数据申请方式、校验和核验步骤、评分代码用法、评测运行方法以及保密边界说明。
 
 `schemas/`  
-约定实验产出的 JSON 里应有哪些字段。这不是某一次的真实跑分。
+JSON 格式规范，约定每次实验产出的配置文件与结果文件中应包含哪些字段。
 
 `examples/`  
-按上面约定填好的示例（假数据），方便对照着写自己的文件。
+按照上述规范填写的示例文件（使用演示用虚拟数据），供实验记录时参考格式。
 
 `what-these-files-are.md`  
-就是本说明。
+即本文档，提供实验规范与文件作用的通俗说明。
 
-## 每次实验在仓库外生成的（默认不进 Git）
+## 每次实验在仓库外生成的产物（默认不提交至 Git）
 
-常见目录：`~/.cache/xskill/officeqa/runs/<run_id>/`，或你自己指定的输出目录。
+建议存放在 `~/.cache/xskill/officeqa/runs/<run_id>/` 或指定的本地实验目录中。
 
-`run.json` / `run_config.json`  
-记录「这一次怎么跑」：用哪份划分、跑 train 还是 test、**哪个模型**、超时、并发、技能包 SHA-256、代码 commit、做题环境（harness）等。开跑前或开跑时写好。
+`run_config.json`（或 runner 生成的 `run.json`）  
+记录本次运行配置：使用哪份划分、运行哪个子集、做题模型、超时时间、并发数、技能哈希、代码 commit 与做题环境等。开跑前或开跑时生成。一次评测对应一个模型；如需测试多个模型，请为每个模型分别开跑并记录独立的配置与结果文件。
 
-一次评测只对应一个模型。要看多个模型在同一项目（同一划分、同一文档、同一评分、同一技能或同一套对比协议）上的效果，就开多次 run：每个模型一份 `run_id` / `run_config.json` / `results.jsonl` / `summary.json`，不要把多个模型的结果混进同一个 `results.jsonl`。汇总表可以事后把多份 `summary.json` 拼在一起比。
+`train_provenance.json`（仅在包含训练时生成）  
+记录技能的训练来源：实际使用的训练题范围、验证集是否合并入训练集、关键超参数以及最终产出的技能哈希。其中 `train_uids_sha256` 为实际训练题号列表的哈希校验和。论文主表引用的分数应使用训练完成后的冻结技能另行评测，不建议直接使用训练过程中的中间成绩。
 
-`train_provenance.json`（训练才有）  
-记录「这个技能是怎么训出来的」：实际用了哪些训练题、val 有没有并进 train、关键超参、最后交出的技能 SHA-256。其中 `train_uids_sha256` 就是对本趟实际训练题号名单算的校验和（见上文「每跑一趟」里的说明），用来核对有没有多吃题或少用题。论文主表的分数不要用训练过程中的中间分，应另用冻结技能做评测。
-
-`skill/` 和技能的 SHA-256 文件  
-训练结束后冻结、拿去正式评测的那份技能。评测必须用这一份。
+`skill/` 目录及技能 SHA-256 文件  
+训练完成后固定、用于正式评测的技能文件包。
 
 `results.jsonl`  
-逐题结果：对错、失败类型（如 timeout）、耗时、token、费用等。一行一题。中断后可以续跑；已有最终结果的题可以跳过。token / 费用也可以事后用 LiteLLM 的 spend 日志补上。
+逐题评测明细：每题一行，包含对错判定、失败原因（如 timeout）、耗时、token 与费用。支持中断后续跑。关于超时（timeout）：结果明细中单独标记为 `timeout` 便于区分原因；在统计准确率时与 fail 同样计为未通过（准确率 = 答对题数 / 总题数，超时计入分母不计入分子）。
 
-关于 timeout：结果里可以单独写成 `timeout`，方便和「答错了」区分原因；计分时与 fail 一样算未通过，和榜单网站一致。准确率 = 答对题数 / 全部应考题数（timeout 进分母，不进分子）。不要把 timeout 当成既不算对也不算错的「第三种成绩」。
-
-`attempts.jsonl`（若 runner 会写）  
-同一题多次尝试的明细，用来查重试；最终是否算对，仍以 `results.jsonl` 为准。
+`attempts.jsonl`（若 runner 记录了重试过程）  
+单题多次尝试的详细日志，用于排查重试情况；最终成绩以 `results.jsonl` 为准。
 
 `summary.json`  
-把 `results.jsonl` 汇总成总准确率、按 easy/hard、按失败类型、总费用等，并写明汇总依据了哪份配置、哪份结果文件。论文表格应指向这个文件。
+基于 `results.jsonl` 统计出的总准确率、分难度准确率、状态统计与总用量等，并记录引用的配置文件和结果文件哈希。论文表格应对应此文件的统计数据。
 
-## LiteLLM 做什么、不做什么
+## LiteLLM 的作用与定位
 
-若请求走 LiteLLM 代理，可以用它的 spend 日志统计每题的 token 和费用。它不负责出题，也不负责判分。跑完后按 `run_id`、`uid` 等 metadata 填回 `results.jsonl`，再汇总到 `summary.json`。没有 LiteLLM 时，费用可以留空，但要标明未采集，不要写成精确账单。
+如果请求通过 LiteLLM 代理，可以利用其 spend 日志统计每题消耗的 token 与费用。LiteLLM 不参与题目发放与结果判分。实验结束后，可根据 `run_id` 和 `uid` 将用量数据回填至 `results.jsonl` 并汇总到 `summary.json`。若未使用 LiteLLM，费用部分可标记为未采集，无需估算。
 
-## 和 SkillOpt / xskill 对比时怎么用
+## 与 SkillOpt 和 xskill 对比时的规范
 
-正式比分：两边都用 `officeqa_skillopt_id_split.json` 里的 test（172 题），同一套文档语料，同一版 `reward.py`。
+正式对比成绩时，双方均应使用 `officeqa_skillopt_id_split.json` 中的测试集（test，172 题）、相同的文档语料以及相同版本的 `reward.py` 评分脚本。
 
-做题环境也要同一套：训练时真正答题（SkillOpt 的 target / xskill 的 rollout）和正式测评，都走 Claude Code 原生 Skills（技能装进 skills 目录，用 Skill 工具调用）。不要一边用 `openai_chat` 工具循环做题、一边用 Claude Code 考试。这样 xskill 和 SkillOpt 比的是算法和技能怎么演化，不是比两套不同的做题外壳。SkillOpt 里若还有 `openai_chat`，只用于改技能文案（optimizer），不用于做题。
+做题环境同样保持一致：训练时真正答题（SkillOpt 的 target 或 xskill 的 rollout）与正式评测，都统一使用 Claude Code 原生技能环境（技能放入 skills 目录，通过 Skill 工具调用）。避免在训练时使用 Chat 接口循环答题、评测时切换为 Claude Code。这样对比的是技能演化算法本身的效果，而不是外层交互环境的差异。
 
-模型可以换：DeepSeek V4 Flash 以及其他要报的模型，各自单独跑一轮并写进各自的 `run_config.json`（字段 `model`）。对比时同一张表里应标明模型；换模型等于换一轮实验。  
-训练阶段可以不同：例如 xskill 把 val 并进 train；SkillOpt 用 val 做 gate。这些差异写在 `train_provenance.json` 和论文方法里，不要因此换成另一套测试题或另一套做题环境。
+做题模型可以灵活选择：DeepSeek V4 Flash 或其他待测试模型，每个模型单独运行一轮并在 `run_config.json` 中记录。对比表格中明确注明模型名称。
+训练阶段的设定可以各有侧重：例如 xskill 将验证集合并入训练集；SkillOpt 将验证集作为门禁筛选。这些属于算法实现策略，记录在 `train_provenance.json` 中即可，无需因此更换测试题集。
 
-## SkillOpt 里：改技能（optimizer）和做题（target）不是一回事
+## SkillOpt 中改写技能（optimizer）与做题（target）的区别
 
-SkillOpt 训练里有两个角色：
+在 SkillOpt 的训练流程中包含两个不同的环节：
 
-target（做题）：用当前技能去读文档、答题。要和 xskill 公平对比时，target 应与正式评测一样，走 Claude Code 的原生 Skills（技能装到 skills 目录，通过 Skill 工具调用）。不要再用 `openai_chat` 那条 Chat + 工具循环去做题。
+1. 做题环节（target）：使用当前技能去阅读文档并回答题目。为了与 xskill 保持公平对比，做题环境应当与正式评测一致，使用 Claude Code 原生技能环境（技能放入 skills 目录，通过 Skill 工具调用）。
 
-optimizer（改技能）：根据做题对错，修改技能正文（SKILL.md 里的说明文字）。它不去做 OfficeQA 题。这一步仍可用 `openai_chat`（普通 Chat Completions）。
+2. 改写技能环节（optimizer）：根据做题结果与错误反馈，修改技能说明正文（SKILL.md 中的文字）。该环节不直接做题，可以使用标准的 Chat Completions 接口完成。
 
-这样比最终分数算不算公平：算公平——只要正式评测时，两边都在同一 Claude Code 原生 Skills 环境、同一 test、同一文档和评分下，考的是冻结后的技能。此时若还有 `openai_chat`，只用于 SkillOpt 改技能文案，不用于考试。  
-训练过程中每一次调用是否完全相同：不需要相同；论文比的是两套方法。还要写明：SkillOpt 的 optimizer 通常只改文本，默认演化不出带 `scripts/`、`references/` 的技能包，这是方法差异，不是评测作弊。建议写明：同一张对比表里，xskill 与 SkillOpt 使用同一做题模型；若还要报其它模型，每个模型各跑一轮。若 SkillOpt 的 optimizer（改文案）也用同一模型的 Chat 接口，一并写上。
+这种配置下的最终分数对比是公平的：因为在最终评测阶段，双方都是在完全相同的 Claude Code 原生环境、相同的测试集、相同的文档语料与评分标准下，对训练完成后的冻结技能进行测试。Chat 接口仅用于 SkillOpt 内部改写文案，不影响评测标准。
 
-请在 `train_provenance.json` 里分别填写：
-
-- `optimizer_backend`：例如 `openai_chat`（改文案）
-- `target_harness`：例如 `claude_code_native_skills`（做题，应与评测一致）
-
-避免以后被人理解成「训练做题仍是 openai_chat」。
+在 `train_provenance.json` 中请分别注明：
+- `optimizer_backend`：例如 `openai_chat`（改写技能文案）
+- `target_harness`：例如 `claude_code_native_skills`（做题环境，需与评测保持一致）

--- a/scripts/bench/officeqa/contracts.py
+++ b/scripts/bench/officeqa/contracts.py
@@ -1,0 +1,62 @@
+"""SkillOpt 划分名单，以及读写这些约定文件的小工具。"""
+
+from __future__ import annotations
+
+import hashlib
+import json
+from pathlib import Path
+from typing import Any
+
+REPOSITORY_ROOT = Path(__file__).resolve().parents[3]
+SPLIT_MANIFEST = (
+    REPOSITORY_ROOT
+    / "benchmarks"
+    / "officeqa"
+    / "manifests"
+    / "officeqa_skillopt_id_split.json"
+)
+FULL_MANIFEST = (
+    REPOSITORY_ROOT / "benchmarks" / "officeqa" / "manifests" / "officeqa_full.json"
+)
+
+
+def sha256_text(text: str) -> str:
+    return hashlib.sha256(text.encode("utf-8")).hexdigest()
+
+
+def sha256_json(value: Any) -> str:
+    """对 JSON 对象做稳定序列化后再算 SHA-256（末尾带换行）。"""
+    payload = json.dumps(value, ensure_ascii=False, separators=(",", ":"), sort_keys=True)
+    return sha256_text(payload + "\n")
+
+
+def load_json(path: Path | str) -> dict[str, Any]:
+    return json.loads(Path(path).read_text(encoding="utf-8"))
+
+
+def load_skillopt_split(
+    path: Path | str | None = None,
+) -> dict[str, Any]:
+    """读取 SkillOpt 的 train/val/test 划分名单。"""
+    return load_json(path or SPLIT_MANIFEST)
+
+
+def uids_for_split(
+    split_name: str,
+    *,
+    manifest: dict[str, Any] | None = None,
+) -> list[str]:
+    """返回某一段（train/val/test）或 full（三段并集）的 UID 列表。"""
+    data = manifest or load_skillopt_split()
+    if split_name == "full":
+        items = []
+        for name in ("train", "val", "test"):
+            items.extend(data["splits"][name])
+    else:
+        items = data["splits"][split_name]
+    return [str(item["uid"]) for item in items]
+
+
+def required_keys_present(obj: dict[str, Any], required: list[str]) -> list[str]:
+    """返回缺失的必填字段名；都在则返回空列表。"""
+    return [key for key in required if key not in obj]

--- a/scripts/bench/officeqa/contracts.py
+++ b/scripts/bench/officeqa/contracts.py
@@ -1,4 +1,4 @@
-"""SkillOpt 划分名单，以及读写这些约定文件的小工具。"""
+"""SkillOpt 数据划分名单与实验规范处理工具。"""
 
 from __future__ import annotations
 
@@ -25,7 +25,7 @@ def sha256_text(text: str) -> str:
 
 
 def sha256_json(value: Any) -> str:
-    """对 JSON 对象做稳定序列化后再算 SHA-256（末尾带换行）。"""
+    """对 JSON 对象进行稳定序列化后计算 SHA-256 哈希值（末尾追加换行符）。"""
     payload = json.dumps(value, ensure_ascii=False, separators=(",", ":"), sort_keys=True)
     return sha256_text(payload + "\n")
 
@@ -37,7 +37,7 @@ def load_json(path: Path | str) -> dict[str, Any]:
 def load_skillopt_split(
     path: Path | str | None = None,
 ) -> dict[str, Any]:
-    """读取 SkillOpt 的 train/val/test 划分名单。"""
+    """读取 SkillOpt 的训练集、验证集与测试集划分名单。"""
     return load_json(path or SPLIT_MANIFEST)
 
 
@@ -46,7 +46,7 @@ def uids_for_split(
     *,
     manifest: dict[str, Any] | None = None,
 ) -> list[str]:
-    """返回某一段（train/val/test）或 full（三段并集）的 UID 列表。"""
+    """获取指定划分（train、val 或 test）或全量集合（full）的 UID 列表。"""
     data = manifest or load_skillopt_split()
     if split_name == "full":
         items = []
@@ -58,5 +58,5 @@ def uids_for_split(
 
 
 def required_keys_present(obj: dict[str, Any], required: list[str]) -> list[str]:
-    """返回缺失的必填字段名；都在则返回空列表。"""
+    """检查字典中是否存在指定的必填字段，返回缺失字段列表。"""
     return [key for key in required if key not in obj]

--- a/scripts/bench/officeqa/litellm_usage.py
+++ b/scripts/bench/officeqa/litellm_usage.py
@@ -1,0 +1,146 @@
+"""从 LiteLLM 代理的 spend 日志里补 token / 费用。
+
+不做判分。只根据请求里带的 metadata（如 run_id、uid）把用量填回结果。
+"""
+
+from __future__ import annotations
+
+import json
+from typing import Any
+from urllib.error import HTTPError, URLError
+from urllib.parse import urlencode
+from urllib.request import Request, urlopen
+
+
+def aggregate_spend_logs_by_uid(
+    logs: list[dict[str, Any]],
+    *,
+    run_id: str | None = None,
+) -> dict[str, dict[str, Any]]:
+    """按 metadata.uid 汇总 LiteLLM spend 日志。
+
+    每条日志常见字段（不同版本名字可能略有差别，这里多认几种）：
+    - metadata.run_id / metadata.uid（或 spend_logs_metadata）
+    - prompt_tokens / completion_tokens / total_tokens
+    - spend（美元）
+    - request_id
+    """
+    by_uid: dict[str, dict[str, Any]] = {}
+    for row in logs:
+        meta = _metadata(row)
+        if run_id is not None and str(meta.get("run_id") or "") != run_id:
+            continue
+        uid = str(meta.get("uid") or "").strip()
+        if not uid:
+            continue
+        bucket = by_uid.setdefault(
+            uid,
+            {
+                "source": "litellm",
+                "input_tokens": 0,
+                "output_tokens": 0,
+                "cache_read_tokens": 0,
+                "total_tokens": 0,
+                "cost_usd": 0.0,
+                "request_ids": [],
+            },
+        )
+        prompt = int(row.get("prompt_tokens") or row.get("input_tokens") or 0)
+        completion = int(row.get("completion_tokens") or row.get("output_tokens") or 0)
+        cache_read = int(row.get("cache_read_input_tokens") or row.get("cache_read_tokens") or 0)
+        total = int(row.get("total_tokens") or (prompt + completion))
+        spend = float(row.get("spend") or row.get("cost") or 0.0)
+        bucket["input_tokens"] += prompt
+        bucket["output_tokens"] += completion
+        bucket["cache_read_tokens"] += cache_read
+        bucket["total_tokens"] += total
+        bucket["cost_usd"] = float(bucket["cost_usd"]) + spend
+        req_id = row.get("request_id") or row.get("id")
+        if req_id:
+            bucket["request_ids"].append(str(req_id))
+    return by_uid
+
+
+def merge_usage_into_results(
+    results: list[dict[str, Any]],
+    usage_by_uid: dict[str, dict[str, Any]],
+) -> list[dict[str, Any]]:
+    """把按 uid 汇总好的用量写回结果列表（浅拷贝每一行）。"""
+    out: list[dict[str, Any]] = []
+    for row in results:
+        item = dict(row)
+        uid = str(item.get("uid") or "")
+        usage = usage_by_uid.get(uid)
+        if usage is None:
+            current = dict(item.get("usage") or {})
+            current.setdefault("source", "missing")
+            item["usage"] = current
+        else:
+            item["usage"] = dict(usage)
+        out.append(item)
+    return out
+
+
+def fetch_spend_logs(
+    *,
+    base_url: str,
+    api_key: str,
+    start_date: str,
+    end_date: str,
+    timeout_s: float = 60.0,
+) -> list[dict[str, Any]]:
+    """向 LiteLLM 代理请求 /spend/logs?summarize=false。
+
+    api_key 从环境变量传入，不要写进仓库。
+    """
+    query = urlencode(
+        {
+            "start_date": start_date,
+            "end_date": end_date,
+            "summarize": "false",
+        }
+    )
+    url = base_url.rstrip("/") + "/spend/logs?" + query
+    req = Request(url, headers={"Authorization": f"Bearer {api_key}"})
+    try:
+        with urlopen(req, timeout=timeout_s) as resp:
+            payload = json.loads(resp.read().decode("utf-8"))
+    except (HTTPError, URLError, TimeoutError, json.JSONDecodeError) as exc:
+        raise RuntimeError(f"LiteLLM spend log fetch failed: {exc}") from exc
+    if isinstance(payload, list):
+        return payload
+    if isinstance(payload, dict):
+        for key in ("data", "logs", "results"):
+            value = payload.get(key)
+            if isinstance(value, list):
+                return value
+    raise RuntimeError("LiteLLM spend log response was not a list of rows")
+
+
+def _metadata(row: dict[str, Any]) -> dict[str, Any]:
+    meta = row.get("metadata")
+    if not isinstance(meta, dict):
+        meta = {}
+    nested = meta.get("spend_logs_metadata")
+    if isinstance(nested, dict):
+        merged = dict(nested)
+        merged.update({k: v for k, v in meta.items() if k != "spend_logs_metadata"})
+        return merged
+    return meta
+
+
+def load_jsonl(path: str) -> list[dict[str, Any]]:
+    rows: list[dict[str, Any]] = []
+    with open(path, encoding="utf-8") as handle:
+        for line in handle:
+            line = line.strip()
+            if not line:
+                continue
+            rows.append(json.loads(line))
+    return rows
+
+
+def write_jsonl(path: str, rows: list[dict[str, Any]]) -> None:
+    with open(path, "w", encoding="utf-8") as handle:
+        for row in rows:
+            handle.write(json.dumps(row, ensure_ascii=False) + "\n")

--- a/scripts/bench/officeqa/litellm_usage.py
+++ b/scripts/bench/officeqa/litellm_usage.py
@@ -1,6 +1,6 @@
-"""从 LiteLLM 代理的 spend 日志里补 token / 费用。
+"""从 LiteLLM 代理的用量日志中提取 token 消耗与费用统计。
 
-不做判分。只根据请求里带的 metadata（如 run_id、uid）把用量填回结果。
+本模块仅负责用量回填，不参与题目判定与评分。
 """
 
 from __future__ import annotations
@@ -17,12 +17,12 @@ def aggregate_spend_logs_by_uid(
     *,
     run_id: str | None = None,
 ) -> dict[str, dict[str, Any]]:
-    """按 metadata.uid 汇总 LiteLLM spend 日志。
+    """按 metadata.uid 聚合 LiteLLM 的费用与 token 消耗日志。
 
-    每条日志常见字段（不同版本名字可能略有差别，这里多认几种）：
-    - metadata.run_id / metadata.uid（或 spend_logs_metadata）
+    日志中支持识别的字段包括：
+    - metadata.run_id 与 metadata.uid（或 spend_logs_metadata）
     - prompt_tokens / completion_tokens / total_tokens
-    - spend（美元）
+    - spend（美元费用）
     - request_id
     """
     by_uid: dict[str, dict[str, Any]] = {}
@@ -65,7 +65,7 @@ def merge_usage_into_results(
     results: list[dict[str, Any]],
     usage_by_uid: dict[str, dict[str, Any]],
 ) -> list[dict[str, Any]]:
-    """把按 uid 汇总好的用量写回结果列表（浅拷贝每一行）。"""
+    """将按 uid 汇总的用量信息回填到逐题结果列表中（浅拷贝每一行）。"""
     out: list[dict[str, Any]] = []
     for row in results:
         item = dict(row)
@@ -89,9 +89,9 @@ def fetch_spend_logs(
     end_date: str,
     timeout_s: float = 60.0,
 ) -> list[dict[str, Any]]:
-    """向 LiteLLM 代理请求 /spend/logs?summarize=false。
+    """从 LiteLLM 代理接口获取用量日志（/spend/logs?summarize=false）。
 
-    api_key 从环境变量传入，不要写进仓库。
+    api_key 从环境变量传入，请勿写进代码或提交到仓库。
     """
     query = urlencode(
         {

--- a/tests/test_officeqa_contracts.py
+++ b/tests/test_officeqa_contracts.py
@@ -1,0 +1,135 @@
+"""SkillOpt 划分与实验约定文件的测试。"""
+
+from __future__ import annotations
+
+import json
+from pathlib import Path
+
+from scripts.bench.officeqa.contracts import (
+    FULL_MANIFEST,
+    SPLIT_MANIFEST,
+    load_json,
+    required_keys_present,
+    sha256_json,
+    uids_for_split,
+)
+from scripts.bench.officeqa.litellm_usage import (
+    aggregate_spend_logs_by_uid,
+    merge_usage_into_results,
+)
+
+ROOT = Path(__file__).resolve().parents[1]
+EXAMPLES = ROOT / "benchmarks" / "officeqa" / "examples"
+
+
+def test_skillopt_split_counts_and_union_match_full():
+    split = load_json(SPLIT_MANIFEST)
+    full = load_json(FULL_MANIFEST)
+
+    assert split["counts"] == {"train": 50, "val": 24, "test": 172}
+    assert len(split["splits"]["train"]) == 50
+    assert len(split["splits"]["val"]) == 24
+    assert len(split["splits"]["test"]) == 172
+
+    split_uids = set(uids_for_split("full", manifest=split))
+    full_uids = {sample["uid"] for sample in full["samples"]}
+    assert split_uids == full_uids
+    assert len(split_uids) == 246
+
+    difficulty = {sample["uid"]: sample["difficulty"] for sample in full["samples"]}
+    for part in ("train", "val", "test"):
+        for item in split["splits"][part]:
+            assert set(item) == {"uid", "difficulty"}
+            assert item["difficulty"] == difficulty[item["uid"]]
+
+    assert sha256_json(split["splits"]) == split["splits_sha256"]
+
+
+def test_example_contracts_have_required_fields():
+    run_config = load_json(EXAMPLES / "run_config.example.json")
+    train = load_json(EXAMPLES / "train_provenance.example.json")
+    result = load_json(EXAMPLES / "result_record.example.json")
+    summary = load_json(EXAMPLES / "summary.example.json")
+
+    assert not required_keys_present(
+        run_config,
+        [
+            "schema_version",
+            "run_id",
+            "phase",
+            "algo",
+            "split_manifest",
+            "split_name",
+            "full_manifest",
+            "model",
+            "harness",
+            "scorer",
+        ],
+    )
+    assert not required_keys_present(
+        train,
+        [
+            "schema_version",
+            "run_id",
+            "algo",
+            "split_manifest",
+            "merge_val_into_train",
+            "skill_sha256",
+        ],
+    )
+    assert not required_keys_present(
+        result,
+        ["schema_version", "run_id", "uid", "status"],
+    )
+    assert not required_keys_present(
+        summary,
+        [
+            "schema_version",
+            "run_id",
+            "n_total",
+            "n_pass",
+            "accuracy",
+            "status_counts",
+        ],
+    )
+    assert run_config["split_name"] == "test"
+    assert train["merge_val_into_train"] is True
+
+
+def test_litellm_usage_aggregate_and_merge():
+    logs = [
+        {
+            "request_id": "r1",
+            "prompt_tokens": 10,
+            "completion_tokens": 5,
+            "total_tokens": 15,
+            "spend": 0.01,
+            "metadata": {"run_id": "demo", "uid": "UID0002"},
+        },
+        {
+            "request_id": "r2",
+            "prompt_tokens": 3,
+            "completion_tokens": 2,
+            "total_tokens": 5,
+            "spend": 0.002,
+            "metadata": {"run_id": "demo", "uid": "UID0002"},
+        },
+        {
+            "request_id": "other",
+            "prompt_tokens": 9,
+            "completion_tokens": 1,
+            "total_tokens": 10,
+            "spend": 0.1,
+            "metadata": {"run_id": "other-run", "uid": "UID0002"},
+        },
+    ]
+    by_uid = aggregate_spend_logs_by_uid(logs, run_id="demo")
+    assert by_uid["UID0002"]["input_tokens"] == 13
+    assert by_uid["UID0002"]["output_tokens"] == 7
+    assert abs(by_uid["UID0002"]["cost_usd"] - 0.012) < 1e-9
+    assert by_uid["UID0002"]["request_ids"] == ["r1", "r2"]
+
+    results = [{"uid": "UID0002", "status": "pass", "usage": {"source": "missing"}}]
+    merged = merge_usage_into_results(results, by_uid)
+    assert merged[0]["usage"]["source"] == "litellm"
+    assert merged[0]["usage"]["total_tokens"] == 20

--- a/tests/test_officeqa_contracts.py
+++ b/tests/test_officeqa_contracts.py
@@ -1,8 +1,7 @@
-"""SkillOpt 划分与实验约定文件的测试。"""
+"""SkillOpt 数据划分与实验规范测试。"""
 
 from __future__ import annotations
 
-import json
 from pathlib import Path
 
 from scripts.bench.officeqa.contracts import (


### PR DESCRIPTION
## 概述

在 OfficeQA Full 246 题公开名单与评测脚本的基础上，本次提交补充了以下内容：
- 和 SkillOpt 保持一致的训练集、验证集与测试集划分名单（50 / 24 / 172）
- 每次实验需要记录的配置、过程和结果说明
- 运行配置、训练来源、逐题明细、最终汇总的 JSON 格式规范与填写示例
- 可选支持：从 LiteLLM 代理日志中补充 token 用量和费用统计

本 PR 不执行真实跑分，不改动核心训练代码，也不提交受保护的题目、答案或模型轨迹。

## 做题环境与公平对比说明

为了保证 xskill 和 SkillOpt 对比的公平性，对实验环境做如下约定：

1. 正式评测统一环境
在测试集（172 题）上对比最终成绩时，双方均在相同的 Claude Code 原生环境（安装技能并通过 Skill 工具调用）中运行，使用同一份文档语料、同一版评分代码、同一个做题模型，并以训练完成后的冻结技能做最终测试。

2. 训练做题与改写技能分工
SkillOpt 训练包含两个环节：
- 做题环节（target）：拿着技能去读文档并回答问题。
- 改写技能环节（optimizer）：根据做题结果分析错误并修改技能说明。这步使用标准 Chat 接口即可，不直接参与做题。

3. 为什么常见配置是「训练用 Chat 接口，评测用 Claude Code」
SkillOpt 论文在主表中对不同环境分别做了测试，同时也验证了跨环境迁移：在基础环境中训练出的技能，直接迁移到 Claude Code 中使用，效果往往很好。
在实际实验中，如果训练阶段就使用能力较强且工具完整的 Claude Code 环境，模型在验证集上的得分容易偏高，导致门禁筛选过于严格、错误反馈减少，技能反而难以持续改进。因此，采用「标准 Chat 接口训练 + Claude Code 原生评测」是合理且更稳定的做法。如果需要做严格同环境的对照实验，可以在记录中明确注明训练和评测具体使用的环境。

## 每次实验需要记录的信息

一次实验对应「一个算法版本 + 一个做题模型 + 一次训练或评测」。更换模型或修改算法均视作独立实验。

1. 运行前（写入 run_config.json）
- 评测范围：具体跑哪一部分（如测试集 172 题），使用哪份划分文件
- 做题模型名称（每次实验单一模型，多模型分别开跑）
- 做题环境：明确记录所使用的环境（如 Claude Code 原生技能环境）与工具列表
- 技能与代码版本：技能文件的 SHA-256 哈希值、代码 commit 或镜像版本
- 语料与评分：语料树哈希、评分脚本 commit 与数值容差
- 运行参数：超时时间、并发数、最大工具轮数、重试策略、随机种子，以及是否配置了 LiteLLM

2. 训练过程（如有训练，写入 train_provenance.json）
- 训练样本范围：记录实际参与训练的题号哈希（train_uids_sha256），用于核验是否包含了验证集
- 数据使用方式：验证集是否合并入训练集，门禁筛选使用了哪部分数据
- 模块配置：改写技能使用的后端（如 openai_chat）与做题使用的环境（如 claude_code_native_skills）
- 产出技能：训练完成并冻结的技能文件 SHA-256 哈希值

3. 逐题明细（写入 results.jsonl，每题一行）
- 题号 UID、最终状态（pass、fail、timeout、invalid 等）
- 是否正确、耗时、重试次数、消耗的 token（输入、输出、缓存）与估算费用
- 超时处理：记录为 timeout，在计算准确率时与 fail 同样计为未通过（准确率 = pass 数量 / 总题数）

4. 最终汇总（写入 summary.json）
- 总题数、通过题数、整体准确率以及按难度（easy 与 hard）分别统计的准确率
- 各状态数量统计、合计 token 与总费用
- 关联配置、结果明细、技能包及划分文件的哈希值，确保结果可追溯

## 本 PR 包含的文件及作用

1. 说明文档
- `benchmarks/officeqa/what-these-files-are.md`：详细的通俗说明，包含实验记录清单、字段含义及环境对比说明。
- `benchmarks/officeqa/README.md`：补充 SkillOpt 划分用法、多模型测试建议与规范说明。
- `benchmarks/officeqa/artifacts/README.md` 与 `.gitignore`：说明本地实验产物的存放路径，避免将包含具体题目答案的真实结果误提交到 Git。

2. 数据划分名单
- `benchmarks/officeqa/manifests/officeqa_skillopt_id_split.json`：按 SkillOpt 公开划分整理的 50 / 24 / 172 题号列表，只包含题号和难度，不含题目与答案正文。

3. 格式规范与示例
- `benchmarks/officeqa/schemas/`：运行配置（run_config）、训练来源（train_provenance）、逐题结果（result_record）和汇总结果（summary）的 JSON 格式规范。
- `benchmarks/officeqa/examples/`：上述格式的填写示例（均为演示用虚拟数据）。

4. 工具代码与测试
- `scripts/bench/officeqa/contracts.py`：读取划分名单与校验题号的工具函数。
- `scripts/bench/officeqa/litellm_usage.py`：可选工具，用于从 LiteLLM 代理的日志中提取 token 和费用并回填到结果中。
- `tests/test_officeqa_contracts.py`：离线单元测试，校验划分完整性与格式规范。

## 非目标
- 不执行付费大模型全量测试，不提交数据集题目与答案。
- 本 PR 侧重规范与数据名单对齐，暂不修改现有训练主程序代码。
- LiteLLM 仅作为基准测试用量统计的可选组件，不侵入核心系统逻辑。

## 验证情况
- 运行单元测试通过：`python3.11 -m pytest tests/test_officeqa_contracts.py tests/test_officeqa_manifest.py -q`
- 已核对 SkillOpt 划分名单与上游公开数据 SHA-256 完全一致。

## 关联 Issue
- 推进 #262
- 基于 #309 与 feat/officeqa-full-runner 分支
- 替代 #395