### PR TITLE
fix(search): rank results by relevance（让相关会话先出现在搜索首页）

### DIFF
--- a/src/xskill/agents/traj_tools.py
+++ b/src/xskill/agents/traj_tools.py
@@ -11,7 +11,7 @@ GenerateAgent 的完整工具面（18 个，这里实现前 4 个）
 1. ``traj_search(query, offset, limit, context)`` —— 找轨迹的唯一入口。不带
    query 是翻目录，按最近修改排序分页给 traj_id、行数、首问一句；带 query 是
    全文检索，每行带首个命中行号、片段与该条总命中处数，context>0 时首命中处
-   带前后原文，同名前缀的轨迹会错开展示。
+   带前后原文，按命中处数、首次命中行、修改时间和 ID 排序。
 2. ``atom_search(query, top_k)`` —— 语义检索轨迹原子。query 用整句自然语言，
    返回每个原子的 traj_id、行号区间、intent、summary 摘句和 tags；关键词搜
    不准、想按"这类事怎么做"找轨迹时用它。旧原子行号可能不可靠，会标注。
@@ -325,32 +325,6 @@ def _line_count(path: Path) -> int:
         return 0
 
 
-def _family(stem: str) -> str:
-    parts = stem.split("_")
-    return "_".join(parts[:3]) if len(parts) >= 3 else stem
-
-
-def _spread(paths: list[Path], take: int) -> list[Path]:
-    """按 traj_id 前缀分桶轮取，避免一个项目的会话刷满整页。"""
-    buckets: dict[str, list[Path]] = {}
-    for path in paths:
-        buckets.setdefault(_family(path.stem), []).append(path)
-    out: list[Path] = []
-    index = 0
-    while len(out) < take:
-        advanced = False
-        for items in buckets.values():
-            if index < len(items):
-                out.append(items[index])
-                advanced = True
-                if len(out) >= take:
-                    break
-        if not advanced:
-            break
-        index += 1
-    return out
-
-
 def _rg(args: list[str], timeout: int) -> str:
     try:
         completed = subprocess.run(
@@ -389,6 +363,8 @@ def _format_search_hit(
 
 
 def _search_by_query(query: str, take: int, context: int = 0) -> str:
+    from xskill.traj_browse import TrajHit, query_hit_sort_key
+
     roots = _traj_roots()
     if not shutil.which("rg"):
         return _search_by_query_python(query, take, roots, context)
@@ -414,16 +390,19 @@ def _search_by_query(query: str, take: int, context: int = 0) -> str:
                     counts[path] = int(num)
                 except ValueError:
                     counts[path] = 1
-    hits = list(counts)
-    if not hits:
+    if not counts:
         return (
             f"query={query!r} 没有命中。换一组更常见的词，"
             "或不给 query 直接翻目录。"
         )
-    shown = _spread(hits, take)
-    leftover = len(hits) - len(shown)
-    rows: list[str] = []
-    for path in shown:
+    # Only the top count bands can reach this page. Read first-hit lines for
+    # the entire cutoff band so ties are ranked correctly without reopening
+    # every lower-relevance file just to discard it afterward.
+    cutoff = sorted(counts.values(), reverse=True)[min(take, len(counts)) - 1]
+    hits: list[TrajHit] = []
+    for path, count in counts.items():
+        if count < cutoff:
+            continue
         args = ["rg", "-n", "--no-heading", "--color", "never", "--smart-case",
                 "-m", "1", "-e", query, str(path)]
         out = _rg(args, 10)
@@ -431,14 +410,16 @@ def _search_by_query(query: str, take: int, context: int = 0) -> str:
         first = lines[0] if lines else "1:"
         lineno, _, content = first.partition(":")
         hit_line = int(lineno) if lineno.isdigit() else 1
-        rows.append(
-            _format_search_hit(
-                path, hit_line, content, counts.get(path, 1), context,
-            )
-        )
+        hits.append(TrajHit(path.stem, path, "", hit_line, content, count))
+    shown = sorted(hits, key=query_hit_sort_key)[:take]
+    leftover = len(counts) - len(shown)
+    rows = [
+        _format_search_hit(hit.path, hit.line, hit.snippet, hit.hit_count, context)
+        for hit in shown
+    ]
     head = (
-        f"query={query!r} 命中 {len(hits)} 条不同轨迹，展示 {len(shown)} 条"
-        f"（同名前缀已错开）。看内容用 traj_cards，一次最多 {CARDS_MAX} 个 id。"
+        f"query={query!r} 命中 {len(counts)} 条不同轨迹，展示 {len(shown)} 条"
+        f"（按相关度排序）。看内容用 traj_cards，一次最多 {CARDS_MAX} 个 id。"
         "命中处数多的轨迹通常整条都和主题相关，优先精读；"
         "想看某一处的前后文，read_traj 按行号跳过去。"
     )
@@ -450,8 +431,10 @@ def _search_by_query(query: str, take: int, context: int = 0) -> str:
 def _search_by_query_python(
     query: str, take: int, roots: list[Path], context: int = 0,
 ) -> str:
+    from xskill.traj_browse import TrajHit, query_hit_sort_key
+
     needle = query.lower()
-    hits: list[tuple[Path, int, str, int]] = []
+    hits: list[TrajHit] = []
     for path in _traj_files():
         first_no, first_line, count = 0, "", 0
         try:
@@ -464,21 +447,18 @@ def _search_by_query_python(
         except OSError:
             continue
         if count:
-            hits.append((path, first_no, first_line, count))
+            hits.append(TrajHit(path.stem, path, "", first_no, first_line, count))
     if not hits:
         return f"query={query!r} 没有命中。换一组词，或不给 query 直接翻目录。"
-    ordered = _spread([path for path, _, _, _ in hits], take)
-    lookup = {path: (number, line, count) for path, number, line, count in hits}
-    rows = []
-    for path in ordered:
-        if path not in lookup:
-            continue
-        number, line, count = lookup[path]
-        rows.append(_format_search_hit(path, number, line, count, context))
+    ordered = sorted(hits, key=query_hit_sort_key)[:take]
+    rows = [
+        _format_search_hit(hit.path, hit.line, hit.snippet, hit.hit_count, context)
+        for hit in ordered
+    ]
     leftover = len(hits) - len(rows)
     head = (
         f"query={query!r} 命中 {len(hits)} 条不同轨迹，展示 {len(rows)} 条"
-        f"（无 rg，退回逐行匹配）。看内容用 traj_cards。"
+        "（按相关度排序；无 rg，退回逐行匹配）。看内容用 traj_cards。"
     )
     if leftover > 0:
         head += f" 还有 {leftover} 条未列出。"
@@ -495,9 +475,9 @@ def traj_search(
 
     带 query 时按关键词搜全部轨迹正文，每条命中给 traj_id、首个命中行号和该条
     的总命中处数；命中处数多的轨迹通常整条都和主题相关。context 大于 0 时首个
-    命中处会带出前后几行原文，用来快速判断命中是不是想要的。同一项目的会话会
-    错开，避免一页全是同一个前缀。用户指令里的关键词、报错片段、命令名、模块
-    名都适合当 query。不带 query 时按最近修改排序分页，每条给 traj_id、总行
+    命中处会带出前后几行原文，用来快速判断命中是不是想要的。先按命中处数降序、
+    首次命中行升序，再按修改时间降序和 ID 排序。用户指令里的关键词、报错片段、
+    命令名、模块名都适合当 query。不带 query 时按最近修改排序分页，每条给 traj_id、总行
     数、首问一句，用于摸清库里有什么。
     两种模式返回的都只是索引，要看内容用 traj_cards，要精读用 read_traj。
     轨迹目录不要用 list_files 或 grep_files。

--- a/src/xskill/data/skill/xskill-helper/SKILL.md
+++ b/src/xskill/data/skill/xskill-helper/SKILL.md
@@ -119,7 +119,8 @@ The default entry is the trajectory, not Atom.
 `xskill traj search` is full-text over `traj_*.md`, not the first-user-query
 index. Default listing is one block per hit: `traj_id`, then the first
 match with three lines before and after (the hit line is marked `*`).
-Same-name prefixes are spread. A page shows at most 30 hits. `--page N`
+Hits rank by matching-line count (descending), first matching line (ascending),
+modification time (newest first), then trajectory ID. A page shows at most 30 hits. `--page N`
 turns the page. `--cards` returns index cards (source, line count, user
 turns, tools, then `L 问` / `L 答`), at most 8 per page; cards are not
 close reading. Close-read with

--- a/src/xskill/traj_browse.py
+++ b/src/xskill/traj_browse.py
@@ -104,29 +104,9 @@ def _source_of(traj_id: str) -> str:
     return "unknown"
 
 
-def _family(stem: str) -> str:
-    parts = stem.split("_")
-    return "_".join(parts[:3]) if len(parts) >= 3 else stem
-
-
-def _spread(paths: list[Path], take: int) -> list[Path]:
-    buckets: dict[str, list[Path]] = {}
-    for path in paths:
-        buckets.setdefault(_family(path.stem), []).append(path)
-    out: list[Path] = []
-    index = 0
-    while len(out) < take:
-        advanced = False
-        for items in buckets.values():
-            if index < len(items):
-                out.append(items[index])
-                advanced = True
-                if len(out) >= take:
-                    break
-        if not advanced:
-            break
-        index += 1
-    return out
+def query_hit_sort_key(hit: TrajHit) -> tuple[int, int, float, str]:
+    """Shared CLI/team/Generate relevance order, applied before pagination."""
+    return (-hit.hit_count, hit.line, -_mtime(hit.path), hit.traj_id)
 
 
 def _parse_sections(text: str) -> list[_Section]:
@@ -324,9 +304,7 @@ def find_query_hits(
     hits = _search_rg(query, files)
     if hits is None:
         hits = _search_python(query, files)
-    by_path = {hit.path: hit for hit in hits}
-    ordered = _spread([hit.path for hit in hits], len(hits))
-    return [by_path[path] for path in ordered if path in by_path]
+    return sorted(hits, key=query_hit_sort_key)
 
 
 def page_slice(items: list[Any], page: int, page_size: int) -> list[Any]:
@@ -399,7 +377,7 @@ def format_listing(
     flag = f" {extra_flags}" if extra_flags else ""
     head = (
         f"query={query!r} 命中 {total} 条不同轨迹，展示 {shown} 条"
-        f"（同名前缀已错开）。看内容用 --cards，一次最多 {CARDS_MAX} 个 id。"
+        f"（按相关度排序）。看内容用 --cards，一次最多 {CARDS_MAX} 个 id。"
     )
     if leftover > 0:
         head += f" 还有 {leftover} 条未列出，换一组词可以搜到别的。"

--- a/tests/test_server_no_llm_fallback.py
+++ b/tests/test_server_no_llm_fallback.py
@@ -128,10 +128,14 @@ def test_standalone_worker_commands_share_resolved_ecosystem_home(
         str(ecosystem_home.resolve()),
     ]
     assert set(records_by_name) == {
-        "agent-worker", "ecosystem-ingest", "ux-scores-sync",
+        "agent-worker", "ecosystem-ingest", "kernel-host", "ux-scores-sync",
     }
     assert records_by_name["agent-worker"].command[-2:] == expected_home_arguments
     assert records_by_name["agent-worker"].keyword_arguments["persistent"] is True
+    kernel_command = records_by_name["kernel-host"].command
+    assert kernel_command[-1] == "kernel-host"
+    assert "--server" not in kernel_command
+    assert records_by_name["kernel-host"].keyword_arguments["persistent"] is True
     ingest_command = records_by_name["ecosystem-ingest"].command
     home_argument_index = ingest_command.index("--home")
     assert ingest_command[
@@ -244,12 +248,15 @@ def test_team_server_schedules_only_server_watcher(
         record.name: record for record in scheduler_records
     }
     assert set(records_by_name) == {
-        "recommend-heavy", "agent-worker", "ux-scores-sync",
+        "recommend-heavy", "agent-worker", "kernel-host", "ux-scores-sync",
     }
     watcher_command = records_by_name["agent-worker"].command
     assert watcher_command[-1] == "--server"
     assert "--home" not in watcher_command
     assert records_by_name["agent-worker"].keyword_arguments["persistent"] is True
+    kernel_command = records_by_name["kernel-host"].command
+    assert kernel_command[-2:] == ["kernel-host", "--server"]
+    assert records_by_name["kernel-host"].keyword_arguments["persistent"] is True
     assert "persistent" not in records_by_name["recommend-heavy"].keyword_arguments
     assert records_by_name["recommend-heavy"].command[-1] == "recommend-heavy"
     assert "persistent" not in records_by_name["ux-scores-sync"].keyword_arguments

--- a/tests/test_traj_browse.py
+++ b/tests/test_traj_browse.py
@@ -36,7 +36,7 @@ def _short_card_md(query: str) -> str:
     )
 
 
-def test_find_query_hits_first_line_and_spread(tmp_path):
+def test_find_query_hits_first_line(tmp_path):
     alice = tmp_path / "alice"
     bob = tmp_path / "bob"
     _write(alice, "traj_cc_alice_memleak", _short_card_md(
@@ -104,7 +104,7 @@ def test_format_listing_matches_product_header():
     )
     assert text.startswith(
         "query='patentdagger' 命中 179 条不同轨迹，展示 2 条"
-        "（同名前缀已错开）。看内容用 --cards，一次最多 8 个 id。"
+        "（按相关度排序）。看内容用 --cards，一次最多 8 个 id。"
     )
     assert "还有 177 条未列出，换一组词可以搜到别的。" in text
     assert "下一页：xskill traj search patentdagger --page 2" in text

--- a/tests/test_traj_relevance.py
+++ b/tests/test_traj_relevance.py
@@ -1,0 +1,200 @@
+"""Issue #405: relevance must precede pagination on every search surface."""
+
+from __future__ import annotations
+
+import json
+import os
+import re
+from pathlib import Path
+
+import pytest
+
+from tests.test_traj_search import _args, _make_team_app, _register
+from xskill import cli, traj_browse
+from xskill.agents import agent_tools, traj_tools
+
+
+def _seed(root: Path) -> list[str]:
+    root.mkdir(parents=True, exist_ok=True)
+    # Creation order and recency both favor weak matches on the old path.
+    specs = [
+        ("traj_cc_project_high", 12, 5, 100),
+        ("traj_cc_project_early", 3, 5, 100),
+        ("traj_cc_project_alpha", 3, 9, 300),
+        ("traj_cc_project_beta", 3, 9, 300),
+        ("traj_cc_project_old", 3, 9, 200),
+        ("traj_cc_project_weak", 1, 20, 900),
+    ]
+    specs.extend((f"traj_oc_other{index}_weak", 1, 25, 1000) for index in range(32))
+    for name, count, first, mtime in specs:
+        lines = ["# Trajectory", "", "## User", ""]
+        lines += ["background context"] * (first - 5)
+        lines += ["phoenix research"] * count
+        lines += ["", "## Assistant", "", "Observed and verified the result."]
+        lines += ["padding " * 40]  # Both search surfaces' minimum file sizes.
+        path = root / f"{name}.md"
+        path.write_text("\n".join(lines) + "\n", encoding="utf-8")
+        os.utime(path, (mtime, mtime))
+    return [item[0] for item in specs[:6]] + sorted(item[0] for item in specs[6:])
+
+
+def _fake_rg(args, _timeout):
+    """Supply rg's count/first-line protocol in deliberately reversed order."""
+    target = Path(args[-1])
+    query = args[args.index("-e") + 1]
+    paths = (
+        sorted(target.rglob("traj_*.md"), reverse=True) if target.is_dir() else [target]
+    )
+    rows = []
+    for path in paths:
+        matches = [
+            (number, line)
+            for number, line in enumerate(
+                path.read_text(encoding="utf-8").splitlines(), 1
+            )
+            if query in line
+        ]
+        if not matches:
+            continue
+        if "-c" in args:
+            rows.append(f"{path}:{len(matches)}")
+        else:
+            number, line = matches[0]
+            rows.append(f"{number}:{line}")
+    return "\n".join(rows)
+
+
+@pytest.mark.parametrize("backend", ["python", "rg"])
+def test_relevance_matches_generate_and_browse_before_limit(
+    tmp_path, monkeypatch, backend
+):
+    expected = _seed(tmp_path)
+    monkeypatch.setattr(
+        traj_browse.shutil, "which", lambda _name: "rg" if backend == "rg" else None
+    )
+    monkeypatch.setattr(traj_browse, "_rg", _fake_rg)
+    monkeypatch.setattr(traj_tools, "_rg", _fake_rg)
+    hits = traj_browse.find_query_hits("phoenix", dataset_dirs=[("alice", tmp_path)])
+    assert [hit.traj_id for hit in hits] == expected
+    assert [(hit.hit_count, hit.line) for hit in hits[:6]] == [
+        (12, 5),
+        (3, 5),
+        (3, 9),
+        (3, 9),
+        (3, 9),
+        (1, 20),
+    ]
+    ctx = agent_tools.create_agent_tool_context(default_traj_root=tmp_path)
+    with agent_tools.use_agent_tool_context(ctx):
+        for limit in (1, 3, 8, 30):
+            text = traj_tools.traj_search.entrypoint(query="phoenix", limit=limit)
+            assert re.findall(r"^(traj_\S+)\t", text, re.MULTILINE) == expected[:limit]
+            assert "按相关度排序" in text
+            assert "同名前缀已错开" not in text
+
+
+def _card_ids(text: str) -> list[str]:
+    return re.findall(r"^--- (traj_\S+) ---$", text, re.MULTILINE)
+
+
+@pytest.mark.performance_contract
+def test_relevance_generate_only_reads_competitive_count_bands(tmp_path, monkeypatch):
+    expected = _seed(tmp_path)
+    monkeypatch.setattr(traj_tools.shutil, "which", lambda _name: "rg")
+    first_reads = []
+
+    def tracked_rg(args, timeout):
+        if "-n" in args:
+            first_reads.append(Path(args[-1]).stem)
+        return _fake_rg(args, timeout)
+
+    monkeypatch.setattr(traj_tools, "_rg", tracked_rg)
+    ctx = agent_tools.create_agent_tool_context(default_traj_root=tmp_path)
+    with agent_tools.use_agent_tool_context(ctx):
+        text = traj_tools.traj_search.entrypoint(query="phoenix", limit=3)
+    assert re.findall(r"^(traj_\S+)\t", text, re.MULTILINE) == expected[:3]
+    # All count=3 ties must compete; 33 count=1 files need no second read.
+    assert set(first_reads) == set(expected[:5])
+    assert len(first_reads) == 5
+
+
+def test_relevance_missing_file_uses_stable_tiebreaker(tmp_path):
+    hits = [
+        traj_browse.TrajHit(name, tmp_path / f"{name}.md", "", 5, "phoenix", 2)
+        for name in ("traj_cc_beta", "traj_cc_alpha")
+    ]
+    assert [
+        hit.traj_id for hit in sorted(hits, key=traj_browse.query_hit_sort_key)
+    ] == [
+        "traj_cc_alpha",
+        "traj_cc_beta",
+    ]
+
+
+def test_relevance_local_team_pages_cards_and_explicit_ids(
+    tmp_path, monkeypatch, capsys
+):
+    monkeypatch.setattr(traj_browse.shutil, "which", lambda _name: None)
+    monkeypatch.setattr(cli, "_maybe_bootstrap_local_traj", lambda: None)
+    monkeypatch.setattr("xskill.runtime.role", lambda: "standalone")
+    client, traj_root, registry = _make_team_app(tmp_path)
+    headers = _register(client, "alice")
+    client_id = registry.find_by_user_name("alice")
+    sessions = traj_root / "clients" / registry.dir_name_for(client_id) / "sessions"
+    expected = _seed(sessions)
+    monkeypatch.setattr(
+        "xskill.traj_search.watch_session_dirs", lambda: [("alice", sessions)]
+    )
+    endpoint = "/api/v1/team/trajectories/search"
+    with client:
+        for page in (1, 2):
+            assert (
+                cli.cmd_search_traj(
+                    _args(terms=["phoenix"], json=True, top_k=30, page=page)
+                )
+                == 0
+            )
+            local = json.loads(capsys.readouterr().out)
+            response = client.get(
+                endpoint,
+                params={"query": "phoenix", "limit": 30, "page": page},
+                headers=headers,
+            )
+            assert response.status_code == 200
+            selected = expected[(page - 1) * 30 : page * 30]
+            assert [hit["traj_id"] for hit in local] == selected
+            assert [hit["traj_id"] for hit in response.json()["results"]] == selected
+            assert (
+                cli.cmd_search_traj(_args(terms=["phoenix"], cards=True, page=page))
+                == 0
+            )
+            cards = capsys.readouterr().out
+            response = client.get(
+                endpoint,
+                params={"query": "phoenix", "cards": "1", "page": page},
+                headers=headers,
+            )
+            assert response.status_code == 200
+            selected = expected[(page - 1) * 8 : page * 8]
+            assert _card_ids(cards) == selected
+            assert _card_ids(response.json()["text"]) == selected
+        # A named member filter changes the scope, not its ordering.
+        response = client.get(
+            endpoint,
+            params={"query": "phoenix", "names": "alice", "limit": 30},
+            headers=headers,
+        )
+        assert [hit["traj_id"] for hit in response.json()["results"]] == expected[:30]
+        chosen = [expected[-1], expected[0]]
+        assert cli.cmd_search_traj(_args(terms=chosen, cards=True)) == 0
+        assert _card_ids(capsys.readouterr().out) == chosen
+        response = client.get(
+            endpoint, params={"cards": "1", "ids": ",".join(chosen)}, headers=headers
+        )
+        assert _card_ids(response.json()["text"]) == chosen
+    ctx = agent_tools.create_agent_tool_context(default_traj_root=sessions)
+    with agent_tools.use_agent_tool_context(ctx):
+        assert (
+            _card_ids(traj_tools.traj_cards.entrypoint(traj_ids=",".join(chosen)))
+            == chosen
+        )

--- a/tests/test_traj_search.py
+++ b/tests/test_traj_search.py
@@ -495,7 +495,7 @@ def test_cli_search_traj_local_prints_hits(monkeypatch, capsys, tmp_path):
     assert rc == 0
     out = capsys.readouterr()
     assert "query='django migration' 命中 1 条不同轨迹，展示 1 条" in out.out
-    assert "同名前缀已错开" in out.out
+    assert "按相关度排序" in out.out
     assert "看内容用 --cards，一次最多 8 个 id。" in out.out
     assert "看原文：xskill traj read <traj_id>" not in out.out
     assert "traj_cc_alice_memleak" in out.out


### PR DESCRIPTION
## Summary

搜索一个主题时，用户希望第一页先出现讨论这个主题最多的会话。原来的排序会把同名前缀的记录轮流展示，一条只顺带提到查询词的会话，也可能排在反复讨论该主题的会话前面。

这张 PR 让搜索先按相关程度排列，再分页。它同时覆盖命令行、team 服务端和生成代理使用的搜索工具。

## Changes

排序按以下顺序逐项比较：

1. 命中查询词的行数越多，越靠前。
2. 行数相同时，第一次命中出现得越早，越靠前。
3. 再相同时，文件修改时间越近，越靠前。
4. 最后按记录 ID 排序，让完全并列的结果保持稳定。

列表和卡片使用同一顺序。调用方明确指定几个记录 ID 时，卡片继续按给定顺序展示；正文读取窗口、卡片字数预算和可查询范围保持原样。

生成代理还减少了一类额外读取：先统计每份记录命中多少行，只有可能进入结果的记录，才继续查第一次命中的位置。排在结果边界上、命中行数相同的记录仍全部参与比较，避免为了少读文件而丢掉真正该靠前的记录。

在 38 份记录、取前三条的测试中，只有 5 份需要这次额外读取。这个测试说明读取范围受控；我们还没有据此测得生产延迟或真实模型成功率的变化。

## 建议怎么审

先看 `tests/test_traj_relevance.py`，它列出了排序、分页、name 过滤、并列结果、明确指定 ID 等行为。再看 `src/xskill/traj_browse.py` 中的共同排序规则，以及 `src/xskill/agents/traj_tools.py` 怎样复用它。

请重点检查：高相关记录会不会被挤到下一页；列表和卡片是不是先排序再分页；在候选记录和文件元数据相同的情况下，本机、team 和代理工具是否得到一致顺序。新增测试覆盖了 Python 搜索路径，并用固定返回值模拟 rg（ripgrep 文本搜索工具）的命中统计和首次命中位置。它没有测量真实 rg 命令的运行耗时。

## 前置改动和合入顺序

建议先审并合入 #404。它修正了 main 上两条过时的后台进程测试，本分支已经包含该修复。#404 合入后，再把最新 main 同步到本分支，核对 PR 中剩余的是搜索改动，然后完成本 PR 的 review 与 CI。

搜索实现提交是 `be6b7442b6644a5e8fb15755beef0c64598be280`。它可以单独交付，不需要等待任务学习整条流程完成。

## Test plan

- [x] 新增及相关定向测试：65 通过。
- [x] Linux/Python 3.12 的默认 `make test` 等价测试选择：2852 通过、11 跳过。
- [x] 修改 Python 文件的 Ruff 检查、新测试格式和 wheel/sdist 构建通过。
- [ ] 人工交互检查与外部 reviewer 审阅待完成。

测试在隔离容器中运行，测试阶段无网络。未重跑 `make e2e`；本改动不修改 ingestion/install/daemon 的生命周期。没有执行真实 LLM 效果或生产延迟实验。

实际测试命令：

- `.venv/bin/python -m pytest tests/test_traj_relevance.py tests/test_traj_browse.py tests/test_traj_search.py tests/test_server_no_llm_fallback.py -q`
- `.venv/bin/python -m pytest tests/ --ignore=tests/docker_e2e --ignore=tests/live -q`

2026-09-05 本次核对时，本 PR 的非跳过 GitHub 检查全部通过。后续代码或基线发生变化时，仍需以新提交的 CI 为准。

## Linked issues

Closes #405

## Automation

Codex 协助准备了代码、回归测试和说明。用户授权发布为 Draft，供线上审阅；外部 review 与合并批准仍待完成。
