### PR TITLE
fix(tasks): keep task graph active with external kernels（外部内核继续构建 Task）

### DIFF
--- a/docs/task-graph-runtime.md
+++ b/docs/task-graph-runtime.md
@@ -8,6 +8,10 @@
 
 开启后，Task Graph 使用独立 worker 消费持久脏队列，不阻塞 Atom 到 Skill 的拆分、路由和编辑流水线。
 
+选择外部算法内核后，Task Graph 仍处理 Session/Atom 的回填和增量更新；
+`task_graph.enabled: false` 才会暂停它。外部内核继续负责 Skill 生产，
+原生 cluster 和自动 SkillEdit 不会因此重新启用。
+
 ## 数据流
 
 1. Harness 适配器从 Codex、DeepSeek Harness 和 OpenClaw 轨迹中保留模型、Harness、run id、结构化终态和 execution usage event。

--- a/src/xskill/pipeline/runner.py
+++ b/src/xskill/pipeline/runner.py
@@ -530,7 +530,9 @@ class DirectoryWatcher:
         # do not let the native classifier create baby skills.
         if self.native_distill:
             self._submit_cluster_batches()
-            self._submit_task_graph()
+        # Task tracking is independent of which kernel produces Skills.
+        # Its own enabled flag still controls backfill and dirty processing.
+        self._submit_task_graph()
 
         # ── Step 5a: 用户点名的 generate 入队到 SkillEdit 同一线程池 ──
         # 先于自动 SkillEdit 提交，避免后台整理把用户任务挤到池外。

--- a/tests/test_external_kernel_task_graph.py
+++ b/tests/test_external_kernel_task_graph.py
@@ -1,0 +1,81 @@
+"""External Skill production must not disable Session/Atom task tracking."""
+
+import pytest
+
+from tests.test_task_graph_runtime import _add_source
+from xskill.pipeline.atom import AtomTaskStore
+from xskill.pipeline.runner import DirectoryWatcher
+from xskill.tasks.projection import list_dirty_sources, list_logical_tasks
+
+
+@pytest.mark.parametrize("server_mode", [False, True])
+@pytest.mark.parametrize("enabled", [False, True])
+def test_external_kernel_preserves_task_graph_backfill_and_updates(
+    tmp_path, monkeypatch, server_mode, enabled
+):
+    db_path = tmp_path / "registry.db"
+    source = _add_source(
+        tmp_path,
+        db_path,
+        source_name="external-kernel",
+        atoms=[{"intent": "Inspect task evidence"}],
+    )
+    skill_dir = tmp_path / "skills"
+    skill_dir.mkdir()
+    watcher = DirectoryWatcher(
+        llm=None,
+        embed_client=None,
+        config={"task_graph": {"enabled": enabled}},
+        skill_dir=skill_dir,
+        db_path=db_path,
+        home_root=tmp_path,
+        xskill_home=tmp_path / "xskill-state",
+        native_distill=False,
+        server_mode=server_mode,
+    )
+
+    def native_skill_work():
+        pytest.fail("external kernels must retain ownership of Skill production")
+
+    monkeypatch.setattr(watcher, "_submit_cluster_batches", native_skill_work)
+    monkeypatch.setattr(watcher, "_run_skill_edit_step", native_skill_work)
+
+    def scan_and_finish():
+        watcher._scan_once()
+        for future in list(watcher._futures):
+            future.result(timeout=10)
+        watcher._harvest()
+
+    try:
+        scan_and_finish()
+        service = watcher._task_graph_service
+        if not enabled:
+            assert watcher.stats["task_graph_generations"] == 0
+            assert service.resolver.existing_tenant_id is None
+            return
+
+        tenant_id = service.resolver.existing_tenant_id
+        assert tenant_id is not None
+        tasks = list_logical_tasks(tenant_id, db_path=db_path)
+        assert len(tasks) == 1
+        assert watcher.stats["task_graph_generations"] == 1
+        store = service.store_for_scope(tasks[0]["task_scope_id"])
+        before = store.load_current().generation_id
+
+        atoms = AtomTaskStore(tmp_path / "trajectories")
+        atom = atoms.list_by_traj(source[1][:-3])[0]
+        atom.summary = "The source now includes verified recovery instructions"
+        atoms.save(atom)
+        service.mark_dirty(*source, reason="atom_updated")
+        scan_and_finish()
+
+        assert list_dirty_sources(db_path=db_path) == []
+        assert store.load_current().generation_id != before
+        assert [
+            task["task_id"] for task in list_logical_tasks(tenant_id, db_path=db_path)
+        ] == [tasks[0]["task_id"]]
+        assert not watcher.pending_atoms
+        assert list(skill_dir.iterdir()) == []
+    finally:
+        watcher.stop()
+        watcher._task_graph_pool.shutdown(wait=True, cancel_futures=True)

--- a/tests/test_server_no_llm_fallback.py
+++ b/tests/test_server_no_llm_fallback.py
@@ -128,10 +128,14 @@ def test_standalone_worker_commands_share_resolved_ecosystem_home(
         str(ecosystem_home.resolve()),
     ]
     assert set(records_by_name) == {
-        "agent-worker", "ecosystem-ingest", "ux-scores-sync",
+        "agent-worker", "ecosystem-ingest", "kernel-host", "ux-scores-sync",
     }
     assert records_by_name["agent-worker"].command[-2:] == expected_home_arguments
     assert records_by_name["agent-worker"].keyword_arguments["persistent"] is True
+    kernel_command = records_by_name["kernel-host"].command
+    assert kernel_command[-1] == "kernel-host"
+    assert "--server" not in kernel_command
+    assert records_by_name["kernel-host"].keyword_arguments["persistent"] is True
     ingest_command = records_by_name["ecosystem-ingest"].command
     home_argument_index = ingest_command.index("--home")
     assert ingest_command[
@@ -244,12 +248,15 @@ def test_team_server_schedules_only_server_watcher(
         record.name: record for record in scheduler_records
     }
     assert set(records_by_name) == {
-        "recommend-heavy", "agent-worker", "ux-scores-sync",
+        "recommend-heavy", "agent-worker", "kernel-host", "ux-scores-sync",
     }
     watcher_command = records_by_name["agent-worker"].command
     assert watcher_command[-1] == "--server"
     assert "--home" not in watcher_command
     assert records_by_name["agent-worker"].keyword_arguments["persistent"] is True
+    kernel_command = records_by_name["kernel-host"].command
+    assert kernel_command[-2:] == ["kernel-host", "--server"]
+    assert records_by_name["kernel-host"].keyword_arguments["persistent"] is True
     assert "persistent" not in records_by_name["recommend-heavy"].keyword_arguments
     assert records_by_name["recommend-heavy"].command[-1] == "recommend-heavy"
     assert "persistent" not in records_by_name["ux-scores-sync"].keyword_arguments


### PR DESCRIPTION
<!-- real-skill-production-gate-20260909 -->
2026-09-09 合入条件更新：已确认 [maintainer 的要求](https://github.com/SkillNerds/xskill/issues/407#issuecomment-5580309058)。本 PR 保持 Draft，暂不提合入审查。需要先在能够实际产出 Skill 的环境中，用一条平时能生成 Skill 的会话证明现有生产路径仍然正常，并贴回本次产物及运行证据，再由 maintainer 判断是否转正式审查。现有单测、GitHub CI 和组合测试通过均不能替代这项验证；目前还没有这份真实产出证据。

下文保留已有实现和验证记录；涉及合入顺序的旧说明以本段为准。

---

## Summary

选择外部算法内核后，原始 Session 仍会拆成 Atom，但 Task Graph 的后台调度也被意外停掉。结果是 `task_graph.enabled=True`，Task 却不再回填或更新。

本 PR 让 Task Graph 调度继续由它自己的开关和待处理队列决定。外部内核继续负责 Skill 生产，原生 cluster 和自动 SkillEdit 保持关闭。

## Changes

`DirectoryWatcher._scan_once` 原来把 `_submit_task_graph()` 和原生 cluster 一起放在 `if self.native_distill` 中。这次把 Task Graph 调度移到条件之外，并补充运行说明。

新增 4 个回归场景，覆盖单机/团队模式与 Task Graph 开启/关闭配置。测试使用真实 watcher、持久队列和 Task 投影，检查已拆 Atom 的首次回填、后续更新、Task 身份稳定，以及原生 Skill 生产保持关闭。测试自己的 xskill 状态目录也明确隔离。

建议 reviewer 先看 `tests/test_external_kernel_task_graph.py`，确认这两个要求同时成立：Task 能继续处理；Skill 的生产权仍属于外部内核。然后看 `pipeline/runner.py` 的调度位置及运行文档。

## Test plan

在隔离 Linux/Python 3.12 环境中验证：

- [x] 修复前，Task Graph 开启的两个场景失败；关闭的两个场景通过。
- [x] 修复后针对性测试 62 项通过。
- [x] 完整单元/集成测试 2851 项通过、11 项跳过。
- [x] 新增测试的 Ruff 和格式检查、sdist/wheel 构建通过；生产 `runner.py` 的 Ruff 检查通过。
- [ ] 官方 Docker 全场景 E2E 通过。

最后一项已实际尝试。第一次 `make e2e` 在 Python 3.11 构建 wheel 时报告 `No module named build`。随后先用已准备好的 Python 3.12 环境成功生成 sdist/wheel，再执行同一脚本，运行推进到 `docker build`，但隔离验证镜像没有 Docker CLI，报告 `docker: command not found`。Docker 场景尚未开始运行，需要在支持该套 E2E 的环境中继续验证；本 PR 保持 Draft。

```text
.venv/bin/python -m pytest tests/test_external_kernel_task_graph.py tests/test_task_graph_runtime.py tests/test_watcher.py tests/test_agent_worker.py -q
.venv/bin/python -m ruff check tests/test_external_kernel_task_graph.py
.venv/bin/python -m ruff format --check tests/test_external_kernel_task_graph.py
.venv/bin/python -m build --no-isolation
.venv/bin/python -m pytest tests/ --ignore=tests/docker_e2e --ignore=tests/live -q
```

同一发布提交已经通过 RepoSteward 的独立验证。代码由 Codex 协助准备，以上结果不代替 GitHub CI 和独立 reviewer 审查；未进行真实外部内核的长期运行或模型质量实验。

## Linked issues

Closes #416

依赖 #404 的 scheduler 测试修复，当前分支包含该提交。请先合入 #404，再同步本分支并复核 CI。可与 [#418](https://github.com/SkillNerds/xskill/pull/418) 的证据读取恢复修复并行审阅。

与 #414 组合时，运行文档的状态说明存在一处文本冲突：应保留外部内核说明和 Task 学习队列说明。组合验证分支已保留两段内容，代码没有冲突；完整组合验证为 2972 项通过、11 项跳过。
