### PR TITLE
test(tasks): add privacy-safe Codex-history Task linker replay

### DIFF
--- a/scripts/bench/task_graph_replay/README.md
+++ b/scripts/bench/task_graph_replay/README.md
@@ -30,6 +30,14 @@ Task grouping 通过 contingency table 线性累计，confirmed Task 的 gold �
 
 `linker_structure_v1.json` 是覆盖 A→B→A、跨 Session 显式/隐式延续、相似负例、新目标、重试、纠正和多 Skill Atom 的小规模合成结构 pilot；它用于锁定指标、风险和生产 linker 行为，不替代后续 50–100 个经人工复核的代表性离线样本。
 
+`codex_history_pilot_v1.json` 是从本机 Codex 对话中人工筛选后进行语义改写的隐私安全 pilot。它保留重复请求、短上下文跟进、“进一步推进”和显式“继续”等真实表达形态，但不包含原始 rollout、绝对路径、账号、凭据或工具输出。运行：
+
+```bash
+python -m scripts.bench.task_graph_replay.evaluate_linker scripts/bench/task_graph_replay/fixtures/codex_history_pilot_v1.json
+```
+
+该 pilot 只有 13 个单人复核 Atom，且 user turn 到 Atom intent 经人工归一化；它用于把真实对话中 rules-only 的漏合并风险变成可重复回归信号，不是正式线上质量结论，也不能替代双人标注、分歧仲裁和 held-out 数据。
+
 ## Fixture 契约
 
 根对象包含版本号、指标配置、运行清单和多个脱敏 case。

--- a/scripts/bench/task_graph_replay/fixtures/codex_history_pilot_v1.json
+++ b/scripts/bench/task_graph_replay/fixtures/codex_history_pilot_v1.json
@@ -1,0 +1,181 @@
+{
+  "schema_version": 1,
+  "suite_id": "privacy-safe-codex-history-pilot-v1",
+  "run_manifest": {
+    "repository_revision": "c7be097",
+    "generated_at": "2026-08-31T14:00:00Z",
+    "fixture_kind": "privacy-safe-local-codex-pilot",
+    "source_note": "Semantic paraphrases of locally reviewed Codex user turns; no raw rollout, path, credential, or tool output is included."
+  },
+  "linker_config": {
+    "top_k": 8,
+    "recent_k": 6,
+    "posting_cap": 64
+  },
+  "cases": [
+    {
+      "case_id": "codex-maintenance-followup",
+      "sessions": [
+        {
+          "source_scope_id": "source-local-codex",
+          "traj_id": "traj-maintenance-followup",
+          "atoms": [
+            {
+              "atom_id": "atom-maintenance-prep",
+              "intent": "持续维护并迭代工具项目，完成本地开发准备",
+              "summary": "同步项目并建立后续维护所需的本地环境",
+              "raw_segment": "## User\n持续维护并迭代工具项目，先完成基本准备。\n",
+              "skills": []
+            },
+            {
+              "atom_id": "atom-maintainer-audit",
+              "intent": "核对维护者在远端仓库的全部进行中工作",
+              "summary": "检查维护者当前的 Issue、PR 和分支状态",
+              "raw_segment": "## User\n先核对维护者的全部线上工作情况。\n",
+              "skills": []
+            },
+            {
+              "atom_id": "atom-linker-question-1",
+              "intent": "确认 Atom 到 Logical Task 是否依靠规则并检查非 mock 测试",
+              "summary": "调查 Task linker 的实现与真实测试覆盖",
+              "raw_segment": "## User\n当前 Atom 到 Logical Task 依靠规则吗？有非 mock 的效果测试吗？\n",
+              "skills": []
+            },
+            {
+              "atom_id": "atom-linker-question-2",
+              "intent": "确认 Atom 到 Logical Task 是否依靠规则并检查非 mock 测试",
+              "summary": "再次确认 Task linker 的实现与真实测试覆盖",
+              "raw_segment": "## User\n当前 Atom 到 Logical Task 依靠规则吗？有非 mock 的效果测试吗？\n",
+              "skills": []
+            },
+            {
+              "atom_id": "atom-linker-history-eval",
+              "intent": "使用本机 Codex 历史验证 Atom 到 Logical Task 效果并设计 LLM 增强",
+              "summary": "延续 Task linker 调查，增加真实回放和 LLM 判别方案",
+              "raw_segment": "## User\n可以使用本机 Codex 历史验证效果吗？后续还需要增加 LLM 推理能力。\n",
+              "skills": []
+            }
+          ]
+        }
+      ],
+      "gold_memberships": [
+        {"atom_id": "atom-maintenance-prep", "task_id": "task-maintenance-prep"},
+        {"atom_id": "atom-maintainer-audit", "task_id": "task-maintainer-audit"},
+        {"atom_id": "atom-linker-question-1", "task_id": "task-linker-evaluation"},
+        {"atom_id": "atom-linker-question-2", "task_id": "task-linker-evaluation"},
+        {"atom_id": "atom-linker-history-eval", "task_id": "task-linker-evaluation"}
+      ],
+      "expected_attempt_count": 3,
+      "expected_attempt_relations": []
+    },
+    {
+      "case_id": "codex-main-promotion-followup",
+      "sessions": [
+        {
+          "source_scope_id": "source-local-codex",
+          "traj_id": "traj-main-promotion",
+          "atoms": [
+            {
+              "atom_id": "atom-promote-1",
+              "intent": "进一步推进项目并最终合入 main 分支",
+              "summary": "继续现有实现并准备合入主分支",
+              "raw_segment": "## User\n进一步推进，这个最终要合入 main 分支。\n",
+              "skills": []
+            },
+            {
+              "atom_id": "atom-promote-2",
+              "intent": "进一步推进项目并最终合入 main 分支",
+              "summary": "继续现有实现并准备合入主分支",
+              "raw_segment": "## User\n进一步推进，最终都要合入主分支。\n",
+              "skills": []
+            },
+            {
+              "atom_id": "atom-promote-3",
+              "intent": "进一步推进项目并最终合入 main 分支",
+              "summary": "继续现有实现并准备合入主分支",
+              "raw_segment": "## User\n进一步推进，最终都要合入主分支。\n",
+              "skills": []
+            },
+            {
+              "atom_id": "atom-promote-optimize",
+              "intent": "持续推进并优化当前项目",
+              "summary": "在同一交付目标下继续优化",
+              "raw_segment": "## User\n持续化推进和优化。\n",
+              "skills": []
+            }
+          ]
+        }
+      ],
+      "gold_memberships": [
+        {"atom_id": "atom-promote-1", "task_id": "task-project-promotion"},
+        {"atom_id": "atom-promote-2", "task_id": "task-project-promotion"},
+        {"atom_id": "atom-promote-3", "task_id": "task-project-promotion"},
+        {"atom_id": "atom-promote-optimize", "task_id": "task-project-promotion"}
+      ],
+      "expected_attempt_count": 1,
+      "expected_attempt_relations": []
+    },
+    {
+      "case_id": "codex-short-contextual-followup",
+      "sessions": [
+        {
+          "source_scope_id": "source-local-codex",
+          "traj_id": "traj-read-project",
+          "atoms": [
+            {
+              "atom_id": "atom-read-project",
+              "intent": "阅读当前项目",
+              "summary": "检查项目结构和实现",
+              "raw_segment": "## User\n阅读当前项目。\n",
+              "skills": []
+            },
+            {
+              "atom_id": "atom-understand-project",
+              "intent": "阅读并理解当前项目",
+              "summary": "继续检查项目结构并形成整体理解",
+              "raw_segment": "## User\n阅读和理解当前项目。\n",
+              "skills": []
+            }
+          ]
+        }
+      ],
+      "gold_memberships": [
+        {"atom_id": "atom-read-project", "task_id": "task-read-project"},
+        {"atom_id": "atom-understand-project", "task_id": "task-read-project"}
+      ],
+      "expected_attempt_count": 1,
+      "expected_attempt_relations": []
+    },
+    {
+      "case_id": "codex-explicit-frontend-continuation",
+      "sessions": [
+        {
+          "source_scope_id": "source-local-codex",
+          "traj_id": "traj-frontend-continuation",
+          "atoms": [
+            {
+              "atom_id": "atom-frontend-1",
+              "intent": "继续推进修改并参照既有项目重构前端",
+              "summary": "延续当前修改并改善前端实现",
+              "raw_segment": "## User\n继续推进修改，并参照既有项目重构前端。\n",
+              "skills": []
+            },
+            {
+              "atom_id": "atom-frontend-2",
+              "intent": "继续推进修改并参照既有项目重构前端",
+              "summary": "延续当前修改并改善前端实现",
+              "raw_segment": "## User\n继续推进修改，并参照既有项目重构前端。\n",
+              "skills": []
+            }
+          ]
+        }
+      ],
+      "gold_memberships": [
+        {"atom_id": "atom-frontend-1", "task_id": "task-frontend-redesign"},
+        {"atom_id": "atom-frontend-2", "task_id": "task-frontend-redesign"}
+      ],
+      "expected_attempt_count": 1,
+      "expected_attempt_relations": []
+    }
+  ]
+}

--- a/tests/test_task_graph_replay.py
+++ b/tests/test_task_graph_replay.py
@@ -3,6 +3,7 @@
 from __future__ import annotations
 
 import json
+import re
 from copy import deepcopy
 from pathlib import Path
 
@@ -30,6 +31,7 @@ BASELINE_PATH = FIXTURE_DIR / "baseline_v1.json"
 REPORT_PATH = FIXTURE_DIR / "baseline_v1.report.json"
 LINKER_FIXTURE_PATH = FIXTURE_DIR / "linker_structure_v1.json"
 LINKER_REPORT_PATH = FIXTURE_DIR / "linker_structure_v1.report.json"
+CODEX_HISTORY_FIXTURE_PATH = FIXTURE_DIR / "codex_history_pilot_v1.json"
 
 
 pytestmark = pytest.mark.algorithm_replay
@@ -300,6 +302,43 @@ def test_production_linker_beats_session_and_atom_grouping_baselines():
     assert metrics["proposals"]["max_proposals_per_atom"] <= 8
     assert metrics["attempts"]["exact_case_rate"] == 1.0
     assert metrics["attempt_relations"]["f1"] == 1.0
+
+
+def test_privacy_safe_codex_history_pilot_records_real_conversation_gap():
+    suite = evaluate_linker.load_suite(CODEX_HISTORY_FIXTURE_PATH)
+    report = evaluate_linker.evaluate_suite(suite)
+    metrics = report["metrics"]
+    task_graph = metrics["grouping"]["task_graph"]
+
+    assert report["run_manifest"]["fixture_kind"] == ("privacy-safe-local-codex-pilot")
+    assert sum(case["atom_count"] for case in report["cases"]) == 13
+    assert sum(case["gold_task_count"] for case in report["cases"]) == 6
+    assert task_graph["pairwise"] == {
+        "true_positive": 1,
+        "false_positive": 0,
+        "false_negative": 10,
+        "precision": 1.0,
+        "recall": 0.090909,
+        "f1": 0.166667,
+    }
+    assert task_graph["b3"]["f1"] == 0.7
+    assert metrics["proposals"]["recoverable_recall"] == 0.5
+    assert metrics["attempts"]["exact_case_rate"] == 0.25
+
+
+def test_privacy_safe_codex_history_pilot_contains_no_raw_local_identifiers():
+    payload = CODEX_HISTORY_FIXTURE_PATH.read_text(encoding="utf-8")
+
+    for forbidden in (
+        "/home/",
+        ".codex/",
+        "github.com",
+        "tiammomo",
+        "api_key",
+        "Bearer ",
+    ):
+        assert forbidden not in payload
+    assert re.search(r"\bsk-[A-Za-z0-9_-]{8,}", payload) is None
 
 
 def test_linker_structure_keeps_a_b_a_and_cross_session_uncertainty_visible():

--- a/tests/test_task_graph_replay.py
+++ b/tests/test_task_graph_replay.py
@@ -331,13 +331,36 @@ def test_privacy_safe_codex_history_pilot_contains_no_raw_local_identifiers():
 
     for forbidden in (
         "/home/",
+        "/Users/",
         ".codex/",
         "github.com",
         "tiammomo",
         "api_key",
         "Bearer ",
+        "DESKTOP-",
+        "password",
     ):
         assert forbidden not in payload
+    assert re.search(r"\b[A-Za-z]:\\", payload) is None
+    assert re.search(r"[\w.%+-]+@[\w.-]+\.[A-Za-z]{2,}", payload) is None
+    assert re.search(r"\bc\d{7,}\b", payload, re.IGNORECASE) is None
+    assert (
+        re.search(
+            r"\b(?:10\.\d{1,3}\.\d{1,3}\.\d{1,3}"
+            r"|192\.168\.\d{1,3}\.\d{1,3}"
+            r"|172\.(?:1[6-9]|2\d|3[0-1])\.\d{1,3}\.\d{1,3})\b",
+            payload,
+        )
+        is None
+    )
+    assert (
+        re.search(
+            r"\bclient(?:_id)?\s*[`:=\s]+\s*`?[a-f0-9]{16,}`?",
+            payload,
+            re.IGNORECASE,
+        )
+        is None
+    )
     assert re.search(r"\bsk-[A-Za-z0-9_-]{8,}", payload) is None
 
 


### PR DESCRIPTION
2026-09-12: Superseded by #422. Please review and continue the work there. The replacement preserves the original commit history, includes current main and passed fresh local verification. Its branch meets the publication tool's author-prefix requirement. This PR is closed to keep review in one place; Issue #397 remains open until the replacement is merged.

The notes below describe the previous state of this old branch.

---

<!-- branch-refresh-status-20260909 -->
2026-09-09 更新：已在独立本地分支用 merge 同步 main `7447a23`，保留已发布历史；完整单元/集成测试 2894 项通过、11 项跳过，Ruff、所选格式检查及 wheel/sdist 构建通过。旧 scheduler 断言失败在这个本地组合中已消除。

**这次分支同步尚未推送到本 PR，线上 CI 仍对应原提交。** 现有分支名不满足当前 RepoSteward 接管入口要求的账号前缀；接管被拒绝。没有改名另开重复 PR，也没有绕过 submit 推送。

验证结果不代表真实 Skill 产出已验证；生产行为改动仍须遵守 [maintainer 的实际产出要求](https://github.com/SkillNerds/xskill/issues/407#issuecomment-5580309058)。

---

## Summary

Add a small privacy-safe replay pilot derived from locally reviewed Codex conversations. It makes the rules-only Task linker miss-merge risk reproducible without publishing raw rollout data or local identifiers.

## Changes

- add a semantically paraphrased fixture with 13 Atoms and 6 gold Logical Tasks
- pin the observed rules-only pairwise and B³ metrics as regression evidence
- reject Unix and Windows paths, account/repository markers, emails, employee IDs, private IPs, desktop names, labelled client IDs, API-key fields, and secret-like patterns
- align the privacy guard with the repository Issue redaction patterns
- document the pilot source, privacy boundary, and single-review/limited-scale caveat

## Test plan

- `python -m pytest tests/test_task_graph_replay.py -q` — 37 passed
- `python -m scripts.bench.task_graph_replay.evaluate_linker scripts/bench/task_graph_replay/fixtures/codex_history_pilot_v1.json` — pairwise F1 0.166667, B³ F1 0.7, report SHA-256 `c95fe4ee1dea11c5e63a57ecec17c9b00861b15708799f1bbb8a6e58d2069959`
- `ruff check tests/test_task_graph_replay.py`
- `ruff format --check tests/test_task_graph_replay.py`
- `git diff --check`

## Current CI status

- The current UT/IT failures reproduce the two-test regression already present on `main@bac932c`; see #403 and the focused fix in #404.
- Branch-specific focused tests pass. Re-run or refresh the merge-ref after #404 lands.

## Linked issues

Closes #397

Follow-up to #325 and #378.
Refs #379.

Depends on #404
