### PR TITLE
test(server): 恢复 kernel-host 调度器契约

### DIFF
--- a/tests/test_server_no_llm_fallback.py
+++ b/tests/test_server_no_llm_fallback.py
@@ -128,10 +128,14 @@ def test_standalone_worker_commands_share_resolved_ecosystem_home(
         str(ecosystem_home.resolve()),
     ]
     assert set(records_by_name) == {
-        "agent-worker", "ecosystem-ingest", "ux-scores-sync",
+        "agent-worker", "ecosystem-ingest", "kernel-host", "ux-scores-sync",
     }
     assert records_by_name["agent-worker"].command[-2:] == expected_home_arguments
     assert records_by_name["agent-worker"].keyword_arguments["persistent"] is True
+    kernel_command = records_by_name["kernel-host"].command
+    assert kernel_command[-1] == "kernel-host"
+    assert "--server" not in kernel_command
+    assert records_by_name["kernel-host"].keyword_arguments["persistent"] is True
     ingest_command = records_by_name["ecosystem-ingest"].command
     home_argument_index = ingest_command.index("--home")
     assert ingest_command[
@@ -244,12 +248,15 @@ def test_team_server_schedules_only_server_watcher(
         record.name: record for record in scheduler_records
     }
     assert set(records_by_name) == {
-        "recommend-heavy", "agent-worker", "ux-scores-sync",
+        "recommend-heavy", "agent-worker", "kernel-host", "ux-scores-sync",
     }
     watcher_command = records_by_name["agent-worker"].command
     assert watcher_command[-1] == "--server"
     assert "--home" not in watcher_command
     assert records_by_name["agent-worker"].keyword_arguments["persistent"] is True
+    kernel_command = records_by_name["kernel-host"].command
+    assert kernel_command[-2:] == ["kernel-host", "--server"]
+    assert records_by_name["kernel-host"].keyword_arguments["persistent"] is True
     assert "persistent" not in records_by_name["recommend-heavy"].keyword_arguments
     assert records_by_name["recommend-heavy"].command[-1] == "recommend-heavy"
     assert "persistent" not in records_by_name["ux-scores-sync"].keyword_arguments


### PR DESCRIPTION
## 摘要

修复 #364 引入持久化 `kernel-host` 调度器后，两个既有 scheduler 契约断言未同步更新导致的主分支 UT/IT 回归。

## 变更

- 将 `kernel-host` 纳入 standalone 与 team-server 调度器集合
- 验证 standalone kernel host 不携带 `--server`
- 验证 team-server kernel host 携带 `--server`
- 验证两种模式均沿用已覆盖停机检查的 persistent 生命周期

## 测试

- `python -m pytest tests/test_server_no_llm_fallback.py -q`：8 通过
- `python -m pytest tests/ --ignore=tests/e2e --ignore=tests/bdd -q -m "not nightly" --durations=25`：2806 通过、3 跳过、3 取消选择
- `ruff check tests/test_server_no_llm_fallback.py`
- `git diff --check`

## CI

GitHub Actions 必需检查已全部通过，覆盖 Python 3.9–3.12、Linux、macOS 与 Windows。PR 事件下按设计跳过 `real-llm-e2e`。

Closes #403

该回归来自 #364，并解除 #399、#400 及后续 Task Graph 分支的基线阻塞。
