### PR TITLE
feat(pipeline): add task learning queue and candidate storage（任务学习队列与候选保存）

### DIFF
--- a/docs/task-graph-runtime.md
+++ b/docs/task-graph-runtime.md
@@ -8,6 +8,19 @@
 
 开启后，Task Graph 使用独立 worker 消费持久脏队列，不阻塞 Atom 到 Skill 的拆分、路由和编辑流水线。
 
+### Task 学习队列状态
+
+管理员接口 `GET /api/v1/dashboard/task-graph/overview` 的 `evidence_feed`
+包含 `pending`、`processed`、`fallback`、`rejected` 四类数量，空状态返回 0。
+这些数量只读取当前实例数据库中已解析 tenant 的持久队列；尚无 tenant 时返回
+全零，不会退回全局统计，也不会扫描 Task Graph 文件重建状态。
+
+`pending` 表示等待消费或重新核对的 Task，包含尚不具备学习资格的 Task；
+`processed` 只表示对应队列版本已被确认处理，不能单凭它认定 Skill 已编辑或发布。
+`fallback` 和 `rejected` 分别统计已记录的回退和拒绝状态。
+当前阶段已提供持久队列、候选存储和状态接口，TaskCluster/SkillEdit 的生产消费
+尚未接通，因此这些统计不代表 Task-grounded 学习闭环已上线。
+
 ## 数据流
 
 1. Harness 适配器从 Codex、DeepSeek Harness 和 OpenClaw 轨迹中保留模型、Harness、run id、结构化终态和 execution usage event。

--- a/src/xskill/pipeline/registry.py
+++ b/src/xskill/pipeline/registry.py
@@ -716,7 +716,7 @@ CREATE TABLE IF NOT EXISTS task_evidence_feed (
     task_scope_id          TEXT NOT NULL,
     task_id                TEXT NOT NULL,
     task_generation_id     TEXT NOT NULL,
-    bundle_fingerprint     TEXT NOT NULL,
+    task_evidence_fingerprint TEXT NOT NULL,
     learning_eligibility   TEXT NOT NULL,
     eligibility_reasons_json TEXT NOT NULL DEFAULT '[]',
     status                 TEXT NOT NULL

--- a/src/xskill/pipeline/registry.py
+++ b/src/xskill/pipeline/registry.py
@@ -707,6 +707,29 @@ CREATE TABLE IF NOT EXISTS task_graph_dirty_scopes (
 );
 CREATE INDEX IF NOT EXISTS idx_task_dirty_scope_marked
     ON task_graph_dirty_scopes(marked_at, tenant_id, task_scope_id);
+
+-- Task-grounded learning feed. Rows are a durable, coalesced projection of the
+-- latest TaskEvidenceBundle for each Task; bundle content remains rebuildable
+-- from the immutable Task Graph generation rather than being copied here.
+CREATE TABLE IF NOT EXISTS task_evidence_feed (
+    tenant_id              TEXT NOT NULL,
+    task_scope_id          TEXT NOT NULL,
+    task_id                TEXT NOT NULL,
+    task_generation_id     TEXT NOT NULL,
+    bundle_fingerprint     TEXT NOT NULL,
+    learning_eligibility   TEXT NOT NULL,
+    eligibility_reasons_json TEXT NOT NULL DEFAULT '[]',
+    status                 TEXT NOT NULL
+        CHECK(status IN ('pending','processed','fallback','rejected')),
+    generation             INTEGER NOT NULL DEFAULT 1,
+    marked_at              TEXT NOT NULL DEFAULT (datetime('now')),
+    processed_at           TEXT,
+    PRIMARY KEY (tenant_id, task_scope_id, task_id)
+);
+CREATE INDEX IF NOT EXISTS idx_task_evidence_feed_status
+    ON task_evidence_feed(
+        status, marked_at, tenant_id, task_scope_id, task_id
+    );
 """
 
 _WATCH_STATUS_INDEX_SQL = """
@@ -2237,6 +2260,7 @@ def clear_rebuild_derived_state(
         cursor = connection.execute("DELETE FROM skill_trigger_eval")
         deleted_counts["skill_trigger_eval"] = cursor.rowcount
         for table_name in (
+            "task_evidence_feed",
             "task_usage_allocations", "task_attempt_relations",
             "task_evidence_ranges", "task_attempts", "task_relations",
             "task_atom_memberships", "logical_tasks", "task_graph_generations",

--- a/src/xskill/skill/candidates.py
+++ b/src/xskill/skill/candidates.py
@@ -330,6 +330,36 @@ def add_atom_contributions(
         return new_flags, buffer_total
 
 
+def add_evidence_candidates(
+    skill_dir: Path,
+    contributions: Iterable,
+) -> tuple[list[bool], int]:
+    """Atomically upsert versioned Task/Atom evidence into one Skill buffer."""
+    from xskill.skill.evidence_candidate_refs import EvidenceCandidateError
+    from xskill.skill.evidence_candidates import (
+        TaskSkillCandidate,
+        upsert_evidence_candidates,
+    )
+
+    candidate_list = tuple(contributions)
+    if not candidate_list:
+        raise EvidenceCandidateError("candidate batch must not be empty")
+    expected_skill = Path(skill_dir).name
+    if not all(
+        isinstance(candidate, TaskSkillCandidate)
+        and candidate.skill_name == expected_skill
+        for candidate in candidate_list
+    ):
+        raise EvidenceCandidateError(
+            "evidence candidates must target the containing Skill"
+        )
+    with skill_repo_lock(skill_dir, use_git_write_limit=False):
+        data = _load_candidates_unlocked(skill_dir)
+        new_flags, total = upsert_evidence_candidates(data, candidate_list)
+        _atomic_save_candidates_unlocked(skill_dir, data)
+        return new_flags, total
+
+
 def ready_for_promotion_v2(
     data: dict, threshold: int = ATOM_PROMOTION_THRESHOLD,
 ) -> list[dict]:

--- a/src/xskill/skill/candidates.py
+++ b/src/xskill/skill/candidates.py
@@ -368,10 +368,20 @@ def ready_for_promotion_v2(
 
     返回 buffer 中所有 candidates iff 总分 ≥ threshold；否则空列表。
     """
+    from xskill.skill.evidence_candidates import TaskSkillCandidate
+
     cands = data.get("candidates", []) or []
-    total = sum(int(c.get("weightscore", 0)) for c in cands)
+    promotable = []
+    total = 0
+    for candidate in cands:
+        if "schema_version" in candidate or "candidate_id" in candidate:
+            parsed = TaskSkillCandidate.from_dict(candidate)
+            if not parsed.contributes_to_promotion:
+                continue
+        promotable.append(candidate)
+        total += int(candidate.get("weightscore", 0))
     if total >= threshold:
-        return list(cands)
+        return promotable
     return []
 
 

--- a/src/xskill/skill/evidence_candidate_refs.py
+++ b/src/xskill/skill/evidence_candidate_refs.py
@@ -1,0 +1,218 @@
+"""Strict, text-free references used by Task-grounded Skill candidates."""
+
+from __future__ import annotations
+
+import hashlib
+import json
+import re
+from dataclasses import dataclass
+from typing import Any
+
+from xskill.tasks.models import (
+    ATTEMPT_LIFECYCLES,
+    ATTEMPT_OUTCOMES,
+    USER_DISPOSITIONS,
+    VERIFICATIONS,
+    AtomRef,
+)
+
+FINGERPRINT_RE = re.compile(r"^sha256:[0-9a-f]{64}$")
+
+
+class EvidenceCandidateError(ValueError):
+    """A candidate record violates the versioned evidence contract."""
+
+
+def ensure(condition: bool, message: str) -> None:
+    if not condition:
+        raise EvidenceCandidateError(message)
+
+
+def canonical_json(value: Any) -> bytes:
+    return json.dumps(
+        value,
+        ensure_ascii=False,
+        allow_nan=False,
+        sort_keys=True,
+        separators=(",", ":"),
+    ).encode("utf-8")
+
+
+def fingerprint(value: Any) -> str:
+    return "sha256:" + hashlib.sha256(canonical_json(value)).hexdigest()
+
+
+def stable_candidate_id(identity: dict[str, Any]) -> str:
+    return "candidate_" + hashlib.sha256(canonical_json(identity)).hexdigest()
+
+
+def strict_object(value: Any, expected: set[str], name: str) -> dict[str, Any]:
+    if not isinstance(value, dict):
+        raise EvidenceCandidateError(f"{name} must be an object")
+    actual = set(value)
+    if actual != expected:
+        raise EvidenceCandidateError(
+            f"invalid {name} fields: missing={sorted(expected - actual)}, "
+            f"unknown={sorted(actual - expected)}"
+        )
+    return value
+
+
+def required_string(value: Any, name: str, *, maximum: int = 500) -> str:
+    ensure(isinstance(value, str) and bool(value.strip()), f"{name} must be non-empty")
+    ensure(len(value) <= maximum, f"{name} exceeds {maximum} characters")
+    return value
+
+
+def optional_fingerprint(value: str | None, name: str) -> None:
+    if value is not None:
+        ensure(
+            isinstance(value, str) and bool(FINGERPRINT_RE.fullmatch(value)),
+            f"{name} must be a sha256 fingerprint",
+        )
+
+
+@dataclass(frozen=True)
+class CandidateAtomRef:
+    """Scoped Atom reference; legacy migration may retain only ``atom_id``."""
+
+    atom_id: str
+    tenant_id: str | None = None
+    task_scope_id: str | None = None
+    source_scope_id: str | None = None
+    traj_id: str | None = None
+
+    def __post_init__(self) -> None:
+        required_string(self.atom_id, "atom_ref.atom_id", maximum=300)
+        scopes = (
+            self.tenant_id,
+            self.task_scope_id,
+            self.source_scope_id,
+            self.traj_id,
+        )
+        ensure(
+            all(value is None for value in scopes)
+            or all(isinstance(value, str) and bool(value) for value in scopes),
+            "atom_ref scope must be complete or entirely unavailable",
+        )
+
+    @property
+    def scoped(self) -> bool:
+        return self.tenant_id is not None
+
+    @property
+    def key(self) -> tuple[str, str, str, str, str]:
+        return (
+            self.tenant_id or "",
+            self.task_scope_id or "",
+            self.source_scope_id or "",
+            self.traj_id or "",
+            self.atom_id,
+        )
+
+    @classmethod
+    def from_atom_ref(cls, atom_ref: AtomRef) -> CandidateAtomRef:
+        return cls(
+            atom_id=atom_ref.atom_id,
+            tenant_id=atom_ref.tenant_id,
+            task_scope_id=atom_ref.task_scope_id,
+            source_scope_id=atom_ref.source_scope_id,
+            traj_id=atom_ref.traj_id,
+        )
+
+    def to_dict(self) -> dict[str, str | None]:
+        return {
+            "atom_id": self.atom_id,
+            "tenant_id": self.tenant_id,
+            "task_scope_id": self.task_scope_id,
+            "source_scope_id": self.source_scope_id,
+            "traj_id": self.traj_id,
+        }
+
+    @classmethod
+    def from_dict(cls, value: Any) -> CandidateAtomRef:
+        data = strict_object(
+            value,
+            {"atom_id", "tenant_id", "task_scope_id", "source_scope_id", "traj_id"},
+            "CandidateAtomRef",
+        )
+        return cls(**data)
+
+
+@dataclass(frozen=True)
+class CandidateAttemptRef:
+    """Outcome-bearing Attempt reference without duplicated evidence text."""
+
+    attempt_id: str
+    started_at: str
+    ended_at: str | None
+    lifecycle: str
+    outcome: str
+    verification: str
+    user_disposition: str
+    evidence_range_ids: tuple[str, ...]
+
+    def __post_init__(self) -> None:
+        required_string(self.attempt_id, "attempt_ref.attempt_id", maximum=300)
+        required_string(self.started_at, "attempt_ref.started_at", maximum=100)
+        if self.ended_at is not None:
+            required_string(self.ended_at, "attempt_ref.ended_at", maximum=100)
+        ensure(
+            isinstance(self.lifecycle, str) and self.lifecycle in ATTEMPT_LIFECYCLES,
+            "invalid Attempt lifecycle",
+        )
+        ensure(
+            isinstance(self.outcome, str) and self.outcome in ATTEMPT_OUTCOMES,
+            "invalid Attempt outcome",
+        )
+        ensure(
+            isinstance(self.verification, str) and self.verification in VERIFICATIONS,
+            "invalid Attempt verification",
+        )
+        ensure(
+            isinstance(self.user_disposition, str)
+            and self.user_disposition in USER_DISPOSITIONS,
+            "invalid Attempt user disposition",
+        )
+        if self.lifecycle == "running":
+            ensure(self.ended_at is None, "running Attempt cannot have ended_at")
+            ensure(self.outcome == "unknown", "running Attempt outcome must be unknown")
+        else:
+            ensure(bool(self.ended_at), "finished Attempt requires ended_at")
+        ensure(
+            isinstance(self.evidence_range_ids, tuple)
+            and all(isinstance(item, str) for item in self.evidence_range_ids),
+            "evidence_range_ids must contain strings",
+        )
+        ensure(bool(self.evidence_range_ids), "Attempt needs evidence references")
+        ensure(
+            len(self.evidence_range_ids) == len(set(self.evidence_range_ids)),
+            "Attempt evidence references must be unique",
+        )
+        ensure(
+            self.evidence_range_ids == tuple(sorted(self.evidence_range_ids)),
+            "Attempt evidence references must be ordered",
+        )
+        for evidence_id in self.evidence_range_ids:
+            required_string(evidence_id, "evidence_range_id", maximum=300)
+
+    def to_dict(self) -> dict[str, Any]:
+        return {
+            "attempt_id": self.attempt_id,
+            "started_at": self.started_at,
+            "ended_at": self.ended_at,
+            "lifecycle": self.lifecycle,
+            "outcome": self.outcome,
+            "verification": self.verification,
+            "user_disposition": self.user_disposition,
+            "evidence_range_ids": list(self.evidence_range_ids),
+        }
+
+    @classmethod
+    def from_dict(cls, value: Any) -> CandidateAttemptRef:
+        expected = set(cls.__dataclass_fields__)
+        data = dict(strict_object(value, expected, "CandidateAttemptRef"))
+        evidence_ids = data["evidence_range_ids"]
+        ensure(isinstance(evidence_ids, list), "evidence_range_ids must be a list")
+        data["evidence_range_ids"] = tuple(evidence_ids)
+        return cls(**data)

--- a/src/xskill/skill/evidence_candidates.py
+++ b/src/xskill/skill/evidence_candidates.py
@@ -8,6 +8,7 @@ references and fingerprints, never copied trajectory or Task prompt text.
 from __future__ import annotations
 
 import copy
+import re
 from dataclasses import dataclass
 from typing import Any, Iterable
 
@@ -47,6 +48,11 @@ FALLBACK_REASONS = frozenset(
 MAX_CANDIDATE_ATOM_REFS = 256
 MAX_CANDIDATE_ATTEMPT_REFS = 128
 MAX_CANDIDATE_NOTE_CHARS = 500
+MAX_CANDIDATE_REASON_CODE_CHARS = 100
+PROMOTION_ELIGIBLE_FALLBACK_REASONS = frozenset(
+    ("task_graph_disabled", "legacy_atom_candidate")
+)
+_REASON_CODE_RE = re.compile(r"[a-z][a-z0-9_:-]*\Z")
 
 
 @dataclass(frozen=True)
@@ -99,6 +105,12 @@ class TaskSkillCandidate:
             len(self.note) <= MAX_CANDIDATE_NOTE_CHARS,
             f"note exceeds {MAX_CANDIDATE_NOTE_CHARS} characters",
         )
+        if self.note and self.fallback_reason != "legacy_atom_candidate":
+            _ensure(
+                len(self.note) <= MAX_CANDIDATE_REASON_CODE_CHARS
+                and _REASON_CODE_RE.fullmatch(self.note) is not None,
+                "note must be a bounded reason code, not free-form Task text",
+            )
         _ensure(
             isinstance(self.atom_refs, tuple)
             and all(isinstance(item, CandidateAtomRef) for item in self.atom_refs),
@@ -156,6 +168,12 @@ class TaskSkillCandidate:
             self.candidate_id == self._expected_candidate_id(),
             "candidate_id does not match stable evidence identity",
         )
+
+    @property
+    def contributes_to_promotion(self) -> bool:
+        if self.evidence_unit == "logical_task":
+            return self.learning_eligibility == "eligible"
+        return self.fallback_reason in PROMOTION_ELIGIBLE_FALLBACK_REASONS
 
     def _validate_evidence_shape(self) -> None:
         fingerprint_fields = (
@@ -229,6 +247,18 @@ class TaskSkillCandidate:
                 ),
                 "Task Atom reference crosses scope",
             )
+            if self.learning_eligibility == "eligible":
+                _ensure(
+                    self.task_lifecycle == "closed"
+                    and self.task_outcome not in {"unknown", "cancelled", "abandoned"}
+                    and self.task_verification in {"verified", "not_applicable"}
+                    and bool(self.attempt_refs)
+                    and all(
+                        attempt.lifecycle == "finished"
+                        for attempt in self.attempt_refs
+                    ),
+                    "eligible Task candidate requires verified terminal evidence",
+                )
             return
         _ensure(
             all(value is None for value in task_fields),
@@ -522,11 +552,13 @@ def upsert_evidence_candidates(
         )
         total += weightscore
         candidate_id = value.get("candidate_id")
-        if candidate_id is not None:
+        if "schema_version" in value or candidate_id is not None:
             parsed = TaskSkillCandidate.from_dict(value)
             _ensure(parsed.skill_name == skill_name, "candidate belongs to another Skill")
             _ensure(parsed.candidate_id not in positions, "duplicate candidate_id in buffer")
             positions[parsed.candidate_id] = index
+            if not parsed.contributes_to_promotion:
+                total -= weightscore
     new_flags: list[bool] = []
     for candidate in incoming:
         serialized = candidate.to_dict()
@@ -534,11 +566,15 @@ def upsert_evidence_candidates(
         if position is None:
             positions[candidate.candidate_id] = len(buffer)
             buffer.append(serialized)
-            total += candidate.weightscore
+            if candidate.contributes_to_promotion:
+                total += candidate.weightscore
             new_flags.append(True)
         else:
-            total -= int(buffer[position]["weightscore"])
+            previous = TaskSkillCandidate.from_dict(buffer[position])
+            if previous.contributes_to_promotion:
+                total -= previous.weightscore
             buffer[position] = serialized
-            total += candidate.weightscore
+            if candidate.contributes_to_promotion:
+                total += candidate.weightscore
             new_flags.append(False)
     return new_flags, total

--- a/src/xskill/skill/evidence_candidates.py
+++ b/src/xskill/skill/evidence_candidates.py
@@ -1,0 +1,428 @@
+"""Versioned candidate records for Task-grounded Skill learning.
+
+The existing ``.candidates.yml`` buffer remains the durable queue.  This
+module defines the bounded record written into that queue; it stores stable
+references and fingerprints, never copied trajectory or Task prompt text.
+"""
+
+from __future__ import annotations
+
+from dataclasses import dataclass
+from typing import Any
+
+from xskill.skill.evidence_candidate_refs import (
+    CandidateAtomRef,
+    CandidateAttemptRef,
+    EvidenceCandidateError as EvidenceCandidateError,
+    ensure as _ensure,
+    fingerprint as _fingerprint,
+    optional_fingerprint as _optional_fingerprint,
+    required_string as _required_string,
+    stable_candidate_id as _candidate_id,
+    strict_object as _strict_object,
+)
+from xskill.tasks.evidence_bundle import (
+    LEARNING_ELIGIBILITIES,
+    TaskEvidenceBundle,
+)
+from xskill.tasks.models import (
+    TASK_LIFECYCLES,
+    TASK_OUTCOMES,
+    USER_DISPOSITIONS,
+    VERIFICATIONS,
+    AtomRef,
+)
+
+CANDIDATE_SCHEMA_VERSION = 1
+EVIDENCE_UNITS = frozenset(("logical_task", "atom_fallback"))
+FALLBACK_REASONS = frozenset(
+    (
+        "task_graph_disabled",
+        "task_unresolved",
+        "task_evidence_unavailable",
+        "legacy_atom_candidate",
+    )
+)
+MAX_CANDIDATE_ATOM_REFS = 256
+MAX_CANDIDATE_ATTEMPT_REFS = 128
+MAX_CANDIDATE_NOTE_CHARS = 500
+
+
+@dataclass(frozen=True)
+class TaskSkillCandidate:
+    """One Skill support record backed by a Task bundle or explicit fallback."""
+
+    candidate_id: str
+    evidence_unit: str
+    skill_name: str
+    weightscore: int
+    note: str
+    tenant_id: str | None
+    task_scope_id: str | None
+    task_id: str | None
+    task_fingerprint: str | None
+    generation_id: str | None
+    generation_fingerprint: str | None
+    bundle_fingerprint: str | None
+    generator_fingerprint: str | None
+    atom_refs: tuple[CandidateAtomRef, ...]
+    attempt_refs: tuple[CandidateAttemptRef, ...]
+    task_lifecycle: str | None
+    task_outcome: str | None
+    task_verification: str | None
+    task_user_disposition: str | None
+    learning_eligibility: str
+    eligibility_reasons: tuple[str, ...]
+    fallback_reason: str | None
+    schema_version: int = CANDIDATE_SCHEMA_VERSION
+
+    def __post_init__(self) -> None:
+        _ensure(
+            self.schema_version == CANDIDATE_SCHEMA_VERSION,
+            f"unsupported candidate schema_version={self.schema_version}",
+        )
+        _ensure(
+            isinstance(self.evidence_unit, str)
+            and self.evidence_unit in EVIDENCE_UNITS,
+            "invalid evidence_unit",
+        )
+        _required_string(self.skill_name, "skill_name", maximum=200)
+        _ensure(
+            not isinstance(self.weightscore, bool)
+            and isinstance(self.weightscore, int)
+            and 1 <= self.weightscore <= 10,
+            "weightscore must be an integer from 1 through 10",
+        )
+        _ensure(isinstance(self.note, str), "note must be a string")
+        _ensure(
+            len(self.note) <= MAX_CANDIDATE_NOTE_CHARS,
+            f"note exceeds {MAX_CANDIDATE_NOTE_CHARS} characters",
+        )
+        _ensure(
+            isinstance(self.atom_refs, tuple)
+            and all(isinstance(item, CandidateAtomRef) for item in self.atom_refs),
+            "atom_refs must contain CandidateAtomRef values",
+        )
+        _ensure(bool(self.atom_refs), "candidate needs Atom references")
+        _ensure(
+            len(self.atom_refs) <= MAX_CANDIDATE_ATOM_REFS,
+            "candidate Atom references exceed bound",
+        )
+        _ensure(
+            isinstance(self.attempt_refs, tuple)
+            and all(
+                isinstance(item, CandidateAttemptRef)
+                for item in self.attempt_refs
+            ),
+            "attempt_refs must contain CandidateAttemptRef values",
+        )
+        _ensure(
+            len(self.attempt_refs) <= MAX_CANDIDATE_ATTEMPT_REFS,
+            "candidate Attempt references exceed bound",
+        )
+        atom_keys = tuple(item.key for item in self.atom_refs)
+        _ensure(len(atom_keys) == len(set(atom_keys)), "Atom references must be unique")
+        _ensure(atom_keys == tuple(sorted(atom_keys)), "Atom references must be ordered")
+        attempt_keys = tuple(
+            (item.started_at, item.attempt_id) for item in self.attempt_refs
+        )
+        _ensure(
+            len(attempt_keys) == len(set(attempt_keys)),
+            "Attempt references must be unique",
+        )
+        _ensure(
+            attempt_keys == tuple(sorted(attempt_keys)),
+            "Attempt references must be ordered",
+        )
+        _ensure(
+            isinstance(self.learning_eligibility, str)
+            and self.learning_eligibility in LEARNING_ELIGIBILITIES,
+            "invalid learning_eligibility",
+        )
+        _ensure(
+            isinstance(self.eligibility_reasons, tuple),
+            "eligibility_reasons must be a tuple",
+        )
+        _ensure(bool(self.eligibility_reasons), "eligibility_reasons must be non-empty")
+        for reason in self.eligibility_reasons:
+            _required_string(reason, "eligibility_reason", maximum=200)
+        _ensure(
+            len(self.eligibility_reasons) == len(set(self.eligibility_reasons)),
+            "eligibility_reasons must be unique",
+        )
+        self._validate_evidence_shape()
+        _ensure(
+            self.candidate_id == self._expected_candidate_id(),
+            "candidate_id does not match stable evidence identity",
+        )
+
+    def _validate_evidence_shape(self) -> None:
+        fingerprint_fields = (
+            (self.task_fingerprint, "task_fingerprint"),
+            (self.generation_fingerprint, "generation_fingerprint"),
+            (self.bundle_fingerprint, "bundle_fingerprint"),
+            (self.generator_fingerprint, "generator_fingerprint"),
+        )
+        for value, name in fingerprint_fields:
+            _optional_fingerprint(value, name)
+        task_fields = (
+            self.tenant_id,
+            self.task_scope_id,
+            self.task_id,
+            self.task_fingerprint,
+            self.generation_id,
+            self.generation_fingerprint,
+            self.bundle_fingerprint,
+            self.generator_fingerprint,
+            self.task_lifecycle,
+            self.task_outcome,
+            self.task_verification,
+            self.task_user_disposition,
+        )
+        if self.evidence_unit == "logical_task":
+            _ensure(all(task_fields), "logical_task candidate needs Task provenance")
+            for value, name in (
+                (self.tenant_id, "tenant_id"),
+                (self.task_scope_id, "task_scope_id"),
+                (self.task_id, "task_id"),
+                (self.generation_id, "generation_id"),
+            ):
+                _required_string(value, name, maximum=300)
+            _ensure(
+                isinstance(self.task_lifecycle, str)
+                and self.task_lifecycle in TASK_LIFECYCLES,
+                "invalid Task lifecycle",
+            )
+            _ensure(
+                isinstance(self.task_outcome, str)
+                and self.task_outcome in TASK_OUTCOMES,
+                "invalid Task outcome",
+            )
+            _ensure(
+                isinstance(self.task_verification, str)
+                and self.task_verification in VERIFICATIONS,
+                "invalid Task verification",
+            )
+            _ensure(
+                isinstance(self.task_user_disposition, str)
+                and self.task_user_disposition in USER_DISPOSITIONS,
+                "invalid Task user disposition",
+            )
+            if self.task_lifecycle in {"open", "blocked"}:
+                _ensure(
+                    self.task_outcome == "unknown",
+                    "open or blocked Task outcome must be unknown",
+                )
+            else:
+                _ensure(
+                    self.task_outcome != "unknown",
+                    "closed Task requires a terminal outcome",
+                )
+            _ensure(self.fallback_reason is None, "logical_task cannot be a fallback")
+            _ensure(all(item.scoped for item in self.atom_refs), "Task Atom refs need scope")
+            _ensure(
+                all(
+                    item.tenant_id == self.tenant_id
+                    and item.task_scope_id == self.task_scope_id
+                    for item in self.atom_refs
+                ),
+                "Task Atom reference crosses scope",
+            )
+            return
+        _ensure(
+            all(value is None for value in task_fields),
+            "atom_fallback cannot claim Task provenance",
+        )
+        _ensure(not self.attempt_refs, "atom_fallback cannot claim Attempts")
+        _ensure(len(self.atom_refs) == 1, "atom_fallback requires exactly one Atom")
+        _ensure(
+            isinstance(self.fallback_reason, str)
+            and self.fallback_reason in FALLBACK_REASONS,
+            "invalid fallback_reason",
+        )
+        _ensure(
+            self.learning_eligibility == "needs_review",
+            "atom_fallback must remain visible as needs_review",
+        )
+        _ensure(
+            self.eligibility_reasons == (f"atom_fallback:{self.fallback_reason}",),
+            "atom_fallback eligibility reason must identify the fallback",
+        )
+
+    def _expected_candidate_id(self) -> str:
+        if self.evidence_unit == "logical_task":
+            identity = {
+                "evidence_unit": self.evidence_unit,
+                "tenant_id": self.tenant_id,
+                "task_scope_id": self.task_scope_id,
+                "task_id": self.task_id,
+                "skill_name": self.skill_name,
+            }
+        else:
+            identity = {
+                "evidence_unit": self.evidence_unit,
+                "atom_ref": self.atom_refs[0].to_dict(),
+                "skill_name": self.skill_name,
+            }
+        return _candidate_id(identity)
+
+    def to_dict(self) -> dict[str, Any]:
+        return {
+            "schema_version": self.schema_version,
+            "candidate_id": self.candidate_id,
+            "evidence_unit": self.evidence_unit,
+            "skill_name": self.skill_name,
+            "weightscore": self.weightscore,
+            "note": self.note,
+            "tenant_id": self.tenant_id,
+            "task_scope_id": self.task_scope_id,
+            "task_id": self.task_id,
+            "task_fingerprint": self.task_fingerprint,
+            "generation_id": self.generation_id,
+            "generation_fingerprint": self.generation_fingerprint,
+            "bundle_fingerprint": self.bundle_fingerprint,
+            "generator_fingerprint": self.generator_fingerprint,
+            "atom_refs": [item.to_dict() for item in self.atom_refs],
+            "attempt_refs": [item.to_dict() for item in self.attempt_refs],
+            "task_lifecycle": self.task_lifecycle,
+            "task_outcome": self.task_outcome,
+            "task_verification": self.task_verification,
+            "task_user_disposition": self.task_user_disposition,
+            "learning_eligibility": self.learning_eligibility,
+            "eligibility_reasons": list(self.eligibility_reasons),
+            "fallback_reason": self.fallback_reason,
+        }
+
+    @classmethod
+    def from_dict(cls, value: Any) -> TaskSkillCandidate:
+        expected = set(cls.__dataclass_fields__)
+        data = dict(_strict_object(value, expected, "TaskSkillCandidate"))
+        atom_refs = data["atom_refs"]
+        attempt_refs = data["attempt_refs"]
+        eligibility_reasons = data["eligibility_reasons"]
+        _ensure(isinstance(atom_refs, list), "atom_refs must be a list")
+        _ensure(isinstance(attempt_refs, list), "attempt_refs must be a list")
+        _ensure(
+            isinstance(eligibility_reasons, list),
+            "eligibility_reasons must be a list",
+        )
+        data["atom_refs"] = tuple(CandidateAtomRef.from_dict(item) for item in atom_refs)
+        data["attempt_refs"] = tuple(
+            CandidateAttemptRef.from_dict(item) for item in attempt_refs
+        )
+        data["eligibility_reasons"] = tuple(eligibility_reasons)
+        return cls(**data)
+
+    @classmethod
+    def from_task_bundle(
+        cls,
+        bundle: TaskEvidenceBundle,
+        *,
+        skill_name: str,
+        weightscore: int,
+        note: str = "",
+    ) -> TaskSkillCandidate:
+        atom_refs = tuple(
+            CandidateAtomRef.from_atom_ref(item.atom_ref)
+            for item in bundle.confirmed_memberships
+        )
+        attempt_refs = tuple(
+            CandidateAttemptRef(
+                attempt_id=item.attempt_id,
+                started_at=item.started_at,
+                ended_at=item.ended_at,
+                lifecycle=item.lifecycle,
+                outcome=item.outcome,
+                verification=item.verification,
+                user_disposition=item.user_disposition,
+                evidence_range_ids=tuple(
+                    sorted(evidence.evidence_id for evidence in item.evidence_ranges)
+                ),
+            )
+            for item in bundle.attempts
+        )
+        generation_fingerprint = _fingerprint(
+            {
+                "generation_id": bundle.generation_id,
+                "source_revision": bundle.source_revision,
+                "created_at": bundle.created_at,
+                "generator_fingerprint": bundle.generator_fingerprint,
+            }
+        )
+        candidate_identity = {
+            "evidence_unit": "logical_task",
+            "tenant_id": bundle.tenant_id,
+            "task_scope_id": bundle.task_scope_id,
+            "task_id": bundle.task.task_id,
+            "skill_name": skill_name,
+        }
+        return cls(
+            candidate_id=_candidate_id(candidate_identity),
+            evidence_unit="logical_task",
+            skill_name=skill_name,
+            weightscore=weightscore,
+            note=note,
+            tenant_id=bundle.tenant_id,
+            task_scope_id=bundle.task_scope_id,
+            task_id=bundle.task.task_id,
+            task_fingerprint=_fingerprint(bundle.task.to_dict()),
+            generation_id=bundle.generation_id,
+            generation_fingerprint=generation_fingerprint,
+            bundle_fingerprint=bundle.bundle_fingerprint,
+            generator_fingerprint=bundle.generator_fingerprint,
+            atom_refs=atom_refs,
+            attempt_refs=attempt_refs,
+            task_lifecycle=bundle.task.lifecycle,
+            task_outcome=bundle.task.outcome,
+            task_verification=bundle.task.verification,
+            task_user_disposition=bundle.task.user_disposition,
+            learning_eligibility=bundle.learning_eligibility,
+            eligibility_reasons=bundle.eligibility_reasons,
+            fallback_reason=None,
+        )
+
+    @classmethod
+    def from_atom_fallback(
+        cls,
+        *,
+        atom_id: str,
+        skill_name: str,
+        weightscore: int,
+        fallback_reason: str,
+        atom_ref: AtomRef | None = None,
+        note: str = "",
+    ) -> TaskSkillCandidate:
+        if atom_ref is not None:
+            _ensure(atom_ref.atom_id == atom_id, "atom_id does not match atom_ref")
+            candidate_atom = CandidateAtomRef.from_atom_ref(atom_ref)
+        else:
+            candidate_atom = CandidateAtomRef(atom_id=atom_id)
+        candidate_identity = {
+            "evidence_unit": "atom_fallback",
+            "atom_ref": candidate_atom.to_dict(),
+            "skill_name": skill_name,
+        }
+        return cls(
+            candidate_id=_candidate_id(candidate_identity),
+            evidence_unit="atom_fallback",
+            skill_name=skill_name,
+            weightscore=weightscore,
+            note=note,
+            tenant_id=None,
+            task_scope_id=None,
+            task_id=None,
+            task_fingerprint=None,
+            generation_id=None,
+            generation_fingerprint=None,
+            bundle_fingerprint=None,
+            generator_fingerprint=None,
+            atom_refs=(candidate_atom,),
+            attempt_refs=(),
+            task_lifecycle=None,
+            task_outcome=None,
+            task_verification=None,
+            task_user_disposition=None,
+            learning_eligibility="needs_review",
+            eligibility_reasons=(f"atom_fallback:{fallback_reason}",),
+            fallback_reason=fallback_reason,
+        )

--- a/src/xskill/skill/evidence_candidates.py
+++ b/src/xskill/skill/evidence_candidates.py
@@ -124,8 +124,7 @@ class TaskSkillCandidate:
         _ensure(
             isinstance(self.attempt_refs, tuple)
             and all(
-                isinstance(item, CandidateAttemptRef)
-                for item in self.attempt_refs
+                isinstance(item, CandidateAttemptRef) for item in self.attempt_refs
             ),
             "attempt_refs must contain CandidateAttemptRef values",
         )
@@ -135,7 +134,9 @@ class TaskSkillCandidate:
         )
         atom_keys = tuple(item.key for item in self.atom_refs)
         _ensure(len(atom_keys) == len(set(atom_keys)), "Atom references must be unique")
-        _ensure(atom_keys == tuple(sorted(atom_keys)), "Atom references must be ordered")
+        _ensure(
+            atom_keys == tuple(sorted(atom_keys)), "Atom references must be ordered"
+        )
         attempt_keys = tuple(
             (item.started_at, item.attempt_id) for item in self.attempt_refs
         )
@@ -238,7 +239,9 @@ class TaskSkillCandidate:
                     "closed Task requires a terminal outcome",
                 )
             _ensure(self.fallback_reason is None, "logical_task cannot be a fallback")
-            _ensure(all(item.scoped for item in self.atom_refs), "Task Atom refs need scope")
+            _ensure(
+                all(item.scoped for item in self.atom_refs), "Task Atom refs need scope"
+            )
             _ensure(
                 all(
                     item.tenant_id == self.tenant_id
@@ -254,8 +257,7 @@ class TaskSkillCandidate:
                     and self.task_verification in {"verified", "not_applicable"}
                     and bool(self.attempt_refs)
                     and all(
-                        attempt.lifecycle == "finished"
-                        for attempt in self.attempt_refs
+                        attempt.lifecycle == "finished" for attempt in self.attempt_refs
                     ),
                     "eligible Task candidate requires verified terminal evidence",
                 )
@@ -337,7 +339,9 @@ class TaskSkillCandidate:
             isinstance(eligibility_reasons, list),
             "eligibility_reasons must be a list",
         )
-        data["atom_refs"] = tuple(CandidateAtomRef.from_dict(item) for item in atom_refs)
+        data["atom_refs"] = tuple(
+            CandidateAtomRef.from_dict(item) for item in atom_refs
+        )
         data["attempt_refs"] = tuple(
             CandidateAttemptRef.from_dict(item) for item in attempt_refs
         )
@@ -497,7 +501,9 @@ def migrate_legacy_candidate_buffer(
             raise EvidenceCandidateError("candidate buffer entries must be objects")
         if "schema_version" in value or "candidate_id" in value:
             parsed = TaskSkillCandidate.from_dict(value)
-            _ensure(parsed.skill_name == skill_name, "candidate belongs to another Skill")
+            _ensure(
+                parsed.skill_name == skill_name, "candidate belongs to another Skill"
+            )
             migrated.append(parsed.to_dict())
         elif "atom_id" in value:
             migrated.append(
@@ -554,8 +560,12 @@ def upsert_evidence_candidates(
         candidate_id = value.get("candidate_id")
         if "schema_version" in value or candidate_id is not None:
             parsed = TaskSkillCandidate.from_dict(value)
-            _ensure(parsed.skill_name == skill_name, "candidate belongs to another Skill")
-            _ensure(parsed.candidate_id not in positions, "duplicate candidate_id in buffer")
+            _ensure(
+                parsed.skill_name == skill_name, "candidate belongs to another Skill"
+            )
+            _ensure(
+                parsed.candidate_id not in positions, "duplicate candidate_id in buffer"
+            )
             positions[parsed.candidate_id] = index
             if not parsed.contributes_to_promotion:
                 total -= weightscore

--- a/src/xskill/skill/evidence_candidates.py
+++ b/src/xskill/skill/evidence_candidates.py
@@ -7,8 +7,9 @@ references and fingerprints, never copied trajectory or Task prompt text.
 
 from __future__ import annotations
 
+import copy
 from dataclasses import dataclass
-from typing import Any
+from typing import Any, Iterable
 
 from xskill.skill.evidence_candidate_refs import (
     CandidateAtomRef,
@@ -426,3 +427,118 @@ class TaskSkillCandidate:
             eligibility_reasons=(f"atom_fallback:{fallback_reason}",),
             fallback_reason=fallback_reason,
         )
+
+
+def migrate_legacy_atom_candidate(
+    value: Any,
+    *,
+    skill_name: str,
+) -> TaskSkillCandidate:
+    """Deterministically wrap one current v2.1 Atom candidate as fallback."""
+    if not isinstance(value, dict):
+        raise EvidenceCandidateError("legacy Atom candidate must be an object")
+    allowed = {"atom_id", "weightscore", "note"}
+    unknown = set(value) - allowed
+    _ensure(not unknown, f"unsupported legacy Atom candidate fields: {sorted(unknown)}")
+    _ensure("atom_id" in value and "weightscore" in value, "legacy Atom fields missing")
+    return TaskSkillCandidate.from_atom_fallback(
+        atom_id=value["atom_id"],
+        skill_name=skill_name,
+        weightscore=value["weightscore"],
+        note=value.get("note", ""),
+        fallback_reason="legacy_atom_candidate",
+    )
+
+
+def migrate_legacy_candidate_buffer(
+    data: dict[str, Any],
+    *,
+    skill_name: str,
+) -> tuple[dict[str, Any], int]:
+    """Return a migrated copy; legacy pattern candidates stay byte-for-byte data."""
+    if not isinstance(data, dict):
+        raise EvidenceCandidateError("candidate buffer must be an object")
+    buffer = data.get("candidates", [])
+    _ensure(isinstance(buffer, list), "candidates must be a list")
+    migrated: list[dict[str, Any]] = []
+    migrated_count = 0
+    for value in buffer:
+        if not isinstance(value, dict):
+            raise EvidenceCandidateError("candidate buffer entries must be objects")
+        if "schema_version" in value or "candidate_id" in value:
+            parsed = TaskSkillCandidate.from_dict(value)
+            _ensure(parsed.skill_name == skill_name, "candidate belongs to another Skill")
+            migrated.append(parsed.to_dict())
+        elif "atom_id" in value:
+            migrated.append(
+                migrate_legacy_atom_candidate(value, skill_name=skill_name).to_dict()
+            )
+            migrated_count += 1
+        else:
+            migrated.append(copy.deepcopy(value))
+    result = copy.deepcopy(data)
+    result["candidates"] = migrated
+    return result, migrated_count
+
+
+def upsert_evidence_candidates(
+    data: dict[str, Any],
+    candidates: Iterable[TaskSkillCandidate],
+) -> tuple[list[bool], int]:
+    """Upsert a bounded batch with one O(existing + incoming) buffer scan."""
+    if not isinstance(data, dict):
+        raise EvidenceCandidateError("candidate buffer must be an object")
+    incoming = tuple(candidates)
+    _ensure(bool(incoming), "candidate batch must not be empty")
+    _ensure(
+        all(isinstance(item, TaskSkillCandidate) for item in incoming),
+        "candidate batch must contain TaskSkillCandidate values",
+    )
+    skill_name = incoming[0].skill_name
+    _ensure(
+        all(item.skill_name == skill_name for item in incoming),
+        "candidate batch cannot cross Skills",
+    )
+    incoming_ids = [item.candidate_id for item in incoming]
+    _ensure(
+        len(incoming_ids) == len(set(incoming_ids)),
+        "candidate batch contains duplicate stable identities",
+    )
+    buffer = data.setdefault("candidates", [])
+    _ensure(isinstance(buffer, list), "candidates must be a list")
+    positions: dict[str, int] = {}
+    total = 0
+    for index, value in enumerate(buffer):
+        if not isinstance(value, dict):
+            raise EvidenceCandidateError("candidate buffer entries must be objects")
+        weightscore = value.get("weightscore", 0)
+        _ensure(
+            not isinstance(weightscore, bool) and isinstance(weightscore, int),
+            "candidate weightscore must be an integer",
+        )
+        _ensure(
+            "weightscore" not in value or 1 <= weightscore <= 10,
+            "candidate weightscore must be from 1 through 10",
+        )
+        total += weightscore
+        candidate_id = value.get("candidate_id")
+        if candidate_id is not None:
+            parsed = TaskSkillCandidate.from_dict(value)
+            _ensure(parsed.skill_name == skill_name, "candidate belongs to another Skill")
+            _ensure(parsed.candidate_id not in positions, "duplicate candidate_id in buffer")
+            positions[parsed.candidate_id] = index
+    new_flags: list[bool] = []
+    for candidate in incoming:
+        serialized = candidate.to_dict()
+        position = positions.get(candidate.candidate_id)
+        if position is None:
+            positions[candidate.candidate_id] = len(buffer)
+            buffer.append(serialized)
+            total += candidate.weightscore
+            new_flags.append(True)
+        else:
+            total -= int(buffer[position]["weightscore"])
+            buffer[position] = serialized
+            total += candidate.weightscore
+            new_flags.append(False)
+    return new_flags, total

--- a/src/xskill/tasks/evidence_bundle.py
+++ b/src/xskill/tasks/evidence_bundle.py
@@ -26,6 +26,7 @@ from xskill.tasks.models import (
 BUNDLE_SCHEMA_VERSION = 1
 ELIGIBILITY_POLICY_VERSION = "task-outcome-v1"
 LEARNING_ELIGIBILITIES = frozenset(("eligible", "ineligible", "needs_review"))
+MAX_TASK_EVIDENCE_BUNDLE_BYTES = 1024 * 1024
 _T = TypeVar("_T")
 
 
@@ -47,11 +48,16 @@ class TaskEvidenceLimits:
     attempt_relations: int = 256
     evidence_ranges: int = 512
     usage_allocations: int = 512
+    serialized_bytes: int = MAX_TASK_EVIDENCE_BUNDLE_BYTES
 
     def __post_init__(self) -> None:
         for field_name, value in vars(self).items():
             if isinstance(value, bool) or not isinstance(value, int) or value <= 0:
                 raise ValueError(f"{field_name} limit must be a positive integer")
+        if self.serialized_bytes > MAX_TASK_EVIDENCE_BUNDLE_BYTES:
+            raise ValueError(
+                "serialized_bytes cannot exceed the Task evidence hard bound"
+            )
 
 
 def _canonical_json(value: Any) -> bytes:
@@ -70,6 +76,23 @@ def _fingerprint(value: Any) -> str:
 
 def _ordered(values: Iterable[_T], key: Callable[[_T], Any]) -> tuple[_T, ...]:
     return tuple(sorted(values, key=key))
+
+
+def _bounded_ordered(
+    values: Iterable[_T],
+    *,
+    key: Callable[[_T], Any],
+    maximum: int,
+    field_name: str,
+) -> tuple[_T, ...]:
+    bounded: list[_T] = []
+    for value in values:
+        bounded.append(value)
+        if len(bounded) > maximum:
+            raise TaskEvidenceBundleError(
+                f"Task evidence {field_name} exceeds bound: {len(bounded)}>{maximum}"
+            )
+    return tuple(sorted(bounded, key=key))
 
 
 def _strict_object(value: dict[str, Any], expected: set[str]) -> None:
@@ -247,52 +270,96 @@ class TaskEvidenceBundle:
             "eligibility_policy_version": self.eligibility_policy_version,
         }
 
+    def _task_evidence_payload(self) -> dict[str, Any]:
+        """Return generation-independent Task evidence for dirty detection."""
+        payload = self._payload()
+        for field_name in (
+            "generation_id",
+            "source_revision",
+            "created_at",
+            "generator_fingerprint",
+        ):
+            payload.pop(field_name)
+        return payload
+
     @property
     def bundle_fingerprint(self) -> str:
         return _fingerprint(self._payload())
 
+    @property
+    def task_evidence_fingerprint(self) -> str:
+        return _fingerprint(self._task_evidence_payload())
+
     def to_dict(self) -> dict[str, Any]:
-        return {**self._payload(), "bundle_fingerprint": self.bundle_fingerprint}
+        return {
+            **self._payload(),
+            "bundle_fingerprint": self.bundle_fingerprint,
+            "task_evidence_fingerprint": self.task_evidence_fingerprint,
+        }
 
     @classmethod
     def from_dict(cls, value: dict[str, Any]) -> TaskEvidenceBundle:
         if not isinstance(value, dict):
             raise TaskEvidenceBundleError("TaskEvidenceBundle must be an object")
-        expected = set(cls.__dataclass_fields__) | {"bundle_fingerprint"}
+        expected = set(cls.__dataclass_fields__) | {
+            "bundle_fingerprint",
+            "task_evidence_fingerprint",
+        }
         _strict_object(value, expected)
-        bundle = cls(
-            schema_version=value["schema_version"],
-            generation_id=value["generation_id"],
-            tenant_id=value["tenant_id"],
-            task_scope_id=value["task_scope_id"],
-            source_revision=value["source_revision"],
-            created_at=value["created_at"],
-            generator_fingerprint=value["generator_fingerprint"],
-            task=LogicalTask.from_dict(value["task"]),
-            confirmed_memberships=tuple(
-                TaskAtomMembership.from_dict(item)
-                for item in value["confirmed_memberships"]
-            ),
-            review_memberships=tuple(
-                TaskAtomMembership.from_dict(item)
-                for item in value["review_memberships"]
-            ),
-            task_relations=tuple(
-                TaskRelation.from_dict(item) for item in value["task_relations"]
-            ),
-            attempts=tuple(TaskAttempt.from_dict(item) for item in value["attempts"]),
-            attempt_relations=tuple(
-                AttemptRelation.from_dict(item) for item in value["attempt_relations"]
-            ),
-            usage_allocations=tuple(
-                UsageAllocation.from_dict(item) for item in value["usage_allocations"]
-            ),
-            learning_eligibility=value["learning_eligibility"],
-            eligibility_reasons=tuple(value["eligibility_reasons"]),
-            eligibility_policy_version=value["eligibility_policy_version"],
-        )
+        try:
+            serialized_size = len(_canonical_json(value))
+            _ensure(
+                serialized_size <= MAX_TASK_EVIDENCE_BUNDLE_BYTES,
+                "Task evidence serialized_bytes exceeds hard bound: "
+                f"{serialized_size}>{MAX_TASK_EVIDENCE_BUNDLE_BYTES}",
+            )
+            bundle = cls(
+                schema_version=value["schema_version"],
+                generation_id=value["generation_id"],
+                tenant_id=value["tenant_id"],
+                task_scope_id=value["task_scope_id"],
+                source_revision=value["source_revision"],
+                created_at=value["created_at"],
+                generator_fingerprint=value["generator_fingerprint"],
+                task=LogicalTask.from_dict(value["task"]),
+                confirmed_memberships=tuple(
+                    TaskAtomMembership.from_dict(item)
+                    for item in value["confirmed_memberships"]
+                ),
+                review_memberships=tuple(
+                    TaskAtomMembership.from_dict(item)
+                    for item in value["review_memberships"]
+                ),
+                task_relations=tuple(
+                    TaskRelation.from_dict(item) for item in value["task_relations"]
+                ),
+                attempts=tuple(
+                    TaskAttempt.from_dict(item) for item in value["attempts"]
+                ),
+                attempt_relations=tuple(
+                    AttemptRelation.from_dict(item)
+                    for item in value["attempt_relations"]
+                ),
+                usage_allocations=tuple(
+                    UsageAllocation.from_dict(item)
+                    for item in value["usage_allocations"]
+                ),
+                learning_eligibility=value["learning_eligibility"],
+                eligibility_reasons=tuple(value["eligibility_reasons"]),
+                eligibility_policy_version=value["eligibility_policy_version"],
+            )
+        except TaskEvidenceBundleError:
+            raise
+        except (KeyError, TypeError, ValueError) as exc:
+            raise TaskEvidenceBundleError(
+                f"invalid nested TaskEvidenceBundle value: {exc}"
+            ) from exc
         if value["bundle_fingerprint"] != bundle.bundle_fingerprint:
             raise TaskEvidenceBundleError("TaskEvidenceBundle fingerprint mismatch")
+        if value["task_evidence_fingerprint"] != bundle.task_evidence_fingerprint:
+            raise TaskEvidenceBundleError(
+                "TaskEvidenceBundle task evidence fingerprint mismatch"
+            )
         return bundle
 
 
@@ -312,7 +379,7 @@ def build_task_evidence_bundle(
     if task.tombstoned:
         raise TaskEvidenceBundleError("tombstoned Task cannot become learning evidence")
 
-    confirmed = _ordered(
+    confirmed = _bounded_ordered(
         (
             item
             for item in generation.memberships
@@ -321,9 +388,11 @@ def build_task_evidence_bundle(
             and item.decision == "confirmed"
             and not item.stale
         ),
-        lambda item: item.atom_ref.key,
+        key=lambda item: item.atom_ref.key,
+        maximum=limit.memberships,
+        field_name="memberships",
     )
-    review = _ordered(
+    review = _bounded_ordered(
         (
             item
             for item in generation.memberships
@@ -331,18 +400,36 @@ def build_task_evidence_bundle(
             and item.decision in {"proposed", "needs_review"}
             and not item.stale
         ),
-        lambda item: (item.atom_ref.key, item.membership_id),
+        key=lambda item: (item.atom_ref.key, item.membership_id),
+        maximum=limit.review_memberships,
+        field_name="review_memberships",
     )
-    task_relations = _ordered(
+    task_relations = _bounded_ordered(
         (
             item
             for item in generation.relations
             if task_id in {item.from_task_id, item.to_task_id} and not item.stale
         ),
-        lambda item: item.relation_id,
+        key=lambda item: item.relation_id,
+        maximum=limit.task_relations,
+        field_name="task_relations",
     )
-    attempts = _ordered(
-        (
+    raw_attempts = _bounded_ordered(
+        (item for item in generation.attempts if item.task_id == task_id),
+        key=lambda item: (item.started_at, item.attempt_id),
+        maximum=limit.attempts,
+        field_name="attempts",
+    )
+    evidence_range_count = 0
+    attempts_list: list[TaskAttempt] = []
+    for item in raw_attempts:
+        evidence_range_count += len(item.evidence_ranges)
+        if evidence_range_count > limit.evidence_ranges:
+            raise TaskEvidenceBundleError(
+                "Task evidence evidence_ranges exceeds bound: "
+                f"{evidence_range_count}>{limit.evidence_ranges}"
+            )
+        attempts_list.append(
             replace(
                 item,
                 evidence_ranges=_ordered(
@@ -350,41 +437,27 @@ def build_task_evidence_bundle(
                     lambda evidence: evidence.evidence_id,
                 ),
             )
-            for item in generation.attempts
-            if item.task_id == task_id
-        ),
-        lambda item: (item.started_at, item.attempt_id),
-    )
+        )
+    attempts = tuple(attempts_list)
     attempt_ids = {item.attempt_id for item in attempts}
-    attempt_relations = _ordered(
+    attempt_relations = _bounded_ordered(
         (
             item
             for item in generation.attempt_relations
             if item.from_attempt_id in attempt_ids and item.to_attempt_id in attempt_ids
         ),
-        lambda item: item.relation_id,
+        key=lambda item: item.relation_id,
+        maximum=limit.attempt_relations,
+        field_name="attempt_relations",
     )
-    usage = _ordered(
+    usage = _bounded_ordered(
         (item for item in generation.usage_allocations if item.task_id == task_id),
-        lambda item: item.allocation_id,
+        key=lambda item: item.allocation_id,
+        maximum=limit.usage_allocations,
+        field_name="usage_allocations",
     )
-    counts = {
-        "memberships": len(confirmed),
-        "review_memberships": len(review),
-        "task_relations": len(task_relations),
-        "attempts": len(attempts),
-        "attempt_relations": len(attempt_relations),
-        "evidence_ranges": sum(len(item.evidence_ranges) for item in attempts),
-        "usage_allocations": len(usage),
-    }
-    for field_name, count in counts.items():
-        maximum = getattr(limit, field_name)
-        if count > maximum:
-            raise TaskEvidenceBundleError(
-                f"Task evidence {field_name} exceeds bound: {count}>{maximum}"
-            )
     eligibility, reasons = _learning_eligibility(task, attempts, review)
-    return TaskEvidenceBundle(
+    bundle = TaskEvidenceBundle(
         generation_id=generation.generation_id,
         tenant_id=generation.tenant_id,
         task_scope_id=generation.task_scope_id,
@@ -401,3 +474,10 @@ def build_task_evidence_bundle(
         learning_eligibility=eligibility,
         eligibility_reasons=reasons,
     )
+    serialized_size = len(_canonical_json(bundle.to_dict()))
+    if serialized_size > limit.serialized_bytes:
+        raise TaskEvidenceBundleError(
+            "Task evidence serialized_bytes exceeds bound: "
+            f"{serialized_size}>{limit.serialized_bytes}"
+        )
+    return bundle

--- a/src/xskill/tasks/evidence_bundle.py
+++ b/src/xskill/tasks/evidence_bundle.py
@@ -27,6 +27,7 @@ from xskill.tasks.models import (
 BUNDLE_SCHEMA_VERSION = 1
 ELIGIBILITY_POLICY_VERSION = "task-outcome-v1"
 LEARNING_ELIGIBILITIES = frozenset(("eligible", "ineligible", "needs_review"))
+MAX_TASK_EVIDENCE_BUNDLE_BYTES = 1024 * 1024
 _T = TypeVar("_T")
 
 
@@ -48,11 +49,16 @@ class TaskEvidenceLimits:
     attempt_relations: int = 256
     evidence_ranges: int = 512
     usage_allocations: int = 512
+    serialized_bytes: int = MAX_TASK_EVIDENCE_BUNDLE_BYTES
 
     def __post_init__(self) -> None:
         for field_name, value in vars(self).items():
             if isinstance(value, bool) or not isinstance(value, int) or value <= 0:
                 raise ValueError(f"{field_name} limit must be a positive integer")
+        if self.serialized_bytes > MAX_TASK_EVIDENCE_BUNDLE_BYTES:
+            raise ValueError(
+                "serialized_bytes cannot exceed the Task evidence hard bound"
+            )
 
 
 def _canonical_json(value: Any) -> bytes:
@@ -71,6 +77,23 @@ def _fingerprint(value: Any) -> str:
 
 def _ordered(values: Iterable[_T], key: Callable[[_T], Any]) -> tuple[_T, ...]:
     return tuple(sorted(values, key=key))
+
+
+def _bounded_ordered(
+    values: Iterable[_T],
+    *,
+    key: Callable[[_T], Any],
+    maximum: int,
+    field_name: str,
+) -> tuple[_T, ...]:
+    bounded: list[_T] = []
+    for value in values:
+        bounded.append(value)
+        if len(bounded) > maximum:
+            raise TaskEvidenceBundleError(
+                f"Task evidence {field_name} exceeds bound: {len(bounded)}>{maximum}"
+            )
+    return tuple(sorted(bounded, key=key))
 
 
 def _strict_object(value: dict[str, Any], expected: set[str]) -> None:
@@ -248,52 +271,96 @@ class TaskEvidenceBundle:
             "eligibility_policy_version": self.eligibility_policy_version,
         }
 
+    def _task_evidence_payload(self) -> dict[str, Any]:
+        """Return generation-independent Task evidence for dirty detection."""
+        payload = self._payload()
+        for field_name in (
+            "generation_id",
+            "source_revision",
+            "created_at",
+            "generator_fingerprint",
+        ):
+            payload.pop(field_name)
+        return payload
+
     @property
     def bundle_fingerprint(self) -> str:
         return _fingerprint(self._payload())
 
+    @property
+    def task_evidence_fingerprint(self) -> str:
+        return _fingerprint(self._task_evidence_payload())
+
     def to_dict(self) -> dict[str, Any]:
-        return {**self._payload(), "bundle_fingerprint": self.bundle_fingerprint}
+        return {
+            **self._payload(),
+            "bundle_fingerprint": self.bundle_fingerprint,
+            "task_evidence_fingerprint": self.task_evidence_fingerprint,
+        }
 
     @classmethod
     def from_dict(cls, value: dict[str, Any]) -> TaskEvidenceBundle:
         if not isinstance(value, dict):
             raise TaskEvidenceBundleError("TaskEvidenceBundle must be an object")
-        expected = set(cls.__dataclass_fields__) | {"bundle_fingerprint"}
+        expected = set(cls.__dataclass_fields__) | {
+            "bundle_fingerprint",
+            "task_evidence_fingerprint",
+        }
         _strict_object(value, expected)
-        bundle = cls(
-            schema_version=value["schema_version"],
-            generation_id=value["generation_id"],
-            tenant_id=value["tenant_id"],
-            task_scope_id=value["task_scope_id"],
-            source_revision=value["source_revision"],
-            created_at=value["created_at"],
-            generator_fingerprint=value["generator_fingerprint"],
-            task=LogicalTask.from_dict(value["task"]),
-            confirmed_memberships=tuple(
-                TaskAtomMembership.from_dict(item)
-                for item in value["confirmed_memberships"]
-            ),
-            review_memberships=tuple(
-                TaskAtomMembership.from_dict(item)
-                for item in value["review_memberships"]
-            ),
-            task_relations=tuple(
-                TaskRelation.from_dict(item) for item in value["task_relations"]
-            ),
-            attempts=tuple(TaskAttempt.from_dict(item) for item in value["attempts"]),
-            attempt_relations=tuple(
-                AttemptRelation.from_dict(item) for item in value["attempt_relations"]
-            ),
-            usage_allocations=tuple(
-                UsageAllocation.from_dict(item) for item in value["usage_allocations"]
-            ),
-            learning_eligibility=value["learning_eligibility"],
-            eligibility_reasons=tuple(value["eligibility_reasons"]),
-            eligibility_policy_version=value["eligibility_policy_version"],
-        )
+        try:
+            serialized_size = len(_canonical_json(value))
+            _ensure(
+                serialized_size <= MAX_TASK_EVIDENCE_BUNDLE_BYTES,
+                "Task evidence serialized_bytes exceeds hard bound: "
+                f"{serialized_size}>{MAX_TASK_EVIDENCE_BUNDLE_BYTES}",
+            )
+            bundle = cls(
+                schema_version=value["schema_version"],
+                generation_id=value["generation_id"],
+                tenant_id=value["tenant_id"],
+                task_scope_id=value["task_scope_id"],
+                source_revision=value["source_revision"],
+                created_at=value["created_at"],
+                generator_fingerprint=value["generator_fingerprint"],
+                task=LogicalTask.from_dict(value["task"]),
+                confirmed_memberships=tuple(
+                    TaskAtomMembership.from_dict(item)
+                    for item in value["confirmed_memberships"]
+                ),
+                review_memberships=tuple(
+                    TaskAtomMembership.from_dict(item)
+                    for item in value["review_memberships"]
+                ),
+                task_relations=tuple(
+                    TaskRelation.from_dict(item) for item in value["task_relations"]
+                ),
+                attempts=tuple(
+                    TaskAttempt.from_dict(item) for item in value["attempts"]
+                ),
+                attempt_relations=tuple(
+                    AttemptRelation.from_dict(item)
+                    for item in value["attempt_relations"]
+                ),
+                usage_allocations=tuple(
+                    UsageAllocation.from_dict(item)
+                    for item in value["usage_allocations"]
+                ),
+                learning_eligibility=value["learning_eligibility"],
+                eligibility_reasons=tuple(value["eligibility_reasons"]),
+                eligibility_policy_version=value["eligibility_policy_version"],
+            )
+        except TaskEvidenceBundleError:
+            raise
+        except (KeyError, TypeError, ValueError) as exc:
+            raise TaskEvidenceBundleError(
+                f"invalid nested TaskEvidenceBundle value: {exc}"
+            ) from exc
         if value["bundle_fingerprint"] != bundle.bundle_fingerprint:
             raise TaskEvidenceBundleError("TaskEvidenceBundle fingerprint mismatch")
+        if value["task_evidence_fingerprint"] != bundle.task_evidence_fingerprint:
+            raise TaskEvidenceBundleError(
+                "TaskEvidenceBundle task evidence fingerprint mismatch"
+            )
         return bundle
 
 
@@ -317,38 +384,75 @@ class TaskEvidenceBundleIndex:
         self._attempt_relations: dict[str, list[AttemptRelation]] = defaultdict(list)
         self._usage: dict[str, list[UsageAllocation]] = defaultdict(list)
 
+        def append_bounded(
+            mapping: dict[str, list[Any]],
+            task_id: str,
+            item: Any,
+            maximum: int,
+        ) -> None:
+            values = mapping[task_id]
+            if len(values) <= maximum:
+                values.append(item)
+
         for item in generation.memberships:
             if item.stale:
                 continue
             if item.role == "primary" and item.decision == "confirmed":
-                self._confirmed[item.task_id].append(item)
+                append_bounded(
+                    self._confirmed,
+                    item.task_id,
+                    item,
+                    self._limits.memberships,
+                )
             elif item.decision in {"proposed", "needs_review"}:
-                self._review[item.task_id].append(item)
+                append_bounded(
+                    self._review,
+                    item.task_id,
+                    item,
+                    self._limits.review_memberships,
+                )
         for item in generation.relations:
             if item.stale:
                 continue
-            self._relations[item.from_task_id].append(item)
+            append_bounded(
+                self._relations,
+                item.from_task_id,
+                item,
+                self._limits.task_relations,
+            )
             if item.to_task_id != item.from_task_id:
-                self._relations[item.to_task_id].append(item)
+                append_bounded(
+                    self._relations,
+                    item.to_task_id,
+                    item,
+                    self._limits.task_relations,
+                )
         attempt_tasks: dict[str, str] = {}
         for item in generation.attempts:
             attempt_tasks[item.attempt_id] = item.task_id
-            self._attempts[item.task_id].append(
-                replace(
-                    item,
-                    evidence_ranges=_ordered(
-                        item.evidence_ranges,
-                        lambda evidence: evidence.evidence_id,
-                    ),
-                )
+            append_bounded(
+                self._attempts,
+                item.task_id,
+                item,
+                self._limits.attempts,
             )
         for item in generation.attempt_relations:
             task_id = attempt_tasks.get(item.from_attempt_id)
             if task_id and attempt_tasks.get(item.to_attempt_id) == task_id:
-                self._attempt_relations[task_id].append(item)
+                append_bounded(
+                    self._attempt_relations,
+                    task_id,
+                    item,
+                    self._limits.attempt_relations,
+                )
         for item in generation.usage_allocations:
             if item.task_id:
-                self._usage[item.task_id].append(item)
+                append_bounded(
+                    self._usage,
+                    item.task_id,
+                    item,
+                    self._limits.usage_allocations,
+                )
 
     def build(self, task_id: str) -> TaskEvidenceBundle:
         if not isinstance(task_id, str) or not task_id.strip():
@@ -361,39 +465,64 @@ class TaskEvidenceBundleIndex:
                 "tombstoned Task cannot become learning evidence"
             )
 
-        confirmed = _ordered(self._confirmed[task_id], lambda item: item.atom_ref.key)
-        review = _ordered(
+        confirmed = _bounded_ordered(
+            self._confirmed[task_id],
+            key=lambda item: item.atom_ref.key,
+            maximum=self._limits.memberships,
+            field_name="memberships",
+        )
+        review = _bounded_ordered(
             self._review[task_id],
-            lambda item: (item.atom_ref.key, item.membership_id),
+            key=lambda item: (item.atom_ref.key, item.membership_id),
+            maximum=self._limits.review_memberships,
+            field_name="review_memberships",
         )
-        task_relations = _ordered(
-            self._relations[task_id], lambda item: item.relation_id
+        task_relations = _bounded_ordered(
+            self._relations[task_id],
+            key=lambda item: item.relation_id,
+            maximum=self._limits.task_relations,
+            field_name="task_relations",
         )
-        attempts = _ordered(
-            self._attempts[task_id], lambda item: (item.started_at, item.attempt_id)
+        raw_attempts = _bounded_ordered(
+            self._attempts[task_id],
+            key=lambda item: (item.started_at, item.attempt_id),
+            maximum=self._limits.attempts,
+            field_name="attempts",
         )
-        attempt_relations = _ordered(
-            self._attempt_relations[task_id], lambda item: item.relation_id
-        )
-        usage = _ordered(self._usage[task_id], lambda item: item.allocation_id)
-        counts = {
-            "memberships": len(confirmed),
-            "review_memberships": len(review),
-            "task_relations": len(task_relations),
-            "attempts": len(attempts),
-            "attempt_relations": len(attempt_relations),
-            "evidence_ranges": sum(len(item.evidence_ranges) for item in attempts),
-            "usage_allocations": len(usage),
-        }
-        for field_name, count in counts.items():
-            maximum = getattr(self._limits, field_name)
-            if count > maximum:
+        evidence_range_count = 0
+        attempts_list: list[TaskAttempt] = []
+        for item in raw_attempts:
+            evidence_range_count += len(item.evidence_ranges)
+            if evidence_range_count > self._limits.evidence_ranges:
                 raise TaskEvidenceBundleError(
-                    f"Task evidence {field_name} exceeds bound: {count}>{maximum}"
+                    "Task evidence evidence_ranges exceeds bound: "
+                    f"{evidence_range_count}>{self._limits.evidence_ranges}"
                 )
+            attempts_list.append(
+                replace(
+                    item,
+                    evidence_ranges=_ordered(
+                        item.evidence_ranges,
+                        lambda evidence: evidence.evidence_id,
+                    ),
+                )
+            )
+        attempts = tuple(attempts_list)
+        attempt_relations = _bounded_ordered(
+            self._attempt_relations[task_id],
+            key=lambda item: item.relation_id,
+            maximum=self._limits.attempt_relations,
+            field_name="attempt_relations",
+        )
+        usage = _bounded_ordered(
+            self._usage[task_id],
+            key=lambda item: item.allocation_id,
+            maximum=self._limits.usage_allocations,
+            field_name="usage_allocations",
+        )
         eligibility, reasons = _learning_eligibility(task, attempts, review)
         generation = self._generation
-        return TaskEvidenceBundle(
+        bundle = TaskEvidenceBundle(
             generation_id=generation.generation_id,
             tenant_id=generation.tenant_id,
             task_scope_id=generation.task_scope_id,
@@ -410,6 +539,13 @@ class TaskEvidenceBundleIndex:
             learning_eligibility=eligibility,
             eligibility_reasons=reasons,
         )
+        serialized_size = len(_canonical_json(bundle.to_dict()))
+        if serialized_size > self._limits.serialized_bytes:
+            raise TaskEvidenceBundleError(
+                "Task evidence serialized_bytes exceeds bound: "
+                f"{serialized_size}>{self._limits.serialized_bytes}"
+            )
+        return bundle
 
 
 def build_task_evidence_bundle(

--- a/src/xskill/tasks/evidence_bundle.py
+++ b/src/xskill/tasks/evidence_bundle.py
@@ -9,6 +9,7 @@ from __future__ import annotations
 
 import hashlib
 import json
+from collections import defaultdict
 from collections.abc import Callable, Iterable
 from dataclasses import dataclass, replace
 from typing import Any, TypeVar
@@ -296,6 +297,121 @@ class TaskEvidenceBundle:
         return bundle
 
 
+class TaskEvidenceBundleIndex:
+    """Index one generation once, then build Task bundles without rescanning it."""
+
+    def __init__(
+        self,
+        generation: TaskGraphGeneration,
+        *,
+        limits: TaskEvidenceLimits | None = None,
+    ) -> None:
+        self._generation = generation
+        self._generator_fingerprint = _fingerprint(generation.generator)
+        self._limits = limits or TaskEvidenceLimits()
+        self._tasks = {item.task_id: item for item in generation.tasks}
+        self._confirmed: dict[str, list[TaskAtomMembership]] = defaultdict(list)
+        self._review: dict[str, list[TaskAtomMembership]] = defaultdict(list)
+        self._relations: dict[str, list[TaskRelation]] = defaultdict(list)
+        self._attempts: dict[str, list[TaskAttempt]] = defaultdict(list)
+        self._attempt_relations: dict[str, list[AttemptRelation]] = defaultdict(list)
+        self._usage: dict[str, list[UsageAllocation]] = defaultdict(list)
+
+        for item in generation.memberships:
+            if item.stale:
+                continue
+            if item.role == "primary" and item.decision == "confirmed":
+                self._confirmed[item.task_id].append(item)
+            elif item.decision in {"proposed", "needs_review"}:
+                self._review[item.task_id].append(item)
+        for item in generation.relations:
+            if item.stale:
+                continue
+            self._relations[item.from_task_id].append(item)
+            if item.to_task_id != item.from_task_id:
+                self._relations[item.to_task_id].append(item)
+        attempt_tasks: dict[str, str] = {}
+        for item in generation.attempts:
+            attempt_tasks[item.attempt_id] = item.task_id
+            self._attempts[item.task_id].append(
+                replace(
+                    item,
+                    evidence_ranges=_ordered(
+                        item.evidence_ranges,
+                        lambda evidence: evidence.evidence_id,
+                    ),
+                )
+            )
+        for item in generation.attempt_relations:
+            task_id = attempt_tasks.get(item.from_attempt_id)
+            if task_id and attempt_tasks.get(item.to_attempt_id) == task_id:
+                self._attempt_relations[task_id].append(item)
+        for item in generation.usage_allocations:
+            if item.task_id:
+                self._usage[item.task_id].append(item)
+
+    def build(self, task_id: str) -> TaskEvidenceBundle:
+        if not isinstance(task_id, str) or not task_id.strip():
+            raise TaskEvidenceBundleError("task_id must be non-empty")
+        task = self._tasks.get(task_id)
+        if task is None:
+            raise TaskEvidenceBundleError(f"Task not found in generation: {task_id}")
+        if task.tombstoned:
+            raise TaskEvidenceBundleError(
+                "tombstoned Task cannot become learning evidence"
+            )
+
+        confirmed = _ordered(self._confirmed[task_id], lambda item: item.atom_ref.key)
+        review = _ordered(
+            self._review[task_id],
+            lambda item: (item.atom_ref.key, item.membership_id),
+        )
+        task_relations = _ordered(
+            self._relations[task_id], lambda item: item.relation_id
+        )
+        attempts = _ordered(
+            self._attempts[task_id], lambda item: (item.started_at, item.attempt_id)
+        )
+        attempt_relations = _ordered(
+            self._attempt_relations[task_id], lambda item: item.relation_id
+        )
+        usage = _ordered(self._usage[task_id], lambda item: item.allocation_id)
+        counts = {
+            "memberships": len(confirmed),
+            "review_memberships": len(review),
+            "task_relations": len(task_relations),
+            "attempts": len(attempts),
+            "attempt_relations": len(attempt_relations),
+            "evidence_ranges": sum(len(item.evidence_ranges) for item in attempts),
+            "usage_allocations": len(usage),
+        }
+        for field_name, count in counts.items():
+            maximum = getattr(self._limits, field_name)
+            if count > maximum:
+                raise TaskEvidenceBundleError(
+                    f"Task evidence {field_name} exceeds bound: {count}>{maximum}"
+                )
+        eligibility, reasons = _learning_eligibility(task, attempts, review)
+        generation = self._generation
+        return TaskEvidenceBundle(
+            generation_id=generation.generation_id,
+            tenant_id=generation.tenant_id,
+            task_scope_id=generation.task_scope_id,
+            source_revision=generation.source_revision,
+            created_at=generation.created_at,
+            generator_fingerprint=self._generator_fingerprint,
+            task=task,
+            confirmed_memberships=confirmed,
+            review_memberships=review,
+            task_relations=task_relations,
+            attempts=attempts,
+            attempt_relations=attempt_relations,
+            usage_allocations=usage,
+            learning_eligibility=eligibility,
+            eligibility_reasons=reasons,
+        )
+
+
 def build_task_evidence_bundle(
     generation: TaskGraphGeneration,
     task_id: str,
@@ -303,101 +419,4 @@ def build_task_evidence_bundle(
     limits: TaskEvidenceLimits | None = None,
 ) -> TaskEvidenceBundle:
     """Build one safe learning bundle from an immutable generation."""
-    if not isinstance(task_id, str) or not task_id.strip():
-        raise TaskEvidenceBundleError("task_id must be non-empty")
-    limit = limits or TaskEvidenceLimits()
-    task = next((item for item in generation.tasks if item.task_id == task_id), None)
-    if task is None:
-        raise TaskEvidenceBundleError(f"Task not found in generation: {task_id}")
-    if task.tombstoned:
-        raise TaskEvidenceBundleError("tombstoned Task cannot become learning evidence")
-
-    confirmed = _ordered(
-        (
-            item
-            for item in generation.memberships
-            if item.task_id == task_id
-            and item.role == "primary"
-            and item.decision == "confirmed"
-            and not item.stale
-        ),
-        lambda item: item.atom_ref.key,
-    )
-    review = _ordered(
-        (
-            item
-            for item in generation.memberships
-            if item.task_id == task_id
-            and item.decision in {"proposed", "needs_review"}
-            and not item.stale
-        ),
-        lambda item: (item.atom_ref.key, item.membership_id),
-    )
-    task_relations = _ordered(
-        (
-            item
-            for item in generation.relations
-            if task_id in {item.from_task_id, item.to_task_id} and not item.stale
-        ),
-        lambda item: item.relation_id,
-    )
-    attempts = _ordered(
-        (
-            replace(
-                item,
-                evidence_ranges=_ordered(
-                    item.evidence_ranges,
-                    lambda evidence: evidence.evidence_id,
-                ),
-            )
-            for item in generation.attempts
-            if item.task_id == task_id
-        ),
-        lambda item: (item.started_at, item.attempt_id),
-    )
-    attempt_ids = {item.attempt_id for item in attempts}
-    attempt_relations = _ordered(
-        (
-            item
-            for item in generation.attempt_relations
-            if item.from_attempt_id in attempt_ids and item.to_attempt_id in attempt_ids
-        ),
-        lambda item: item.relation_id,
-    )
-    usage = _ordered(
-        (item for item in generation.usage_allocations if item.task_id == task_id),
-        lambda item: item.allocation_id,
-    )
-    counts = {
-        "memberships": len(confirmed),
-        "review_memberships": len(review),
-        "task_relations": len(task_relations),
-        "attempts": len(attempts),
-        "attempt_relations": len(attempt_relations),
-        "evidence_ranges": sum(len(item.evidence_ranges) for item in attempts),
-        "usage_allocations": len(usage),
-    }
-    for field_name, count in counts.items():
-        maximum = getattr(limit, field_name)
-        if count > maximum:
-            raise TaskEvidenceBundleError(
-                f"Task evidence {field_name} exceeds bound: {count}>{maximum}"
-            )
-    eligibility, reasons = _learning_eligibility(task, attempts, review)
-    return TaskEvidenceBundle(
-        generation_id=generation.generation_id,
-        tenant_id=generation.tenant_id,
-        task_scope_id=generation.task_scope_id,
-        source_revision=generation.source_revision,
-        created_at=generation.created_at,
-        generator_fingerprint=_fingerprint(generation.generator),
-        task=task,
-        confirmed_memberships=confirmed,
-        review_memberships=review,
-        task_relations=task_relations,
-        attempts=attempts,
-        attempt_relations=attempt_relations,
-        usage_allocations=usage,
-        learning_eligibility=eligibility,
-        eligibility_reasons=reasons,
-    )
+    return TaskEvidenceBundleIndex(generation, limits=limits).build(task_id)

--- a/src/xskill/tasks/evidence_bundle.py
+++ b/src/xskill/tasks/evidence_bundle.py
@@ -1,0 +1,403 @@
+"""Versioned, bounded Task-grounded evidence for Skill learning.
+
+The bundle is a read contract over one immutable :class:`TaskGraphGeneration`.
+It deliberately contains references and provenance rather than trajectory text.
+Production routing and SkillEdit integration live outside this module.
+"""
+
+from __future__ import annotations
+
+import hashlib
+import json
+from collections.abc import Callable, Iterable
+from dataclasses import dataclass, replace
+from typing import Any, TypeVar
+
+from xskill.tasks.models import (
+    AttemptRelation,
+    LogicalTask,
+    TaskAtomMembership,
+    TaskAttempt,
+    TaskGraphGeneration,
+    TaskRelation,
+    UsageAllocation,
+)
+
+BUNDLE_SCHEMA_VERSION = 1
+ELIGIBILITY_POLICY_VERSION = "task-outcome-v1"
+LEARNING_ELIGIBILITIES = frozenset(("eligible", "ineligible", "needs_review"))
+_T = TypeVar("_T")
+
+
+class TaskEvidenceBundleError(ValueError):
+    """The current Task fact set cannot produce safe learning evidence."""
+
+
+def _ensure(condition: bool, message: str) -> None:
+    if not condition:
+        raise TaskEvidenceBundleError(message)
+
+
+@dataclass(frozen=True)
+class TaskEvidenceLimits:
+    memberships: int = 256
+    review_memberships: int = 256
+    task_relations: int = 256
+    attempts: int = 128
+    attempt_relations: int = 256
+    evidence_ranges: int = 512
+    usage_allocations: int = 512
+
+    def __post_init__(self) -> None:
+        for field_name, value in vars(self).items():
+            if isinstance(value, bool) or not isinstance(value, int) or value <= 0:
+                raise ValueError(f"{field_name} limit must be a positive integer")
+
+
+def _canonical_json(value: Any) -> bytes:
+    return json.dumps(
+        value,
+        ensure_ascii=False,
+        allow_nan=False,
+        sort_keys=True,
+        separators=(",", ":"),
+    ).encode("utf-8")
+
+
+def _fingerprint(value: Any) -> str:
+    return "sha256:" + hashlib.sha256(_canonical_json(value)).hexdigest()
+
+
+def _ordered(values: Iterable[_T], key: Callable[[_T], Any]) -> tuple[_T, ...]:
+    return tuple(sorted(values, key=key))
+
+
+def _strict_object(value: dict[str, Any], expected: set[str]) -> None:
+    actual = set(value)
+    if actual != expected:
+        missing = sorted(expected - actual)
+        unknown = sorted(actual - expected)
+        raise TaskEvidenceBundleError(
+            f"invalid TaskEvidenceBundle fields: missing={missing}, unknown={unknown}"
+        )
+
+
+def _learning_eligibility(
+    task: LogicalTask,
+    attempts: tuple[TaskAttempt, ...],
+    review_memberships: tuple[TaskAtomMembership, ...],
+) -> tuple[str, tuple[str, ...]]:
+    reasons: list[str] = []
+    if review_memberships:
+        reasons.append("unresolved_task_membership")
+    if task.verification in {"contradicted", "conflicted"}:
+        reasons.append(f"task_verification_{task.verification}")
+        return "ineligible", tuple(reasons)
+    if task.outcome in {"cancelled", "abandoned"}:
+        reasons.append(f"task_outcome_{task.outcome}")
+        return "ineligible", tuple(reasons)
+    if task.lifecycle != "closed" or task.outcome == "unknown":
+        reasons.append("task_not_terminal")
+    if not attempts:
+        reasons.append("no_task_attempt")
+    elif any(attempt.lifecycle != "finished" for attempt in attempts):
+        reasons.append("attempt_not_terminal")
+    if task.verification not in {"verified", "not_applicable"}:
+        reasons.append("task_outcome_not_verified")
+    if reasons:
+        return "needs_review", tuple(dict.fromkeys(reasons))
+    return "eligible", ("verified_terminal_task",)
+
+
+@dataclass(frozen=True)
+class TaskEvidenceBundle:
+    generation_id: str
+    tenant_id: str
+    task_scope_id: str
+    source_revision: str
+    created_at: str
+    generator_fingerprint: str
+    task: LogicalTask
+    confirmed_memberships: tuple[TaskAtomMembership, ...]
+    review_memberships: tuple[TaskAtomMembership, ...]
+    task_relations: tuple[TaskRelation, ...]
+    attempts: tuple[TaskAttempt, ...]
+    attempt_relations: tuple[AttemptRelation, ...]
+    usage_allocations: tuple[UsageAllocation, ...]
+    learning_eligibility: str
+    eligibility_reasons: tuple[str, ...]
+    eligibility_policy_version: str = ELIGIBILITY_POLICY_VERSION
+    schema_version: int = BUNDLE_SCHEMA_VERSION
+
+    def __post_init__(self) -> None:
+        _ensure(
+            self.schema_version == BUNDLE_SCHEMA_VERSION,
+            f"unsupported TaskEvidenceBundle schema_version={self.schema_version}",
+        )
+        for field_name in (
+            "generation_id",
+            "tenant_id",
+            "task_scope_id",
+            "source_revision",
+            "created_at",
+            "generator_fingerprint",
+            "eligibility_policy_version",
+        ):
+            value = getattr(self, field_name)
+            if not isinstance(value, str) or not value.strip():
+                raise TaskEvidenceBundleError(f"{field_name} must be non-empty")
+        _ensure(not self.task.tombstoned, "tombstoned Task is not learning evidence")
+        _ensure(bool(self.confirmed_memberships), "Task needs confirmed primary Atom")
+        _ensure(
+            self.learning_eligibility in LEARNING_ELIGIBILITIES,
+            "invalid learning_eligibility",
+        )
+        _ensure(bool(self.eligibility_reasons), "eligibility_reasons must be non-empty")
+        _ensure(
+            all(isinstance(item, str) and item for item in self.eligibility_reasons),
+            "eligibility_reasons must contain strings",
+        )
+        _ensure(
+            (self.learning_eligibility, self.eligibility_reasons)
+            == _learning_eligibility(self.task, self.attempts, self.review_memberships),
+            "learning eligibility does not match Task outcome",
+        )
+        confirmed_atoms = set()
+        for membership in self.confirmed_memberships:
+            _ensure(
+                membership.task_id == self.task.task_id
+                and membership.role == "primary"
+                and membership.decision == "confirmed"
+                and not membership.stale,
+                "learning membership must be live confirmed primary",
+            )
+            self._check_atom_scope(membership)
+            confirmed_atoms.add(membership.atom_ref.key)
+        for membership in self.review_memberships:
+            _ensure(
+                membership.task_id == self.task.task_id
+                and membership.decision in {"proposed", "needs_review"}
+                and not membership.stale,
+                "invalid review membership",
+            )
+            self._check_atom_scope(membership)
+        attempt_ids = {attempt.attempt_id for attempt in self.attempts}
+        for attempt in self.attempts:
+            _ensure(attempt.task_id == self.task.task_id, "Attempt belongs elsewhere")
+            for evidence in attempt.evidence_ranges:
+                _ensure(
+                    not evidence.stale, "stale EvidenceRange is not learning evidence"
+                )
+                _ensure(
+                    evidence.session_ref.tenant_id == self.tenant_id
+                    and evidence.session_ref.task_scope_id == self.task_scope_id,
+                    "evidence crosses TaskScope",
+                )
+                _ensure(
+                    not evidence.atom_ref or evidence.atom_ref.key in confirmed_atoms,
+                    "Attempt evidence Atom lacks confirmed primary membership",
+                )
+        for relation in self.attempt_relations:
+            _ensure(
+                relation.from_attempt_id in attempt_ids
+                and relation.to_attempt_id in attempt_ids,
+                "Attempt relation leaves the Task bundle",
+            )
+        for relation in self.task_relations:
+            _ensure(
+                self.task.task_id in {relation.from_task_id, relation.to_task_id},
+                "Task relation does not touch bundle Task",
+            )
+            _ensure(not relation.stale, "stale Task relation is not bundle evidence")
+        for allocation in self.usage_allocations:
+            _ensure(allocation.task_id == self.task.task_id, "usage belongs elsewhere")
+            _ensure(
+                not allocation.attempt_id or allocation.attempt_id in attempt_ids,
+                "usage references another Attempt",
+            )
+
+    def _check_atom_scope(self, membership: TaskAtomMembership) -> None:
+        atom_ref = membership.atom_ref
+        if (
+            atom_ref.tenant_id != self.tenant_id
+            or atom_ref.task_scope_id != self.task_scope_id
+        ):
+            raise TaskEvidenceBundleError("membership crosses TaskScope")
+
+    def _payload(self) -> dict[str, Any]:
+        return {
+            "schema_version": self.schema_version,
+            "generation_id": self.generation_id,
+            "tenant_id": self.tenant_id,
+            "task_scope_id": self.task_scope_id,
+            "source_revision": self.source_revision,
+            "created_at": self.created_at,
+            "generator_fingerprint": self.generator_fingerprint,
+            "task": self.task.to_dict(),
+            "confirmed_memberships": [
+                item.to_dict() for item in self.confirmed_memberships
+            ],
+            "review_memberships": [item.to_dict() for item in self.review_memberships],
+            "task_relations": [item.to_dict() for item in self.task_relations],
+            "attempts": [item.to_dict() for item in self.attempts],
+            "attempt_relations": [item.to_dict() for item in self.attempt_relations],
+            "usage_allocations": [item.to_dict() for item in self.usage_allocations],
+            "learning_eligibility": self.learning_eligibility,
+            "eligibility_reasons": list(self.eligibility_reasons),
+            "eligibility_policy_version": self.eligibility_policy_version,
+        }
+
+    @property
+    def bundle_fingerprint(self) -> str:
+        return _fingerprint(self._payload())
+
+    def to_dict(self) -> dict[str, Any]:
+        return {**self._payload(), "bundle_fingerprint": self.bundle_fingerprint}
+
+    @classmethod
+    def from_dict(cls, value: dict[str, Any]) -> TaskEvidenceBundle:
+        if not isinstance(value, dict):
+            raise TaskEvidenceBundleError("TaskEvidenceBundle must be an object")
+        expected = set(cls.__dataclass_fields__) | {"bundle_fingerprint"}
+        _strict_object(value, expected)
+        bundle = cls(
+            schema_version=value["schema_version"],
+            generation_id=value["generation_id"],
+            tenant_id=value["tenant_id"],
+            task_scope_id=value["task_scope_id"],
+            source_revision=value["source_revision"],
+            created_at=value["created_at"],
+            generator_fingerprint=value["generator_fingerprint"],
+            task=LogicalTask.from_dict(value["task"]),
+            confirmed_memberships=tuple(
+                TaskAtomMembership.from_dict(item)
+                for item in value["confirmed_memberships"]
+            ),
+            review_memberships=tuple(
+                TaskAtomMembership.from_dict(item)
+                for item in value["review_memberships"]
+            ),
+            task_relations=tuple(
+                TaskRelation.from_dict(item) for item in value["task_relations"]
+            ),
+            attempts=tuple(TaskAttempt.from_dict(item) for item in value["attempts"]),
+            attempt_relations=tuple(
+                AttemptRelation.from_dict(item) for item in value["attempt_relations"]
+            ),
+            usage_allocations=tuple(
+                UsageAllocation.from_dict(item) for item in value["usage_allocations"]
+            ),
+            learning_eligibility=value["learning_eligibility"],
+            eligibility_reasons=tuple(value["eligibility_reasons"]),
+            eligibility_policy_version=value["eligibility_policy_version"],
+        )
+        if value["bundle_fingerprint"] != bundle.bundle_fingerprint:
+            raise TaskEvidenceBundleError("TaskEvidenceBundle fingerprint mismatch")
+        return bundle
+
+
+def build_task_evidence_bundle(
+    generation: TaskGraphGeneration,
+    task_id: str,
+    *,
+    limits: TaskEvidenceLimits | None = None,
+) -> TaskEvidenceBundle:
+    """Build one safe learning bundle from an immutable generation."""
+    if not isinstance(task_id, str) or not task_id.strip():
+        raise TaskEvidenceBundleError("task_id must be non-empty")
+    limit = limits or TaskEvidenceLimits()
+    task = next((item for item in generation.tasks if item.task_id == task_id), None)
+    if task is None:
+        raise TaskEvidenceBundleError(f"Task not found in generation: {task_id}")
+    if task.tombstoned:
+        raise TaskEvidenceBundleError("tombstoned Task cannot become learning evidence")
+
+    confirmed = _ordered(
+        (
+            item
+            for item in generation.memberships
+            if item.task_id == task_id
+            and item.role == "primary"
+            and item.decision == "confirmed"
+            and not item.stale
+        ),
+        lambda item: item.atom_ref.key,
+    )
+    review = _ordered(
+        (
+            item
+            for item in generation.memberships
+            if item.task_id == task_id
+            and item.decision in {"proposed", "needs_review"}
+            and not item.stale
+        ),
+        lambda item: (item.atom_ref.key, item.membership_id),
+    )
+    task_relations = _ordered(
+        (
+            item
+            for item in generation.relations
+            if task_id in {item.from_task_id, item.to_task_id} and not item.stale
+        ),
+        lambda item: item.relation_id,
+    )
+    attempts = _ordered(
+        (
+            replace(
+                item,
+                evidence_ranges=_ordered(
+                    item.evidence_ranges,
+                    lambda evidence: evidence.evidence_id,
+                ),
+            )
+            for item in generation.attempts
+            if item.task_id == task_id
+        ),
+        lambda item: (item.started_at, item.attempt_id),
+    )
+    attempt_ids = {item.attempt_id for item in attempts}
+    attempt_relations = _ordered(
+        (
+            item
+            for item in generation.attempt_relations
+            if item.from_attempt_id in attempt_ids and item.to_attempt_id in attempt_ids
+        ),
+        lambda item: item.relation_id,
+    )
+    usage = _ordered(
+        (item for item in generation.usage_allocations if item.task_id == task_id),
+        lambda item: item.allocation_id,
+    )
+    counts = {
+        "memberships": len(confirmed),
+        "review_memberships": len(review),
+        "task_relations": len(task_relations),
+        "attempts": len(attempts),
+        "attempt_relations": len(attempt_relations),
+        "evidence_ranges": sum(len(item.evidence_ranges) for item in attempts),
+        "usage_allocations": len(usage),
+    }
+    for field_name, count in counts.items():
+        maximum = getattr(limit, field_name)
+        if count > maximum:
+            raise TaskEvidenceBundleError(
+                f"Task evidence {field_name} exceeds bound: {count}>{maximum}"
+            )
+    eligibility, reasons = _learning_eligibility(task, attempts, review)
+    return TaskEvidenceBundle(
+        generation_id=generation.generation_id,
+        tenant_id=generation.tenant_id,
+        task_scope_id=generation.task_scope_id,
+        source_revision=generation.source_revision,
+        created_at=generation.created_at,
+        generator_fingerprint=_fingerprint(generation.generator),
+        task=task,
+        confirmed_memberships=confirmed,
+        review_memberships=review,
+        task_relations=task_relations,
+        attempts=attempts,
+        attempt_relations=attempt_relations,
+        usage_allocations=usage,
+        learning_eligibility=eligibility,
+        eligibility_reasons=reasons,
+    )

--- a/src/xskill/tasks/projection.py
+++ b/src/xskill/tasks/projection.py
@@ -750,16 +750,28 @@ def acknowledge_task_evidence(
             raise
 
 
-def task_evidence_feed_counts(*, db_path: Path | None = None) -> dict[str, int]:
-    """Return zero-filled operational counts for the durable feed."""
+def _task_evidence_feed_counts(connection, tenant_id: str | None) -> dict[str, int]:
     counts = {status: 0 for status in ("pending", "processed", "fallback", "rejected")}
-    with pooled_connection(db_path) as connection:
-        rows = connection.execute(
-            "SELECT status,COUNT(*) AS count FROM task_evidence_feed"
-            " GROUP BY status"
-        ).fetchall()
+    query = "SELECT status,COUNT(*) AS count FROM task_evidence_feed"
+    parameters = ()
+    if tenant_id is not None:
+        query += " WHERE tenant_id=?"
+        parameters = (tenant_id,)
+    rows = connection.execute(query + " GROUP BY status", parameters).fetchall()
     counts.update({row["status"]: row["count"] for row in rows})
     return counts
+
+
+def task_evidence_feed_counts(
+    *, tenant_id: str | None = None, db_path: Path | None = None,
+) -> dict[str, int]:
+    """Return zero-filled feed counts, optionally restricted to one tenant.
+
+    Workers may omit the tenant for an operational total. Business reads must
+    pass their resolved tenant, including an empty identity before first ingest.
+    """
+    with pooled_connection(db_path) as connection:
+        return _task_evidence_feed_counts(connection, tenant_id)
 
 
 def _decode_json_fields(row: dict, fields: Iterable[str]) -> dict:
@@ -1008,6 +1020,7 @@ def task_graph_overview(
             "SELECT COUNT(*) FROM task_graph_generations WHERE tenant_id=?",
             (tenant_id,),
         ).fetchone()[0]
+        evidence_feed = _task_evidence_feed_counts(connection, tenant_id)
     return {
         "scopes": scopes,
         "tasks": task_row["tasks"] or 0,
@@ -1017,4 +1030,5 @@ def task_graph_overview(
         "uncertain_memberships": uncertain,
         "execution_tokens": task_row["execution_tokens"],
         "execution_cost_usd": task_row["execution_cost_usd"],
+        "evidence_feed": evidence_feed,
     }

--- a/src/xskill/tasks/projection.py
+++ b/src/xskill/tasks/projection.py
@@ -381,7 +381,8 @@ def _task_evidence_feed_rows(generation: TaskGraphGeneration) -> list[tuple]:
         except TaskEvidenceBundleError as exc:
             rejection = str(exc)
             payload = {
-                "generation_id": generation.generation_id,
+                "tenant_id": generation.tenant_id,
+                "task_scope_id": generation.task_scope_id,
                 "task": task.to_dict(),
                 "rejection": rejection,
             }
@@ -399,10 +400,10 @@ def _task_evidence_feed_rows(generation: TaskGraphGeneration) -> list[tuple]:
             reasons = (rejection,)
             status = "rejected"
         else:
-            fingerprint = bundle.bundle_fingerprint
+            fingerprint = bundle.task_evidence_fingerprint
             eligibility = bundle.learning_eligibility
             reasons = bundle.eligibility_reasons
-            status = "pending" if eligibility == "eligible" else "rejected"
+            status = "pending"
         rows.append(
             (
                 generation.tenant_id,
@@ -663,34 +664,36 @@ def project_generation(
             connection.executemany(
                 "INSERT INTO task_evidence_feed("
                 "tenant_id,task_scope_id,task_id,task_generation_id,"
-                "bundle_fingerprint,learning_eligibility,"
+                "task_evidence_fingerprint,learning_eligibility,"
                 "eligibility_reasons_json,status) VALUES(?,?,?,?,?,?,?,?)"
                 " ON CONFLICT(tenant_id,task_scope_id,task_id) DO UPDATE SET"
                 " task_generation_id=excluded.task_generation_id,"
-                " bundle_fingerprint=excluded.bundle_fingerprint,"
+                " task_evidence_fingerprint=excluded.task_evidence_fingerprint,"
                 " learning_eligibility=excluded.learning_eligibility,"
                 " eligibility_reasons_json=excluded.eligibility_reasons_json,"
-                " status=excluded.status,generation=task_evidence_feed.generation+1,"
-                " marked_at=datetime('now'),processed_at=NULL"
-                " WHERE task_evidence_feed.bundle_fingerprint"
-                "<>excluded.bundle_fingerprint",
+                " status=CASE WHEN task_evidence_feed.task_evidence_fingerprint"
+                "<>excluded.task_evidence_fingerprint THEN excluded.status"
+                " ELSE task_evidence_feed.status END,"
+                " generation=task_evidence_feed.generation+CASE WHEN"
+                " task_evidence_feed.task_evidence_fingerprint"
+                "<>excluded.task_evidence_fingerprint THEN 1 ELSE 0 END,"
+                " marked_at=CASE WHEN task_evidence_feed.task_evidence_fingerprint"
+                "<>excluded.task_evidence_fingerprint THEN datetime('now')"
+                " ELSE task_evidence_feed.marked_at END,"
+                " processed_at=CASE WHEN task_evidence_feed.task_evidence_fingerprint"
+                "<>excluded.task_evidence_fingerprint THEN NULL"
+                " ELSE task_evidence_feed.processed_at END",
                 evidence_feed_rows,
             )
-            if evidence_feed_rows:
-                task_ids = [row[2] for row in evidence_feed_rows]
-                placeholders = ",".join("?" for _ in task_ids)
-                connection.execute(
-                    "DELETE FROM task_evidence_feed"
-                    " WHERE tenant_id=? AND task_scope_id=?"
-                    f" AND task_id NOT IN ({placeholders})",
-                    [tenant_id, task_scope_id, *task_ids],
-                )
-            else:
-                connection.execute(
-                    "DELETE FROM task_evidence_feed"
-                    " WHERE tenant_id=? AND task_scope_id=?",
-                    (tenant_id, task_scope_id),
-                )
+            connection.execute(
+                "DELETE FROM task_evidence_feed"
+                " WHERE tenant_id=? AND task_scope_id=?"
+                " AND NOT EXISTS (SELECT 1 FROM logical_tasks"
+                " WHERE logical_tasks.tenant_id=task_evidence_feed.tenant_id"
+                " AND logical_tasks.task_scope_id=task_evidence_feed.task_scope_id"
+                " AND logical_tasks.task_id=task_evidence_feed.task_id)",
+                (tenant_id, task_scope_id),
+            )
             connection.commit()
         except Exception:
             connection.rollback()

--- a/src/xskill/tasks/projection.py
+++ b/src/xskill/tasks/projection.py
@@ -1,12 +1,17 @@
 """Registry queue, Task Graph projection and bounded query functions."""
 from __future__ import annotations
 
+import hashlib
 import json
 from collections.abc import Iterable
 from pathlib import Path
 
 from xskill.pipeline.registry import pooled_connection
 from xskill.tasks.evidence import ExecutionUsageEvent, ScopedTrajectoryEvidence
+from xskill.tasks.evidence_bundle import (
+    TaskEvidenceBundleError,
+    TaskEvidenceBundleIndex,
+)
 from xskill.tasks.models import TaskGraphGeneration
 
 DEFAULT_BACKFILL_BATCH_SIZE = 512
@@ -366,6 +371,53 @@ _PROJECTED_TABLES = (
 )
 
 
+def _task_evidence_feed_rows(generation: TaskGraphGeneration) -> list[tuple]:
+    """Build one coalesced feed row per Task with a single generation scan."""
+    index = TaskEvidenceBundleIndex(generation)
+    rows = []
+    for task in sorted(generation.tasks, key=lambda item: item.task_id):
+        try:
+            bundle = index.build(task.task_id)
+        except TaskEvidenceBundleError as exc:
+            rejection = str(exc)
+            payload = {
+                "generation_id": generation.generation_id,
+                "task": task.to_dict(),
+                "rejection": rejection,
+            }
+            digest = hashlib.sha256(
+                json.dumps(
+                    payload,
+                    ensure_ascii=False,
+                    allow_nan=False,
+                    sort_keys=True,
+                    separators=(",", ":"),
+                ).encode("utf-8")
+            ).hexdigest()
+            fingerprint = f"sha256:{digest}"
+            eligibility = "ineligible"
+            reasons = (rejection,)
+            status = "rejected"
+        else:
+            fingerprint = bundle.bundle_fingerprint
+            eligibility = bundle.learning_eligibility
+            reasons = bundle.eligibility_reasons
+            status = "pending" if eligibility == "eligible" else "rejected"
+        rows.append(
+            (
+                generation.tenant_id,
+                generation.task_scope_id,
+                task.task_id,
+                generation.generation_id,
+                fingerprint,
+                eligibility,
+                _json(list(reasons)),
+                status,
+            )
+        )
+    return rows
+
+
 def project_generation(
     generation: TaskGraphGeneration,
     *,
@@ -405,6 +457,7 @@ def project_generation(
     tenant_id = generation.tenant_id
     task_scope_id = generation.task_scope_id
     source_list = tuple(sources)
+    evidence_feed_rows = _task_evidence_feed_rows(generation)
     with pooled_connection(db_path) as connection:
         connection.execute("BEGIN IMMEDIATE")
         try:
@@ -607,10 +660,103 @@ def project_generation(
                     for source in source_list
                 ],
             )
+            connection.executemany(
+                "INSERT INTO task_evidence_feed("
+                "tenant_id,task_scope_id,task_id,task_generation_id,"
+                "bundle_fingerprint,learning_eligibility,"
+                "eligibility_reasons_json,status) VALUES(?,?,?,?,?,?,?,?)"
+                " ON CONFLICT(tenant_id,task_scope_id,task_id) DO UPDATE SET"
+                " task_generation_id=excluded.task_generation_id,"
+                " bundle_fingerprint=excluded.bundle_fingerprint,"
+                " learning_eligibility=excluded.learning_eligibility,"
+                " eligibility_reasons_json=excluded.eligibility_reasons_json,"
+                " status=excluded.status,generation=task_evidence_feed.generation+1,"
+                " marked_at=datetime('now'),processed_at=NULL"
+                " WHERE task_evidence_feed.bundle_fingerprint"
+                "<>excluded.bundle_fingerprint",
+                evidence_feed_rows,
+            )
+            if evidence_feed_rows:
+                task_ids = [row[2] for row in evidence_feed_rows]
+                placeholders = ",".join("?" for _ in task_ids)
+                connection.execute(
+                    "DELETE FROM task_evidence_feed"
+                    " WHERE tenant_id=? AND task_scope_id=?"
+                    f" AND task_id NOT IN ({placeholders})",
+                    [tenant_id, task_scope_id, *task_ids],
+                )
+            else:
+                connection.execute(
+                    "DELETE FROM task_evidence_feed"
+                    " WHERE tenant_id=? AND task_scope_id=?",
+                    (tenant_id, task_scope_id),
+                )
             connection.commit()
         except Exception:
             connection.rollback()
             raise
+
+
+def list_pending_task_evidence(
+    *, limit: int = 128, db_path: Path | None = None,
+) -> list[dict]:
+    """Return pending Task bundles in stable order without loading payloads."""
+    if isinstance(limit, bool) or not isinstance(limit, int) or limit <= 0:
+        raise ValueError("limit must be a positive integer")
+    with pooled_connection(db_path) as connection:
+        rows = connection.execute(
+            "SELECT * FROM task_evidence_feed WHERE status='pending'"
+            " ORDER BY marked_at,tenant_id,task_scope_id,task_id LIMIT ?",
+            (limit,),
+        ).fetchall()
+    return [
+        _decode_json_fields(dict(row), ("eligibility_reasons_json",))
+        for row in rows
+    ]
+
+
+def acknowledge_task_evidence(
+    rows: Iterable[dict], *, db_path: Path | None = None,
+) -> int:
+    """Acknowledge exactly the observed feed generations."""
+    acknowledgements = [
+        (
+            row["tenant_id"],
+            row["task_scope_id"],
+            row["task_id"],
+            row["generation"],
+        )
+        for row in rows
+    ]
+    if not acknowledgements:
+        return 0
+    with pooled_connection(db_path) as connection:
+        connection.execute("BEGIN IMMEDIATE")
+        try:
+            cursor = connection.executemany(
+                "UPDATE task_evidence_feed SET status='processed',"
+                " processed_at=datetime('now')"
+                " WHERE tenant_id=? AND task_scope_id=? AND task_id=?"
+                " AND generation=? AND status='pending'",
+                acknowledgements,
+            )
+            connection.commit()
+            return max(0, cursor.rowcount)
+        except Exception:
+            connection.rollback()
+            raise
+
+
+def task_evidence_feed_counts(*, db_path: Path | None = None) -> dict[str, int]:
+    """Return zero-filled operational counts for the durable feed."""
+    counts = {status: 0 for status in ("pending", "processed", "fallback", "rejected")}
+    with pooled_connection(db_path) as connection:
+        rows = connection.execute(
+            "SELECT status,COUNT(*) AS count FROM task_evidence_feed"
+            " GROUP BY status"
+        ).fetchall()
+    counts.update({row["status"]: row["count"] for row in rows})
+    return counts
 
 
 def _decode_json_fields(row: dict, fields: Iterable[str]) -> dict:

--- a/tests/test_candidates_evidence.py
+++ b/tests/test_candidates_evidence.py
@@ -1,0 +1,54 @@
+from __future__ import annotations
+
+import pytest
+
+from xskill.skill.candidates import (
+    add_evidence_candidates,
+    load_candidates,
+    save_candidates,
+)
+from xskill.skill.evidence_candidate_refs import EvidenceCandidateError
+from xskill.skill.evidence_candidates import TaskSkillCandidate
+
+
+def _candidate(skill_name: str, *, weightscore: int) -> TaskSkillCandidate:
+    return TaskSkillCandidate.from_atom_fallback(
+        atom_id="atom-a",
+        skill_name=skill_name,
+        weightscore=weightscore,
+        fallback_reason="task_graph_disabled",
+    )
+
+
+def test_evidence_candidate_uses_existing_atomic_buffer_and_upsert_semantics(
+    tmp_path,
+):
+    skill_dir = tmp_path / "safe-skill"
+    save_candidates(
+        skill_dir,
+        {"candidates": [{"atom_id": "legacy", "weightscore": 3}]},
+    )
+
+    assert add_evidence_candidates(
+        skill_dir, (_candidate("safe-skill", weightscore=4),)
+    ) == ([True], 7)
+    assert add_evidence_candidates(
+        skill_dir, (_candidate("safe-skill", weightscore=9),)
+    ) == ([False], 12)
+
+    data = load_candidates(skill_dir)
+    assert len(data["candidates"]) == 2
+    assert data["candidates"][0]["atom_id"] == "legacy"
+    assert data["candidates"][1]["weightscore"] == 9
+
+
+def test_evidence_candidate_cannot_cross_the_containing_skill(tmp_path):
+    skill_dir = tmp_path / "safe-skill"
+
+    with pytest.raises(EvidenceCandidateError, match="containing Skill"):
+        add_evidence_candidates(
+            skill_dir,
+            (_candidate("another-skill", weightscore=5),),
+        )
+
+    assert not (skill_dir / ".candidates.yml").exists()

--- a/tests/test_server_no_llm_fallback.py
+++ b/tests/test_server_no_llm_fallback.py
@@ -128,10 +128,14 @@ def test_standalone_worker_commands_share_resolved_ecosystem_home(
         str(ecosystem_home.resolve()),
     ]
     assert set(records_by_name) == {
-        "agent-worker", "ecosystem-ingest", "ux-scores-sync",
+        "agent-worker", "ecosystem-ingest", "kernel-host", "ux-scores-sync",
     }
     assert records_by_name["agent-worker"].command[-2:] == expected_home_arguments
     assert records_by_name["agent-worker"].keyword_arguments["persistent"] is True
+    kernel_command = records_by_name["kernel-host"].command
+    assert kernel_command[-1] == "kernel-host"
+    assert "--server" not in kernel_command
+    assert records_by_name["kernel-host"].keyword_arguments["persistent"] is True
     ingest_command = records_by_name["ecosystem-ingest"].command
     home_argument_index = ingest_command.index("--home")
     assert ingest_command[
@@ -244,12 +248,15 @@ def test_team_server_schedules_only_server_watcher(
         record.name: record for record in scheduler_records
     }
     assert set(records_by_name) == {
-        "recommend-heavy", "agent-worker", "ux-scores-sync",
+        "recommend-heavy", "agent-worker", "kernel-host", "ux-scores-sync",
     }
     watcher_command = records_by_name["agent-worker"].command
     assert watcher_command[-1] == "--server"
     assert "--home" not in watcher_command
     assert records_by_name["agent-worker"].keyword_arguments["persistent"] is True
+    kernel_command = records_by_name["kernel-host"].command
+    assert kernel_command[-2:] == ["kernel-host", "--server"]
+    assert records_by_name["kernel-host"].keyword_arguments["persistent"] is True
     assert "persistent" not in records_by_name["recommend-heavy"].keyword_arguments
     assert records_by_name["recommend-heavy"].command[-1] == "recommend-heavy"
     assert "persistent" not in records_by_name["ux-scores-sync"].keyword_arguments

--- a/tests/test_task_evidence_bundle.py
+++ b/tests/test_task_evidence_bundle.py
@@ -5,6 +5,7 @@ from dataclasses import replace
 import pytest
 
 from xskill.tasks.evidence_bundle import (
+    MAX_TASK_EVIDENCE_BUNDLE_BYTES,
     TaskEvidenceBundle,
     TaskEvidenceBundleError,
     TaskEvidenceLimits,
@@ -170,6 +171,24 @@ def test_published_generation_reload_preserves_bundle_fingerprint(tmp_path):
     )
 
 
+def test_task_evidence_fingerprint_ignores_generation_metadata():
+    generation = _generation()
+    first = build_task_evidence_bundle(generation, "task-a")
+    rebuilt = build_task_evidence_bundle(
+        replace(
+            generation,
+            generation_id="generation-b",
+            source_revision="source-revision-b",
+            created_at="2026-09-02T00:00:00Z",
+            generator={"name": "linker", "version": "v2"},
+        ),
+        "task-a",
+    )
+
+    assert rebuilt.bundle_fingerprint != first.bundle_fingerprint
+    assert rebuilt.task_evidence_fingerprint == first.task_evidence_fingerprint
+
+
 def test_bundle_rejects_unknown_fields_and_fingerprint_drift():
     payload = build_task_evidence_bundle(_generation(), "task-a").to_dict()
     payload["unknown"] = True
@@ -179,6 +198,14 @@ def test_bundle_rejects_unknown_fields_and_fingerprint_drift():
     payload = build_task_evidence_bundle(_generation(), "task-a").to_dict()
     payload["task"]["summary"] = "changed"
     with pytest.raises(TaskEvidenceBundleError, match="fingerprint"):
+        TaskEvidenceBundle.from_dict(payload)
+
+
+def test_bundle_normalizes_nested_parse_errors():
+    payload = build_task_evidence_bundle(_generation(), "task-a").to_dict()
+    payload["task"] = []
+
+    with pytest.raises(TaskEvidenceBundleError, match="invalid nested"):
         TaskEvidenceBundle.from_dict(payload)
 
 
@@ -294,3 +321,17 @@ def test_bundle_rejects_cross_scope_membership_defensively():
 def test_bundle_cardinality_is_bounded(limits, message):
     with pytest.raises(TaskEvidenceBundleError, match=message):
         build_task_evidence_bundle(_generation(), "task-a", limits=limits)
+
+
+def test_bundle_serialized_size_is_bounded():
+    generation = _generation()
+    oversized_task = replace(
+        generation.tasks[0],
+        summary="x" * MAX_TASK_EVIDENCE_BUNDLE_BYTES,
+    )
+
+    with pytest.raises(TaskEvidenceBundleError, match="serialized_bytes"):
+        build_task_evidence_bundle(
+            replace(generation, tasks=(oversized_task,)),
+            "task-a",
+        )

--- a/tests/test_task_evidence_bundle.py
+++ b/tests/test_task_evidence_bundle.py
@@ -4,9 +4,11 @@ from dataclasses import replace
 
 import pytest
 
+from xskill.pipeline.registry import get_connection
 from xskill.tasks.evidence_bundle import (
     TaskEvidenceBundle,
     TaskEvidenceBundleError,
+    TaskEvidenceBundleIndex,
     TaskEvidenceLimits,
     build_task_evidence_bundle,
 )
@@ -20,6 +22,12 @@ from xskill.tasks.models import (
     TaskAttempt,
     TaskGraphGeneration,
     UsageAllocation,
+)
+from xskill.tasks.projection import (
+    acknowledge_task_evidence,
+    list_pending_task_evidence,
+    project_generation,
+    task_evidence_feed_counts,
 )
 from xskill.tasks.store import TaskGraphStore
 
@@ -294,3 +302,135 @@ def test_bundle_rejects_cross_scope_membership_defensively():
 def test_bundle_cardinality_is_bounded(limits, message):
     with pytest.raises(TaskEvidenceBundleError, match=message):
         build_task_evidence_bundle(_generation(), "task-a", limits=limits)
+
+
+def test_generation_index_builds_many_tasks_without_per_task_rescans():
+    class CountingTuple(tuple):
+        iterations = 0
+
+        def __iter__(self):
+            self.iterations += 1
+            return super().__iter__()
+
+    generation = _generation()
+    tasks = []
+    memberships = []
+    for number in range(200):
+        task_id = f"task-{number:04d}"
+        tasks.append(
+            replace(
+                generation.tasks[0],
+                task_id=task_id,
+                summary=f"summary {number}",
+            )
+        )
+        memberships.append(
+            replace(
+                generation.memberships[0],
+                membership_id=f"membership-{number:04d}",
+                task_id=task_id,
+                atom_ref=replace(
+                    generation.memberships[0].atom_ref,
+                    atom_id=f"atom-{number:04d}",
+                ),
+            )
+        )
+    generation = replace(
+        generation,
+        tasks=tuple(tasks),
+        memberships=tuple(memberships),
+        attempts=(),
+        attempt_relations=(),
+        usage_allocations=(),
+    )
+    task_ids = [task.task_id for task in generation.tasks]
+    tracked_collections = {}
+    for field_name in (
+        "tasks",
+        "memberships",
+        "relations",
+        "attempts",
+        "attempt_relations",
+        "usage_allocations",
+    ):
+        tracked = CountingTuple(getattr(generation, field_name))
+        tracked_collections[field_name] = tracked
+        object.__setattr__(generation, field_name, tracked)
+
+    index = TaskEvidenceBundleIndex(generation)
+    bundles = [index.build(task_id) for task_id in task_ids]
+
+    assert [bundle.task.task_id for bundle in bundles] == task_ids
+    assert {bundle.learning_eligibility for bundle in bundles} == {"needs_review"}
+    assert {
+        field_name: values.iterations
+        for field_name, values in tracked_collections.items()
+    } == {
+        "tasks": 1,
+        "memberships": 1,
+        "relations": 1,
+        "attempts": 1,
+        "attempt_relations": 1,
+        "usage_allocations": 1,
+    }
+
+
+def test_projection_emits_changed_task_bundle_once_and_fences_stale_ack(tmp_path):
+    db_path = tmp_path / "registry.db"
+    get_connection(db_path).close()
+    generation = _generation()
+
+    project_generation(generation, sources=(), db_path=db_path)
+    first = list_pending_task_evidence(db_path=db_path)
+    assert len(first) == 1
+    assert first[0]["task_id"] == "task-a"
+    assert first[0]["generation"] == 1
+    assert first[0]["learning_eligibility"] == "eligible"
+
+    project_generation(generation, sources=(), db_path=db_path)
+    replay = list_pending_task_evidence(db_path=db_path)
+    assert replay[0]["generation"] == 1
+    assert acknowledge_task_evidence(replay, db_path=db_path) == 1
+    assert list_pending_task_evidence(db_path=db_path) == []
+
+    project_generation(generation, sources=(), db_path=db_path)
+    assert list_pending_task_evidence(db_path=db_path) == []
+    assert task_evidence_feed_counts(db_path=db_path)["processed"] == 1
+
+    changed = replace(
+        generation,
+        generation_id="generation-b",
+        source_revision="source-revision-b",
+        created_at="2026-09-01T00:04:00Z",
+        tasks=(replace(generation.tasks[0], summary="changed summary"),),
+    )
+    project_generation(changed, sources=(), db_path=db_path)
+    current = list_pending_task_evidence(db_path=db_path)
+    assert len(current) == 1
+    assert current[0]["generation"] == 2
+    assert current[0]["bundle_fingerprint"] != first[0]["bundle_fingerprint"]
+
+    assert acknowledge_task_evidence(first, db_path=db_path) == 0
+    assert len(list_pending_task_evidence(db_path=db_path)) == 1
+    assert acknowledge_task_evidence(current, db_path=db_path) == 1
+    assert task_evidence_feed_counts(db_path=db_path) == {
+        "pending": 0,
+        "processed": 1,
+        "fallback": 0,
+        "rejected": 0,
+    }
+
+
+def test_projection_rejects_incomplete_task_from_learning_feed(tmp_path):
+    db_path = tmp_path / "registry.db"
+    get_connection(db_path).close()
+
+    project_generation(_generation(verified=False), sources=(), db_path=db_path)
+
+    assert list_pending_task_evidence(db_path=db_path) == []
+    assert task_evidence_feed_counts(db_path=db_path) == {
+        "pending": 0,
+        "processed": 0,
+        "fallback": 0,
+        "rejected": 1,
+    }

--- a/tests/test_task_evidence_bundle.py
+++ b/tests/test_task_evidence_bundle.py
@@ -6,6 +6,7 @@ import pytest
 
 from xskill.pipeline.registry import get_connection
 from xskill.tasks.evidence_bundle import (
+    MAX_TASK_EVIDENCE_BUNDLE_BYTES,
     TaskEvidenceBundle,
     TaskEvidenceBundleError,
     TaskEvidenceBundleIndex,
@@ -178,6 +179,24 @@ def test_published_generation_reload_preserves_bundle_fingerprint(tmp_path):
     )
 
 
+def test_task_evidence_fingerprint_ignores_generation_metadata():
+    generation = _generation()
+    first = build_task_evidence_bundle(generation, "task-a")
+    rebuilt = build_task_evidence_bundle(
+        replace(
+            generation,
+            generation_id="generation-b",
+            source_revision="source-revision-b",
+            created_at="2026-09-02T00:00:00Z",
+            generator={"name": "linker", "version": "v2"},
+        ),
+        "task-a",
+    )
+
+    assert rebuilt.bundle_fingerprint != first.bundle_fingerprint
+    assert rebuilt.task_evidence_fingerprint == first.task_evidence_fingerprint
+
+
 def test_bundle_rejects_unknown_fields_and_fingerprint_drift():
     payload = build_task_evidence_bundle(_generation(), "task-a").to_dict()
     payload["unknown"] = True
@@ -187,6 +206,14 @@ def test_bundle_rejects_unknown_fields_and_fingerprint_drift():
     payload = build_task_evidence_bundle(_generation(), "task-a").to_dict()
     payload["task"]["summary"] = "changed"
     with pytest.raises(TaskEvidenceBundleError, match="fingerprint"):
+        TaskEvidenceBundle.from_dict(payload)
+
+
+def test_bundle_normalizes_nested_parse_errors():
+    payload = build_task_evidence_bundle(_generation(), "task-a").to_dict()
+    payload["task"] = []
+
+    with pytest.raises(TaskEvidenceBundleError, match="invalid nested"):
         TaskEvidenceBundle.from_dict(payload)
 
 
@@ -304,6 +331,20 @@ def test_bundle_cardinality_is_bounded(limits, message):
         build_task_evidence_bundle(_generation(), "task-a", limits=limits)
 
 
+def test_bundle_serialized_size_is_bounded():
+    generation = _generation()
+    oversized_task = replace(
+        generation.tasks[0],
+        summary="x" * MAX_TASK_EVIDENCE_BUNDLE_BYTES,
+    )
+
+    with pytest.raises(TaskEvidenceBundleError, match="serialized_bytes"):
+        build_task_evidence_bundle(
+            replace(generation, tasks=(oversized_task,)),
+            "task-a",
+        )
+
+
 def test_generation_index_builds_many_tasks_without_per_task_rescans():
     class CountingTuple(tuple):
         iterations = 0
@@ -397,18 +438,32 @@ def test_projection_emits_changed_task_bundle_once_and_fences_stale_ack(tmp_path
     assert list_pending_task_evidence(db_path=db_path) == []
     assert task_evidence_feed_counts(db_path=db_path)["processed"] == 1
 
-    changed = replace(
+    metadata_only = replace(
         generation,
         generation_id="generation-b",
         source_revision="source-revision-b",
         created_at="2026-09-01T00:04:00Z",
+    )
+    project_generation(metadata_only, sources=(), db_path=db_path)
+    assert list_pending_task_evidence(db_path=db_path) == []
+    with get_connection(db_path) as connection:
+        unchanged = connection.execute(
+            "SELECT task_generation_id,generation FROM task_evidence_feed"
+        ).fetchone()
+    assert tuple(unchanged) == ("generation-b", 1)
+
+    changed = replace(
+        metadata_only,
+        generation_id="generation-c",
         tasks=(replace(generation.tasks[0], summary="changed summary"),),
     )
     project_generation(changed, sources=(), db_path=db_path)
     current = list_pending_task_evidence(db_path=db_path)
     assert len(current) == 1
     assert current[0]["generation"] == 2
-    assert current[0]["bundle_fingerprint"] != first[0]["bundle_fingerprint"]
+    assert current[0]["task_evidence_fingerprint"] != first[0][
+        "task_evidence_fingerprint"
+    ]
 
     assert acknowledge_task_evidence(first, db_path=db_path) == 0
     assert len(list_pending_task_evidence(db_path=db_path)) == 1
@@ -421,16 +476,77 @@ def test_projection_emits_changed_task_bundle_once_and_fences_stale_ack(tmp_path
     }
 
 
-def test_projection_rejects_incomplete_task_from_learning_feed(tmp_path):
+def test_projection_queues_incomplete_task_for_reconciliation(tmp_path):
     db_path = tmp_path / "registry.db"
     get_connection(db_path).close()
 
     project_generation(_generation(verified=False), sources=(), db_path=db_path)
 
-    assert list_pending_task_evidence(db_path=db_path) == []
+    rows = list_pending_task_evidence(db_path=db_path)
+    assert len(rows) == 1
+    assert rows[0]["learning_eligibility"] == "needs_review"
     assert task_evidence_feed_counts(db_path=db_path) == {
-        "pending": 0,
+        "pending": 1,
         "processed": 0,
         "fallback": 0,
-        "rejected": 1,
+        "rejected": 0,
     }
+
+
+def test_projection_cleanup_is_not_limited_by_sql_parameter_count(tmp_path):
+    db_path = tmp_path / "registry.db"
+    get_connection(db_path).close()
+    generation = _generation()
+    tasks = []
+    memberships = []
+    for number in range(1200):
+        task_id = f"task-{number:04d}"
+        tasks.append(
+            replace(
+                generation.tasks[0],
+                task_id=task_id,
+                summary=f"summary {number}",
+            )
+        )
+        memberships.append(
+            replace(
+                generation.memberships[0],
+                membership_id=f"membership-{number:04d}",
+                task_id=task_id,
+                atom_ref=replace(
+                    generation.memberships[0].atom_ref,
+                    atom_id=f"atom-{number:04d}",
+                ),
+            )
+        )
+    large = replace(
+        generation,
+        tasks=tuple(tasks),
+        memberships=tuple(memberships),
+        attempts=(),
+        attempt_relations=(),
+        usage_allocations=(),
+    )
+
+    project_generation(large, sources=(), db_path=db_path)
+    with get_connection(db_path) as connection:
+        count = connection.execute(
+            "SELECT COUNT(*) FROM task_evidence_feed"
+        ).fetchone()[0]
+    assert count == 1200
+
+    project_generation(
+        replace(
+            large,
+            generation_id="generation-small",
+            tasks=(large.tasks[0],),
+            memberships=(large.memberships[0],),
+        ),
+        sources=(),
+        db_path=db_path,
+    )
+    with get_connection(db_path) as connection:
+        remaining = connection.execute(
+            "SELECT task_id FROM task_evidence_feed"
+        ).fetchall()
+    assert [row[0] for row in remaining] == ["task-0000"]

--- a/tests/test_task_evidence_bundle.py
+++ b/tests/test_task_evidence_bundle.py
@@ -1,0 +1,296 @@
+from __future__ import annotations
+
+from dataclasses import replace
+
+import pytest
+
+from xskill.tasks.evidence_bundle import (
+    TaskEvidenceBundle,
+    TaskEvidenceBundleError,
+    TaskEvidenceLimits,
+    build_task_evidence_bundle,
+)
+from xskill.tasks.models import (
+    AtomRef,
+    AttemptRelation,
+    EvidenceRange,
+    LogicalTask,
+    SessionRef,
+    TaskAtomMembership,
+    TaskAttempt,
+    TaskGraphGeneration,
+    UsageAllocation,
+)
+from xskill.tasks.store import TaskGraphStore
+
+
+def _membership(membership_id, atom, observed_at):
+    fixed = ("primary", None, "confirmed", "rules", "v1", ())
+    return TaskAtomMembership(membership_id, "task-a", atom, *fixed, observed_at)
+
+
+def _attempt(
+    attempt_id,
+    times,
+    outcome,
+    disposition,
+    evidence,
+):
+    state = ("finished", outcome, "verified", disposition, (evidence,))
+    return TaskAttempt(
+        attempt_id,
+        "task-a",
+        *times,
+        *state,
+        execution_identity={"run_id": attempt_id.replace("attempt", "run")},
+    )
+
+
+def _evidence(evidence_id, session, atom, start, *, skills=()):
+    suffix = evidence_id.removeprefix("evidence-")
+    return EvidenceRange(
+        evidence_id,
+        session,
+        "trajectory_line",
+        start,
+        start + 4,
+        f"hash-{suffix}",
+        atom_ref=atom,
+        model={"model_id": "model-a"},
+        harness={"name": "runtime-a"},
+        skills=skills,
+    )
+
+
+def _generation(*, verified: bool = True) -> TaskGraphGeneration:
+    session = SessionRef("tenant", "scope", "source", "traj")
+    atom_a = AtomRef("tenant", "scope", "source", "traj", "atom-a")
+    atom_b = AtomRef("tenant", "scope", "source", "traj", "atom-b")
+    evidence_a = _evidence(
+        "evidence-a",
+        session,
+        atom_a,
+        1,
+        skills=({"name": "skill-a", "version": "sha-a"},),
+    )
+    evidence_b = _evidence("evidence-b", session, atom_b, 5)
+    task = LogicalTask(
+        "task-a",
+        "repair",
+        "repair and verify",
+        "2026-09-01T00:00:00Z",
+        lifecycle="closed",
+        outcome="succeeded",
+        verification="verified" if verified else "unverified",
+        user_disposition="accepted",
+    )
+    memberships = (
+        _membership("membership-b", atom_b, "2026-09-01T00:00:02Z"),
+        _membership("membership-a", atom_a, "2026-09-01T00:00:01Z"),
+    )
+    attempts = (
+        _attempt(
+            "attempt-b",
+            ("2026-09-01T00:01:00Z", "2026-09-01T00:02:00Z"),
+            "succeeded",
+            "accepted",
+            evidence_b,
+        ),
+        _attempt(
+            "attempt-a",
+            ("2026-09-01T00:00:00Z", "2026-09-01T00:01:00Z"),
+            "failed",
+            "corrected",
+            evidence_a,
+        ),
+    )
+    return TaskGraphGeneration(
+        generation_id="generation-a",
+        tenant_id="tenant",
+        task_scope_id="scope",
+        source_revision="source-revision-a",
+        generator={"name": "linker", "version": "v1"},
+        base_override_seq=0,
+        created_at="2026-09-01T00:03:00Z",
+        tasks=(task,),
+        memberships=memberships,
+        relations=(),
+        attempts=attempts,
+        attempt_relations=(
+            AttemptRelation(
+                "attempt-relation-a",
+                *("attempt-a", "attempt-b", "correction_of"),
+                *(None, "confirmed", "rules", "v1", ()),
+                "2026-09-01T00:02:00Z",
+            ),
+        ),
+        usage_allocations=(
+            UsageAllocation(
+                "allocation-a",
+                *("usage-a", "execution", "direct", 1.0),
+                task_id="task-a",
+                attempt_id="attempt-b",
+                total_tokens=None,
+                cost_usd=None,
+                method="evidence_span",
+                method_version="v1",
+            ),
+        ),
+    )
+
+
+def test_bundle_is_deterministic_bounded_and_round_trips_strictly():
+    generation = _generation()
+    bundle = build_task_evidence_bundle(generation, "task-a")
+
+    atom_ids = [item.atom_ref.atom_id for item in bundle.confirmed_memberships]
+    assert atom_ids == ["atom-a", "atom-b"]
+    assert [item.attempt_id for item in bundle.attempts] == ["attempt-a", "attempt-b"]
+    assert [
+        evidence.evidence_id
+        for attempt in bundle.attempts
+        for evidence in attempt.evidence_ranges
+    ] == ["evidence-a", "evidence-b"]
+    assert bundle.learning_eligibility == "eligible"
+    assert bundle.eligibility_reasons == ("verified_terminal_task",)
+    assert bundle.to_dict() == TaskEvidenceBundle.from_dict(bundle.to_dict()).to_dict()
+    rebuilt = build_task_evidence_bundle(generation, "task-a")
+    assert bundle.bundle_fingerprint == rebuilt.bundle_fingerprint
+
+
+def test_published_generation_reload_preserves_bundle_fingerprint(tmp_path):
+    store = TaskGraphStore(tmp_path)
+    store.publish(_generation())
+    first = build_task_evidence_bundle(store.load_current(), "task-a")
+    reloaded = TaskGraphStore(tmp_path).load_current()
+
+    assert reloaded is not None
+    assert build_task_evidence_bundle(reloaded, "task-a").bundle_fingerprint == (
+        first.bundle_fingerprint
+    )
+
+
+def test_bundle_rejects_unknown_fields_and_fingerprint_drift():
+    payload = build_task_evidence_bundle(_generation(), "task-a").to_dict()
+    payload["unknown"] = True
+    with pytest.raises(TaskEvidenceBundleError, match="unknown"):
+        TaskEvidenceBundle.from_dict(payload)
+
+    payload = build_task_evidence_bundle(_generation(), "task-a").to_dict()
+    payload["task"]["summary"] = "changed"
+    with pytest.raises(TaskEvidenceBundleError, match="fingerprint"):
+        TaskEvidenceBundle.from_dict(payload)
+
+
+def test_unresolved_membership_is_observable_but_never_learning_evidence():
+    generation = _generation()
+    proposed = replace(
+        generation.memberships[0],
+        membership_id="membership-review",
+        decision="needs_review",
+    )
+    generation = replace(generation, memberships=(*generation.memberships, proposed))
+    bundle = build_task_evidence_bundle(generation, "task-a")
+
+    assert [item.membership_id for item in bundle.review_memberships] == [
+        "membership-review",
+    ]
+    assert all(
+        item.membership_id != "membership-review"
+        for item in bundle.confirmed_memberships
+    )
+    assert bundle.learning_eligibility == "needs_review"
+    assert "unresolved_task_membership" in bundle.eligibility_reasons
+
+
+def test_unverified_outcome_needs_review_without_inventing_a_score():
+    bundle = build_task_evidence_bundle(_generation(verified=False), "task-a")
+    assert bundle.learning_eligibility == "needs_review"
+    assert bundle.eligibility_reasons == ("task_outcome_not_verified",)
+    serialized = bundle.to_dict()
+    assert "ux_score" not in str(serialized)
+    allocation = serialized["usage_allocations"][0]
+    assert allocation["total_tokens"] is None
+    assert allocation["cost_usd"] is None
+    with pytest.raises(TaskEvidenceBundleError, match="does not match"):
+        replace(bundle, learning_eligibility="eligible")
+
+
+@pytest.mark.parametrize(
+    ("changes", "reason"),
+    [
+        (
+            {"outcome": "cancelled", "verification": "not_applicable"},
+            "task_outcome_cancelled",
+        ),
+        ({"verification": "contradicted"}, "task_verification_contradicted"),
+    ],
+)
+def test_cancelled_or_contradicted_task_is_ineligible(changes, reason):
+    generation = _generation()
+    task = replace(generation.tasks[0], **changes)
+    bundle = build_task_evidence_bundle(
+        replace(generation, tasks=(task,)),
+        "task-a",
+    )
+    assert bundle.learning_eligibility == "ineligible"
+    assert bundle.eligibility_reasons == (reason,)
+
+
+def test_tombstone_and_stale_evidence_fail_closed():
+    generation = _generation()
+    tombstoned_task = replace(generation.tasks[0], tombstoned=True)
+    tombstoned_memberships = tuple(
+        replace(item, stale=True) for item in generation.memberships
+    )
+    tombstoned = replace(
+        generation,
+        tasks=(tombstoned_task,),
+        memberships=tombstoned_memberships,
+    )
+    with pytest.raises(TaskEvidenceBundleError, match="tombstoned"):
+        build_task_evidence_bundle(tombstoned, "task-a")
+
+    stale_range = replace(generation.attempts[0].evidence_ranges[0], stale=True)
+    stale_attempt = replace(generation.attempts[0], evidence_ranges=(stale_range,))
+    with pytest.raises(TaskEvidenceBundleError, match="stale EvidenceRange"):
+        build_task_evidence_bundle(
+            replace(generation, attempts=(stale_attempt, generation.attempts[1])),
+            "task-a",
+        )
+
+
+def test_evidence_atom_must_have_confirmed_primary_membership():
+    generation = _generation()
+    with pytest.raises(TaskEvidenceBundleError, match="confirmed primary"):
+        build_task_evidence_bundle(
+            replace(generation, memberships=(generation.memberships[1],)),
+            "task-a",
+        )
+
+
+def test_bundle_rejects_cross_scope_membership_defensively():
+    bundle = build_task_evidence_bundle(_generation(), "task-a")
+    membership = bundle.confirmed_memberships[0]
+    foreign_atom = replace(membership.atom_ref, tenant_id="other-tenant")
+    with pytest.raises(TaskEvidenceBundleError, match="crosses TaskScope"):
+        replace(
+            bundle,
+            confirmed_memberships=(
+                replace(membership, atom_ref=foreign_atom),
+                *bundle.confirmed_memberships[1:],
+            ),
+        )
+
+
+@pytest.mark.parametrize(
+    ("limits", "message"),
+    [
+        (TaskEvidenceLimits(memberships=1), "memberships"),
+        (TaskEvidenceLimits(attempts=1), "attempts"),
+        (TaskEvidenceLimits(evidence_ranges=1), "evidence_ranges"),
+    ],
+)
+def test_bundle_cardinality_is_bounded(limits, message):
+    with pytest.raises(TaskEvidenceBundleError, match=message):
+        build_task_evidence_bundle(_generation(), "task-a", limits=limits)

--- a/tests/test_task_evidence_candidate.py
+++ b/tests/test_task_evidence_candidate.py
@@ -9,7 +9,9 @@ from xskill.skill.evidence_candidates import (
     MAX_CANDIDATE_ATOM_REFS,
     EvidenceCandidateError,
     TaskSkillCandidate,
+    upsert_evidence_candidates,
 )
+from xskill.skill.candidates import ready_for_promotion_v2
 from xskill.tasks.evidence_bundle import build_task_evidence_bundle
 from xskill.tasks.models import (
     AtomRef,
@@ -94,7 +96,7 @@ def test_task_candidate_is_versioned_bounded_private_and_round_trips():
         _bundle(),
         skill_name="safe-skill",
         weightscore=8,
-        note="bounded routing support",
+        note="bounded_routing_support",
     )
 
     payload = candidate.to_dict()
@@ -153,6 +155,35 @@ def test_unverified_task_cannot_silently_become_eligible():
 
     assert candidate.learning_eligibility == "needs_review"
     assert "task_outcome_not_verified" in candidate.eligibility_reasons
+
+
+def test_ineligible_task_never_promotes_and_revokes_prior_support():
+    eligible = TaskSkillCandidate.from_task_bundle(
+        _bundle(),
+        skill_name="safe-skill",
+        weightscore=10,
+    )
+    needs_review = TaskSkillCandidate.from_task_bundle(
+        _bundle(verified=False),
+        skill_name="safe-skill",
+        weightscore=10,
+    )
+    data = {"candidates": []}
+
+    assert upsert_evidence_candidates(data, (eligible,)) == ([True], 10)
+    assert ready_for_promotion_v2(data, threshold=10)
+    assert upsert_evidence_candidates(data, (needs_review,)) == ([False], 0)
+    assert ready_for_promotion_v2(data, threshold=10) == []
+
+
+def test_logical_task_note_rejects_free_form_private_text():
+    with pytest.raises(EvidenceCandidateError, match="reason code"):
+        TaskSkillCandidate.from_task_bundle(
+            _bundle(),
+            skill_name="safe-skill",
+            weightscore=8,
+            note="private Task summary /home/user/secret",
+        )
 
 
 def test_atom_fallback_is_explicit_and_never_claims_task_provenance():
@@ -214,6 +245,17 @@ def test_new_schema_rejects_inconsistent_task_state():
     payload["task_lifecycle"] = "open"
 
     with pytest.raises(EvidenceCandidateError, match="outcome must be unknown"):
+        TaskSkillCandidate.from_dict(payload)
+
+
+def test_new_schema_rejects_forged_eligibility():
+    payload = TaskSkillCandidate.from_task_bundle(
+        _bundle(verified=False), skill_name="safe-skill", weightscore=8
+    ).to_dict()
+    payload["learning_eligibility"] = "eligible"
+    payload["eligibility_reasons"] = ["verified_terminal_task"]
+
+    with pytest.raises(EvidenceCandidateError, match="verified terminal evidence"):
         TaskSkillCandidate.from_dict(payload)
 
 

--- a/tests/test_task_evidence_candidate.py
+++ b/tests/test_task_evidence_candidate.py
@@ -1,0 +1,232 @@
+from __future__ import annotations
+
+import json
+from dataclasses import replace
+
+import pytest
+
+from xskill.skill.evidence_candidates import (
+    MAX_CANDIDATE_ATOM_REFS,
+    EvidenceCandidateError,
+    TaskSkillCandidate,
+)
+from xskill.tasks.evidence_bundle import build_task_evidence_bundle
+from xskill.tasks.models import (
+    AtomRef,
+    EvidenceRange,
+    LogicalTask,
+    SessionRef,
+    TaskAtomMembership,
+    TaskAttempt,
+    TaskGraphGeneration,
+)
+
+
+def _bundle(*, verified: bool = True):
+    session = SessionRef("tenant", "scope", "source", "traj")
+    atom_a = AtomRef("tenant", "scope", "source", "traj", "atom-a")
+    atom_b = AtomRef("tenant", "scope", "source", "traj", "atom-b")
+    memberships = tuple(
+        TaskAtomMembership(
+            membership_id=f"membership-{atom.atom_id}",
+            task_id="task-a",
+            atom_ref=atom,
+            role="primary",
+            confidence=None,
+            decision="confirmed",
+            decided_by="rules",
+            algorithm_version="v1",
+            evidence_refs=(),
+            observed_at=f"2026-09-01T00:00:0{index}Z",
+        )
+        for index, atom in enumerate((atom_b, atom_a), 1)
+    )
+    evidence = EvidenceRange(
+        evidence_id="evidence-a",
+        session_ref=session,
+        locator_kind="trajectory_line",
+        start=1,
+        end=5,
+        content_hash="hash-a",
+        atom_ref=atom_a,
+    )
+    attempt = TaskAttempt(
+        attempt_id="attempt-a",
+        task_id="task-a",
+        started_at="2026-09-01T00:00:00Z",
+        ended_at="2026-09-01T00:01:00Z",
+        lifecycle="finished",
+        outcome="succeeded",
+        verification="verified",
+        user_disposition="accepted",
+        evidence_ranges=(evidence,),
+    )
+    task = LogicalTask(
+        task_id="task-a",
+        title="private goal text",
+        summary="private Task summary",
+        created_at="2026-09-01T00:00:00Z",
+        lifecycle="closed",
+        outcome="succeeded",
+        verification="verified" if verified else "unverified",
+        user_disposition="accepted",
+    )
+    generation = TaskGraphGeneration(
+        generation_id="generation-a",
+        tenant_id="tenant",
+        task_scope_id="scope",
+        source_revision="source-revision-a",
+        generator={"name": "linker", "version": "v1"},
+        base_override_seq=0,
+        created_at="2026-09-01T00:02:00Z",
+        tasks=(task,),
+        memberships=memberships,
+        relations=(),
+        attempts=(attempt,),
+        attempt_relations=(),
+        usage_allocations=(),
+    )
+    return build_task_evidence_bundle(generation, "task-a")
+
+
+def test_task_candidate_is_versioned_bounded_private_and_round_trips():
+    candidate = TaskSkillCandidate.from_task_bundle(
+        _bundle(),
+        skill_name="safe-skill",
+        weightscore=8,
+        note="bounded routing support",
+    )
+
+    payload = candidate.to_dict()
+    serialized = json.dumps(payload, ensure_ascii=False)
+    assert payload["schema_version"] == 1
+    assert payload["evidence_unit"] == "logical_task"
+    assert [item["atom_id"] for item in payload["atom_refs"]] == [
+        "atom-a",
+        "atom-b",
+    ]
+    assert payload["attempt_refs"][0]["outcome"] == "succeeded"
+    assert payload["learning_eligibility"] == "eligible"
+    assert "private goal text" not in serialized
+    assert "private Task summary" not in serialized
+    assert TaskSkillCandidate.from_dict(payload).to_dict() == payload
+
+
+def test_stable_identity_survives_a_new_generation_revision():
+    original_bundle = _bundle()
+    changed_bundle = replace(
+        original_bundle,
+        generation_id="generation-b",
+        source_revision="source-revision-b",
+    )
+    original = TaskSkillCandidate.from_task_bundle(
+        original_bundle,
+        skill_name="safe-skill",
+        weightscore=6,
+    )
+    changed = TaskSkillCandidate.from_task_bundle(
+        changed_bundle,
+        skill_name="safe-skill",
+        weightscore=9,
+    )
+    assert changed.candidate_id == original.candidate_id
+    assert changed.bundle_fingerprint != original.bundle_fingerprint
+
+
+def test_one_task_can_support_multiple_skills_without_identity_collision():
+    first = TaskSkillCandidate.from_task_bundle(
+        _bundle(), skill_name="skill-a", weightscore=7
+    )
+    second = TaskSkillCandidate.from_task_bundle(
+        _bundle(), skill_name="skill-b", weightscore=5
+    )
+
+    assert first.candidate_id != second.candidate_id
+
+
+def test_unverified_task_cannot_silently_become_eligible():
+    candidate = TaskSkillCandidate.from_task_bundle(
+        _bundle(verified=False),
+        skill_name="safe-skill",
+        weightscore=8,
+    )
+
+    assert candidate.learning_eligibility == "needs_review"
+    assert "task_outcome_not_verified" in candidate.eligibility_reasons
+
+
+def test_atom_fallback_is_explicit_and_never_claims_task_provenance():
+    atom_ref = AtomRef("tenant", "scope", "source", "traj", "atom-a")
+    candidate = TaskSkillCandidate.from_atom_fallback(
+        atom_id="atom-a",
+        atom_ref=atom_ref,
+        skill_name="safe-skill",
+        weightscore=4,
+        fallback_reason="task_unresolved",
+    )
+
+    assert candidate.evidence_unit == "atom_fallback"
+    assert candidate.task_id is None
+    assert candidate.attempt_refs == ()
+    assert candidate.learning_eligibility == "needs_review"
+    assert candidate.eligibility_reasons == ("atom_fallback:task_unresolved",)
+
+
+def test_new_schema_rejects_unknown_fields_and_identity_tampering():
+    payload = TaskSkillCandidate.from_task_bundle(
+        _bundle(), skill_name="safe-skill", weightscore=8
+    ).to_dict()
+    payload["unknown"] = True
+    with pytest.raises(EvidenceCandidateError, match="unknown"):
+        TaskSkillCandidate.from_dict(payload)
+
+    payload.pop("unknown")
+    payload["candidate_id"] = "candidate_tampered"
+    with pytest.raises(EvidenceCandidateError, match="stable evidence identity"):
+        TaskSkillCandidate.from_dict(payload)
+
+
+@pytest.mark.parametrize(
+    ("field", "value"),
+    [
+        ("evidence_unit", []),
+        ("task_lifecycle", []),
+        ("learning_eligibility", []),
+        ("eligibility_reasons", [{}]),
+        ("atom_refs", [{}]),
+        ("attempt_refs", [{}]),
+    ],
+)
+def test_new_schema_rejects_type_confusion(field, value):
+    payload = TaskSkillCandidate.from_task_bundle(
+        _bundle(), skill_name="safe-skill", weightscore=8
+    ).to_dict()
+    payload[field] = value
+
+    with pytest.raises(EvidenceCandidateError):
+        TaskSkillCandidate.from_dict(payload)
+
+
+def test_new_schema_rejects_inconsistent_task_state():
+    payload = TaskSkillCandidate.from_task_bundle(
+        _bundle(), skill_name="safe-skill", weightscore=8
+    ).to_dict()
+    payload["task_lifecycle"] = "open"
+
+    with pytest.raises(EvidenceCandidateError, match="outcome must be unknown"):
+        TaskSkillCandidate.from_dict(payload)
+
+
+def test_candidate_atom_references_have_a_hard_bound():
+    bundle = _bundle()
+    candidate = TaskSkillCandidate.from_task_bundle(
+        bundle, skill_name="safe-skill", weightscore=8
+    )
+    with pytest.raises(EvidenceCandidateError, match="exceed bound"):
+        replace(
+            candidate,
+            atom_refs=tuple(
+                replace(candidate.atom_refs[0], atom_id=f"atom-{index:04d}")
+                for index in range(MAX_CANDIDATE_ATOM_REFS + 1)
+            ),
+        )

--- a/tests/test_task_evidence_candidate_migration.py
+++ b/tests/test_task_evidence_candidate_migration.py
@@ -1,0 +1,123 @@
+from __future__ import annotations
+
+from dataclasses import replace
+
+import pytest
+
+from xskill.skill.evidence_candidate_refs import EvidenceCandidateError
+from xskill.skill.evidence_candidates import (
+    TaskSkillCandidate,
+    migrate_legacy_atom_candidate,
+    migrate_legacy_candidate_buffer,
+    upsert_evidence_candidates,
+)
+
+
+def _fallback(*, weightscore: int = 5) -> TaskSkillCandidate:
+    return TaskSkillCandidate.from_atom_fallback(
+        atom_id="atom-a",
+        skill_name="safe-skill",
+        weightscore=weightscore,
+        fallback_reason="task_unresolved",
+    )
+
+
+def test_legacy_atom_migration_is_deterministic_and_non_destructive():
+    legacy = {"atom_id": "atom-a", "weightscore": 5, "note": "keep me"}
+
+    first = migrate_legacy_atom_candidate(legacy, skill_name="safe-skill")
+    second = migrate_legacy_atom_candidate(dict(legacy), skill_name="safe-skill")
+
+    assert first == second
+    assert first.fallback_reason == "legacy_atom_candidate"
+    assert first.note == "keep me"
+    assert legacy == {"atom_id": "atom-a", "weightscore": 5, "note": "keep me"}
+
+
+def test_buffer_migration_preserves_legacy_patterns_and_does_not_mutate_input():
+    pattern = {"pattern": "legacy pattern", "supporting_trajs": ["traj-a"]}
+    source = {
+        "metadata": {"owner": "test"},
+        "candidates": [pattern, {"atom_id": "atom-a", "weightscore": 4}],
+    }
+
+    migrated, count = migrate_legacy_candidate_buffer(
+        source, skill_name="safe-skill"
+    )
+
+    assert count == 1
+    assert migrated["metadata"] == source["metadata"]
+    assert migrated["candidates"][0] == pattern
+    assert migrated["candidates"][1]["evidence_unit"] == "atom_fallback"
+    assert "schema_version" not in source["candidates"][1]
+    migrated["metadata"]["owner"] = "changed"
+    migrated["candidates"][0]["supporting_trajs"].append("traj-b")
+    assert source["metadata"]["owner"] == "test"
+    assert source["candidates"][0]["supporting_trajs"] == ["traj-a"]
+
+
+class _CountingList(list):
+    iterations = 0
+
+    def __iter__(self):
+        self.iterations += 1
+        return super().__iter__()
+
+
+def test_upsert_replaces_stable_identity_in_one_scan_without_double_counting():
+    original = _fallback(weightscore=4)
+    changed = replace(original, weightscore=9)
+    buffer = _CountingList((original.to_dict(),))
+    data = {"candidates": buffer}
+
+    flags, total = upsert_evidence_candidates(data, (changed,))
+
+    assert flags == [False]
+    assert total == 9
+    assert len(buffer) == 1
+    assert buffer[0]["weightscore"] == 9
+    assert buffer.iterations == 1
+
+
+def test_upsert_keeps_legacy_entries_and_rejects_duplicate_input():
+    candidate = _fallback()
+    data = {"candidates": [{"atom_id": "legacy", "weightscore": 3}]}
+
+    assert upsert_evidence_candidates(data, (candidate,)) == ([True], 8)
+    assert data["candidates"][0]["atom_id"] == "legacy"
+    with pytest.raises(EvidenceCandidateError, match="duplicate stable identities"):
+        upsert_evidence_candidates(data, (candidate, candidate))
+
+    other_skill = TaskSkillCandidate.from_atom_fallback(
+        atom_id="atom-b",
+        skill_name="other-skill",
+        weightscore=5,
+        fallback_reason="task_unresolved",
+    )
+    with pytest.raises(EvidenceCandidateError, match="cannot cross Skills"):
+        upsert_evidence_candidates(
+            {"candidates": []}, (candidate, other_skill)
+        )
+
+
+@pytest.mark.parametrize(
+    "legacy",
+    [
+        {"weightscore": 5},
+        {"atom_id": "atom-a", "weightscore": 5, "extra": True},
+        {"atom_id": "atom-a", "weightscore": True},
+    ],
+)
+def test_legacy_migration_fails_closed_on_ambiguous_records(legacy):
+    with pytest.raises(EvidenceCandidateError):
+        migrate_legacy_atom_candidate(legacy, skill_name="safe-skill")
+
+
+def test_buffer_migration_rejects_cross_skill_versioned_candidates():
+    candidate = _fallback().to_dict()
+    candidate["skill_name"] = "another-skill"
+
+    with pytest.raises(EvidenceCandidateError):
+        migrate_legacy_candidate_buffer(
+            {"candidates": [candidate]}, skill_name="safe-skill"
+        )

--- a/tests/test_task_evidence_candidate_migration.py
+++ b/tests/test_task_evidence_candidate_migration.py
@@ -73,7 +73,7 @@ def test_upsert_replaces_stable_identity_in_one_scan_without_double_counting():
     flags, total = upsert_evidence_candidates(data, (changed,))
 
     assert flags == [False]
-    assert total == 9
+    assert total == 0
     assert len(buffer) == 1
     assert buffer[0]["weightscore"] == 9
     assert buffer.iterations == 1
@@ -83,7 +83,7 @@ def test_upsert_keeps_legacy_entries_and_rejects_duplicate_input():
     candidate = _fallback()
     data = {"candidates": [{"atom_id": "legacy", "weightscore": 3}]}
 
-    assert upsert_evidence_candidates(data, (candidate,)) == ([True], 8)
+    assert upsert_evidence_candidates(data, (candidate,)) == ([True], 3)
     assert data["candidates"][0]["atom_id"] == "legacy"
     with pytest.raises(EvidenceCandidateError, match="duplicate stable identities"):
         upsert_evidence_candidates(data, (candidate, candidate))
@@ -121,3 +121,28 @@ def test_buffer_migration_rejects_cross_skill_versioned_candidates():
         migrate_legacy_candidate_buffer(
             {"candidates": [candidate]}, skill_name="safe-skill"
         )
+
+
+def test_upsert_rejects_malformed_versioned_entry_without_candidate_id():
+    malformed = _fallback().to_dict()
+    malformed.pop("candidate_id")
+
+    with pytest.raises(EvidenceCandidateError, match="missing"):
+        upsert_evidence_candidates(
+            {"candidates": [malformed]},
+            (_fallback(weightscore=6),),
+        )
+
+
+def test_only_compatibility_fallback_contributes_to_promotion():
+    unresolved = _fallback(weightscore=10)
+    disabled = TaskSkillCandidate.from_atom_fallback(
+        atom_id="atom-a",
+        skill_name="safe-skill",
+        weightscore=10,
+        fallback_reason="task_graph_disabled",
+    )
+    data = {"candidates": []}
+
+    assert upsert_evidence_candidates(data, (unresolved,)) == ([True], 0)
+    assert upsert_evidence_candidates(data, (disabled,)) == ([False], 10)

--- a/tests/test_task_evidence_candidate_refs.py
+++ b/tests/test_task_evidence_candidate_refs.py
@@ -1,0 +1,69 @@
+from __future__ import annotations
+
+from dataclasses import replace
+
+import pytest
+
+from xskill.skill.evidence_candidate_refs import (
+    CandidateAtomRef,
+    CandidateAttemptRef,
+    EvidenceCandidateError,
+)
+from xskill.tasks.models import AtomRef
+
+
+def test_atom_reference_supports_scoped_and_explicit_legacy_forms():
+    source = AtomRef("tenant", "scope", "source", "traj", "atom-a")
+    scoped = CandidateAtomRef.from_atom_ref(source)
+    legacy = CandidateAtomRef(atom_id="atom-a")
+
+    assert scoped.scoped is True
+    assert CandidateAtomRef.from_dict(scoped.to_dict()) == scoped
+    assert legacy.scoped is False
+    assert CandidateAtomRef.from_dict(legacy.to_dict()) == legacy
+
+
+def test_atom_reference_rejects_partial_scope_and_unknown_fields():
+    with pytest.raises(EvidenceCandidateError, match="scope must be complete"):
+        CandidateAtomRef(atom_id="atom-a", tenant_id="tenant")
+
+    payload = CandidateAtomRef(atom_id="atom-a").to_dict()
+    payload["unknown"] = True
+    with pytest.raises(EvidenceCandidateError, match="unknown"):
+        CandidateAtomRef.from_dict(payload)
+
+
+def _attempt_ref() -> CandidateAttemptRef:
+    return CandidateAttemptRef(
+        attempt_id="attempt-a",
+        started_at="2026-09-01T00:00:00Z",
+        ended_at="2026-09-01T00:01:00Z",
+        lifecycle="finished",
+        outcome="succeeded",
+        verification="verified",
+        user_disposition="accepted",
+        evidence_range_ids=("evidence-a", "evidence-b"),
+    )
+
+
+def test_attempt_reference_round_trips_outcome_and_ordered_evidence():
+    attempt = _attempt_ref()
+
+    assert CandidateAttemptRef.from_dict(attempt.to_dict()) == attempt
+    assert attempt.to_dict()["outcome"] == "succeeded"
+
+
+@pytest.mark.parametrize(
+    "changed",
+    [
+        {"lifecycle": []},
+        {"outcome": "invented"},
+        {"lifecycle": "running"},
+        {"evidence_range_ids": ("evidence-b", "evidence-a")},
+        {"evidence_range_ids": ("evidence-a", "evidence-a")},
+        {"evidence_range_ids": ({},)},
+    ],
+)
+def test_attempt_reference_fails_closed_on_invalid_values(changed):
+    with pytest.raises(EvidenceCandidateError):
+        replace(_attempt_ref(), **changed)

--- a/tests/test_task_evidence_status.py
+++ b/tests/test_task_evidence_status.py
@@ -1,0 +1,75 @@
+"""Task learning status comes from the requested tenant's registry projection."""
+
+import pytest
+
+from xskill.pipeline.registry import get_connection
+from xskill.tasks.projection import task_evidence_feed_counts, task_graph_overview
+
+
+def _seed(db_path):
+    with get_connection(db_path) as connection:
+        connection.executemany(
+            "INSERT INTO task_evidence_feed("
+            "tenant_id,task_scope_id,task_id,task_generation_id,"
+            "task_evidence_fingerprint,learning_eligibility,status)"
+            " VALUES(?,?,?,?,?,?,?)",
+            [
+                (tenant, "scope", str(i), "generation", "digest", "eligible", status)
+                for tenant, statuses in (
+                    ("tenant-a", ("pending", "pending", "processed", "fallback")),
+                    ("tenant-b", ("pending", "rejected")),
+                )
+                for i, status in enumerate(statuses)
+            ],
+        )
+
+
+def test_feed_counts_include_every_state_without_merging_tenants(tmp_path):
+    db_path = tmp_path / "registry.db"
+    _seed(db_path)
+
+    assert task_evidence_feed_counts(tenant_id="tenant-a", db_path=db_path) == {
+        "pending": 2,
+        "processed": 1,
+        "fallback": 1,
+        "rejected": 0,
+    }
+    assert task_evidence_feed_counts(db_path=db_path) == {
+        "pending": 3,
+        "processed": 1,
+        "fallback": 1,
+        "rejected": 1,
+    }
+
+
+@pytest.mark.parametrize("tenant_id", ["", "unknown", "tenant-a' OR 1=1 --"])
+def test_missing_or_untrusted_identity_never_selects_other_tenants(tmp_path, tenant_id):
+    db_path = tmp_path / "registry.db"
+    _seed(db_path)
+
+    assert task_graph_overview(tenant_id, db_path=db_path)["evidence_feed"] == {
+        "pending": 0,
+        "processed": 0,
+        "fallback": 0,
+        "rejected": 0,
+    }
+
+
+def test_overview_uses_explicit_registry_and_tenant(tmp_path):
+    populated = tmp_path / "populated.db"
+    empty = tmp_path / "other-home.db"
+    _seed(populated)
+    get_connection(empty).close()
+
+    assert task_graph_overview("tenant-b", db_path=populated)["evidence_feed"] == {
+        "pending": 1,
+        "processed": 0,
+        "fallback": 0,
+        "rejected": 1,
+    }
+    assert task_graph_overview("tenant-b", db_path=empty)["evidence_feed"] == {
+        "pending": 0,
+        "processed": 0,
+        "fallback": 0,
+        "rejected": 0,
+    }

--- a/tests/test_task_graph_runtime.py
+++ b/tests/test_task_graph_runtime.py
@@ -311,9 +311,13 @@ def test_task_graph_dashboard_routes_require_admin_and_apply_override(
         json={"user_name": "reviewer", "secret": "secret"},
     )
     assert login.status_code == 200
-    assert admin.get(
+    overview = admin.get(
         "/api/v1/dashboard/task-graph/overview",
-    ).json()["tasks"] == 1
+    ).json()
+    assert overview["tasks"] == 1
+    assert overview["evidence_feed"] == {
+        "pending": 1, "processed": 0, "fallback": 0, "rejected": 0,
+    }
     response = admin.post(
         "/api/v1/dashboard/task-graph/override",
         json={


### PR DESCRIPTION
<!-- real-skill-production-gate-20260909 -->
## 2026-09-19：筛选候选前核对当前证据

当前提交 `c7429c5`。本次修复的问题是：Task 内容或来源证据已经变化，候选文件里仍保留旧的 eligible 标记，原筛选函数会继续把它计入晋升分数。

现在候选格式升级为 schema 2，保存与队列同语义的 `task_evidence_fingerprint`。筛选函数 `ready_for_promotion_v2(..., db_path=...)` 读取当前租户/范围/Task 的记录，先排除版本不同、已删除、被拒绝或失去资格的支持，再计算阈值。仅重建 generation 元数据不失效；只有证据变化才需要重新处理。

旧 schema 1 记录仍可读取，但不能凭 Task 字段指纹或包含 generation 的包指纹补造证据版本。缺少证据版本的旧 Task 候选需要重新处理。函数不修改旧候选或刷新其指纹来沿用旧结论。

调用未提供明确注册表时，Task 候选不参与这次筛选；Atom-only 调用维持原行为、不访问注册表。显式注册表查询使用同一读快照、每批最多 250 个身份，覆盖 400 Task 的参数边界。

71 项针对性测试通过；容器内完整测试 2985 passed, 11 skipped，本次修改的 Python 文件 Ruff、候选契约与测试格式检查、wheel/sdist 构建通过。当前线上已出现 14 项检查，14 项尚未完成；尚未发现失败。

**这还不是完整 Task → Skill 接入。** 生产调用尚未传入 Task 注册表；baby、jam 仍需统一证据选择，SkillEdit 提交前还需复核版本，处理完成后按候选身份和版本确认。此次读快照不是锁定证据的承诺，也不替代最终提交检查。PR 保持 Draft，真实 Skill 产出证据尚未补齐。

## Summary

xskill 已经能把相关的工作片段整理成完整任务，但生成 Skill 的生产程序还没有完整用上这些任务资料。这张 PR 先补上处理前需要的部分：记住哪些任务有变化、保存候选经验、避免重复写入时重复加分，并让管理员查到处理状态。

它把 #407 已完成的阶段放到线上，便于一起审阅。TaskCluster 和 SkillEdit 的实际接入仍要继续做，因此合入本 PR 后，Issue #407 也应保持开放。

## 先说明代码中的几个词

Atom 是从会话中提取的一小段工作信息。Logical Task 表示用户要完成的一项目标，可以关联多个片段；Attempt 记录其中一次执行过程。#411 已经定义怎样把任务目标、执行尝试、关系、结果和来源引用整理成一份资料，代码名为 `TaskEvidenceBundle`。

这里的 candidate 是待写入某个 Skill 的候选经验。它保存支持这项经验的任务引用和分数，生成或编辑 Skill 的程序后续会读取这些候选。

## Changes

任务内容发生变化时，系统在 SQLite 中记一条待处理记录。再次构建相同内容，不会反复产生同一份工作；程序重启后，待处理记录仍然存在。只改了重建时间或批次编号，也不会让内容相同的任务再处理一遍。

确认处理结果时，系统会核对工作版本。如果处理期间任务内容又变了，旧一轮返回的完成信号不能把新版工作一起标成已处理。这就是代码中版本检查要保护的情况。

整理一批任务资料时，程序复用同一份索引，避免每处理一个任务就重新遍历整张图。每类引用仍有数量上限，整份材料仍受 1 MiB 限制。测试既检查扫描次数，也覆盖了 1,200 个任务时的数据库清理。

候选记录有稳定身份。同一项任务对同一个 Skill 的候选再次写入时，会更新已有记录，支持分不会重复累加；不同 Skill 可以分别保存自己的候选。旧 Atom 候选会转换成明确的兼容格式，保留原来的来源和含义。候选保存有界的 Task/Attempt/Atom 引用，不复制轨迹正文。

候选文件采用原子替换，减少写到一半留下损坏文件的风险。候选格式和晋升筛选会检查资料是否具备学习资格；后续资料不再合格时，更新可以撤销旧支持。生产编辑中的加塞更新路径（代码中的 jam）还需要在后续接入时统一使用这些判断。

状态接口沿用现有管理员 overview 查询，返回等待处理、已确认处理、回退、拒绝四类数量，即 `pending`、`processed`、`fallback`、`rejected`。查询只返回当前租户的数据；身份尚未解析出来时返回零，也不会误用另一个本地实例的数据库。

`processed` 表示队列中的这一版工作已经被确认处理。它不能单独说明 Skill 已经生成或发布，回退和拒绝计数的可查询性也不能说明生产消费者已经接通。

## 建议怎么审代码

建议按最终代码的职责查看，测试与实现一起读：

| 先看哪里 | 要确认的问题 |
| --- | --- |
| `src/xskill/tasks/projection.py` | 相同内容是否重复排队；旧版本的完成信号是否会清掉新版本；状态查询是否限制在当前租户和指定数据库 |
| `src/xskill/tasks/evidence_bundle.py` | 是否保留 #411 的资料格式和大小限制；批量处理是否复用索引 |
| `src/xskill/skill/evidence_candidate_refs.py`、`evidence_candidates.py` | 候选身份是否稳定；旧候选迁移后是否保留含义；不合格资料是否仍提供支持分 |
| `src/xskill/skill/candidates.py` | 文件写入失败时是否保留可用内容；候选更新和晋升筛选是否使用上述规则 |
| 对应测试及 `docs/task-graph-runtime.md` | 重复处理、重启、版本变化、资格撤销和状态含义是否有证据对应 |

## 阶段提交与依赖

#404 已合并，本分支已同步当前 main。#411 的证据包已包含在本分支，按维护者意见联合审阅，不能把单独合入 #411 作为前置。本分支保留 #407 的批量索引实现。

历史提交按下面顺序组织。它们帮助 reviewer 理解每一步在补什么，不能把早期提交当成可以单独上线的成品；后面的资格和大小限制修复需要一起看。

| 阶段 | 提交 | 完成的工作 |
| --- | --- | --- |
| 1 | `9734190f` | 把发生变化的任务记入持久待处理队列 |
| 2 | `6d844157` | 定义候选可以保存哪些来源引用 |
| 3 | `556522b1` | 定义一条任务候选包含哪些信息 |
| 4 | `901651c7` | 迁移旧候选，按稳定身份更新记录 |
| 5 | `a4e7b488` | 原子保存候选文件 |
| 6 | `b974c003` | 补齐资格撤销、内容变化判断和资料大小限制 |
| 7 | `6c8de54a` | 增加当前租户的队列状态查询及回归测试 |

## #407 还缺哪些工作

- [ ] 让 TaskClusterAgent 实际读取完整任务资料，并把经验分配给一个或多个 Skill。
- [ ] 防止整项 Task 和其下属 Atom 同时进入生产程序后，对同一份证据重复加分。当前解决的是同一候选重复写入的问题。
- [ ] 让 SkillEditAgent 编辑前读取任务目标、尝试、重试/纠正关系、结果和有界正文证据。
- [ ] 在实际消费候选时核对候选身份与处理版本，并统一 jam 路径的资格筛选。
- [ ] 完成关闭任务图时的整条兼容测试，以及 Task 到 Skill 处理过程中断后的恢复测试。

## 历史验证：2026-09-18 SQLite 事务调整（230c4f5）

#428 已合入 main，本 PR 与任务投影初始化发生冲突。本次以 merge 保留双方历史，同步 main `aeee7c1`，当时提交为 `230c4f5`。

冲突处理保留两项约束：证据包、JSON 和 SQL 参数在获取写锁前准备；Task 图和学习队列仍在同一个事务中发布，不能出现图已更新而队列没更新的半成品。

补充验证包括：在原事务边界测试中确认学习队列也在锁外准备；用数据库触发器模拟队列写入失败，确认图和已处理队列均回滚，重试只产生下一版工作，旧确认不能清掉新版。

针对性测试 101 passed、1 skipped；容器内完整测试 2975 passed, 11 skipped，修改文件 Ruff、证据包测试格式检查及 wheel/sdist 构建通过。该提交后续已执行跨平台 CI 全部通过（2026-09-19 核对）。

#428 合并前的 Windows 并发用例曾失败。后续 `230c4f5` 的 Windows 检查已通过；此前失败根因未单独确定，本次提交仍需自己的 CI。

## 已保留的续写衔接修复

助手或工具追加结果后，Task Graph 会保留失效的旧证据用于审计。原构建器把旧记录也放进学习证据包，导致包含有效新证据的任务整体被拒绝，队列记录变成 rejected。

现在学习证据包只选择当前有效范围，审计历史仍保留。全部范围失效时仍拒绝；历史范围仍计入数量限制，不能通过过滤绕过上限。新增两条回归分别验证学习指纹稳定和输入边界。

## Test plan

- [x] 容器内完整测试：2985 passed, 11 skipped（排除 docker_e2e 和 live 目录）。
- [x] 修改文件的 Ruff、格式检查和 wheel/sdist 构建通过。
- [x] 新增历史证据与数量上限回归。
- [ ] 当前提交的线上 CI 完成后另行确认。
- [ ] 已知有效会话在真实环境中实际生成 Skill，保存产物和运行证据。

历史合成回放曾临时整合 #426 + #414：构建器修复相关的 51 项通过，覆盖助手/工具续写、重启、旧版本确认和重复回放；当时另有一个旧候选筛选用例未通过。本轮已为候选筛选增加持久回归，并使用显式注册表验证过期证据被排除；尚未重新运行包含本轮改动的 #426 完整组合。这些测试均不代表真实模型产出。

## 仍需完成

TaskCluster/SkillEdit 消费、Atom/Task 重复计分防护、baby/jam 统一筛选、提交前版本复核、按版本确认和禁用兼容仍待验收。`processed` 只表示该版队列工作被确认，不等于 Skill 已产出。#411 的契约已包含在本 PR，按维护者意见一起审阅，不独立安排合入；#407 保持开放。

## Linked issues

Refs #407. Includes the evidence contract from #411 / #406. Session continuation integration: #426 / #417. #407 remains open.

## Automation

Codex 协助完成代码、测试与说明。通过 RepoSteward 的独立验证和 submit 流程更新原 PR；外部 review、真实产出验收和合并批准仍待完成。
