### PR TITLE
fix(tasks): retry unreadable session evidence（读取失败时保留 Task 并重试）

### DIFF
--- a/src/xskill/tasks/evidence.py
+++ b/src/xskill/tasks/evidence.py
@@ -20,6 +20,10 @@ from xskill.tasks.models import (
 from xskill.tasks.scopes import ScopeIdentity
 
 
+class TrajectorySourceMissing(FileNotFoundError):
+    """The original Session disappeared, rather than a referenced Atom file."""
+
+
 def _hash_json(value: Any) -> str:
     payload = json.dumps(
         value, ensure_ascii=False, sort_keys=True, separators=(",", ":"),
@@ -430,8 +434,10 @@ def collect_trajectory_evidence(
         observed_at = datetime.fromtimestamp(
             markdown_path.stat().st_mtime, tz=timezone.utc,
         ).isoformat(timespec="milliseconds")
-    except OSError as error:
-        raise FileNotFoundError(f"trajectory evidence is unavailable: {markdown_path}") from error
+    except FileNotFoundError as error:
+        raise TrajectorySourceMissing(
+            f"trajectory evidence is unavailable: {markdown_path}"
+        ) from error
     session_hash = hashlib.sha256(markdown_payload).hexdigest()
     session_ref = SessionRef(
         tenant_id=scope.tenant_id,

--- a/src/xskill/tasks/service.py
+++ b/src/xskill/tasks/service.py
@@ -11,6 +11,7 @@ from pathlib import Path
 
 from xskill.tasks.evidence import (
     ScopedTrajectoryEvidence,
+    TrajectorySourceMissing,
     collect_trajectory_evidence,
 )
 from xskill.tasks.linker import BoundedTaskLinker
@@ -209,6 +210,7 @@ class TaskGraphService:
 
         resolved: dict[tuple[int, str], ScopedTrajectoryEvidence | None] = {}
         collection_failed: set[tuple[int, str]] = set()
+        failed_collection_scopes: set[tuple[str, str]] = set()
         old_scopes_by_key: dict[tuple[int, str], tuple[str, str] | None] = {}
         for row in dirty_rows:
             key = (int(row["watch_dir_id"]), str(row["filename"]))
@@ -231,6 +233,7 @@ class TaskGraphService:
                 )
                 continue
             watch_dir, trajectory = live
+            scope = None
             try:
                 scope = self.resolver.resolve(
                     watch_dir=watch_dir, trajectory=trajectory,
@@ -238,7 +241,7 @@ class TaskGraphService:
                 evidence = collect_trajectory_evidence(
                     watch_dir=watch_dir, trajectory=trajectory, scope=scope,
                 )
-            except FileNotFoundError:
+            except TrajectorySourceMissing:
                 logger.info(
                     "Task Graph source disappeared before collection: %s/%s",
                     watch_dir.get("path"), row["filename"],
@@ -250,6 +253,10 @@ class TaskGraphService:
                     watch_dir.get("path"), row["filename"], exc_info=True,
                 )
                 collection_failed.add(key)
+                if old_scope is not None:
+                    failed_collection_scopes.add(old_scope)
+                if scope is not None:
+                    failed_collection_scopes.add((scope.tenant_id, scope.task_scope_id))
                 continue
             resolved[key] = evidence
             if evidence is not None:
@@ -283,9 +290,13 @@ class TaskGraphService:
         selected_scopes = sorted(selected_scope_set)
         processed_rows: list[dict] = []
         built = []
-        failed_scopes = []
+        failed_scopes = sorted({scope_id for _tenant, scope_id in failed_collection_scopes})
         successful_scope_set: set[tuple[str, str]] = set()
         for tenant_id, task_scope_id in selected_scopes:
+            # A warm cache must not hide a failed collection while another
+            # source in this scope advances. Retry the complete scope instead.
+            if (tenant_id, task_scope_id) in failed_collection_scopes:
+                continue
             try:
                 generation, source_count = self._rebuild_scope(
                     tenant_id, task_scope_id, resolved,
@@ -407,7 +418,7 @@ class TaskGraphService:
                                 scope=scope,
                             )
                             self._cache_evidence(evidence)
-                        except FileNotFoundError:
+                        except TrajectorySourceMissing:
                             evidence = None
                     else:
                         evidence = None

--- a/tests/test_server_no_llm_fallback.py
+++ b/tests/test_server_no_llm_fallback.py
@@ -128,10 +128,14 @@ def test_standalone_worker_commands_share_resolved_ecosystem_home(
         str(ecosystem_home.resolve()),
     ]
     assert set(records_by_name) == {
-        "agent-worker", "ecosystem-ingest", "ux-scores-sync",
+        "agent-worker", "ecosystem-ingest", "kernel-host", "ux-scores-sync",
     }
     assert records_by_name["agent-worker"].command[-2:] == expected_home_arguments
     assert records_by_name["agent-worker"].keyword_arguments["persistent"] is True
+    kernel_command = records_by_name["kernel-host"].command
+    assert kernel_command[-1] == "kernel-host"
+    assert "--server" not in kernel_command
+    assert records_by_name["kernel-host"].keyword_arguments["persistent"] is True
     ingest_command = records_by_name["ecosystem-ingest"].command
     home_argument_index = ingest_command.index("--home")
     assert ingest_command[
@@ -244,12 +248,15 @@ def test_team_server_schedules_only_server_watcher(
         record.name: record for record in scheduler_records
     }
     assert set(records_by_name) == {
-        "recommend-heavy", "agent-worker", "ux-scores-sync",
+        "recommend-heavy", "agent-worker", "kernel-host", "ux-scores-sync",
     }
     watcher_command = records_by_name["agent-worker"].command
     assert watcher_command[-1] == "--server"
     assert "--home" not in watcher_command
     assert records_by_name["agent-worker"].keyword_arguments["persistent"] is True
+    kernel_command = records_by_name["kernel-host"].command
+    assert kernel_command[-2:] == ["kernel-host", "--server"]
+    assert records_by_name["kernel-host"].keyword_arguments["persistent"] is True
     assert "persistent" not in records_by_name["recommend-heavy"].keyword_arguments
     assert records_by_name["recommend-heavy"].command[-1] == "recommend-heavy"
     assert "persistent" not in records_by_name["ux-scores-sync"].keyword_arguments

--- a/tests/test_task_graph_source_recovery.py
+++ b/tests/test_task_graph_source_recovery.py
@@ -1,0 +1,188 @@
+"""A temporarily unreadable Session must not look like deleted evidence."""
+
+from pathlib import Path
+
+import pytest
+
+from tests.test_task_graph_runtime import _add_source, _build
+from xskill.pipeline.atom import AtomTaskStore
+from xskill.tasks.projection import list_dirty_sources, list_logical_tasks
+from xskill.tasks.service import TaskGraphService
+
+
+def _fail_read(monkeypatch, path, error_type, *, once=False):
+    original = Path.read_bytes
+    calls = []
+
+    def read_bytes(candidate):
+        if candidate == path and (not once or not calls):
+            calls.append(candidate)
+            raise error_type("injected temporary read failure")
+        return original(candidate)
+
+    monkeypatch.setattr(Path, "read_bytes", read_bytes)
+    return calls
+
+
+@pytest.mark.parametrize("error_type", [PermissionError, OSError])
+@pytest.mark.parametrize("restart", [False, True])
+def test_dirty_source_read_failure_preserves_graph_until_retry(
+    tmp_path, monkeypatch, error_type, restart
+):
+    db_path = tmp_path / "registry.db"
+    source = _add_source(
+        tmp_path,
+        db_path,
+        source_name="read-retry",
+        atoms=[{"intent": "Inspect source evidence"}],
+    )
+    service = _build(tmp_path, db_path, [source])
+    tenant_id = service.resolver.tenant_id
+    tasks = list_logical_tasks(tenant_id, db_path=db_path)
+    graph_store = service.store_for_scope(tasks[0]["task_scope_id"])
+    before = graph_store.load_current().generation_id
+    service.mark_dirty(*source, reason="session_updated")
+    with monkeypatch.context() as patch:
+        _fail_read(patch, tmp_path / "trajectories" / source[1], error_type)
+        result = service.process_dirty()
+    assert result["sources"] == 0
+    assert graph_store.load_current().generation_id == before
+    assert list_logical_tasks(tenant_id, db_path=db_path) == tasks
+    assert len(list_dirty_sources(db_path=db_path)) == 1
+
+    if restart:
+        service = TaskGraphService(state_root=tmp_path, db_path=db_path)
+    assert service.process_dirty()["sources"] == 1
+    assert list_dirty_sources(db_path=db_path) == []
+    assert graph_store.load_current().generation_id == before
+    assert list_logical_tasks(tenant_id, db_path=db_path) == tasks
+
+
+@pytest.mark.parametrize("failed_source_is_dirty", [False, True])
+def test_scope_update_cannot_publish_around_an_unreadable_peer(
+    tmp_path, monkeypatch, failed_source_is_dirty
+):
+    db_path = tmp_path / "registry.db"
+    failed = _add_source(
+        tmp_path, db_path, source_name="blocked", atoms=[{"intent": "Inspect logs"}]
+    )
+    changed = _add_source(
+        tmp_path, db_path, source_name="changed", atoms=[{"intent": "Write docs"}]
+    )
+    service = _build(tmp_path, db_path, [failed, changed])
+    tenant_id = service.resolver.tenant_id
+    tasks = list_logical_tasks(tenant_id, db_path=db_path)
+    scope_id = tasks[0]["task_scope_id"]
+    graph_store = service.store_for_scope(scope_id)
+    before = graph_store.load_current().generation_id
+    atoms = AtomTaskStore(tmp_path / "trajectories")
+    updated_atom = atoms.list_by_traj(changed[1][:-3])[0]
+    updated_atom.summary = "Documentation now includes recovery instructions"
+    atoms.save(updated_atom)
+    if failed_source_is_dirty:
+        # Keep a warm cache and fail only the initial collection. A rebuild
+        # must not silently substitute the previously cached source revision.
+        service.mark_dirty(*failed, reason="session_updated")
+    else:
+        # A restarted worker must reload unchanged peers while rebuilding.
+        service = TaskGraphService(state_root=tmp_path, db_path=db_path)
+    service.mark_dirty(*changed, reason="atom_updated")
+    with monkeypatch.context() as patch:
+        calls = _fail_read(
+            patch,
+            tmp_path / "trajectories" / failed[1],
+            PermissionError,
+            once=True,
+        )
+        result = service.process_dirty()
+    assert len(calls) == 1
+    assert result["sources"] == 0
+    assert result["failed_scopes"] == [scope_id]
+    assert graph_store.load_current().generation_id == before
+    assert list_logical_tasks(tenant_id, db_path=db_path) == tasks
+    assert len(list_dirty_sources(db_path=db_path)) == 1 + failed_source_is_dirty
+
+    assert service.process_dirty()["sources"] == 1 + failed_source_is_dirty
+    assert list_dirty_sources(db_path=db_path) == []
+    assert graph_store.load_current().generation_id != before
+    assert {
+        task["task_id"] for task in list_logical_tasks(tenant_id, db_path=db_path)
+    } == {task["task_id"] for task in tasks}
+
+
+def test_real_session_deletion_still_removes_automatic_task(tmp_path):
+    db_path = tmp_path / "registry.db"
+    source = _add_source(
+        tmp_path, db_path, source_name="removed", atoms=[{"intent": "Inspect logs"}]
+    )
+    service = _build(tmp_path, db_path, [source])
+    tenant_id = service.resolver.tenant_id
+    assert len(list_logical_tasks(tenant_id, db_path=db_path)) == 1
+    (tmp_path / "trajectories" / source[1]).unlink()
+    service.mark_dirty(*source, reason="source_missing")
+    assert service.process_dirty()["sources"] == 1
+    assert list_dirty_sources(db_path=db_path) == []
+    assert list_logical_tasks(tenant_id, db_path=db_path) == []
+
+
+def test_missing_atom_during_read_is_not_a_deleted_session(tmp_path, monkeypatch):
+    db_path = tmp_path / "registry.db"
+    source = _add_source(
+        tmp_path, db_path, source_name="atom-race", atoms=[{"intent": "Inspect logs"}]
+    )
+    service = _build(tmp_path, db_path, [source])
+    tenant_id = service.resolver.tenant_id
+    tasks = list_logical_tasks(tenant_id, db_path=db_path)
+    service.mark_dirty(*source, reason="atom_updated")
+    original = Path.read_text
+
+    def read_text(path, *args, **kwargs):
+        if path.name.startswith("atom_") and path.suffix == ".json":
+            raise FileNotFoundError("injected Atom replacement race")
+        return original(path, *args, **kwargs)
+
+    with monkeypatch.context() as patch:
+        patch.setattr(Path, "read_text", read_text)
+        assert service.process_dirty()["sources"] == 0
+    assert list_logical_tasks(tenant_id, db_path=db_path) == tasks
+    assert len(list_dirty_sources(db_path=db_path)) == 1
+    assert service.process_dirty()["sources"] == 1
+
+
+def test_new_unreadable_source_blocks_its_scope_but_not_another_workspace(
+    tmp_path, monkeypatch
+):
+    db_path = tmp_path / "registry.db"
+    existing = _add_source(
+        tmp_path, db_path, source_name="existing", atoms=[{"intent": "Inspect logs"}]
+    )
+    service = _build(tmp_path, db_path, [existing])
+    tenant_id = service.resolver.tenant_id
+    task = list_logical_tasks(tenant_id, db_path=db_path)[0]
+    store = service.store_for_scope(task["task_scope_id"])
+    before = store.load_current().generation_id
+    blocked = _add_source(
+        tmp_path, db_path, source_name="new-blocked", atoms=[{"intent": "Write docs"}]
+    )
+    independent = _add_source(
+        tmp_path,
+        db_path,
+        source_name="independent",
+        workspace="/workspace/other",
+        atoms=[{"intent": "Build a dashboard"}],
+    )
+    for source in [existing, blocked, independent]:
+        service.mark_dirty(*source, reason="session_updated")
+    with monkeypatch.context() as patch:
+        _fail_read(patch, tmp_path / "trajectories" / blocked[1], PermissionError)
+        result = service.process_dirty()
+    assert result["sources"] == 1
+    assert result["failed_scopes"] == [task["task_scope_id"]]
+    assert store.load_current().generation_id == before
+    assert len(list_logical_tasks(tenant_id, db_path=db_path)) == 2
+    assert {row["filename"] for row in list_dirty_sources(db_path=db_path)} == {
+        existing[1],
+        blocked[1],
+    }
+    assert service.process_dirty()["sources"] == 2
+    assert len(list_logical_tasks(tenant_id, db_path=db_path)) == 3


### PR DESCRIPTION
<!-- real-skill-production-gate-20260909 -->
2026-09-09 合入条件更新：已确认 [maintainer 的要求](https://github.com/SkillNerds/xskill/issues/407#issuecomment-5580309058)。本 PR 保持 Draft，暂不提合入审查。需要先在能够实际产出 Skill 的环境中，用一条平时能生成 Skill 的会话证明现有生产路径仍然正常，并贴回本次产物及运行证据，再由 maintainer 判断是否转正式审查。现有单测、GitHub CI 和组合测试通过均不能替代这项验证；目前还没有这份真实产出证据。

下文保留已有实现和验证记录；涉及合入顺序的旧说明以本段为准。

---

## Summary

原始会话暂时读不到时，已有 Task 应继续保留，恢复读取后再处理更新。

之前读取 Markdown 或查询文件属性遇到的所有 `OSError` 都被转成 `FileNotFoundError`。Task worker 会把它理解成“来源已经删除”，可能撤下已有 Task，并确认本应重试的待处理记录。权限错误和普通 I/O 故障因此也会走到删除路径。

Closes #415。

## Changes

这次修复区分两件事：原始 Session 确实消失，以及它或引用的 Atom 暂时无法读取。只有前者按删除处理；读取异常继续留在待处理队列中。

同一工作区有多份会话时，一份读取失败、另一份更新成功，也会保留该工作区的整轮更新等待重试。这样不会拿缓存中的旧来源与新来源拼成一次不完整发布。其他工作区仍可继续处理。

新增 9 项回归覆盖：权限错误、普通 I/O 错误、重启后重试、热缓存中的失败来源、重建时读取未变化的来源、新来源读取失败、独立工作区继续处理、Atom 替换时的文件缺失，以及真实 Session 删除。

建议 reviewer 先读 `tests/test_task_graph_source_recovery.py`，再读 `src/xskill/tasks/evidence.py` 与 `src/xskill/tasks/service.py`。重点确认读取失败时旧图不变、待处理记录不被确认、恢复后能完成重试，同时真实删除仍正常工作。

## Test plan

在无网络、非 root、丢弃 capabilities 的隔离 Linux/Python 3.12 容器中验证：

- [x] 修复前的 6 个新增故障场景失败，真实删除场景通过。
- [x] 修复后针对性测试 87 项通过。
- [x] 完整单元/集成测试目标 2856 项通过、11 项跳过。
- [x] 所选 Ruff、新增测试文件格式检查及 sdist/wheel 构建通过。

```text
.venv/bin/python -m pytest tests/test_task_graph_source_recovery.py tests/test_task_graph_runtime.py tests/test_task_graph_replay.py -q
.venv/bin/python -m ruff check src/xskill/tasks/evidence.py src/xskill/tasks/service.py tests/test_task_graph_source_recovery.py
.venv/bin/python -m ruff format --check tests/test_task_graph_source_recovery.py
.venv/bin/python -m build --no-isolation
.venv/bin/python -m pytest tests/ --ignore=tests/docker_e2e --ignore=tests/live -q
```

同一发布提交已经通过 RepoSteward 的独立验证。以上结果来自本地隔离验证，不代替本 PR 的 GitHub CI 或独立人工审查。本 PR 不改摄取、安装或 daemon 调度；未运行 Docker 全场景测试或真实模型效果实验。

## Linked issues

Closes #415

依赖 #404 的 scheduler 测试基线修复，当前分支包含该提交。请先合入 #404，再更新本分支、检查剩余差异并重新确认 CI。与 #416 的外部内核调度修复可并行审阅。

代码由 Codex 协助准备。本 PR 保持 Draft 供 reviewer 审查，尚未获得独立人工批准。
