### PR TITLE
feat(tasks): provide versioned bounded Task evidence bundles

### DIFF
--- a/src/xskill/tasks/evidence_bundle.py
+++ b/src/xskill/tasks/evidence_bundle.py
@@ -26,6 +26,7 @@ from xskill.tasks.models import (
 BUNDLE_SCHEMA_VERSION = 1
 ELIGIBILITY_POLICY_VERSION = "task-outcome-v1"
 LEARNING_ELIGIBILITIES = frozenset(("eligible", "ineligible", "needs_review"))
+MAX_TASK_EVIDENCE_BUNDLE_BYTES = 1024 * 1024
 _T = TypeVar("_T")
 
 
@@ -47,11 +48,16 @@ class TaskEvidenceLimits:
     attempt_relations: int = 256
     evidence_ranges: int = 512
     usage_allocations: int = 512
+    serialized_bytes: int = MAX_TASK_EVIDENCE_BUNDLE_BYTES
 
     def __post_init__(self) -> None:
         for field_name, value in vars(self).items():
             if isinstance(value, bool) or not isinstance(value, int) or value <= 0:
                 raise ValueError(f"{field_name} limit must be a positive integer")
+        if self.serialized_bytes > MAX_TASK_EVIDENCE_BUNDLE_BYTES:
+            raise ValueError(
+                "serialized_bytes cannot exceed the Task evidence hard bound"
+            )
 
 
 def _canonical_json(value: Any) -> bytes:
@@ -70,6 +76,23 @@ def _fingerprint(value: Any) -> str:
 
 def _ordered(values: Iterable[_T], key: Callable[[_T], Any]) -> tuple[_T, ...]:
     return tuple(sorted(values, key=key))
+
+
+def _bounded_ordered(
+    values: Iterable[_T],
+    *,
+    key: Callable[[_T], Any],
+    maximum: int,
+    field_name: str,
+) -> tuple[_T, ...]:
+    bounded: list[_T] = []
+    for value in values:
+        bounded.append(value)
+        if len(bounded) > maximum:
+            raise TaskEvidenceBundleError(
+                f"Task evidence {field_name} exceeds bound: {len(bounded)}>{maximum}"
+            )
+    return tuple(sorted(bounded, key=key))
 
 
 def _strict_object(value: dict[str, Any], expected: set[str]) -> None:
@@ -247,52 +270,96 @@ class TaskEvidenceBundle:
             "eligibility_policy_version": self.eligibility_policy_version,
         }
 
+    def _task_evidence_payload(self) -> dict[str, Any]:
+        """Return generation-independent Task evidence for dirty detection."""
+        payload = self._payload()
+        for field_name in (
+            "generation_id",
+            "source_revision",
+            "created_at",
+            "generator_fingerprint",
+        ):
+            payload.pop(field_name)
+        return payload
+
     @property
     def bundle_fingerprint(self) -> str:
         return _fingerprint(self._payload())
 
+    @property
+    def task_evidence_fingerprint(self) -> str:
+        return _fingerprint(self._task_evidence_payload())
+
     def to_dict(self) -> dict[str, Any]:
-        return {**self._payload(), "bundle_fingerprint": self.bundle_fingerprint}
+        return {
+            **self._payload(),
+            "bundle_fingerprint": self.bundle_fingerprint,
+            "task_evidence_fingerprint": self.task_evidence_fingerprint,
+        }
 
     @classmethod
     def from_dict(cls, value: dict[str, Any]) -> TaskEvidenceBundle:
         if not isinstance(value, dict):
             raise TaskEvidenceBundleError("TaskEvidenceBundle must be an object")
-        expected = set(cls.__dataclass_fields__) | {"bundle_fingerprint"}
+        expected = set(cls.__dataclass_fields__) | {
+            "bundle_fingerprint",
+            "task_evidence_fingerprint",
+        }
         _strict_object(value, expected)
-        bundle = cls(
-            schema_version=value["schema_version"],
-            generation_id=value["generation_id"],
-            tenant_id=value["tenant_id"],
-            task_scope_id=value["task_scope_id"],
-            source_revision=value["source_revision"],
-            created_at=value["created_at"],
-            generator_fingerprint=value["generator_fingerprint"],
-            task=LogicalTask.from_dict(value["task"]),
-            confirmed_memberships=tuple(
-                TaskAtomMembership.from_dict(item)
-                for item in value["confirmed_memberships"]
-            ),
-            review_memberships=tuple(
-                TaskAtomMembership.from_dict(item)
-                for item in value["review_memberships"]
-            ),
-            task_relations=tuple(
-                TaskRelation.from_dict(item) for item in value["task_relations"]
-            ),
-            attempts=tuple(TaskAttempt.from_dict(item) for item in value["attempts"]),
-            attempt_relations=tuple(
-                AttemptRelation.from_dict(item) for item in value["attempt_relations"]
-            ),
-            usage_allocations=tuple(
-                UsageAllocation.from_dict(item) for item in value["usage_allocations"]
-            ),
-            learning_eligibility=value["learning_eligibility"],
-            eligibility_reasons=tuple(value["eligibility_reasons"]),
-            eligibility_policy_version=value["eligibility_policy_version"],
-        )
+        try:
+            serialized_size = len(_canonical_json(value))
+            _ensure(
+                serialized_size <= MAX_TASK_EVIDENCE_BUNDLE_BYTES,
+                "Task evidence serialized_bytes exceeds hard bound: "
+                f"{serialized_size}>{MAX_TASK_EVIDENCE_BUNDLE_BYTES}",
+            )
+            bundle = cls(
+                schema_version=value["schema_version"],
+                generation_id=value["generation_id"],
+                tenant_id=value["tenant_id"],
+                task_scope_id=value["task_scope_id"],
+                source_revision=value["source_revision"],
+                created_at=value["created_at"],
+                generator_fingerprint=value["generator_fingerprint"],
+                task=LogicalTask.from_dict(value["task"]),
+                confirmed_memberships=tuple(
+                    TaskAtomMembership.from_dict(item)
+                    for item in value["confirmed_memberships"]
+                ),
+                review_memberships=tuple(
+                    TaskAtomMembership.from_dict(item)
+                    for item in value["review_memberships"]
+                ),
+                task_relations=tuple(
+                    TaskRelation.from_dict(item) for item in value["task_relations"]
+                ),
+                attempts=tuple(
+                    TaskAttempt.from_dict(item) for item in value["attempts"]
+                ),
+                attempt_relations=tuple(
+                    AttemptRelation.from_dict(item)
+                    for item in value["attempt_relations"]
+                ),
+                usage_allocations=tuple(
+                    UsageAllocation.from_dict(item)
+                    for item in value["usage_allocations"]
+                ),
+                learning_eligibility=value["learning_eligibility"],
+                eligibility_reasons=tuple(value["eligibility_reasons"]),
+                eligibility_policy_version=value["eligibility_policy_version"],
+            )
+        except TaskEvidenceBundleError:
+            raise
+        except (KeyError, TypeError, ValueError) as exc:
+            raise TaskEvidenceBundleError(
+                f"invalid nested TaskEvidenceBundle value: {exc}"
+            ) from exc
         if value["bundle_fingerprint"] != bundle.bundle_fingerprint:
             raise TaskEvidenceBundleError("TaskEvidenceBundle fingerprint mismatch")
+        if value["task_evidence_fingerprint"] != bundle.task_evidence_fingerprint:
+            raise TaskEvidenceBundleError(
+                "TaskEvidenceBundle task evidence fingerprint mismatch"
+            )
         return bundle
 
 
@@ -312,7 +379,7 @@ def build_task_evidence_bundle(
     if task.tombstoned:
         raise TaskEvidenceBundleError("tombstoned Task cannot become learning evidence")
 
-    confirmed = _ordered(
+    confirmed = _bounded_ordered(
         (
             item
             for item in generation.memberships
@@ -321,9 +388,11 @@ def build_task_evidence_bundle(
             and item.decision == "confirmed"
             and not item.stale
         ),
-        lambda item: item.atom_ref.key,
+        key=lambda item: item.atom_ref.key,
+        maximum=limit.memberships,
+        field_name="memberships",
     )
-    review = _ordered(
+    review = _bounded_ordered(
         (
             item
             for item in generation.memberships
@@ -331,18 +400,36 @@ def build_task_evidence_bundle(
             and item.decision in {"proposed", "needs_review"}
             and not item.stale
         ),
-        lambda item: (item.atom_ref.key, item.membership_id),
+        key=lambda item: (item.atom_ref.key, item.membership_id),
+        maximum=limit.review_memberships,
+        field_name="review_memberships",
     )
-    task_relations = _ordered(
+    task_relations = _bounded_ordered(
         (
             item
             for item in generation.relations
             if task_id in {item.from_task_id, item.to_task_id} and not item.stale
         ),
-        lambda item: item.relation_id,
+        key=lambda item: item.relation_id,
+        maximum=limit.task_relations,
+        field_name="task_relations",
     )
-    attempts = _ordered(
-        (
+    raw_attempts = _bounded_ordered(
+        (item for item in generation.attempts if item.task_id == task_id),
+        key=lambda item: (item.started_at, item.attempt_id),
+        maximum=limit.attempts,
+        field_name="attempts",
+    )
+    evidence_range_count = 0
+    attempts_list: list[TaskAttempt] = []
+    for item in raw_attempts:
+        evidence_range_count += len(item.evidence_ranges)
+        if evidence_range_count > limit.evidence_ranges:
+            raise TaskEvidenceBundleError(
+                "Task evidence evidence_ranges exceeds bound: "
+                f"{evidence_range_count}>{limit.evidence_ranges}"
+            )
+        attempts_list.append(
             replace(
                 item,
                 evidence_ranges=_ordered(
@@ -350,41 +437,27 @@ def build_task_evidence_bundle(
                     lambda evidence: evidence.evidence_id,
                 ),
             )
-            for item in generation.attempts
-            if item.task_id == task_id
-        ),
-        lambda item: (item.started_at, item.attempt_id),
-    )
+        )
+    attempts = tuple(attempts_list)
     attempt_ids = {item.attempt_id for item in attempts}
-    attempt_relations = _ordered(
+    attempt_relations = _bounded_ordered(
         (
             item
             for item in generation.attempt_relations
             if item.from_attempt_id in attempt_ids and item.to_attempt_id in attempt_ids
         ),
-        lambda item: item.relation_id,
+        key=lambda item: item.relation_id,
+        maximum=limit.attempt_relations,
+        field_name="attempt_relations",
     )
-    usage = _ordered(
+    usage = _bounded_ordered(
         (item for item in generation.usage_allocations if item.task_id == task_id),
-        lambda item: item.allocation_id,
+        key=lambda item: item.allocation_id,
+        maximum=limit.usage_allocations,
+        field_name="usage_allocations",
     )
-    counts = {
-        "memberships": len(confirmed),
-        "review_memberships": len(review),
-        "task_relations": len(task_relations),
-        "attempts": len(attempts),
-        "attempt_relations": len(attempt_relations),
-        "evidence_ranges": sum(len(item.evidence_ranges) for item in attempts),
-        "usage_allocations": len(usage),
-    }
-    for field_name, count in counts.items():
-        maximum = getattr(limit, field_name)
-        if count > maximum:
-            raise TaskEvidenceBundleError(
-                f"Task evidence {field_name} exceeds bound: {count}>{maximum}"
-            )
     eligibility, reasons = _learning_eligibility(task, attempts, review)
-    return TaskEvidenceBundle(
+    bundle = TaskEvidenceBundle(
         generation_id=generation.generation_id,
         tenant_id=generation.tenant_id,
         task_scope_id=generation.task_scope_id,
@@ -401,3 +474,10 @@ def build_task_evidence_bundle(
         learning_eligibility=eligibility,
         eligibility_reasons=reasons,
     )
+    serialized_size = len(_canonical_json(bundle.to_dict()))
+    if serialized_size > limit.serialized_bytes:
+        raise TaskEvidenceBundleError(
+            "Task evidence serialized_bytes exceeds bound: "
+            f"{serialized_size}>{limit.serialized_bytes}"
+        )
+    return bundle

--- a/src/xskill/tasks/evidence_bundle.py
+++ b/src/xskill/tasks/evidence_bundle.py
@@ -1,0 +1,403 @@
+"""Versioned, bounded Task-grounded evidence for Skill learning.
+
+The bundle is a read contract over one immutable :class:`TaskGraphGeneration`.
+It deliberately contains references and provenance rather than trajectory text.
+Production routing and SkillEdit integration live outside this module.
+"""
+
+from __future__ import annotations
+
+import hashlib
+import json
+from collections.abc import Callable, Iterable
+from dataclasses import dataclass, replace
+from typing import Any, TypeVar
+
+from xskill.tasks.models import (
+    AttemptRelation,
+    LogicalTask,
+    TaskAtomMembership,
+    TaskAttempt,
+    TaskGraphGeneration,
+    TaskRelation,
+    UsageAllocation,
+)
+
+BUNDLE_SCHEMA_VERSION = 1
+ELIGIBILITY_POLICY_VERSION = "task-outcome-v1"
+LEARNING_ELIGIBILITIES = frozenset(("eligible", "ineligible", "needs_review"))
+_T = TypeVar("_T")
+
+
+class TaskEvidenceBundleError(ValueError):
+    """The current Task fact set cannot produce safe learning evidence."""
+
+
+def _ensure(condition: bool, message: str) -> None:
+    if not condition:
+        raise TaskEvidenceBundleError(message)
+
+
+@dataclass(frozen=True)
+class TaskEvidenceLimits:
+    memberships: int = 256
+    review_memberships: int = 256
+    task_relations: int = 256
+    attempts: int = 128
+    attempt_relations: int = 256
+    evidence_ranges: int = 512
+    usage_allocations: int = 512
+
+    def __post_init__(self) -> None:
+        for field_name, value in vars(self).items():
+            if isinstance(value, bool) or not isinstance(value, int) or value <= 0:
+                raise ValueError(f"{field_name} limit must be a positive integer")
+
+
+def _canonical_json(value: Any) -> bytes:
+    return json.dumps(
+        value,
+        ensure_ascii=False,
+        allow_nan=False,
+        sort_keys=True,
+        separators=(",", ":"),
+    ).encode("utf-8")
+
+
+def _fingerprint(value: Any) -> str:
+    return "sha256:" + hashlib.sha256(_canonical_json(value)).hexdigest()
+
+
+def _ordered(values: Iterable[_T], key: Callable[[_T], Any]) -> tuple[_T, ...]:
+    return tuple(sorted(values, key=key))
+
+
+def _strict_object(value: dict[str, Any], expected: set[str]) -> None:
+    actual = set(value)
+    if actual != expected:
+        missing = sorted(expected - actual)
+        unknown = sorted(actual - expected)
+        raise TaskEvidenceBundleError(
+            f"invalid TaskEvidenceBundle fields: missing={missing}, unknown={unknown}"
+        )
+
+
+def _learning_eligibility(
+    task: LogicalTask,
+    attempts: tuple[TaskAttempt, ...],
+    review_memberships: tuple[TaskAtomMembership, ...],
+) -> tuple[str, tuple[str, ...]]:
+    reasons: list[str] = []
+    if review_memberships:
+        reasons.append("unresolved_task_membership")
+    if task.verification in {"contradicted", "conflicted"}:
+        reasons.append(f"task_verification_{task.verification}")
+        return "ineligible", tuple(reasons)
+    if task.outcome in {"cancelled", "abandoned"}:
+        reasons.append(f"task_outcome_{task.outcome}")
+        return "ineligible", tuple(reasons)
+    if task.lifecycle != "closed" or task.outcome == "unknown":
+        reasons.append("task_not_terminal")
+    if not attempts:
+        reasons.append("no_task_attempt")
+    elif any(attempt.lifecycle != "finished" for attempt in attempts):
+        reasons.append("attempt_not_terminal")
+    if task.verification not in {"verified", "not_applicable"}:
+        reasons.append("task_outcome_not_verified")
+    if reasons:
+        return "needs_review", tuple(dict.fromkeys(reasons))
+    return "eligible", ("verified_terminal_task",)
+
+
+@dataclass(frozen=True)
+class TaskEvidenceBundle:
+    generation_id: str
+    tenant_id: str
+    task_scope_id: str
+    source_revision: str
+    created_at: str
+    generator_fingerprint: str
+    task: LogicalTask
+    confirmed_memberships: tuple[TaskAtomMembership, ...]
+    review_memberships: tuple[TaskAtomMembership, ...]
+    task_relations: tuple[TaskRelation, ...]
+    attempts: tuple[TaskAttempt, ...]
+    attempt_relations: tuple[AttemptRelation, ...]
+    usage_allocations: tuple[UsageAllocation, ...]
+    learning_eligibility: str
+    eligibility_reasons: tuple[str, ...]
+    eligibility_policy_version: str = ELIGIBILITY_POLICY_VERSION
+    schema_version: int = BUNDLE_SCHEMA_VERSION
+
+    def __post_init__(self) -> None:
+        _ensure(
+            self.schema_version == BUNDLE_SCHEMA_VERSION,
+            f"unsupported TaskEvidenceBundle schema_version={self.schema_version}",
+        )
+        for field_name in (
+            "generation_id",
+            "tenant_id",
+            "task_scope_id",
+            "source_revision",
+            "created_at",
+            "generator_fingerprint",
+            "eligibility_policy_version",
+        ):
+            value = getattr(self, field_name)
+            if not isinstance(value, str) or not value.strip():
+                raise TaskEvidenceBundleError(f"{field_name} must be non-empty")
+        _ensure(not self.task.tombstoned, "tombstoned Task is not learning evidence")
+        _ensure(bool(self.confirmed_memberships), "Task needs confirmed primary Atom")
+        _ensure(
+            self.learning_eligibility in LEARNING_ELIGIBILITIES,
+            "invalid learning_eligibility",
+        )
+        _ensure(bool(self.eligibility_reasons), "eligibility_reasons must be non-empty")
+        _ensure(
+            all(isinstance(item, str) and item for item in self.eligibility_reasons),
+            "eligibility_reasons must contain strings",
+        )
+        _ensure(
+            (self.learning_eligibility, self.eligibility_reasons)
+            == _learning_eligibility(self.task, self.attempts, self.review_memberships),
+            "learning eligibility does not match Task outcome",
+        )
+        confirmed_atoms = set()
+        for membership in self.confirmed_memberships:
+            _ensure(
+                membership.task_id == self.task.task_id
+                and membership.role == "primary"
+                and membership.decision == "confirmed"
+                and not membership.stale,
+                "learning membership must be live confirmed primary",
+            )
+            self._check_atom_scope(membership)
+            confirmed_atoms.add(membership.atom_ref.key)
+        for membership in self.review_memberships:
+            _ensure(
+                membership.task_id == self.task.task_id
+                and membership.decision in {"proposed", "needs_review"}
+                and not membership.stale,
+                "invalid review membership",
+            )
+            self._check_atom_scope(membership)
+        attempt_ids = {attempt.attempt_id for attempt in self.attempts}
+        for attempt in self.attempts:
+            _ensure(attempt.task_id == self.task.task_id, "Attempt belongs elsewhere")
+            for evidence in attempt.evidence_ranges:
+                _ensure(
+                    not evidence.stale, "stale EvidenceRange is not learning evidence"
+                )
+                _ensure(
+                    evidence.session_ref.tenant_id == self.tenant_id
+                    and evidence.session_ref.task_scope_id == self.task_scope_id,
+                    "evidence crosses TaskScope",
+                )
+                _ensure(
+                    not evidence.atom_ref or evidence.atom_ref.key in confirmed_atoms,
+                    "Attempt evidence Atom lacks confirmed primary membership",
+                )
+        for relation in self.attempt_relations:
+            _ensure(
+                relation.from_attempt_id in attempt_ids
+                and relation.to_attempt_id in attempt_ids,
+                "Attempt relation leaves the Task bundle",
+            )
+        for relation in self.task_relations:
+            _ensure(
+                self.task.task_id in {relation.from_task_id, relation.to_task_id},
+                "Task relation does not touch bundle Task",
+            )
+            _ensure(not relation.stale, "stale Task relation is not bundle evidence")
+        for allocation in self.usage_allocations:
+            _ensure(allocation.task_id == self.task.task_id, "usage belongs elsewhere")
+            _ensure(
+                not allocation.attempt_id or allocation.attempt_id in attempt_ids,
+                "usage references another Attempt",
+            )
+
+    def _check_atom_scope(self, membership: TaskAtomMembership) -> None:
+        atom_ref = membership.atom_ref
+        if (
+            atom_ref.tenant_id != self.tenant_id
+            or atom_ref.task_scope_id != self.task_scope_id
+        ):
+            raise TaskEvidenceBundleError("membership crosses TaskScope")
+
+    def _payload(self) -> dict[str, Any]:
+        return {
+            "schema_version": self.schema_version,
+            "generation_id": self.generation_id,
+            "tenant_id": self.tenant_id,
+            "task_scope_id": self.task_scope_id,
+            "source_revision": self.source_revision,
+            "created_at": self.created_at,
+            "generator_fingerprint": self.generator_fingerprint,
+            "task": self.task.to_dict(),
+            "confirmed_memberships": [
+                item.to_dict() for item in self.confirmed_memberships
+            ],
+            "review_memberships": [item.to_dict() for item in self.review_memberships],
+            "task_relations": [item.to_dict() for item in self.task_relations],
+            "attempts": [item.to_dict() for item in self.attempts],
+            "attempt_relations": [item.to_dict() for item in self.attempt_relations],
+            "usage_allocations": [item.to_dict() for item in self.usage_allocations],
+            "learning_eligibility": self.learning_eligibility,
+            "eligibility_reasons": list(self.eligibility_reasons),
+            "eligibility_policy_version": self.eligibility_policy_version,
+        }
+
+    @property
+    def bundle_fingerprint(self) -> str:
+        return _fingerprint(self._payload())
+
+    def to_dict(self) -> dict[str, Any]:
+        return {**self._payload(), "bundle_fingerprint": self.bundle_fingerprint}
+
+    @classmethod
+    def from_dict(cls, value: dict[str, Any]) -> TaskEvidenceBundle:
+        if not isinstance(value, dict):
+            raise TaskEvidenceBundleError("TaskEvidenceBundle must be an object")
+        expected = set(cls.__dataclass_fields__) | {"bundle_fingerprint"}
+        _strict_object(value, expected)
+        bundle = cls(
+            schema_version=value["schema_version"],
+            generation_id=value["generation_id"],
+            tenant_id=value["tenant_id"],
+            task_scope_id=value["task_scope_id"],
+            source_revision=value["source_revision"],
+            created_at=value["created_at"],
+            generator_fingerprint=value["generator_fingerprint"],
+            task=LogicalTask.from_dict(value["task"]),
+            confirmed_memberships=tuple(
+                TaskAtomMembership.from_dict(item)
+                for item in value["confirmed_memberships"]
+            ),
+            review_memberships=tuple(
+                TaskAtomMembership.from_dict(item)
+                for item in value["review_memberships"]
+            ),
+            task_relations=tuple(
+                TaskRelation.from_dict(item) for item in value["task_relations"]
+            ),
+            attempts=tuple(TaskAttempt.from_dict(item) for item in value["attempts"]),
+            attempt_relations=tuple(
+                AttemptRelation.from_dict(item) for item in value["attempt_relations"]
+            ),
+            usage_allocations=tuple(
+                UsageAllocation.from_dict(item) for item in value["usage_allocations"]
+            ),
+            learning_eligibility=value["learning_eligibility"],
+            eligibility_reasons=tuple(value["eligibility_reasons"]),
+            eligibility_policy_version=value["eligibility_policy_version"],
+        )
+        if value["bundle_fingerprint"] != bundle.bundle_fingerprint:
+            raise TaskEvidenceBundleError("TaskEvidenceBundle fingerprint mismatch")
+        return bundle
+
+
+def build_task_evidence_bundle(
+    generation: TaskGraphGeneration,
+    task_id: str,
+    *,
+    limits: TaskEvidenceLimits | None = None,
+) -> TaskEvidenceBundle:
+    """Build one safe learning bundle from an immutable generation."""
+    if not isinstance(task_id, str) or not task_id.strip():
+        raise TaskEvidenceBundleError("task_id must be non-empty")
+    limit = limits or TaskEvidenceLimits()
+    task = next((item for item in generation.tasks if item.task_id == task_id), None)
+    if task is None:
+        raise TaskEvidenceBundleError(f"Task not found in generation: {task_id}")
+    if task.tombstoned:
+        raise TaskEvidenceBundleError("tombstoned Task cannot become learning evidence")
+
+    confirmed = _ordered(
+        (
+            item
+            for item in generation.memberships
+            if item.task_id == task_id
+            and item.role == "primary"
+            and item.decision == "confirmed"
+            and not item.stale
+        ),
+        lambda item: item.atom_ref.key,
+    )
+    review = _ordered(
+        (
+            item
+            for item in generation.memberships
+            if item.task_id == task_id
+            and item.decision in {"proposed", "needs_review"}
+            and not item.stale
+        ),
+        lambda item: (item.atom_ref.key, item.membership_id),
+    )
+    task_relations = _ordered(
+        (
+            item
+            for item in generation.relations
+            if task_id in {item.from_task_id, item.to_task_id} and not item.stale
+        ),
+        lambda item: item.relation_id,
+    )
+    attempts = _ordered(
+        (
+            replace(
+                item,
+                evidence_ranges=_ordered(
+                    item.evidence_ranges,
+                    lambda evidence: evidence.evidence_id,
+                ),
+            )
+            for item in generation.attempts
+            if item.task_id == task_id
+        ),
+        lambda item: (item.started_at, item.attempt_id),
+    )
+    attempt_ids = {item.attempt_id for item in attempts}
+    attempt_relations = _ordered(
+        (
+            item
+            for item in generation.attempt_relations
+            if item.from_attempt_id in attempt_ids and item.to_attempt_id in attempt_ids
+        ),
+        lambda item: item.relation_id,
+    )
+    usage = _ordered(
+        (item for item in generation.usage_allocations if item.task_id == task_id),
+        lambda item: item.allocation_id,
+    )
+    counts = {
+        "memberships": len(confirmed),
+        "review_memberships": len(review),
+        "task_relations": len(task_relations),
+        "attempts": len(attempts),
+        "attempt_relations": len(attempt_relations),
+        "evidence_ranges": sum(len(item.evidence_ranges) for item in attempts),
+        "usage_allocations": len(usage),
+    }
+    for field_name, count in counts.items():
+        maximum = getattr(limit, field_name)
+        if count > maximum:
+            raise TaskEvidenceBundleError(
+                f"Task evidence {field_name} exceeds bound: {count}>{maximum}"
+            )
+    eligibility, reasons = _learning_eligibility(task, attempts, review)
+    return TaskEvidenceBundle(
+        generation_id=generation.generation_id,
+        tenant_id=generation.tenant_id,
+        task_scope_id=generation.task_scope_id,
+        source_revision=generation.source_revision,
+        created_at=generation.created_at,
+        generator_fingerprint=_fingerprint(generation.generator),
+        task=task,
+        confirmed_memberships=confirmed,
+        review_memberships=review,
+        task_relations=task_relations,
+        attempts=attempts,
+        attempt_relations=attempt_relations,
+        usage_allocations=usage,
+        learning_eligibility=eligibility,
+        eligibility_reasons=reasons,
+    )

--- a/tests/test_task_evidence_bundle.py
+++ b/tests/test_task_evidence_bundle.py
@@ -5,6 +5,7 @@ from dataclasses import replace
 import pytest
 
 from xskill.tasks.evidence_bundle import (
+    MAX_TASK_EVIDENCE_BUNDLE_BYTES,
     TaskEvidenceBundle,
     TaskEvidenceBundleError,
     TaskEvidenceLimits,
@@ -170,6 +171,24 @@ def test_published_generation_reload_preserves_bundle_fingerprint(tmp_path):
     )
 
 
+def test_task_evidence_fingerprint_ignores_generation_metadata():
+    generation = _generation()
+    first = build_task_evidence_bundle(generation, "task-a")
+    rebuilt = build_task_evidence_bundle(
+        replace(
+            generation,
+            generation_id="generation-b",
+            source_revision="source-revision-b",
+            created_at="2026-09-02T00:00:00Z",
+            generator={"name": "linker", "version": "v2"},
+        ),
+        "task-a",
+    )
+
+    assert rebuilt.bundle_fingerprint != first.bundle_fingerprint
+    assert rebuilt.task_evidence_fingerprint == first.task_evidence_fingerprint
+
+
 def test_bundle_rejects_unknown_fields_and_fingerprint_drift():
     payload = build_task_evidence_bundle(_generation(), "task-a").to_dict()
     payload["unknown"] = True
@@ -179,6 +198,14 @@ def test_bundle_rejects_unknown_fields_and_fingerprint_drift():
     payload = build_task_evidence_bundle(_generation(), "task-a").to_dict()
     payload["task"]["summary"] = "changed"
     with pytest.raises(TaskEvidenceBundleError, match="fingerprint"):
+        TaskEvidenceBundle.from_dict(payload)
+
+
+def test_bundle_normalizes_nested_parse_errors():
+    payload = build_task_evidence_bundle(_generation(), "task-a").to_dict()
+    payload["task"] = []
+
+    with pytest.raises(TaskEvidenceBundleError, match="invalid nested"):
         TaskEvidenceBundle.from_dict(payload)
 
 
@@ -294,3 +321,17 @@ def test_bundle_rejects_cross_scope_membership_defensively():
 def test_bundle_cardinality_is_bounded(limits, message):
     with pytest.raises(TaskEvidenceBundleError, match=message):
         build_task_evidence_bundle(_generation(), "task-a", limits=limits)
+
+
+def test_bundle_serialized_size_is_bounded():
+    generation = _generation()
+    oversized_task = replace(
+        generation.tasks[0],
+        summary="x" * MAX_TASK_EVIDENCE_BUNDLE_BYTES,
+    )
+
+    with pytest.raises(TaskEvidenceBundleError, match="serialized_bytes"):
+        build_task_evidence_bundle(
+            replace(generation, tasks=(oversized_task,)),
+            "task-a",
+        )

--- a/tests/test_task_evidence_bundle.py
+++ b/tests/test_task_evidence_bundle.py
@@ -1,0 +1,296 @@
+from __future__ import annotations
+
+from dataclasses import replace
+
+import pytest
+
+from xskill.tasks.evidence_bundle import (
+    TaskEvidenceBundle,
+    TaskEvidenceBundleError,
+    TaskEvidenceLimits,
+    build_task_evidence_bundle,
+)
+from xskill.tasks.models import (
+    AtomRef,
+    AttemptRelation,
+    EvidenceRange,
+    LogicalTask,
+    SessionRef,
+    TaskAtomMembership,
+    TaskAttempt,
+    TaskGraphGeneration,
+    UsageAllocation,
+)
+from xskill.tasks.store import TaskGraphStore
+
+
+def _membership(membership_id, atom, observed_at):
+    fixed = ("primary", None, "confirmed", "rules", "v1", ())
+    return TaskAtomMembership(membership_id, "task-a", atom, *fixed, observed_at)
+
+
+def _attempt(
+    attempt_id,
+    times,
+    outcome,
+    disposition,
+    evidence,
+):
+    state = ("finished", outcome, "verified", disposition, (evidence,))
+    return TaskAttempt(
+        attempt_id,
+        "task-a",
+        *times,
+        *state,
+        execution_identity={"run_id": attempt_id.replace("attempt", "run")},
+    )
+
+
+def _evidence(evidence_id, session, atom, start, *, skills=()):
+    suffix = evidence_id.removeprefix("evidence-")
+    return EvidenceRange(
+        evidence_id,
+        session,
+        "trajectory_line",
+        start,
+        start + 4,
+        f"hash-{suffix}",
+        atom_ref=atom,
+        model={"model_id": "model-a"},
+        harness={"name": "runtime-a"},
+        skills=skills,
+    )
+
+
+def _generation(*, verified: bool = True) -> TaskGraphGeneration:
+    session = SessionRef("tenant", "scope", "source", "traj")
+    atom_a = AtomRef("tenant", "scope", "source", "traj", "atom-a")
+    atom_b = AtomRef("tenant", "scope", "source", "traj", "atom-b")
+    evidence_a = _evidence(
+        "evidence-a",
+        session,
+        atom_a,
+        1,
+        skills=({"name": "skill-a", "version": "sha-a"},),
+    )
+    evidence_b = _evidence("evidence-b", session, atom_b, 5)
+    task = LogicalTask(
+        "task-a",
+        "repair",
+        "repair and verify",
+        "2026-09-01T00:00:00Z",
+        lifecycle="closed",
+        outcome="succeeded",
+        verification="verified" if verified else "unverified",
+        user_disposition="accepted",
+    )
+    memberships = (
+        _membership("membership-b", atom_b, "2026-09-01T00:00:02Z"),
+        _membership("membership-a", atom_a, "2026-09-01T00:00:01Z"),
+    )
+    attempts = (
+        _attempt(
+            "attempt-b",
+            ("2026-09-01T00:01:00Z", "2026-09-01T00:02:00Z"),
+            "succeeded",
+            "accepted",
+            evidence_b,
+        ),
+        _attempt(
+            "attempt-a",
+            ("2026-09-01T00:00:00Z", "2026-09-01T00:01:00Z"),
+            "failed",
+            "corrected",
+            evidence_a,
+        ),
+    )
+    return TaskGraphGeneration(
+        generation_id="generation-a",
+        tenant_id="tenant",
+        task_scope_id="scope",
+        source_revision="source-revision-a",
+        generator={"name": "linker", "version": "v1"},
+        base_override_seq=0,
+        created_at="2026-09-01T00:03:00Z",
+        tasks=(task,),
+        memberships=memberships,
+        relations=(),
+        attempts=attempts,
+        attempt_relations=(
+            AttemptRelation(
+                "attempt-relation-a",
+                *("attempt-a", "attempt-b", "correction_of"),
+                *(None, "confirmed", "rules", "v1", ()),
+                "2026-09-01T00:02:00Z",
+            ),
+        ),
+        usage_allocations=(
+            UsageAllocation(
+                "allocation-a",
+                *("usage-a", "execution", "direct", 1.0),
+                task_id="task-a",
+                attempt_id="attempt-b",
+                total_tokens=None,
+                cost_usd=None,
+                method="evidence_span",
+                method_version="v1",
+            ),
+        ),
+    )
+
+
+def test_bundle_is_deterministic_bounded_and_round_trips_strictly():
+    generation = _generation()
+    bundle = build_task_evidence_bundle(generation, "task-a")
+
+    atom_ids = [item.atom_ref.atom_id for item in bundle.confirmed_memberships]
+    assert atom_ids == ["atom-a", "atom-b"]
+    assert [item.attempt_id for item in bundle.attempts] == ["attempt-a", "attempt-b"]
+    assert [
+        evidence.evidence_id
+        for attempt in bundle.attempts
+        for evidence in attempt.evidence_ranges
+    ] == ["evidence-a", "evidence-b"]
+    assert bundle.learning_eligibility == "eligible"
+    assert bundle.eligibility_reasons == ("verified_terminal_task",)
+    assert bundle.to_dict() == TaskEvidenceBundle.from_dict(bundle.to_dict()).to_dict()
+    rebuilt = build_task_evidence_bundle(generation, "task-a")
+    assert bundle.bundle_fingerprint == rebuilt.bundle_fingerprint
+
+
+def test_published_generation_reload_preserves_bundle_fingerprint(tmp_path):
+    store = TaskGraphStore(tmp_path)
+    store.publish(_generation())
+    first = build_task_evidence_bundle(store.load_current(), "task-a")
+    reloaded = TaskGraphStore(tmp_path).load_current()
+
+    assert reloaded is not None
+    assert build_task_evidence_bundle(reloaded, "task-a").bundle_fingerprint == (
+        first.bundle_fingerprint
+    )
+
+
+def test_bundle_rejects_unknown_fields_and_fingerprint_drift():
+    payload = build_task_evidence_bundle(_generation(), "task-a").to_dict()
+    payload["unknown"] = True
+    with pytest.raises(TaskEvidenceBundleError, match="unknown"):
+        TaskEvidenceBundle.from_dict(payload)
+
+    payload = build_task_evidence_bundle(_generation(), "task-a").to_dict()
+    payload["task"]["summary"] = "changed"
+    with pytest.raises(TaskEvidenceBundleError, match="fingerprint"):
+        TaskEvidenceBundle.from_dict(payload)
+
+
+def test_unresolved_membership_is_observable_but_never_learning_evidence():
+    generation = _generation()
+    proposed = replace(
+        generation.memberships[0],
+        membership_id="membership-review",
+        decision="needs_review",
+    )
+    generation = replace(generation, memberships=(*generation.memberships, proposed))
+    bundle = build_task_evidence_bundle(generation, "task-a")
+
+    assert [item.membership_id for item in bundle.review_memberships] == [
+        "membership-review",
+    ]
+    assert all(
+        item.membership_id != "membership-review"
+        for item in bundle.confirmed_memberships
+    )
+    assert bundle.learning_eligibility == "needs_review"
+    assert "unresolved_task_membership" in bundle.eligibility_reasons
+
+
+def test_unverified_outcome_needs_review_without_inventing_a_score():
+    bundle = build_task_evidence_bundle(_generation(verified=False), "task-a")
+    assert bundle.learning_eligibility == "needs_review"
+    assert bundle.eligibility_reasons == ("task_outcome_not_verified",)
+    serialized = bundle.to_dict()
+    assert "ux_score" not in str(serialized)
+    allocation = serialized["usage_allocations"][0]
+    assert allocation["total_tokens"] is None
+    assert allocation["cost_usd"] is None
+    with pytest.raises(TaskEvidenceBundleError, match="does not match"):
+        replace(bundle, learning_eligibility="eligible")
+
+
+@pytest.mark.parametrize(
+    ("changes", "reason"),
+    [
+        (
+            {"outcome": "cancelled", "verification": "not_applicable"},
+            "task_outcome_cancelled",
+        ),
+        ({"verification": "contradicted"}, "task_verification_contradicted"),
+    ],
+)
+def test_cancelled_or_contradicted_task_is_ineligible(changes, reason):
+    generation = _generation()
+    task = replace(generation.tasks[0], **changes)
+    bundle = build_task_evidence_bundle(
+        replace(generation, tasks=(task,)),
+        "task-a",
+    )
+    assert bundle.learning_eligibility == "ineligible"
+    assert bundle.eligibility_reasons == (reason,)
+
+
+def test_tombstone_and_stale_evidence_fail_closed():
+    generation = _generation()
+    tombstoned_task = replace(generation.tasks[0], tombstoned=True)
+    tombstoned_memberships = tuple(
+        replace(item, stale=True) for item in generation.memberships
+    )
+    tombstoned = replace(
+        generation,
+        tasks=(tombstoned_task,),
+        memberships=tombstoned_memberships,
+    )
+    with pytest.raises(TaskEvidenceBundleError, match="tombstoned"):
+        build_task_evidence_bundle(tombstoned, "task-a")
+
+    stale_range = replace(generation.attempts[0].evidence_ranges[0], stale=True)
+    stale_attempt = replace(generation.attempts[0], evidence_ranges=(stale_range,))
+    with pytest.raises(TaskEvidenceBundleError, match="stale EvidenceRange"):
+        build_task_evidence_bundle(
+            replace(generation, attempts=(stale_attempt, generation.attempts[1])),
+            "task-a",
+        )
+
+
+def test_evidence_atom_must_have_confirmed_primary_membership():
+    generation = _generation()
+    with pytest.raises(TaskEvidenceBundleError, match="confirmed primary"):
+        build_task_evidence_bundle(
+            replace(generation, memberships=(generation.memberships[1],)),
+            "task-a",
+        )
+
+
+def test_bundle_rejects_cross_scope_membership_defensively():
+    bundle = build_task_evidence_bundle(_generation(), "task-a")
+    membership = bundle.confirmed_memberships[0]
+    foreign_atom = replace(membership.atom_ref, tenant_id="other-tenant")
+    with pytest.raises(TaskEvidenceBundleError, match="crosses TaskScope"):
+        replace(
+            bundle,
+            confirmed_memberships=(
+                replace(membership, atom_ref=foreign_atom),
+                *bundle.confirmed_memberships[1:],
+            ),
+        )
+
+
+@pytest.mark.parametrize(
+    ("limits", "message"),
+    [
+        (TaskEvidenceLimits(memberships=1), "memberships"),
+        (TaskEvidenceLimits(attempts=1), "attempts"),
+        (TaskEvidenceLimits(evidence_ranges=1), "evidence_ranges"),
+    ],
+)
+def test_bundle_cardinality_is_bounded(limits, message):
+    with pytest.raises(TaskEvidenceBundleError, match=message):
+        build_task_evidence_bundle(_generation(), "task-a", limits=limits)


### PR DESCRIPTION
## Summary

提供版本化、有界的 Task 证据包，把任务目标、执行尝试、归属关系、结果和来源引用整理为稳定的学习输入。按维护者意见，本实现已包含在 #414 中，两张 PR 一起审阅，不单独安排合入 #411。

## Changes

- 确定性排序并校验 Task、Attempt、membership、关系和证据引用；只接受有效且确认的归属。
- 区分整包指纹与跨 generation 稳定的任务证据指纹，避免仅因重建元数据变化就重复学习。
- 各类引用有数量上限，序列化有 1 MiB 硬边界；不复制原始会话正文。
- 修复续写衔接：学习输入只取有效证据，原 Task Graph 保留失效历史用于审计。没有有效范围的 Attempt 仍拒绝，历史范围仍计入输入上限。

## Test plan

当前提交 `1ebef7c`：容器内 2,919 项测试通过、11 项跳过；Ruff、格式和包构建通过。2026-09-17 核对，该提交所有已执行线上检查通过；real-llm-e2e 跳过。

两条新增回归覆盖历史记录不改变学习指纹、不绕过数量限制。#414 的索引版构建器已同步修复至 `a09f7f8`。真实 Skill 产出尚未验证，候选晋升前检查当前证据版本及生产消费者仍需在 #407 中补齐。

## Linked issues

Closes #406. Review together with #414; #407 remains open. #404 is already merged.

## Automation

Codex 协助准备代码、回归测试和说明。
