### PR TITLE
feat(team-client): 按项目的轨迹上传规则与 allowlist/denylist 模式（#244）

### DIFF
--- a/README.en.md
+++ b/README.en.md
@@ -134,6 +134,8 @@ xskill serve --server                          # prints a join token
 xskill connect <host:port> --token <token> --name <user-id>
 ```
 
+Everything is uploaded by default. To upload only some projects, run `xskill privacy mode allowlist`, then `xskill privacy allow` inside each project; `xskill privacy status` shows the decision per project. Server operators can force the allowlist for everyone with `team.server.privacy_mode: allowlist`.
+
 After connect succeeds, type `/xskill-helper` in Claude Code, Codex, Cursor, or another detected agent to see generate, search, and upgrade. If you do not have a host and token yet, treat the command above as the example and ask your own server operator. Do not connect to a public instance.
 
 - **Silently distill your top performers** — one person's solution reaches the whole team automatically.

--- a/README.en.md
+++ b/README.en.md
@@ -134,7 +134,7 @@ xskill serve --server                          # prints a join token
 xskill connect <host:port> --token <token> --name <user-id>
 ```
 
-Everything is uploaded by default. To upload only some projects, run `xskill privacy mode allowlist`, then `xskill privacy allow` inside each project; `xskill privacy status` shows the decision per project. Server operators can force the allowlist for everyone with `team.server.privacy_mode: allowlist`.
+Everything is uploaded by default. To upload only some projects, run `xskill privacy mode allowlist`, then `xskill privacy allow` inside each project; `xskill privacy status` shows the decision per project. Server operators can require the allowlist for everyone with `team.server.privacy_mode: allowlist` (clients on this version or newer).
 
 After connect succeeds, type `/xskill-helper` in Claude Code, Codex, Cursor, or another detected agent to see generate, search, and upgrade. If you do not have a host and token yet, treat the command above as the example and ask your own server operator. Do not connect to a public instance.
 

--- a/README.md
+++ b/README.md
@@ -217,6 +217,8 @@ xskill serve --server  # 会打印connect join命令，复制给组内同事便�
 xskill connect <host:port> --token <token>  --name <工号/姓名>
 ```
 
+默认全部上传；只想上传部分项目时 `xskill privacy mode allowlist`，再到项目目录里 `xskill privacy allow`，`xskill privacy status` 查看每个项目的判定。server 端 `team.server.privacy_mode: allowlist` 可全员强制白名单。
+
 connect 成功后，指南会装进本机已探测到的 Claude Code、Codex、Cursor 等 agent。在对应 agent 里输入 `/xskill-helper`，就可以查 generate、search、升级这些用法。没有地址和 token 时，把上面这条命令当示例，向你们自己的 server 管理员要 host、token 和工号，不要连外网公开实例。
 
 #### 额外功能：管控面板

--- a/README.md
+++ b/README.md
@@ -217,7 +217,7 @@ xskill serve --server  # 会打印connect join命令，复制给组内同事便�
 xskill connect <host:port> --token <token>  --name <工号/姓名>
 ```
 
-默认全部上传；只想上传部分项目时 `xskill privacy mode allowlist`，再到项目目录里 `xskill privacy allow`，`xskill privacy status` 查看每个项目的判定。server 端 `team.server.privacy_mode: allowlist` 可全员强制白名单。
+默认全部上传；只想上传部分项目时 `xskill privacy mode allowlist`，再到项目目录里 `xskill privacy allow`，`xskill privacy status` 查看每个项目的判定。server 端 `team.server.privacy_mode: allowlist` 可要求全员白名单（客户端需本版本及以上）。
 
 connect 成功后，指南会装进本机已探测到的 Claude Code、Codex、Cursor 等 agent。在对应 agent 里输入 `/xskill-helper`，就可以查 generate、search、升级这些用法。没有地址和 token 时，把上面这条命令当示例，向你们自己的 server 管理员要 host、token 和工号，不要连外网公开实例。
 

--- a/README.zh-CN.md
+++ b/README.zh-CN.md
@@ -118,6 +118,7 @@ Windows 下 `connect` 会自动把自己装成「计划任务」后台常驻（�
 xskill connect <host:port> --token <token>   # 首次:握手 + 自动拉起后台常驻
 xskill status                                  # 查看常驻状态
 xskill stop / xskill start                     # 停止 / 重新拉起(需先 connect 过)
+xskill privacy status                          # 每个项目的上传判定；mode allowlist 后只传 allow 过的项目
 ```
 
 macOS / Linux 的原生常驻（launchd / systemd --user）仍在路上，当前用自己的 init 系统托管 `xskill connect --foreground` 即可。

--- a/config.yaml.server.example
+++ b/config.yaml.server.example
@@ -90,3 +90,5 @@ team:
                          # 剩余 20 个（100-80）留给向量推荐引擎
     allow_anonymous: false  # 强制要求客户端 connect 时带 --name <工号>
                             # 设 true 则兼容不带工号的旧客户端（默认）
+    privacy_mode: denylist  # 客户端轨迹上传模式：denylist（默认）全部上传、用户可 deny 项目；
+                            # allowlist 要求只上传各自放行的项目（旧版客户端不识别）

--- a/src/xskill/cli.py
+++ b/src/xskill/cli.py
@@ -582,7 +582,8 @@ def _print_connect_status(st: dict, as_json: bool) -> None:
     if st.get("client_id"):
         print(f"  client_id: {st['client_id']}")
     privacy = st.get("privacy")
-    if privacy:
+    # 纯升级用户（无规则、生效 denylist）status 输出保持原样，不多这一行。
+    if privacy and (privacy["mode"] == "allowlist" or privacy["rules"]["allow"] or privacy["rules"]["deny"]):
         rules = privacy["rules"]
         server_text = privacy["server_mode"] or ("未下发" if privacy["connected"] else "(未连接)")
         print(f"  privacy  : {privacy['mode']} ({_PRIVACY_ORIGIN_LABEL[privacy['mode_origin']]}"
@@ -2996,13 +2997,13 @@ def cmd_privacy(args) -> int:
             else:
                 kept += 1
         save_policy(policy, policy_path)
-        final = _privacy_report(state, policy)
+        final_report = _privacy_report(state, policy)
         print()
         print(f"完成：放行 {allowed} 个，排除 {denied} 个，保持不变 {kept} 个。"
-              f"上传 {final.upload} 条，不上传 {final.skip} 条。")
-        if final.no_cwd.traj:
-            default_text = "上传" if final.no_cwd.effective == "upload" else "不上传"
-            print(f"另有 {final.no_cwd.traj} 条轨迹未记录工作目录（Cursor / Trae 等），按模式默认处理（{default_text}）。")
+              f"上传 {final_report.upload} 条，不上传 {final_report.skip} 条。")
+        if final_report.no_cwd.traj:
+            default_text = "上传" if final_report.no_cwd.effective == "upload" else "不上传"
+            print(f"另有 {final_report.no_cwd.traj} 条轨迹未记录工作目录（Cursor / Trae 等），按模式默认处理（{default_text}）。")
         return 0
 
     target_path = Path(args.target) if args.target else Path.cwd()

--- a/src/xskill/cli.py
+++ b/src/xskill/cli.py
@@ -584,6 +584,8 @@ def _print_connect_status(st: dict, as_json: bool) -> None:
               f"; server {server_text})  "
               f"allow {rules['allow']}, deny {rules['deny']}; "
               f"上传 {privacy['upload']} 条 / 不上传 {privacy['skip']} 条")
+    if st.get("privacy_error"):
+        print(f"  privacy  : 规则文件损坏，采集已停止：{st['privacy_error']}")
     if st.get("warning"):
         print(f"  warning  : {st['warning']}")
 
@@ -2850,12 +2852,10 @@ def _privacy_report(state, policy, *, time_budget_seconds=None):
     rows, complete = scan_local_trajectories(
         XSKILL_HOME, time_budget_seconds=time_budget_seconds,
     )
-    report = build_report(
-        policy, state.server_privacy_mode if state else None, rows, complete=complete,
+    return build_report(
+        policy, state.server_privacy_mode if state else None, rows,
+        complete=complete, connected=state is not None,
     )
-    if state is None:
-        report.origin = "disconnected" if policy.local_mode == "auto" else "local"
-    return report
 
 
 def cmd_privacy(args) -> int:
@@ -2894,8 +2894,7 @@ def cmd_privacy(args) -> int:
             emit({"local_mode": policy.local_mode, "server_mode": server_mode,
                   "mode": effective,
                   "mode_origin": _PRIVACY_ORIGIN_LABEL[
-                      ("local" if policy.local_mode != "auto" else "disconnected")
-                      if state is None else mode_origin(server_mode, policy.local_mode)]},
+                      mode_origin(server_mode, policy.local_mode, connected=state is not None)]},
                  [f"mode: {policy.local_mode}"
                   + ("（跟随 server）" if policy.local_mode == "auto" else "（本机设置）")
                   + f"  server: {server_mode or '(未连接)' if state is None else server_mode or '未下发'}"

--- a/src/xskill/cli.py
+++ b/src/xskill/cli.py
@@ -411,6 +411,9 @@ def cmd_connect(args) -> int:
     except ValueError as exc:
         report = None
         print(f"privacy: 规则文件损坏，采集已停止：{exc}", file=sys.stderr)
+    except Exception as exc:  # noqa: BLE001 摘要只是展示，不能挡住 connect
+        report = None
+        print(f"privacy: 本机轨迹清单统计失败，稍后用 xskill privacy status 查看：{exc}", file=sys.stderr)
     if report is not None:
         print(f"privacy: {report.mode}（{_PRIVACY_ORIGIN_LABEL[report.origin]}；"
               f"{_PRIVACY_MODE_MEANING[report.mode]}）")
@@ -510,7 +513,9 @@ def _connect_handshake(args, state_path):
         return None
     state = ClientState(server_url=server_url, client_id=client_id,
                         join_token=args.token,
-                        server_privacy_mode=reg.get("privacy_mode"))
+                        server_privacy_mode=(reg.get("privacy_mode")
+                                             if reg.get("privacy_mode") in ("allowlist", "denylist")
+                                             else None))
     save_client_state(state, state_path)
     name_hint = f"  (--name={args.name})" if args.name else ""
     print(f"connected: client_id={client_id}  server={server_url}{name_hint}")
@@ -777,7 +782,7 @@ def cmd_status(args) -> int:
                 "deny": sum(1 for rule in policy.projects.values() if rule.rule == "deny"),
             },
         }
-    except ValueError as exc:
+    except Exception as exc:  # noqa: BLE001 隐私行只是展示，不能挡住 status
         st["privacy_error"] = str(exc)
     _print_connect_status(st, as_json=getattr(args, "json", False))
     return 0
@@ -2822,7 +2827,7 @@ _PRIVACY_HELP_EPILOG = """\
     子目录规则优先于父目录规则。
   · 不上传的轨迹不会被读取、不会上传，也不会记为已上传；之后放行会在
     下一轮扫描中正常上传。
-  · Cursor 与 Trae 的轨迹目前不记录工作目录，无法归属到项目：
+  · 轨迹 sidecar 没记录工作目录时（目前 Cursor 与 Trae 都不记）无法归属到项目：
     allowlist 模式下不上传，denylist 模式下上传。status 会单独列出。
 
 examples:
@@ -2833,8 +2838,8 @@ examples:
 """
 
 _PRIVACY_ORIGIN_LABEL = {
-    "server_forced": "server 强制",
     "local": "本机设置",
+    "server_required": "server 要求",
     "server_default": "server 默认",
     "server_missing": "server 未下发，按 denylist",
     "disconnected": "未连接 server",
@@ -2893,8 +2898,7 @@ def cmd_privacy(args) -> int:
             effective = effective_mode(server_mode, policy.local_mode)
             emit({"local_mode": policy.local_mode, "server_mode": server_mode,
                   "mode": effective,
-                  "mode_origin": _PRIVACY_ORIGIN_LABEL[
-                      mode_origin(server_mode, policy.local_mode, connected=state is not None)]},
+                  "mode_origin": mode_origin(server_mode, policy.local_mode, connected=state is not None)},
                  [f"mode: {policy.local_mode}"
                   + ("（跟随 server）" if policy.local_mode == "auto" else "（本机设置）")
                   + f"  server: {server_mode or '(未连接)' if state is None else server_mode or '未下发'}"
@@ -2908,7 +2912,7 @@ def cmd_privacy(args) -> int:
         effective = effective_mode(server_mode, policy.local_mode)
         server_text = server_mode or ("(未连接)" if state is None else "未下发")
         head = (f"Mode: {policy.local_mode}（本机设置；server 当前 {server_text}，生效 {effective}"
-                + ("，server 强制" if server_mode == "allowlist" and policy.local_mode != "allowlist" else "")
+                + ("，server 要求" if server_mode == "allowlist" and policy.local_mode != "allowlist" else "")
                 + "）")
         if policy.local_mode == "auto":
             head = f"Mode: auto（跟随 server；server 当前 {server_text}，生效 {effective}）"
@@ -2957,7 +2961,7 @@ def cmd_privacy(args) -> int:
         print()
         print(f"上传 {report.upload} 条，不上传 {report.skip} 条。")
         if report.no_cwd.traj:
-            print(f"提示：{report.no_cwd.traj} 条来自 Cursor / Trae，这两个来源不记录工作目录，无法按项目放行。")
+            print(f"提示：{report.no_cwd.traj} 条轨迹的 sidecar 未记录工作目录（Cursor / Trae 等），无法按项目放行。")
         if report.broken_sidecar.traj:
             print(f"提示：{report.broken_sidecar.traj} 条轨迹的 sidecar 缺失或损坏，无法归属项目。")
         if not report.complete:
@@ -2998,7 +3002,7 @@ def cmd_privacy(args) -> int:
               f"上传 {final.upload} 条，不上传 {final.skip} 条。")
         if final.no_cwd.traj:
             default_text = "上传" if final.no_cwd.effective == "upload" else "不上传"
-            print(f"另有 {final.no_cwd.traj} 条来自 Cursor / Trae，无法归属项目，按模式默认处理（{default_text}）。")
+            print(f"另有 {final.no_cwd.traj} 条轨迹未记录工作目录（Cursor / Trae 等），按模式默认处理（{default_text}）。")
         return 0
 
     target_path = Path(args.target) if args.target else Path.cwd()
@@ -3025,7 +3029,7 @@ def cmd_privacy(args) -> int:
     save_policy(policy, policy_path)
     rows, _complete = scan_local_trajectories(XSKILL_HOME)
     matched = [row for row in rows if row.cwd and path_is_within(normalize_project_path(row.cwd), key)]
-    no_cwd_count = sum(1 for row in rows if row.cwd is None and row.harness in ("cursor", "trae"))
+    no_cwd_count = sum(1 for row in rows if row.cwd is None and row.sidecar_readable)
     effective = effective_mode(server_mode, policy.local_mode)
     payload = {"status": f"{rule}ed", "path": shown, "matched": len(matched),
                "unattributed": no_cwd_count, "mode": effective}
@@ -3035,7 +3039,7 @@ def cmd_privacy(args) -> int:
         if not Path(shown).exists():
             lines[1] = "  提示：该目录当前不存在，规则已保存，将对之后在此目录下产生的轨迹生效。"
         if no_cwd_count:
-            lines.append(f"  注意：本机另有 {no_cwd_count} 条 Cursor / Trae 轨迹不记录工作目录，本规则对它们不生效。")
+            lines.append(f"  注意：本机另有 {no_cwd_count} 条轨迹未记录工作目录（Cursor / Trae 等），本规则对它们不生效。")
         lines.append("  取消：xskill privacy deny  或  xskill privacy clear")
         emit(payload, lines)
         return 0
@@ -3043,16 +3047,20 @@ def cmd_privacy(args) -> int:
              f"  该目录及子目录下的轨迹不会读取、不会上传（含已有的 {len(matched)} 条）。"]
     if not Path(shown).exists():
         lines[1] = "  提示：该目录当前不存在，规则已保存，将对之后在此目录下产生的轨迹生效。"
-    from xskill.team.client.upload_state import TrajectoryUploadStateStore
+    import sqlite3
     previously_uploaded: set[str] = set()
     for db_path in sorted((XSKILL_HOME / "clients").glob("*/client_state.db")):
         try:
-            store = TrajectoryUploadStateStore(db_path=db_path)
-            for row in matched:
-                uploaded_row = store.get(row.traj_id)
-                if uploaded_row is not None and uploaded_row["uploaded_cleaned_content_hash"]:
-                    previously_uploaded.add(row.traj_id)
-        except Exception:  # noqa: BLE001 只读探测，旧库损坏不阻塞 CLI
+            with sqlite3.connect(f"file:{db_path}?mode=ro", uri=True) as readonly_db:
+                for row in matched:
+                    found = readonly_db.execute(
+                        "SELECT 1 FROM trajectory_upload_state "
+                        "WHERE trajectory_id=? AND uploaded_cleaned_content_hash IS NOT NULL",
+                        (row.traj_id,),
+                    ).fetchone()
+                    if found:
+                        previously_uploaded.add(row.traj_id)
+        except sqlite3.Error:
             continue
     uploaded_count = len(previously_uploaded)
     payload["previously_uploaded"] = uploaded_count

--- a/src/xskill/cli.py
+++ b/src/xskill/cli.py
@@ -2882,17 +2882,17 @@ def cmd_privacy(args) -> int:
         policy_path = default_privacy_path()
         policy = load_policy(policy_path)
     except ValueError as exc:
-        print(f"error: {exc}", file=sys.stderr)
+        _write_search_output(f"error: {exc}", to_stderr=True)
         return 2
     server_mode = state.server_privacy_mode if state else None
     action = args.privacy_action
 
     def emit(payload: dict, lines: list[str]) -> None:
         if as_json:
-            print(_json.dumps(payload, ensure_ascii=False, indent=2))
+            _write_search_output(_json.dumps(payload, ensure_ascii=False, indent=2))
             return
         for line in lines:
-            print(line)
+            _write_search_output(line)
 
     if action == "mode":
         if not args.target:
@@ -2906,7 +2906,7 @@ def cmd_privacy(args) -> int:
                   + f"  生效: {effective}"])
             return 0
         if args.target not in LOCAL_MODES:
-            print(f"error: mode 只能是 {' / '.join(LOCAL_MODES)}", file=sys.stderr)
+            _write_search_output(f"error: mode 只能是 {' / '.join(LOCAL_MODES)}", to_stderr=True)
             return 2
         policy.local_mode = args.target
         save_policy(policy, policy_path)
@@ -2932,12 +2932,12 @@ def cmd_privacy(args) -> int:
     if action == "status":
         report = _privacy_report(state, policy)
         if as_json:
-            print(_json.dumps(report.to_dict(), ensure_ascii=False, indent=2))
+            _write_search_output(_json.dumps(report.to_dict(), ensure_ascii=False, indent=2))
             return 0
         server_text = report.server_mode or ("(未连接)" if state is None else "未下发")
-        print(f"mode: {report.mode}（{_PRIVACY_ORIGIN_LABEL[report.origin]}；server {server_text}）"
+        _write_search_output(f"mode: {report.mode}（{_PRIVACY_ORIGIN_LABEL[report.origin]}；server {server_text}）"
               f"  {_PRIVACY_MODE_MEANING[report.mode]}")
-        print()
+        _write_search_output("")
         rows = [(summary.path, summary.traj, ", ".join(summary.harnesses),
                  summary.rule or ("默认·上传" if summary.effective == "upload" else "默认·不上传"))
                 for summary in report.projects]
@@ -2946,7 +2946,7 @@ def cmd_privacy(args) -> int:
                 rows.append((extra.path, extra.traj, ", ".join(extra.harnesses),
                              "默认·上传" if extra.effective == "upload" else "默认·不上传"))
         if not rows:
-            print("(本机尚未发现任何轨迹)")
+            _write_search_output("(本机尚未发现任何轨迹)")
             return 0
         import unicodedata
 
@@ -2956,32 +2956,31 @@ def cmd_privacy(args) -> int:
 
         path_width = max(len("PROJECT"), *(len(row[0]) for row in rows))
         harness_width = max(len("SOURCES"), *(len(row[2]) for row in rows))
-        print(f"{padded('PROJECT', path_width)}  {'TRAJ':>5}  {padded('SOURCES', harness_width)}  DECISION")
+        _write_search_output(f"{padded('PROJECT', path_width)}  {'TRAJ':>5}  {padded('SOURCES', harness_width)}  DECISION")
         for path, traj, harnesses, decision in rows:
-            print(f"{padded(path, path_width)}  {traj:>5}  {padded(harnesses, harness_width)}  {decision}")
-        print()
-        print(f"上传 {report.upload} 条，不上传 {report.skip} 条。")
+            _write_search_output(f"{padded(path, path_width)}  {traj:>5}  {padded(harnesses, harness_width)}  {decision}")
+        _write_search_output("")
+        _write_search_output(f"上传 {report.upload} 条，不上传 {report.skip} 条。")
         if report.no_cwd.traj:
-            print(f"提示：{report.no_cwd.traj} 条轨迹的 sidecar 未记录工作目录（Cursor / Trae 等），无法按项目放行。")
+            _write_search_output(f"提示：{report.no_cwd.traj} 条轨迹的 sidecar 未记录工作目录（Cursor / Trae 等），无法按项目放行。")
         if report.broken_sidecar.traj:
-            print(f"提示：{report.broken_sidecar.traj} 条轨迹的 sidecar 缺失或损坏，无法归属项目。")
+            _write_search_output(f"提示：{report.broken_sidecar.traj} 条轨迹的 sidecar 缺失或损坏，无法归属项目。")
         if not report.complete:
-            print("提示：本机轨迹较多，清单在时间预算内未统计完整。")
+            _write_search_output("提示：本机轨迹较多，清单在时间预算内未统计完整。")
         return 0
 
     if action == "review":
         if not sys.stdin.isatty() or not sys.stdout.isatty():
-            print("error: review 需要交互式终端。脚本里请用 xskill privacy allow <path> / deny <path>。",
-                  file=sys.stderr)
+            _write_search_output("error: review 需要交互式终端。脚本里请用 xskill privacy allow <path> / deny <path>。", to_stderr=True)
             return 2
         report = _privacy_report(state, policy)
-        print(f"mode: {report.mode}  本机发现 {len(report.projects)} 个项目。"
+        _write_search_output(f"mode: {report.mode}  本机发现 {len(report.projects)} 个项目。"
               "每项输入 a=放行 d=排除 回车=保持不变 q=退出")
-        print()
+        _write_search_output("")
         allowed = denied = kept = 0
         for index, summary in enumerate(report.projects, start=1):
             current = summary.rule or ("默认·上传" if summary.effective == "upload" else "默认·不上传")
-            print(f"[{index}/{len(report.projects)}] {summary.path}   {summary.traj} 条  "
+            _write_search_output(f"[{index}/{len(report.projects)}] {summary.path}   {summary.traj} 条  "
                   f"{', '.join(summary.harnesses)}   当前: {current}")
             choice = input("  > ").strip().lower()
             if choice == "q":
@@ -2989,21 +2988,21 @@ def cmd_privacy(args) -> int:
             if choice == "a":
                 policy.set_project(summary.path, "allow")
                 allowed += 1
-                print("  Allowed.")
+                _write_search_output("  Allowed.")
             elif choice == "d":
                 policy.set_project(summary.path, "deny")
                 denied += 1
-                print("  Denied.")
+                _write_search_output("  Denied.")
             else:
                 kept += 1
         save_policy(policy, policy_path)
         final_report = _privacy_report(state, policy)
-        print()
-        print(f"完成：放行 {allowed} 个，排除 {denied} 个，保持不变 {kept} 个。"
+        _write_search_output("")
+        _write_search_output(f"完成：放行 {allowed} 个，排除 {denied} 个，保持不变 {kept} 个。"
               f"上传 {final_report.upload} 条，不上传 {final_report.skip} 条。")
         if final_report.no_cwd.traj:
             default_text = "上传" if final_report.no_cwd.effective == "upload" else "不上传"
-            print(f"另有 {final_report.no_cwd.traj} 条轨迹未记录工作目录（Cursor / Trae 等），按模式默认处理（{default_text}）。")
+            _write_search_output(f"另有 {final_report.no_cwd.traj} 条轨迹未记录工作目录（Cursor / Trae 等），按模式默认处理（{default_text}）。")
         return 0
 
     target_path = Path(args.target) if args.target else Path.cwd()

--- a/src/xskill/cli.py
+++ b/src/xskill/cli.py
@@ -228,6 +228,7 @@ def _init_connect_args(args, address: str, token: str, name: str | None):
         no_auto_update=bool(getattr(args, "no_auto_update", False)),
         no_skill=True,
         target_root=getattr(args, "target_root", None),
+        privacy=None,
     )
 
 
@@ -382,6 +383,17 @@ def cmd_connect(args) -> int:
 
     state_path = get_team_client_state_path()
 
+    requested_privacy = getattr(args, "privacy", None)
+    if requested_privacy:
+        from xskill.team.client.privacy import load_policy, save_policy
+        try:
+            policy = load_policy()
+        except ValueError as exc:
+            print(f"error: {exc}", file=sys.stderr)
+            return 2
+        policy.local_mode = requested_privacy
+        save_policy(policy)
+
     if args.address:
         state = _connect_handshake(args, state_path)
         if state is None:
@@ -392,6 +404,33 @@ def cmd_connect(args) -> int:
         except FileNotFoundError as e:
             print(f"error: {e}", file=sys.stderr)
             return 1
+
+    from xskill.team.client.privacy import load_policy
+    try:
+        report = _privacy_report(state, load_policy(), time_budget_seconds=2.0)
+    except ValueError as exc:
+        report = None
+        print(f"privacy: 规则文件损坏，采集已停止：{exc}", file=sys.stderr)
+    if report is not None:
+        print(f"privacy: {report.mode}（{_PRIVACY_ORIGIN_LABEL[report.origin]}；"
+              f"{_PRIVACY_MODE_MEANING[report.mode]}）")
+        total = report.upload + report.skip
+        if not report.complete:
+            print("  本机轨迹较多，项目清单仍在统计中，稍后用 xskill privacy status 查看。")
+        elif report.mode == "allowlist":
+            if report.upload == 0:
+                print(f"  本机发现 {len(report.projects)} 个项目、共 {total} 条轨迹，当前全部不会上传。")
+            else:
+                print(f"  本机发现 {len(report.projects)} 个项目、共 {total} 条轨迹，"
+                      f"将上传 {report.upload} 条，不上传 {report.skip} 条。")
+            print("  放行方式：")
+            print("    cd <项目目录> && xskill privacy allow     放行一个项目")
+            print("    xskill privacy review                       逐个过一遍")
+            print("    xskill privacy status                       查看清单")
+        else:
+            print(f"  本机发现 {len(report.projects)} 个项目、共 {total} 条轨迹，将在后台开始上传。")
+            print("  不想上传的项目：xskill privacy deny <path>（下一轮扫描即生效，已传的不会删除）")
+            print("  改为只传放行项目：xskill privacy mode allowlist")
 
     # 握手或复用已存连接成功后再装 /xskill-helper：前台阻塞循环开始前必须先装，
     # 否则 Linux 退化成 run_forever 后这条命令再也走不到安装。
@@ -470,7 +509,8 @@ def _connect_handshake(args, state_path):
         print(f"error: 注册失败: {e}", file=sys.stderr)
         return None
     state = ClientState(server_url=server_url, client_id=client_id,
-                        join_token=args.token)
+                        join_token=args.token,
+                        server_privacy_mode=reg.get("privacy_mode"))
     save_client_state(state, state_path)
     name_hint = f"  (--name={args.name})" if args.name else ""
     print(f"connected: client_id={client_id}  server={server_url}{name_hint}")
@@ -489,7 +529,7 @@ def _run_team_client_forever(state, *, use_proxy: bool,
     import httpx
     from xskill.config import (
         get_team_client_cursor_path, get_team_client_history_path,
-        resolve_local_skill_dir,
+        get_team_client_state_path, resolve_local_skill_dir,
     )
     from xskill.team.client.daemon import TeamClient
 
@@ -502,6 +542,7 @@ def _run_team_client_forever(state, *, use_proxy: bool,
         history_path=get_team_client_history_path(state.server_url),
         auto_update=auto_update,
         use_proxy=use_proxy,
+        state_path=get_team_client_state_path(),
     )
     client.run_forever()   # 阻塞
 
@@ -535,6 +576,14 @@ def _print_connect_status(st: dict, as_json: bool) -> None:
         print(f"  server   : {st['server_url']}")
     if st.get("client_id"):
         print(f"  client_id: {st['client_id']}")
+    privacy = st.get("privacy")
+    if privacy:
+        rules = privacy["rules"]
+        server_text = privacy["server_mode"] or ("未下发" if privacy["connected"] else "(未连接)")
+        print(f"  privacy  : {privacy['mode']} ({_PRIVACY_ORIGIN_LABEL[privacy['mode_origin']]}"
+              f"; server {server_text})  "
+              f"allow {rules['allow']}, deny {rules['deny']}; "
+              f"上传 {privacy['upload']} 条 / 不上传 {privacy['skip']} 条")
     if st.get("warning"):
         print(f"  warning  : {st['warning']}")
 
@@ -709,6 +758,25 @@ def cmd_status(args) -> int:
     except ServiceError as e:
         print(f"error: {e}", file=sys.stderr)
         return 1
+    try:
+        from xskill.config import get_team_client_state_path
+        from xskill.team.client.privacy import default_privacy_path, load_policy
+        from xskill.team.client.state import load_client_state
+        state_path = get_team_client_state_path()
+        state = load_client_state(state_path) if state_path.is_file() else None
+        policy_path = default_privacy_path()
+        policy = load_policy(policy_path)
+        report = _privacy_report(state, policy, time_budget_seconds=2.0)
+        st["privacy"] = {
+            **report.to_dict(),
+            "connected": state is not None,
+            "rules": {
+                "allow": sum(1 for rule in policy.projects.values() if rule.rule == "allow"),
+                "deny": sum(1 for rule in policy.projects.values() if rule.rule == "deny"),
+            },
+        }
+    except ValueError as exc:
+        st["privacy_error"] = str(exc)
     _print_connect_status(st, as_json=getattr(args, "json", False))
     return 0
 
@@ -2738,6 +2806,265 @@ def cmd_repair_baselines(args) -> int:
 # argparse
 # ═══════════════════════════════════════════════════════════════
 
+
+_PRIVACY_HELP_DESCRIPTION = """\
+管理本机轨迹是否上传到 team server。规则只保存在本机，不会发送服务器。
+
+模式决定"没写规则的项目怎么办"，server 与本机各有一个设置，生效的是更严的那个：
+  allowlist  默认不上传，只上传你用 allow 放行的项目
+  denylist   默认上传，只跳过你用 deny 排除的项目（server 默认）"""
+
+_PRIVACY_HELP_EPILOG = """\
+说明:
+  · 项目按绝对路径匹配，会解析符号链接；macOS 与 Windows 上不区分大小写。
+    子目录规则优先于父目录规则。
+  · 不上传的轨迹不会被读取、不会上传，也不会记为已上传；之后放行会在
+    下一轮扫描中正常上传。
+  · Cursor 与 Trae 的轨迹目前不记录工作目录，无法归属到项目：
+    allowlist 模式下不上传，denylist 模式下上传。status 会单独列出。
+
+examples:
+  xskill privacy mode allowlist            # 本机改为白名单，server 无法放宽
+  cd ~/code/my-service && xskill privacy allow
+  xskill privacy deny ~/code/secret-project
+  xskill privacy status
+"""
+
+_PRIVACY_ORIGIN_LABEL = {
+    "server_forced": "server 强制",
+    "local": "本机设置",
+    "server_default": "server 默认",
+    "server_missing": "server 未下发，按 denylist",
+    "disconnected": "未连接 server",
+}
+
+_PRIVACY_MODE_MEANING = {
+    "allowlist": "默认不上传，只上传你放行的项目",
+    "denylist": "默认上传，只跳过你排除的项目",
+}
+
+
+def _privacy_report(state, policy, *, time_budget_seconds=None):
+    from xskill.config import XSKILL_HOME
+    from xskill.team.client.privacy import build_report, scan_local_trajectories
+    rows, complete = scan_local_trajectories(
+        XSKILL_HOME, time_budget_seconds=time_budget_seconds,
+    )
+    report = build_report(
+        policy, state.server_privacy_mode if state else None, rows, complete=complete,
+    )
+    if state is None:
+        report.origin = "disconnected" if policy.local_mode == "auto" else "local"
+    return report
+
+
+def cmd_privacy(args) -> int:
+    import json as _json
+    from pathlib import Path
+    from xskill.config import XSKILL_HOME
+    from xskill.team.client.privacy import (
+        LOCAL_MODES, canonical_project_path, effective_mode, mode_origin,
+        normalize_project_path, path_is_within, save_policy, scan_local_trajectories,
+    )
+    as_json = getattr(args, "json", False)
+    try:
+        from xskill.config import get_team_client_state_path
+        from xskill.team.client.privacy import default_privacy_path, load_policy
+        from xskill.team.client.state import load_client_state
+        state_path = get_team_client_state_path()
+        state = load_client_state(state_path) if state_path.is_file() else None
+        policy_path = default_privacy_path()
+        policy = load_policy(policy_path)
+    except ValueError as exc:
+        print(f"error: {exc}", file=sys.stderr)
+        return 2
+    server_mode = state.server_privacy_mode if state else None
+    action = args.privacy_action
+
+    def emit(payload: dict, lines: list[str]) -> None:
+        if as_json:
+            print(_json.dumps(payload, ensure_ascii=False, indent=2))
+            return
+        for line in lines:
+            print(line)
+
+    if action == "mode":
+        if not args.target:
+            effective = effective_mode(server_mode, policy.local_mode)
+            emit({"local_mode": policy.local_mode, "server_mode": server_mode,
+                  "mode": effective,
+                  "mode_origin": _PRIVACY_ORIGIN_LABEL[
+                      ("local" if policy.local_mode != "auto" else "disconnected")
+                      if state is None else mode_origin(server_mode, policy.local_mode)]},
+                 [f"mode: {policy.local_mode}"
+                  + ("（跟随 server）" if policy.local_mode == "auto" else "（本机设置）")
+                  + f"  server: {server_mode or '(未连接)' if state is None else server_mode or '未下发'}"
+                  + f"  生效: {effective}"])
+            return 0
+        if args.target not in LOCAL_MODES:
+            print(f"error: mode 只能是 {' / '.join(LOCAL_MODES)}", file=sys.stderr)
+            return 2
+        policy.local_mode = args.target
+        save_policy(policy, policy_path)
+        effective = effective_mode(server_mode, policy.local_mode)
+        server_text = server_mode or ("(未连接)" if state is None else "未下发")
+        head = (f"Mode: {policy.local_mode}（本机设置；server 当前 {server_text}，生效 {effective}"
+                + ("，server 强制" if server_mode == "allowlist" and policy.local_mode != "allowlist" else "")
+                + "）")
+        if policy.local_mode == "auto":
+            head = f"Mode: auto（跟随 server；server 当前 {server_text}，生效 {effective}）"
+        lines = [head]
+        allowed_count = sum(1 for rule in policy.projects.values() if rule.rule == "allow")
+        if policy.local_mode == "allowlist":
+            lines.append(f"  未放行的项目从下一轮扫描起不再上传。已放行 {allowed_count} 个项目不受影响。")
+        elif policy.local_mode == "denylist" and server_mode == "allowlist":
+            lines.append("  server 要求白名单，本机设置暂不生效；server 放宽后自动按 denylist 运行。")
+        elif effective == "denylist":
+            lines.append("  未排除的项目默认上传。")
+        emit({"status": "set", "local_mode": policy.local_mode, "server_mode": server_mode,
+              "mode": effective}, lines)
+        return 0
+
+    if action == "status":
+        report = _privacy_report(state, policy)
+        if as_json:
+            print(_json.dumps(report.to_dict(), ensure_ascii=False, indent=2))
+            return 0
+        server_text = report.server_mode or ("(未连接)" if state is None else "未下发")
+        print(f"mode: {report.mode}（{_PRIVACY_ORIGIN_LABEL[report.origin]}；server {server_text}）"
+              f"  {_PRIVACY_MODE_MEANING[report.mode]}")
+        print()
+        rows = [(summary.path, summary.traj, ", ".join(summary.harnesses),
+                 summary.rule or ("默认·上传" if summary.effective == "upload" else "默认·不上传"))
+                for summary in report.projects]
+        for extra in (report.no_cwd, report.broken_sidecar):
+            if extra.traj:
+                rows.append((extra.path, extra.traj, ", ".join(extra.harnesses),
+                             "默认·上传" if extra.effective == "upload" else "默认·不上传"))
+        if not rows:
+            print("(本机尚未发现任何轨迹)")
+            return 0
+        import unicodedata
+
+        def padded(text: str, width: int) -> str:
+            display_width = sum(2 if unicodedata.east_asian_width(char) in "WF" else 1 for char in text)
+            return text + " " * max(0, width - display_width)
+
+        path_width = max(len("PROJECT"), *(len(row[0]) for row in rows))
+        harness_width = max(len("SOURCES"), *(len(row[2]) for row in rows))
+        print(f"{padded('PROJECT', path_width)}  {'TRAJ':>5}  {padded('SOURCES', harness_width)}  DECISION")
+        for path, traj, harnesses, decision in rows:
+            print(f"{padded(path, path_width)}  {traj:>5}  {padded(harnesses, harness_width)}  {decision}")
+        print()
+        print(f"上传 {report.upload} 条，不上传 {report.skip} 条。")
+        if report.no_cwd.traj:
+            print(f"提示：{report.no_cwd.traj} 条来自 Cursor / Trae，这两个来源不记录工作目录，无法按项目放行。")
+        if report.broken_sidecar.traj:
+            print(f"提示：{report.broken_sidecar.traj} 条轨迹的 sidecar 缺失或损坏，无法归属项目。")
+        if not report.complete:
+            print("提示：本机轨迹较多，清单在时间预算内未统计完整。")
+        return 0
+
+    if action == "review":
+        if not sys.stdin.isatty() or not sys.stdout.isatty():
+            print("error: review 需要交互式终端。脚本里请用 xskill privacy allow <path> / deny <path>。",
+                  file=sys.stderr)
+            return 2
+        report = _privacy_report(state, policy)
+        print(f"mode: {report.mode}  本机发现 {len(report.projects)} 个项目。"
+              "每项输入 a=放行 d=排除 回车=保持不变 q=退出")
+        print()
+        allowed = denied = kept = 0
+        for index, summary in enumerate(report.projects, start=1):
+            current = summary.rule or ("默认·上传" if summary.effective == "upload" else "默认·不上传")
+            print(f"[{index}/{len(report.projects)}] {summary.path}   {summary.traj} 条  "
+                  f"{', '.join(summary.harnesses)}   当前: {current}")
+            choice = input("  > ").strip().lower()
+            if choice == "q":
+                break
+            if choice == "a":
+                policy.set_project(summary.path, "allow")
+                allowed += 1
+                print("  Allowed.")
+            elif choice == "d":
+                policy.set_project(summary.path, "deny")
+                denied += 1
+                print("  Denied.")
+            else:
+                kept += 1
+        save_policy(policy, policy_path)
+        final = _privacy_report(state, policy)
+        print()
+        print(f"完成：放行 {allowed} 个，排除 {denied} 个，保持不变 {kept} 个。"
+              f"上传 {final.upload} 条，不上传 {final.skip} 条。")
+        if final.no_cwd.traj:
+            default_text = "上传" if final.no_cwd.effective == "upload" else "不上传"
+            print(f"另有 {final.no_cwd.traj} 条来自 Cursor / Trae，无法归属项目，按模式默认处理（{default_text}）。")
+        return 0
+
+    target_path = Path(args.target) if args.target else Path.cwd()
+    shown = canonical_project_path(target_path)
+    key = normalize_project_path(target_path)
+    if action == "clear":
+        removed, _key = policy.clear_project(target_path)
+        if not removed:
+            emit({"status": "not_found", "path": shown}, [f"Not found: {shown}"])
+            return 1
+        save_policy(policy, policy_path)
+        effective = effective_mode(server_mode, policy.local_mode)
+        default_text = "不上传" if effective == "allowlist" else "上传"
+        emit({"status": "cleared", "path": shown, "mode": effective},
+             [f"Cleared: {shown}", f"  回到模式默认（{effective}：{default_text}）。"])
+        return 0
+
+    rule = "allow" if action == "allow" else "deny"
+    changed, _key = policy.set_project(target_path, rule)
+    if not changed:
+        emit({"status": f"already_{rule}ed", "path": shown},
+             [f"Already {'allowed' if rule == 'allow' else 'denied'}: {shown}"])
+        return 0
+    save_policy(policy, policy_path)
+    rows, _complete = scan_local_trajectories(XSKILL_HOME)
+    matched = [row for row in rows if row.cwd and path_is_within(normalize_project_path(row.cwd), key)]
+    no_cwd_count = sum(1 for row in rows if row.cwd is None and row.harness in ("cursor", "trae"))
+    effective = effective_mode(server_mode, policy.local_mode)
+    payload = {"status": f"{rule}ed", "path": shown, "matched": len(matched),
+               "unattributed": no_cwd_count, "mode": effective}
+    if rule == "allow":
+        lines = [f"Allowed: {shown}",
+                 f"  该目录及子目录下的轨迹将上传（含已有的 {len(matched)} 条，下一轮扫描开始）。"]
+        if not Path(shown).exists():
+            lines[1] = "  提示：该目录当前不存在，规则已保存，将对之后在此目录下产生的轨迹生效。"
+        if no_cwd_count:
+            lines.append(f"  注意：本机另有 {no_cwd_count} 条 Cursor / Trae 轨迹不记录工作目录，本规则对它们不生效。")
+        lines.append("  取消：xskill privacy deny  或  xskill privacy clear")
+        emit(payload, lines)
+        return 0
+    lines = [f"Denied: {shown}",
+             f"  该目录及子目录下的轨迹不会读取、不会上传（含已有的 {len(matched)} 条）。"]
+    if not Path(shown).exists():
+        lines[1] = "  提示：该目录当前不存在，规则已保存，将对之后在此目录下产生的轨迹生效。"
+    from xskill.team.client.upload_state import TrajectoryUploadStateStore
+    previously_uploaded: set[str] = set()
+    for db_path in sorted((XSKILL_HOME / "clients").glob("*/client_state.db")):
+        try:
+            store = TrajectoryUploadStateStore(db_path=db_path)
+            for row in matched:
+                uploaded_row = store.get(row.traj_id)
+                if uploaded_row is not None and uploaded_row["uploaded_cleaned_content_hash"]:
+                    previously_uploaded.add(row.traj_id)
+        except Exception:  # noqa: BLE001 只读探测，旧库损坏不阻塞 CLI
+            continue
+    uploaded_count = len(previously_uploaded)
+    payload["previously_uploaded"] = uploaded_count
+    if uploaded_count:
+        lines.append(f"  注意：其中 {uploaded_count} 条此前已上传过，本规则只阻止之后的上传，不会删除服务器上的副本。")
+    if effective == "allowlist":
+        lines.append("  当前模式下该目录本来就不上传；此规则会在 server 切换为 denylist 后继续生效。")
+    emit(payload, lines)
+    return 0
+
+
 def build_parser() -> argparse.ArgumentParser:
     p = argparse.ArgumentParser(
         prog="xskill",
@@ -3018,6 +3345,27 @@ def build_parser() -> argparse.ArgumentParser:
         "--target-root", default=None,
         help="[测试/隔离] 安装与探测的 HOME 根（默认真实 HOME）",
     )
+    p_conn.add_argument(
+        "--privacy", choices=["allowlist", "denylist", "auto"], default=None,
+        help="连接前设置本机上传模式（同 xskill privacy mode）。allowlist=只上传放行的项目",
+    )
+
+    p_privacy = sub.add_parser(
+        "privacy",
+        help="管理本机哪些项目的轨迹上传到 team server",
+        description=_PRIVACY_HELP_DESCRIPTION,
+        epilog=_PRIVACY_HELP_EPILOG,
+        formatter_class=argparse.RawDescriptionHelpFormatter,
+    )
+    p_privacy.add_argument(
+        "privacy_action",
+        choices=["status", "mode", "allow", "deny", "clear", "review"],
+        metavar="<command>",
+        help="status | mode [allowlist|denylist|auto] | allow [path] | deny [path] | clear [path] | review",
+    )
+    p_privacy.add_argument("target", nargs="?", type=str,
+                           help="mode 的取值，或项目路径（默认当前目录）")
+    p_privacy.add_argument("--json", action="store_true", help="机读 JSON 输出")
 
     p_start = sub.add_parser(
         "start", help="把 connect 装成后台常驻（开机自启 + 崩溃自愈）",
@@ -3157,6 +3505,8 @@ def main() -> int:
         return cmd_stop(args)
     if args.command == "status":
         return cmd_status(args)
+    if args.command == "privacy":
+        return cmd_privacy(args)
     if args.command == "update":
         return cmd_update(args)
     if args.command == "dashboard":

--- a/src/xskill/config.py
+++ b/src/xskill/config.py
@@ -294,8 +294,9 @@ team:
     allow_read_others: false     # false（缺省）时 traj/atom read 只能读自己工号目录；
                                  # true 时允许读他人已上传轨迹
     privacy_mode: denylist       # 客户端轨迹上传模式。denylist（缺省）默认上传、用户
-                                 # 可 deny 项目；allowlist 全员只上传各自放行的项目。
-                                 # 客户端本机可设 allowlist 收紧，不能放宽 server 的 allowlist
+                                 # 可 deny 项目；allowlist 要求全员只上传各自放行的项目
+                                 # （旧版客户端不识别此字段）。本机可设 allowlist 收紧，
+                                 # 不能放宽 server 的 allowlist
 
 # ===== Skill recommend engine =====
 # 用户画像 + skill 特征 + 推荐引擎参数。仅 team server 端生效。

--- a/src/xskill/config.py
+++ b/src/xskill/config.py
@@ -293,6 +293,9 @@ team:
                                  # true（缺省）允许匿名，沿用既有 uuid/hashid 逻辑
     allow_read_others: false     # false（缺省）时 traj/atom read 只能读自己工号目录；
                                  # true 时允许读他人已上传轨迹
+    privacy_mode: denylist       # 客户端轨迹上传模式。denylist（缺省）默认上传、用户
+                                 # 可 deny 项目；allowlist 全员只上传各自放行的项目。
+                                 # 客户端本机可设 allowlist 收紧，不能放宽 server 的 allowlist
 
 # ===== Skill recommend engine =====
 # 用户画像 + skill 特征 + 推荐引擎参数。仅 team server 端生效。
@@ -1204,6 +1207,17 @@ def allow_anonymous_user(cfg: Optional[dict] = None) -> bool:
         raise ValueError(
             "team.server.allow_anonymous_user 必须是布尔，"
             f"got {type(val).__name__}"
+        )
+    return val
+
+
+def team_privacy_mode(cfg: Optional[dict] = None) -> str:
+    """读 ``team.server.privacy_mode``，缺省 ``denylist``（与未配置时的旧行为一致）。"""
+    section = _team_server_section(cfg)
+    val = section.get("privacy_mode", "denylist")
+    if val not in ("allowlist", "denylist"):
+        raise ValueError(
+            f"team.server.privacy_mode 必须是 allowlist 或 denylist，got {val!r}"
         )
     return val
 

--- a/src/xskill/core.py
+++ b/src/xskill/core.py
@@ -203,11 +203,11 @@ class XSkill:
             print(f"  clients join with:")
             print(f"    xskill connect <THIS_HOST>:{port} --token {token}")
             if privacy_mode == "allowlist":
-                print("  privacy mode: allowlist  (client 只上传各自放行的项目；"
+                print("  privacy mode: allowlist  (要求客户端只上传各自放行的项目，旧版客户端不识别；"
                       "config team.server.privacy_mode 可改为 denylist)")
             else:
                 print("  privacy mode: denylist  (默认上传，用户可 deny 项目或本机改为 allowlist；"
-                      "config team.server.privacy_mode=allowlist 可全员强制白名单)")
+                      "config team.server.privacy_mode=allowlist 可要求全员白名单)")
         elif home_root:
             print(f"xskill serve at http://{host}:{port}/  [debug home: {home_root}]")
         else:

--- a/src/xskill/core.py
+++ b/src/xskill/core.py
@@ -8,6 +8,7 @@ xskill.py — XSkill 顶层门面
 from __future__ import annotations
 
 import logging
+import sys
 from pathlib import Path
 from typing import Optional
 
@@ -198,7 +199,11 @@ class XSkill:
             from xskill.config import get_team_server_state_path
             token = ensure_join_token(get_team_server_state_path())
             from xskill.config import get_config, team_privacy_mode
-            privacy_mode = team_privacy_mode(get_config())
+            try:
+                privacy_mode = team_privacy_mode(get_config())
+            except ValueError as config_error:
+                print(f"error: {config_error}", file=sys.stderr)
+                return
             print(f"xskill team server at http://{host}:{port}/")
             print(f"  clients join with:")
             print(f"    xskill connect <THIS_HOST>:{port} --token {token}")

--- a/src/xskill/core.py
+++ b/src/xskill/core.py
@@ -197,9 +197,17 @@ class XSkill:
             from xskill.team.server.state import ensure_join_token
             from xskill.config import get_team_server_state_path
             token = ensure_join_token(get_team_server_state_path())
+            from xskill.config import get_config, team_privacy_mode
+            privacy_mode = team_privacy_mode(get_config())
             print(f"xskill team server at http://{host}:{port}/")
             print(f"  clients join with:")
             print(f"    xskill connect <THIS_HOST>:{port} --token {token}")
+            if privacy_mode == "allowlist":
+                print("  privacy mode: allowlist  (client 只上传各自放行的项目；"
+                      "config team.server.privacy_mode 可改为 denylist)")
+            else:
+                print("  privacy mode: denylist  (默认上传，用户可 deny 项目或本机改为 allowlist；"
+                      "config team.server.privacy_mode=allowlist 可全员强制白名单)")
         elif home_root:
             print(f"xskill serve at http://{host}:{port}/  [debug home: {home_root}]")
         else:

--- a/src/xskill/dashboard/console.py
+++ b/src/xskill/dashboard/console.py
@@ -682,8 +682,9 @@ def _validate_config_text(raw: str) -> dict:
             ) from exc
     from xskill.canary import CanaryConfig
     CanaryConfig.from_dict(cfg.get("canary", {}) or {})
-    from xskill.config import team_server_slots_config
+    from xskill.config import team_privacy_mode, team_server_slots_config
     team_server_slots_config(cfg)  # 槽位是热生效的,非法值必须落盘前就拒
+    team_privacy_mode(cfg)  # 同样热生效:register / sync 每请求现取
     llm = cfg.get("llm", {}) or {}
     if llm and not llm.get("base_url"):
         raise ValueError("llm.base_url 不能为空")

--- a/src/xskill/data/skill/xskill-helper/SKILL.md
+++ b/src/xskill/data/skill/xskill-helper/SKILL.md
@@ -14,9 +14,10 @@ description: >-
 
 xskill is a thin client + background daemon that (1) mounts your team's shared
 Skills into every AI-agent tool you use (Claude Code, Codex, OpenCode, Cursor,
-Trae, DeepSeek Harness) and (2) quietly collects your agent trajectories and
-syncs them to a team server. You join a server once, then it keeps skills in
-sync and auto-updates itself.
+Trae, DeepSeek Harness) and (2) collects your agent trajectories and syncs
+them to a team server; you choose which projects are uploaded (see
+"Controlling which trajectories are uploaded"). You join a server once, then
+it keeps skills in sync and auto-updates itself.
 
 `xskill init` can install this guide into chosen harnesses on this machine.
 `xskill connect` also installs it after a team join. Invoke it as
@@ -28,7 +29,8 @@ All state lives under `~/.xskill/`:
 | File | What |
 |---|---|
 | `~/.xskill/local_init.json` | local harness scan marker (no team server required) |
-| `~/.xskill/team_client.json` | connection identity (server_url, client_id, join_token) — survives restarts |
+| `~/.xskill/team_client.json` | connection identity (server_url, client_id, join_token, server privacy mode) — survives restarts |
+| `~/.xskill/privacy.json` | local upload rules: mode + per-project allow/deny — never sent to the server |
 | `~/.xskill/connect_daemon.json` | current background daemon (pid / host task) — used by `status`/`stop` |
 | `~/.xskill/logs/xskill.*.log` | split logs (one file per component) |
 | `~/.xskill/skill/` | the local skill repo everything is mounted from |
@@ -75,6 +77,31 @@ background daemon. Later reconnects can omit the address and token; they
 reuse `~/.xskill/team_client.json`.
 
 In the agent, invoke this guide as `/xskill-helper`.
+
+## Controlling which trajectories are uploaded
+
+Rules live only on this machine. A *mode* decides what happens to projects
+without a rule; the server and this machine each have one, and the stricter
+wins (`allowlist` is stricter than `denylist`):
+
+- `allowlist` — nothing is uploaded except projects you `allow`.
+- `denylist` — everything is uploaded except projects you `deny` (server default).
+
+```bash
+xskill privacy status                 # effective mode + every discovered project and its decision
+xskill privacy mode allowlist         # this machine: only upload allowed projects (server cannot loosen it)
+cd ~/code/my-service && xskill privacy allow   # allow this project (and subdirectories)
+xskill privacy deny ~/code/secret     # never read or upload this project
+xskill privacy clear ~/code/secret    # drop the rule, back to the mode default
+xskill privacy review                 # interactive walk through discovered projects
+xskill connect <host:port> --token <t> --privacy allowlist   # set the mode before the first upload
+```
+
+A skipped trajectory is never read, never uploaded and never marked as
+uploaded, so allowing it later uploads it on the next scan. Cursor and Trae
+do not record a working directory, so their trajectories cannot be matched to
+a project: they follow the mode default and `status` lists them separately.
+Rules never delete what was already uploaded.
 
 ## Generate or rewrite a Skill
 
@@ -238,6 +265,7 @@ xskill connect --foreground --debug  # + verbose logging
 | Symptom | Command | Expected |
 |---|---|---|
 | Is it running / connected? | `xskill status` | prints background task + pid, or "not running" |
+| My trajectories never reach the server | `xskill privacy status` | shows the effective mode and the decision per project; `allow` the project or switch mode |
 | Skills not updating | `xskill connect --foreground` | watch the reconcile loop; look for `copy-mode` / `fell back to copy` warnings |
 | Stop it | `xskill stop` | tears down the Scheduled Task / systemd unit |
 | Restart clean | `xskill stop` then `xskill connect` | re-handshakes and re-daemonizes |

--- a/src/xskill/data/skill/xskill-helper/SKILL.md
+++ b/src/xskill/data/skill/xskill-helper/SKILL.md
@@ -87,6 +87,9 @@ wins (`allowlist` is stricter than `denylist`):
 - `allowlist` — nothing is uploaded except projects you `allow`.
 - `denylist` — everything is uploaded except projects you `deny` (server default).
 
+A server set to `allowlist` requires it from every client on this version or
+newer; older clients do not know the field.
+
 ```bash
 xskill privacy status                 # effective mode + every discovered project and its decision
 xskill privacy mode allowlist         # this machine: only upload allowed projects (server cannot loosen it)
@@ -98,9 +101,10 @@ xskill connect <host:port> --token <t> --privacy allowlist   # set the mode befo
 ```
 
 A skipped trajectory is never read, never uploaded and never marked as
-uploaded, so allowing it later uploads it on the next scan. Cursor and Trae
-do not record a working directory, so their trajectories cannot be matched to
-a project: they follow the mode default and `status` lists them separately.
+uploaded, so allowing it later uploads it on the next scan. A trajectory whose
+sidecar records no working directory (Cursor and Trae never do) cannot be
+matched to a project: it follows the mode default and `status` lists it
+separately.
 Rules never delete what was already uploaded.
 
 ## Generate or rewrite a Skill

--- a/src/xskill/data/skill/xskill-helper/references/troubleshooting.md
+++ b/src/xskill/data/skill/xskill-helper/references/troubleshooting.md
@@ -65,6 +65,17 @@ Each item: **symptom → cause → command/fix → expected**.
 - **Fix:** get the token from whoever ran `xskill serve --server` and pass
   `--token <t>` once.
 
+## My trajectories never show up on the server
+
+- **Cause:** the effective privacy mode is `allowlist` (set by the server, or
+  by `xskill privacy mode allowlist` on this machine) and the project has no
+  `allow` rule; or the project was explicitly denied. Cursor / Trae
+  trajectories carry no working directory and follow the mode default.
+- **Fix:** run `xskill privacy status` — it prints the effective mode, where it
+  comes from, and the decision for every discovered project. Then
+  `cd <project> && xskill privacy allow`, or `xskill privacy clear <path>` to
+  drop a deny rule. The next scan uploads them; nothing needs a reconnect.
+
 ## Daemon isn't running after reboot / seems dead
 
 ```bash

--- a/src/xskill/team/client/collector.py
+++ b/src/xskill/team/client/collector.py
@@ -192,7 +192,7 @@ class TeamCollector:
             if sidecar.present and not sidecar.readable:
                 logger.warning("读 sidecar 失败,model 记 unknown、cwd 视为缺失: %s", md.with_suffix(".json"))
             # 隐私闸门在读正文、写状态之前；被跳过的轨迹不留任何状态，规则放开后即正常上传。
-            decision = policy.decide(sidecar.cwd, harness_name, privacy_mode)
+            decision = policy.decide(sidecar.cwd, sidecar.readable, privacy_mode)
             if decision.action == ACTION_SKIP:
                 logger.debug("privacy: skip %s (%s)", traj_id, decision.reason)
                 continue

--- a/src/xskill/team/client/collector.py
+++ b/src/xskill/team/client/collector.py
@@ -25,6 +25,9 @@ from pathlib import Path
 from typing import Callable
 
 from xskill.team.client.upload_state import TrajectoryUploadStateStore
+from xskill.team.client.privacy import (
+    PrivacyPolicy, load_policy, read_trajectory_cwd,
+)
 from xskill.team.client.redact import redact_text
 
 logger = logging.getLogger("xskill.team.client.collector")
@@ -93,6 +96,7 @@ class TeamCollector:
         poll_interval: float = 10.0,
         time_fn: Callable[[], float] = time.time,
         state_db_path: Path | None = None,
+        privacy_path: Path | None = None,
     ):
         self.cursor_path = Path(cursor_path)
         self.quiet_seconds = quiet_seconds
@@ -121,6 +125,17 @@ class TeamCollector:
             home_root=self.home_root,
             time_fn=self._now,
         )
+        # 本机上传排除规则（issue #244）：默认 <home>/.xskill/privacy.json，
+        # 全局、跨 server；每轮 pending() 重新加载，规则改动下一轮即生效。
+        self.privacy_path = (
+            Path(privacy_path) if privacy_path
+            else self._bridge_root / "privacy.json"
+        )
+
+    def _load_privacy_policy(self) -> "PrivacyPolicy":
+        """每轮扫描重读一次规则文件（很小）。文件损坏时抛错而不是当作
+        「无规则」——静默放行会让用户以为受保护的项目其实在上传。"""
+        return load_policy(self.privacy_path)
 
     def mark_uploaded(self, traj_id: str, sha256: str) -> None:
         """记录某 traj 的某版本已上传。同时清掉它的去抖状态（该版本已落地）。"""
@@ -184,11 +199,21 @@ class TeamCollector:
         now = self._now()
         out: list[PendingTrajectory] = []
         seen_ids: set[str] = set()
+        policy = self._load_privacy_policy()
         for md in sorted(self._bridge_root.glob("*_sessions/traj_*.md")):
             if not md.is_file():
                 continue
             traj_id = md.stem
             seen_ids.add(traj_id)
+            # 隐私闸门（issue #244）：在读正文、算摘要、写状态之前判定。
+            # 命中即跳过，且**不**记录任何上传状态——删掉规则后它会像新
+            # 轨迹一样正常进入上传流程。cwd 来自旁边的元数据小文件。
+            if not policy.is_empty:
+                cwd = read_trajectory_cwd(md)
+                rule = policy.denied_by(traj_id, cwd)
+                if rule is not None:
+                    logger.debug("privacy: skip %s (%s)", traj_id, rule)
+                    continue
             try:
                 stat = md.stat()
             except OSError:

--- a/src/xskill/team/client/collector.py
+++ b/src/xskill/team/client/collector.py
@@ -180,6 +180,13 @@ class TeamCollector:
                 continue
             traj_id = md.stem
             seen_ids.add(traj_id)
+            try:
+                stat = md.stat()
+            except OSError:
+                continue
+            # 闸 1：mtime 静默窗口
+            if (now - stat.st_mtime) < self.quiet_seconds:
+                continue
             harness_name = harness_for_bridge(md)
             sidecar = read_sidecar_metadata(md)
             if sidecar.present and not sidecar.readable:
@@ -188,13 +195,6 @@ class TeamCollector:
             decision = policy.decide(sidecar.cwd, harness_name, privacy_mode)
             if decision.action == ACTION_SKIP:
                 logger.debug("privacy: skip %s (%s)", traj_id, decision.reason)
-                continue
-            try:
-                stat = md.stat()
-            except OSError:
-                continue
-            # 闸 1：mtime 静默窗口
-            if (now - stat.st_mtime) < self.quiet_seconds:
                 continue
             model_name = sidecar.model
             state = self._state_store.get(traj_id)

--- a/src/xskill/team/client/collector.py
+++ b/src/xskill/team/client/collector.py
@@ -27,6 +27,7 @@ from typing import Callable
 from xskill.team.client.upload_state import TrajectoryUploadStateStore
 from xskill.team.client.privacy import (
     PrivacyPolicy, load_policy, read_trajectory_cwd,
+    read_trajectory_source, source_lacks_cwd,
 )
 from xskill.team.client.redact import redact_text
 
@@ -214,6 +215,15 @@ class TeamCollector:
                 if rule is not None:
                     logger.debug("privacy: skip %s (%s)", traj_id, rule)
                     continue
+                if policy.projects and cwd is None:
+                    source = read_trajectory_source(md)
+                    if not source_lacks_cwd(source):
+                        logger.warning(
+                            "privacy: skip %s because project rules are active "
+                            "but its cwd metadata is missing or unreadable",
+                            traj_id,
+                        )
+                        continue
             try:
                 stat = md.stat()
             except OSError:

--- a/src/xskill/team/client/collector.py
+++ b/src/xskill/team/client/collector.py
@@ -17,7 +17,6 @@
 from __future__ import annotations
 
 import hashlib
-import json
 import logging
 import time
 from dataclasses import dataclass
@@ -26,8 +25,7 @@ from typing import Callable
 
 from xskill.team.client.upload_state import TrajectoryUploadStateStore
 from xskill.team.client.privacy import (
-    PrivacyPolicy, load_policy, read_trajectory_cwd,
-    read_trajectory_source, source_lacks_cwd,
+    ACTION_SKIP, effective_mode, load_policy, read_sidecar_metadata,
 )
 from xskill.team.client.redact import redact_text
 
@@ -58,30 +56,10 @@ _HARNESS_BY_BRIDGE = {
 }
 
 
-def _harness_for(md_path: Path) -> str:
+def harness_for_bridge(md_path: Path) -> str:
     """从 traj_*.md 所在 bridge 目录名推断 harness（coding agent）。"""
     bridge = md_path.parent.name
     return _HARNESS_BY_BRIDGE.get(bridge, bridge.replace("_sessions", ""))
-
-
-def _sidecar_model(md_path: Path) -> str:
-    """读 ``<traj>.md`` 同目录同名 ``.json`` sidecar 里的 ``model``；
-    无 sidecar / 无该键 / 解析失败 → 空串（保持 unknown，不抛错不影响上传）。
-
-    ``errors="replace"``：sidecar 可能由 Windows 工具以 GBK(cp936) 写入，严格
-    utf-8 解码会抛 UnicodeDecodeError。它是 ValueError 的子类而**不是**
-    JSONDecodeError，下面的 except 拦不住，会穿透本函数炸掉整个 pending()
-    轮询——一个坏 sidecar 就停掉这台机器的全部上传。
-    """
-    jp = md_path.with_suffix(".json")
-    if not jp.is_file():
-        return ""
-    try:
-        return str(json.loads(
-            jp.read_text(encoding="utf-8", errors="replace")).get("model") or "")
-    except (OSError, json.JSONDecodeError) as exc:
-        logger.warning("读 sidecar 失败,model 记 unknown: %s (%s)", jp, exc)
-        return ""
 
 
 class TeamCollector:
@@ -126,17 +104,12 @@ class TeamCollector:
             home_root=self.home_root,
             time_fn=self._now,
         )
-        # 本机上传排除规则（issue #244）：默认 <home>/.xskill/privacy.json，
-        # 全局、跨 server；每轮 pending() 重新加载，规则改动下一轮即生效。
+        # 规则文件每轮 pending() 重读，改动下一轮即生效；server 下发的模式由 TeamClient 写入。
         self.privacy_path = (
             Path(privacy_path) if privacy_path
             else self._bridge_root / "privacy.json"
         )
-
-    def _load_privacy_policy(self) -> "PrivacyPolicy":
-        """每轮扫描重读一次规则文件（很小）。文件损坏时抛错而不是当作
-        「无规则」——静默放行会让用户以为受保护的项目其实在上传。"""
-        return load_policy(self.privacy_path)
+        self.server_privacy_mode: str | None = None
 
     def mark_uploaded(self, traj_id: str, sha256: str) -> None:
         """记录某 traj 的某版本已上传。同时清掉它的去抖状态（该版本已落地）。"""
@@ -200,30 +173,22 @@ class TeamCollector:
         now = self._now()
         out: list[PendingTrajectory] = []
         seen_ids: set[str] = set()
-        policy = self._load_privacy_policy()
+        policy = load_policy(self.privacy_path)
+        privacy_mode = effective_mode(self.server_privacy_mode, policy.local_mode)
         for md in sorted(self._bridge_root.glob("*_sessions/traj_*.md")):
             if not md.is_file():
                 continue
             traj_id = md.stem
             seen_ids.add(traj_id)
-            # 隐私闸门（issue #244）：在读正文、算摘要、写状态之前判定。
-            # 命中即跳过，且**不**记录任何上传状态——删掉规则后它会像新
-            # 轨迹一样正常进入上传流程。cwd 来自旁边的元数据小文件。
-            if not policy.is_empty:
-                cwd = read_trajectory_cwd(md)
-                rule = policy.denied_by(traj_id, cwd)
-                if rule is not None:
-                    logger.debug("privacy: skip %s (%s)", traj_id, rule)
-                    continue
-                if policy.projects and cwd is None:
-                    source = read_trajectory_source(md)
-                    if not source_lacks_cwd(source):
-                        logger.warning(
-                            "privacy: skip %s because project rules are active "
-                            "but its cwd metadata is missing or unreadable",
-                            traj_id,
-                        )
-                        continue
+            harness_name = harness_for_bridge(md)
+            sidecar = read_sidecar_metadata(md)
+            if sidecar.present and not sidecar.readable:
+                logger.warning("读 sidecar 失败,model 记 unknown、cwd 视为缺失: %s", md.with_suffix(".json"))
+            # 隐私闸门在读正文、写状态之前；被跳过的轨迹不留任何状态，规则放开后即正常上传。
+            decision = policy.decide(sidecar.cwd, harness_name, privacy_mode)
+            if decision.action == ACTION_SKIP:
+                logger.debug("privacy: skip %s (%s)", traj_id, decision.reason)
+                continue
             try:
                 stat = md.stat()
             except OSError:
@@ -231,8 +196,7 @@ class TeamCollector:
             # 闸 1：mtime 静默窗口
             if (now - stat.st_mtime) < self.quiet_seconds:
                 continue
-            model_name = _sidecar_model(md)
-            harness_name = _harness_for(md)
+            model_name = sidecar.model
             state = self._state_store.get(traj_id)
             metadata_same = (
                 state is not None

--- a/src/xskill/team/client/daemon.py
+++ b/src/xskill/team/client/daemon.py
@@ -38,8 +38,9 @@ from xskill.ecosystems.installation import (
     read_install_metadata_file,
     read_skill_head_sha,
 )
-from xskill.team.client.state import ClientState
+from xskill.team.client.state import ClientState, save_client_state
 from xskill.team.client.collector import TeamCollector
+from xskill.team.client.privacy import SERVER_MODES, effective_mode, load_policy
 from xskill.team.shared.git_bundle import apply_repo_bundle, make_branch_bundle
 from xskill.team.shared.reconcile import reconcile_skill_side
 from xskill.team.shared.protocol import (
@@ -139,9 +140,12 @@ class TeamClient:
         min_change_interval: int = 600,
         auto_update: bool = True,
         use_proxy: bool = False,
+        state_path: Path | None = None,
     ):
         self.state = state
         self.http = http
+        # server 改模式后 sync 回写连接文件；None（测试）只改内存。
+        self.state_path = Path(state_path) if state_path else None
         self.home_root = Path(home_root) if home_root else Path.home()
         from xskill.config import XSKILL_HOME, resolve_team_client_skill_dir
         # 状态根只认仓库约定的 XSKILL_HOME（测试可 monkeypatch），不从 skill_dir 猜父目录。
@@ -166,6 +170,7 @@ class TeamClient:
             quiet_seconds=quiet_seconds, home_root=self.home_root,
             min_change_interval=min_change_interval,
         )
+        self.collector.server_privacy_mode = state.server_privacy_mode
         self._stop = threading.Event()
         self.auto_update = auto_update
         # updater 的 server 方向请求跟随 connect 的 --use-proxy；默认直连内网 server。
@@ -211,7 +216,19 @@ class TeamClient:
         resp = self.http.get("/api/v1/team/sync", headers=self._hdr())
         if resp.status_code != 200:
             raise RuntimeError(f"sync failed: HTTP {resp.status_code} — {resp.text}")
-        return SyncResponse.model_validate(resp.json())
+        manifest = SyncResponse.model_validate(resp.json())
+        if (manifest.privacy_mode in SERVER_MODES
+                and manifest.privacy_mode != self.state.server_privacy_mode):
+            local_mode = load_policy(self.collector.privacy_path).local_mode
+            before = effective_mode(self.state.server_privacy_mode, local_mode)
+            after = effective_mode(manifest.privacy_mode, local_mode)
+            self.state.server_privacy_mode = manifest.privacy_mode
+            self.collector.server_privacy_mode = manifest.privacy_mode
+            if self.state_path is not None:
+                save_client_state(self.state, self.state_path)
+            logger.info("privacy: server mode %s, effective mode %s -> %s",
+                        manifest.privacy_mode, before, after)
+        return manifest
 
     @staticmethod
     def apply_client_take(manifest: SyncResponse) -> SyncResponse:

--- a/src/xskill/team/client/daemon.py
+++ b/src/xskill/team/client/daemon.py
@@ -781,6 +781,11 @@ class TeamClient:
         if updater:
             updater.start()
         self.collector.start_ingesters()
+        # 先同步一次拿最新模式，避免离线期间 server 收紧后首轮按旧模式上传。
+        try:
+            self.sync()
+        except Exception as sync_error:
+            logger.warning("initial sync failed error_type=%s", type(sync_error).__name__)
         logger.info(
             "team client running server_hash=%s client_id_hash=%s",
             hashlib.sha256(

--- a/src/xskill/team/client/daemon.py
+++ b/src/xskill/team/client/daemon.py
@@ -190,7 +190,11 @@ class TeamClient:
     # ── ① 采集 + 上传 ────────────────────────────────────────────
     def collect_and_upload(self) -> int:
         """扫 outbox 静默轨迹，脱敏后上传 server。返回成功上传条数。"""
-        pending = self.collector.pending()
+        try:
+            pending = self.collector.pending()
+        except ValueError as rules_error:
+            logger.error("privacy rules unreadable, uploads paused until fixed: %s", rules_error)
+            return 0
         if not pending:
             return 0
         req = UploadRequest(trajectories=[
@@ -219,7 +223,10 @@ class TeamClient:
         manifest = SyncResponse.model_validate(resp.json())
         if (manifest.privacy_mode in SERVER_MODES
                 and manifest.privacy_mode != self.state.server_privacy_mode):
-            local_mode = load_policy(self.collector.privacy_path).local_mode
+            try:
+                local_mode = load_policy(self.collector.privacy_path).local_mode
+            except ValueError:
+                local_mode = "auto"
             before = effective_mode(self.state.server_privacy_mode, local_mode)
             after = effective_mode(manifest.privacy_mode, local_mode)
             self.state.server_privacy_mode = manifest.privacy_mode

--- a/src/xskill/team/client/privacy.py
+++ b/src/xskill/team/client/privacy.py
@@ -1,0 +1,243 @@
+"""
+team/client/privacy.py -- 客户端本地的轨迹上传排除规则（issue #244）
+====================================================================
+
+team 模式下客户端会自动采集本机 coding agent 的轨迹并上传。脱敏与
+``ingest.mask_patterns`` 只能改上传的**内容**，无法表达「这条轨迹 / 这个
+项目根本不许上传」。本模块提供在**读取正文之前**生效的排除闸门：
+
+- 按项目目录排除：该目录及其子目录下产生的全部轨迹；
+- 按轨迹 id 排除：某一条轨迹。
+
+规则只保存在本机（默认 ``~/.xskill/privacy.json``），是「这台机器上用户的
+隐私意愿」，与连接哪个 team server 无关；被排除的项目路径、轨迹 id 与原因
+都不会发送到服务器。默认没有规则 = 行为与以前完全一致。
+
+匹配语义：
+- 项目路径存入时规范化为绝对路径并解析符号链接；匹配时同样规范化后判断
+  「等于该目录，或位于其子目录下」；macOS / Windows 上不区分大小写。
+- 项目归属来自轨迹旁边的元数据（同名 ``.json`` 的 ``cwd``）。Cursor 与
+  Trae 两个来源不写 ``cwd``，按项目排除对它们不生效，只能按轨迹 id 排除；
+  调用方应如实提示，而不是静默放行。
+"""
+
+from __future__ import annotations
+
+import json
+import logging
+import os
+import sys
+from dataclasses import dataclass, field
+from datetime import datetime, timezone
+from pathlib import Path
+from typing import Optional
+
+logger = logging.getLogger("xskill.team.client.privacy")
+
+# 项目路径大小写：macOS（默认 APFS/HFS+）与 Windows 的文件系统不区分大小写。
+_CASE_INSENSITIVE_FS = sys.platform in ("darwin", "win32")
+
+# 这些来源的轨迹元数据没有 cwd，按项目排除对它们不生效。
+SOURCES_WITHOUT_CWD = frozenset({"cursor", "trae"})
+
+
+def default_privacy_path(xskill_home: Path | str | None = None) -> Path:
+    """规则文件位置：``<XSKILL_HOME>/privacy.json``（全局，跨 server 生效）。"""
+    if xskill_home is None:
+        from xskill.config import XSKILL_HOME
+        xskill_home = XSKILL_HOME
+    return Path(xskill_home) / "privacy.json"
+
+
+def canonical_project_path(path: Path | str) -> str:
+    """规范化为**可展示**的绝对路径：展开 ``~``、转绝对路径、解析符号链接，
+    保留原始大小写（回显给用户）。"""
+    p = Path(os.path.expanduser(str(path)))
+    try:
+        p = p.resolve()
+    except (OSError, RuntimeError):
+        p = p.absolute()
+    return str(p)
+
+
+def normalize_project_path(path: Path | str) -> str:
+    """规范化为**比较用**的键：在 ``canonical_project_path`` 之上，不区分
+    大小写的平台再统一小写。存入与匹配都走这一函数，保证同一目录的不同
+    写法相等。展示请用 ``canonical_project_path``。"""
+    s = canonical_project_path(path)
+    return s.lower() if _CASE_INSENSITIVE_FS else s
+
+
+def _is_within(child: str, parent: str) -> bool:
+    """``child`` 是否等于 ``parent`` 或位于其子目录下（两者均已规范化）。"""
+    if child == parent:
+        return True
+    sep = os.sep
+    return child.startswith(parent.rstrip(sep) + sep)
+
+
+@dataclass
+class PrivacyPolicy:
+    """本机的排除规则集合。``projects`` / ``trajectories`` 的值是添加时间
+    （ISO 8601，UTC），供 ``list`` 展示；键分别是规范化后的项目路径与轨迹 id。"""
+
+    projects: dict[str, str] = field(default_factory=dict)
+    trajectories: dict[str, str] = field(default_factory=dict)
+    # 比较键 -> 用户输入解析后的可展示路径（保留大小写）。缺失时展示比较键。
+    project_display: dict[str, str] = field(default_factory=dict)
+
+    def display_project(self, key: str) -> str:
+        return self.project_display.get(key, key)
+
+    # ── 查询 ────────────────────────────────────────────────────
+
+    def is_denied(self, trajectory_id: str, cwd: Optional[str]) -> bool:
+        """轨迹是否被排除。``cwd`` 为 None（来源不记录工作目录）时只按 id 判。"""
+        if trajectory_id in self.trajectories:
+            return True
+        if not cwd:
+            return False
+        norm = normalize_project_path(cwd)
+        return any(_is_within(norm, proj) for proj in self.projects)
+
+    def denied_by(self, trajectory_id: str, cwd: Optional[str]) -> Optional[str]:
+        """返回命中的规则描述（``trajectory:<id>`` / ``project:<path>``），
+        未命中返回 None。供日志与 ``list`` 的统计使用。"""
+        if trajectory_id in self.trajectories:
+            return f"trajectory:{trajectory_id}"
+        if cwd:
+            norm = normalize_project_path(cwd)
+            for proj in self.projects:
+                if _is_within(norm, proj):
+                    return f"project:{proj}"
+        return None
+
+    @property
+    def is_empty(self) -> bool:
+        return not self.projects and not self.trajectories
+
+    # ── 修改（返回 True 表示状态有变化） ─────────────────────────
+
+    def deny_project(self, path: Path | str) -> tuple[bool, str]:
+        norm = normalize_project_path(path)
+        self.project_display.setdefault(norm, canonical_project_path(path))
+        if norm in self.projects:
+            return False, norm
+        self.projects[norm] = _now_iso()
+        return True, norm
+
+    def allow_project(self, path: Path | str) -> tuple[bool, str]:
+        norm = normalize_project_path(path)
+        removed = self.projects.pop(norm, None) is not None
+        if removed:
+            self.project_display.pop(norm, None)
+        return removed, norm
+
+    def deny_trajectory(self, trajectory_id: str) -> bool:
+        tid = trajectory_id.strip()
+        if tid in self.trajectories:
+            return False
+        self.trajectories[tid] = _now_iso()
+        return True
+
+    def allow_trajectory(self, trajectory_id: str) -> bool:
+        return self.trajectories.pop(trajectory_id.strip(), None) is not None
+
+    # ── 持久化 ──────────────────────────────────────────────────
+
+    def to_dict(self) -> dict:
+        return {"version": 1, "projects": dict(self.projects),
+                "trajectories": dict(self.trajectories),
+                "project_display": dict(self.project_display)}
+
+    @classmethod
+    def from_dict(cls, data: dict) -> PrivacyPolicy:
+        projects = data.get("projects") or {}
+        trajectories = data.get("trajectories") or {}
+        display = data.get("project_display") or {}
+        if (not isinstance(projects, dict) or not isinstance(trajectories, dict)
+                or not isinstance(display, dict)):
+            raise ValueError("privacy.json: projects / trajectories must be objects")
+        return cls(projects={str(k): str(v) for k, v in projects.items()},
+                   trajectories={str(k): str(v) for k, v in trajectories.items()},
+                   project_display={str(k): str(v) for k, v in display.items()})
+
+
+def _now_iso() -> str:
+    return datetime.now(timezone.utc).replace(microsecond=0).isoformat()
+
+
+def load_policy(path: Path | str | None = None) -> PrivacyPolicy:
+    """读取规则文件；不存在返回空策略（默认允许上传）。文件损坏时**告警并
+    视为空策略**是不可接受的——那会让用户以为受保护的项目其实在上传——因此
+    损坏时抛错，让调用方（CLI / 采集器）明确失败。"""
+    p = Path(path) if path else default_privacy_path()
+    if not p.is_file():
+        return PrivacyPolicy()
+    try:
+        data = json.loads(p.read_text(encoding="utf-8"))
+    except (OSError, json.JSONDecodeError) as exc:
+        raise ValueError(f"cannot read privacy rules {p}: {exc}") from exc
+    if not isinstance(data, dict):
+        raise ValueError(f"privacy rules {p}: top-level must be an object")
+    return PrivacyPolicy.from_dict(data)
+
+
+def save_policy(policy: PrivacyPolicy, path: Path | str | None = None) -> Path:
+    """原子写入（先写临时文件再替换），避免采集器读到半截文件。"""
+    p = Path(path) if path else default_privacy_path()
+    p.parent.mkdir(parents=True, exist_ok=True)
+    tmp = p.with_suffix(p.suffix + ".tmp")
+    tmp.write_text(json.dumps(policy.to_dict(), indent=2, ensure_ascii=False) + "\n",
+                   encoding="utf-8")
+    os.replace(tmp, p)
+    return p
+
+
+def read_trajectory_cwd(md_path: Path) -> Optional[str]:
+    """从轨迹旁边的元数据（同名 ``.json``）读 ``cwd``。文件缺失、损坏或无
+    该字段返回 None。这一步只读一个小文件，不读轨迹正文。"""
+    jp = md_path.with_suffix(".json")
+    if not jp.is_file():
+        return None
+    try:
+        data = json.loads(jp.read_text(encoding="utf-8"))
+    except (OSError, json.JSONDecodeError):
+        return None
+    cwd = data.get("cwd") if isinstance(data, dict) else None
+    return str(cwd) if cwd else None
+
+
+def read_trajectory_source(md_path: Path) -> str:
+    """从元数据读来源（``source`` 字段，如 ``claude_code_jsonl``）；缺失时按
+    bridge 目录名推断。用于提示「该来源不记录工作目录」。"""
+    jp = md_path.with_suffix(".json")
+    if jp.is_file():
+        try:
+            data = json.loads(jp.read_text(encoding="utf-8"))
+            src = data.get("source") if isinstance(data, dict) else None
+            if src:
+                return str(src)
+        except (OSError, json.JSONDecodeError):
+            pass
+    return md_path.parent.name.replace("_sessions", "")
+
+
+def source_lacks_cwd(source: str) -> bool:
+    """来源是否属于不记录工作目录的那一类（Cursor / Trae）。"""
+    s = source.lower()
+    return any(s.startswith(k) for k in SOURCES_WITHOUT_CWD)
+
+
+__all__ = [
+    "SOURCES_WITHOUT_CWD",
+    "PrivacyPolicy",
+    "canonical_project_path",
+    "default_privacy_path",
+    "load_policy",
+    "normalize_project_path",
+    "read_trajectory_cwd",
+    "read_trajectory_source",
+    "save_policy",
+    "source_lacks_cwd",
+]

--- a/src/xskill/team/client/privacy.py
+++ b/src/xskill/team/client/privacy.py
@@ -1,48 +1,53 @@
+"""team/client/privacy.py — 本机轨迹上传规则（issue #244）
+
+按项目目录记 allow / deny；没写规则的项目按生效模式处理。生效模式取 server
+下发的模式与本机设置中更严的那个（allowlist 严于 denylist）。规则只存本机
+``~/.xskill/privacy.json``，不发送服务器；采集器在读正文之前判定。
 """
-team/client/privacy.py -- 客户端本地的轨迹上传排除规则（issue #244）
-====================================================================
-
-team 模式下客户端会自动采集本机 coding agent 的轨迹并上传。脱敏与
-``ingest.mask_patterns`` 只能改上传的**内容**，无法表达「这条轨迹 / 这个
-项目根本不许上传」。本模块提供在**读取正文之前**生效的排除闸门：
-
-- 按项目目录排除：该目录及其子目录下产生的全部轨迹；
-- 按轨迹 id 排除：某一条轨迹。
-
-规则只保存在本机（默认 ``~/.xskill/privacy.json``），是「这台机器上用户的
-隐私意愿」，与连接哪个 team server 无关；被排除的项目路径、轨迹 id 与原因
-都不会发送到服务器。默认没有规则 = 行为与以前完全一致。
-
-匹配语义：
-- 项目路径存入时规范化为绝对路径并解析符号链接；匹配时同样规范化后判断
-  「等于该目录，或位于其子目录下」；macOS / Windows 上不区分大小写。
-- 项目归属来自轨迹旁边的元数据（同名 ``.json`` 的 ``cwd``）。Cursor 与
-  Trae 两个来源不写 ``cwd``，按项目排除对它们不生效，只能按轨迹 id 排除；
-  调用方应如实提示，而不是静默放行。
-"""
-
 from __future__ import annotations
 
 import json
-import logging
 import os
 import sys
+import time
 from dataclasses import dataclass, field
 from datetime import datetime, timezone
 from pathlib import Path
 from typing import Optional
 
-logger = logging.getLogger("xskill.team.client.privacy")
+MODE_ALLOWLIST = "allowlist"
+MODE_DENYLIST = "denylist"
+MODE_AUTO = "auto"
+SERVER_MODES = (MODE_ALLOWLIST, MODE_DENYLIST)
+LOCAL_MODES = (MODE_ALLOWLIST, MODE_DENYLIST, MODE_AUTO)
+RULE_ALLOW = "allow"
+RULE_DENY = "deny"
+ACTION_UPLOAD = "upload"
+ACTION_SKIP = "skip"
 
-# 项目路径大小写：macOS（默认 APFS/HFS+）与 Windows 的文件系统不区分大小写。
+# 这两个 harness 的轨迹 sidecar 不记录工作目录，无法归属到项目。
+HARNESSES_WITHOUT_CWD = frozenset({"cursor", "trae"})
+
 _CASE_INSENSITIVE_FS = sys.platform in ("darwin", "win32")
 
-# 这些来源的轨迹元数据没有 cwd，按项目排除对它们不生效。
-SOURCES_WITHOUT_CWD = frozenset({"cursor", "trae"})
+
+def effective_mode(server_mode: Optional[str], local_mode: str) -> str:
+    """两边只要有一方是 allowlist 就是 allowlist；server 未下发按 denylist。"""
+    if MODE_ALLOWLIST in (server_mode, local_mode):
+        return MODE_ALLOWLIST
+    return MODE_DENYLIST
+
+
+def mode_origin(server_mode: Optional[str], local_mode: str) -> str:
+    """生效模式来自哪里：server_forced / local / server_default / server_missing。"""
+    if server_mode == MODE_ALLOWLIST:
+        return "server_forced"
+    if local_mode != MODE_AUTO:
+        return "local"
+    return "server_default" if server_mode in SERVER_MODES else "server_missing"
 
 
 def default_privacy_path(xskill_home: Path | str | None = None) -> Path:
-    """规则文件位置：``<XSKILL_HOME>/privacy.json``（全局，跨 server 生效）。"""
     if xskill_home is None:
         from xskill.config import XSKILL_HOME
         xskill_home = XSKILL_HOME
@@ -50,194 +55,268 @@ def default_privacy_path(xskill_home: Path | str | None = None) -> Path:
 
 
 def canonical_project_path(path: Path | str) -> str:
-    """规范化为**可展示**的绝对路径：展开 ``~``、转绝对路径、解析符号链接，
-    保留原始大小写（回显给用户）。"""
-    p = Path(os.path.expanduser(str(path)))
+    """展示用绝对路径：展开 ``~``、解析符号链接，保留原始大小写。"""
+    expanded = Path(os.path.expanduser(str(path)))
     try:
-        p = p.resolve()
+        expanded = expanded.resolve()
     except (OSError, RuntimeError):
-        p = p.absolute()
-    return str(p)
+        expanded = expanded.absolute()
+    return str(expanded)
 
 
 def normalize_project_path(path: Path | str) -> str:
-    """规范化为**比较用**的键：在 ``canonical_project_path`` 之上，不区分
-    大小写的平台再统一小写。存入与匹配都走这一函数，保证同一目录的不同
-    写法相等。展示请用 ``canonical_project_path``。"""
-    s = canonical_project_path(path)
-    return s.lower() if _CASE_INSENSITIVE_FS else s
+    """比较用键：在展示路径之上，大小写不敏感的平台统一小写。"""
+    canonical = canonical_project_path(path)
+    return canonical.lower() if _CASE_INSENSITIVE_FS else canonical
 
 
-def _is_within(child: str, parent: str) -> bool:
-    """``child`` 是否等于 ``parent`` 或位于其子目录下（两者均已规范化）。"""
+def path_is_within(child: str, parent: str) -> bool:
+    """``child`` 等于 ``parent`` 或位于其子目录下（两者均已规范化）。"""
     if child == parent:
         return True
-    sep = os.sep
-    return child.startswith(parent.rstrip(sep) + sep)
+    return child.startswith(parent.rstrip(os.sep) + os.sep)
+
+
+@dataclass
+class ProjectRule:
+    rule: str            # allow | deny
+    display: str         # 保留大小写的展示路径
+    added_at: str        # ISO 8601 UTC
+
+
+@dataclass
+class Decision:
+    action: str                    # upload | skip
+    reason: str                    # allow | deny | default | no_cwd | broken_sidecar
+    rule_key: Optional[str] = None
 
 
 @dataclass
 class PrivacyPolicy:
-    """本机的排除规则集合。``projects`` / ``trajectories`` 的值是添加时间
-    （ISO 8601，UTC），供 ``list`` 展示；键分别是规范化后的项目路径与轨迹 id。"""
+    local_mode: str = MODE_AUTO
+    projects: dict[str, ProjectRule] = field(default_factory=dict)
 
-    projects: dict[str, str] = field(default_factory=dict)
-    trajectories: dict[str, str] = field(default_factory=dict)
-    # 比较键 -> 用户输入解析后的可展示路径（保留大小写）。缺失时展示比较键。
-    project_display: dict[str, str] = field(default_factory=dict)
+    def rule_for(self, cwd: str) -> Optional[tuple[str, ProjectRule]]:
+        """最长前缀匹配：子目录规则优先于父目录规则。"""
+        normalized = normalize_project_path(cwd)
+        best: Optional[tuple[str, ProjectRule]] = None
+        for key, project_rule in self.projects.items():
+            if path_is_within(normalized, key) and (best is None or len(key) > len(best[0])):
+                best = (key, project_rule)
+        return best
 
-    def display_project(self, key: str) -> str:
-        return self.project_display.get(key, key)
-
-    # ── 查询 ────────────────────────────────────────────────────
-
-    def is_denied(self, trajectory_id: str, cwd: Optional[str]) -> bool:
-        """轨迹是否被排除。``cwd`` 为 None（来源不记录工作目录）时只按 id 判。"""
-        if trajectory_id in self.trajectories:
-            return True
-        if not cwd:
-            return False
-        norm = normalize_project_path(cwd)
-        return any(_is_within(norm, proj) for proj in self.projects)
-
-    def denied_by(self, trajectory_id: str, cwd: Optional[str]) -> Optional[str]:
-        """返回命中的规则描述（``trajectory:<id>`` / ``project:<path>``），
-        未命中返回 None。供日志与 ``list`` 的统计使用。"""
-        if trajectory_id in self.trajectories:
-            return f"trajectory:{trajectory_id}"
+    def decide(self, cwd: Optional[str], harness: str, mode: str) -> Decision:
         if cwd:
-            norm = normalize_project_path(cwd)
-            for proj in self.projects:
-                if _is_within(norm, proj):
-                    return f"project:{proj}"
-        return None
+            matched = self.rule_for(cwd)
+            if matched is not None:
+                key, project_rule = matched
+                action = ACTION_UPLOAD if project_rule.rule == RULE_ALLOW else ACTION_SKIP
+                return Decision(action, project_rule.rule, key)
+            reason = "default"
+        else:
+            reason = "no_cwd" if harness in HARNESSES_WITHOUT_CWD else "broken_sidecar"
+        action = ACTION_UPLOAD if mode == MODE_DENYLIST else ACTION_SKIP
+        return Decision(action, reason)
 
-    @property
-    def is_empty(self) -> bool:
-        return not self.projects and not self.trajectories
+    def set_project(self, path: Path | str, rule: str) -> tuple[bool, str]:
+        """写入规则；已是同一规则返回 (False, key)。"""
+        key = normalize_project_path(path)
+        existing = self.projects.get(key)
+        if existing is not None and existing.rule == rule:
+            return False, key
+        self.projects[key] = ProjectRule(
+            rule=rule, display=canonical_project_path(path),
+            added_at=datetime.now(timezone.utc).replace(microsecond=0).isoformat(),
+        )
+        return True, key
 
-    # ── 修改（返回 True 表示状态有变化） ─────────────────────────
-
-    def deny_project(self, path: Path | str) -> tuple[bool, str]:
-        norm = normalize_project_path(path)
-        self.project_display.setdefault(norm, canonical_project_path(path))
-        if norm in self.projects:
-            return False, norm
-        self.projects[norm] = _now_iso()
-        return True, norm
-
-    def allow_project(self, path: Path | str) -> tuple[bool, str]:
-        norm = normalize_project_path(path)
-        removed = self.projects.pop(norm, None) is not None
-        if removed:
-            self.project_display.pop(norm, None)
-        return removed, norm
-
-    def deny_trajectory(self, trajectory_id: str) -> bool:
-        tid = trajectory_id.strip()
-        if tid in self.trajectories:
-            return False
-        self.trajectories[tid] = _now_iso()
-        return True
-
-    def allow_trajectory(self, trajectory_id: str) -> bool:
-        return self.trajectories.pop(trajectory_id.strip(), None) is not None
-
-    # ── 持久化 ──────────────────────────────────────────────────
+    def clear_project(self, path: Path | str) -> tuple[bool, str]:
+        key = normalize_project_path(path)
+        return self.projects.pop(key, None) is not None, key
 
     def to_dict(self) -> dict:
-        return {"version": 1, "projects": dict(self.projects),
-                "trajectories": dict(self.trajectories),
-                "project_display": dict(self.project_display)}
+        return {
+            "version": 2,
+            "mode": self.local_mode,
+            "projects": {
+                key: {"rule": project_rule.rule, "display": project_rule.display,
+                      "added_at": project_rule.added_at}
+                for key, project_rule in self.projects.items()
+            },
+        }
 
     @classmethod
-    def from_dict(cls, data: dict) -> PrivacyPolicy:
-        projects = data.get("projects") or {}
-        trajectories = data.get("trajectories") or {}
-        display = data.get("project_display") or {}
-        if (not isinstance(projects, dict) or not isinstance(trajectories, dict)
-                or not isinstance(display, dict)):
-            raise ValueError("privacy.json: projects / trajectories must be objects")
-        return cls(projects={str(k): str(v) for k, v in projects.items()},
-                   trajectories={str(k): str(v) for k, v in trajectories.items()},
-                   project_display={str(k): str(v) for k, v in display.items()})
-
-
-def _now_iso() -> str:
-    return datetime.now(timezone.utc).replace(microsecond=0).isoformat()
+    def from_dict(cls, data: dict) -> "PrivacyPolicy":
+        local_mode = data.get("mode", MODE_AUTO)
+        if local_mode not in LOCAL_MODES:
+            raise ValueError(f"privacy.json: mode must be one of {LOCAL_MODES}, got {local_mode!r}")
+        raw_projects = data.get("projects") or {}
+        if not isinstance(raw_projects, dict):
+            raise ValueError("privacy.json: projects must be an object")
+        projects: dict[str, ProjectRule] = {}
+        for key, raw_rule in raw_projects.items():
+            if not isinstance(raw_rule, dict) or raw_rule.get("rule") not in (RULE_ALLOW, RULE_DENY):
+                raise ValueError(f"privacy.json: bad project rule for {key!r}")
+            projects[str(key)] = ProjectRule(
+                rule=raw_rule["rule"], display=str(raw_rule.get("display") or key),
+                added_at=str(raw_rule.get("added_at") or ""),
+            )
+        return cls(local_mode=local_mode, projects=projects)
 
 
 def load_policy(path: Path | str | None = None) -> PrivacyPolicy:
-    """读取规则文件；不存在返回空策略（默认允许上传）。文件损坏时**告警并
-    视为空策略**是不可接受的——那会让用户以为受保护的项目其实在上传——因此
-    损坏时抛错，让调用方（CLI / 采集器）明确失败。"""
-    p = Path(path) if path else default_privacy_path()
-    if not p.is_file():
+    """不存在返回默认策略；损坏时抛错——静默放行会让用户以为受保护的项目其实在上传。"""
+    policy_path = Path(path) if path else default_privacy_path()
+    if not policy_path.is_file():
         return PrivacyPolicy()
     try:
-        data = json.loads(p.read_text(encoding="utf-8"))
-    except (OSError, json.JSONDecodeError) as exc:
-        raise ValueError(f"cannot read privacy rules {p}: {exc}") from exc
+        data = json.loads(policy_path.read_text(encoding="utf-8"))
+    except (OSError, ValueError) as exc:
+        raise ValueError(f"cannot read privacy rules {policy_path}: {exc}") from exc
     if not isinstance(data, dict):
-        raise ValueError(f"privacy rules {p}: top-level must be an object")
+        raise ValueError(f"privacy rules {policy_path}: top-level must be an object")
     return PrivacyPolicy.from_dict(data)
 
 
 def save_policy(policy: PrivacyPolicy, path: Path | str | None = None) -> Path:
-    """原子写入（先写临时文件再替换），避免采集器读到半截文件。"""
-    p = Path(path) if path else default_privacy_path()
-    p.parent.mkdir(parents=True, exist_ok=True)
-    tmp = p.with_suffix(p.suffix + ".tmp")
-    tmp.write_text(json.dumps(policy.to_dict(), indent=2, ensure_ascii=False) + "\n",
-                   encoding="utf-8")
-    os.replace(tmp, p)
-    return p
+    policy_path = Path(path) if path else default_privacy_path()
+    policy_path.parent.mkdir(parents=True, exist_ok=True)
+    temp_path = policy_path.with_suffix(policy_path.suffix + ".tmp")
+    temp_path.write_text(
+        json.dumps(policy.to_dict(), indent=2, ensure_ascii=False) + "\n", encoding="utf-8",
+    )
+    os.replace(temp_path, policy_path)
+    return policy_path
 
 
-def read_trajectory_cwd(md_path: Path) -> Optional[str]:
-    """从轨迹旁边的元数据（同名 ``.json``）读 ``cwd``。文件缺失、损坏或无
-    该字段返回 None。这一步只读一个小文件，不读轨迹正文。"""
-    jp = md_path.with_suffix(".json")
-    if not jp.is_file():
-        return None
+@dataclass
+class SidecarMetadata:
+    cwd: Optional[str]
+    model: str
+    present: bool
+    readable: bool
+
+
+def read_sidecar_metadata(md_path: Path) -> SidecarMetadata:
+    """只读轨迹旁边的同名 ``.json``，不读正文。Windows 工具可能以 GBK 写入，故降级解码。"""
+    sidecar_path = md_path.with_suffix(".json")
+    if not sidecar_path.is_file():
+        return SidecarMetadata(cwd=None, model="", present=False, readable=False)
     try:
-        data = json.loads(jp.read_text(encoding="utf-8"))
-    except (OSError, json.JSONDecodeError):
-        return None
-    cwd = data.get("cwd") if isinstance(data, dict) else None
-    return str(cwd) if cwd else None
+        data = json.loads(sidecar_path.read_text(encoding="utf-8", errors="replace"))
+    except (OSError, ValueError):
+        return SidecarMetadata(cwd=None, model="", present=True, readable=False)
+    if not isinstance(data, dict):
+        return SidecarMetadata(cwd=None, model="", present=True, readable=False)
+    cwd = data.get("cwd")
+    return SidecarMetadata(
+        cwd=str(cwd) if cwd else None, model=str(data.get("model") or ""),
+        present=True, readable=True,
+    )
 
 
-def read_trajectory_source(md_path: Path) -> str:
-    """从元数据读来源（``source`` 字段，如 ``claude_code_jsonl``）；缺失时按
-    bridge 目录名推断。用于提示「该来源不记录工作目录」。"""
-    jp = md_path.with_suffix(".json")
-    if jp.is_file():
-        try:
-            data = json.loads(jp.read_text(encoding="utf-8"))
-            src = data.get("source") if isinstance(data, dict) else None
-            if src:
-                return str(src)
-        except (OSError, json.JSONDecodeError):
-            pass
-    return md_path.parent.name.replace("_sessions", "")
+@dataclass
+class LocalTrajectory:
+    traj_id: str
+    path: Path
+    cwd: Optional[str]
+    harness: str
 
 
-def source_lacks_cwd(source: str) -> bool:
-    """来源是否属于不记录工作目录的那一类（Cursor / Trae）。"""
-    s = source.lower()
-    return any(s.startswith(k) for k in SOURCES_WITHOUT_CWD)
+def scan_local_trajectories(
+    bridge_root: Path, *, time_budget_seconds: Optional[float] = None,
+) -> tuple[list[LocalTrajectory], bool]:
+    """列出本机 bridge 目录下的轨迹（只读 sidecar）。超出时间预算提前返回，第二项为 False。"""
+    from xskill.team.client.collector import harness_for_bridge
+    started = time.monotonic()
+    rows: list[LocalTrajectory] = []
+    for md_path in sorted(Path(bridge_root).glob("*_sessions/traj_*.md")):
+        if not md_path.is_file():
+            continue
+        if time_budget_seconds is not None and time.monotonic() - started > time_budget_seconds:
+            return rows, False
+        rows.append(LocalTrajectory(
+            traj_id=md_path.stem, path=md_path,
+            cwd=read_sidecar_metadata(md_path).cwd, harness=harness_for_bridge(md_path),
+        ))
+    return rows, True
 
 
-__all__ = [
-    "SOURCES_WITHOUT_CWD",
-    "PrivacyPolicy",
-    "canonical_project_path",
-    "default_privacy_path",
-    "load_policy",
-    "normalize_project_path",
-    "read_trajectory_cwd",
-    "read_trajectory_source",
-    "save_policy",
-    "source_lacks_cwd",
-]
+@dataclass
+class ProjectSummary:
+    path: str
+    key: str
+    traj: int
+    harnesses: list[str]
+    rule: Optional[str]
+    effective: str
+
+
+@dataclass
+class PrivacyReport:
+    mode: str
+    origin: str
+    server_mode: Optional[str]
+    local_mode: str
+    projects: list[ProjectSummary]
+    no_cwd: ProjectSummary
+    broken_sidecar: ProjectSummary
+    upload: int
+    skip: int
+    complete: bool
+
+    def to_dict(self) -> dict:
+        def summary_dict(summary: ProjectSummary) -> dict:
+            return {"path": summary.path, "traj": summary.traj, "harnesses": summary.harnesses,
+                    "rule": summary.rule, "effective": summary.effective}
+        return {
+            "mode": self.mode, "mode_origin": self.origin,
+            "server_mode": self.server_mode, "local_mode": self.local_mode,
+            "projects": [summary_dict(summary) for summary in self.projects],
+            "unattributed": summary_dict(self.no_cwd),
+            "broken_sidecar": summary_dict(self.broken_sidecar),
+            "upload": self.upload, "skip": self.skip, "scan_complete": self.complete,
+        }
+
+
+def build_report(
+    policy: PrivacyPolicy, server_mode: Optional[str], rows: list[LocalTrajectory],
+    *, complete: bool = True,
+) -> PrivacyReport:
+    """把本机轨迹按项目归组，每组给出规则与生效判定；无轨迹的规则也列出（traj=0）。"""
+    mode = effective_mode(server_mode, policy.local_mode)
+    grouped: dict[str, ProjectSummary] = {}
+    for key, project_rule in policy.projects.items():
+        grouped[key] = ProjectSummary(
+            path=project_rule.display, key=key, traj=0, harnesses=[], rule=project_rule.rule,
+            effective=ACTION_UPLOAD if project_rule.rule == RULE_ALLOW else ACTION_SKIP,
+        )
+    default_action = ACTION_UPLOAD if mode == MODE_DENYLIST else ACTION_SKIP
+    no_cwd = ProjectSummary("(无法归属项目)", "", 0, [], None, default_action)
+    broken = ProjectSummary("(sidecar 缺失或损坏)", "", 0, [], None, default_action)
+    for row in rows:
+        decision = policy.decide(row.cwd, row.harness, mode)
+        if decision.reason == "no_cwd":
+            target = no_cwd
+        elif decision.reason == "broken_sidecar":
+            target = broken
+        elif decision.rule_key is not None:
+            target = grouped[decision.rule_key]
+        else:
+            key = normalize_project_path(row.cwd)
+            target = grouped.setdefault(key, ProjectSummary(
+                path=canonical_project_path(row.cwd), key=key, traj=0, harnesses=[],
+                rule=None, effective=default_action,
+            ))
+        target.traj += 1
+        if row.harness not in target.harnesses:
+            target.harnesses.append(row.harness)
+    projects = sorted(grouped.values(), key=lambda summary: summary.path)
+    everything = projects + [no_cwd, broken]
+    upload = sum(summary.traj for summary in everything if summary.effective == ACTION_UPLOAD)
+    skip = sum(summary.traj for summary in everything if summary.effective == ACTION_SKIP)
+    return PrivacyReport(
+        mode=mode, origin=mode_origin(server_mode, policy.local_mode),
+        server_mode=server_mode, local_mode=policy.local_mode, projects=projects,
+        no_cwd=no_cwd, broken_sidecar=broken, upload=upload, skip=skip, complete=complete,
+    )

--- a/src/xskill/team/client/privacy.py
+++ b/src/xskill/team/client/privacy.py
@@ -25,9 +25,6 @@ RULE_DENY = "deny"
 ACTION_UPLOAD = "upload"
 ACTION_SKIP = "skip"
 
-# 这两个 harness 的轨迹 sidecar 不记录工作目录，无法归属到项目。
-HARNESSES_WITHOUT_CWD = frozenset({"cursor", "trae"})
-
 _CASE_INSENSITIVE_FS = sys.platform in ("darwin", "win32")
 
 
@@ -39,9 +36,11 @@ def effective_mode(server_mode: Optional[str], local_mode: str) -> str:
 
 
 def mode_origin(server_mode: Optional[str], local_mode: str, *, connected: bool = True) -> str:
-    """生效模式来自哪里：server_forced / local / server_default / server_missing / disconnected。"""
+    """生效模式来自哪里：local / server_required / server_default / server_missing / disconnected。"""
+    if local_mode == MODE_ALLOWLIST:
+        return "local"
     if server_mode == MODE_ALLOWLIST:
-        return "server_forced"
+        return "server_required"
     if local_mode != MODE_AUTO:
         return "local"
     if not connected:
@@ -112,7 +111,7 @@ class PrivacyPolicy:
                 best = (key, project_rule)
         return best
 
-    def decide(self, cwd: Optional[str], harness: str, mode: str) -> Decision:
+    def decide(self, cwd: Optional[str], sidecar_readable: bool, mode: str) -> Decision:
         if cwd:
             matched = self.rule_for(cwd)
             if matched is not None:
@@ -121,7 +120,7 @@ class PrivacyPolicy:
                 return Decision(action, project_rule.rule, key)
             reason = "default"
         else:
-            reason = "no_cwd" if harness in HARNESSES_WITHOUT_CWD else "broken_sidecar"
+            reason = "no_cwd" if sidecar_readable else "broken_sidecar"
         action = ACTION_UPLOAD if mode == MODE_DENYLIST else ACTION_SKIP
         return Decision(action, reason)
 
@@ -227,6 +226,7 @@ class LocalTrajectory:
     traj_id: str
     path: Path
     cwd: Optional[str]
+    sidecar_readable: bool
     harness: str
 
 
@@ -242,9 +242,10 @@ def scan_local_trajectories(
             continue
         if time_budget_seconds is not None and time.monotonic() - started > time_budget_seconds:
             return rows, False
+        sidecar = read_sidecar_metadata(md_path)
         rows.append(LocalTrajectory(
-            traj_id=md_path.stem, path=md_path,
-            cwd=read_sidecar_metadata(md_path).cwd, harness=harness_for_bridge(md_path),
+            traj_id=md_path.stem, path=md_path, cwd=sidecar.cwd,
+            sidecar_readable=sidecar.readable, harness=harness_for_bridge(md_path),
         ))
     return rows, True
 
@@ -299,10 +300,10 @@ def build_report(
             effective=ACTION_UPLOAD if project_rule.rule == RULE_ALLOW else ACTION_SKIP,
         )
     default_action = ACTION_UPLOAD if mode == MODE_DENYLIST else ACTION_SKIP
-    no_cwd = ProjectSummary("(无法归属项目)", "", 0, [], None, default_action)
+    no_cwd = ProjectSummary("(sidecar 未记录工作目录)", "", 0, [], None, default_action)
     broken = ProjectSummary("(sidecar 缺失或损坏)", "", 0, [], None, default_action)
     for row in rows:
-        decision = policy.decide(row.cwd, row.harness, mode)
+        decision = policy.decide(row.cwd, row.sidecar_readable, mode)
         if decision.reason == "no_cwd":
             target = no_cwd
         elif decision.reason == "broken_sidecar":

--- a/src/xskill/team/client/privacy.py
+++ b/src/xskill/team/client/privacy.py
@@ -38,12 +38,14 @@ def effective_mode(server_mode: Optional[str], local_mode: str) -> str:
     return MODE_DENYLIST
 
 
-def mode_origin(server_mode: Optional[str], local_mode: str) -> str:
-    """生效模式来自哪里：server_forced / local / server_default / server_missing。"""
+def mode_origin(server_mode: Optional[str], local_mode: str, *, connected: bool = True) -> str:
+    """生效模式来自哪里：server_forced / local / server_default / server_missing / disconnected。"""
     if server_mode == MODE_ALLOWLIST:
         return "server_forced"
     if local_mode != MODE_AUTO:
         return "local"
+    if not connected:
+        return "disconnected"
     return "server_default" if server_mode in SERVER_MODES else "server_missing"
 
 
@@ -58,15 +60,20 @@ def canonical_project_path(path: Path | str) -> str:
     """展示用绝对路径：展开 ``~``、解析符号链接，保留原始大小写。"""
     expanded = Path(os.path.expanduser(str(path)))
     try:
-        expanded = expanded.resolve()
+        resolved = str(expanded.resolve())
     except (OSError, RuntimeError):
-        expanded = expanded.absolute()
-    return str(expanded)
+        resolved = str(expanded.absolute())
+    if os.name == "nt":
+        if resolved.startswith("\\\\?\\UNC\\"):
+            resolved = "\\\\" + resolved[8:]
+        elif resolved.startswith("\\\\?\\"):
+            resolved = resolved[4:]
+    return resolved
 
 
 def normalize_project_path(path: Path | str) -> str:
-    """比较用键：在展示路径之上，大小写不敏感的平台统一小写。"""
-    canonical = canonical_project_path(path)
+    """比较用键：展示路径经 normcase（Windows 折叠大小写与分隔符），macOS 再统一小写。"""
+    canonical = os.path.normcase(canonical_project_path(path))
     return canonical.lower() if _CASE_INSENSITIVE_FS else canonical
 
 
@@ -281,7 +288,7 @@ class PrivacyReport:
 
 def build_report(
     policy: PrivacyPolicy, server_mode: Optional[str], rows: list[LocalTrajectory],
-    *, complete: bool = True,
+    *, complete: bool = True, connected: bool = True,
 ) -> PrivacyReport:
     """把本机轨迹按项目归组，每组给出规则与生效判定；无轨迹的规则也列出（traj=0）。"""
     mode = effective_mode(server_mode, policy.local_mode)
@@ -316,7 +323,7 @@ def build_report(
     upload = sum(summary.traj for summary in everything if summary.effective == ACTION_UPLOAD)
     skip = sum(summary.traj for summary in everything if summary.effective == ACTION_SKIP)
     return PrivacyReport(
-        mode=mode, origin=mode_origin(server_mode, policy.local_mode),
+        mode=mode, origin=mode_origin(server_mode, policy.local_mode, connected=connected),
         server_mode=server_mode, local_mode=policy.local_mode, projects=projects,
         no_cwd=no_cwd, broken_sidecar=broken, upload=upload, skip=skip, complete=complete,
     )

--- a/src/xskill/team/client/state.py
+++ b/src/xskill/team/client/state.py
@@ -18,6 +18,8 @@ class ClientState:
     server_url: str          # 形如 http://1.2.3.4:8000
     client_id: str
     join_token: str
+    # server 下发的上传模式（allowlist / denylist）；旧 server 不下发为 None。
+    server_privacy_mode: str | None = None
 
 
 def save_client_state(state: ClientState, path: Path | str) -> None:
@@ -40,4 +42,5 @@ def load_client_state(path: Path | str) -> ClientState:
         server_url=data["server_url"],
         client_id=data["client_id"],
         join_token=data["join_token"],
+        server_privacy_mode=data.get("server_privacy_mode"),
     )

--- a/src/xskill/team/client/state.py
+++ b/src/xskill/team/client/state.py
@@ -9,6 +9,7 @@ server_url / client_id / join_token，落 ~/.xskill/team_client.json。
 from __future__ import annotations
 
 import json
+import os
 from dataclasses import asdict, dataclass
 from pathlib import Path
 
@@ -25,8 +26,10 @@ class ClientState:
 def save_client_state(state: ClientState, path: Path | str) -> None:
     path = Path(path)
     path.parent.mkdir(parents=True, exist_ok=True)
-    path.write_text(json.dumps(asdict(state), indent=2), encoding="utf-8")
-    path.chmod(0o600)
+    temp_path = path.with_suffix(path.suffix + ".tmp")
+    temp_path.write_text(json.dumps(asdict(state), indent=2), encoding="utf-8")
+    temp_path.chmod(0o600)
+    os.replace(temp_path, path)
 
 
 def load_client_state(path: Path | str) -> ClientState:

--- a/src/xskill/team/server/api.py
+++ b/src/xskill/team/server/api.py
@@ -659,7 +659,7 @@ async def team_register(req: RegisterRequest) -> RegisterResponse:
     # serve（同 live_manifest_tuning 的理由——admin_config_reload 原地 mutate
     # app._config）。函数内 import：app 模块 import 本模块，模块级会循环。
     from xskill.api import app as app_mod
-    from xskill.config import allow_anonymous_user
+    from xskill.config import allow_anonymous_user, team_privacy_mode
     if not user_name and not allow_anonymous_user(app_mod._config or {}):  # pylint: disable=protected-access
         raise HTTPException(
             status_code=403, detail="anonymous users not allowed"
@@ -679,7 +679,10 @@ async def team_register(req: RegisterRequest) -> RegisterResponse:
         _ctx.client_registry.ensure_dashboard_token(client_id)
         if user_name else None
     )
-    return RegisterResponse(client_id=client_id, dashboard_token=dashboard_token)
+    return RegisterResponse(
+        client_id=client_id, dashboard_token=dashboard_token,
+        privacy_mode=team_privacy_mode(app_mod._config or {}),  # pylint: disable=protected-access
+    )
 
 
 @router.post("/upload", response_model=UploadResponse)
@@ -858,6 +861,9 @@ def team_sync(
         except Exception:  # pylint: disable=broad-exception-caught
             logger.warning("profile refresh request failed for %s", client_id,
                            exc_info=True)
+    from xskill.api import app as app_mod
+    from xskill.config import team_privacy_mode
+    resp.privacy_mode = team_privacy_mode(app_mod._config or {})  # pylint: disable=protected-access
     return resp.model_dump()
 
 

--- a/src/xskill/team/server/api.py
+++ b/src/xskill/team/server/api.py
@@ -97,6 +97,17 @@ def team_context() -> _Ctx:
     return _ctx
 
 
+def _live_privacy_mode() -> str:
+    """现取 team.server.privacy_mode；手改 config 写坏时退回 denylist 并告警，不让 register / sync 500。"""
+    from xskill.api import app as app_mod
+    from xskill.config import team_privacy_mode
+    try:
+        return team_privacy_mode(app_mod._config or {})  # pylint: disable=protected-access
+    except ValueError as config_error:
+        logger.warning("team.server.privacy_mode invalid, serving denylist: %s", config_error)
+        return "denylist"
+
+
 def live_manifest_tuning() -> tuple[int, int, float]:
     """现取 ``(total_slots, ranked_slots, probability)``——热生效的唯一来源。
 
@@ -659,7 +670,7 @@ async def team_register(req: RegisterRequest) -> RegisterResponse:
     # serve（同 live_manifest_tuning 的理由——admin_config_reload 原地 mutate
     # app._config）。函数内 import：app 模块 import 本模块，模块级会循环。
     from xskill.api import app as app_mod
-    from xskill.config import allow_anonymous_user, team_privacy_mode
+    from xskill.config import allow_anonymous_user
     if not user_name and not allow_anonymous_user(app_mod._config or {}):  # pylint: disable=protected-access
         raise HTTPException(
             status_code=403, detail="anonymous users not allowed"
@@ -681,7 +692,7 @@ async def team_register(req: RegisterRequest) -> RegisterResponse:
     )
     return RegisterResponse(
         client_id=client_id, dashboard_token=dashboard_token,
-        privacy_mode=team_privacy_mode(app_mod._config or {}),  # pylint: disable=protected-access
+        privacy_mode=_live_privacy_mode(),
     )
 
 
@@ -861,9 +872,7 @@ def team_sync(
         except Exception:  # pylint: disable=broad-exception-caught
             logger.warning("profile refresh request failed for %s", client_id,
                            exc_info=True)
-    from xskill.api import app as app_mod
-    from xskill.config import team_privacy_mode
-    resp.privacy_mode = team_privacy_mode(app_mod._config or {})  # pylint: disable=protected-access
+    resp.privacy_mode = _live_privacy_mode()
     return resp.model_dump()
 
 

--- a/src/xskill/team/shared/protocol.py
+++ b/src/xskill/team/shared/protocol.py
@@ -47,6 +47,8 @@ class RegisterResponse(BaseModel):
     # P2-2.2(Q2a):--name 注册时发放的 dashboard 登录 token,client 侧打印一次。
     # 匿名注册为 None(dashboard 登录依赖 user_name 身份)。
     dashboard_token: str | None = None
+    # server 的轨迹上传模式（allowlist / denylist），client 与本机设置取更严者。
+    privacy_mode: str | None = None
 
 
 class UploadTrajectory(BaseModel):
@@ -92,6 +94,8 @@ class SyncResponse(BaseModel):
     # client 截取安装：对 slots 取前 take_n；None=装全部（兼容旧 client）
     take_n: int | None = None
     server_slots: int | None = None
+    # 每轮 sync 带回，server 改模式后 client 下一轮生效，无需重新 connect。
+    privacy_mode: str | None = None
 
 
 class PushEditResponse(BaseModel):

--- a/tests/test_deepseek_harness_adapter.py
+++ b/tests/test_deepseek_harness_adapter.py
@@ -475,9 +475,9 @@ class TestInstall:
 
     def test_harness_name_for_dsh_bridge_dir(self, tmp_path):
         """上传元数据里的 harness 必须是 deepseek_harness，不能退化为 dsh。"""
-        from xskill.team.client.collector import _harness_for
+        from xskill.team.client.collector import harness_for_bridge
         md = tmp_path / "dsh_sessions" / "traj_dsh_x.md"
-        assert _harness_for(md) == "deepseek_harness"
+        assert harness_for_bridge(md) == "deepseek_harness"
 
 
 # ──────────────────────────────────────────────────────────────────

--- a/tests/test_team_client_privacy.py
+++ b/tests/test_team_client_privacy.py
@@ -18,6 +18,8 @@ test_team_client_privacy.py -- 客户端本地上传排除规则（issue #244）
 from __future__ import annotations
 
 import json
+import os
+import subprocess
 import sys
 from pathlib import Path
 
@@ -230,6 +232,32 @@ def test_corrupt_policy_file_fails_loud_not_silent_allow(tmp_path):
         _collector(home).pending()
 
 
+@pytest.mark.parametrize("metadata", [None, "{not json"])
+def test_project_rules_fail_closed_when_cwd_metadata_is_unreadable(
+        tmp_path, monkeypatch, metadata):
+    home = tmp_path
+    md = _write_traj(
+        home / ".xskill", "cc_sessions", "traj_unknown_project",
+        cwd="/w/private",
+    )
+    sidecar = md.with_suffix(".json")
+    if metadata is None:
+        sidecar.unlink()
+    else:
+        sidecar.write_text(metadata, encoding="utf-8")
+    pol = pv.PrivacyPolicy()
+    pol.deny_project("/w/private")
+    pv.save_policy(pol, home / ".xskill" / "privacy.json")
+    collector = _collector(home)
+    monkeypatch.setattr(
+        collector,
+        "_read_trajectory_text",
+        lambda path: pytest.fail(f"不得读取无法判定项目的轨迹正文: {path}"),
+    )
+
+    assert collector.pending() == []
+
+
 # ── T10 CLI ────────────────────────────────────────────────────
 
 def test_cli_privacy_roundtrip(tmp_path, monkeypatch, capsys):
@@ -295,3 +323,20 @@ def test_cli_privacy_help_mentions_cursor_trae_limitation():
     help_text = sub.choices["privacy"].format_help()
     assert "Cursor 与 Trae" in help_text
     assert "deny-project" in help_text and "allow-trajectory" in help_text
+
+
+def test_python_module_entrypoint_can_run_privacy_command(tmp_path):
+    env = os.environ.copy()
+    env["HOME"] = str(tmp_path)
+    env["USERPROFILE"] = str(tmp_path)
+
+    completed = subprocess.run(
+        [sys.executable, "-m", "xskill.cli", "privacy", "list"],
+        capture_output=True,
+        text=True,
+        env=env,
+        timeout=15,
+    )
+
+    assert completed.returncode == 0, completed.stderr
+    assert "(no privacy rules)" in completed.stdout

--- a/tests/test_team_client_privacy.py
+++ b/tests/test_team_client_privacy.py
@@ -101,8 +101,11 @@ def test_deny_project_normalizes_relative_tilde_and_symlink(tmp_path, monkeypatc
     _write_traj(home / ".xskill", "cc_sessions", "traj_via_link", cwd=str(link))
     _write_traj(home / ".xskill", "cc_sessions", "traj_via_real", cwd=str(real))
 
-    # 用 ~ 与相对路径写规则，均应命中同一目录
+    # 用 ~ 与相对路径写规则，均应命中同一目录。
+    # Windows 上 os.path.expanduser 读 USERPROFILE 而非 HOME（Python ≥3.8），
+    # 两个都设，测试在三平台行为一致。
     monkeypatch.setenv("HOME", str(tmp_path))
+    monkeypatch.setenv("USERPROFILE", str(tmp_path))
     monkeypatch.chdir(tmp_path)
     pol = pv.PrivacyPolicy()
     changed, norm = pol.deny_project("~/real-proj")

--- a/tests/test_team_client_privacy.py
+++ b/tests/test_team_client_privacy.py
@@ -1,0 +1,294 @@
+"""
+test_team_client_privacy.py -- 客户端本地上传排除规则（issue #244）
+=================================================================
+
+对应 issue 验收标准：
+* 默认无规则时行为与当前一致（T1）
+* 按项目排除后，该项目已有及以后产生的轨迹均不进入上传（T2，含子目录、
+  符号链接、大小写、相对路径 / ~）
+* 按轨迹 id 排除后，仅该轨迹不进入上传（T3）
+* 排除判断完全在客户端、发生在读正文之前（T4：正文读取函数不被调用）
+* 被排除轨迹不被标记为已上传，且不写任何状态（T5）
+* 删除规则后可重新进入上传流程（T6）
+* 混合放行 / 排除的一批（T7）
+* Cursor / Trae 无 cwd 来源：项目规则不生效、轨迹规则生效（T8）
+* 规则文件损坏时明确失败，而不是当作无规则放行（T9）
+* CLI 五个子命令与 --json（T10）
+"""
+from __future__ import annotations
+
+import json
+import sys
+from pathlib import Path
+
+import pytest
+
+from xskill.team.client import privacy as pv
+from xskill.team.client.collector import TeamCollector
+
+# ── helpers ────────────────────────────────────────────────────────
+
+def _write_traj(bridge: Path, eco_dir: str, traj_id: str, *,
+                cwd: str | None, source: str = "claude_code_jsonl",
+                body: str = "# traj\n\nhello world\n") -> Path:
+    d = bridge / eco_dir
+    d.mkdir(parents=True, exist_ok=True)
+    md = d / f"{traj_id}.md"
+    md.write_text(body, encoding="utf-8")
+    meta = {"source": source, "session_id": traj_id}
+    if cwd is not None:
+        meta["cwd"] = cwd
+    md.with_suffix(".json").write_text(json.dumps(meta), encoding="utf-8")
+    return md
+
+
+def _collector(home: Path) -> TeamCollector:
+    """quiet_seconds=0 / min_change_interval=0：让闸门只剩隐私规则一道。
+    时钟用真实时间：mtime 静默判断是 ``now - mtime < quiet``，固定的假时钟
+    会让刚写的文件被当作「来自未来」而拦下。"""
+    import time as _time
+    xh = home / ".xskill"
+    xh.mkdir(parents=True, exist_ok=True)
+    return TeamCollector(
+        cursor_path=xh / "clients" / "srv" / "cursor.json",
+        quiet_seconds=0, min_change_interval=0,
+        home_root=home, time_fn=lambda: _time.time() + 1.0,
+        state_db_path=xh / "clients" / "srv" / "client_state.db",
+        privacy_path=xh / "privacy.json",
+    )
+
+
+def _pending_ids(c: TeamCollector) -> list[str]:
+    return sorted(p.traj_id for p in c.pending())
+
+
+# ── T1 默认行为不变 ─────────────────────────────────────────────
+
+def test_no_rules_uploads_everything(tmp_path):
+    home = tmp_path
+    _write_traj(home / ".xskill", "cc_sessions", "traj_cc_a", cwd="/w/proj-a")
+    _write_traj(home / ".xskill", "codex_sessions", "traj_codex_b", cwd="/w/proj-b")
+    c = _collector(home)
+    assert not (home / ".xskill" / "privacy.json").exists()
+    assert _pending_ids(c) == ["traj_cc_a", "traj_codex_b"]
+
+
+# ── T2 按项目排除 ───────────────────────────────────────────────
+
+def test_deny_project_excludes_dir_and_subdirs(tmp_path):
+    home = tmp_path
+    proj = tmp_path / "work" / "secret"
+    (proj / "backend").mkdir(parents=True)
+    _write_traj(home / ".xskill", "cc_sessions", "traj_root", cwd=str(proj))
+    _write_traj(home / ".xskill", "cc_sessions", "traj_sub", cwd=str(proj / "backend"))
+    _write_traj(home / ".xskill", "cc_sessions", "traj_other", cwd=str(tmp_path / "work" / "public"))
+    _write_traj(home / ".xskill", "cc_sessions", "traj_prefix_trap",
+                cwd=str(tmp_path / "work" / "secret-but-different"))  # 前缀相同的兄弟目录，不得误伤
+
+    pol = pv.PrivacyPolicy()
+    pol.deny_project(proj)
+    pv.save_policy(pol, home / ".xskill" / "privacy.json")
+
+    assert _pending_ids(_collector(home)) == ["traj_other", "traj_prefix_trap"]
+
+
+def test_deny_project_normalizes_relative_tilde_and_symlink(tmp_path, monkeypatch):
+    home = tmp_path
+    real = tmp_path / "real-proj"
+    real.mkdir()
+    link = tmp_path / "link-proj"
+    link.symlink_to(real, target_is_directory=True)
+    _write_traj(home / ".xskill", "cc_sessions", "traj_via_link", cwd=str(link))
+    _write_traj(home / ".xskill", "cc_sessions", "traj_via_real", cwd=str(real))
+
+    # 用 ~ 与相对路径写规则，均应命中同一目录
+    monkeypatch.setenv("HOME", str(tmp_path))
+    monkeypatch.chdir(tmp_path)
+    pol = pv.PrivacyPolicy()
+    changed, norm = pol.deny_project("~/real-proj")
+    assert changed
+    changed2, norm2 = pol.deny_project("./link-proj")   # 解析符号链接后与上一条相同
+    assert not changed2 and norm2 == norm
+    pv.save_policy(pol, home / ".xskill" / "privacy.json")
+
+    assert _pending_ids(_collector(home)) == []
+
+
+@pytest.mark.skipif(sys.platform not in ("darwin", "win32"),
+                    reason="仅在不区分大小写的平台上验证大小写不敏感匹配")
+def test_deny_project_case_insensitive_on_mac_win(tmp_path):
+    home = tmp_path
+    proj = tmp_path / "MixedCase"
+    proj.mkdir()
+    _write_traj(home / ".xskill", "cc_sessions", "traj_mc", cwd=str(tmp_path / "mixedcase"))
+    pol = pv.PrivacyPolicy(); pol.deny_project(proj)
+    pv.save_policy(pol, home / ".xskill" / "privacy.json")
+    assert _pending_ids(_collector(home)) == []
+
+
+# ── T3 按轨迹 id 排除 ───────────────────────────────────────────
+
+def test_deny_trajectory_excludes_only_that_one(tmp_path):
+    home = tmp_path
+    _write_traj(home / ".xskill", "cc_sessions", "traj_keep", cwd="/w/p")
+    _write_traj(home / ".xskill", "cc_sessions", "traj_drop", cwd="/w/p")
+    pol = pv.PrivacyPolicy(); pol.deny_trajectory("traj_drop")
+    pv.save_policy(pol, home / ".xskill" / "privacy.json")
+    assert _pending_ids(_collector(home)) == ["traj_keep"]
+
+
+# ── T4 判定发生在读正文之前 ─────────────────────────────────────
+
+def test_denied_trajectory_body_is_never_read(tmp_path, monkeypatch):
+    home = tmp_path
+    _write_traj(home / ".xskill", "cc_sessions", "traj_secret", cwd="/w/secret")
+    _write_traj(home / ".xskill", "cc_sessions", "traj_open", cwd="/w/open")
+    pol = pv.PrivacyPolicy(); pol.deny_project("/w/secret")
+    pv.save_policy(pol, home / ".xskill" / "privacy.json")
+
+    c = _collector(home)
+    read_ids: list[str] = []
+    orig = c._read_trajectory_text
+
+    def spy(md_path):
+        read_ids.append(md_path.stem)
+        return orig(md_path)
+
+    monkeypatch.setattr(c, "_read_trajectory_text", spy)
+    c.pending()
+    assert read_ids == ["traj_open"]     # 被排除的正文一次都没读
+
+
+# ── T5 不写状态 / 不标记为已上传 ─────────────────────────────────
+
+def test_denied_trajectory_leaves_no_state(tmp_path):
+    home = tmp_path
+    _write_traj(home / ".xskill", "cc_sessions", "traj_secret", cwd="/w/secret")
+    pol = pv.PrivacyPolicy(); pol.deny_project("/w/secret")
+    pv.save_policy(pol, home / ".xskill" / "privacy.json")
+    c = _collector(home)
+    c.pending()
+    assert c._state_store.get("traj_secret") is None
+
+
+# ── T6 删除规则后恢复上传 ───────────────────────────────────────
+
+def test_allow_after_deny_restores_upload(tmp_path):
+    home = tmp_path
+    _write_traj(home / ".xskill", "cc_sessions", "traj_x", cwd="/w/p")
+    ppath = home / ".xskill" / "privacy.json"
+    pol = pv.PrivacyPolicy(); pol.deny_trajectory("traj_x"); pv.save_policy(pol, ppath)
+    c = _collector(home)
+    assert _pending_ids(c) == []
+    pol = pv.load_policy(ppath); assert pol.allow_trajectory("traj_x"); pv.save_policy(pol, ppath)
+    assert _pending_ids(c) == ["traj_x"]      # 同一个 collector，下一轮即生效
+
+
+# ── T7 混合批次 ─────────────────────────────────────────────────
+
+def test_mixed_allow_deny_batch(tmp_path):
+    home = tmp_path
+    b = home / ".xskill"
+    _write_traj(b, "cc_sessions", "traj_a_ok", cwd="/w/a")
+    _write_traj(b, "cc_sessions", "traj_a_secret", cwd="/w/secret/x")
+    _write_traj(b, "codex_sessions", "traj_b_ok", cwd="/w/b")
+    _write_traj(b, "codex_sessions", "traj_b_denied_id", cwd="/w/b")
+    _write_traj(b, "openclaw_sessions", "traj_c_ok", cwd="/w/c")
+    pol = pv.PrivacyPolicy()
+    pol.deny_project("/w/secret"); pol.deny_trajectory("traj_b_denied_id")
+    pv.save_policy(pol, b / "privacy.json")
+    assert _pending_ids(_collector(home)) == ["traj_a_ok", "traj_b_ok", "traj_c_ok"]
+
+
+# ── T8 无 cwd 来源（Cursor / Trae） ──────────────────────────────
+
+def test_cursor_without_cwd_project_rule_does_not_apply_but_id_rule_does(tmp_path):
+    home = tmp_path
+    b = home / ".xskill"
+    _write_traj(b, "cursor_sessions", "traj_cursor_1", cwd=None, source="cursor_transcripts_jsonl")
+    _write_traj(b, "cursor_sessions", "traj_cursor_2", cwd=None, source="cursor_transcripts_jsonl")
+    pol = pv.PrivacyPolicy()
+    pol.deny_project("/w/anything")            # 项目规则：对无 cwd 的轨迹不生效
+    pol.deny_trajectory("traj_cursor_2")       # 轨迹规则：生效
+    pv.save_policy(pol, b / "privacy.json")
+    assert _pending_ids(_collector(home)) == ["traj_cursor_1"]
+    assert pv.source_lacks_cwd("cursor_transcripts_jsonl")
+    assert pv.source_lacks_cwd("trae_ide_session_json")
+    assert not pv.source_lacks_cwd("claude_code_jsonl")
+
+
+# ── T9 损坏的规则文件必须明确失败 ────────────────────────────────
+
+def test_corrupt_policy_file_fails_loud_not_silent_allow(tmp_path):
+    home = tmp_path
+    _write_traj(home / ".xskill", "cc_sessions", "traj_x", cwd="/w/p")
+    (home / ".xskill" / "privacy.json").write_text("{not json", encoding="utf-8")
+    with pytest.raises(ValueError):
+        _collector(home).pending()
+
+
+# ── T10 CLI ────────────────────────────────────────────────────
+
+def test_cli_privacy_roundtrip(tmp_path, monkeypatch, capsys):
+    import xskill.config as cfg
+    import xskill.team.client.privacy as pvm
+    from xskill import cli
+
+    xh = tmp_path / ".xskill"
+    monkeypatch.setattr(cfg, "XSKILL_HOME", xh)
+    monkeypatch.setattr(pvm, "default_privacy_path", lambda xskill_home=None: xh / "privacy.json")
+    _write_traj(xh, "cc_sessions", "traj_cc_backend_a1b2c3d4", cwd=str(tmp_path / "code" / "backend"))
+    _write_traj(xh, "cursor_sessions", "traj_cursor_unknown_9f8e7d6c", cwd=None,
+                source="cursor_transcripts_jsonl")
+    (tmp_path / "code" / "secret").mkdir(parents=True)
+
+    def run(*argv):
+        args = cli.build_parser().parse_args(["privacy", *argv])
+        rc = cli.cmd_privacy(args)
+        return rc, capsys.readouterr().out
+
+    rc, out = run("list")
+    assert rc == 0 and "(no privacy rules)" in out
+
+    rc, out = run("deny-project", str(tmp_path / "code" / "secret"))
+    assert rc == 0 and out.startswith("Denied project:")
+    assert "Cursor 或 Trae" in out                     # 提示无 cwd 来源
+
+    rc, out = run("deny-project", str(tmp_path / "code" / "secret"))
+    assert rc == 0 and out.startswith("Already denied:")
+
+    rc, out = run("deny-trajectory", "traj_cc_backend_a1b2c3d4")
+    assert rc == 0 and "Denied trajectory: traj_cc_backend_a1b2c3d4" in out
+    assert "来源: claude_code_jsonl" in out and "尚未上传" in out
+
+    rc, out = run("deny-trajectory", "traj_not_here")
+    assert rc == 0 and "规则已保存" in out           # 不存在的 id 仍保存（预设）
+
+    rc, out = run("list")
+    assert rc == 0
+    assert "项目排除规则 (1)" in out and "轨迹排除规则 (2)" in out
+    assert "共 1 条轨迹被排除上传" in out or "共 2 条轨迹被排除上传" in out
+
+    rc, out = run("list", "--json")
+    data = json.loads(out)
+    # JSON / 回显中给用户看的是保留大小写的展示路径，不是比较用的小写键
+    assert {p["path"] for p in data["projects"]} == {pv.canonical_project_path(tmp_path / "code" / "secret")}
+    assert {t["trajectory_id"] for t in data["trajectories"]} == {"traj_cc_backend_a1b2c3d4", "traj_not_here"}
+
+    rc, out = run("allow-trajectory", "traj_cc_backend_a1b2c3d4")
+    assert rc == 0 and out.startswith("Allowed trajectory:")
+    rc, out = run("allow-trajectory", "traj_cc_backend_a1b2c3d4")
+    assert rc == 1 and out.startswith("Not found:")
+    rc, out = run("allow-project", str(tmp_path / "code" / "secret"))
+    assert rc == 0 and out.startswith("Allowed project:")
+
+
+def test_cli_privacy_help_mentions_cursor_trae_limitation():
+    import argparse
+
+    from xskill import cli
+    p = cli.build_parser()
+    sub = next(a for a in p._actions if isinstance(a, argparse._SubParsersAction))
+    help_text = sub.choices["privacy"].format_help()
+    assert "Cursor 与 Trae" in help_text
+    assert "deny-project" in help_text and "allow-trajectory" in help_text

--- a/tests/test_team_client_privacy.py
+++ b/tests/test_team_client_privacy.py
@@ -92,10 +92,13 @@ def test_effective_mode_is_the_stricter_side(server_mode, local_mode, expected):
 
 
 def test_mode_origin_labels():
-    assert pv.mode_origin("allowlist", "denylist") == "server_forced"
+    assert pv.mode_origin("allowlist", "denylist") == "server_required"
+    assert pv.mode_origin("allowlist", "auto") == "server_required"
+    assert pv.mode_origin("allowlist", "allowlist") == "local"
     assert pv.mode_origin("denylist", "allowlist") == "local"
     assert pv.mode_origin("denylist", "auto") == "server_default"
     assert pv.mode_origin(None, "auto") == "server_missing"
+    assert pv.mode_origin(None, "auto", connected=False) == "disconnected"
 
 
 # ── 默认行为不变 ─────────────────────────────────────────────────
@@ -210,11 +213,21 @@ def test_no_cwd_and_broken_sidecar_follow_mode_default(tmp_path):
     assert _pending_ids(_collector(tmp_path, server_mode="allowlist")) == []
 
 
-def test_decide_reasons():
+def test_decide_reasons_follow_sidecar_facts_not_harness_name():
     policy = pv.PrivacyPolicy()
-    assert policy.decide(None, "cursor", "allowlist").reason == "no_cwd"
-    assert policy.decide(None, "claude_code", "allowlist").reason == "broken_sidecar"
-    assert policy.decide("/w/x", "claude_code", "denylist") == pv.Decision("upload", "default")
+    assert policy.decide(None, True, "allowlist").reason == "no_cwd"
+    assert policy.decide(None, False, "allowlist").reason == "broken_sidecar"
+    assert policy.decide("/w/x", True, "denylist") == pv.Decision("upload", "default")
+
+
+def test_readable_sidecar_with_empty_cwd_is_unattributed_not_broken(tmp_path):
+    bridge = tmp_path / ".xskill"
+    md_path = _write_traj(bridge, "dsh_sessions", "traj_dsh_a", cwd="")
+    assert json.loads(md_path.with_suffix(".json").read_text())["cwd"] == ""
+    rows, _complete = pv.scan_local_trajectories(bridge)
+    report = pv.build_report(pv.PrivacyPolicy(), "allowlist", rows)
+    assert report.no_cwd.traj == 1 and report.broken_sidecar.traj == 0
+    assert report.no_cwd.harnesses == ["deepseek_harness"]
 
 
 # ── 路径规范化 ───────────────────────────────────────────────────
@@ -294,7 +307,7 @@ def test_build_report_groups_by_rule_and_lists_unattributed(tmp_path):
     assert by_path[pv.canonical_project_path("/w/future")].traj == 0
     assert report.no_cwd.traj == 1 and report.no_cwd.effective == "skip"
     assert (report.upload, report.skip) == (2, 2)
-    assert report.to_dict()["mode_origin"] == "server_forced"
+    assert report.to_dict()["mode_origin"] == "server_required"
 
 
 def test_scan_respects_time_budget(tmp_path, monkeypatch):
@@ -373,6 +386,47 @@ def test_client_sync_adopts_server_mode_and_persists_it(team_app, tmp_path, monk
     assert load_client_state(state_path).server_privacy_mode == "denylist"
 
 
+def test_initial_sync_adopts_server_mode_before_first_upload(team_app, tmp_path, monkeypatch):
+    _set_server_config(monkeypatch, {"team": {"server": {"privacy_mode": "allowlist"}}})
+    http = TestClient(team_app)
+    reg = register_with_server_full(http, token="tok", label="a", hostname="h")
+    client_home = tmp_path / "client_home"
+    _write_traj(client_home / ".xskill", "cc_sessions", "traj_cc_a", cwd="/w/a")
+    team_client = TeamClient(
+        state=ClientState(server_url="http://testserver", client_id=reg["client_id"], join_token="tok"),
+        http=http, skill_dir=client_home / ".xskill" / "skill",
+        cursor_path=tmp_path / "cursor.json", history_path=tmp_path / "history.jsonl",
+        home_root=client_home, min_change_interval=0, auto_update=False,
+    )
+    uploads: list[int] = []
+    monkeypatch.setattr(team_client, "_tick", lambda: uploads.append(team_client.collect_and_upload()))
+    monkeypatch.setattr(team_client.collector, "start_ingesters", lambda: None)
+    monkeypatch.setattr(team_client.collector, "stop_ingesters", lambda: None)
+    original_wait = team_client._stop.wait
+    monkeypatch.setattr(team_client._stop, "wait", lambda timeout=None: team_client._stop.set() or original_wait(0))
+    team_client.run_forever()
+    assert team_client.collector.server_privacy_mode == "allowlist"
+    assert uploads == [0]
+
+
+def test_handshake_ignores_unknown_server_mode(tmp_path, monkeypatch):
+    import argparse
+    from xskill import cli
+    from xskill.team.client import daemon as daemon_module
+    monkeypatch.setattr(daemon_module, "register_with_server_full",
+                        lambda http, **kwargs: {"client_id": "c1", "privacy_mode": "whitelist"})
+    args = argparse.Namespace(address="127.0.0.1:1", token="t", label="", name=None, use_proxy=False)
+    state = cli._connect_handshake(args, tmp_path / "team_client.json")
+    assert state is not None and state.server_privacy_mode is None
+    assert load_client_state(tmp_path / "team_client.json").server_privacy_mode is None
+
+
+def test_collector_default_rules_path_matches_cli_default(tmp_path):
+    collector = TeamCollector(cursor_path=tmp_path / ".xskill" / "clients" / "s" / "cursor.json",
+                              home_root=tmp_path)
+    assert collector.privacy_path == pv.default_privacy_path(tmp_path / ".xskill")
+
+
 def test_old_state_file_without_mode_loads_as_none(tmp_path):
     state_path = tmp_path / "team_client.json"
     state_path.write_text(json.dumps({"server_url": "http://s", "client_id": "c", "join_token": "t"}))
@@ -415,6 +469,9 @@ def test_cli_status_and_mode_before_connect(cli_home, capsys):
 
     return_code, captured = _run_privacy(capsys, "mode")
     assert return_code == 0 and "生效: allowlist" in captured.out
+
+    return_code, captured = _run_privacy(capsys, "mode", "--json")
+    assert json.loads(captured.out)["mode_origin"] == "local"
 
     return_code, captured = _run_privacy(capsys, "status", "--json")
     payload = json.loads(captured.out)

--- a/tests/test_team_client_privacy.py
+++ b/tests/test_team_client_privacy.py
@@ -1,19 +1,16 @@
-"""
-test_team_client_privacy.py -- 客户端本地上传排除规则（issue #244）
-=================================================================
+"""test_team_client_privacy.py — 本机轨迹上传规则与模式（issue #244）
 
-对应 issue 验收标准：
-* 默认无规则时行为与当前一致（T1）
-* 按项目排除后，该项目已有及以后产生的轨迹均不进入上传（T2，含子目录、
-  符号链接、大小写、相对路径 / ~）
-* 按轨迹 id 排除后，仅该轨迹不进入上传（T3）
-* 排除判断完全在客户端、发生在读正文之前（T4：正文读取函数不被调用）
-* 被排除轨迹不被标记为已上传，且不写任何状态（T5）
-* 删除规则后可重新进入上传流程（T6）
-* 混合放行 / 排除的一批（T7）
-* Cursor / Trae 无 cwd 来源：项目规则不生效、轨迹规则生效（T8）
-* 规则文件损坏时明确失败，而不是当作无规则放行（T9）
-* CLI 五个子命令与 --json（T10）
+验收点：
+* server 与本机都不配置时，行为与当前版本一致（全部上传）
+* 生效模式取 server 与本机中更严者：本机 allowlist 不被 server denylist 放宽，
+  server allowlist 下本机 denylist 无效
+* allowlist 下无规则一条都不上传，且正文一次都不读、不留任何上传状态
+* 项目规则含子目录、符号链接、相对路径、~、大小写；子目录规则优先于父目录
+* Cursor / Trae 无 cwd 与 sidecar 损坏的轨迹按模式默认处理
+* 删除规则后可重新进入上传流程
+* server 改模式后下一轮 sync 生效并落盘，无需重新 connect
+* 规则文件损坏时明确失败，而不是当作无规则放行
+* CLI mode / status / allow / deny / clear / review 与 --json；review 非 TTY 退出码 2
 """
 from __future__ import annotations
 
@@ -21,322 +18,515 @@ import json
 import os
 import subprocess
 import sys
+import time
 from pathlib import Path
 
 import pytest
+from fastapi import FastAPI
+from fastapi.testclient import TestClient
 
 from xskill.team.client import privacy as pv
 from xskill.team.client.collector import TeamCollector
-
-# ── helpers ────────────────────────────────────────────────────────
-
-def _write_traj(bridge: Path, eco_dir: str, traj_id: str, *,
-                cwd: str | None, source: str = "claude_code_jsonl",
-                body: str = "# traj\n\nhello world\n") -> Path:
-    d = bridge / eco_dir
-    d.mkdir(parents=True, exist_ok=True)
-    md = d / f"{traj_id}.md"
-    md.write_text(body, encoding="utf-8")
-    meta = {"source": source, "session_id": traj_id}
-    if cwd is not None:
-        meta["cwd"] = cwd
-    md.with_suffix(".json").write_text(json.dumps(meta), encoding="utf-8")
-    return md
+from xskill.team.client.daemon import TeamClient, register_with_server_full
+from xskill.team.client.state import ClientState, load_client_state, save_client_state
+from xskill.team.server import api as server_api
+from xskill.team.server.client_registry import ClientRegistry
 
 
-def _collector(home: Path) -> TeamCollector:
-    """quiet_seconds=0 / min_change_interval=0：让闸门只剩隐私规则一道。
-    时钟用真实时间：mtime 静默判断是 ``now - mtime < quiet``，固定的假时钟
-    会让刚写的文件被当作「来自未来」而拦下。"""
-    import time as _time
-    xh = home / ".xskill"
-    xh.mkdir(parents=True, exist_ok=True)
-    return TeamCollector(
-        cursor_path=xh / "clients" / "srv" / "cursor.json",
-        quiet_seconds=0, min_change_interval=0,
-        home_root=home, time_fn=lambda: _time.time() + 1.0,
-        state_db_path=xh / "clients" / "srv" / "client_state.db",
-        privacy_path=xh / "privacy.json",
+def _write_traj(bridge: Path, eco_dir: str, traj_id: str, *, cwd: str | None,
+                sidecar: str | None = "ok", body: str = "# traj\n\nhello world\n") -> Path:
+    """sidecar="ok" 正常写；None 不写；"broken" 写坏 JSON。"""
+    bridge_dir = bridge / eco_dir
+    bridge_dir.mkdir(parents=True, exist_ok=True)
+    md_path = bridge_dir / f"{traj_id}.md"
+    md_path.write_text(body, encoding="utf-8")
+    if sidecar == "ok":
+        meta = {"session_id": traj_id, "model": "m"}
+        if cwd is not None:
+            meta["cwd"] = cwd
+        md_path.with_suffix(".json").write_text(json.dumps(meta), encoding="utf-8")
+    elif sidecar == "broken":
+        md_path.with_suffix(".json").write_text("{not json", encoding="utf-8")
+    old = time.time() - 600
+    os.utime(md_path, (old, old))
+    return md_path
+
+
+def _collector(home: Path, *, server_mode: str | None = None) -> TeamCollector:
+    xskill_home = home / ".xskill"
+    xskill_home.mkdir(parents=True, exist_ok=True)
+    collector = TeamCollector(
+        cursor_path=xskill_home / "clients" / "srv" / "cursor.json",
+        quiet_seconds=0, min_change_interval=0, home_root=home,
+        state_db_path=xskill_home / "clients" / "srv" / "client_state.db",
+        privacy_path=xskill_home / "privacy.json",
     )
+    collector.server_privacy_mode = server_mode
+    return collector
 
 
-def _pending_ids(c: TeamCollector) -> list[str]:
-    return sorted(p.traj_id for p in c.pending())
+def _pending_ids(collector: TeamCollector) -> list[str]:
+    return sorted(pending.traj_id for pending in collector.pending())
 
 
-# ── T1 默认行为不变 ─────────────────────────────────────────────
-
-def test_no_rules_uploads_everything(tmp_path):
-    home = tmp_path
-    _write_traj(home / ".xskill", "cc_sessions", "traj_cc_a", cwd="/w/proj-a")
-    _write_traj(home / ".xskill", "codex_sessions", "traj_codex_b", cwd="/w/proj-b")
-    c = _collector(home)
-    assert not (home / ".xskill" / "privacy.json").exists()
-    assert _pending_ids(c) == ["traj_cc_a", "traj_codex_b"]
+def _policy_with(home: Path, *, local_mode: str = "auto", **rules: str) -> Path:
+    policy = pv.PrivacyPolicy(local_mode=local_mode)
+    for path, rule in rules.items():
+        policy.set_project(path, rule)
+    return pv.save_policy(policy, home / ".xskill" / "privacy.json")
 
 
-# ── T2 按项目排除 ───────────────────────────────────────────────
+# ── 模式合成 ─────────────────────────────────────────────────────
 
-def test_deny_project_excludes_dir_and_subdirs(tmp_path):
-    home = tmp_path
-    proj = tmp_path / "work" / "secret"
-    (proj / "backend").mkdir(parents=True)
-    _write_traj(home / ".xskill", "cc_sessions", "traj_root", cwd=str(proj))
-    _write_traj(home / ".xskill", "cc_sessions", "traj_sub", cwd=str(proj / "backend"))
-    _write_traj(home / ".xskill", "cc_sessions", "traj_other", cwd=str(tmp_path / "work" / "public"))
-    _write_traj(home / ".xskill", "cc_sessions", "traj_prefix_trap",
-                cwd=str(tmp_path / "work" / "secret-but-different"))  # 前缀相同的兄弟目录，不得误伤
-
-    pol = pv.PrivacyPolicy()
-    pol.deny_project(proj)
-    pv.save_policy(pol, home / ".xskill" / "privacy.json")
-
-    assert _pending_ids(_collector(home)) == ["traj_other", "traj_prefix_trap"]
+@pytest.mark.parametrize("server_mode,local_mode,expected", [
+    (None, "auto", "denylist"),
+    ("denylist", "auto", "denylist"),
+    ("allowlist", "auto", "allowlist"),
+    ("denylist", "allowlist", "allowlist"),
+    ("allowlist", "denylist", "allowlist"),
+    (None, "allowlist", "allowlist"),
+    ("denylist", "denylist", "denylist"),
+])
+def test_effective_mode_is_the_stricter_side(server_mode, local_mode, expected):
+    assert pv.effective_mode(server_mode, local_mode) == expected
 
 
-def test_deny_project_normalizes_relative_tilde_and_symlink(tmp_path, monkeypatch):
-    home = tmp_path
-    real = tmp_path / "real-proj"
-    real.mkdir()
-    link = tmp_path / "link-proj"
+def test_mode_origin_labels():
+    assert pv.mode_origin("allowlist", "denylist") == "server_forced"
+    assert pv.mode_origin("denylist", "allowlist") == "local"
+    assert pv.mode_origin("denylist", "auto") == "server_default"
+    assert pv.mode_origin(None, "auto") == "server_missing"
+
+
+# ── 默认行为不变 ─────────────────────────────────────────────────
+
+def test_no_config_anywhere_uploads_everything_like_before(tmp_path):
+    bridge = tmp_path / ".xskill"
+    _write_traj(bridge, "cc_sessions", "traj_cc_a", cwd="/w/proj-a")
+    _write_traj(bridge, "codex_sessions", "traj_codex_b", cwd="/w/proj-b")
+    _write_traj(bridge, "cursor_sessions", "traj_cursor_c", cwd=None)
+    _write_traj(bridge, "cc_sessions", "traj_cc_broken", cwd=None, sidecar="broken")
+    _write_traj(bridge, "cc_sessions", "traj_cc_nosidecar", cwd=None, sidecar=None)
+    collector = _collector(tmp_path)
+    assert not (bridge / "privacy.json").exists()
+    assert _pending_ids(collector) == [
+        "traj_cc_a", "traj_cc_broken", "traj_cc_nosidecar", "traj_codex_b", "traj_cursor_c",
+    ]
+
+
+# ── allowlist ────────────────────────────────────────────────────
+
+def test_allowlist_without_rules_uploads_nothing_and_never_reads_body(tmp_path, monkeypatch):
+    bridge = tmp_path / ".xskill"
+    _write_traj(bridge, "cc_sessions", "traj_cc_a", cwd="/w/proj-a")
+    _write_traj(bridge, "cursor_sessions", "traj_cursor_c", cwd=None)
+    collector = _collector(tmp_path, server_mode="allowlist")
+    read_calls: list[Path] = []
+    original = TeamCollector._read_trajectory_text
+
+    def spy(self, md_path):
+        read_calls.append(md_path)
+        return original(self, md_path)
+
+    monkeypatch.setattr(TeamCollector, "_read_trajectory_text", spy)
+    assert _pending_ids(collector) == []
+    assert read_calls == []
+    assert collector._state_store.get("traj_cc_a") is None
+
+
+def test_allowlist_allow_project_covers_subdirs_only(tmp_path):
+    bridge = tmp_path / ".xskill"
+    _write_traj(bridge, "cc_sessions", "traj_cc_root", cwd="/w/proj")
+    _write_traj(bridge, "cc_sessions", "traj_cc_sub", cwd="/w/proj/backend/api")
+    _write_traj(bridge, "cc_sessions", "traj_cc_sibling", cwd="/w/proj-other")
+    _write_traj(bridge, "cc_sessions", "traj_cc_prefix", cwd="/w/project")
+    _policy_with(tmp_path, **{"/w/proj": "allow"})
+    collector = _collector(tmp_path, server_mode="allowlist")
+    assert _pending_ids(collector) == ["traj_cc_root", "traj_cc_sub"]
+
+
+def test_local_allowlist_is_not_loosened_by_server_denylist(tmp_path):
+    bridge = tmp_path / ".xskill"
+    _write_traj(bridge, "cc_sessions", "traj_cc_a", cwd="/w/proj-a")
+    _write_traj(bridge, "cc_sessions", "traj_cc_b", cwd="/w/proj-b")
+    _policy_with(tmp_path, local_mode="allowlist", **{"/w/proj-a": "allow"})
+    assert _pending_ids(_collector(tmp_path, server_mode="denylist")) == ["traj_cc_a"]
+    assert _pending_ids(_collector(tmp_path, server_mode=None)) == ["traj_cc_a"]
+
+
+def test_server_allowlist_overrides_local_denylist(tmp_path):
+    bridge = tmp_path / ".xskill"
+    _write_traj(bridge, "cc_sessions", "traj_cc_a", cwd="/w/proj-a")
+    _policy_with(tmp_path, local_mode="denylist")
+    assert _pending_ids(_collector(tmp_path, server_mode="allowlist")) == []
+
+
+# ── denylist ─────────────────────────────────────────────────────
+
+def test_denylist_deny_project_skips_only_that_tree(tmp_path):
+    bridge = tmp_path / ".xskill"
+    _write_traj(bridge, "cc_sessions", "traj_cc_secret", cwd="/w/secret")
+    _write_traj(bridge, "cc_sessions", "traj_cc_secret_sub", cwd="/w/secret/x")
+    _write_traj(bridge, "cc_sessions", "traj_cc_open", cwd="/w/open")
+    _write_traj(bridge, "cc_sessions", "traj_cc_lookalike", cwd="/w/secret-but-different")
+    _policy_with(tmp_path, **{"/w/secret": "deny"})
+    collector = _collector(tmp_path, server_mode="denylist")
+    assert _pending_ids(collector) == ["traj_cc_lookalike", "traj_cc_open"]
+    assert collector._state_store.get("traj_cc_secret") is None
+
+
+def test_subdir_rule_wins_over_parent_rule(tmp_path):
+    bridge = tmp_path / ".xskill"
+    _write_traj(bridge, "cc_sessions", "traj_cc_code", cwd="/w/code/app")
+    _write_traj(bridge, "cc_sessions", "traj_cc_secret", cwd="/w/code/secret/x")
+    _policy_with(tmp_path, **{"/w/code": "allow", "/w/code/secret": "deny"})
+    assert _pending_ids(_collector(tmp_path, server_mode="allowlist")) == ["traj_cc_code"]
+    assert _pending_ids(_collector(tmp_path, server_mode="denylist")) == ["traj_cc_code"]
+
+
+def test_clearing_rule_restores_upload_on_next_scan(tmp_path):
+    bridge = tmp_path / ".xskill"
+    _write_traj(bridge, "cc_sessions", "traj_cc_a", cwd="/w/proj-a")
+    policy_path = _policy_with(tmp_path, **{"/w/proj-a": "deny"})
+    collector = _collector(tmp_path, server_mode="denylist")
+    assert _pending_ids(collector) == []
+    policy = pv.load_policy(policy_path)
+    assert policy.clear_project("/w/proj-a")[0]
+    pv.save_policy(policy, policy_path)
+    assert _pending_ids(collector) == ["traj_cc_a"]
+
+
+# ── 无 cwd / sidecar 损坏 ────────────────────────────────────────
+
+def test_no_cwd_and_broken_sidecar_follow_mode_default(tmp_path):
+    bridge = tmp_path / ".xskill"
+    _write_traj(bridge, "cursor_sessions", "traj_cursor_c", cwd=None)
+    _write_traj(bridge, "trae_sessions", "traj_trae_t", cwd=None)
+    _write_traj(bridge, "cc_sessions", "traj_cc_broken", cwd=None, sidecar="broken")
+    _policy_with(tmp_path, **{"/w/anything": "allow"})
+    assert _pending_ids(_collector(tmp_path, server_mode="denylist")) == [
+        "traj_cc_broken", "traj_cursor_c", "traj_trae_t",
+    ]
+    assert _pending_ids(_collector(tmp_path, server_mode="allowlist")) == []
+
+
+def test_decide_reasons():
+    policy = pv.PrivacyPolicy()
+    assert policy.decide(None, "cursor", "allowlist").reason == "no_cwd"
+    assert policy.decide(None, "claude_code", "allowlist").reason == "broken_sidecar"
+    assert policy.decide("/w/x", "claude_code", "denylist") == pv.Decision("upload", "default")
+
+
+# ── 路径规范化 ───────────────────────────────────────────────────
+
+def test_rule_path_normalizes_relative_tilde_and_symlink(tmp_path, monkeypatch):
+    real = tmp_path / "home" / "code" / "proj"
+    real.mkdir(parents=True)
+    link = tmp_path / "home" / "link"
     link.symlink_to(real, target_is_directory=True)
-    _write_traj(home / ".xskill", "cc_sessions", "traj_via_link", cwd=str(link))
-    _write_traj(home / ".xskill", "cc_sessions", "traj_via_real", cwd=str(real))
-
-    # 用 ~ 与相对路径写规则，均应命中同一目录。
-    # Windows 上 os.path.expanduser 读 USERPROFILE 而非 HOME（Python ≥3.8），
-    # 两个都设，测试在三平台行为一致。
-    monkeypatch.setenv("HOME", str(tmp_path))
-    monkeypatch.setenv("USERPROFILE", str(tmp_path))
-    monkeypatch.chdir(tmp_path)
-    pol = pv.PrivacyPolicy()
-    changed, norm = pol.deny_project("~/real-proj")
-    assert changed
-    changed2, norm2 = pol.deny_project("./link-proj")   # 解析符号链接后与上一条相同
-    assert not changed2 and norm2 == norm
-    pv.save_policy(pol, home / ".xskill" / "privacy.json")
-
-    assert _pending_ids(_collector(home)) == []
+    monkeypatch.setenv("HOME", str(tmp_path / "home"))
+    monkeypatch.setenv("USERPROFILE", str(tmp_path / "home"))
+    monkeypatch.chdir(tmp_path / "home" / "code")
+    policy = pv.PrivacyPolicy()
+    changed, key = policy.set_project("proj", "deny")
+    assert changed and key == pv.normalize_project_path(real)
+    assert policy.decide(str(link / "sub"), "claude_code", "denylist").action == "skip"
+    assert policy.decide("~/code/proj", "claude_code", "denylist").action == "skip"
+    assert policy.set_project("~/link", "deny") == (False, key)
 
 
-@pytest.mark.skipif(sys.platform not in ("darwin", "win32"),
-                    reason="仅在不区分大小写的平台上验证大小写不敏感匹配")
-def test_deny_project_case_insensitive_on_mac_win(tmp_path):
-    home = tmp_path
-    proj = tmp_path / "MixedCase"
-    proj.mkdir()
-    _write_traj(home / ".xskill", "cc_sessions", "traj_mc", cwd=str(tmp_path / "mixedcase"))
-    pol = pv.PrivacyPolicy(); pol.deny_project(proj)
-    pv.save_policy(pol, home / ".xskill" / "privacy.json")
-    assert _pending_ids(_collector(home)) == []
+def test_case_insensitive_match_on_mac_and_windows(monkeypatch):
+    monkeypatch.setattr(pv, "_CASE_INSENSITIVE_FS", True)
+    policy = pv.PrivacyPolicy()
+    policy.set_project("/W/Proj", "deny")
+    assert policy.decide("/w/proj/Sub", "claude_code", "denylist").action == "skip"
+    assert policy.projects[pv.normalize_project_path("/W/Proj")].display.endswith("Proj")
 
 
-# ── T3 按轨迹 id 排除 ───────────────────────────────────────────
+# ── 规则文件 ─────────────────────────────────────────────────────
 
-def test_deny_trajectory_excludes_only_that_one(tmp_path):
-    home = tmp_path
-    _write_traj(home / ".xskill", "cc_sessions", "traj_keep", cwd="/w/p")
-    _write_traj(home / ".xskill", "cc_sessions", "traj_drop", cwd="/w/p")
-    pol = pv.PrivacyPolicy(); pol.deny_trajectory("traj_drop")
-    pv.save_policy(pol, home / ".xskill" / "privacy.json")
-    assert _pending_ids(_collector(home)) == ["traj_keep"]
-
-
-# ── T4 判定发生在读正文之前 ─────────────────────────────────────
-
-def test_denied_trajectory_body_is_never_read(tmp_path, monkeypatch):
-    home = tmp_path
-    _write_traj(home / ".xskill", "cc_sessions", "traj_secret", cwd="/w/secret")
-    _write_traj(home / ".xskill", "cc_sessions", "traj_open", cwd="/w/open")
-    pol = pv.PrivacyPolicy(); pol.deny_project("/w/secret")
-    pv.save_policy(pol, home / ".xskill" / "privacy.json")
-
-    c = _collector(home)
-    read_ids: list[str] = []
-    orig = c._read_trajectory_text
-
-    def spy(md_path):
-        read_ids.append(md_path.stem)
-        return orig(md_path)
-
-    monkeypatch.setattr(c, "_read_trajectory_text", spy)
-    c.pending()
-    assert read_ids == ["traj_open"]     # 被排除的正文一次都没读
-
-
-# ── T5 不写状态 / 不标记为已上传 ─────────────────────────────────
-
-def test_denied_trajectory_leaves_no_state(tmp_path):
-    home = tmp_path
-    _write_traj(home / ".xskill", "cc_sessions", "traj_secret", cwd="/w/secret")
-    pol = pv.PrivacyPolicy(); pol.deny_project("/w/secret")
-    pv.save_policy(pol, home / ".xskill" / "privacy.json")
-    c = _collector(home)
-    c.pending()
-    assert c._state_store.get("traj_secret") is None
-
-
-# ── T6 删除规则后恢复上传 ───────────────────────────────────────
-
-def test_allow_after_deny_restores_upload(tmp_path):
-    home = tmp_path
-    _write_traj(home / ".xskill", "cc_sessions", "traj_x", cwd="/w/p")
-    ppath = home / ".xskill" / "privacy.json"
-    pol = pv.PrivacyPolicy(); pol.deny_trajectory("traj_x"); pv.save_policy(pol, ppath)
-    c = _collector(home)
-    assert _pending_ids(c) == []
-    pol = pv.load_policy(ppath); assert pol.allow_trajectory("traj_x"); pv.save_policy(pol, ppath)
-    assert _pending_ids(c) == ["traj_x"]      # 同一个 collector，下一轮即生效
-
-
-# ── T7 混合批次 ─────────────────────────────────────────────────
-
-def test_mixed_allow_deny_batch(tmp_path):
-    home = tmp_path
-    b = home / ".xskill"
-    _write_traj(b, "cc_sessions", "traj_a_ok", cwd="/w/a")
-    _write_traj(b, "cc_sessions", "traj_a_secret", cwd="/w/secret/x")
-    _write_traj(b, "codex_sessions", "traj_b_ok", cwd="/w/b")
-    _write_traj(b, "codex_sessions", "traj_b_denied_id", cwd="/w/b")
-    _write_traj(b, "openclaw_sessions", "traj_c_ok", cwd="/w/c")
-    pol = pv.PrivacyPolicy()
-    pol.deny_project("/w/secret"); pol.deny_trajectory("traj_b_denied_id")
-    pv.save_policy(pol, b / "privacy.json")
-    assert _pending_ids(_collector(home)) == ["traj_a_ok", "traj_b_ok", "traj_c_ok"]
-
-
-# ── T8 无 cwd 来源（Cursor / Trae） ──────────────────────────────
-
-def test_cursor_without_cwd_project_rule_does_not_apply_but_id_rule_does(tmp_path):
-    home = tmp_path
-    b = home / ".xskill"
-    _write_traj(b, "cursor_sessions", "traj_cursor_1", cwd=None, source="cursor_transcripts_jsonl")
-    _write_traj(b, "cursor_sessions", "traj_cursor_2", cwd=None, source="cursor_transcripts_jsonl")
-    pol = pv.PrivacyPolicy()
-    pol.deny_project("/w/anything")            # 项目规则：对无 cwd 的轨迹不生效
-    pol.deny_trajectory("traj_cursor_2")       # 轨迹规则：生效
-    pv.save_policy(pol, b / "privacy.json")
-    assert _pending_ids(_collector(home)) == ["traj_cursor_1"]
-    assert pv.source_lacks_cwd("cursor_transcripts_jsonl")
-    assert pv.source_lacks_cwd("trae_ide_session_json")
-    assert not pv.source_lacks_cwd("claude_code_jsonl")
-
-
-# ── T9 损坏的规则文件必须明确失败 ────────────────────────────────
-
-def test_corrupt_policy_file_fails_loud_not_silent_allow(tmp_path):
-    home = tmp_path
-    _write_traj(home / ".xskill", "cc_sessions", "traj_x", cwd="/w/p")
-    (home / ".xskill" / "privacy.json").write_text("{not json", encoding="utf-8")
+def test_policy_roundtrip_and_corrupt_file_fails_loud(tmp_path):
+    policy_path = tmp_path / "privacy.json"
+    policy = pv.PrivacyPolicy(local_mode="allowlist")
+    policy.set_project("/w/a", "allow")
+    policy.set_project("/w/b", "deny")
+    pv.save_policy(policy, policy_path)
+    loaded = pv.load_policy(policy_path)
+    assert loaded.local_mode == "allowlist"
+    assert {key: rule.rule for key, rule in loaded.projects.items()} == {
+        pv.normalize_project_path("/w/a"): "allow", pv.normalize_project_path("/w/b"): "deny",
+    }
+    policy_path.write_text("{oops", encoding="utf-8")
     with pytest.raises(ValueError):
-        _collector(home).pending()
+        pv.load_policy(policy_path)
+    policy_path.write_text(json.dumps({"mode": "sometimes"}), encoding="utf-8")
+    with pytest.raises(ValueError):
+        pv.load_policy(policy_path)
 
 
-@pytest.mark.parametrize("metadata", [None, "{not json"])
-def test_project_rules_fail_closed_when_cwd_metadata_is_unreadable(
-        tmp_path, monkeypatch, metadata):
-    home = tmp_path
-    md = _write_traj(
-        home / ".xskill", "cc_sessions", "traj_unknown_project",
-        cwd="/w/private",
+def test_corrupt_policy_stops_collector_instead_of_uploading(tmp_path):
+    bridge = tmp_path / ".xskill"
+    _write_traj(bridge, "cc_sessions", "traj_cc_a", cwd="/w/proj-a")
+    bridge.mkdir(exist_ok=True)
+    (bridge / "privacy.json").write_text("{oops", encoding="utf-8")
+    with pytest.raises(ValueError):
+        _collector(tmp_path).pending()
+
+
+# ── 报表归组 ─────────────────────────────────────────────────────
+
+def test_build_report_groups_by_rule_and_lists_unattributed(tmp_path):
+    bridge = tmp_path / ".xskill"
+    _write_traj(bridge, "cc_sessions", "traj_cc_a1", cwd="/w/a/x")
+    _write_traj(bridge, "codex_sessions", "traj_codex_a2", cwd="/w/a/y")
+    _write_traj(bridge, "cc_sessions", "traj_cc_b", cwd="/w/b")
+    _write_traj(bridge, "cursor_sessions", "traj_cursor_c", cwd=None)
+    policy = pv.PrivacyPolicy()
+    policy.set_project("/w/a", "allow")
+    policy.set_project("/w/future", "deny")
+    rows, complete = pv.scan_local_trajectories(bridge)
+    assert complete and len(rows) == 4
+    report = pv.build_report(policy, "allowlist", rows)
+    by_path = {summary.path: summary for summary in report.projects}
+    assert by_path[pv.canonical_project_path("/w/a")].traj == 2
+    assert by_path[pv.canonical_project_path("/w/a")].harnesses == ["claude_code", "codex"]
+    assert by_path[pv.canonical_project_path("/w/b")].effective == "skip"
+    assert by_path[pv.canonical_project_path("/w/future")].traj == 0
+    assert report.no_cwd.traj == 1 and report.no_cwd.effective == "skip"
+    assert (report.upload, report.skip) == (2, 2)
+    assert report.to_dict()["mode_origin"] == "server_forced"
+
+
+def test_scan_respects_time_budget(tmp_path, monkeypatch):
+    bridge = tmp_path / ".xskill"
+    for index in range(3):
+        _write_traj(bridge, "cc_sessions", f"traj_cc_{index}", cwd="/w/a")
+    ticks = iter([0.0, 0.0, 10.0, 10.0, 10.0])
+    monkeypatch.setattr(pv.time, "monotonic", lambda: next(ticks))
+    rows, complete = pv.scan_local_trajectories(bridge, time_budget_seconds=1.0)
+    assert not complete and len(rows) == 1
+
+
+# ── server 下发与热切换 ──────────────────────────────────────────
+
+@pytest.fixture
+def team_app(tmp_path):
+    skill_dir = tmp_path / "skill"
+    skill_dir.mkdir()
+    server_api.init_team_context(
+        join_token="tok", client_registry=ClientRegistry(tmp_path / "clients.db"),
+        skill_dir=skill_dir, traj_root=tmp_path / "team_traj",
+        register_dir=lambda path, label: None,
     )
-    sidecar = md.with_suffix(".json")
-    if metadata is None:
-        sidecar.unlink()
-    else:
-        sidecar.write_text(metadata, encoding="utf-8")
-    pol = pv.PrivacyPolicy()
-    pol.deny_project("/w/private")
-    pv.save_policy(pol, home / ".xskill" / "privacy.json")
-    collector = _collector(home)
-    monkeypatch.setattr(
-        collector,
-        "_read_trajectory_text",
-        lambda path: pytest.fail(f"不得读取无法判定项目的轨迹正文: {path}"),
+    app = FastAPI()
+    app.include_router(server_api.router)
+    return app
+
+
+def _set_server_config(monkeypatch, cfg: dict | None):
+    from xskill.api import app as app_mod
+    monkeypatch.setattr(app_mod, "_config", cfg)
+
+
+def test_register_and_sync_report_server_mode_without_restart(team_app, monkeypatch):
+    _set_server_config(monkeypatch, {"team": {"server": {}}})
+    http = TestClient(team_app)
+    reg = register_with_server_full(http, token="tok", label="a", hostname="h")
+    assert reg["privacy_mode"] == "denylist"
+    headers = {"X-Xskill-Token": "tok", "X-Xskill-Client": reg["client_id"]}
+    assert http.get("/api/v1/team/sync", headers=headers).json()["privacy_mode"] == "denylist"
+    from xskill.api import app as app_mod
+    app_mod._config["team"]["server"]["privacy_mode"] = "allowlist"
+    assert http.get("/api/v1/team/sync", headers=headers).json()["privacy_mode"] == "allowlist"
+    reg_again = register_with_server_full(http, token="tok", label="a", hostname="h")
+    assert reg_again["privacy_mode"] == "allowlist"
+
+
+def test_team_privacy_mode_config_validation():
+    from xskill.config import team_privacy_mode
+    assert team_privacy_mode(None) == "denylist"
+    assert team_privacy_mode({"team": {"server": {"privacy_mode": "allowlist"}}}) == "allowlist"
+    with pytest.raises(ValueError):
+        team_privacy_mode({"team": {"server": {"privacy_mode": "whitelist"}}})
+
+
+def test_client_sync_adopts_server_mode_and_persists_it(team_app, tmp_path, monkeypatch):
+    _set_server_config(monkeypatch, {"team": {"server": {"privacy_mode": "allowlist"}}})
+    http = TestClient(team_app)
+    reg = register_with_server_full(http, token="tok", label="a", hostname="h")
+    state_path = tmp_path / "client_home" / ".xskill" / "team_client.json"
+    state = ClientState(server_url="http://testserver", client_id=reg["client_id"],
+                        join_token="tok", server_privacy_mode=reg["privacy_mode"])
+    save_client_state(state, state_path)
+    assert load_client_state(state_path).server_privacy_mode == "allowlist"
+    team_client = TeamClient(
+        state=state, http=http, skill_dir=tmp_path / "client_home" / ".xskill" / "skill",
+        cursor_path=tmp_path / "cursor.json", history_path=tmp_path / "history.jsonl",
+        home_root=tmp_path / "client_home", min_change_interval=0, state_path=state_path,
     )
+    assert team_client.collector.server_privacy_mode == "allowlist"
+    from xskill.api import app as app_mod
+    app_mod._config["team"]["server"]["privacy_mode"] = "denylist"
+    team_client.sync()
+    assert team_client.state.server_privacy_mode == "denylist"
+    assert team_client.collector.server_privacy_mode == "denylist"
+    assert load_client_state(state_path).server_privacy_mode == "denylist"
 
-    assert collector.pending() == []
+
+def test_old_state_file_without_mode_loads_as_none(tmp_path):
+    state_path = tmp_path / "team_client.json"
+    state_path.write_text(json.dumps({"server_url": "http://s", "client_id": "c", "join_token": "t"}))
+    assert load_client_state(state_path).server_privacy_mode is None
 
 
-# ── T10 CLI ────────────────────────────────────────────────────
+# ── CLI ──────────────────────────────────────────────────────────
 
-def test_cli_privacy_roundtrip(tmp_path, monkeypatch, capsys):
+@pytest.fixture
+def cli_home(tmp_path, monkeypatch):
     import xskill.config as cfg
-    import xskill.team.client.privacy as pvm
-    from xskill import cli
-
-    xh = tmp_path / ".xskill"
-    monkeypatch.setattr(cfg, "XSKILL_HOME", xh)
-    monkeypatch.setattr(pvm, "default_privacy_path", lambda xskill_home=None: xh / "privacy.json")
-    _write_traj(xh, "cc_sessions", "traj_cc_backend_a1b2c3d4", cwd=str(tmp_path / "code" / "backend"))
-    _write_traj(xh, "cursor_sessions", "traj_cursor_unknown_9f8e7d6c", cwd=None,
-                source="cursor_transcripts_jsonl")
+    xskill_home = tmp_path / ".xskill"
+    xskill_home.mkdir()
+    monkeypatch.setattr(cfg, "XSKILL_HOME", xskill_home)
+    _write_traj(xskill_home, "cc_sessions", "traj_cc_backend", cwd=str(tmp_path / "code" / "backend"))
+    _write_traj(xskill_home, "cc_sessions", "traj_cc_secret", cwd=str(tmp_path / "code" / "secret"))
+    _write_traj(xskill_home, "cursor_sessions", "traj_cursor_x", cwd=None)
+    (tmp_path / "code" / "backend").mkdir(parents=True)
     (tmp_path / "code" / "secret").mkdir(parents=True)
-
-    def run(*argv):
-        args = cli.build_parser().parse_args(["privacy", *argv])
-        rc = cli.cmd_privacy(args)
-        return rc, capsys.readouterr().out
-
-    rc, out = run("list")
-    assert rc == 0 and "(no privacy rules)" in out
-
-    rc, out = run("deny-project", str(tmp_path / "code" / "secret"))
-    assert rc == 0 and out.startswith("Denied project:")
-    assert "Cursor 或 Trae" in out                     # 提示无 cwd 来源
-
-    rc, out = run("deny-project", str(tmp_path / "code" / "secret"))
-    assert rc == 0 and out.startswith("Already denied:")
-
-    rc, out = run("deny-trajectory", "traj_cc_backend_a1b2c3d4")
-    assert rc == 0 and "Denied trajectory: traj_cc_backend_a1b2c3d4" in out
-    assert "来源: claude_code_jsonl" in out and "尚未上传" in out
-
-    rc, out = run("deny-trajectory", "traj_not_here")
-    assert rc == 0 and "规则已保存" in out           # 不存在的 id 仍保存（预设）
-
-    rc, out = run("list")
-    assert rc == 0
-    assert "项目排除规则 (1)" in out and "轨迹排除规则 (2)" in out
-    assert "共 1 条轨迹被排除上传" in out or "共 2 条轨迹被排除上传" in out
-
-    rc, out = run("list", "--json")
-    data = json.loads(out)
-    # JSON / 回显中给用户看的是保留大小写的展示路径，不是比较用的小写键
-    assert {p["path"] for p in data["projects"]} == {pv.canonical_project_path(tmp_path / "code" / "secret")}
-    assert {t["trajectory_id"] for t in data["trajectories"]} == {"traj_cc_backend_a1b2c3d4", "traj_not_here"}
-
-    rc, out = run("allow-trajectory", "traj_cc_backend_a1b2c3d4")
-    assert rc == 0 and out.startswith("Allowed trajectory:")
-    rc, out = run("allow-trajectory", "traj_cc_backend_a1b2c3d4")
-    assert rc == 1 and out.startswith("Not found:")
-    rc, out = run("allow-project", str(tmp_path / "code" / "secret"))
-    assert rc == 0 and out.startswith("Allowed project:")
+    return tmp_path
 
 
-def test_cli_privacy_help_mentions_cursor_trae_limitation():
-    import argparse
-
+def _run_privacy(capsys, *argv):
     from xskill import cli
-    p = cli.build_parser()
-    sub = next(a for a in p._actions if isinstance(a, argparse._SubParsersAction))
-    help_text = sub.choices["privacy"].format_help()
+    args = cli.build_parser().parse_args(["privacy", *argv])
+    return cli.cmd_privacy(args), capsys.readouterr()
+
+
+def test_cli_status_and_mode_before_connect(cli_home, capsys):
+    return_code, captured = _run_privacy(capsys, "status")
+    assert return_code == 0
+    assert "mode: denylist（未连接 server；server (未连接)）" in captured.out
+    assert "上传 3 条，不上传 0 条。" in captured.out
+    assert "Cursor / Trae" in captured.out
+
+    return_code, captured = _run_privacy(capsys, "mode", "allowlist")
+    assert return_code == 0
+    assert captured.out.startswith("Mode: allowlist（本机设置；server 当前 (未连接)，生效 allowlist）")
+    assert "已放行 0 个项目" in captured.out
+
+    return_code, captured = _run_privacy(capsys, "mode")
+    assert return_code == 0 and "生效: allowlist" in captured.out
+
+    return_code, captured = _run_privacy(capsys, "status", "--json")
+    payload = json.loads(captured.out)
+    assert payload["mode"] == "allowlist" and payload["mode_origin"] == "local"
+    assert (payload["upload"], payload["skip"]) == (0, 3)
+    assert payload["unattributed"]["traj"] == 1
+
+
+def test_cli_allow_deny_clear_roundtrip(cli_home, capsys, monkeypatch):
+    backend = cli_home / "code" / "backend"
+    secret = cli_home / "code" / "secret"
+    _run_privacy(capsys, "mode", "allowlist")
+
+    monkeypatch.chdir(backend)
+    return_code, captured = _run_privacy(capsys, "allow")
+    assert return_code == 0
+    assert captured.out.startswith(f"Allowed: {pv.canonical_project_path(backend)}")
+    assert "含已有的 1 条" in captured.out and "Cursor / Trae" in captured.out
+
+    return_code, captured = _run_privacy(capsys, "allow", str(backend))
+    assert return_code == 0 and captured.out.startswith("Already allowed:")
+
+    return_code, captured = _run_privacy(capsys, "deny", str(secret))
+    assert return_code == 0
+    assert captured.out.startswith(f"Denied: {pv.canonical_project_path(secret)}")
+    assert "本来就不上传" in captured.out and "已上传过" not in captured.out
+
+    return_code, captured = _run_privacy(capsys, "allow", str(cli_home / "code" / "future"))
+    assert return_code == 0 and "该目录当前不存在" in captured.out
+
+    return_code, captured = _run_privacy(capsys, "status")
+    assert "allow" in captured.out and "deny" in captured.out
+    assert "上传 1 条，不上传 2 条。" in captured.out
+
+    return_code, captured = _run_privacy(capsys, "clear", str(secret), "--json")
+    assert return_code == 0 and json.loads(captured.out)["status"] == "cleared"
+    return_code, captured = _run_privacy(capsys, "clear", str(secret))
+    assert return_code == 1 and captured.out.startswith("Not found:")
+
+    policy = pv.load_policy(cli_home / ".xskill" / "privacy.json")
+    assert policy.local_mode == "allowlist"
+    assert {rule.rule for rule in policy.projects.values()} == {"allow"}
+
+
+def test_cli_deny_reports_previously_uploaded_count(cli_home, capsys):
+    from xskill.team.client.upload_state import TrajectoryUploadStateStore
+    store = TrajectoryUploadStateStore(
+        db_path=cli_home / ".xskill" / "clients" / "srv" / "client_state.db",
+        legacy_cursor_path=cli_home / ".xskill" / "clients" / "srv" / "cursor.json",
+        home_root=cli_home,
+    )
+    md_path = cli_home / ".xskill" / "cc_sessions" / "traj_cc_secret.md"
+    stat = md_path.stat()
+    store.record_seen_file(
+        trajectory_id="traj_cc_secret", file_path=str(md_path), harness_name="claude_code",
+        model_name="m", file_size_bytes=stat.st_size,
+        file_modified_time_nanoseconds=stat.st_mtime_ns,
+        file_changed_time_nanoseconds=stat.st_ctime_ns,
+        original_content_hash="raw", cleaned_content_hash="clean",
+    )
+    store.mark_uploaded("traj_cc_secret", "clean")
+    return_code, captured = _run_privacy(capsys, "deny", str(cli_home / "code" / "secret"))
+    assert return_code == 0 and "其中 1 条此前已上传过" in captured.out
+
+
+def test_cli_mode_rejects_unknown_value_and_review_needs_tty(cli_home, capsys, monkeypatch):
+    return_code, captured = _run_privacy(capsys, "mode", "whitelist")
+    assert return_code == 2 and "mode 只能是" in captured.err
+    monkeypatch.setattr(sys.stdin, "isatty", lambda: False)
+    return_code, captured = _run_privacy(capsys, "review")
+    assert return_code == 2 and "交互式终端" in captured.err
+
+
+def test_cli_review_applies_choices(cli_home, capsys, monkeypatch):
+    monkeypatch.setattr(sys.stdin, "isatty", lambda: True)
+    monkeypatch.setattr(sys.stdout, "isatty", lambda: True)
+    answers = iter(["a", "d"])
+    monkeypatch.setattr("builtins.input", lambda prompt="": next(answers))
+    return_code, captured = _run_privacy(capsys, "review")
+    assert return_code == 0
+    assert "完成：放行 1 个，排除 1 个，保持不变 0 个。" in captured.out
+    policy = pv.load_policy(cli_home / ".xskill" / "privacy.json")
+    assert sorted(rule.rule for rule in policy.projects.values()) == ["allow", "deny"]
+
+
+def test_cli_corrupt_rules_file_errors_out(cli_home, capsys):
+    (cli_home / ".xskill" / "privacy.json").write_text("{oops", encoding="utf-8")
+    return_code, captured = _run_privacy(capsys, "status")
+    assert return_code == 2 and "cannot read privacy rules" in captured.err
+
+
+def test_cli_help_explains_modes():
+    import argparse
+    from xskill import cli
+    parser = cli.build_parser()
+    subparsers = next(action for action in parser._actions
+                      if isinstance(action, argparse._SubParsersAction))
+    help_text = subparsers.choices["privacy"].format_help()
+    assert "allowlist" in help_text and "denylist" in help_text
     assert "Cursor 与 Trae" in help_text
-    assert "deny-project" in help_text and "allow-trajectory" in help_text
+    connect_help = subparsers.choices["connect"].format_help()
+    assert "--privacy" in connect_help
 
 
-def test_python_module_entrypoint_can_run_privacy_command(tmp_path):
+def test_python_module_entrypoint_runs_privacy_status(tmp_path):
     env = os.environ.copy()
     env["HOME"] = str(tmp_path)
     env["USERPROFILE"] = str(tmp_path)
-
     completed = subprocess.run(
-        [sys.executable, "-m", "xskill.cli", "privacy", "list"],
-        capture_output=True,
-        text=True,
-        env=env,
-        timeout=15,
+        [sys.executable, "-m", "xskill.cli", "privacy", "status"],
+        capture_output=True, text=True, env=env, timeout=30,
     )
-
     assert completed.returncode == 0, completed.stderr
-    assert "(no privacy rules)" in completed.stdout
+    assert "mode: denylist" in completed.stdout
+    assert "(本机尚未发现任何轨迹)" in completed.stdout

--- a/tests/test_team_client_privacy.py
+++ b/tests/test_team_client_privacy.py
@@ -580,13 +580,14 @@ def test_python_module_entrypoint_runs_privacy_status(tmp_path):
     env = os.environ.copy()
     env["HOME"] = str(tmp_path)
     env["USERPROFILE"] = str(tmp_path)
+    env["PYTHONIOENCODING"] = "cp1252"
     completed = subprocess.run(
-        [sys.executable, "-m", "xskill.cli", "privacy", "status"],
+        [sys.executable, "-m", "xskill.cli", "privacy", "status"],  # cp1252 模拟 Windows 控制台
         capture_output=True, text=True, env=env, timeout=30,
     )
     assert completed.returncode == 0, completed.stderr
     assert "mode: denylist" in completed.stdout
-    assert "(本机尚未发现任何轨迹)" in completed.stdout
+    assert "PROJECT" not in completed.stdout, "空 HOME 不应打印项目表"
 
 
 # ── review 修补：损坏规则不拖垮整轮 tick、status 文本可见、热重载校验 ───

--- a/tests/test_team_client_privacy.py
+++ b/tests/test_team_client_privacy.py
@@ -530,3 +530,51 @@ def test_python_module_entrypoint_runs_privacy_status(tmp_path):
     assert completed.returncode == 0, completed.stderr
     assert "mode: denylist" in completed.stdout
     assert "(本机尚未发现任何轨迹)" in completed.stdout
+
+
+# ── review 修补：损坏规则不拖垮整轮 tick、status 文本可见、热重载校验 ───
+
+def test_corrupt_rules_pause_uploads_but_not_the_rest_of_the_tick(team_app, tmp_path, monkeypatch, caplog):
+    import logging
+    _set_server_config(monkeypatch, {"team": {"server": {}}})
+    http = TestClient(team_app)
+    reg = register_with_server_full(http, token="tok", label="a", hostname="h")
+    client_home = tmp_path / "client_home"
+    _write_traj(client_home / ".xskill", "cc_sessions", "traj_cc_a", cwd="/w/a")
+    (client_home / ".xskill" / "privacy.json").write_text("{oops", encoding="utf-8")
+    team_client = TeamClient(
+        state=ClientState(server_url="http://testserver", client_id=reg["client_id"], join_token="tok"),
+        http=http, skill_dir=client_home / ".xskill" / "skill",
+        cursor_path=tmp_path / "cursor.json", history_path=tmp_path / "history.jsonl",
+        home_root=client_home, min_change_interval=0,
+    )
+    with caplog.at_level(logging.ERROR):
+        assert team_client.collect_and_upload() == 0
+    assert any("privacy rules unreadable" in record.message for record in caplog.records)
+    assert team_client.sync().privacy_mode == "denylist"
+
+
+def test_status_text_reports_corrupt_rules(cli_home, capsys, monkeypatch):
+    from xskill import cli
+    from xskill.team.client import service
+
+    class FakeBackend:
+        def status(self):
+            return {"running": False, "installed": False, "backend": "fake"}
+
+    monkeypatch.setattr(service, "get_backend", lambda: FakeBackend())
+    (cli_home / ".xskill" / "privacy.json").write_text("{oops", encoding="utf-8")
+    assert cli.cmd_status(cli.build_parser().parse_args(["status"])) == 0
+    out = capsys.readouterr().out
+    assert "privacy  : 规则文件损坏" in out
+    (cli_home / ".xskill" / "privacy.json").unlink()
+    assert cli.cmd_status(cli.build_parser().parse_args(["status"])) == 0
+    out = capsys.readouterr().out
+    assert "privacy  : denylist (未连接 server; server (未连接))" in out
+
+
+def test_dashboard_config_reload_rejects_bad_privacy_mode():
+    from xskill.dashboard.console import _validate_config_text
+    with pytest.raises(ValueError, match="privacy_mode"):
+        _validate_config_text("team:\n  server:\n    privacy_mode: whitelist\n")
+    assert _validate_config_text("team:\n  server:\n    privacy_mode: allowlist\n")["team"]["server"]["privacy_mode"] == "allowlist"

--- a/tests/test_team_client_privacy.py
+++ b/tests/test_team_client_privacy.py
@@ -627,7 +627,44 @@ def test_status_text_reports_corrupt_rules(cli_home, capsys, monkeypatch):
     (cli_home / ".xskill" / "privacy.json").unlink()
     assert cli.cmd_status(cli.build_parser().parse_args(["status"])) == 0
     out = capsys.readouterr().out
-    assert "privacy  : denylist (未连接 server; server (未连接))" in out
+    assert "privacy" not in out, "无规则且生效 denylist 的用户，status 输出应与升级前一致"
+    assert cli.cmd_status(cli.build_parser().parse_args(["status", "--json"])) == 0
+    assert json.loads(capsys.readouterr().out)["privacy"]["mode"] == "denylist"
+    _run_privacy(capsys, "mode", "allowlist")
+    assert cli.cmd_status(cli.build_parser().parse_args(["status"])) == 0
+    assert "privacy  : allowlist (本机设置; server (未连接))" in capsys.readouterr().out
+
+
+def test_connect_privacy_flag_sets_local_mode_and_prints_summary(cli_home, capsys, monkeypatch):
+    from xskill import cli
+    from xskill.team.client import service
+
+    class FakeBackend:
+        supported = True
+
+        def install_and_start(self):
+            return {"task_name": "fake", "pid": 1}
+
+    monkeypatch.setattr(service, "get_backend", lambda: FakeBackend())
+    monkeypatch.setattr(cli, "_connect_handshake", lambda args, state_path: ClientState(
+        server_url="http://s", client_id="c", join_token="t", server_privacy_mode="denylist"))
+    args = cli.build_parser().parse_args(
+        ["connect", "127.0.0.1:1", "--token", "t", "--no-skill", "--privacy", "allowlist"])
+    assert cli.cmd_connect(args) == 0
+    out = capsys.readouterr().out
+    assert "privacy: allowlist（本机设置；默认不上传，只上传你放行的项目）" in out
+    assert "共 3 条轨迹，当前全部不会上传" in out
+    assert "background task started: fake" in out
+    assert pv.load_policy(cli_home / ".xskill" / "privacy.json").local_mode == "allowlist"
+
+
+def test_register_and_sync_fall_back_to_denylist_on_bad_config(team_app, monkeypatch):
+    _set_server_config(monkeypatch, {"team": {"server": {"privacy_mode": "whitelist"}}})
+    http = TestClient(team_app)
+    reg = register_with_server_full(http, token="tok", label="a", hostname="h")
+    assert reg["privacy_mode"] == "denylist"
+    headers = {"X-Xskill-Token": "tok", "X-Xskill-Client": reg["client_id"]}
+    assert http.get("/api/v1/team/sync", headers=headers).json()["privacy_mode"] == "denylist"
 
 
 def test_dashboard_config_reload_rejects_bad_privacy_mode():

--- a/tests/test_team_sync_profile.py
+++ b/tests/test_team_sync_profile.py
@@ -178,7 +178,7 @@ def test_sync_returns_before_uncached_embedding_finishes(team_runtime):
 
     assert response.status_code == 200
     assert set(response.json()) == {
-        "slots", "server_time", "server_slots", "take_n",
+        "slots", "server_time", "server_slots", "take_n", "privacy_mode",
     }
     assert embed.started.wait(2)
     assert engine.profile_store.load(client_id) is None
@@ -381,7 +381,7 @@ def test_thirty_clients_return_while_embedding_is_bounded(tmp_path, monkeypatch)
         assert not not_done, f"{len(not_done)} sync calls did not return"
         responses = [future.result() for future in done]
         assert all(
-            set(response) == {"slots", "server_time", "server_slots", "take_n"}
+            set(response) == {"slots", "server_time", "server_slots", "take_n", "privacy_mode"}
             for response in responses
         )
         assert embed.started.wait(2)


### PR DESCRIPTION
## Summary

实现 #244 定稿方案（[设计评论](https://github.com/SkillNerds/xskill/issues/244#issuecomment-5578931795)）：客户端按项目目录记 allow / deny，没写规则的项目按生效模式处理；模式 server 与本机各一个，**生效取更严者**（allowlist 严于 denylist）。

**现有用户升级后不动配置，行为与升级前一致**：server 默认 denylist、本机默认 auto，全部上传；`xskill connect` 的调用方式、退出码与 `connected:` / `background task started:` 两行不变，只多打印一份项目清单。

在 #259 的规则存储、原子写入、损坏 fail-loud 与读正文之前的闸门基础上重做（保留其两个提交），吸收 @tiammomo 的入口顺序修复与 cwd 缺失处理；去掉按轨迹 id 的子命令。

## Changes

**server**
- config `team.server.privacy_mode: allowlist | denylist`，默认 denylist，非法值 fail-loud；配成 allowlist 即全员强制白名单
- `RegisterResponse` 与 `/sync` 响应新增 `privacy_mode`，每请求现取 live config，改配置热生效
- `xskill serve --server` 启动 banner 多一行 `privacy mode: …`

**client**
- `team/client/privacy.py` 重写：`PrivacyPolicy`（本机 mode + 按项目规则，最长前缀匹配，子目录规则优先）、`effective_mode`、只读 sidecar 的本机轨迹扫描（可设时间预算）、按项目归组的报表
- `TeamCollector.pending()`：读正文之前按生效模式判定；被跳过的轨迹不读、不传、不写状态。Cursor / Trae 无 cwd 与 sidecar 损坏的轨迹按模式默认处理（denylist 照传，allowlist 不传）
- `TeamClient.sync()`：server 模式变化时更新采集器并回写 `team_client.json`，记一行日志；下一轮生效，不需要重新 connect
- `ClientState` 新增 `server_privacy_mode`（旧文件缺字段按 None 读）

**CLI**
- `xskill privacy status | mode [allowlist|denylist|auto] | allow [path] | deny [path] | clear [path] | review`，均支持 `--json`；`allow` / `deny` 默认当前目录；`review` 非 TTY 直接报错退出码 2
- `xskill connect --privacy allowlist|denylist|auto` 在握手前设置本机模式；connect 收尾打印生效模式、来源、本机项目数与放行方式（扫描 2 秒预算，超时提示用 status 查看）
- `xskill status` 新增 `privacy  :` 一行与 `--json` 的 `privacy` 对象；原有 `warning` 字段含义不变

**文档**：三份 README、内置 xskill-helper 的 SKILL.md（新节「Controlling which trajectories are uploaded」）与 troubleshooting（「My trajectories never show up on the server」）、config 模板注释。

## 用户可见行为

| 场景 | 行为 |
|---|---|
| 老用户升级，不动配置 | 全部上传，与现在一致 |
| 个人想收紧 | `xskill privacy mode allowlist`，之后只传 `xskill privacy allow` 过的项目，server 改不动 |
| 只想排除某个项目 | 项目目录里 `xskill privacy deny`，下一轮扫描起不读不传 |
| 管理员全员白名单 | server 配 `privacy_mode: allowlist`，各客户端下一轮 sync 自动收紧 |
| 查看状态 | `xskill privacy status`：生效模式、每个项目多少条、传不传 |

## Tests

- `tests/test_team_client_privacy.py` 36 例：模式合成表、默认行为不变、allowlist 无规则一条不传且正文不读、子目录/符号链接/相对路径/~/大小写、子目录规则优先、无 cwd 与 sidecar 损坏、删规则恢复、规则文件损坏 fail-loud、server 下发与热切换、client sync 采纳并落盘、旧 state 文件兼容、CLI 六个子命令与 --json、review 非 TTY、`python -m xskill.cli privacy status` 真实入口
- `tests/test_team_sync_profile.py` 两处精确键集合断言补上 `privacy_mode`
- 本地全量（排除 bdd / docker_e2e / 存量 flaky 的 canary 用例）通过

## 不在本 PR

关键词过滤 / 脱敏（需读正文）、服务端读权限与蒸馏授权（@Shimmering-Ruby 的提案）、删除已上传历史、Cursor / Trae 适配器补写 cwd（前置小 PR 另提）。

Closes #244. Supersedes #259.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_015puq6TUwSg1pUWjtuEomai
