### PR TITLE
feat(cursor): 从会话目录名反解真实项目目录写入 sidecar cwd（#244 后续）

### DIFF
--- a/src/xskill/cli.py
+++ b/src/xskill/cli.py
@@ -2828,7 +2828,7 @@ _PRIVACY_HELP_EPILOG = """\
     子目录规则优先于父目录规则。
   · 不上传的轨迹不会被读取、不会上传，也不会记为已上传；之后放行会在
     下一轮扫描中正常上传。
-  · 轨迹 sidecar 没记录工作目录时（目前 Cursor 与 Trae 都不记）无法归属到项目：
+  · 轨迹 sidecar 没记录工作目录时无法归属到项目（Trae 不记；Cursor 只在项目目录仍存在时能反解）：
     allowlist 模式下不上传，denylist 模式下上传。status 会单独列出。
 
 examples:
@@ -2962,7 +2962,7 @@ def cmd_privacy(args) -> int:
         _write_search_output("")
         _write_search_output(f"上传 {report.upload} 条，不上传 {report.skip} 条。")
         if report.no_cwd.traj:
-            _write_search_output(f"提示：{report.no_cwd.traj} 条轨迹的 sidecar 未记录工作目录（Cursor / Trae 等），无法按项目放行。")
+            _write_search_output(f"提示：{report.no_cwd.traj} 条轨迹的 sidecar 未记录工作目录（Trae、已删除项目的 Cursor 会话等），无法按项目放行。")
         if report.broken_sidecar.traj:
             _write_search_output(f"提示：{report.broken_sidecar.traj} 条轨迹的 sidecar 缺失或损坏，无法归属项目。")
         if not report.complete:
@@ -3002,7 +3002,7 @@ def cmd_privacy(args) -> int:
               f"上传 {final_report.upload} 条，不上传 {final_report.skip} 条。")
         if final_report.no_cwd.traj:
             default_text = "上传" if final_report.no_cwd.effective == "upload" else "不上传"
-            _write_search_output(f"另有 {final_report.no_cwd.traj} 条轨迹未记录工作目录（Cursor / Trae 等），按模式默认处理（{default_text}）。")
+            _write_search_output(f"另有 {final_report.no_cwd.traj} 条轨迹未记录工作目录（Trae 等），按模式默认处理（{default_text}）。")
         return 0
 
     target_path = Path(args.target) if args.target else Path.cwd()
@@ -3039,7 +3039,7 @@ def cmd_privacy(args) -> int:
         if not Path(shown).exists():
             lines[1] = "  提示：该目录当前不存在，规则已保存，将对之后在此目录下产生的轨迹生效。"
         if no_cwd_count:
-            lines.append(f"  注意：本机另有 {no_cwd_count} 条轨迹未记录工作目录（Cursor / Trae 等），本规则对它们不生效。")
+            lines.append(f"  注意：本机另有 {no_cwd_count} 条轨迹未记录工作目录（Trae 等），本规则对它们不生效。")
         lines.append("  取消：xskill privacy deny  或  xskill privacy clear")
         emit(payload, lines)
         return 0

--- a/src/xskill/data/skill/xskill-helper/SKILL.md
+++ b/src/xskill/data/skill/xskill-helper/SKILL.md
@@ -102,9 +102,9 @@ xskill connect <host:port> --token <t> --privacy allowlist   # set the mode befo
 
 A skipped trajectory is never read, never uploaded and never marked as
 uploaded, so allowing it later uploads it on the next scan. A trajectory whose
-sidecar records no working directory (Cursor and Trae never do) cannot be
-matched to a project: it follows the mode default and `status` lists it
-separately.
+sidecar records no working directory (Trae never does; Cursor only when the
+project directory still exists on disk) cannot be matched to a project: it
+follows the mode default and `status` lists it separately.
 Rules never delete what was already uploaded.
 
 ## Generate or rewrite a Skill

--- a/src/xskill/data/skill/xskill-helper/references/troubleshooting.md
+++ b/src/xskill/data/skill/xskill-helper/references/troubleshooting.md
@@ -69,8 +69,9 @@ Each item: **symptom → cause → command/fix → expected**.
 
 - **Cause:** the effective privacy mode is `allowlist` (set by the server, or
   by `xskill privacy mode allowlist` on this machine) and the project has no
-  `allow` rule; or the project was explicitly denied. Cursor / Trae
-  trajectories carry no working directory and follow the mode default.
+  `allow` rule; or the project was explicitly denied. Trae trajectories (and
+  Cursor sessions whose project directory was deleted) carry no working
+  directory and follow the mode default.
 - **Fix:** run `xskill privacy status` — it prints the effective mode, where it
   comes from, and the decision for every discovered project. Then
   `cd <project> && xskill privacy allow`, or `xskill privacy clear <path>` to

--- a/src/xskill/ecosystems/_shared.py
+++ b/src/xskill/ecosystems/_shared.py
@@ -118,6 +118,8 @@ class EcosystemSpec:
     is_session_complete: Optional[Callable[[str], bool]] = None
     is_session_complete_path: Optional[Callable[[Path], bool]] = None
     cwd_from_path: Optional[Callable[[Path], str]] = None
+    # 可选：从源文件路径反解出真实项目目录，写进 sidecar 的 cwd（cwd_from_path 只管 traj_id 的项目段）。
+    project_dir_from_path: Optional[Callable[[Path], str]] = None
     adapt_path: Optional[Callable[[Path, dict], tuple[str, dict]]] = None
     # 可选：自定义「文件 → 文本」读取。默认 None = ``read_text``。给需要先
     # 解码再解析的生态用（DeepSeek Harness 默认写 zstd 帧序列的
@@ -1095,7 +1097,7 @@ class JsonlIngester:
                 session_start_t = session_start_time(jsonl_path)
                 traj_id = self._make_traj_id("", sid, source_path=jsonl_path)
                 md_content, json_metadata = self.spec.adapt_path(
-                    jsonl_path, {"session_id": sid},
+                    jsonl_path, self._session_metadata(sid, jsonl_path),
                 )
                 result = _store_adapted_trajectory(
                     md_content,
@@ -1133,7 +1135,7 @@ class JsonlIngester:
                 result = submit_trajectory(
                     content=content,
                     format=self.spec.adapter_format,
-                    metadata={"session_id": sid},
+                    metadata=self._session_metadata(sid, jsonl_path),
                     traj_id=traj_id,
                     traj_dir=target_traj_dir,
                 )
@@ -1186,6 +1188,15 @@ class JsonlIngester:
         for md in target_traj_dir.glob(f"{self.spec.traj_id_prefix}*.md"):
             out[md.stem.rsplit("_", 1)[-1]] = md
         return out
+
+    def _session_metadata(self, sid: str, jsonl_path: Path) -> dict:
+        """交给 adapter 的初始 meta；生态能从路径反解项目目录时带上 cwd。"""
+        metadata = {"session_id": sid}
+        if self.spec.project_dir_from_path is not None:
+            project_dir = self.spec.project_dir_from_path(jsonl_path)
+            if project_dir:
+                metadata["cwd"] = project_dir
+        return metadata
 
     def _make_traj_id(
         self,

--- a/src/xskill/ecosystems/cursor.py
+++ b/src/xskill/ecosystems/cursor.py
@@ -15,6 +15,7 @@ from __future__ import annotations
 
 import json
 import logging
+import os
 import re
 from pathlib import Path
 from typing import Any, Iterable, Optional
@@ -131,6 +132,48 @@ def _cwd_from_cursor_path(jsonl_path: Path) -> str:
     return ""
 
 
+def _decode_cursor_slug(slug: str) -> str:
+    """把 ``home-admin-my-service`` 反解成磁盘上真实存在的 ``/home/admin/my-service``。
+
+    slug 里的连字符既可能是路径分隔符也可能是目录名的一部分，且已被小写，
+    只能逐级对照磁盘上的目录名试出来；对不上（项目已删除）返回空串。
+    """
+    tokens = [token for token in slug.split("-") if token]
+    if not tokens:
+        return ""
+    if os.name == "nt":
+        if len(tokens[0]) != 1 or not tokens[0].isalpha():
+            return ""
+        root = Path(f"{tokens[0].upper()}:\\")
+        tokens = tokens[1:]
+    else:
+        root = Path("/")
+
+    def walk(current: Path, index: int) -> Optional[Path]:
+        if index == len(tokens):
+            return current
+        try:
+            entries = {name.lower(): name for name in os.listdir(current)}
+        except OSError:
+            return None
+        # 先试最长的候选名，让带连字符的目录名优先于把它拆成多级
+        for end in range(len(tokens), index, -1):
+            actual = entries.get("-".join(tokens[index:end]))
+            if actual is None or not (current / actual).is_dir():
+                continue
+            found = walk(current / actual, end)
+            if found is not None:
+                return found
+        return None
+
+    decoded = walk(root, 0)
+    return str(decoded) if decoded is not None else ""
+
+
+def _project_dir_from_cursor_path(jsonl_path: Path) -> str:
+    return _decode_cursor_slug(_cwd_from_cursor_path(jsonl_path))
+
+
 # ─────────────────────────────────────────────────────────────────
 # Ecosystem spec
 # ─────────────────────────────────────────────────────────────────
@@ -145,6 +188,7 @@ CURSOR_SPEC = EcosystemSpec(
     session_id_from_path=_cursor_session_id_from_path,
     cwd_from_content=_read_cwd_from_cursor_jsonl,
     cwd_from_path=_cwd_from_cursor_path,
+    project_dir_from_path=_project_dir_from_cursor_path,
     adapter_format="cursor_transcripts_jsonl",
     traj_id_prefix="traj_cursor_",
     skills_install_path=_cursor_skills_path,  # ~/.cursor/skills/ — Cursor 自己的 skill 目录
@@ -225,8 +269,8 @@ def _adapt_cursor_transcripts_jsonl(content: str, metadata: dict) -> tuple[str, 
     ```
 
     Cursor 没有显式 ``sessionId`` / ``cwd`` 字段——sid 在文件名，cwd 在父目录名
-    （encoded slug，本 adapter 不反解）。所以 meta 里 ``session_id`` / ``cwd``
-    都为空，由上层 ingester 用 ``source_jsonl`` 推断（如有需要）。
+    （encoded slug）。两者都由上层 ingester 从路径推断后放进 ``metadata`` 传入：
+    ``cwd`` 只在 slug 能对照磁盘反解成真实目录时才有。
     """
     timeline: list[dict] = []
     tool_names: list[str] = []

--- a/tests/test_cursor_adapter.py
+++ b/tests/test_cursor_adapter.py
@@ -373,3 +373,57 @@ class TestJsonlIngesterIsolation:
             tmp_path / "traj", home_root=tmp_path,
         )
         assert results == []
+
+
+# ──────────────────────────────────────────────────────────────────
+# T4. slug → 真实项目目录（sidecar cwd，供 xskill privacy 按项目放行）
+# ──────────────────────────────────────────────────────────────────
+
+def _slug_for(path: Path) -> str:
+    return str(path.resolve()).strip("/").replace("/", "-").lower()
+
+
+class TestCursorProjectDir:
+    def test_decodes_hyphenated_dir_names_by_checking_disk(self, tmp_path):
+        from xskill.ecosystems.cursor import _decode_cursor_slug
+        project = tmp_path / "my-service" / "backend-api"
+        project.mkdir(parents=True)
+        assert _decode_cursor_slug(_slug_for(project)) == str(project.resolve())
+
+    def test_prefers_existing_layout_when_slug_is_ambiguous(self, tmp_path):
+        from xskill.ecosystems.cursor import _decode_cursor_slug
+        (tmp_path / "gq" / "code").mkdir(parents=True)
+        (tmp_path / "gq-code").mkdir()
+        assert _decode_cursor_slug(_slug_for(tmp_path / "gq-code")) == str((tmp_path / "gq-code").resolve())
+        (tmp_path / "gq-code").rmdir()
+        assert _decode_cursor_slug(_slug_for(tmp_path / "gq" / "code")) == str((tmp_path / "gq" / "code").resolve())
+
+    def test_matches_case_insensitively(self, tmp_path):
+        from xskill.ecosystems.cursor import _decode_cursor_slug
+        project = tmp_path / "MyProj"
+        project.mkdir()
+        assert _decode_cursor_slug(_slug_for(project)) == str(project.resolve())
+
+    def test_returns_empty_when_project_no_longer_exists(self, tmp_path):
+        from xskill.ecosystems.cursor import _decode_cursor_slug
+        assert _decode_cursor_slug(_slug_for(tmp_path / "gone-project")) == ""
+        assert _decode_cursor_slug("") == ""
+
+    def test_ingest_writes_real_cwd_into_sidecar(self, tmp_path, fixture_content):
+        project = tmp_path / "code" / "my-service"
+        project.mkdir(parents=True)
+        _place_fixture_in_cursor_home(tmp_path, fixture_content, encoded_cwd=_slug_for(project))
+        results = ingest_cursor_sessions(tmp_path / "traj", home_root=tmp_path)
+        assert len(results) == 1
+        meta = json.loads(Path(results[0]["path"]).with_suffix(".json").read_text(encoding="utf-8"))
+        assert meta["cwd"] == str(project.resolve())
+        from xskill.ecosystems._shared import _sanitize_for_filename
+        expected_project = _sanitize_for_filename(_slug_for(project), maxlen=32)
+        assert results[0]["traj_id"] == f"traj_cursor_{expected_project}_abc12345"
+
+    def test_ingest_leaves_cwd_absent_when_project_missing(self, tmp_path, fixture_content):
+        _place_fixture_in_cursor_home(tmp_path, fixture_content, encoded_cwd="c-proj-foo")
+        results = ingest_cursor_sessions(tmp_path / "traj", home_root=tmp_path)
+        meta = json.loads(Path(results[0]["path"]).with_suffix(".json").read_text(encoding="utf-8"))
+        assert "cwd" not in meta
+        assert results[0]["traj_id"] == "traj_cursor_c-proj-foo_abc12345"

--- a/tests/test_cursor_adapter.py
+++ b/tests/test_cursor_adapter.py
@@ -380,7 +380,13 @@ class TestJsonlIngesterIsolation:
 # ──────────────────────────────────────────────────────────────────
 
 def _slug_for(path: Path) -> str:
-    return str(path.resolve()).strip("/").replace("/", "-").lower()
+    """按 Cursor 的编码方式把真实路径变成目录名：去掉根（Windows 保留盘符）、分隔符换连字符、小写。"""
+    parts = list(path.resolve().parts)
+    root = parts.pop(0)
+    drive = root.rstrip("\\/").rstrip(":")
+    if drive:
+        parts.insert(0, drive)
+    return "-".join(parts).lower()
 
 
 class TestCursorProjectDir:

--- a/tests/test_team_client_privacy.py
+++ b/tests/test_team_client_privacy.py
@@ -6,7 +6,7 @@
   server allowlist 下本机 denylist 无效
 * allowlist 下无规则一条都不上传，且正文一次都不读、不留任何上传状态
 * 项目规则含子目录、符号链接、相对路径、~、大小写；子目录规则优先于父目录
-* Cursor / Trae 无 cwd 与 sidecar 损坏的轨迹按模式默认处理
+* 无 cwd（Trae、已删项目的 Cursor 会话）与 sidecar 损坏的轨迹按模式默认处理
 * 删除规则后可重新进入上传流程
 * server 改模式后下一轮 sync 生效并落盘，无需重新 connect
 * 规则文件损坏时明确失败，而不是当作无规则放行
@@ -460,7 +460,7 @@ def test_cli_status_and_mode_before_connect(cli_home, capsys):
     assert return_code == 0
     assert "mode: denylist（未连接 server；server (未连接)）" in captured.out
     assert "上传 3 条，不上传 0 条。" in captured.out
-    assert "Cursor / Trae" in captured.out
+    assert "未记录工作目录" in captured.out
 
     return_code, captured = _run_privacy(capsys, "mode", "allowlist")
     assert return_code == 0
@@ -489,7 +489,7 @@ def test_cli_allow_deny_clear_roundtrip(cli_home, capsys, monkeypatch):
     return_code, captured = _run_privacy(capsys, "allow")
     assert return_code == 0
     assert captured.out.startswith(f"Allowed: {pv.canonical_project_path(backend)}")
-    assert "含已有的 1 条" in captured.out and "Cursor / Trae" in captured.out
+    assert "含已有的 1 条" in captured.out and "未记录工作目录" in captured.out
 
     return_code, captured = _run_privacy(capsys, "allow", str(backend))
     assert return_code == 0 and captured.out.startswith("Already allowed:")
@@ -571,7 +571,7 @@ def test_cli_help_explains_modes():
                       if isinstance(action, argparse._SubParsersAction))
     help_text = subparsers.choices["privacy"].format_help()
     assert "allowlist" in help_text and "denylist" in help_text
-    assert "Cursor 与 Trae" in help_text
+    assert "Trae 不记" in help_text and "Cursor" in help_text
     connect_help = subparsers.choices["connect"].format_help()
     assert "--privacy" in connect_help
 


### PR DESCRIPTION
## Summary

#420 的后续：Cursor 轨迹的 sidecar 补上 `cwd`，让 `xskill privacy allow / deny` 能按项目放行 Cursor 会话。

Cursor 把工作目录编码成 `~/.cursor/projects/<slug>/` 的目录名（路径分隔符换成连字符并小写，例如 `/home/alice/gq/code/nexent` → `home-alice-gq-code-nexent`）。此前转换出来的轨迹 sidecar 没有 `cwd`，隐私规则只能把它们归入"未记录工作目录"。

## Changes

- `EcosystemSpec` 新增可选钩子 `project_dir_from_path`；`JsonlIngester` 把反解结果作为 `cwd` 放进交给 adapter 的初始 metadata。只有 Cursor 设置了这个钩子，其它生态的 sidecar 不变。
- Cursor 反解逐级对照磁盘上的目录名试出真实路径：连字符既可能是分隔符也可能是目录名的一部分，且已被小写，所以先试更长的候选名再回退拆分；大小写不敏感匹配。项目目录已删除时对不上，sidecar 仍不写 `cwd`，privacy 里照旧列为"未记录工作目录"。
- `traj_id` 的项目段仍用 slug，已有轨迹 id 与文件名不变。
- privacy 帮助与提示文案改为"Trae 不记；Cursor 只在项目目录仍存在时能反解"。Trae 本次不做。

## 验证

本机真实 slug 反解：`home-admin-gq-code-nexent240pristine-nexent` → `/home/admin/gq/code/nexent240pristine/nexent`；已删除的 `home-admin-hermes-cursor-workspace` → 空。

新增 6 个测试：带连字符目录名、二义 slug 按磁盘实际布局决定、大小写、项目不存在返回空、ingest 写入真实 cwd 且 traj_id 不变、项目不存在时 sidecar 无 cwd。`tests/test_cursor_adapter.py` 与 `tests/test_team_client_privacy.py` 共 78 例通过。

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_015puq6TUwSg1pUWjtuEomai
